### PR TITLE
bug(settings): Login breaking after swapping secondary and primary emails.

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -575,7 +575,7 @@ export default class AuthClient {
   async signInWithAuthPW(
     email: string,
     authPW: string,
-    options: Omit<SignInOptions, 'skipCaseError' | 'originalLoginEmail'> = {},
+    options: SignInOptions = {},
     headers?: Headers
   ): Promise<Omit<SignedInAccountData, 'unwrapBKey'>> {
     const payloadOptions = ({ keys, ...rest }: any) => rest;

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -639,7 +639,6 @@ export async function trySignIn(
       const { v1Credentials, v2Credentials } = await onRetryCorrectedEmail(
         result.error.email
       );
-      options.originalLoginEmail = email;
       // Try one more time with the corrected email
       return trySignIn(
         result.error.email,
@@ -647,7 +646,10 @@ export async function trySignIn(
         v2Credentials,
         unverifiedAccount,
         beginSignin,
-        options
+        {
+          ...options,
+          originalLoginEmail: email,
+        }
       );
     }
 


### PR DESCRIPTION
## Because

- We found a bug that occurred during sign in  after swapping secondary and primary emails.

## This pull request

- Makes sure to send up the 'originalEmail'

## Issue that this pull request solves

Closes: FXA-9663

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This addresses feedback left by rvass on FXA-9663. The issue occurred when swapping primary and secondary email addresses. once this happens

To test:
 - create an account with email aaa@mozilla.com
 - logout
 - login
 - add secondary email bbb@mozilla.com
 - swap primary and secondary
 - logout
 - login
 
