### PR TITLE
fix(next): readd readOnly to payment element

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CheckoutForm.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm.tsx
@@ -180,6 +180,7 @@ export function CheckoutForm({ readOnly, cart, locale }: CheckoutFormProps) {
             radios: false,
             spacedAccordionItems: true,
           },
+          readOnly,
         }}
       />
       {!isPaymentElementLoading && (


### PR DESCRIPTION
## Because

- Stripe Payment Element is missing readOnly config value

## This pull request

- Readds readOnly config value to Payment Element

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
