### PR TITLE
fix(sync): Do not send fxaLogin on login submit when next page is 2FA

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -357,6 +357,18 @@ describe('Signin', () => {
                 '/connect_another_device?showSuccessMessage=true'
               );
             });
+            it('is not sent if user has 2FA enabled', async () => {
+              const beginSigninHandler = jest.fn().mockReturnValueOnce(
+                createBeginSigninResponse({
+                  verified: false,
+                  verificationMethod: VerificationMethods.TOTP_2FA,
+                })
+              );
+              const integration = createMockSigninSyncIntegration();
+              render({ beginSigninHandler, integration });
+              enterPasswordAndSubmit();
+              expect(fxaLoginSpy).not.toHaveBeenCalled();
+            });
             it('is not sent otherwise', async () => {
               render();
               enterPasswordAndSubmit();

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -58,7 +58,14 @@ export async function handleNavigation(
     return { error };
   }
 
-  if (tempHandleSyncLogin && navigationOptions.integration.isSync()) {
+  if (
+    tempHandleSyncLogin &&
+    navigationOptions.integration.isSync() &&
+    // If the _next page_ is `signin_totp_code`, we also don't want to send this
+    // because we end up sending it twice with the first message containing
+    // `verified: false`, causing a Sync sign-in issue (see FXA-9837).
+    !to?.includes('signin_totp_code')
+  ) {
     firefox.fxaLogin({
       email: navigationOptions.email,
       // keyFetchToken and unwrapBKey should always exist if Sync integration


### PR DESCRIPTION
Because:
* Users are not signed in to Sync after entering their 2FA code

This commit:
* Prevents the fxaLogin web channel message from being sent up if the next page in the navigation flow is TOTP since we send it up on submit on that page

fixes FXA-9837

---

To test this, create an account and add 2FA, then launch `fxa-dev-launcher` and go through the flow in Backbone and observe behavior. Then go through the flow again with React and ensure parity.

Also please double check going through this without TOTP to ensure no regression (which I did test). Might be good also to check the flow that goes through `signin_token_code` (I did not test) but Vijay is working on an intermittent issue in that flow.