### PR TITLE
fix(input): Show text keyboard for recovery code input

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -11,6 +11,7 @@ import CardHeader from '../../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode, {
   FormAttributes,
+  InputModeEnum,
 } from '../../../components/FormVerifyCode';
 import GleanMetrics from '../../../lib/glean';
 import AppLayout from '../../../components/AppLayout';
@@ -53,7 +54,8 @@ const SigninRecoveryCode = ({
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-recovery-code-input-label',
     inputLabelText: 'Enter 10-digit backup authentication code',
-    pattern: '[0-9]{10}',
+    inputMode: InputModeEnum.text,
+    pattern: '[a-zA-Z0-9]',
     maxLength: 10,
     submitButtonFtlId: 'signin-recovery-code-confirm-button',
     submitButtonText: 'Confirm',


### PR DESCRIPTION
## Because

- Recovery codes are alpha numeric so we need to display the `text` keyboard on mobile

## This pull request

- Displays text keyboard on mobile

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9838

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="382" alt="Screenshot 2024-06-10 at 12 35 38 PM" src="https://github.com/mozilla/fxa/assets/1295288/3781328d-b911-4acb-805b-02c5dc26ef83">
