### PR TITLE
fix(auth): add class for sensitive data that is passed between components

### DIFF
--- a/packages/fxa-settings/src/lib/sensitive-data-client.ts
+++ b/packages/fxa-settings/src/lib/sensitive-data-client.ts
@@ -1,0 +1,44 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Class representing a client for handling sensitive data.
+ *
+ * @class
+ */
+export class SensitiveDataClient {
+  /**
+   * Object to store sensitive data.
+   * @private
+   */
+  private sensitiveData: { [key: string]: object } = {};
+
+  /**
+   * Create a SensitiveDataClient.
+   * @constructor
+   */
+  constructor() {
+    this.sensitiveData = {};
+  }
+
+  /**
+   * Set data in the sensitiveData object.
+   * @param {string} key - The key under which the data should be stored.
+   * @param {any} value - The data to be stored.
+   */
+  setData(key: string, value: any): void {
+    this.sensitiveData[key] = value;
+  }
+
+  /**
+   * Get data from the sensitiveData object.
+   * @param {string} key - The key under which the data is stored.
+   * @return {any} The data stored under the provided key.
+   */
+  getData(key: string): any {
+    return this.sensitiveData[key];
+  }
+}

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -13,12 +13,14 @@ import { AlertBarInfo } from '../AlertBarInfo';
 import { KeyStretchExperiment } from '../experiments/key-stretch-experiment';
 import { UrlQueryData } from '../../lib/model-data';
 import { ReachRouterWindow } from '../../lib/window';
