### PR TITLE
feat(many): add partial stack startup scripts

### DIFF
--- a/_scripts/pm2-all.sh
+++ b/_scripts/pm2-all.sh
@@ -4,6 +4,7 @@ start=`date +%s`
 
 DIR=$(dirname "$0")
 COMMAND=$1
+PROJECTS=$2
 cd "$DIR/.."
 
 if ! node -p 's = require("semver");v = require("./package.json").engines.node; process.exitCode = s.satisfies(process.version, v) ? 0 : 1; if(process.exitCode) {"\nPlease use node: " + v + "\n"}';
@@ -12,7 +13,16 @@ then
 fi
 
 mkdir -p artifacts
-npx nx run-many -t start --all --exclude=fxa-dev-launcher --verbose;
+
+if [ -z "$PROJECTS" ] 
+then
+  # No tags provided, start the entire stack
+  npx nx run-many -t $COMMAND --all --exclude=fxa-dev-launcher --verbose;
+else
+  # Start only provided projects and dependencies
+  # Note dependencies are automatically determined by Nx
+  npx nx run-many -t $COMMAND --projects=$PROJECTS --exclude=fxa-dev-launcher --verbose;
+fi
 
 end=`date +%s`
 runtime=$((end-start))

--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -118,5 +118,5 @@
       }
     }
   },
