### PR TITLE
fix(signin): retry signin unblock with signup email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -476,7 +476,10 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
     },
 
     async createKeyFetchToken(request, accountRecord, password, sessionToken) {
-      const wrapWrapKb = password.clientVersion === 2 ? accountRecord.wrapWrapKbVersion2 : accountRecord.wrapWrapKb;
+      const wrapWrapKb =
+        password.clientVersion === 2
+          ? accountRecord.wrapWrapKbVersion2
+          : accountRecord.wrapWrapKb;
       const wrapKb = await password.unwrap(wrapWrapKb);
       const keyFetchToken = await db.createKeyFetchToken({
         uid: accountRecord.uid,
@@ -507,7 +510,6 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
           verificationReason: 'signup',
         };
       }
-
 
       if (sessionToken.mustVerify && !sessionToken.tokenVerified) {
         return {

--- a/packages/fxa-graphql-api/src/gql/dto/input/sign-in.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/sign-in.ts
@@ -31,6 +31,9 @@ export class SignInOptionsInput {
   @Field({ nullable: true })
   public originalLoginEmail?: string;
 
+  @Field({ nullable: true })
+  public skipCaseError?: boolean;
+
   @Field(() => MetricsContext, { nullable: true })
   public metricsContext?: MetricsContext;
 }

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { SignInOptions } from 'fxa-auth-client/browser';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { BeginSigninResult, SigninIntegration } from '../interfaces';
 
@@ -23,7 +24,9 @@ export interface SigninUnblockProps {
 }
 
 export type BeginSigninWithUnblockCodeHandler = (
-  code: string
+  code: string,
+  authEmail?: string,
+  signInOptions?: SignInOptions
 ) => Promise<BeginSigninResult>;
 
 export type SigninWithUnblockCode = (code: string) => void;


### PR DESCRIPTION
Because:
 - the React + gql-api sign in unblock does not handle the "incorrect email" error when the user sign in with a new primary email

This commit:
 - retries the unblock sign in with the original sign up email

