### PR TITLE
fix(settings): Disable ConfirmResetPassword submit button

### DIFF
--- a/packages/fxa-settings/src/components/ConfirmWithLink/index.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/index.tsx
@@ -40,8 +40,8 @@ const ConfirmWithLink = ({
         headingTextFtlId={confirmWithLinkPageStrings.headingFtlId}
       />
 
-      {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}
-      {resendStatus === ResendStatus['error'] && errorMessage && (
+      {resendStatus === ResendStatus.sent && <ResendEmailSuccessBanner />}
+      {resendStatus === ResendStatus.error && errorMessage && (
         <Banner type={BannerType.error}>{errorMessage}</Banner>
       )}
 

--- a/packages/fxa-settings/src/components/ConfirmWithLink/mocks.tsx
+++ b/packages/fxa-settings/src/components/ConfirmWithLink/mocks.tsx
@@ -21,7 +21,7 @@ export const MOCK_GOBACK_CB = () => {
 
 export const SubjectWithEmailResendSuccess = () => {
   const [mockResendStatus, setMockResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
 
   const MOCK_EMAIL_RESEND_SUCCESS = () => {
@@ -43,7 +43,7 @@ export const SubjectWithEmailResendSuccess = () => {
 
 export const SubjectWithEmailResendError = () => {
   const [mockResendStatus, setMockResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
   const [mockErrorMessage, setMockErrorMessage] = useState('');
 
@@ -70,7 +70,7 @@ export const SubjectCanGoBack = ({
   navigateBackHandler,
 }: Partial<ConfirmWithLinkProps>) => {
   const [mockResendStatus, setMockResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
 
   const MOCK_RESEND_HANDLER_SUCCESS = () => {

--- a/packages/fxa-settings/src/components/FormVerifyTotp/en.ftl
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/en.ftl
@@ -1,5 +1,0 @@
-## FormVerifyTotp
-
-# When focused on the button, screen reader will read the action and entire number that will be submitted
-form-verify-code-submit-button =
-  .aria-label = Submit { $codeValue }

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
@@ -32,9 +32,9 @@ describe('FormVerifyTotp component', () => {
       expect(button).toHaveTextContent('Submit');
       expect(button).toBeDisabled();
 
-      expect(
-        screen.getByRole('textbox', { name: 'Digit 1 of 6' })
-      ).toHaveFocus();
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
 
       // type in each input
       for (let i = 1; i <= 6; i++) {
@@ -55,8 +55,11 @@ describe('FormVerifyTotp component', () => {
       expect(button).toHaveTextContent('Submit');
       expect(button).toBeDisabled();
 
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
+
       await waitFor(() => {
-        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }));
         user.paste('123456');
       });
 

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
@@ -36,12 +36,18 @@ const FormVerifyTotp = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const stringifiedCode = codeArray.join('');
+
+  const isFormValid = stringifiedCode.length === codeLength && !errorMessage;
+  const isSubmitDisabled = isSubmitting || !isFormValid;
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    setIsSubmitting(true);
-    await verifyCode(stringifiedCode);
-    setIsSubmitting(false);
+    if (!isSubmitDisabled) {
+      setIsSubmitting(true);
+      await verifyCode(stringifiedCode);
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -64,15 +70,13 @@ const FormVerifyTotp = ({
           }}
         />
         <FtlMsg
-          id="form-verify-code-submit-button"
-          attrs={{ ariaLabel: true }}
+          id="form-verify-code-submit-button-2"
           vars={{ codeValue: stringifiedCode }}
         >
           <button
             type="submit"
             className="cta-primary cta-xl"
-            disabled={isSubmitting || stringifiedCode.length < codeLength}
-            aria-label={`Submit ${stringifiedCode}`}
+            disabled={isSubmitDisabled}
           >
             {localizedSubmitButtonText}
           </button>

--- a/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.stories.tsx
@@ -42,7 +42,7 @@ const mockedProps: LinkExpiredProps = {
   messageText: 'Some text',
   messageFtlId: 'mock-message-id',
   resendLinkHandler: mockResendHandler,
-  resendStatus: ResendStatus['not sent'],
+  resendStatus: ResendStatus.none,
 };
 
 export const Default = () => <LinkExpired {...mockedProps} />;

--- a/packages/fxa-settings/src/components/LinkExpired/index.test.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.test.tsx
@@ -16,7 +16,7 @@ const mockedProps: LinkExpiredProps = {
   messageText: 'Some text',
   messageFtlId: 'mock-message-id',
   resendLinkHandler: mockResendHandler,
-  resendStatus: ResendStatus['not sent'],
+  resendStatus: ResendStatus.none,
 };
 
 describe('LinkExpired', () => {

--- a/packages/fxa-settings/src/components/LinkExpired/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpired/index.tsx
@@ -27,15 +27,15 @@ export const LinkExpired = ({
   messageFtlId,
   showResendLink = true,
   resendLinkHandler,
-  resendStatus = ResendStatus['not sent'],
+  resendStatus = ResendStatus.none,
   errorMessage,
 }: LinkExpiredProps) => {
   return (
     <AppLayout>
       <CardHeader {...{ headingText, headingTextFtlId }} />
 
-      {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}
-      {resendStatus === ResendStatus['error'] && errorMessage && (
+      {resendStatus === ResendStatus.sent && <ResendEmailSuccessBanner />}
+      {resendStatus === ResendStatus.error && errorMessage && (
         <Banner type={BannerType.error}>{errorMessage}</Banner>
       )}
 

--- a/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkExpiredResetPassword/index.tsx
@@ -28,7 +28,7 @@ export const LinkExpiredResetPassword = ({
   const ftlMsgResolver = useFtlMsgResolver();
 
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
   const [errorMessage, setErrorMessage] = useState<string>();
 

--- a/packages/fxa-settings/src/components/TotpInputGroup/index.test.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/index.test.tsx
@@ -21,18 +21,15 @@ describe('TotpInputGroup component', () => {
     expect(inputs).toHaveLength(8);
   });
 
-  it('sets focus on first input box', () => {
-    renderWithLocalizationProvider(<Subject codeLength={8} />);
-    const inputs = screen.getAllByRole('textbox');
-    expect(inputs[0]).toHaveFocus();
-  });
-
   describe('keyboard navigation', () => {
     it('can navigate between inputs with arrow keys', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject codeLength={6} />);
       const inputs = screen.getAllByRole('textbox');
-      expect(inputs[0]).toHaveFocus();
+
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
 
       await waitFor(() => {
         user.keyboard('[ArrowRight]');
@@ -48,8 +45,10 @@ describe('TotpInputGroup component', () => {
     it('can backspace between inputs', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject codeLength={6} />);
-      const inputs = screen.getAllByRole('textbox');
-      expect(inputs[0]).toHaveFocus();
+
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
 
       // type in each input
       for (let i = 1; i <= 6; i++) {
@@ -91,8 +90,10 @@ describe('TotpInputGroup component', () => {
     it('can forward delete inputs', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject codeLength={6} />);
-      const inputs = screen.getAllByRole('textbox');
-      expect(inputs[0]).toHaveFocus();
+
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
 
       // type in each input
       for (let i = 1; i <= 6; i++) {
@@ -135,8 +136,10 @@ describe('TotpInputGroup component', () => {
     it('distributes clipboard content to inputs', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject codeLength={6} />);
-      const inputBox1 = screen.getByRole('textbox', { name: 'Digit 1 of 6' });
-      expect(inputBox1).toHaveFocus();
+
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
 
       // inputs initially have no value
       for (let i = 1; i <= 6; i++) {
@@ -145,8 +148,11 @@ describe('TotpInputGroup component', () => {
         ).toHaveValue('');
       }
 
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
+
       await waitFor(() => {
-        user.click(inputBox1);
         user.paste('123456');
       });
 
@@ -161,8 +167,10 @@ describe('TotpInputGroup component', () => {
     it('skips non-numeric characters in clipboard', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject codeLength={6} />);
-      const inputBox1 = screen.getByRole('textbox', { name: 'Digit 1 of 6' });
-      expect(inputBox1).toHaveFocus();
+
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
 
       // inputs initially have no value
       for (let i = 1; i <= 6; i++) {
@@ -171,8 +179,11 @@ describe('TotpInputGroup component', () => {
         ).toHaveValue('');
       }
 
+      await waitFor(() =>
+        user.click(screen.getByRole('textbox', { name: 'Digit 1 of 6' }))
+      );
+
       await waitFor(() => {
-        user.click(inputBox1);
         user.paste('1b2$3 4B5.6?');
       });
 

--- a/packages/fxa-settings/src/components/TotpInputGroup/index.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/index.tsx
@@ -194,7 +194,6 @@ export const TotpInputGroup = ({
           ref={inputRefs.current[index]}
           type="text"
           autoComplete="one-time-code"
-          autoFocus={index === 0 ? true : false}
           inputMode="numeric"
           size={1}
           pattern="[0-9]{1}"

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -35,7 +35,7 @@ export type RemoteMetadata = {
 };
 
 export enum ResendStatus {
-  'not sent',
+  'none',
   'sent',
   'error',
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -49,7 +49,7 @@ const ConfirmResetPassword = ({
 
   const account = useAccount();
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
   const [errorMessage, setErrorMessage] = useState<string>();
   const [isPolling, setIsPolling] = useState<number | null>(
@@ -98,7 +98,7 @@ const ConfirmResetPassword = ({
         setCurrentPasswordForgotToken(result.passwordForgotToken);
       }
 
-      setResendStatus(ResendStatus['sent']);
+      setResendStatus(ResendStatus.sent);
       logViewEvent(viewName, 'resend', REACT_ENTRYPOINT);
     } catch (err) {
       const localizedErrorMessage = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.tsx
@@ -70,7 +70,6 @@ const CompleteResetPassword = ({
                   recovery key.
                 </p>
               </FtlMsg>
-              {/* TODO add metrics to measure if users see and click on this link */}
               <FtlMsg id="complete-reset-password-recovery-key-link">
                 <Link
                   to={`/account_recovery_confirm_key${location.search}`}

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/interfaces.ts
@@ -18,9 +18,9 @@ export type RecoveryKeyCheckResult = {
 export type ConfirmResetPasswordProps = {
   email: string;
   errorMessage: string;
-  resendCode: () => Promise<boolean>;
-  resendStatus: ResendStatus;
   setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
-  setResendStatus: React.Dispatch<React.SetStateAction<ResendStatus>>;
+  resendCode: () => Promise<void>;
+  resendStatus: ResendStatus;
+  resendErrorMessage: string;
   verifyCode: (code: string) => Promise<void>;
 };

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/mocks.tsx
@@ -10,15 +10,16 @@ import { ResendStatus } from '../../../lib/types';
 import { ConfirmResetPasswordProps } from './interfaces';
 
 const mockVerifyCode = (code: string) => Promise.resolve();
-const mockResendCode = () => Promise.resolve(true);
+const mockResendCode = () => Promise.resolve();
 
 export const Subject = ({
+  resendStatus = ResendStatus.none,
+  resendErrorMessage = '',
   resendCode = mockResendCode,
   verifyCode = mockVerifyCode,
 }: Partial<ConfirmResetPasswordProps>) => {
   const email = MOCK_EMAIL;
   const [errorMessage, setErrorMessage] = useState('');
-  const [resendStatus, setResendStatus] = useState(ResendStatus['not sent']);
 
   return (
     <LocationProvider>
@@ -26,10 +27,10 @@ export const Subject = ({
         {...{
           email,
           errorMessage,
+          setErrorMessage,
           resendCode,
           resendStatus,
-          setErrorMessage,
-          setResendStatus,
+          resendErrorMessage,
           verifyCode,
         }}
       />

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -49,7 +49,7 @@ const SigninUnblock = ({
   const [codeErrorMessage, setCodeErrorMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
 
   const ftlMsgResolver = useFtlMsgResolver();
@@ -97,7 +97,7 @@ const SigninUnblock = ({
 
   const onSubmit = async (unblockCode: string) => {
     setBannerErrorMessage('');
-    setResendStatus(ResendStatus['not sent']);
+    setResendStatus(ResendStatus.none);
 
     // Check if code format is valid and abort submission if not
     const localizedCodeInputError = getCodeFormatErrorMessage(unblockCode);

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -65,7 +65,7 @@ const ConfirmSignupCode = ({
   const session = useSession();
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
   const [resendStatus, setResendStatus] = useState<ResendStatus>(
-    ResendStatus['not sent']
+    ResendStatus.none
   );
 
   const navigate = useNavigate();
@@ -98,15 +98,15 @@ const ConfirmSignupCode = ({
     try {
       await session.sendVerificationCode();
       // if resending a code is successful, clear any banner already present on screen
-      if (resendStatus !== ResendStatus['sent']) {
+      if (resendStatus !== ResendStatus.sent) {
         setBanner({
           type: undefined,
           children: undefined,
         });
-        setResendStatus(ResendStatus['sent']);
+        setResendStatus(ResendStatus.sent);
       }
     } catch (error) {
-      setResendStatus(ResendStatus['not sent']);
+      setResendStatus(ResendStatus.none);
       const localizedErrorMessage = getLocalizedErrorMessage(
         ftlMsgResolver,
         error
@@ -261,7 +261,7 @@ const ConfirmSignupCode = ({
         setCodeErrorMessage(localizedErrorMessage);
       } else {
         // Clear resend link success banner (if displayed) before rendering an error banner
-        setResendStatus(ResendStatus['not sent']);
+        setResendStatus(ResendStatus.none);
         // Any other error messages should be displayed in an error banner
         setBanner({
           type: BannerType.error,
@@ -287,7 +287,7 @@ const ConfirmSignupCode = ({
         <Banner type={banner.type}>{banner.children}</Banner>
       )}
 
-      {resendStatus === ResendStatus['sent'] && <ResendEmailSuccessBanner />}
+      {resendStatus === ResendStatus.sent && <ResendEmailSuccessBanner />}
 
       <div className="flex justify-center mx-auto">
         <MailImage className="w-3/5" />


### PR DESCRIPTION
## Because

* Form submission should be disabled when there was an error on submit
* Re-enable submit after the code is changed
* We want to prevent the user from accidentally hitting the verification limit by submitting the same wrong code too many times
* We do not want the submit button to be disabled if the error is caused by a resend code error
## This pull request

* Update the conditions where the submit button in FormVerify code component is disabled
* Remove the aria-label on submit button that was reading the code
* Separate the resend code error state from code verification error state
* Clear all banners before code verification and code resend to make way for new messages

## Issue that this pull request solves

Closes: #FXA-9724

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