-  "tags": ["app", "payments"]
+  "tags": ["app", "payments", "type:sp3"]
 }

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,25 +1,114 @@
+/**
+ * These are Nx tags used to identify which services to start up
+ * when executing the various partial startup scripts.
+ */
+const mzaProjects = 'tag:type:core,tag:type:demo';
+const sp2Projects = 'tag:type:core,tag:type:demo,tag:type:sp2';
+const sp3Projects = 'tag:type:core,tag:type:demo,tag:type:sp3';
+
 module.exports = {
   scripts: {
     default: 'nps help',
     start: {
-      default: `_dev/pm2/start.sh && _scripts/pm2-all.sh start && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
-      infrastructure: `_dev/pm2/start.sh`,
-      services: `_scripts/pm2-all.sh start`,
+      default: {
+        script: `_dev/pm2/start.sh && _scripts/pm2-all.sh start && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
+        description: 'Start the entire stack, i.e. all infrastructure and services.'
+      },
+      infrastructure: {
+        script: `_dev/pm2/start.sh`,
+        description: 'Start all infrastructure only.',
+      },
+      services: {
+        script: `_scripts/pm2-all.sh start`,
+        description: 'Start all Services only.'
+      },
       firefox: './packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs &',
+      mza: {
+        script: `_dev/pm2/start.sh && _scripts/pm2-all.sh start ${mzaProjects} && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
+        description: 'Start infrastructure and only required Mozilla Accounts services',
+      },
+      sp2: {
+        script: `_dev/pm2/start.sh && _scripts/pm2-all.sh start ${sp2Projects} && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
+        description: 'Start infrastructure and only required SubPlat 2.0 services.'
+      },
+      sp3: {
+        script: `_dev/pm2/start.sh && _scripts/pm2-all.sh start ${sp3Projects} && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
+        description: 'Start infrastructure and only required SubPlat 3.0 services.'
+      },
     },
     stop: {
-      default: 'pm2 kill',
-      infrastructure: `pm2 stop _dev/pm2/infrastructure.config.js`,
-      services: `_scripts/pm2-all.sh stop`,
+      default: {
+          script: 'pm2 kill',
+        description: 'Stop all infrastructure and services.',
+      },
+      infrastructure: {
+        script: `pm2 stop _dev/pm2/infrastructure.config.js`,
+        description: 'Stop all infrastructure, only.',
+      },
+      services: {
+        script: `_scripts/pm2-all.sh stop`,
+        description: 'Stop all services, only.',
+      },
+      mza: {
+        script: `_scripts/pm2-all.sh stop ${mzaProjects}`,
+        description: 'Stop required Mozilla Accounts services.',
+      },
+      sp2: {
+        script: `_scripts/pm2-all.sh stop ${sp2Projects}`,
+        description: 'Stop required SubPlat 2.0 services.',
+      },
+      sp3: {
+        script: `_scripts/pm2-all.sh stop ${sp3Projects}`,
+        description: 'Stop required SubPlat 3.0 services.',
+      },
     },
     restart: {
-      default: 'pm2 restart all',
-      infrastructure: `pm2 restart _dev/pm2/infrastructure.config.js`,
-      services: `_scripts/pm2-all.sh restart`,
+      default: {
+        script: 'pm2 restart all',
+        description: 'Restart all infrastructure and services.',
+      },
+      infrastructure: {
+        script: `pm2 restart _dev/pm2/infrastructure.config.js`,
+        description: 'Restart all infrastructure, only.',
+      },
+      services: {
+        script: `_scripts/pm2-all.sh restart`,
+        description: 'Restart all services, only.',
+      },
+      mza: {
+        script: `_scripts/pm2-all.sh restart ${mzaProjects}`,
+        description: 'Restart required Mozilla Accounts services.',
+      },
+      sp2: {
+        script: `_scripts/pm2-all.sh restart ${sp2Projects}`,
+        description: 'Restart required SubPlat 2.0 services.',
+      },
+      sp3: {
+        script: `_scripts/pm2-all.sh restart ${sp3Projects}`,
+        description: 'Restart required SubPlat 3.0 services.',
+      },
     },
     delete: {
-      default: 'pm2 kill',
-      services: '_scripts/pm2-all.sh delete',
+      default: {
+        script: 'pm2 kill',
+        description: 'Delete all infrastructure and services.',
+      },
+      services: {
+        script: '_scripts/pm2-all.sh delete',
+        description: 'Delete all services, only.',
+      },
+      mza: {
+        script: `_scripts/pm2-all.sh delete ${mzaProjects}`,
+        description: 'Delete required Mozilla Accounts services.',
+      },
+      sp2: {
+        script: `_scripts/pm2-all.sh delete ${sp2Projects}`,
+        description: 'Delete required SubPlat 2.0 services.',
+      },
+      sp3: {
+        script: `_scripts/pm2-all.sh delete ${sp3Projects}`,
+        description: 'Delete required SubPlat 3.0 services.',
+      },
     },
   },
 };

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -46,7 +46,8 @@
   },
   "nx": {
     "tags": [
-      "scope:demo"
+      "scope:demo",
+      "type:demo"
     ]
   }
 }

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -89,7 +89,8 @@
   },
   "nx": {
     "tags": [
-      "scope:frontend"
+      "scope:frontend",
+      "type:admin"
     ]
   }
 }

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -78,7 +78,8 @@
   },
   "nx": {
     "tags": [
-      "scope:server"
+      "scope:server",
+      "type:admin"
     ]
   }
 }

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -222,7 +222,8 @@
   },
   "nx": {
     "tags": [
-      "scope:server:auth"
+      "scope:server:auth",
+      "type:core"
     ]
   }
 }

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -75,7 +75,6 @@
     "fxa-geodb": "workspace:*",
     "fxa-mustache-loader": "0.0.2",
     "fxa-pairing-channel": "1.0.2",
-    "fxa-payments-server": "workspace:*",
     "fxa-profile-server": "workspace:*",
     "fxa-react": "workspace:*",
     "fxa-settings": "workspace:*",
@@ -187,7 +186,8 @@
   "readmeFilename": "README.md",
   "nx": {
     "tags": [
-      "scope:frontend"
+      "scope:frontend",
+      "type:core"
     ]
   }
 }

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -68,7 +68,8 @@
   },
   "nx": {
     "tags": [
-      "scope:server"
+      "scope:server",
+      "type:core"
     ]
   }
 }

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -107,7 +107,8 @@
   },
   "nx": {
     "tags": [
-      "scope:broker"
+      "scope:broker",
+      "type:broker"
     ]
   }
 }

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -89,5 +89,11 @@
     "prettier": "^2.3.1",
     "supertest": "^7.0.0",
     "typescript": "^5.4.2"
+  },
+  "nx": {
+    "tags": [
+      "scope:gql",
+      "type:core"
+    ]
   }
 }

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -197,7 +197,8 @@
   },
   "nx": {
     "tags": [
-      "scope:frontend"
+      "scope:frontend",
+      "type:sp2"
     ]
   }
 }

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -74,7 +74,8 @@
   },
   "nx": {
     "tags": [
-      "scope:server"
+      "scope:server",
+      "type:core"
     ]
   }
 }

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -112,7 +112,8 @@
   },
   "nx": {
     "tags": [
-      "scope:shared:lib"
+      "scope:shared:lib",
+      "type:core"
     ]
   }
 }

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -256,7 +256,8 @@
   },
   "nx": {
     "tags": [
-      "scope:frontend"
+      "scope:frontend",
+      "type:core"
     ]
   },
   "babel": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -343,7 +343,8 @@
   },
   "nx": {
     "tags": [
-      "scope:shared:lib"
+      "scope:shared:lib",
+      "type:core"
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -38013,7 +38013,6 @@ fsevents@~2.1.1:
     fxa-geodb: "workspace:*"
     fxa-mustache-loader: 0.0.2
     fxa-pairing-channel: 1.0.2
-    fxa-payments-server: "workspace:*"
     fxa-profile-server: "workspace:*"
     fxa-react: "workspace:*"
     fxa-settings: "workspace:*"


### PR DESCRIPTION
## Because

- Could be useful to start only parts of the stack needed for specific domains.

## This pull request

- Provides additional stack startup options to only start specific parts of the stack, by using nx projects and tags.
- Fixes bug, allowing for script commands other than `start`, i.e. `restart`, `delete` and `stop`. 

## Issue that this pull request solves

Closes: #FXA-9771

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Motivation

I’ve recently been running into some memory shortage issues when running the full FxA stack. (Maybe you can relate)

As a work around to this, I’ve found myself only running pieces of the stack that I’m working on, or pm2 deleting some memory intensive apps that weren’t necessary. (event-broker (1.2gb), admin-server (2.6gb), etc.)

Instead, what this PR introduces, are a few new script options using some new Nx tags added to apps with start commands in the repo, to only startup the apps necessary depending what you are working on.

## Screenshots

Full stack - `yarn start`
![image](https://github.com/mozilla/fxa/assets/10620585/9a405029-606d-40df-b427-1294ec9322c7)

MzA stack - `yarn start mza`
![image](https://github.com/mozilla/fxa/assets/10620585/79323ec5-64c9-473a-adaa-d465fa802cf7)