+import { SensitiveDataClient } from '../../lib/sensitive-data-client';
 
 // TODO, move some values from AppContext to SettingsContext after
 // using container components, FXA-8107
 export interface AppContextValue {
   authClient?: AuthClient;
   apolloClient?: ApolloClient<object>;
+  sensitiveDataClient?: SensitiveDataClient; // used for sensitive data that needs to be encrypted between components
   config?: Config;
   account?: Account;
   session?: Session; // used exclusively for test mocking
@@ -43,6 +45,7 @@ export function initializeAppContext() {
   const apolloClient = createApolloClient(config.servers.gql.url);
   const account = new Account(authClient, apolloClient);
   const session = new Session(authClient, apolloClient);
+  const sensitiveDataClient = new SensitiveDataClient();
 
   const context: AppContextValue = {
     authClient,
@@ -50,6 +53,7 @@ export function initializeAppContext() {
     config,
     account,
     session,
+    sensitiveDataClient,
   };
 
   return context;

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -62,6 +62,18 @@ export function useAuthClient() {
   return authClient;
 }
 
+export function useSensitiveDataClient() {
+  const { sensitiveDataClient } = useContext(AppContext);
+  if (!sensitiveDataClient) {
+    throw new Error(
+      `Are you forgetting an AppContext.Provider? State:${getMissing({
+        sensitiveDataClient,
+      })}`
+    );
+  }
+  return sensitiveDataClient;
+}
+
 export function useIntegration() {
   const clientInfoState = useClientInfoState();
   const productInfoState = useProductInfoState();

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -71,6 +71,19 @@ jest.mock('fxa-auth-client/lib/recoveryKey', () => ({
   })),
 }));
 
+const mockSetData = jest.fn();
+jest.mock('../../../models', () => {
+  return {
+    ...jest.requireActual('../../../models'),
+    useSensitiveDataClient: () => {
+      return {
+        getData: jest.fn(),
+        setData: mockSetData,
+      };
+    },
+  };
+});
+
 const accountWithValidResetToken = {
   resetPasswordStatus: jest.fn().mockResolvedValue(true),
   getRecoveryKeyBundle: jest.fn().mockResolvedValue({
@@ -281,13 +294,13 @@ describe('PageAccountRecoveryConfirmKey', () => {
         MOCK_RECOVERY_KEY,
         MOCK_ACCOUNT.uid
       );
+      expect(mockSetData).toHaveBeenCalledWith('reset', { kB: MOCK_KB });
       expect(mockNavigate).toHaveBeenCalledWith(
         `/account_recovery_reset_password?${search}`,
         {
           state: {
             accountResetToken: MOCK_RESET_TOKEN,
             recoveryKeyId: MOCK_RECOVERY_KEY_ID,
-            kB: MOCK_KB,
           },
         }
       );

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -8,7 +8,7 @@ import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { logPageViewEvent, logViewEvent } from '../../../lib/metrics';
 import GleanMetrics from '../../../lib/glean';
-import { useAccount } from '../../../models';
+import { useAccount, useSensitiveDataClient } from '../../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
 
@@ -53,6 +53,7 @@ const AccountRecoveryConfirmKey = ({
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
   const navigate = useNavigate();
+  const sensitiveDataClient = useSensitiveDataClient();
 
   useEffect(() => {
     const checkPasswordForgotToken = async (token: string) => {
@@ -117,15 +118,15 @@ const AccountRecoveryConfirmKey = ({
         uid
       );
 
+      sensitiveDataClient.setData('reset', { kB });
       navigate('/account_recovery_reset_password', {
         state: {
           accountResetToken,
           recoveryKeyId,
-          kB,
         },
       });
     },
-    [account, navigate]
+    [account, navigate, sensitiveDataClient]
   );
 
   const checkRecoveryKey = useCallback(

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.test.tsx
@@ -87,6 +87,21 @@ jest.mock('../../../lib/metrics', () => {
   };
 });
 
+const mockGetData = jest.fn().mockReturnValue({
+  kB: 'someKb',
+});
+jest.mock('../../../models', () => {
+  return {
+    ...jest.requireActual('../../../models'),
+    useSensitiveDataClient: () => {
+      return {
+        getData: mockGetData,
+        setData: jest.fn(),
+      };
+    },
+  };
+});
+
 const route = '/reset_password';
 const render = (ui = <Subject />, account = mockAccount()) => {
   const history = createHistoryWithQuery(route);
@@ -147,11 +162,12 @@ describe('AccountRecoveryResetPassword page', () => {
   describe('damaged link', () => {
     describe('required location state recovery key info', () => {
       it('requires kB', async () => {
-        mockLocationState.kB = '';
+        mockGetData.mockReturnValue(undefined);
         render();
         await screen.findByRole('heading', {
           name: 'Reset password link damaged',
         });
+        mockGetData.mockReturnValue({ kB: 'someKb' });
       });
 
       it('requires recoveryKeyId', async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryResetPassword/index.tsx
@@ -24,7 +24,7 @@ import {
   settingsViewName,
   usePageViewEvent,
 } from '../../../lib/metrics';
-import { useAccount } from '../../../models/hooks';
+import { useAccount, useSensitiveDataClient } from '../../../models';
 import { LinkStatus } from '../../../lib/types';
 import {
   isOAuthIntegration,
@@ -57,6 +57,7 @@ const AccountRecoveryResetPassword = ({
 
   const account = useAccount();
   const navigate = useNavigate();
+  const sensitiveDataClient = useSensitiveDataClient();
 
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: AccountRecoveryResetPasswordLocationState;
@@ -69,10 +70,13 @@ const AccountRecoveryResetPassword = ({
       AccountRecoveryResetPasswordBannerState.None
     );
 
+  const sensitiveData = sensitiveDataClient.getData('reset');
+  const { kB } = (sensitiveData as unknown as { kB: string }) || {};
+
   // TODO: This should be done in a container component
   const linkIsValid = !!(
     location.state.accountResetToken &&
-    location.state.kB &&
+    kB &&
     location.state.recoveryKeyId &&
     verificationInfo.email
   );
@@ -205,7 +209,7 @@ const AccountRecoveryResetPassword = ({
       const options = {
         password,
         accountResetToken: location.state.accountResetToken,
-        kB: location.state.kB,
+        kB,
         recoveryKeyId: location.state.recoveryKeyId,
         emailToHashWith: verificationInfo.emailToHashWith || email,
       };

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -14,6 +14,11 @@ jest.mock('../../../lib/metrics', () => ({
   logViewEvent: jest.fn(),
   usePageViewEvent: jest.fn(),
 }));
+jest.mock('../../../lib/glean', () => ({
+  passwordReset: {
+    createNewSuccess: jest.fn(),
+  },
+}));
 
 describe('ResetPasswordConfirmed', () => {
   async function renderResetPasswordConfirmed(

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container.tsx
@@ -7,7 +7,7 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import base32Decode from 'base32-decode';
 
 import { decryptRecoveryKeyData } from 'fxa-auth-client/lib/recoveryKey';
-import { useAccount } from '../../../models';
+import { useAccount, useSensitiveDataClient } from '../../../models';
 import { useFtlMsgResolver } from '../../../models/hooks';
 
 import {
@@ -28,6 +28,7 @@ const AccountRecoveryConfirmKeyContainer = ({
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
   const navigate = useNavigateWithQuery();
+  const sensitiveDataClient = useSensitiveDataClient();
 
   const {
     accountResetToken: previousAccountResetToken,
@@ -66,6 +67,7 @@ const AccountRecoveryConfirmKeyContainer = ({
       uid
     );
 
+    sensitiveDataClient.setData('reset', { kB });
     navigate('/account_recovery_reset_password', {
       state: {
         accountResetToken: fetchedAccountResetToken,

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -73,6 +73,18 @@ jest.mock('../../lib/storage-utils', () => ({
   storeAccountData: jest.fn(),
 }));
 
+const mockSetData = jest.fn();
+jest.mock('../../models', () => {
+  return {
+    ...jest.requireActual('../../models'),
+    useSensitiveDataClient: () => {
+      return {
+        setData: mockSetData,
+      };
+    },
+  };
+});
+
 const mockLocation = () => {
   return {
     pathname: '/signin',
@@ -505,10 +517,12 @@ describe('Signin', () => {
         enterPasswordAndSubmit();
         await waitFor(() => {
           expect(sendUnblockEmailHandler).toHaveBeenCalled();
+          expect(mockSetData).toHaveBeenCalledWith('auth', {
+            password: MOCK_PASSWORD,
+          });
           expect(mockNavigate).toHaveBeenCalledWith('/signin_unblock', {
             state: {
               email: MOCK_EMAIL,
-              authPW: MOCK_AUTHPW,
               hasLinkedAccount: false,
               hasPassword: true,
             },


### PR DESCRIPTION
## Because

- We want to securely pass this data between components

## This pull request

- Creates a client that encrypts and decrypts sensitive data that might need to be passed between views
- Stores data in memory and gets cleared on page refresh

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9695

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I haven't updated the tests but figured it would be good to check the logic before I refactored components. The intended behavior is to use this instead of passing sensitive data (password, authPW, etc) using `navigate` state.
