### PR TITLE
bug(settings): Provide correct value for service when verifying 2fa

### DIFF
--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
@@ -66,7 +66,7 @@ jest.mock('../../models', () => {
   };
 });
 
-let mockGetCode = jest.fn();
+let mockGetCode = jest.fn().mockReturnValue('123456');
 jest.mock('../../lib/totp', () => {
   return {
     ...jest.requireActual('../../lib/totp'),
@@ -124,6 +124,7 @@ const defaultProps = {
   isSignedIn: true,
   integration: {
     returnOnError: () => true,
+    getService: () => '0123456789abcdef',
     getRedirectWithErrorUrl: (error: AuthUiError) =>
       `https://localhost:8080/?error=${error.errno}`,
   } as unknown as OAuthIntegration,
@@ -255,6 +256,14 @@ describe('InlineRecoverySetupContainer', () => {
           const result = await verifyTotpHandler();
           expect(mockGetCode).toHaveBeenCalledWith(MOCK_TOTP_TOKEN.secret);
           expect(mockVerifyTotpMutation).toHaveBeenCalledTimes(1);
+          expect(mockVerifyTotpMutation).toHaveBeenCalledWith({
+            variables: {
+              input: {
+                code: '123456',
+                service: '0123456789abcdef',
+              },
+            },
+          });
           expect(result).toBe(true);
         });
       });

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -58,11 +58,12 @@ export const InlineRecoverySetupContainer = ({
 
   const verifyTotpHandler = useCallback(async () => {
     const code = await getCode(totp!.secret);
+    const service = integration.getService();
     const result = await verifyTotp({
-      variables: { input: { code, service: serviceName } },
+      variables: { input: { code, service } },
     });
     return result.data!.verifyTotp.success;
-  }, [serviceName, totp, verifyTotp]);
+  }, [integration, totp, verifyTotp]);
 
   const successfulSetupHandler = useCallback(async () => {
     // When this is called, we know signinRecoveryLocationState exists.


### PR DESCRIPTION
## Because

- We noticed that gql queries in inline_totp_setup were failing
- The value for service wasn't passing validation
- The service name was being passed instead of the service id

## This pull request
- Passes the service identifier (aka the RPs client id) in for the service value.
- Uses the integration's 'getService' function to determine this value

## Issue that this pull request solves

Closes: FXA-9808

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

