### PR TITLE
task(functional-tests): Add test showing that v1 ks passwords continue to work after upgrade.

### DIFF
--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -66,7 +66,7 @@ test.describe('auth-client-tests', () => {
     expect(status2.clientSalt).toBeUndefined();
   });
 
-  test('it creates with v2 and signs in', async ({
+  test('it creates with v2 and signs in with v2 or v1', async ({
     target,
     testAccountTracker,
   }) => {
@@ -97,6 +97,16 @@ test.describe('auth-client-tests', () => {
     expect(credentialsV2.unwrapBKey).toEqual(signInResult.unwrapBKey);
     const credentialsV1 = await getCredentials(email, password);
     expect(credentialsV1.unwrapBKey).not.toEqual(signInResult.unwrapBKey);
+
+    // Check that we can still sign in with a v1 password. This is needed for legacy clients that don't have key stretching changes.
+    const v1Credentials = await getCredentials(email, password);
+    const v1SignInResult = (await client.signInWithAuthPW(
+      email,
+      v1Credentials.authPW,
+      { keys: true }
+    )) as any;
+    expect(v1SignInResult).toBeDefined();
+    expect(v1SignInResult.keyFetchToken).toBeDefined();
   });
 
   test('it creates with v1 and upgrades to v2 on signin', async ({


### PR DESCRIPTION
## Because

- We should cover support of legacy v1 passwords with a tests.
- Some RPs that have custom implementations will continue to provide v1 credentials.

## This pull request

- Adds some coverage showing that v1 key stretched passwords even after an upgrade.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

