### PR TITLE
fix(settings): Clear VerifyTotp error on backspace, delete, paste

### DIFF
--- a/packages/fxa-settings/src/components/TotpInputGroup/index.tsx
+++ b/packages/fxa-settings/src/components/TotpInputGroup/index.tsx
@@ -46,6 +46,7 @@ export const TotpInputGroup = ({
   };
 
   const handleBackspace = async (index: number) => {
+    errorMessage && setErrorMessage('');
     const currentCodeArray = [...codeArray];
     currentCodeArray[index] = undefined;
     await setCodeArray(currentCodeArray);
@@ -57,6 +58,7 @@ export const TotpInputGroup = ({
   };
 
   const handleDelete = async (index: number) => {
+    errorMessage && setErrorMessage('');
     const currentCodeArray = [...codeArray];
     if (currentCodeArray[index] !== undefined) {
       currentCodeArray[index] = undefined;
@@ -70,6 +72,7 @@ export const TotpInputGroup = ({
       focusOnSpecifiedInput(index);
     }
   };
+
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
     index: number
@@ -140,7 +143,7 @@ export const TotpInputGroup = ({
     e: React.ClipboardEvent<HTMLInputElement>,
     index: number
   ) => {
-    setErrorMessage('');
+    errorMessage && setErrorMessage('');
     let currentIndex = index;
     const currentCodeArray = [...codeArray];
     const clipboardText = e.clipboardData.getData('text');
@@ -157,6 +160,7 @@ export const TotpInputGroup = ({
         currentIndex++;
       }
     });
+
     await setCodeArray(currentCodeArray);
     // if last pasted character is on last input, focus on that input
     // otherwise focus on next input after last pasted character


### PR DESCRIPTION
## Because

- We want to clear the error when the code is edited

## This pull request

- Clears the error message when the users clicks backspace, delete or pastes a new code

## Issue that this pull request solves

Closes: #FXA-9806

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
