### PR TITLE
fix(react): Send missing piece of fxaLogin web channel message for Sync login

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -86,8 +86,8 @@ export type FxALoginRequest = {
   verified: boolean;
   services?: {
     sync: {
-      offeredEngines: string[];
-      declinedEngines: string[];
+      offeredEngines?: string[];
+      declinedEngines?: string[];
     };
   };
 };

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -67,6 +67,10 @@ export async function handleNavigation(
       sessionToken: navigationOptions.signinData.sessionToken,
       uid: navigationOptions.signinData.uid,
       verified: navigationOptions.signinData.verified,
+      // This is necessary or the user will be signed in but Sync will be 'off'
+      services: {
+        sync: {},
+      },
     });
   }
 


### PR DESCRIPTION

Because:
* Users are signed into the browser, but Sync is "off"

This commit:
* Adds `services: sync: {}`  to the fxaLogin web channel message to start Sync

fixes FXA-9791

---

Verify this by creating an account and then launching `fxa-dev-launcher`, click "sign into Sync", add the React params, and login. See Sync says ON.