### PR TITLE
fix(cloud): Don't await for cloud scheduler delete unverified task

### DIFF
--- a/packages/fxa-auth-server/lib/routes/cloud-scheduler.ts
+++ b/packages/fxa-auth-server/lib/routes/cloud-scheduler.ts
@@ -161,7 +161,10 @@ export class CloudSchedulerHandler {
       startDate: startDate.toISOString(),
     });
     this.statsd.increment('cloud-scheduler.deleteUnverifiedAccounts');
-    await this.processAccountDeletionInRange(
+
+    // We don't await because it could take 30+ seconds to create the cloud tasks
+    // to delete all the accounts.
+    this.processAccountDeletionInRange(
       this.config,
       this.accountTasks,
       reason,


### PR DESCRIPTION
## Because

- It could take 30seconds or more to make these tasks

## This pull request

- We don't `await` the function

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9748

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Tested this with Eric and cloud scheduler shows 200 response when timeout was removed at nginx level.
