### PR TITLE
feat(assets): begin uploading assets to GCS buckets

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -20,17 +20,17 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: "Configure Stage AWS credentials"
+      - name: Configure Stage AWS credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::142069644989:role/fxa-content-cdn-stage-asset-upload
           role-session-name: CDNAssetUpload
 
-      - name: "Asset upload to stage CDN S3 bucket"
+      - name: Asset upload to stage CDN S3 bucket
         run: |
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/product-icons  s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/other  s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/other
@@ -43,11 +43,35 @@ jobs:
           role-to-assume: arn:aws:iam::361527076523:role/fxa-content-cdn-prod-asset-upload
           role-session-name: CDNAssetUpload
 
-      - name: "Asset upload to production CDN S3 bucket"
+      - name: Asset upload to production CDN S3 bucket
         run: |
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/product-icons  s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/other  s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/other
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment   assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
+
+      - name: Configure Stage GCP credentials
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: gke-cdn-upload-stage@${{ secrets.GCP_NONPROD_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+
+      - name: Asset upload to stage CDN GCS bucket
+        run: |
+          gcloud storage cp --cache-control='public,max-age=86400' -r assets/product-icons/* gs://fxa-content-cdn-stage-distbucket/product-icons/
+          gcloud storage cp --cache-control='public,max-age=86400' -r assets/other/* gs://fxa-content-cdn-stage-distbucket/other/
+          gcloud storage cp --cache-control='public,max-age=86400' --content-disposition=attachment -r assets/legal/* gs://fxa-content-cdn-stage-distbucket/legal/
+
+      - name: Configure Prod GCP credentials
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: gke-cdn-upload-prod@${{ secrets.GCP_PROD_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+
+      - name: Asset upload to prod CDN GCS bucket
+        run: |
+          gcloud storage cp --cache-control='public,max-age=86400' -r assets/product-icons/* gs://fxa-content-cdn-prod-distbucket/product-icons/
+          gcloud storage cp --cache-control='public,max-age=86400' -r assets/other/* gs://fxa-content-cdn-prod-distbucket/other/
+          gcloud storage cp --cache-control='public,max-age=86400' --content-disposition=attachment -r assets/legal/* gs://fxa-content-cdn-prod-distbucket/legal/
 
       - name: "Post to fxa-team Slack channel"
         uses: slackapi/slack-github-action@v1.26.0


### PR DESCRIPTION
## Because

We are migrating from AWS to GCP and part of that means moving from S3 to GCS buckets.

## This pull request

Adds support for the following workflow change (for each environment):
1. Authenticate with GCP using a service account and Workload Identity
2. Upload assets to GCS bucket

This does not stop uploading to S3. Once we are fully cut over to the GCS CDN + buckets in prod, I'll create a new PR to remove the S3 parts of this workflow.

## Issue that this pull request solves

Doesn't actually close, but helps implement: OPST-1072

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

~~This depends on another PR on the infrastructure side. Once that's merged, I'll take this out of draft status.~~ DONE!

This was successfully tested here: https://github.com/mozilla/fxa/actions/runs/9325064817/job/25671432058