### PR TITLE
fix(react): Address signin_token_code invalid token error + totp check

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -42,7 +42,7 @@ jest.mock('../../../models', () => {
       return {
         checkTotpTokenExists: jest
           .fn()
-          .mockResolvedValue({ exists: mockHasTotpAuthClient }),
+          .mockResolvedValue({ verified: mockHasTotpAuthClient }),
       };
     },
   };


### PR DESCRIPTION
Because:
* Users would be taken to the 2FA page from signin_token_code when they hadn't yet verified 2FA
* There's an edgecase at least in Sync signin causing an invalid token code on this page

This commit:
* Checks for totp verified instead of totp exists
* Uses the sessionToken passed into the component instead of useSession, which was causing console errors

fixes FXA-9836

---

This ended up being a weird one, it'll probably be helpful to read the ticket which has some screenshots.

I first started tackling this because I was working on another React Sync signin bug and saw this case, where a valid code was not being accepted. The console error shown in ticket was suspicious and I was seeing it any time that page is accessed, though it doesn't appear to always be the cause of the invalid code error. The root cause could be investigated more, but using the available `sessionToken` instead of using `useSession` appears to fix it and gets rid of that console error.* **To most reliably repro this on main**, which yes is an edgecase (but, there may be other cases where this happens), create an account, set `SIGNIN_CONFIRMATION_FORCE_GLOBALLY` to true from auth-server config, start dev-launcher, signin to React sync (click sign in through the browser, then add the force React params) sign out from the browser/clear cache, and then try to sign in to React sync again. The signin code is now not accepted.

*I don't think we're doing an initial query for the data `useSession` gives us back. The `private get data` method just tries to _read_ the data from apollo cache, so the error seemed to be because it hadn't yet been queried. We may want a follow up filed for this. I don't think we're trying to access the data anywhere else, just using the methods the `Session` class offers.

While one could argue what may be an edgecase above doesn't need an uplift, I noticed the 2FA bug as well while working through it, which I think needs that uplift.