### PR TITLE
bug(admin-server): Fixes broken startup behavior

### DIFF
--- a/packages/fxa-admin-server/src/gql/gql.module.ts
+++ b/packages/fxa-admin-server/src/gql/gql.module.ts
@@ -11,6 +11,9 @@ import { EmailBounceResolver } from './email-bounce/email-bounce.resolver';
 import { RelyingPartyResolver } from './relying-party/relying-party.resolver';
 import { BackendModule } from '../backend/backend.module';
 import { NewslettersModule } from '../newsletters/newsletters.module';
+import { NotifierService, NotifierSnsFactory } from '@fxa/shared/notifier';
+import { MozLoggerService } from '@fxa/shared/mozlog';
+import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
 
 @Module({
   imports: [
@@ -20,6 +23,14 @@ import { NewslettersModule } from '../newsletters/newsletters.module';
     BackendModule,
     NewslettersModule,
   ],
-  providers: [AccountResolver, EmailBounceResolver, RelyingPartyResolver],
+  providers: [
+    AccountResolver,
+    EmailBounceResolver,
+    LegacyStatsDProvider,
+    NotifierSnsFactory,
+    NotifierService,
+    MozLoggerService,
+    RelyingPartyResolver,
+  ],
 })
 export class GqlModule {}


### PR DESCRIPTION
## Because

- Admin server wasn't starting up cleanly
- NotifierService dependencies weren't being provided

## This pull request

- Adds MozLoggerService to providers
- Adds LegacyStatsDProvider to providers
- Removes SentryModule, which is deprecated in favor of direct initialization

## Issue that this pull request solves

Closes: 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
