### PR TITLE
fix(settings): Support subplat redirectTo for force_auth route

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -206,7 +206,17 @@ Router = Router.extend({
           return this.showView(View);
         });
       } else {
-        this.createReactOrBackboneViewHandler(routeName, ConfirmSignupCodeView);
+        this.createReactOrBackboneViewHandler(
+          routeName,
+          ConfirmSignupCodeView,
+          {
+            ...Url.searchParams(this.window.location.search),
+            // for subplat redirect only
+            ...(this.relier.get('redirectTo') && {
+              redirect_to: this.relier.get('redirectTo'),
+            }),
+          }
+        );
       }
     },
     'connect_another_device(/)': createViewHandler(ConnectAnotherDeviceView),
@@ -231,6 +241,13 @@ Router = Router.extend({
     'force_auth(/)': function () {
       this.createReactOrBackboneViewHandler('force_auth', ForceAuthView, {
         ...Url.searchParams(this.window.location.search),
+        email: this.user.get('emailFromIndex'),
+        hasLinkedAccount: this.user.get('hasLinkedAccount'),
+        hasPassword: this.user.get('hasPassword'),
+        // for subplat redirect only
+        ...(this.relier.get('redirectTo') && {
+          redirect_to: this.relier.get('redirectTo'),
+        }),
       });
     },
     'inline_totp_setup(/)': function () {
@@ -269,15 +286,34 @@ Router = Router.extend({
       });
     },
     'oauth(/)': createViewHandler(IndexView),
-    'oauth/force_auth(/)': createViewHandler(ForceAuthView),
-    'oauth/signin(/)': function () {
-      this.createReactOrBackboneViewHandler('signin', SignInPasswordView, {
-        // see comment in fxa-settings/src/pages/Signin/container.tsx for param explanation
+    'oauth/force_auth(/)': function () {
+      this.createReactOrBackboneViewHandler('oauth/force_auth', ForceAuthView, {
         ...Url.searchParams(this.window.location.search),
         email: this.user.get('emailFromIndex'),
         hasLinkedAccount: this.user.get('hasLinkedAccount'),
         hasPassword: this.user.get('hasPassword'),
+        // for subplat redirect only
+        ...(this.relier.get('redirectTo') && {
+          redirect_to: this.relier.get('redirectTo'),
+        }),
       });
+    },
+    'oauth/signin(/)': function () {
+      this.createReactOrBackboneViewHandler(
+        'oauth/signin',
+        SignInPasswordView,
+        {
+          // see comment in fxa-settings/src/pages/Signin/container.tsx for param explanation
+          ...Url.searchParams(this.window.location.search),
+          email: this.user.get('emailFromIndex'),
+          hasLinkedAccount: this.user.get('hasLinkedAccount'),
+          hasPassword: this.user.get('hasPassword'),
+          // for subplat redirect only
+          ...(this.relier.get('redirectTo') && {
+            redirect_to: this.relier.get('redirectTo'),
+          }),
+        }
+      );
     },
     'oauth/signup(/)': function () {
       this.createReactOrBackboneViewHandler(
@@ -496,7 +532,13 @@ Router = Router.extend({
       this.createReactOrBackboneViewHandler(
         'signin_token_code',
         SignInTokenCodeView,
-        null,
+        {
+          ...Url.searchParams(this.window.location.search),
+          // for subplat redirect only
+          ...(this.relier.get('redirectTo') && {
+            redirect_to: this.relier.get('redirectTo'),
+          }),
+        },
         {
           type: VerificationReasons.SIGN_IN,
         }
@@ -505,13 +547,27 @@ Router = Router.extend({
     'signin_totp_code(/)': function () {
       this.createReactOrBackboneViewHandler(
         'signin_totp_code',
-        SignInTotpCodeView
+        SignInTotpCodeView,
+        {
+          ...Url.searchParams(this.window.location.search),
+          // for subplat redirect only
+          ...(this.relier.get('redirectTo') && {
+            redirect_to: this.relier.get('redirectTo'),
+          }),
+        }
       );
     },
     'signin_unblock(/)': function () {
       this.createReactOrBackboneViewHandler(
         'signin_unblock',
-        SignInUnblockView
+        SignInUnblockView,
+        {
+          ...Url.searchParams(this.window.location.search),
+          // for subplat redirect only
+          ...(this.relier.get('redirectTo') && {
+            redirect_to: this.relier.get('redirectTo'),
+          }),
+        }
       );
     },
     'signin_verified(/)': function () {
@@ -532,7 +588,10 @@ Router = Router.extend({
         ...(this.user.get('emailFromIndex') && {
           emailStatusChecked: 'true',
         }),
-        redirect_to: this.relier.get('redirectTo'),
+        // for subplat redirect only
+        ...(this.relier.get('redirectTo') && {
+          redirect_to: this.relier.get('redirectTo'),
+        }),
       });
     },
     'signup_confirmed(/)': function () {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -352,6 +352,10 @@ const AuthAndAccountSetupRoutes = ({
       {/* Signin */}
       <ReportSigninContainer path="/report_signin/*" />
       <SigninContainer
+        path="/oauth/force_auth/*"
+        {...{ integration, serviceName, flowQueryParams }}
+      />
+      <SigninContainer
         path="/force_auth/*"
         {...{ integration, serviceName, flowQueryParams }}
       />

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver } from '../../../models';
+import { isWebIntegration, useFtlMsgResolver } from '../../../models';
 import { RecoveryCodesImage } from '../../../components/images';
 import CardHeader from '../../../components/CardHeader';
 import LinkExternal from 'fxa-react/components/LinkExternal';
@@ -46,9 +46,10 @@ const SigninRecoveryCode = ({
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
-  const redirectTo = webRedirectCheck.isValid()
-    ? integration.data.redirectTo
-    : '';
+  const redirectTo =
+    isWebIntegration(integration) && webRedirectCheck.isValid()
+      ? integration.data.redirectTo
+      : '';
 
   const formAttributes: FormAttributes = {
     inputFtlId: 'signin-recovery-code-input-label',

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -5,7 +5,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver, useSession } from '../../../models';
+import {
+  isWebIntegration,
+  useFtlMsgResolver,
+  useSession,
+} from '../../../models';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { MailImage } from '../../../components/images';
 import FormVerifyCode, {
@@ -58,9 +62,10 @@ const SigninTokenCode = ({
   const [resendCodeLoading, setResendCodeLoading] = useState<boolean>(false);
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
-  const redirectTo = webRedirectCheck.isValid()
-    ? integration.data.redirectTo
-    : '';
+  const redirectTo =
+    isWebIntegration(integration) && webRedirectCheck.isValid()
+      ? integration.data.redirectTo
+      : '';
 
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -12,7 +12,7 @@ import VerificationMethods from '../../../constants/verification-methods';
 import { VERIFY_TOTP_CODE_MUTATION } from './gql';
 import { getSigninState } from '../utils';
 import { SigninLocationState } from '../interfaces';
-import { Integration, useAuthClient } from '../../../models';
+import { Integration, isWebIntegration, useAuthClient } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
@@ -46,9 +46,10 @@ export const SigninTotpCodeContainer = ({
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
-  const redirectTo = webRedirectCheck.isValid()
-    ? integration.data.redirectTo
-    : '';
+  const redirectTo =
+    isWebIntegration(integration) && webRedirectCheck.isValid()
+      ? integration.data.redirectTo
+      : '';
 
   const [verifyTotpCode] = useMutation(VERIFY_TOTP_CODE_MUTATION);
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -26,6 +26,7 @@ import {
   isOAuthIntegration,
   useSensitiveDataClient,
   useFtlMsgResolver,
+  isWebIntegration,
 } from '../../models';
 import {
   isClientMonitor,
@@ -131,9 +132,10 @@ const Signin = ({
             sessionToken,
           },
           integration,
-          redirectTo: webRedirectCheck.isValid()
-            ? integration.data.redirectTo
-            : '',
+          redirectTo:
+            isWebIntegration(integration) && webRedirectCheck.isValid()
+              ? integration.data.redirectTo
+              : '',
           finishOAuthFlowHandler,
           queryParams: location.search,
         };
@@ -191,9 +193,10 @@ const Signin = ({
           verified: data.signIn.verified,
           integration,
           finishOAuthFlowHandler,
-          redirectTo: webRedirectCheck.isValid()
-            ? integration.data.redirectTo
-            : '',
+          redirectTo:
+            isWebIntegration(integration) && webRedirectCheck.isValid()
+              ? integration.data.redirectTo
+              : '',
           queryParams: location.search,
         };
 


### PR DESCRIPTION
## Because

* Subplat subscriptions page sometimes redirects to force_auth and we need to pass params to this page as well as oauth/force_auth

## This pull request

* Update router.js to route force_auth and oauth/force_auth to react
* Only pass redirectTo to navigation handler if integration is web

## Issue that this pull request solves

Closes: #FXA-9826

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- To test, use 123Done to add a subscription to an existing account.
- Use the "manage billing" link in the welcome email and append `&forceExperiment=generalizedReactApp&forceExperimentGroup=react` to the link 
- Sign in to the account and expect to be redirected to the subscriptions page.
