### PR TITLE
feat(many): add support for libs in webpack apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.8",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.4.2"
   },
   "workspaces": [
@@ -269,6 +270,7 @@
   "packageManager": "yarn@3.3.0",
   "_moduleAliases": {
     "@fxa/vendored/jwtool": "./dist/libs/vendored/jwtool/src/index.js",
-    "@fxa/shared/pem-jwk": "./dist/libs/shared/pem-jwk/src/index.js"
+    "@fxa/shared/pem-jwk": "./dist/libs/shared/pem-jwk/src/index.js",
+    "@fxa/shared/l10n": "./dist/libs/shared/l10n/src/index.js"
   }
 }

--- a/packages/fxa-admin-panel/.rescriptsrc.js
+++ b/packages/fxa-admin-panel/.rescriptsrc.js
@@ -7,9 +7,10 @@ const {
   suppressRuntimeErrorOverlay,
   setModuleNameMapper,
 } = require('fxa-react/configs/rescripts');
+const tsconfigBase = require('../../tsconfig.base.json');
 
 module.exports = {
   webpack: permitAdditionalJSImports,
   devServer: suppressRuntimeErrorOverlay,
-  jest: setModuleNameMapper,
+  jest: setModuleNameMapper(tsconfigBase),
 };

--- a/packages/fxa-payments-server/.rescriptsrc.js
+++ b/packages/fxa-payments-server/.rescriptsrc.js
@@ -7,9 +7,10 @@ const {
   suppressRuntimeErrorOverlay,
   setModuleNameMapper,
 } = require('fxa-react/configs/rescripts');
+const tsconfigBase = require('../../tsconfig.base.json')
 
 module.exports = {
   webpack: permitAdditionalJSImports,
   devServer: suppressRuntimeErrorOverlay,
-  jest: setModuleNameMapper,
+  jest: setModuleNameMapper(tsconfigBase),
 };

--- a/packages/fxa-payments-server/server/bin/fxa-payments-server.js
+++ b/packages/fxa-payments-server/server/bin/fxa-payments-server.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+require('module-alias/register');
 
 // Important! Must be required first to get proper hooks in place.
 require('../lib/monitoring');

--- a/packages/fxa-payments-server/server/jest.config.js
+++ b/packages/fxa-payments-server/server/jest.config.js
@@ -1,3 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+const { pathsToModuleNameMapper } = require('ts-jest')
+const { compilerOptions } = require('../../../tsconfig.base.json')
+
 module.exports = {
   collectCoverageFrom: ['**/*.js', '!bin/*', '!coverage/**', '!**/jest*js'],
   // TO DO: update this file once more server tests are in place
@@ -13,7 +19,9 @@ module.exports = {
     "fxa-shared/*": [ "ts-jest", { "isolatedModules": true } ],
     "libs/shared/l10n/src": [ "ts-jest", { "isolatedModules": true } ],
   },
-  moduleNameMapper: {
-    "@fxa/shared/l10n": "../../../libs/shared/l10n/src",
-  }
+  // ts-jest - Paths mapping - With helper
+  // https://kulshekhar.github.io/ts-jest/docs/getting-started/paths-mapping#jest-config-with-helper
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {prefix: '<rootDir>/../../../'})
 };

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -31,9 +31,7 @@ const remoteAddress =
 const geolocate = require('fxa-shared/express/geo-locate').geolocate(geodb)(
   remoteAddress
 )(log);
