### PR TITLE
bug(auth): Don't send password change email on v2 keystrech upgrade

### DIFF
--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -359,6 +359,8 @@ function mockDB(data, errors) {
       return Promise.resolve({
         createdAt: data.createdAt,
         email: data.email,
+        authSalt:
+          '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF',
         emailCode: data.emailCode,
         emailVerified: data.emailVerified || false,
         locale: data.locale,


### PR DESCRIPTION
## Because

- The email was still going out, even though the previous change attempted to stop this
- The logic to determine whether or not we were in upgrade state was always false

## This pull request

- Fixes the logic to determine whether or not we were in upgrade state

## Issue that this pull request solves

Closes: FXA-9662

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Here's a manual test case:

- Sign up with new account
- Sign out
- Check admin panel and see that account is on v1
- Go to sign in page (add ?stretch=2) to the query
- Sign in
- Check inbox
- Observe that password change email was not sent
- Observe that new sign in email was sent
- Check admin panel
- Observe that account has been upgraded to v2 key stretching


