### PR TITLE
feat(oauth): prompt none redirect replace history

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -12,6 +12,7 @@ import HaltBehavior from '../../views/behaviors/halt';
 import NullBehavior from '../../views/behaviors/null';
 import NavigateBehavior from '../../views/behaviors/navigate';
 import OAuthErrors from '../../lib/oauth-errors';
+import OAuthPrompt from '../../lib/oauth-prompt';
 import p from '../../lib/promise';
 import ScopedKeys from 'lib/crypto/scoped-keys';
 import Transform from '../../lib/transform';
@@ -159,10 +160,16 @@ export default BaseAuthenticationBroker.extend({
         }
       }
 
-      this.window.location.href = Url.updateSearchString(
-        result.redirect,
-        extraParams
-      );
+      if (this.relier.get('prompt') === OAuthPrompt.NONE) {
+        this.window.location.replace(
+          Url.updateSearchString(result.redirect, extraParams)
+        );
+      } else {
+        this.window.location.href = Url.updateSearchString(
+          result.redirect,
+          extraParams
+        );
+      }
     });
   },
 

--- a/packages/fxa-content-server/app/tests/mocks/window.js
+++ b/packages/fxa-content-server/app/tests/mocks/window.js
@@ -29,6 +29,7 @@ function WindowMock() {
     origin: window.location.origin,
     pathname: '/',
     search: window.location.search,
+    replace() {},
   };
 
   this.document = {


### PR DESCRIPTION
## Because

- Prompt none redirect keeps /authorization/* in session history resulting in awkward behavior when the user uses the back button.

## This pull request

- Updates redirect logic to use `replace()` replacing the current resource with the provided redirect URI.

## Issue that this pull request solves

Closes: #FXA-9707

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Session history before change
![image](https://github.com/mozilla/fxa/assets/10620585/91a5f153-5d07-4813-9687-3c956928c252)


Session history after change
![image](https://github.com/mozilla/fxa/assets/10620585/52873150-8c2a-43d7-b959-16801e749a5c)


## Other information (Optional)

Any other information that is important to this pull request.
