### PR TITLE
fix(signin): Fix redirect to /subscriptions after signin

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -455,6 +455,10 @@ Router = Router.extend({
         email: this.user.get('emailFromIndex'),
         hasLinkedAccount: this.user.get('hasLinkedAccount'),
         hasPassword: this.user.get('hasPassword'),
+        // for subplat redirect only
+        ...(this.relier.get('redirectTo') && {
+          redirect_to: this.relier.get('redirectTo'),
+        }),
       });
     },
     'signin_bounced(/)': function () {
@@ -528,6 +532,7 @@ Router = Router.extend({
         ...(this.user.get('emailFromIndex') && {
           emailStatusChecked: 'true',
         }),
+        redirect_to: this.relier.get('redirectTo'),
       });
     },
     'signup_confirmed(/)': function () {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -14,8 +14,6 @@ import { useCallback } from 'react';
 import { getSigninState } from '../utils';
 import { SigninLocationState } from '../interfaces';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
-import { SigninQueryParams } from '../../../models/pages/signin';
 import { ConsumeRecoveryCodeResponse, SubmitRecoveryCode } from './interfaces';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
@@ -39,8 +37,6 @@ export const SigninRecoveryCodeContainer = ({
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: SigninLocationState;
   };
-  const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
-  const { redirectTo } = queryParamModel;
 
   const signinState = getSigninState(location.state);
 
@@ -83,7 +79,6 @@ export const SigninRecoveryCodeContainer = ({
       {...{
         finishOAuthFlowHandler,
         integration,
-        redirectTo,
         serviceName,
         signinState,
         submitRecoveryCode,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -20,13 +20,13 @@ import Banner, { BannerType } from '../../../components/Banner';
 import { storeAccountData } from '../../../lib/storage-utils';
 import { handleNavigation } from '../utils';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
+import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 
 export const viewName = 'signin-recovery-code';
 
 const SigninRecoveryCode = ({
   finishOAuthFlowHandler,
   integration,
-  redirectTo,
   serviceName,
   signinState,
   submitRecoveryCode,
@@ -43,6 +43,12 @@ const SigninRecoveryCode = ({
     'Backup authentication code required'
   );
   const location = useLocation();
+
+  const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
+
+  const redirectTo = webRedirectCheck.isValid()
+    ? integration.data.redirectTo
+    : '';
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-recovery-code-input-label',

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -10,7 +10,6 @@ import { SigninIntegration, SigninLocationState } from '../interfaces';
 export type SigninRecoveryCodeProps = {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
-  redirectTo?: string;
   serviceName?: MozServices;
   signinState: SigninLocationState;
   submitRecoveryCode: SubmitRecoveryCode;

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -25,6 +25,7 @@ import Banner, {
 import { handleNavigation } from '../utils';
 import firefox from '../../../lib/channels/firefox';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
+import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 
 export const viewName = 'signin-token-code';
 
@@ -55,6 +56,11 @@ const SigninTokenCode = ({
   const [animateBanner, setAnimateBanner] = useState(false);
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
   const [resendCodeLoading, setResendCodeLoading] = useState<boolean>(false);
+
+  const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
+  const redirectTo = webRedirectCheck.isValid()
+    ? integration.data.redirectTo
+    : '';
 
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
@@ -161,6 +167,7 @@ const SigninTokenCode = ({
           integration,
           finishOAuthFlowHandler,
           queryParams: location.search,
+          redirectTo,
         };
 
         await GleanMetrics.isDone();
@@ -199,6 +206,7 @@ const SigninTokenCode = ({
       keyFetchToken,
       localizedInvalidCode,
       location.search,
+      redirectTo,
       session,
       sessionToken,
       uid,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -48,7 +48,6 @@ function mockSigninTotpModule() {
 function mockUseValidateModule(opts: any = {}) {
   jest.spyOn(UseValidateModule, 'useValidatedQueryParams').mockReturnValue({
     queryParamModel: {
-      redirectTo: '',
       verificationReason: 'login',
       service: 'sync',
       ...opts,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -18,6 +18,7 @@ import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError } from '../../../lib/error-utils';
+import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
@@ -41,7 +42,13 @@ export const SigninTotpCodeContainer = ({
   const signinState = getSigninState(location.state);
 
   const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
-  const { redirectTo, service } = queryParamModel;
+  const { service } = queryParamModel;
+
+  const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
+
+  const redirectTo = webRedirectCheck.isValid()
+    ? integration.data.redirectTo
+    : '';
 
   const [verifyTotpCode] = useMutation(VERIFY_TOTP_CODE_MUTATION);
 

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -23,7 +23,6 @@ import {
   MOCK_SESSION_TOKEN,
   MOCK_UID,
   MOCK_UNWRAP_BKEY,
-  MOCK_AUTHPW,
 } from '../mocks';
 import { MozServices } from '../../lib/types';
 import * as utils from 'fxa-react/lib/utils';


### PR DESCRIPTION
## Because

* Redirect back to /subscriptions after signin was not working

## This pull request

* Pass the redirectTo as search param
* Validate the redirectTo and if valid navigate there after signin

## Issue that this pull request solves

Closes: #FXA-9826

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

When directly hitting /subscriptions (e.g., from subscription renewal email), the user is bounced back to sign in if they aren't logged in. For React signin, we need to pass the redirectTo value that is held by the relier in content-server by adding it as a search param.

We already had logic in the React Signin component to handle the redirectTo, but the value was undefined.

Also added redirectTo handling for signinTokenCode and signinTotpCode.