-// TODO - FXA-8413 - Delete file. Replaced by @fxa/shared/l10n
-// const { determineLocale } = require('@fxa/shared/l10n');
-const {determineLocale} = require('fxa-shared/l10n/determineLocale')
+const { determineLocale } = require('@fxa/shared/l10n');
 
 const FUZZY_EVENTS = new Map([
   [

--- a/packages/fxa-payments-server/src/components/AlertBar/index.tsx
+++ b/packages/fxa-payments-server/src/components/AlertBar/index.tsx
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { ReactComponent as CloseIcon } from '../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import Portal from 'fxa-react/components/Portal';

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect, useContext, useState } from 'react';
 import { AppContext } from '../../lib/AppContext';
-import logo from '../../../../../libs/shared/assets/src/images/moz-m-logo.svg';
+import logo from '@fxa/shared/assets/images/moz-m-logo.svg';
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 

--- a/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
@@ -10,7 +10,7 @@ import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import Portal from 'fxa-react/components/Portal';
 
 import './index.scss';
-import { ReactComponent as CloseIcon } from '../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 
 type DialogMessageProps = {
   className?: string;

--- a/packages/fxa-payments-server/src/components/Header/index.tsx
+++ b/packages/fxa-payments-server/src/components/Header/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
 import { Profile } from '../../store/types';
-import mozillaLogo from '../../../../../libs/shared/assets/src/images/moz-logo-bw-rgb.svg';
+import mozillaLogo from '@fxa/shared/assets/images/moz-logo-bw-rgb.svg';
 import { useLocalization } from '@fluent/react';
 
 export type HeaderProps = {

--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Localized, useLocalization } from '@fluent/react';
-import React from 'react';
 import LinkExternal from '../LinkExternal';
-import mozLogo from '../../../../libs/shared/assets/src/images/moz-logo-bw-rgb.svg';
+import mozLogo from '@fxa/shared/assets/images/moz-logo-bw-rgb.svg';
 
 export const Footer = () => {
   const { l10n } = useLocalization();

--- a/packages/fxa-react/components/Head/index.tsx
+++ b/packages/fxa-react/components/Head/index.tsx
@@ -3,10 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useLocalization } from '@fluent/react';
-import React from 'react';
 import { Helmet } from 'react-helmet';
-import { determineLocale } from 'fxa-shared/l10n/determineLocale';
-import { determineDirection } from 'fxa-shared/l10n/determineDirection';
+import { determineLocale, determineDirection } from '@fxa/shared/l10n';
 
 const supportedUserLocale = determineLocale(
   window.navigator.languages.join(', ')

--- a/packages/fxa-react/components/LogoLockup/index.tsx
+++ b/packages/fxa-react/components/LogoLockup/index.tsx
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { Localized } from '@fluent/react';
-import logo from '../../../../libs/shared/assets/src/images/moz-m-logo.svg';
+import logo from '@fxa/shared/assets/images/moz-m-logo.svg';
 
 type LogoLockupProps = {
   children: string | ReactElement;

--- a/packages/fxa-react/configs/storybooks.js
+++ b/packages/fxa-react/configs/storybooks.js
@@ -3,20 +3,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { resolve } = require('path');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 const allFxa = resolve(__dirname, '../../');
-const importPaths = [allFxa, resolve(__dirname, '../../../node_modules')];
+const allLibs = resolve(__dirname, '../../libs/');
+const importPaths = [
+  allFxa,
+  allLibs,
+  resolve(__dirname, '../../../node_modules'),
+];
 const additionalJSImports = {
   'fxa-react': resolve(__dirname, '../'),
   'fxa-shared': resolve(__dirname, '../../fxa-shared'),
-  '@fxa/shared/l10n': resolve(__dirname, '../../../libs/shared/l10n/src'),
 };
 
 const customizeWebpackConfig = ({ config }) => ({
   ...config,
   resolve: {
     ...config.resolve,
-    plugins: (config.resolve.plugins || []).map((plugin) => {
+    plugins: [
+      ...(config.resolve.plugins || []),
+      new TsconfigPathsPlugin({ configFile: './tsconfig.json' }),
+    ].map((plugin) => {
       // Rebuild ModuleScopePlugin with some additional allowed paths
       if (
         plugin.constructor &&

--- a/packages/fxa-react/jest.config.js
+++ b/packages/fxa-react/jest.config.js
@@ -1,16 +1,23 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('../../tsconfig.base.json');
 
 module.exports = {
-  roots: ['<rootDir>'],
   transform: {
     '^.+\\.(ts|tsx)?$': ['ts-jest', { isolatedModules: true }],
     '^.+\\.svg$': '<rootDir>/svg-transform.js',
   },
+  // ts-jest - Paths mapping - With helper
+  // https://kulshekhar.github.io/ts-jest/docs/getting-started/paths-mapping#jest-config-with-helper
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl],
   moduleNameMapper: {
+    ...pathsToModuleNameMapper(compilerOptions.paths, {
+      prefix: '<rootDir>/../../',
+    }),
     '\\.(css|scss)$': 'identity-obj-proxy',
-    '@fxa/shared/l10n': '../../../libs/shared/l10n/src',
   },
   testPathIgnorePatterns: ['/dist/', '/node_modules/'],
   // Matches create-react-app

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -5,10 +5,7 @@
 import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { LocalizationProvider, ReactLocalization } from '@fluent/react';
 import React, { Component } from 'react';
-// TODO - FXA-8413 - Replace with @fxa/shared/l10n
-// import { EN_GB_LOCALES, parseAcceptLanguage } from '@fxa/shared/l10n';
-import { EN_GB_LOCALES } from 'fxa-shared/l10n/otherLanguages';
-import { parseAcceptLanguage } from 'fxa-shared/l10n/parseAcceptLanguage';
+import { EN_GB_LOCALES, parseAcceptLanguage } from '@fxa/shared/l10n';
 
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {

--- a/packages/fxa-settings/config/webpack.config.js
+++ b/packages/fxa-settings/config/webpack.config.js
@@ -25,6 +25,7 @@ const ForkTsCheckerWebpackPlugin =
     ? require('react-dev-utils/ForkTsCheckerWarningWebpackPlugin')
     : require('react-dev-utils/ForkTsCheckerWebpackPlugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 const createEnvironmentHash = require('./webpack/persistentCache/createEnvironmentHash');
 
@@ -86,10 +87,10 @@ const hasJsxRuntime = (() => {
 })();
 
 const allFxa = path.resolve(__dirname, '../../');
-const sharedAssets = path.resolve(__dirname, '../../../libs/shared/assets/');
+const allLibs = path.resolve(__dirname, '../../../libs/');
 const importPaths = [
   allFxa,
-  sharedAssets,
+  allLibs,
   path.resolve(__dirname, '../../../node_modules'),
 ];
 
@@ -349,6 +350,7 @@ module.exports = function (webpackEnv) {
             babelRuntimeRegenerator,
           ]
         ),
+        new TsconfigPathsPlugin({ configFile: './tsconfig.json' }),
       ],
       fallback: {
         fs: false,
@@ -424,7 +426,7 @@ module.exports = function (webpackEnv) {
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
-              include: [paths.appSrc, allFxa],
+              include: [paths.appSrc, allFxa, allLibs],
               loader: require.resolve('babel-loader'),
               options: {
                 customize: require.resolve(

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -72,7 +72,9 @@
     "modulePaths": [],
     "moduleNameMapper": {
       "^react-native$": "react-native-web",
-      "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy"
+      "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy",
+      "@fxa/shared/l10n": "<rootDir>/../../libs/shared/l10n/src/index.ts",
+      "^@fxa/shared/assets(.*)$": "<rootDir>/../../libs/shared/assets/src$1"
     },
     "moduleFileExtensions": [
       "web.js",

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import mozLogo from '../../../../../libs/shared/assets/src/images/moz-logo-bw-rgb.svg';
+import mozLogo from '@fxa/shared/assets/images/moz-logo-bw-rgb.svg';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useLocalization } from '@fluent/react';
 import Head from 'fxa-react/components/Head';

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -5,7 +5,7 @@
 import classNames from 'classnames';
 import React, { ReactElement } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { ReactComponent as IconClose } from '../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as IconClose } from '@fxa/shared/assets/images/close.svg';
 import { FIREFOX_NOREPLY_EMAIL } from '../../constants';
 
 export enum BannerType {

--- a/packages/fxa-settings/src/components/BrandMessaging/index.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useConfig } from '../../models';
 import { useMetrics } from '../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { ReactComponent as CloseIcon } from '../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 import { Localized } from '@fluent/react';
 import { createPortal } from 'react-dom';
-import logo from '../../../../../libs/shared/assets/src/images/moz-m-logo.svg';
+import logo from '@fxa/shared/assets/images/moz-m-logo.svg';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 
 export const bannerClosedLocalStorageKey =

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { useAccount, useAlertBar, useFtlMsgResolver } from '../../models';
 import { pdf } from '@react-pdf/renderer';
 import { saveAs } from 'file-saver';
@@ -14,7 +13,7 @@ import {
 } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../lib/metrics';
 import { FontData, getRequiredFont } from './requiredFont';
-import { determineLocale } from 'fxa-shared/l10n/determineLocale';
+import { determineLocale } from '@fxa/shared/l10n';
 
 export interface LocalizedRecoveryKeyPdfContent {
   heading: string;

--- a/packages/fxa-settings/src/components/CardHeader/index.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { MozServices } from '../../lib/types';
-import { ReactComponent as PocketLogo } from '../../../../../libs/shared/assets/src/images/pocket.svg';
+import { ReactComponent as PocketLogo } from '@fxa/shared/assets/images/pocket.svg';
 
 // NOTE: this component is heavily tested in components that use it and has complete line
 // coverage. However, we may file an issue out of FXA-6589 to add more explicit coverage.

--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.tsx
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
 import { useEscKeydownEffect, useChangeFocusEffect } from '../../../lib/hooks';
-import { ReactComponent as CloseIcon } from '../../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 import { alertContent, alertType, alertVisible } from '../../../models';
 import { useReactiveVar } from '@apollo/client';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
@@ -2,19 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useEscKeydownEffect } from '../../../lib/hooks';
 
 import monitorIcon from './monitor.svg';
-import pocketIcon from '../../../../../../libs/shared/assets/src/images/pocket.svg';
+import pocketIcon from '@fxa/shared/assets/images/pocket.svg';
 import desktopIcon from './desktop.svg';
 import mobileIcon from './mobile.svg';
 import relayIcon from './relay.svg';
 import vpnIcon from './vpn-logo.svg';
 import { ReactComponent as BentoIcon } from './bento.svg';
-import { ReactComponent as CloseIcon } from '../../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
 

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-
 import { LinkExternal } from 'fxa-react/components/LinkExternal';
 import { DeviceLocation } from '../../../models/Account';
 import { ReactComponent as WebIcon } from './web.svg';
@@ -13,7 +11,7 @@ import { ReactComponent as MobileIcon } from './mobile.svg';
 import { ReactComponent as SyncIcon } from './sync.svg';
 import { ReactComponent as TabletIcon } from './tablet.svg';
 import { ReactComponent as MonitorIcon } from './monitor.svg';
-import { ReactComponent as PocketIcon } from '../../../../../../libs/shared/assets/src/images/pocket.svg';
+import { ReactComponent as PocketIcon } from '@fxa/shared/assets/images/pocket.svg';
 import { ReactComponent as LockwiseIcon } from './lockwise.svg';
 import { ReactComponent as RelayIcon } from './relay.svg';
 import { ReactComponent as AddonIcon } from './addon.svg';

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import { useEscKeydownEffect, useChangeFocusEffect } from '../../../lib/hooks';
 import classNames from 'classnames';
 import Portal from 'fxa-react/components/Portal';
-import { ReactComponent as CloseIcon } from '../../../../../../libs/shared/assets/src/images/close.svg';
+import { ReactComponent as CloseIcon } from '@fxa/shared/assets/images/close.svg';
 import { Link, useLocation } from '@reach/router';
 import { useFtlMsgResolver } from '../../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -117,14 +117,6 @@
       "import": "./dist/esm/packages/fxa-shared/guards/*.js",
       "require": "./dist/cjs/packages/fxa-shared/guards/*.js"
     },
-    "./l10n/otherLanguages": {
-      "import": "./dist/esm/packages/fxa-shared/l10n/otherLanguages.js",
-      "require": "./dist/cjs/packages/fxa-shared/l10n/otherLanguages.js"
-    },
-    "./l10n/*": {
-      "import": "./dist/esm/packages/fxa-shared/l10n/*.js",
-      "require": "./dist/cjs/packages/fxa-shared/l10n/*.js"
-    },
     "./lib/*": {
       "import": "./dist/esm/packages/fxa-shared/lib/*.js",
       "require": "./dist/cjs/packages/fxa-shared/lib/*.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -38919,6 +38919,7 @@ fsevents@~2.1.1:
     ts-jest: ^29.1.2
     ts-node: ^10.9.2
     tsc-alias: ^1.8.8
+    tsconfig-paths-webpack-plugin: ^4.1.0
     tslib: ^2.6.2
     typescript: ^5.4.2
     uuid: ^9.0.0
@@ -63450,7 +63451,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"tsconfig-paths-webpack-plugin@npm:4.1.0, tsconfig-paths-webpack-plugin@npm:^4.0.1":
+"tsconfig-paths-webpack-plugin@npm:4.1.0, tsconfig-paths-webpack-plugin@npm:^4.0.1, tsconfig-paths-webpack-plugin@npm:^4.1.0":
   version: 4.1.0
   resolution: "tsconfig-paths-webpack-plugin@npm:4.1.0"
   dependencies:


### PR DESCRIPTION
## Because

- Could not import libs/* into apps using webpack
- Some apps failed with compilation errors when switching branches
- Imports from libs/assets used relative paths instead of the alias

## This pull request

- Adds support for libs/* into apps using webpack
- Replaces all relative paths for libs/assets with the alias

## Issue that this pull request solves

Closes: #FXA-9559
Closes: #FXA-9313

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
