### PR TITLE
fix(eslint): Add no test.slow() eslint rule to functional tests

### DIFF
--- a/packages/eslint-plugin-fxa/lib/configs/default.js
+++ b/packages/eslint-plugin-fxa/lib/configs/default.js
@@ -33,6 +33,7 @@ module.exports = {
     'no-empty': 0,
     'no-eval': 2,
     'fxa/no-exclusive-tests': 2,
+    'fxa/no-test-slow': 0,
     'no-irregular-whitespace': 2,
     'no-loop-func': 0,
     'no-multi-spaces': 0,

--- a/packages/eslint-plugin-fxa/lib/rules/no-test-slow.js
+++ b/packages/eslint-plugin-fxa/lib/rules/no-test-slow.js
@@ -1,0 +1,19 @@
+module.exports = {
+  create: function (context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.object.name === 'test' &&
+          node.callee.property.name === 'slow'
+        ) {
+          context.report({
+            node,
+            message:
+              'Avoid using test.slow() in your test, change the default timeout.',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-fxa/test/no-test-slow.js
+++ b/packages/eslint-plugin-fxa/test/no-test-slow.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../lib/rules/no-test-slow');
+
+const ruleTester = new RuleTester();
+
+const fromError = {
+  message: 'Avoid using test.slow() in your test, change the default timeout.',
+};
+
+ruleTester.run('no-test-slow', rule, {
+  valid: ["test.describe('test')"],
+  invalid: [
+    {
+      code: `test.slow();`,
+      errors: [fromError],
+    },
+    {
+      code: `test.slow('condition', 'reason');`,
+      errors: [fromError],
+    },
+  ],
+});

--- a/packages/functional-tests/.eslintrc.js
+++ b/packages/functional-tests/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     browser: true,
   },
   extends: ['eslint:recommended', 'plugin:playwright/recommended'],
+  plugins: ['fxa'],
   globals: {
     globalThis: false, // not writeable
   },
@@ -12,6 +13,7 @@ module.exports = {
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-types': 'warn',
     'playwright/no-skipped-test': ['error', { allowConditional: true }],
+    'fxa/no-test-slow': 'warn',
     'no-console': ['error', { allow: ['log'] }], // console errors cause side effects in CircleCI (FXA-8773)
     'no-unused-vars': 'off',
   },


### PR DESCRIPTION
## Because

- In the last meeting we mentioned that future playwright tests should avoid using `test.slow()` and change default timeout

## This pull request

- Add new eslint rule to check for `test.slow()` usage, shows lint warning if you do use it

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
