### PR TITLE
bug(settings): Use correct current key stretch version for signin unblock

### DIFF
--- a/packages/fxa-graphql-api/src/gql/dto/payload/credential-status.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/credential-status.ts
@@ -16,7 +16,7 @@ export class CredentialStatusPayload {
     description: 'The current version of the credentials.',
     nullable: true,
   })
-  public version?: string;
+  public currentVersion?: string;
 
   @Field({
     description:

--- a/packages/fxa-settings/src/pages/Signin/gql.ts
+++ b/packages/fxa-settings/src/pages/Signin/gql.ts
@@ -65,7 +65,7 @@ export const CREDENTIAL_STATUS_MUTATION = gql`
   mutation CredentialStatus($input: String!) {
     credentialStatus(input: $input) {
       upgradeNeeded
-      version
+      currentVersion
       clientSalt
     }
   }

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -106,7 +106,7 @@ export interface SigninFormData {
 export interface CredentialStatusResponse {
   credentialStatus: {
     upgradeNeeded: boolean;
-    version?: string;
+    currentVersion?: string;
     clientSalt?: string;
   };
 }


### PR DESCRIPTION
## Because
- We were always using v1 ks
- This won't work for an account that has been upgraded to v2 ks

## This pull request
- Gets client salt and current ks version for account
- Fixes bug in gql. The version field should have been called currentVersion.

## Issue that this pull request solves

Closes: FXA-9782

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We need container test for signin unblock. This is filed as a follow up. It'd also be nice to have functional test coverage which has also been filed as a follow up.
