### PR TITLE
task(content): Add cirrus integration to Backbone

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -30,6 +30,7 @@ import FxaClient from './fxa-client';
 import InterTabChannel from './channels/inter-tab';
 import Metrics from './metrics';
 import Notifier from './channels/notifier';
+import Nimbus from './nimbus';
 import OAuthClient from './oauth-client';
 import OAuthRelier from '../models/reliers/oauth';
 import p from './promise';
@@ -134,6 +135,8 @@ Start.prototype = {
         .then(() => this.initializeUser())
         // glean metrics
         .then(() => this.initializeGlean())
+        // nimbus experimentation; does not rely on anything.
+        .then(() => this.initializeNimbusExperiment())
         // depends on nothing
         .then(() => this.initializeFormPrefill())
         // depends on notifier, metrics
@@ -174,6 +177,12 @@ Start.prototype = {
       relier: this._relier,
       user: this._user,
       userAgent: this.getUserAgent(),
+    });
+  },
+
+  initializeNimbusExperiment() {
+    return Nimbus.initialize(this._getUniqueUserId(), {
+      'user-agent': this.getUserAgentString(),
     });
   },
 

--- a/packages/fxa-content-server/app/scripts/lib/nimbus/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/nimbus/index.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/browser';
+
+export default class Nimbus {
+  static experiments: any;
+
+  static async initialize(clientId: string, context: any) {
+    const body = JSON.stringify({
+      client_id: clientId,
+      context,
+    });
+
+    try {
+      const resp = await fetch('/nimbus-experiments', {
+        method: 'POST',
+        body,
+        // A request to cirrus should not be more than 50ms, but we give it a large enough padding.
+        signal: AbortSignal.timeout(1000),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (resp.status !== 200) {
+        this.experiments = null;
+        return;
+      }
+
+      this.experiments = await resp.json();
+    } catch (err) {
+      Sentry.withScope(() => {
+        Sentry.captureMessage('Experiment fetch error', 'error');
+      });
+    }
+  }
+}

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -11,6 +11,7 @@ import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
 import GleanMetrics from '../lib/glean';
+import Nimbus from '../lib/nimbus';
 import PasswordMixin from './mixins/password-mixin';
 import preventDefaultThen from './decorators/prevent_default_then';
 import ServiceMixin from './mixins/service-mixin';
@@ -96,6 +97,7 @@ const SignInPasswordView = FormView.extend({
     const hasLinkedAccountAndNoPassword = hasLinkedAccount && !hasPassword;
     context.set({
       email: account.get('email'),
+      nimbusExperiments: Nimbus.experiments,
       isPasswordNeeded: this.isPasswordNeededForAccount(account) && hasPassword,
       hasLinkedAccountAndNoPassword: hasLinkedAccount && !hasPassword,
       hasLinkedAccount: hasLinkedAccount,

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -621,6 +621,14 @@ const conf = (module.exports = convict({
     env: 'PAGE_TEMPLATE_SUBDIRECTORY',
     format: ['src', 'dist'],
   },
+  nimbus: {
+    host: {
+      default: 'http://localhost:8001',
+      doc: 'Base URI for cirrus (Nimbus experimentation endpoint).',
+      env: 'NIMBUS_CIRRUS_HOST',
+      format: String,
+    },
+  },
   pairing: {
     clients: {
       default: [

--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -40,6 +40,7 @@ module.exports = function (config, i18n, statsd) {
     require('./routes/post-third-party-auth-redirect')(config),
     require('./routes/get-500')(config),
     require('./routes/validate-email-domain')(config),
+    require('./routes/post-nimbus-experiments')(config),
   ].filter((routeDefinition) => routeDefinition); // get rid of null values
 
   if (config.get('csp.enabled')) {

--- a/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
+++ b/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('../configuration');
+const joi = require('joi');
+const Sentry = require('@sentry/node');
+const {
+  overrideJoiMessages,
+} = require('fxa-shared/sentry/joi-message-overrides');
+
+const BODY_SCHEMA = {
+  client_id: joi.string().required(),
+  context: joi.object().required(),
+};
+
+module.exports = function (options = {}) {
+  return {
+    method: 'post',
+    path: '/nimbus-experiments',
+    validate: {
+      body: overrideJoiMessages(BODY_SCHEMA),
+    },
+    process: async function (req, res) {
+      const body = JSON.stringify({
+        client_id: req.body.client_id,
+        context: req.body.context,
+      });
+
+      try {
+        const resp = await fetch(
+          `${config.getProperties().nimbus.host}/v1/features/`,
+          {
+            method: 'POST',
+            body,
+            // A request to cirrus should not be more than 50ms,
+            // but we give it a large enough padding.
+            signal: AbortSignal.timeout(1000),
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+
+        res.end(await resp.text());
+      } catch (err) {
+        Sentry.withScope(() => {
+          let errorMsg = 'experiment fetch error';
+          if (err.name === 'TimeoutError') {
+            errorMsg =
+              'Timeout: It took more than 1 seconds to get the result!';
+          }
+          Sentry.captureMessage(errorMsg, 'error');
+        });
+      }
+    },
+  };
+};


### PR DESCRIPTION
## Because

- We want to integrate Nimbus experimentation into FxA UI.

## This pull request

- We fetch the experiments as a passthrough between the app and server so we don't have to expose another service. In this patch, we've also added the experiments to the sign-in page context.

## Issue that this pull request solves

Closes: # FXA-9788

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
