### PR TITLE
fix(metrics): Fix mismatched Glean metrics name

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/index.tsx
@@ -77,7 +77,7 @@ const CompleteResetPassword = ({
                   state={locationState}
                   className="link-white underline-offset-4"
                   onClick={() =>
-                    GleanMetrics.passwordReset.createNewClickRecoveryKeyMessage()
+                    GleanMetrics.passwordReset.createNewRecoveryKeyMessageClick()
                   }
                 >
                   Reset your password with your account recovery key.

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -87,7 +87,7 @@ export const eventsMap = {
     createNewView: 'password_reset_create_new_view',
     createNewSubmit: 'password_reset_create_new_submit',
     createNewSuccess: 'password_reset_create_new_success_view',
-    createNewClickRecoveryKeyMessage:
+    createNewRecoveryKeyMessageClick:
       'password_reset_create_new_recovery_key_message_click',
 
     emailConfirmationView: 'password_reset_email_confirmation_view',


### PR DESCRIPTION
## Because

* Naming error for glean metric was causing build issues

## This pull request

* Fix the metric name

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
