### PR TITLE
chore(functional-tests): define a test timeout at the config level

### DIFF
--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -36,6 +36,9 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
   // Retry on CI only.
   retries: CI ? 1 : 0,
 
+  // Total allowable time spent for the test function, fixtures, beforeEach and afterEach hooks. Defaults to 30 seconds.
+  timeout: 60000, // 1 minute
+
   use: {
     viewport: { width: 1280, height: 720 },
   },

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -14,8 +14,6 @@ const HINT = 'secret key location';
  * key stretched passwords. We need to ensure that operations are interchangeable!
  */
 test.describe('severity-2 #smoke', () => {
-  test.slow();
-
   // Helpers
   async function _getKeys(
     version: 1 | 2,

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -13,8 +13,6 @@ const AGE_21 = '21';
  * key stretched passwords. We need to ensure that operations are interchangeable!
  */
 test.describe('severity-2 #smoke', () => {
-  test.slow();
-
   // Helpers
   async function _getKeys(
     version: 1 | 2,

--- a/packages/functional-tests/tests/misc.spec.ts
+++ b/packages/functional-tests/tests/misc.spec.ts
@@ -4,7 +4,6 @@ test.describe('severity-1', () => {
   // runs all mocha tests - see output here: http://127.0.0.1:3030/tests/index.html
   test('content-server mocha tests', async ({ target, page }, { project }) => {
     test.skip(project.name !== 'local', 'mocha tests are local only');
-    test.slow();
     await page.goto(`${target.contentServerUrl}/tests/index.html`, {
       waitUntil: 'load',
     });

--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -7,7 +7,6 @@ import { test, expect } from '../../lib/fixtures/standard';
 //Add `disable_local_storage` to the URL to synthesize cookies being disabled.
 test.describe('cookies disabled', () => {
   test.beforeEach(async ({ pages: { login } }) => {
-    test.slow();
     await login.clearCache();
   });
 

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -32,13 +32,12 @@ test.describe('severity-1 #smoke', () => {
     test('with a unregistered email', async ({
       pages: { configPage, login, relier },
       testAccountTracker,
-    }, { project }) => {
+    }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'Scheduled for removal as part of React conversion (see FXA-9410).'
       );
-      test.slow(project.name !== 'local', 'email delivery can be slow');
       const credentials = await testAccountTracker.signUp();
       const newEmail = testAccountTracker.generateEmail();
 
@@ -62,13 +61,12 @@ test.describe('severity-1 #smoke', () => {
       page,
       pages: { configPage, login, relier, settings, deleteAccount },
       testAccountTracker,
-    }, { project }) => {
+    }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes === true,
         'Scheduled for removal as part of React conversion (see FXA-9410).'
       );
-      test.slow(project.name !== 'local', 'email delivery can be slow');
 
       const credentials = await testAccountTracker.signUp();
       const blockedEmail = testAccountTracker.generateBlockedEmail();

--- a/packages/functional-tests/tests/oauth/oauthPermissionsSignin.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissionsSignin.spec.ts
@@ -7,7 +7,6 @@ import { expect, test } from '../../lib/fixtures/standard';
 test.describe('severity-1 #smoke', () => {
   test.describe('oauth permissions for trusted reliers - sign in', () => {
     test.beforeEach(async ({ pages: { login } }) => {
-      test.slow();
       await login.clearCache();
     });
 

--- a/packages/functional-tests/tests/oauth/oauthPermissionsSignup.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPermissionsSignup.spec.ts
@@ -12,7 +12,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signUpRoutes === true,
         'these tests are specific to backbone, skip if seeing React version'
       );
-      test.slow();
     });
 
     test('signup without `prompt=consent`', async ({

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -13,7 +13,6 @@ test.describe('severity-1 #smoke', () => {
       project.name === 'production',
       'test plan not yet available in prod'
     );
-    test.slow();
   });
 
   test.describe('oauth prompt none', () => {

--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -11,7 +11,6 @@ test.describe('severity-1 #smoke', () => {
       config.showReactApp.signUpRoutes === true,
       'this test is specific to backbone, skip if serving react'
     );
-    test.slow();
   });
 
   test.describe('Oauth sign up', () => {

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -5,10 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
-  test.beforeEach(({}, { project }) => {
-    test.slow(project.name !== 'local', 'email delivery can be slow');
-  });
-
   test.describe('OAuth signin', () => {
     test('verified', async ({
       pages: { login, relier },

--- a/packages/functional-tests/tests/oauth/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/oauth/signinBlocked.spec.ts
@@ -7,10 +7,6 @@ import { SettingsPage } from '../../pages/settings';
 import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 
 test.describe('severity-1 #smoke', () => {
-  test.beforeEach(({}, { project }) => {
-    test.slow(project.name !== 'local', 'email delivery can be slow');
-  });
-
   test.describe('OAuth signin blocked', () => {
     test('verified, blocked', async ({
       page,

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -7,10 +7,6 @@ import { expect, test } from '../../lib/fixtures/standard';
 const AGE_21 = '21';
 
 test.describe('severity-1 #smoke', () => {
-  test.beforeEach(() => {
-    test.slow();
-  });
-
   test.describe('signin with OAuth after Sync', () => {
     test('signin to OAuth with Sync creds', async ({
       target,

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -9,10 +9,6 @@ import { LoginPage } from '../../pages/login';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('OAuth totp', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('can add TOTP to account and confirm oauth signin', async ({
       target,
       pages: { page, login, relier, settings, totp },

--- a/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
@@ -6,10 +6,6 @@ import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('post verify - force password change', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('navigate to page directly and can change password', async ({
       target,
       pages: { page, login, postVerify },

--- a/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
@@ -7,7 +7,6 @@ import { getReactFeatureFlagUrl } from '../../lib/react-flag';
 
 test.describe('force auth react', () => {
   test.beforeEach(async ({ pages: { configPage } }) => {
-    test.slow();
     // Ensure that the feature flag is enabled
     const config = await configPage.getConfig();
     test.skip(config.showReactApp.signInRoutes !== true);

--- a/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPassword.spec.ts
@@ -20,7 +20,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('reset password', async ({

--- a/packages/functional-tests/tests/react-conversion/oauthResetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPasswordRecoveryKey.spec.ts
@@ -18,7 +18,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('reset password with account recovery key', async ({

--- a/packages/functional-tests/tests/react-conversion/oauthResetPasswordScopeKeys.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPasswordScopeKeys.spec.ts
@@ -19,7 +19,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('reset password scoped keys', async ({

--- a/packages/functional-tests/tests/react-conversion/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthResetPasswordSyncMobile.spec.ts
@@ -20,7 +20,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('reset password through Sync mobile', async ({

--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -14,7 +14,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signInRoutes !== true,
         'React signInRoutes not enabled'
       );
-      test.slow();
     });
 
     test('verified account, no email confirmation required', async ({
@@ -25,6 +24,7 @@ test.describe('severity-1 #smoke', () => {
         project.name !== 'local',
         'Fix required as of 2024/04/26 (see FXA-9518).'
       );
+      test.setTimeout(120000); // 2 minutes
 
       const credentials = await testAccountTracker.signUp();
 
@@ -218,8 +218,7 @@ test.describe('severity-1 #smoke', () => {
       page,
       pages: { configPage, relier, signinReact, signupReact },
       testAccountTracker,
-    }, { project }) => {
-      test.slow(project.name !== 'local', 'email delivery can be slow');
+    }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.showReactApp.signUpRoutes !== true,

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -17,7 +17,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signUpRoutes !== true,
         'Skip tests if not on React signUpRoutes'
       );
-      test.slow();
     });
 
     test('signup oauth', async ({

--- a/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/recoveryKey.spec.ts
@@ -16,7 +16,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('can reset password with recovery key', async ({

--- a/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/resetPassword.spec.ts
@@ -14,7 +14,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('can reset password', async ({

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -5,9 +5,6 @@
 import { test, expect } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
-  // Slowing down test, was timing out on credentials teardown
-  test.slow();
-
   test('react signin to sync and disconnect', async ({
     syncBrowserPages: {
       configPage,

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -13,7 +13,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signInRoutes !== true,
         'React signInRoutes not enabled'
       );
-      test.slow();
     });
 
     test('add totp', async ({

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -25,7 +25,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signUpRoutes !== true,
         'Skip tests if not on React signUpRoutes'
       );
-      test.slow();
     });
 
     test('signup web', async ({

--- a/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3ResetPassword.spec.ts
@@ -13,7 +13,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
     });
 
     test('reset pw for sync user', async ({

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -12,10 +12,6 @@ import { SecondaryEmailPage } from '../../pages/settings/secondaryEmail';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('change primary email tests', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('change primary email and login', async ({
       target,
       pages: { page, login, settings, secondaryEmail },

--- a/packages/functional-tests/tests/settings/changeEmailBlocked.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmailBlocked.spec.ts
@@ -12,10 +12,6 @@ import { SecondaryEmailPage } from '../../pages/settings/secondaryEmail';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('change primary - unblock', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('change primary email, get blocked with invalid password, redirect enter password page', async ({
       target,
       pages: { page, settings, login, secondaryEmail, deleteAccount },

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -14,8 +14,6 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, login, settings, changePassword },
       testAccountTracker,
     }) => {
-      test.slow();
-
       await signInAccount(target, page, login, testAccountTracker);
       const newPassword = testAccountTracker.generatePassword();
 
@@ -36,8 +34,6 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, settings, changePassword, login },
       testAccountTracker,
     }) => {
-      test.slow();
-
       const credentials = await signInAccount(
         target,
         page,
@@ -111,8 +107,6 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.resetPasswordWithCode === true,
         'see FXA-9612'
       );
-      test.slow();
-
       await signInAccount(target, page, login, testAccountTracker);
 
       await settings.goto();

--- a/packages/functional-tests/tests/settings/deleteAccount.spec.ts
+++ b/packages/functional-tests/tests/settings/deleteAccount.spec.ts
@@ -8,10 +8,6 @@ import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { LoginPage } from '../../pages/login';
 
 test.describe('severity-1 #smoke', () => {
-  test.beforeEach(async () => {
-    test.slow();
-  });
-
   test('cancel delete account step 1', async ({
     target,
     pages: { page, login, settings, deleteAccount },

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -12,7 +12,6 @@ test.describe('fxa_status web channel message in Settings', () => {
     // Ensure that the feature flag is enabled
     const config = await configPage.getConfig();
     test.skip(config.featureFlags.sendFxAStatusOnSettings !== true);
-    test.slow();
   });
 
   test('message is sent when loading with context = oauth_webchannel_v1', async ({

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -5,7 +5,6 @@
 import fs from 'fs';
 import pdfParse from 'pdf-parse';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
-import { EmailHeader, EmailType } from '../../lib/email';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { LoginPage } from '../../pages/login';
@@ -14,12 +13,6 @@ const HINT = 'secret key location';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('recovery key test', () => {
-    test.beforeEach(async () => {
-      // Generating and consuming recovery keys is a slow process
-      // Mail delivery can also be slow
-      test.slow();
-    });
-
     test('can copy recovery key', async ({
       target,
       pages: { page, login, recoveryKey, settings },

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -12,11 +12,6 @@ import { TotpCredentials, TotpPage } from '../../pages/settings/totp';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('two step auth', () => {
-    test.beforeEach(async () => {
-      // 2FA test can be slow because of time to generate recovery keys
-      test.slow();
-    });
-
     test('add and remove totp', async ({
       target,
       pages: { page, settings, totp, login },

--- a/packages/functional-tests/tests/signUp/signUp.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUp.spec.ts
@@ -12,7 +12,6 @@ test.describe('severity-2 #smoke', () => {
         config.showReactApp.signUpRoutes === true,
         'these tests are specific to backbone, skip if serving React version'
       );
-      test.slow();
     });
 
     test('with an invalid email, empty email query query param', async ({

--- a/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
+++ b/packages/functional-tests/tests/signUp/signUpWithCode.spec.ts
@@ -12,7 +12,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signUpRoutes === true,
         'these tests are specific to backbone, skip if serving React version'
       );
-      test.slow();
     });
 
     test('bounced email', async ({

--- a/packages/functional-tests/tests/signin/relyingParties.spec.ts
+++ b/packages/functional-tests/tests/signin/relyingParties.spec.ts
@@ -5,9 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
-  // Slowing down test, was timing out on credentials teardown
-  test.slow();
-
   test('signin to sync and disconnect', async ({
     target,
     syncBrowserPages: { page, login, settings },

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -11,10 +11,6 @@ import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signin blocked', () => {
-    test.beforeEach(() => {
-      test.slow(); //This test has steps for email rendering that runs slow on stage
-    });
-
     test('valid code entered', async ({
       target,
       page,

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -8,10 +8,6 @@ import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { LoginPage } from '../../pages/login';
 
 test.describe('severity-2 #smoke', () => {
-  test.beforeEach(async () => {
-    test.slow(); //This test has steps for email rendering that runs slow on stage
-  });
-
   test.describe('signin cached', () => {
     test('sign in twice, on second attempt email will be cached', async ({
       target,

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
@@ -7,10 +7,6 @@ import { Coupon } from '../../../pages/products';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test expired', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('apply an expired coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
@@ -12,10 +12,6 @@ import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test forever discount', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('subscribe successfully with a forever discount coupon', async ({
       target,
       page,

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
@@ -12,10 +12,6 @@ import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test invalid', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('apply an invalid coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
@@ -12,10 +12,6 @@ import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test one time discount', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('subscribe with a one time discount coupon', async ({
       target,
       page,

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
@@ -13,10 +13,6 @@ import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('payment', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('update mode of payment for stripe', async ({
       target,
       page,

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -13,10 +13,6 @@ import { SigninReactPage } from '../../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('resubscription test', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('resubscribe successfully with the same coupon after canceling for stripe', async ({
       target,
       page,

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -23,7 +23,6 @@ test.describe('severity-2 #smoke', () => {
         project.name === 'production',
         'no real payment method available in prod'
       );
-      test.slow();
 
       await signInAccount(
         target,

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -12,10 +12,6 @@ import { SigninReactPage } from '../../pages/signinReact';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('subscription', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('subscribe with credit card and login to product', async ({
       target,
       page,
@@ -169,10 +165,6 @@ test.describe('severity-2 #smoke', () => {
   });
 
   test.describe('Flow, acquisition and new user checkout funnel metrics', () => {
-    test.beforeEach(() => {
-      test.slow();
-    });
-
     test('Metrics disabled: existing user checkout URL to not have flow params', async ({
       target,
       page,

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -36,7 +36,6 @@ test.describe('severity-1 #smoke', () => {
       pages: { settings, signinReact },
       testAccountTracker,
     }) => {
-      test.slow();
       await signInAccount(
         target,
         page,
@@ -67,7 +66,6 @@ test.describe('severity-2 #smoke', () => {
         project.name === 'production',
         'no real payment method available in prod'
       );
-      test.slow();
 
       const credentials = await signInAccount(
         target,

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -8,10 +8,6 @@ import uaStrings from '../../lib/ua-strings';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox desktop user info handshake', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('Sync - no user signed into browser, no user signed in locally', async ({
       target,
       syncBrowserPages: { login, page },

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
@@ -8,10 +8,6 @@ import uaStrings from '../../lib/ua-strings';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox desktop user info handshake', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('Non-Sync - no user signed into browser, no user signed in locally', async ({
       target,
       syncBrowserPages: { login, page },

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -11,10 +11,6 @@ const makeUid = () =>
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Desktop Sync V3 force auth', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('sync v3 with a registered email, no uid', async ({
       syncBrowserPages: {
         fxDesktopV3ForceAuth,

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuthUnregistered.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuthUnregistered.spec.ts
@@ -11,10 +11,6 @@ const makeUid = () =>
 
 test.describe('severity-1 #smoke', () => {
   test.describe('Desktop Sync V3 force auth', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('sync v3 with an unregistered email, no uid', async ({
       pages: { configPage },
       syncBrowserPages: { fxDesktopV3ForceAuth, login },

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -7,10 +7,6 @@ import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 settings', () => {
-    test.beforeEach(async () => {
-      test.slow();
-    });
-
     test('sign in, change the password', async ({
       target,
       syncBrowserPages: {

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -10,10 +10,6 @@ import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { LoginPage } from '../../pages/login';
 
 test.describe('severity-2 #smoke', () => {
-  test.beforeEach(async () => {
-    test.slow();
-  });
-
   test.describe('Firefox Desktop Sync v3 sign in', () => {
     test('verified email, does not need to confirm', async ({
       target,

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -14,7 +14,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signUpRoutes === true,
         'these tests are specific to backbone, skip if seeing React version'
       );
-      test.slow();
     });
 
     test('sync sign up', async ({

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -16,7 +16,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signUpRoutes === true,
         'these tests are specific to backbone, skip if seeing React version'
       );
-      test.slow();
     });
 
     test('verify with signup code and CWTS', async ({

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -9,10 +9,6 @@ import { LoginPage } from '../../pages/login';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('sync signin cached', () => {
-    test.beforeEach(async () => {
-      test.slow(); //This test has steps for email rendering that runs slow on stage
-    });
-
     test('sign in on desktop then specify a different email on query parameter continues to cache desktop signin', async ({
       target,
       syncBrowserPages: { page, login, connectAnotherDevice },

--- a/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
+++ b/packages/functional-tests/tests/syncV3/syncV3EmailFirst.spec.ts
@@ -5,9 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('Firefox Desktop Sync v3 email first', () => {
-  test.beforeEach(async () => {
-    test.slow();
-  });
 
   test('open directly to /signin page, refresh on the /signin page', async ({
     target,


### PR DESCRIPTION
## Because

- the majority of tests use the `test.slow()` annotation

## This pull request

- increased the default test timeout from 30 seconds to 60 seconds
- sets an exceptional timeout of 2 minutes for `severity-1 #smoke › react OAuth signin › verified account> no email confirmation required`

## Issue that this pull request solves

Closes: # FXA-9388

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

According to the nightly tests run on May 9th 2024 (see [data](https://docs.google.com/spreadsheets/d/1FKT3qM9qkNpnuJzN4-gjutwP4XzIkBNVq5LqkLJe8P4/edit#gid=1996921065)), test cases have the following run time stats:
- AVERAGE    6.6s
- MEDIAN      5.1s
- HIGHEST  98.3s
- LOWEST.    0.5s