### PR TITLE
fix(functional-tests): `no timings found for` error in ci `run-playwright-tests` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ commands:
             cd packages/functional-tests/tests
             TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
             cd ..
-            echo $TEST_FILES | circleci tests run --command="xargs yarn playwright test --project=<< parameters.project >> $GREP" --verbose --split-by=timings
+            echo $TEST_FILES | circleci tests run --command="xargs yarn playwright test --project=<< parameters.project >> $GREP" --verbose --split-by=timings --timings-type=classname
           environment:
             NODE_OPTIONS: --dns-result-order=ipv4first
             JEST_JUNIT_OUTPUT_DIR: ./artifacts/tests

--- a/packages/functional-tests/tests/react-conversion/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/changeEmail.spec.ts
@@ -18,7 +18,6 @@ test.describe('severity-1 #smoke', () => {
         config.showReactApp.signInRoutes !== true,
         'React signInRoutes not enabled'
       );
-      test.slow();
     });
 
     test('change primary email and login', async ({
@@ -128,7 +127,6 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const credentials = await testAccountTracker.signUp();
       const newEmail = testAccountTracker.generateEmail();
-      const newPassword = testAccountTracker.generatePassword();
 
       await signinReact.goto();
       await signinReact.fillOutEmailFirstForm(credentials.email);


### PR DESCRIPTION
## Because

* the `--split-by=timings` default type `file` and alternative type `name` are unsupported for the playwright junit xml file

## This pull request

* adds the `--split-by=classname` option
* removes a rogue `test.slow()` annotation and unused const from changeEmail.spec.ts

## Issue that this pull request solves

Closes: #FXA-9720

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

An alternative to using CircleCI parallel is to use [Playwright sharding](https://playwright.dev/docs/ci#circleci) Example here: https://github.com/mozilla/fxa/pull/17052
- The results are rather similar at this time
- My understanding is that:
  - CircleCI splits the tests by module according to historical timing and would be weak against larger long running modules
  - Sharding splits the tests evenly across parallel processes and would be weak against singular test outliers, where a few tests take a very long time


