### PR TITLE
fix(cart): remove updateAt on createAccountCustomer

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -270,7 +270,6 @@ describe('CheckoutService', () => {
         ).toHaveBeenCalledWith({
           uid: uid,
           stripeCustomerId: mockCart.stripeCustomerId,
-          updatedAt: Date.now(),
         });
       });
     });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -80,7 +80,6 @@ export class CheckoutService {
       await this.accountCustomerManager.createAccountCustomer({
         uid: uid,
         stripeCustomerId: stripeCustomerId,
-        updatedAt: Date.now(),
       });
     }
 

--- a/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.factories.ts
+++ b/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.factories.ts
@@ -34,7 +34,6 @@ export const CreateAccountCustomerFactory = (
   stripeCustomerId: faker.string.alphanumeric({
     length: 14,
   }),
-  updatedAt: faker.date.recent().getTime(),
   ...override,
 });
 

--- a/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.types.ts
+++ b/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.types.ts
@@ -11,7 +11,6 @@ export type ResultAccountCustomer = Readonly<Omit<AccountCustomer, 'uid'>> & {
 export interface CreateAccountCustomer {
   uid: string;
   stripeCustomerId: string | null;
-  updatedAt: number;
 }
 
 export interface UpdateAccountCustomer {


### PR DESCRIPTION
## Because

- AccountCustomerManager.createAccountCustomer included updateAt as a parameter even though it wasn't used.

## This pull request

- Remove updateAt from createAccountCustomer and update related files.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
