### PR TITLE
feat(settings): Update copy in reset password with code flow

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/en.ftl
@@ -1,19 +1,14 @@
 ## Confirm Reset Password With Code
 
-confirm-reset-password-otp-flow-name = Reset password
-
-# The confirmation code is an 8-digit confirmation code sent by email
-# Used to confirm possession of the email account
-confirm-reset-password-otp-heading = Enter confirmation code
+confirm-reset-password-with-code-heading = Check your email
 
 # Text within span appears in bold
-# $email - email address for which a password reset was requested, and where confirmation code was sent
-# code contains numbers only
-confirm-reset-password-otp-instruction = Enter the 8-digit confirmation code we sent to <span>{ $email }</span> within 10 minutes.
+# $email - email address for which a password reset was requested
+confirm-reset-password-with-code-instruction = We sent a confirmation code to <span>{ $email }</span>.
 
 # Shown above a group of 8 single-digit input boxes
 # Only numbers allowed
-confirm-reset-password-otp-input-group-label = Enter 8-digit code
+confirm-reset-password-code-input-group-label = Enter 8-digit code within 10 minutes
 
 # Clicking the button submits and verifies the code
 # If succesful, continues to the next step of the password reset
@@ -22,5 +17,5 @@ confirm-reset-password-otp-submit-button = Continue
 # Button to request a new reset password confirmation code
 confirm-reset-password-otp-resend-code-button = Resend code
 
-# LInk to cancel the password reset and sign in with a different account
+# Link to cancel the password reset and sign in with a different account
 confirm-reset-password-otp-different-account-link = Use a different account

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.test.tsx
@@ -9,6 +9,7 @@ import { Subject } from './mocks';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MOCK_EMAIL } from '../../mocks';
 
 // add Glean mocks
 
@@ -25,12 +26,10 @@ describe('ConfirmResetPassword', () => {
     renderWithLocalizationProvider(<Subject />);
 
     await expect(
-      screen.getByRole('heading', { name: 'Enter confirmation code' })
+      screen.getByRole('heading', { name: 'Check your email' })
     ).toBeVisible();
 
-    expect(
-      screen.getByText(/Enter the 8-digit confirmation code we sent to/)
-    ).toBeVisible();
+    expect(screen.getByText(MOCK_EMAIL)).toBeVisible();
 
     expect(screen.getAllByRole('textbox')).toHaveLength(8);
     const buttons = await screen.findAllByRole('button');

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
@@ -27,8 +27,8 @@ const ConfirmResetPassword = ({
   const location = useLocation();
 
   const localizedInputGroupLabel = ftlMsgResolver.getMsg(
-    'confirm-reset-password-otp-input-group-label',
-    'Enter 8-digit code'
+    'confirm-reset-password-code-input-group-label',
+    'Enter 8-digit code within 10 minutes'
   );
   const localizedSubmitButtonText = ftlMsgResolver.getMsg(
     'confirm-reset-password-otp-submit-button',
@@ -47,21 +47,20 @@ const ConfirmResetPassword = ({
 
   return (
     <AppLayout>
-      <FtlMsg id="confirm-reset-password-otp-flow-name">
-        <p className="text-start text-grey-400 text-sm">Reset password</p>
+      <FtlMsg id="password-reset-flow-heading">
+        <p className="text-start text-grey-400 text-sm">Reset your password</p>
       </FtlMsg>
       <EmailCodeImage />
-      <FtlMsg id="confirm-reset-password-otp-heading">
-        <h2 className="card-header text-start my-4">Enter confirmation code</h2>
+      <FtlMsg id="confirm-reset-password-with-code-heading">
+        <h2 className="card-header text-start my-4">Check your email</h2>
       </FtlMsg>
       <FtlMsg
-        id="confirm-reset-password-otp-instruction"
+        id="confirm-reset-password-with-code-instruction"
         vars={{ email }}
         elems={{ span: spanElement }}
       >
         <p className="text-start">
-          Enter the 8-digit confirmation code we sent to {spanElement} within 10
-          minutes.
+          We sent a confirmation code to {spanElement}.
         </p>
       </FtlMsg>
       {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/en.ftl
@@ -1,12 +1,6 @@
 ## ResetPassword start page
 
-# Strings within the <span> elements appear as a subheading.
-# If more appropriate in a locale, the string within the <span>, "to continue to account settings" can stand alone as "Continue to account settings"
-password-reset-heading-w-default-service = Password reset <span>to continue to account settings</span>
-# Strings within the <span> elements appear as a subheading.
-# If more appropriate in a locale, the string within the <span>, "to continue to { $serviceName }" can stand alone as "Continue to { $serviceName }"
-# { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable
-password-reset-heading-w-custom-service = Password reset <span>to continue to { $serviceName }</span>
+password-reset-flow-heading = Reset your password
 
 password-reset-body = Enter your email and we’ll send you a confirmation code to confirm it’s really you.
 

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/index.test.tsx
@@ -28,11 +28,11 @@ describe('ResetPassword', () => {
   });
 
   describe('renders', () => {
-    it('as expected with default service', async () => {
+    it('as expected', async () => {
       renderWithLocalizationProvider(<Subject />);
 
       await expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-        'Password reset to continue to account settings'
+        'Reset your password'
       );
       expect(
         screen.getByRole('textbox', { name: 'Enter your email' })
@@ -42,16 +42,6 @@ describe('ResetPassword', () => {
       ).toBeVisible();
       expect(screen.getByText('Remember your password?')).toBeVisible();
       expect(screen.getByRole('link', { name: 'Sign in' })).toBeVisible();
-    });
-
-    it('as expected with custom service', async () => {
-      renderWithLocalizationProvider(
-        <Subject serviceName={MozServices.FirefoxSync} />
-      );
-      const headingEl = await screen.findByRole('heading', { level: 1 });
-      expect(headingEl).toHaveTextContent(
-        `Password reset to continue to Firefox Sync`
-      );
     });
 
     it('emits a Glean event on render', async () => {

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ResetPassword/index.tsx
@@ -84,10 +84,8 @@ const ResetPassword = ({
   return (
     <AppLayout>
       <CardHeader
-        headingWithDefaultServiceFtlId="password-reset-heading-w-default-service"
-        headingWithCustomServiceFtlId="password-reset-heading-w-custom-service"
-        headingText="Password reset"
-        {...{ serviceName }}
+        headingText="Reset your password"
+        headingTextFtlId="password-reset-start-heading"
       />
 
       {errorMessage && (


### PR DESCRIPTION
## Because


* The design was updated with revised copy

## This pull request

* Update the copy and ftl strings
* Update unit tests

## Issue that this pull request solves

Closes: #FXA-9747

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/mozilla/fxa/assets/22231637/6aa36fe2-89f9-4ef0-ad68-bfec61aeb486)

![image](https://github.com/mozilla/fxa/assets/22231637/87a4ce10-e793-4081-a349-2e486416b0ac)

## Other information (Optional)
Figma designs:
[New copy for reset_password](https://www.figma.com/design/8NqLKthkW1CWXFgmMv2qLj/Password_reset_flow_2023?node-id=4331-52452&t=RHjPKYpFGh0CKM12-4)
[New copy for confirm_reset_password](https://www.figma.com/design/8NqLKthkW1CWXFgmMv2qLj/Password_reset_flow_2023?node-id=4325-51185&t=4U9qDZPsCbiOmlJ7-4)
