### PR TITLE
fix(totp): pass along signin state to totp view

### DIFF
--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -88,11 +88,6 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
           // Redirect to /signin since that page will send the user
           // to correct location
           return window.location.replace(`/signin?action=email&service=sync`);
-        } else if (
-          window.location &&
-          window.location.pathname.includes('signin_token_code')
-        ) {
-          // If the user is already on the signin_token_code page, we don't need to redirect
         } else {
           // If the user isn't in Settings and they see this message they may hit it due to
           // the initial metrics query - e.g. if they attempt to sign in and see the TOTP page,

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -162,7 +162,9 @@ describe('SigninTokenCode container', () => {
         });
 
         await waitFor(() => {
-          expect(mockNavigate).toBeCalledWith('/signin_totp_code');
+          expect(mockNavigate).toBeCalledWith('/signin_totp_code', {
+            state: mockLocationState,
+          });
         });
       });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -58,7 +58,9 @@ const SigninTokenCodeContainer = ({
   // redirect if there is 2FA is set up for the account,
   // but the session is not TOTP verified
   if (totpVerified) {
-    navigate('/signin_totp_code');
+    navigate('/signin_totp_code', {
+      state: signinState,
+    });
     return <LoadingSpinner fullScreen />;
   }
 


### PR DESCRIPTION
## Because

- We get an invalid token when entering 2FA code after being redirected from the `signin_token_code` page

## This pull request

- Passes the `signinState` to the TOTP view which specifies the session token to verify

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9836

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I tested this by creating an account, adding 2FA. In a new browser profile, attempt to login, after being prompted for 2FA code, replace url `signin_totp_code` with `signin_token_code`.

The page should redirect to totp page and you should be able to login.
