### PR TITLE
fix(reset_password): Display expected 'Try again' message, move error handling fns

### DIFF
--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
@@ -3,14 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import {
-  useAccount, useFtlMsgResolver,
-} from '../../models';
+import { useAccount, useFtlMsgResolver } from '../../models';
 import { ResendStatus } from '../../lib/types';
 import { logViewEvent } from 'fxa-settings/src/lib/metrics';
 import { REACT_ENTRYPOINT } from 'fxa-settings/src/constants';
 import { LinkExpired } from '../LinkExpired';
-import { getLocalizedErrorMessage } from '../../lib/auth-errors/auth-errors';
+import { getLocalizedErrorMessage } from '../../lib/error-utils';
 
 type LinkExpiredResetPasswordProps = {
   viewName: string;

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.tsx
@@ -10,16 +10,14 @@ import { useAccount, useFtlMsgResolver } from '../../../models';
 import { useForm } from 'react-hook-form';
 import base32Encode from 'base32-encode';
 import { logViewEvent } from '../../../lib/metrics';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import InputPassword from '../../InputPassword';
 import { LockImage } from '../../images';
 import Banner, { BannerType } from '../../Banner';
 import { RecoveryKeyAction } from '../PageRecoveryKeyCreate';
 import { Link } from '@reach/router';
 import { HomePath } from '../../../constants';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 type FormData = {
   password: string;

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.tsx
@@ -16,9 +16,9 @@ import Banner, { BannerType } from '../../Banner';
 import {
   AuthUiErrorNos,
   AuthUiErrors,
-  getErrorFtlId,
 } from '../../../lib/auth-errors/auth-errors';
 import classNames from 'classnames';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 export type FlowRecoveryKeyHintProps = {
   navigateForward: () => void;

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
@@ -9,10 +9,8 @@ import InputText from '../../InputText';
 import { ApolloError } from '@apollo/client';
 import { useAccount, useSession } from '../../../models';
 import { Localized, useLocalization } from '@fluent/react';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-} from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 type ModalProps = {
   onDismiss: () => void;

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
@@ -14,12 +14,10 @@ import {
 } from '../../../lib/metrics';
 import { useAccount, useAlertBar } from '../../../models';
 import FlowContainer from '../FlowContainer';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useLocalization, Localized } from '@fluent/react';
 import FormPassword from '../../FormPassword';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 type FormData = {
   oldPassword: string;

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -26,12 +26,10 @@ import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { Checkbox } from '../Checkbox';
 import { useLocalization } from '@fluent/react';
 import { Localized } from '@fluent/react';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 type FormData = {
   password: string;

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -9,10 +9,8 @@ import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { isEmailMask, isEmailValid } from 'fxa-shared/email/helpers';
 import { useAccount, useAlertBar } from 'fxa-settings/src/models';
-import {
-  AuthUiErrorNos,
-  getErrorFtlId,
-} from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { AuthUiErrorNos } from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   usePageViewEvent('settings.emails');

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -9,10 +9,8 @@ import InputText from '../../InputText';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { useForm } from 'react-hook-form';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-} from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 type FormData = {
   verificationCode: string;

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -16,11 +16,9 @@ import { checkCode, copyRecoveryCodes, getCode } from '../../../lib/totp';
 import { HomePath } from '../../../constants';
 import { logViewEvent, useMetrics } from '../../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useAsync } from 'react-async-hook';
+import { getErrorFtlId } from '../../../lib/error-utils';
 
 export const metricsPreInPostFix = 'settings.two-step-authentication';
 

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.test.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.test.ts
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { getErrorFtlId } from '../error-utils';
 import { OAUTH_ERRORS } from '../oauth';
-import { getErrorFtlId, AuthUiErrorNos, AuthUiError } from './auth-errors';
+import { AuthUiErrorNos, AuthUiError } from './auth-errors';
 import * as Sentry from '@sentry/browser';
 
 const notAnExistingErrorNumber = 100000;

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -3,10 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { AuthServerError } from 'fxa-auth-client/browser';
-import * as Sentry from '@sentry/browser';
-import { FtlMsgResolver } from 'fxa-react/lib/utils';
-import { HandledError } from '../interfaces';
-import { OAUTH_ERRORS } from './../oauth/oauth-errors';
 
 export type AuthUiError = AuthServerError & { version?: number };
 
@@ -632,97 +628,6 @@ const ERRORS = {
 
 type ErrorKey = keyof typeof ERRORS;
 type ErrorVal = { errno: number; message: string; version?: number };
-
-/**
- * Utility function to retrieve the localized auth client error message
- * - works for throttling errors that include a localized retry after value
- * - returns an unexpected error if the error is unknown or does not have a localized message
- * @param ftlMsgResolver
- * @param err is an AuthClient error
- * @returns
- */
-
-export const getLocalizedErrorMessage = (
-  ftlMsgResolver: FtlMsgResolver,
-  error: AuthUiError | HandledError
-) => {
-  if (error.errno) {
-    if (AuthUiErrorNos[error.errno]) {
-      if (
-        error.retryAfterLocalized &&
-        error.errno === AuthUiErrors.THROTTLED.errno
-      ) {
-        // For throttling errors where a localized retry after value is provided
-        return ftlMsgResolver.getMsg(
-          getErrorFtlId(error),
-          AuthUiErrorNos[error.errno].message,
-          { retryAfter: error.retryAfterLocalized }
-        );
-      } else if (error.errno === AuthUiErrors.THROTTLED.errno) {
-        // For throttling errors where a localized retry after value is not available
-        return ftlMsgResolver.getMsg(
-          'auth-error-114-generic',
-          AuthUiErrorNos[114].message
-        );
-      } else {
-        // for all other recognized auth UI errors
-        return ftlMsgResolver.getMsg(
-          getErrorFtlId(error),
-          AuthUiErrorNos[error.errno].message
-        );
-      }
-    }
-    const oAuthError = Object.values(OAUTH_ERRORS).find(
-      (oAuthErr) => error.errno === oAuthErr.errno
-    );
-    if (oAuthError) {
-      return ftlMsgResolver.getMsg(
-        getErrorFtlId(oAuthError),
-        oAuthError.message
-      );
-    }
-  }
-
-  const unexpectedError = AuthUiErrors.UNEXPECTED_ERROR;
-  return ftlMsgResolver.getMsg(
-    getErrorFtlId(unexpectedError),
-    unexpectedError.message
-  );
-};
-
-/*
-  TODO in FXA-9502: account for potential errno overlap between auth-errors
-  and oauth errors. Checking the auth-error array currently happens first.
-**/
-export const getErrorFtlId = (err: { errno?: number; message?: string }) => {
-  if (err.errno) {
-    if (err.errno in AuthUiErrorNos) {
-      const error = AuthUiErrorNos[err.errno];
-      return `auth-error-${err.errno}${
-        error.version ? '-' + error.version : ''
-      }`;
-    }
-
-    const oAuthError = Object.values(OAUTH_ERRORS).find(
-      (oAuthErr) => err.errno === oAuthErr.errno
-    );
-    if (oAuthError) {
-      return `oauth-error-${err.errno}${
-        oAuthError.version ? '-' + oAuthError.version : ''
-      }`;
-    }
-  }
-  // If the error isn't found, return an empty string FTL ID and log to Sentry.
-  const logMessage = err.errno
-    ? `WARNING: An error occurred that we attempted to localize and render, but this error was not found in auth-errors or oauth-errors. We should either add this error to our list or not display it. error: ${JSON.stringify(
-        err
-      )}`
-    : `WARNING: An error occurred that we attempted to localize and render, but 'errno' is missing. error: ${JSON.stringify(
-        err
-      )}`;
-  Sentry.captureMessage(logMessage);
-  return '';
-};
 
 export const AuthUiErrors: { [key in ErrorKey]: AuthUiError } = (
   Object.entries(ERRORS) as [[ErrorKey, ErrorVal]]

--- a/packages/fxa-settings/src/lib/error-utils.ts
+++ b/packages/fxa-settings/src/lib/error-utils.ts
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { GraphQLError } from 'graphql';
+import {
+  AuthUiError,
+  AuthUiErrorNos,
+  AuthUiErrors,
+} from './auth-errors/auth-errors';
+import VerificationMethods from '../constants/verification-methods';
+import VerificationReasons from '../constants/verification-reasons';
+import * as Sentry from '@sentry/browser';
+import { FtlMsgResolver } from 'fxa-react/lib/utils';
+import { OAUTH_ERRORS } from './oauth';
+
+// TODO: Consolidate with AuthUiError type
+export interface GenericError {
+  errno: number;
+  message: string;
+  /** Not typically used in the UI, prefer 'errno' instead */
+  code?: number;
+  retryAfter?: number;
+  retryAfterLocalized?: string;
+}
+
+export type BeginSigninError = GenericError & {
+  verificationReason?: VerificationReasons;
+  verificationMethod?: VerificationMethods;
+  /** Important for 'Incorrect email case' edgecase */
+  email?: string;
+};
+
+export type HandledError = GenericError | BeginSigninError;
+
+const handleAuthUiError = (error: {
+  errno: number;
+  message: string;
+}): { error: HandledError } => {
+  const { errno } = error as HandledError;
+  if (errno && AuthUiErrorNos[errno]) {
+    return { error };
+  }
+  return { error: AuthUiErrors.UNEXPECTED_ERROR as HandledError };
+};
+
+export const getHandledError = (error: {
+  errno: number;
+  message: string;
+  graphQLErrors?: GraphQLError[];
+}) => {
+  const graphQLError: GraphQLError | undefined = error.graphQLErrors?.[0];
+  if (graphQLError) {
+    return handleGQLError(graphQLError);
+  }
+  return handleAuthUiError(error);
+};
+
+const handleGQLError = (graphQLError: GraphQLError) => {
+  const errno = graphQLError.extensions.errno as number;
+
+  if (errno && AuthUiErrorNos[errno]) {
+    const uiError = {
+      message: AuthUiErrorNos[errno].message,
+      errno,
+      email:
+        errno === AuthUiErrors.INCORRECT_EMAIL_CASE.errno
+          ? graphQLError.extensions.email
+          : undefined,
+      verificationMethod:
+        (graphQLError.extensions.verificationMethod as VerificationMethods) ||
+        undefined,
+      verificationReason:
+        (graphQLError.extensions.verificationReason as VerificationReasons) ||
+        undefined,
+      retryAfter: (graphQLError.extensions.retryAfter as number) || undefined,
+      retryAfterLocalized:
+        (graphQLError.extensions.retryAfterLocalized as string) || undefined,
+    };
+    return { error: uiError as HandledError };
+  }
+
+  // if not a graphQLError or if no localizable message available for error
+  return { error: AuthUiErrors.UNEXPECTED_ERROR as HandledError };
+};
+
+/**
+ * Utility function to retrieve the localized auth client error message
+ * - works for throttling errors that include a localized retry after value
+ * - returns an unexpected error if the error is unknown or does not have a localized message
+ * @param ftlMsgResolver
+ * @param err is an AuthClient error
+ * @returns
+ */
+export const getLocalizedErrorMessage = (
+  ftlMsgResolver: FtlMsgResolver,
+  error: AuthUiError | HandledError
+) => {
+  if (error.errno) {
+    if (AuthUiErrorNos[error.errno]) {
+      if (
+        error.retryAfterLocalized &&
+        error.errno === AuthUiErrors.THROTTLED.errno
+      ) {
+        // For throttling errors where a localized retry after value is provided
+        return ftlMsgResolver.getMsg(
+          getErrorFtlId(error),
+          AuthUiErrorNos[error.errno].message,
+          { retryAfter: error.retryAfterLocalized }
+        );
+      } else if (error.errno === AuthUiErrors.THROTTLED.errno) {
+        // For throttling errors where a localized retry after value is not available
+        return ftlMsgResolver.getMsg(
+          'auth-error-114-generic',
+          AuthUiErrorNos[114].message
+        );
+      } else {
+        // for all other recognized auth UI errors
+        return ftlMsgResolver.getMsg(
+          getErrorFtlId(error),
+          AuthUiErrorNos[error.errno].message
+        );
+      }
+    }
+    const oAuthError = Object.values(OAUTH_ERRORS).find(
+      (oAuthErr) => error.errno === oAuthErr.errno
+    );
+    if (oAuthError) {
+      return ftlMsgResolver.getMsg(
+        getErrorFtlId(oAuthError),
+        oAuthError.message
+      );
+    }
+  }
+
+  const unexpectedError = AuthUiErrors.UNEXPECTED_ERROR;
+  return ftlMsgResolver.getMsg(
+    getErrorFtlId(unexpectedError),
+    unexpectedError.message
+  );
+};
+
+/*
+  TODO in FXA-9502: account for potential errno overlap between auth-errors
+  and oauth errors. Checking the auth-error array currently happens first.
+**/
+export const getErrorFtlId = (err: { errno?: number; message?: string }) => {
+  if (err.errno) {
+    if (err.errno in AuthUiErrorNos) {
+      const error = AuthUiErrorNos[err.errno];
+      return `auth-error-${err.errno}${
+        error.version ? '-' + error.version : ''
+      }`;
+    }
+
+    const oAuthError = Object.values(OAUTH_ERRORS).find(
+      (oAuthErr) => err.errno === oAuthErr.errno
+    );
+    if (oAuthError) {
+      return `oauth-error-${err.errno}${
+        oAuthError.version ? '-' + oAuthError.version : ''
+      }`;
+    }
+  }
+  // If the error isn't found, return an empty string FTL ID and log to Sentry.
+  const logMessage = err.errno
+    ? `WARNING: An error occurred that we attempted to localize and render, but this error was not found in auth-errors or oauth-errors. We should either add this error to our list or not display it. error: ${JSON.stringify(
+        err
+      )}`
+    : `WARNING: An error occurred that we attempted to localize and render, but 'errno' is missing. error: ${JSON.stringify(
+        err
+      )}`;
+  Sentry.captureMessage(logMessage);
+  return '';
+};

--- a/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
@@ -9,7 +9,8 @@ import {
   useFtlMsgResolver,
 } from '../../../models';
 import { useLocation } from '@reach/router';
-import { AuthUiErrors, getErrorFtlId } from '../../auth-errors/auth-errors';
+import { AuthUiErrors } from '../../auth-errors/auth-errors';
+import { getErrorFtlId } from '../../error-utils';
 
 /*
  * Check if the integration contains a valid `redirectTo` based on

--- a/packages/fxa-settings/src/lib/interfaces.ts
+++ b/packages/fxa-settings/src/lib/interfaces.ts
@@ -13,10 +13,3 @@ export interface AccountTotp {
   exists: boolean;
   verified: boolean;
 }
-
-export interface HandledError {
-  errno: number;
-  message: string;
-  retryAfter?: number;
-  retryAfterLocalized?: string;
-}

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -30,6 +30,7 @@ import {
 } from '../components/App/gql';
 import { AccountAvatar, AccountTotp } from '../lib/interfaces';
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
+import { getHandledError } from '../lib/error-utils';
 
 export interface DeviceLocation {
   city: string | null;
@@ -771,13 +772,7 @@ export class Account implements AccountData {
       sessionToken(accountReset.sessionToken);
       return accountReset;
     } catch (err) {
-      const errno = (err as ApolloError).graphQLErrors[0].extensions?.errno as
-        | number
-        | undefined;
-      if (errno && AuthUiErrorNos[errno]) {
-        throw AuthUiErrorNos[errno];
-      }
-      throw AuthUiErrors.UNEXPECTED_ERROR;
+      throw getHandledError(err);
     }
   }
 

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -13,12 +13,9 @@ import AppLayout from '../../components/AppLayout';
 import Banner, { BannerType } from '../../components/Banner';
 import { copyRecoveryCodes } from '../../lib/totp';
 import FormVerifyCode from '../../components/FormVerifyCode';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-  getLocalizedErrorMessage,
-} from '../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { InlineRecoverySetupProps } from './interfaces';
+import { getErrorFtlId, getLocalizedErrorMessage } from '../../lib/error-utils';
 
 const InlineRecoverySetup = ({
   oAuthError,

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -17,10 +17,7 @@ import CardHeader from '../../../components/CardHeader';
 import WarningMessage from '../../../components/WarningMessage';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import AppLayout from '../../../components/AppLayout';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import base32Decode from 'base32-decode';
 import { decryptRecoveryKeyData } from 'fxa-auth-client/lib/recoveryKey';
 import { isBase32Crockford } from '../../../lib/utilities';
@@ -32,6 +29,7 @@ import {
   AccountRecoveryConfirmKeySubmitData,
 } from './interfaces';
 import { LinkStatus } from '../../../lib/types';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'account-recovery-confirm-key';
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -35,13 +35,11 @@ import {
   CompleteResetPasswordProps,
   CompleteResetPasswordSubmitData,
 } from './interfaces';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../../lib/glean';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { KeyStretchExperiment } from '../../../models/experiments/key-stretch-experiment';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 // The equivalent complete_reset_password mustache file included account_recovery_reset_password
 // For React, we have opted to separate these into two pages to align with the routes.

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -25,7 +25,7 @@ import {
   ConfirmResetPasswordIntegration,
   ConfirmResetPasswordLocationState,
 } from './interfaces';
-import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'confirm-reset-password';
 

--- a/packages/fxa-settings/src/pages/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/index.tsx
@@ -8,7 +8,6 @@ import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigate
 import React, { useCallback, useEffect, useState } from 'react';
 import { Control, useForm, useWatch } from 'react-hook-form';
 import { REACT_ENTRYPOINT } from '../../constants';
-import { getLocalizedErrorMessage } from '../../lib/auth-errors/auth-errors';
 import {
   usePageViewEvent,
   useMetrics,
@@ -34,6 +33,7 @@ import { ResetPasswordFormData, ResetPasswordProps } from './interfaces';
 import { ConfirmResetPasswordLocationState } from './ConfirmResetPassword/interfaces';
 import GleanMetrics from '../../lib/glean';
 import { MetricsContext } from 'fxa-auth-client/browser';
+import { getLocalizedErrorMessage } from '../../lib/error-utils';
 
 export const viewName = 'reset-password';
 

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container.tsx
@@ -7,7 +7,6 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import base32Decode from 'base32-decode';
 
 import { decryptRecoveryKeyData } from 'fxa-auth-client/lib/recoveryKey';
-import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import { useAccount } from '../../../models';
 import { useFtlMsgResolver } from '../../../models/hooks';
 
@@ -18,6 +17,7 @@ import {
 
 import AccountRecoveryConfirmKey from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 const AccountRecoveryConfirmKeyContainer = ({
   serviceName,

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/index.tsx
@@ -6,10 +6,7 @@ import { Link, useLocation } from '@reach/router';
 import React, { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../../lib/glean';
 import { isBase32Crockford } from '../../../lib/utilities';
 import { useFtlMsgResolver } from '../../../models/hooks';
@@ -24,6 +21,7 @@ import {
   AccountRecoveryConfirmKeyFormData,
   AccountRecoveryConfirmKeyProps,
 } from './interfaces';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 const AccountRecoveryConfirmKey = ({
   accountResetToken,

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/container.tsx
@@ -20,9 +20,9 @@ import {
 } from './interfaces';
 import GleanMetrics from '../../../lib/glean';
 import firefox from '../../../lib/channels/firefox';
-import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import { useState } from 'react';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 // This component is used for both /complete_reset_password and /account_recovery_reset_password routes
 // for easier maintenance
@@ -167,7 +167,7 @@ const CompleteResetPasswordContainer = ({
     } catch (err) {
       const localizedBannerMessage = getLocalizedErrorMessage(
         ftlMsgResolver,
-        err
+        err.error
       );
       setErrorMessage(localizedBannerMessage);
     }

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/container.tsx
@@ -5,7 +5,6 @@
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
-import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import ConfirmResetPassword from '.';
 import {
   ConfirmResetPasswordLocationState,
@@ -13,6 +12,7 @@ import {
 } from './interfaces';
 import { ResendStatus } from '../../../lib/types';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
   const [resendStatus, setResendStatus] = useState<ResendStatus>(

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/container.tsx
@@ -4,13 +4,13 @@
 
 import { RouteComponentProps } from '@reach/router';
 import React, { useState } from 'react';
-import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
 
 import { ResetPasswordContainerProps } from './interfaces';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import ResetPassword from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 const ResetPasswordContainer = ({
   flowQueryParams = {},

--- a/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/CompleteSignin/container.tsx
@@ -12,10 +12,10 @@ import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import {
   AuthUiErrorNos,
   AuthUiErrors,
-  getLocalizedErrorMessage,
 } from '../../../lib/auth-errors/auth-errors';
 import { LinkExpired } from '../../../components/LinkExpired';
 import CompleteSignin from '.';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'complete-signin';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -11,7 +11,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useMutation } from '@apollo/client';
 import { CONSUME_RECOVERY_CODE_MUTATION } from './gql';
 import { useCallback } from 'react';
-import { getHandledError, getSigninState } from '../utils';
+import { getSigninState } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
@@ -19,6 +19,7 @@ import { SigninQueryParams } from '../../../models/pages/signin';
 import { ConsumeRecoveryCodeResponse, SubmitRecoveryCode } from './interfaces';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { getHandledError } from '../../../lib/error-utils';
 
 export type SigninRecoveryCodeContainerProps = {
   integration: Integration;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
@@ -8,11 +8,11 @@ import { Meta } from '@storybook/react';
 import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { BeginSigninError } from '../interfaces';
 import { LocationProvider } from '@reach/router';
 import { mockSigninLocationState } from '../mocks';
 import { mockFinishOAuthFlowHandler } from '../../mocks';
 import { mockWebIntegration } from './mocks';
+import { BeginSigninError } from '../../../lib/error-utils';
 
 export default {
   title: 'Pages/Signin/SigninRecoveryCode',

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -15,13 +15,11 @@ import FormVerifyCode, {
 import GleanMetrics from '../../../lib/glean';
 import AppLayout from '../../../components/AppLayout';
 import { SigninRecoveryCodeProps } from './interfaces';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import Banner, { BannerType } from '../../../components/Banner';
 import { storeAccountData } from '../../../lib/storage-utils';
 import { handleNavigation } from '../utils';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'signin-recovery-code';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -2,13 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { BeginSigninError } from '../../../lib/error-utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { MozServices } from '../../../lib/types';
-import {
-  BeginSigninError,
-  SigninIntegration,
-  SigninLocationState,
-} from '../interfaces';
+import { SigninIntegration, SigninLocationState } from '../interfaces';
 
 export type SigninRecoveryCodeProps = {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -16,10 +16,7 @@ import CardHeader from '../../../components/CardHeader';
 import GleanMetrics from '../../../lib/glean';
 import AppLayout from '../../../components/AppLayout';
 import { SigninTokenCodeProps } from './interfaces';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import Banner, {
   BannerProps,
   BannerType,
@@ -27,6 +24,7 @@ import Banner, {
 } from '../../../components/Banner';
 import { handleNavigation } from '../utils';
 import firefox from '../../../lib/channels/firefox';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'signin-token-code';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -10,13 +10,14 @@ import { useMutation } from '@apollo/client';
 import { MozServices } from '../../../lib/types';
 import VerificationMethods from '../../../constants/verification-methods';
 import { VERIFY_TOTP_CODE_MUTATION } from './gql';
-import { getSigninState, getHandledError } from '../utils';
+import { getSigninState } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { Integration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
+import { getHandledError } from '../../../lib/error-utils';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -9,8 +9,8 @@ import { LocationProvider } from '@reach/router';
 import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { BeginSigninError } from '../interfaces';
 import { Subject } from './mocks';
+import { BeginSigninError } from '../../../lib/error-utils';
 
 export default {
   title: 'Pages/Signin/SigninTotpCode',

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -13,21 +13,18 @@ import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
 import { MozServices } from '../../../lib/types';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import Banner, { BannerType } from '../../../components/Banner';
 import AppLayout from '../../../components/AppLayout';
 import GleanMetrics from '../../../lib/glean';
-import {
-  BeginSigninError,
-  SigninIntegration,
-  SigninLocationState,
-} from '../interfaces';
+import { SigninIntegration, SigninLocationState } from '../interfaces';
 import { handleNavigation } from '../utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { storeAccountData } from '../../../lib/storage-utils';
+import {
+  BeginSigninError,
+  getLocalizedErrorMessage,
+} from '../../../lib/error-utils';
 
 // TODO: show a banner success message if a user is coming from reset password
 // in FXA-6491. This differs from content-server where currently, users only

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -8,7 +8,6 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
 import VerificationMethods from '../../../constants/verification-methods';
-import { getLocalizedErrorMessage } from '../../../lib/auth-errors/auth-errors';
 import {
   Integration,
   isOAuthIntegration,
@@ -26,13 +25,16 @@ import {
   ResendUnblockCodeHandler,
   SigninUnblockLocationState,
 } from './interfaces';
-import { getHandledError } from '../utils';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { MozServices } from '../../../lib/types';
 import { QueryParams } from '../../..';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import OAuthDataError from '../../../components/OAuthDataError';
+import {
+  getHandledError,
+  getLocalizedErrorMessage,
+} from '../../../lib/error-utils';
 
 const SigninUnblockContainer = ({
   integration,

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -22,10 +22,7 @@ import Banner, {
   ResendEmailSuccessBanner,
 } from '../../../components/Banner';
 import { MailImage } from '../../../components/images';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../../lib/glean';
 import {
   StoredAccountData,
@@ -33,6 +30,7 @@ import {
 } from '../../../lib/storage-utils';
 import { handleNavigation } from '../utils';
 import { ResendStatus } from '../../../lib/types';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'signin-unblock';
 

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -49,18 +49,13 @@ import {
   getKeysV2,
   unwrapKB,
 } from 'fxa-auth-client/lib/crypto';
-import {
-  AuthUiError,
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../lib/auth-errors/auth-errors';
+import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import AuthenticationMethods from '../../constants/authentication-methods';
 import { KeyStretchExperiment } from '../../models/experiments';
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
 import * as Sentry from '@sentry/browser';
-import { getHandledError } from './utils';
 import { useFinishOAuthFlowHandler } from '../../lib/oauth/hooks';
 import { searchParams } from '../../lib/utilities';
 import { QueryParams } from '../..';
@@ -68,6 +63,10 @@ import { queryParamsToMetricsContext } from '../../lib/metrics';
 import OAuthDataError from '../../components/OAuthDataError';
 import { MetricsContext } from 'fxa-auth-client/browser';
 import { isEmailValid } from 'fxa-shared/email/helpers';
+import {
+  getHandledError,
+  getLocalizedErrorMessage,
+} from '../../lib/error-utils';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -633,6 +632,7 @@ export async function trySignIn(
       onRetryCorrectedEmail &&
       'error' in result &&
       result.error.errno === AuthUiErrors.INCORRECT_EMAIL_CASE.errno &&
+      'email' in result.error &&
       result.error.email != null &&
       result.error.email !== email
     ) {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -17,10 +17,7 @@ import Avatar from '../../components/Settings/Avatar';
 import TermsPrivacyAgreement from '../../components/TermsPrivacyAgreement';
 import ThirdPartyAuth from '../../components/ThirdPartyAuth';
 import { REACT_ENTRYPOINT } from '../../constants';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../lib/glean';
 import { usePageViewEvent } from '../../lib/metrics';
 import { StoredAccountData, storeAccountData } from '../../lib/storage-utils';
@@ -33,6 +30,7 @@ import { SigninFormData, SigninProps } from './interfaces';
 import { handleNavigation } from './utils';
 import { useWebRedirect } from '../../lib/hooks/useWebRedirect';
 import { getCredentials } from 'fxa-auth-client/lib/crypto';
+import { getLocalizedErrorMessage } from '../../lib/error-utils';
 
 export const viewName = 'signin';
 

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -5,6 +5,7 @@
 import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import { AuthUiError } from '../../lib/auth-errors/auth-errors';
+import { BeginSigninError } from '../../lib/error-utils';
 import { AccountAvatar } from '../../lib/interfaces';
 import { FinishOAuthFlowHandler } from '../../lib/oauth/hooks';
 import { MozServices } from '../../lib/types';
@@ -76,16 +77,6 @@ export interface BeginSigninResponse {
     keyFetchToken?: hexstring;
   };
   unwrapBKey?: hexstring;
-}
-
-export interface BeginSigninError {
-  errno: number;
-  message: string;
-  verificationReason?: VerificationReasons;
-  verificationMethod?: VerificationMethods;
-  retryAfter?: number;
-  retryAfterLocalized?: string;
-  email?: string;
 }
 
 export type CachedSigninHandler = (

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -30,7 +30,6 @@ import {
   MOCK_FLOW_ID,
 } from '../mocks';
 import {
-  BeginSigninError,
   BeginSigninHandler,
   BeginSigninResponse,
   CachedSigninHandler,
@@ -56,6 +55,7 @@ import {
 } from './gql';
 import { ApolloError } from '@apollo/client';
 import { GraphQLError } from 'graphql';
+import { BeginSigninError } from '../../lib/error-utils';
 
 // Extend base mocks
 export * from '../mocks';

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -2,18 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { GraphQLError } from 'graphql';
 import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
-import {
-  BeginSigninError,
-  NavigationOptions,
-  SigninLocationState,
-} from './interfaces';
-import {
-  AuthUiErrorNos,
-  AuthUiErrors,
-} from '../../lib/auth-errors/auth-errors';
+import { NavigationOptions, SigninLocationState } from './interfaces';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { isOAuthIntegration } from '../../models';
 import { navigate } from '@reach/router';
 import { hardNavigate } from 'fxa-react/lib/utils';
@@ -196,57 +188,6 @@ const getNavigationTarget = async ({
   }
 
   return { to: '/settings' };
-};
-
-const handleAuthUiError = (error: {
-  errno: number;
-  message: string;
-}): { error: BeginSigninError } => {
-  const { errno } = error as BeginSigninError;
-  if (errno && AuthUiErrorNos[errno]) {
-    return { error };
-  }
-  return { error: AuthUiErrors.UNEXPECTED_ERROR as BeginSigninError };
-};
-
-export const getHandledError = (error: {
-  errno: number;
-  message: string;
-  graphQLErrors?: GraphQLError[];
-}) => {
-  const graphQLError: GraphQLError | undefined = error.graphQLErrors?.[0];
-  if (graphQLError) {
-    return handleGQLError(graphQLError);
-  }
-  return handleAuthUiError(error);
-};
-
-const handleGQLError = (graphQLError: GraphQLError) => {
-  const errno = graphQLError.extensions.errno as number;
-
-  if (errno && AuthUiErrorNos[errno]) {
-    const uiError = {
-      message: AuthUiErrorNos[errno].message,
-      errno,
-      email:
-        errno === AuthUiErrors.INCORRECT_EMAIL_CASE.errno
-          ? graphQLError.extensions.email
-          : undefined,
-      verificationMethod:
-        (graphQLError.extensions.verificationMethod as VerificationMethods) ||
-        undefined,
-      verificationReason:
-        (graphQLError.extensions.verificationReason as VerificationReasons) ||
-        undefined,
-      retryAfter: (graphQLError.extensions.retryAfter as number) || undefined,
-      retryAfterLocalized:
-        (graphQLError?.extensions.retryAfterLocalized as string) || undefined,
-    };
-    return { error: uiError as BeginSigninError };
-  }
-
-  // if not a graphQLError or if no localizable message available for error
-  return { error: AuthUiErrors.UNEXPECTED_ERROR as BeginSigninError };
 };
 
 export function getSigninState(

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -6,11 +6,7 @@ import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { REACT_ENTRYPOINT } from '../../../constants';
-import {
-  AuthUiErrors,
-  getErrorFtlId,
-  getLocalizedErrorMessage,
-} from '../../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import {
   logViewEvent,
   queryParamsToMetricsContext,
@@ -45,6 +41,10 @@ import GleanMetrics from '../../../lib/glean';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { storeAccountData } from '../../../lib/storage-utils';
 import { getSyncNavigate } from '../../Signin/utils';
+import {
+  getErrorFtlId,
+  getLocalizedErrorMessage,
+} from '../../../lib/error-utils';
 
 export const viewName = 'confirm-signup-code';
 

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -45,11 +45,9 @@ import { MozServices } from '../../lib/types';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import firefox from '../../lib/channels/firefox';
 import ThirdPartyAuth from '../../components/ThirdPartyAuth';
-import {
-  AuthUiErrors,
-  getLocalizedErrorMessage,
-} from '../../lib/auth-errors/auth-errors';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { isEmailMask } from 'fxa-shared/email/helpers';
+import { getLocalizedErrorMessage } from '../../lib/error-utils';
 
 export const viewName = 'signup';
 

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { HandledError } from '../../lib/interfaces';
+import { HandledError } from '../../lib/error-utils';
 import {
   BaseIntegration,
   IntegrationType,

--- a/packages/fxa-settings/src/pages/Signup/utils.ts
+++ b/packages/fxa-settings/src/pages/Signup/utils.ts
@@ -7,7 +7,7 @@ import {
   AuthUiErrorNos,
   AuthUiErrors,
 } from '../../lib/auth-errors/auth-errors';
-import { HandledError } from '../../lib/interfaces';
+import { HandledError } from '../../lib/error-utils';
 
 export const handleGQLError = (error: any) => {
   const graphQLError: GraphQLError = error.graphQLErrors?.[0];


### PR DESCRIPTION
Because:
* 'Unexpected error' is displayed when throttling occurs during a password reset
* The consistent fix is to use an already existing handling function

This commit:
* Uses an existing 'getHandledError' function to handle the error, which already differentiates between GQL errors and auth-server errors, which was the crux of the problem
* Moves functions that can be used throughout the app out from the Signin dir and auth-errors file (which also handles oauth errors) to a new file in libs/

fixes FXA-9737

--

You can test this by:
* Creating an account
* Updating `fxa-auth-server/config/dev.json` `customsUrl` to `"http://localhost:7000"`
* Returning something on [this line](https://github.com/mozilla/fxa/blob/c50f3ecbb011fcfdd9b1caf220a3d435cf5e9cad/packages/fxa-customs-server/lib/email_record.js#L298-L299), like `return '27'` (I was going to say it needed to be a number, but apparently I used a stringified number)
* Go through password reset, and see the "Unexpected error" on password set.

Then try the above in this branch and see the "You've tried too many times" message instead of "Unexpected error".

A comment in the ticket mentions possibly revisiting how customs handles this so that the error is thrown earlier in the flow. I think if we want this it should be investigated separately - this is pretty edgecasey, and from a quick look, we throttle when the number of requests hitting a rate-limited endpoint is reached... I _think_ a user would reach the throttle earlier in the flow if they'd done one or two other checks prior to initiating the PW reset. Just not sure it's worth it here.

I think we're going to want a follow up to 1) consolidate `AuthUiError` and `GenericError` or whatever makes sense, and 2) IMO, create a new `errors/` directory in `lib/`, move `oauth-errors.ts` and `auth-errors` inside of it, and rename `error-utils` to `errors/utils.ts`, but LMK what you think (the reviewer). (EDIT: follow up here: https://mozilla-hub.atlassian.net/browse/FXA-9757)