### PR TITLE
bug(event-broker): Recently added profile change events were being rejected

### DIFF
--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -284,6 +284,7 @@ describe('#integration - AccountResolver', () => {
     expect(notifier.send).toBeCalledWith({
       event: 'profileDataChange',
       data: {
+        ts: expect.any(Number),
         uid: USER_1.uid,
         accountDisabled: true,
       },
@@ -303,6 +304,7 @@ describe('#integration - AccountResolver', () => {
     expect(notifier.send).toBeCalledWith({
       event: 'profileDataChange',
       data: {
+        ts: expect.any(Number),
         uid: USER_1.uid,
         accountDisabled: false,
       },
@@ -447,6 +449,7 @@ describe('#integration - AccountResolver', () => {
     expect(notifier.send).toBeCalledWith({
       event: 'profileDataChange',
       data: {
+        ts: expect.any(Number),
         uid: USER_1.uid,
         locale: 'en-CA',
       },

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -201,6 +201,7 @@ export class AccountResolver {
     await this.notifier.send({
       event: 'profileDataChange',
       data: {
+        ts: Date.now() / 1000,
         uid,
         accountDisabled: true,
       },
@@ -229,6 +230,7 @@ export class AccountResolver {
     await this.notifier.send({
       event: 'profileDataChange',
       data: {
+        ts: Date.now() / 1000,
         uid,
         locale,
       },
@@ -249,6 +251,7 @@ export class AccountResolver {
     await this.notifier.send({
       event: 'profileDataChange',
       data: {
+        ts: Date.now() / 1000,
         uid,
         accountDisabled: false,
       },

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -76,6 +76,28 @@ const baseProfileMessage = {
   event: 'profileDataChange',
 };
 
+const profileMessageForEmailChange = {
+  ...baseProfileMessage,
+  email: 'foo@mozilla.com',
+};
+
+const profileMessageForAccountDisabledChange = {
+  ...baseProfileMessage,
+  accountDisabled: true,
+};
+const profileMessageForAccountLockedChange = {
+  ...baseProfileMessage,
+  accountLocked: true,
+};
+const profileMessageForMetricsEnabledChange = {
+  ...baseProfileMessage,
+  metricsEnabled: true,
+};
+const profileMessageForTotpEnabledChange = {
+  ...baseProfileMessage,
+  totpEnabled: true,
+};
+
 const appleMigrationMessage = {
   event: 'appleUserMigration',
   timestamp: now,
@@ -299,6 +321,14 @@ describe('QueueworkerService', () => {
       'password reset message': basePasswordResetMessage,
       'primary email message': basePrimaryEmailMessage,
       'profile change message': baseProfileMessage,
+      'profile change for email message': profileMessageForEmailChange,
+      'profile change for metrics message':
+        profileMessageForMetricsEnabledChange,
+      'profile change for totp message': profileMessageForTotpEnabledChange,
+      'profile change for account locked message':
+        profileMessageForAccountLockedChange,
+      'profile change for account disabled message':
+        profileMessageForAccountDisabledChange,
       'subscription message': baseSubscriptionUpdateMessage,
     };
 

--- a/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
+++ b/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
@@ -88,6 +88,11 @@ export const PROFILE_CHANGE_SCHEMA = joi
     ts: joi.number().required(),
     uid: joi.string().required(),
     email: joi.string().optional(),
+    accountDisabled: joi.bool().optional(),
+    accountLocked: joi.bool().optional(),
+    locale: joi.string().optional(),
+    metricsEnabled: joi.bool().optional(),
+    totpEnabled: joi.bool().optional(),
   })
   .unknown(true)
   .required();

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -487,6 +487,7 @@ describe('#integration - AccountResolver', () => {
         expect(notifierService.send).toBeCalledWith({
           event: 'profileDataChange',
           data: {
+            ts: expect.any(Number),
             uid: USER_1.uid,
             metricsEnabled: false,
           },
@@ -506,6 +507,7 @@ describe('#integration - AccountResolver', () => {
         expect(notifierService.send).toBeCalledWith({
           event: 'profileDataChange',
           data: {
+            ts: expect.any(Number),
             uid: USER_1.uid,
             metricsEnabled: true,
           },

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -464,6 +464,7 @@ export class AccountResolver {
     await this.notifier.send({
       event: 'profileDataChange',
       data: {
+        ts: Date.now() / 1000,
         uid,
         metricsEnabled: input.state === 'in',
       },

--- a/packages/fxa-graphql-api/src/scripts/must-change-password.ts
+++ b/packages/fxa-graphql-api/src/scripts/must-change-password.ts
@@ -145,6 +145,7 @@ async function main() {
       await notifier.send({
         event: 'profileDataChange',
         data: {
+          ts: Date.now() / 1000,
           uid,
           accountLocked: true,
         },


### PR DESCRIPTION
## Because

- The events were rejected because the 'ts' field was missing
- In auth server this added in by the logger, so it wasn't initially detected

## This pull request

- Adds the ts field to all profileDataChange events emitted by admin-server
- Updates the DTO support additional optional fields

## Issue that this pull request solves

Closes: FXA-9802

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
