### PR TITLE
add missing route to react signin routes

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -65,6 +65,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       routes: reactRoute.getRoutes([
         'signin',
         'oauth/signin',
+        'oauth/force_auth',
         'signin_token_code',
         'signin_totp_code',
         'signin_reported',


### PR DESCRIPTION
## Because

- `oauth/force_auth` was missing in react signin routes

## This pull request

- add routes to list

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
