### PR TITLE
refactor(functional-tests): consolidate email waiting and increase timeout

### DIFF
--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -82,7 +82,7 @@ export class EmailClient {
     emailAddress: string,
     type: EmailType,
     header?: EmailHeader,
-    timeout = 15000
+    timeout = 45000
   ) {
     const expires = Date.now() + timeout;
     while (Date.now() < expires) {
@@ -104,11 +104,81 @@ export class EmailClient {
     await got.delete(`${this.host}/mail/${toUsername(emailAddress)}`);
   }
 
-  async getResetPasswordCode(email: string) {
-    const code = this.waitForEmail(
+  async getLowRecoveryLink(email: string): Promise<string> {
+    const link = await this.waitForEmail(
+      email,
+      EmailType.lowRecoveryCodes,
+      EmailHeader.link
+    );
+    await this.clear(email);
+    return link;
+  }
+
+  async getRecoveryLink(email: string): Promise<string> {
+    const link = await this.waitForEmail(
+      email,
+      EmailType.recovery,
+      EmailHeader.link
+    );
+    await this.clear(email);
+    return link;
+  }
+
+  async getResetPasswordCode(email: string): Promise<string> {
+    const code = await this.waitForEmail(
       email,
       EmailType.passwordForgotOtp,
       EmailHeader.resetPasswordCode
+    );
+    await this.clear(email);
+    return code;
+  }
+
+  async getVerifyCode(email: string): Promise<string> {
+    const code = await this.waitForEmail(
+      email,
+      EmailType.verify,
+      EmailHeader.verifyCode
+    );
+    await this.clear(email);
+    return code;
+  }
+
+  async getVerifyLoginCode(email: string): Promise<string> {
+    const code = await this.waitForEmail(
+      email,
+      EmailType.verifyLoginCode,
+      EmailHeader.signinCode
+    );
+    await this.clear(email);
+    return code;
+  }
+
+  async getVerifySecondCode(email: string): Promise<string> {
+    const code = await this.waitForEmail(
+      email,
+      EmailType.verifySecondaryCode,
+      EmailHeader.verifyCode
+    );
+    await this.clear(email);
+    return code;
+  }
+
+  async getVerifyShortCode(email: string): Promise<string> {
+    const code = await this.waitForEmail(
+      email,
+      EmailType.verifyShortCode,
+      EmailHeader.shortCode
+    );
+    await this.clear(email);
+    return code;
+  }
+
+  async getUnblockCode(email: string): Promise<string> {
+    const code = await this.waitForEmail(
+      email,
+      EmailType.unblockCode,
+      EmailHeader.unblockCode
     );
     await this.clear(email);
     return code;

--- a/packages/functional-tests/lib/targets/remote.ts
+++ b/packages/functional-tests/lib/targets/remote.ts
@@ -1,5 +1,4 @@
 import { BaseTarget, Credentials } from './base';
-import { EmailHeader, EmailType } from '../email';
 
 export abstract class RemoteTarget extends BaseTarget {
   async createAccount(
@@ -15,13 +14,8 @@ export abstract class RemoteTarget extends BaseTarget {
       filteredOptions
     );
     if (preVerified === 'true') {
-      const code = await this.emailClient.waitForEmail(
-        email,
-        EmailType.verify,
-        EmailHeader.verifyCode
-      );
+      const code = await this.emailClient.getVerifyCode(email);
       await this.authClient.verifyCode(creds.uid, code);
-      await this.emailClient.clear(email);
     }
     await this.authClient.deviceRegister(
       creds.sessionToken,

--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../lib/email';
 import { BaseLayout } from './layout';
 import { getCode } from 'fxa-settings/src/lib/totp';
 
@@ -204,24 +203,12 @@ export class LoginPage extends BaseLayout {
     }
   }
 
-  async fillOutSignUpCode(email: string, waitForNavOnSubmit = true) {
-    const code = await this.target.emailClient.waitForEmail(
-      email,
-      EmailType.verifyShortCode,
-      EmailHeader.shortCode
-    );
-    await this.target.emailClient.clear(email);
+  async fillOutSignUpCode(code: string, waitForNavOnSubmit = true) {
     await this.setCode(code);
     await this.submit(waitForNavOnSubmit);
   }
 
-  async fillOutSignInCode(email: string) {
-    const code = await this.target.emailClient.waitForEmail(
-      email,
-      EmailType.verifyLoginCode,
-      EmailHeader.signinCode
-    );
-    await this.target.emailClient.clear(email);
+  async fillOutSignInCode(code: string) {
     await this.setCode(code);
     await this.submit();
   }
@@ -335,13 +322,7 @@ export class LoginPage extends BaseLayout {
     return this.page.locator(selectors.TOOLTIP);
   }
 
-  async unblock(email: string) {
-    const code = await this.target.emailClient.waitForEmail(
-      email,
-      EmailType.unblockCode,
-      EmailHeader.unblockCode
-    );
-    await this.target.emailClient.clear(email);
+  async unblock(code: string) {
     await this.setCode(code);
     await this.submit();
   }

--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { EmailHeader, EmailType } from '../../lib/email';
 import { SettingsLayout } from './layout';
 
 export class SecondaryEmailPage extends SettingsLayout {
@@ -39,19 +38,15 @@ export class SecondaryEmailPage extends SettingsLayout {
     return waitForNavigation;
   }
 
-  async addSecondaryEmail(email: string): Promise<void> {
+  async fillOutEmail(email: string): Promise<void> {
     await expect(this.secondaryEmailHeading).toBeVisible();
     await expect(this.step1Heading).toBeVisible();
 
     await this.emailTextbox.fill(email);
     await this.saveButton.click();
-    const code: string = await this.target.emailClient.waitForEmail(
-      email,
-      EmailType.verifySecondaryCode,
-      EmailHeader.verifyCode
-    );
-    await this.target.emailClient.clear(email);
+  }
 
+  async fillOutVerificationCode(code: string): Promise<void> {
     await expect(this.step2Heading).toBeVisible();
 
     await this.verificationCodeTextbox.fill(code);

--- a/packages/functional-tests/pages/signinReact.ts
+++ b/packages/functional-tests/pages/signinReact.ts
@@ -5,7 +5,6 @@
 import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 import { getReactFeatureFlagUrl } from '../lib/react-flag';
-import { EmailHeader, EmailType } from '../lib/email';
 
 export class SigninReactPage extends BaseLayout {
   readonly path = 'signin';
@@ -106,18 +105,5 @@ export class SigninReactPage extends BaseLayout {
 
     await this.passwordTextbox.fill(password);
     await this.signInButton.click();
-  }
-
-  async fillOutCodeForm(email: string) {
-    const code = await this.target.emailClient.waitForEmail(
-      email,
-      EmailType.verifyShortCode || EmailType.verifyLoginCode,
-      EmailHeader.shortCode || EmailHeader.signinCode
-    );
-
-    await expect(this.codeFormHeading).toBeVisible();
-
-    await this.codeTextbox.fill(code);
-    await this.confirmButton.click();
   }
 }

--- a/packages/functional-tests/pages/signupReact.ts
+++ b/packages/functional-tests/pages/signupReact.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 import { getReactFeatureFlagUrl } from '../lib/react-flag';
-import { EmailHeader, EmailType } from '../lib/email';
 
 export class SignupReactPage extends BaseLayout {
   readonly path = 'signup';
@@ -92,20 +91,7 @@ export class SignupReactPage extends BaseLayout {
     await this.createAccountButton.click();
   }
 
-  async fillOutFirstSignUp(email: string, password: string, age: string) {
-    await this.fillOutEmailForm(email);
-    await this.fillOutSignupForm(password, age);
-    await this.fillOutCodeForm(email);
-  }
-
-  async fillOutCodeForm(email: string) {
-    const code = await this.target.emailClient.waitForEmail(
-      email,
-      EmailType.verifyShortCode,
-      EmailHeader.shortCode
-    );
-    await this.target.emailClient.clear(email);
-
+  async fillOutCodeForm(code: string) {
     await expect(this.codeFormHeading).toBeVisible();
 
     await this.codeTextbox.fill(code);

--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -51,7 +51,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -91,7 +94,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/settings/);
 

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -77,7 +77,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const verifyCode = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(verifyCode);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -99,10 +102,8 @@ test.describe('severity-2 #smoke', () => {
         `${target.contentServerUrl}/reset_password?${reset.query}`
       );
       await resetPasswordReact.fillOutEmailForm(email);
-      const code = await target.emailClient.getResetPasswordCode(email);
-
-      await resetPasswordReact.fillOutResetPasswordCodeForm(code);
-
+      const resetCode = await target.emailClient.getResetPasswordCode(email);
+      await resetPasswordReact.fillOutResetPasswordCodeForm(resetCode);
       await resetPasswordReact.fillOutRecoveryKeyForm(key);
 
       await expect(page).toHaveURL(

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKeyWithLink.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKeyWithLink.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../lib/email';
 import { expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
@@ -80,7 +79,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -103,11 +105,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await resetPasswordReact.fillOutEmailForm(email);
       const link =
-        (await target.emailClient.waitForEmail(
-          email,
-          EmailType.recovery,
-          EmailHeader.link
-        )) + `&${reset.query}`;
+        (await target.emailClient.getRecoveryLink(email)) + `&${reset.query}`;
       await page.goto(link);
       await resetPasswordReact.fillOutRecoveryKeyForm(key);
 

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -75,7 +75,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const verifyCode = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(verifyCode);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -95,8 +98,8 @@ test.describe('severity-2 #smoke', () => {
       );
       await resetPasswordReact.fillOutEmailForm(email);
 
-      const code = await target.emailClient.getResetPasswordCode(email);
-      await resetPasswordReact.fillOutResetPasswordCodeForm(code);
+      const resetCode = await target.emailClient.getResetPasswordCode(email);
+      await resetPasswordReact.fillOutResetPasswordCodeForm(resetCode);
 
       await resetPasswordReact.fillOutNewPasswordForm(password);
 

--- a/packages/functional-tests/tests/key-stretching-v2/resetPasswordWithLink.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPasswordWithLink.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../lib/email';
 import { expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
@@ -78,7 +77,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -98,12 +100,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await resetPasswordReact.fillOutEmailForm(email);
       const link =
-        (await target.emailClient.waitForEmail(
-          email,
-          EmailType.recovery,
-          EmailHeader.link
-        )) + `&${reset.version}`;
-      target.emailClient.clear(email);
+        (await target.emailClient.getRecoveryLink(email)) + `&${reset.version}`;
       await page.goto(link);
       await resetPasswordReact.fillOutNewPasswordForm(password);
 

--- a/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../lib/email';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
@@ -50,7 +49,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const verifyCode = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(verifyCode);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -63,12 +65,8 @@ test.describe('severity-2 #smoke', () => {
 
       await expect(page).toHaveURL(/signin_unblock/);
 
-      const code = await target.emailClient.waitForEmail(
-        email,
-        EmailType.unblockCode,
-        EmailHeader.unblockCode
-      );
-      await signinUnblock.input.fill(code);
+      const unblockCode = await target.emailClient.getUnblockCode(email);
+      await signinUnblock.input.fill(unblockCode);
       await signinUnblock.submit.click();
 
       await expect(page).toHaveURL(/settings/);

--- a/packages/functional-tests/tests/key-stretching-v2/signup.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signup.spec.ts
@@ -39,7 +39,10 @@ test.describe('severity-2 #smoke', () => {
     await page.goto(
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
     );
-    await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+    await signupReact.fillOutEmailForm(email);
+    await signupReact.fillOutSignupForm(password, AGE_21);
+    const code = await target.emailClient.getVerifyShortCode(email);
+    await signupReact.fillOutCodeForm(code);
 
     await expect(page).toHaveURL(/settings/);
 
@@ -68,7 +71,10 @@ test.describe('severity-2 #smoke', () => {
     await page.goto(
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
     );
-    await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+    await signupReact.fillOutEmailForm(email);
+    await signupReact.fillOutSignupForm(password, AGE_21);
+    const code = await target.emailClient.getVerifyShortCode(email);
+    await signupReact.fillOutCodeForm(code);
 
     await expect(page).toHaveURL(/settings/);
 
@@ -97,7 +103,10 @@ test.describe('severity-2 #smoke', () => {
     await page.goto(
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
     );
-    await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+    await signupReact.fillOutEmailForm(email);
+    await signupReact.fillOutSignupForm(password, AGE_21);
+    const code = await target.emailClient.getVerifyShortCode(email);
+    await signupReact.fillOutCodeForm(code);
 
     await expect(page).toHaveURL(/settings/);
 
@@ -126,7 +135,10 @@ test.describe('severity-2 #smoke', () => {
     await page.goto(
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
     );
-    await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+    await signupReact.fillOutEmailForm(email);
+    await signupReact.fillOutSignupForm(password, AGE_21);
+    const code = await target.emailClient.getVerifyShortCode(email);
+    await signupReact.fillOutCodeForm(code);
 
     await expect(page).toHaveURL(/settings/);
 

--- a/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
@@ -33,7 +33,10 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signup.query}`
       );
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const verifyCode = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(verifyCode);
 
       await expect(page).toHaveURL(/settings/);
 

--- a/packages/functional-tests/tests/oauth/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/oauth/forceAuth.spec.ts
@@ -30,6 +30,7 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('with a unregistered email', async ({
+      target,
       pages: { configPage, login, relier },
       testAccountTracker,
     }) => {
@@ -50,7 +51,8 @@ test.describe('severity-1 #smoke', () => {
 
       await login.setAge(AGE_21);
       await login.setNewPassword(credentials.password);
-      await login.fillOutSignUpCode(newEmail);
+      const code = await target.emailClient.getVerifyShortCode(newEmail);
+      await login.fillOutSignUpCode(code);
 
       expect(await relier.isLoggedIn()).toBe(true);
     });
@@ -58,6 +60,7 @@ test.describe('severity-1 #smoke', () => {
 
   test.describe('OAuth force auth', () => {
     test('with blocked email', async ({
+      target,
       page,
       pages: { configPage, login, relier, settings, deleteAccount },
       testAccountTracker,
@@ -78,7 +81,10 @@ test.describe('severity-1 #smoke', () => {
 
       await login.setAge(AGE_21);
       await login.setNewPassword(credentials.password);
-      await login.fillOutSignUpCode(blockedEmail);
+      const shortCode = await target.emailClient.getVerifyShortCode(
+        blockedEmail
+      );
+      await login.fillOutSignUpCode(shortCode);
 
       expect(await relier.isLoggedIn()).toBe(true);
 
@@ -88,7 +94,8 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickForceAuth();
       await login.setPassword(credentials.password);
       await login.submit();
-      await login.unblock(blockedEmail);
+      const unblockCode = await target.emailClient.getUnblockCode(blockedEmail);
+      await login.unblock(unblockCode);
 
       expect(await relier.isLoggedIn()).toBe(true);
 

--- a/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
+++ b/packages/functional-tests/tests/oauth/scopeKeys.spec.ts
@@ -33,7 +33,8 @@ test.describe('OAuth scopeKeys', () => {
 
     await page.goto(target.contentServerUrl + `/?${query.toString()}`);
     await login.login(credentials.email, credentials.password);
-    await login.fillOutSignInCode(credentials.email);
+    const code = await target.emailClient.getVerifyLoginCode(credentials.email);
+    await login.fillOutSignInCode(code);
 
     await expect(login.notesHeader).toBeVisible();
   });

--- a/packages/functional-tests/tests/oauth/signUp.spec.ts
+++ b/packages/functional-tests/tests/oauth/signUp.spec.ts
@@ -15,6 +15,7 @@ test.describe('severity-1 #smoke', () => {
 
   test.describe('Oauth sign up', () => {
     test('sign up', async ({
+      target,
       pages: { login, relier },
       testAccountTracker,
     }) => {
@@ -26,7 +27,8 @@ test.describe('severity-1 #smoke', () => {
       //Verify sign up code header
       await expect(login.signUpCodeHeader).toBeVisible();
 
-      await login.fillOutSignUpCode(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await login.fillOutSignUpCode(code);
 
       //Verify logged in on relier page
       expect(await relier.isLoggedIn()).toBe(true);
@@ -86,7 +88,8 @@ test.describe('severity-1 #smoke', () => {
 
       //Verify sign up code header
       await expect(login.signUpCodeHeader).toBeVisible();
-      await login.fillOutSignUpCode(account.email);
+      const code = await target.emailClient.getVerifyShortCode(account.email);
+      await login.fillOutSignUpCode(code);
 
       //Verify logged in on relier page
       expect(await relier.isLoggedIn()).toBe(true);

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -77,6 +77,7 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('unverified, acts like signup', async ({
+      target,
       pages: { login, relier },
       testAccountTracker,
     }) => {
@@ -90,7 +91,10 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickEmailFirst();
       await login.login(credentials.email, credentials.password);
       // User is shown confirm email page
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
 
       expect(await relier.isLoggedIn()).toBe(true);
     });
@@ -120,7 +124,8 @@ test.describe('severity-1 #smoke', () => {
 
       await login.submit();
       // Verify email and ensure user is redirected to relier
-      await login.fillOutSignUpCode(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await login.fillOutSignUpCode(code);
 
       expect(await relier.isLoggedIn()).toBe(true);
     });

--- a/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
+++ b/packages/functional-tests/tests/oauth/signinTokenCode.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../lib/email';
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
@@ -89,10 +88,8 @@ test.describe('severity-2 #smoke', () => {
       // Correctly submits the token code and navigates to oauth page
       await expect(signinTokenCode.tokenCodeHeader).toBeVisible();
 
-      const code = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.verifyLoginCode,
-        EmailHeader.signinCode
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
       );
       await signinTokenCode.input.fill(code);
       await signinTokenCode.submit.click();

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -26,7 +26,10 @@ test.describe('severity-1 #smoke', () => {
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&`
       );
       await login.login(syncCredentials.email, syncCredentials.password);
-      await login.fillOutSignInCode(syncCredentials.email);
+      const loginCode = await target.emailClient.getVerifyLoginCode(
+        syncCredentials.email
+      );
+      await login.fillOutSignInCode(loginCode);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
@@ -34,12 +37,12 @@ test.describe('severity-1 #smoke', () => {
       await relier.goto();
       await relier.clickEmailFirst();
       await login.useDifferentAccountLink();
-
-      await signupReact.fillOutFirstSignUp(
-        account.email,
-        account.password,
-        AGE_21
+      await signupReact.fillOutEmailForm(account.email);
+      await signupReact.fillOutSignupForm(account.password, AGE_21);
+      const shortCode = await target.emailClient.getVerifyShortCode(
+        account.email
       );
+      await signupReact.fillOutCodeForm(shortCode);
 
       // RP is logged in, logout then back in again
       expect(await relier.isLoggedIn()).toBe(true);
@@ -73,8 +76,10 @@ test.describe('severity-1 #smoke', () => {
 
       await relier.goto();
       await relier.clickEmailFirst();
-
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const verifyCode = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(verifyCode);
 
       expect(await relier.isLoggedIn()).toBe(true);
 
@@ -86,7 +91,8 @@ test.describe('severity-1 #smoke', () => {
 
       await login.setPassword(password);
       await login.submit();
-      await login.fillOutSignInCode(email);
+      const loginCode = await target.emailClient.getVerifyLoginCode(email);
+      await login.fillOutSignInCode(loginCode);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });

--- a/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/forcePasswordChange.spec.ts
@@ -19,7 +19,10 @@ test.describe('severity-2 #smoke', () => {
         credentials.email,
         credentials.password
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);
@@ -34,6 +37,7 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('force change password on login - oauth', async ({
+      target,
       pages: { login, postVerify, relier },
       testAccountTracker,
     }) => {
@@ -46,7 +50,10 @@ test.describe('severity-2 #smoke', () => {
         credentials.email,
         credentials.password
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);

--- a/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
@@ -21,7 +21,10 @@ test.describe('severity-2 #smoke', () => {
         credentials.email,
         credentials.password
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
 
       //Verify force password change header
       expect(await postVerify.isForcePasswordChangeHeader()).toBe(true);

--- a/packages/functional-tests/tests/react-conversion/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/changeEmail.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
 import { ChangePasswordPage } from '../../pages/settings/changePassword';
 import { SecondaryEmailPage } from '../../pages/settings/secondaryEmail';
@@ -35,7 +36,7 @@ test.describe('severity-1 #smoke', () => {
       // Verify successfully navigated to settings
       await expect(page).toHaveURL(/settings/);
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       const previousEmail = credentials.email;
       credentials.email = newEmail;
 
@@ -80,7 +81,7 @@ test.describe('severity-1 #smoke', () => {
       // Verify successfully navigated to settings
       await expect(page).toHaveURL(/settings/);
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       credentials.email = newEmail;
 
       await setNewPassword(
@@ -135,7 +136,7 @@ test.describe('severity-1 #smoke', () => {
       // Verify successfully navigated to settings
       await expect(page).toHaveURL(/settings/);
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       credentials.email = newEmail;
 
       // Click delete account
@@ -157,12 +158,15 @@ test.describe('severity-1 #smoke', () => {
 });
 
 async function changePrimaryEmail(
+  target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
   email: string
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
-  await secondaryEmail.addSecondaryEmail(email);
+  await secondaryEmail.fillOutEmail(email);
+  const code: string = await target.emailClient.getVerifySecondCode(email);
+  await secondaryEmail.fillOutVerificationCode(code);
   await settings.secondaryEmail.makePrimaryButton.click();
 
   await expect(settings.settingsHeading).toBeVisible();

--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -140,6 +140,7 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('unverified account, requires signup confirmation code', async ({
+      target,
       pages: { configPage, page, relier, signinReact, signupReact },
       testAccountTracker,
     }) => {
@@ -168,12 +169,16 @@ test.describe('severity-1 #smoke', () => {
       // User is shown confirm code page
       await expect(page).toHaveURL(/confirm_signup_code/);
       await signupReact.resendCodeButton.click();
-      await signupReact.fillOutCodeForm(credentials.email);
+      const code = await target.emailClient.getVerifyShortCode(
+        credentials.email
+      );
+      await signupReact.fillOutCodeForm(code);
 
       expect(await relier.isLoggedIn()).toBe(true);
     });
 
     test('unverified account with a cached login, requires signup confirmation', async ({
+      target,
       pages: { configPage, page, relier, signinReact, signupReact },
       testAccountTracker,
     }) => {
@@ -209,12 +214,14 @@ test.describe('severity-1 #smoke', () => {
 
       // Verify email and ensure user is redirected to relier
       await expect(page).toHaveURL(/confirm_signup_code/);
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       expect(await relier.isLoggedIn()).toBe(true);
     });
 
     test('oauth endpoint chooses the right auth flows', async ({
+      target,
       page,
       pages: { configPage, relier, signinReact, signupReact },
       testAccountTracker,
@@ -238,7 +245,8 @@ test.describe('severity-1 #smoke', () => {
 
       await signupReact.fillOutEmailForm(email);
       await signupReact.fillOutSignupForm(password, AGE_21);
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       // go back to the OAuth app, the /oauth flow should
       // now suggest a cached login

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -41,10 +41,9 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await signupReact.fillOutEmailForm(email);
-
       await signupReact.fillOutSignupForm(password, AGE_21);
-
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       // expect to be redirected to relier after confirming signup code
       await expect(page).toHaveURL(target.relierUrl);
@@ -80,10 +79,9 @@ test.describe('severity-1 #smoke', () => {
       await expect(page).toHaveURL(/^((?!redirect_uri).)*$/);
 
       await signupReact.fillOutEmailForm(email);
-
       await signupReact.fillOutSignupForm(password, AGE_21);
-
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
       // redirectUri should have fallen back to the clientInfo config redirect URI
       // Expect to be redirected to relier
       await page.waitForURL(target.relierUrl);
@@ -94,6 +92,7 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup oauth webchannel - sync mobile or FF desktop 123+', async ({
+      target,
       syncBrowserPages: { page, login, signupReact },
       testAccountTracker,
     }) => {
@@ -133,8 +132,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(login.CWTSEngineAddresses).toBeHidden();
 
       await signupReact.fillOutSignupForm(password, AGE_21);
-
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
       await page.waitForURL(/connect_another_device/);
 
       await signupReact.checkWebChannelMessage(FirefoxCommand.OAuthLogin);

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -28,6 +28,7 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup web', async ({
+      target,
       page,
       pages: { settings, signupReact },
       testAccountTracker,
@@ -41,8 +42,8 @@ test.describe('severity-1 #smoke', () => {
       await signupReact.waitForRoot();
 
       await signupReact.fillOutSignupForm(password, AGE_21);
-
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/settings/);
 
@@ -50,6 +51,7 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signup sync desktop v3, verify account', async ({
+      target,
       syncBrowserPages: { page, signupReact, login },
       testAccountTracker,
     }) => {
@@ -84,8 +86,8 @@ test.describe('severity-1 #smoke', () => {
       await signupReact.fillOutSignupForm(password, AGE_21);
 
       await login.checkWebChannelMessage(FirefoxCommand.Login);
-
-      await signupReact.fillOutCodeForm(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
       await page.waitForURL(/connect_another_device/);
 
       await expect(page.getByText('You’re signed into Firefox')).toBeVisible();
@@ -163,7 +165,10 @@ test.describe('severity-2 #smoke', () => {
 
       // Click the sign in link
       await subscribe.signinLink.click();
-      await signupReact.fillOutFirstSignUp(email, password, AGE_21);
+      await signupReact.fillOutEmailForm(email);
+      await signupReact.fillOutSignupForm(password, AGE_21);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await signupReact.fillOutCodeForm(code);
       /*
        * We must `waitUntil: 'load'` due to redirects that occur here. Note,
        * React signup for SubPlat has one additional redirect compared to Backbone.

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPassword.spec.ts
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../../lib/email';
 import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { syncMobileOAuthQueryParams } from '../../../lib/query-params';
-import { BaseTarget } from '../../../lib/targets/base';
 import { ResetPasswordReactPage } from '../../../pages/resetPasswordReact';
 import { LoginPage } from '../../../pages/login';
 
@@ -44,12 +42,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_123
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
       credentials.password = newPassword;
@@ -91,12 +85,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_FIREFOX
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
       credentials.password = newPassword;
@@ -136,12 +126,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_123
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       // Clearing session state simulates a 'new' tab, and changes the navigation at the end of the flow.
       await page.evaluate(() => window.sessionStorage.clear());
 
@@ -195,12 +181,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_123
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       // Clearing session state simulates a 'new' tab, and changes the navigation at the end of the flow.
       await page.evaluate(() => window.sessionStorage.clear());
 
@@ -258,12 +240,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_123
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link, { waitUntil: 'load' });
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
       credentials.password = newPassword;
@@ -307,19 +285,5 @@ test.describe('severity-1 #smoke', () => {
     await expect(resetPasswordReact.resetPasswordHeading).toContainText(
       serviceName
     );
-  }
-
-  async function getConfirmationEmail(
-    target: BaseTarget,
-    resetPasswordReact: ResetPasswordReactPage,
-    email: string
-  ) {
-    await resetPasswordReact.fillOutEmailForm(email);
-    const link = await target.emailClient.waitForEmail(
-      email,
-      EmailType.recovery,
-      EmailHeader.link
-    );
-    return link;
   }
 });

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordRecoveryKey.spec.ts
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../../lib/email';
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import { BaseTarget } from '../../../lib/targets/base';
 import { ResetPasswordReactPage } from '../../../pages/resetPasswordReact';
 import { LoginPage } from '../../../pages/login';
 
@@ -61,12 +59,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_123
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link, { waitUntil: 'load' });
       await resetPasswordReact.fillOutRecoveryKeyForm(accountRecoveryKey);
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
@@ -112,19 +106,5 @@ test.describe('severity-1 #smoke', () => {
     await expect(resetPasswordReact.resetPasswordHeading).toContainText(
       serviceName
     );
-  }
-
-  async function getConfirmationEmail(
-    target: BaseTarget,
-    resetPasswordReact: ResetPasswordReactPage,
-    email: string
-  ) {
-    await resetPasswordReact.fillOutEmailForm(email);
-    const link = await target.emailClient.waitForEmail(
-      email,
-      EmailType.recovery,
-      EmailHeader.link
-    );
-    return link;
   }
 });

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordScopeKeys.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordScopeKeys.spec.ts
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../../lib/email';
 import { Page, expect, test } from '../../../lib/fixtures/standard';
-import { BaseTarget } from '../../../lib/targets/base';
 import { ResetPasswordReactPage } from '../../../pages/resetPasswordReact';
 import { LoginPage } from '../../../pages/login';
 
@@ -42,12 +40,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_123
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
       credentials.password = newPassword;
@@ -93,19 +87,5 @@ test.describe('severity-1 #smoke', () => {
     await expect(resetPasswordReact.resetPasswordHeading).toContainText(
       serviceName
     );
-  }
-
-  async function getConfirmationEmail(
-    target: BaseTarget,
-    resetPasswordReact: ResetPasswordReactPage,
-    email: string
-  ) {
-    await resetPasswordReact.fillOutEmailForm(email);
-    const link = await target.emailClient.waitForEmail(
-      email,
-      EmailType.recovery,
-      EmailHeader.link
-    );
-    return link;
   }
 });

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordSyncMobile.spec.ts
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../../lib/email';
 import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { syncMobileOAuthQueryParams } from '../../../lib/query-params';
-import { BaseTarget } from '../../../lib/targets/base';
 import { ResetPasswordReactPage } from '../../../pages/resetPasswordReact';
 import { LoginPage } from '../../../pages/login';
 
@@ -44,12 +42,8 @@ test.describe('severity-1 #smoke', () => {
         SERVICE_NAME_FIREFOX
       );
 
-      const link = await getConfirmationEmail(
-        target,
-        resetPasswordReact,
-        credentials.email
-      );
-
+      await resetPasswordReact.fillOutEmailForm(credentials.email);
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
       credentials.password = newPassword;
@@ -95,19 +89,5 @@ test.describe('severity-1 #smoke', () => {
     await expect(resetPasswordReact.resetPasswordHeading).toContainText(
       serviceName
     );
-  }
-
-  async function getConfirmationEmail(
-    target: BaseTarget,
-    resetPasswordReact: ResetPasswordReactPage,
-    email: string
-  ) {
-    await resetPasswordReact.fillOutEmailForm(email);
-    const link = await target.emailClient.waitForEmail(
-      email,
-      EmailType.recovery,
-      EmailHeader.link
-    );
-    return link;
   }
 });

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/resetPassword.spec.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../../lib/fixtures/standard';
-import { EmailHeader, EmailType } from '../../../lib/email';
 import { ResetPasswordReactPage } from '../../../pages/resetPasswordReact';
 
 test.describe('severity-1 #smoke', () => {
@@ -35,12 +34,7 @@ test.describe('severity-1 #smoke', () => {
         resetPasswordReact.confirmResetPasswordHeading
       ).toBeVisible();
 
-      const link = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.recovery,
-        EmailHeader.link
-      );
-
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       // Open link in a new window
       const diffPage = await context.newPage();
       const diffResetPasswordReact = new ResetPasswordReactPage(
@@ -99,11 +93,7 @@ test.describe('severity-1 #smoke', () => {
       await resetPasswordReact.goto();
 
       await resetPasswordReact.fillOutEmailForm(credentials.email);
-      const link = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.recovery,
-        EmailHeader.link
-      );
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.fillOutNewPasswordForm(credentials.password);
 
@@ -145,12 +135,9 @@ test.describe('severity-1 #smoke', () => {
           resetPasswordReact.confirmResetPasswordHeading
         ).toBeVisible();
 
-        const link = await target.emailClient.waitForEmail(
-          credentials.email,
-          EmailType.recovery,
-          EmailHeader.link
+        const link = await target.emailClient.getRecoveryLink(
+          credentials.email
         );
-
         // Open link in a new window
         const diffPage = await context.newPage();
         const diffResetPasswordReact = new ResetPasswordReactPage(

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/resetPasswordRecoveryKey.spec.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../../lib/fixtures/standard';
-import { EmailHeader, EmailType } from '../../../lib/email';
 
 const HINT = 'secret key location';
 
@@ -70,11 +69,7 @@ test.describe('severity-1 #smoke', () => {
         resetPasswordReact.confirmResetPasswordHeading
       ).toBeVisible();
 
-      const link = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.recovery,
-        EmailHeader.link
-      );
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.fillOutRecoveryKeyForm(key);
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);
@@ -129,11 +124,7 @@ test.describe('severity-1 #smoke', () => {
       await resetPasswordReact.goto();
 
       await resetPasswordReact.fillOutEmailForm(credentials.email);
-      const link = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.recovery,
-        EmailHeader.link
-      );
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
       await resetPasswordReact.forgotKeyLink.click();
       await resetPasswordReact.fillOutNewPasswordForm(credentials.password);

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/syncV3ResetPassword.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../../lib/email';
 import { expect, test } from '../../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
@@ -35,11 +34,7 @@ test.describe('severity-1 #smoke', () => {
 
       await resetPasswordReact.fillOutEmailForm(credentials.email);
 
-      const link = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.recovery,
-        EmailHeader.link
-      );
+      const link = await target.emailClient.getRecoveryLink(credentials.email);
       await page.goto(link);
 
       await resetPasswordReact.fillOutNewPasswordForm(newPassword);

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -27,7 +27,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       const oldEmail = credentials.email;
       credentials.email = newEmail;
 
@@ -66,7 +66,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       credentials.email = newEmail;
 
       await setNewPassword(
@@ -111,7 +111,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       const oldEmail = credentials.email;
       credentials.email = newEmail;
 
@@ -168,7 +168,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       credentials.email = newEmail;
 
       // Click delete account
@@ -199,7 +199,11 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
-      await secondaryEmail.addSecondaryEmail(newEmail);
+      await secondaryEmail.fillOutEmail(newEmail);
+      const code: string = await target.emailClient.getVerifySecondCode(
+        newEmail
+      );
+      await secondaryEmail.fillOutVerificationCode(code);
 
       await expect(settings.alertBar).toHaveText(/successfully added/);
 
@@ -243,12 +247,15 @@ async function signInAccount(
 }
 
 async function changePrimaryEmail(
+  target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
   email: string
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
-  await secondaryEmail.addSecondaryEmail(email);
+  await secondaryEmail.fillOutEmail(email);
+  const code: string = await target.emailClient.getVerifySecondCode(email);
+  await secondaryEmail.fillOutVerificationCode(code);
   await settings.secondaryEmail.makePrimaryButton.click();
 
   await expect(settings.settingsHeading).toBeVisible();

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { EmailHeader, EmailType } from '../../lib/email';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
@@ -184,10 +183,8 @@ test.describe('severity-1 #smoke', () => {
         recoveryCodes[recoveryCodes.length - 1]
       );
       await login.page.waitForURL(/settings/);
-      const link = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.lowRecoveryCodes,
-        EmailHeader.link
+      const link = await target.emailClient.getLowRecoveryLink(
+        credentials.email
       );
       await page.goto(link);
       const newCodes = await totp.getRecoveryCodes();

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -25,7 +25,8 @@ test.describe('severity-2 #smoke', () => {
       );
 
       //Unblock the email
-      await login.unblock(credentials.email);
+      const code = await target.emailClient.getUnblockCode(credentials.email);
+      await login.unblock(code);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -55,7 +56,8 @@ test.describe('severity-2 #smoke', () => {
       );
 
       //Unblock the email
-      await login.unblock(credentials.email);
+      const code = await target.emailClient.getUnblockCode(credentials.email);
+      await login.unblock(code);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -84,7 +86,8 @@ test.describe('severity-2 #smoke', () => {
       await expect(signinUnblock.successMessage).toBeVisible();
 
       //Unblock the email
-      await login.unblock(credentials.email);
+      const code = await target.emailClient.getUnblockCode(credentials.email);
+      await login.unblock(code);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -114,12 +117,18 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.getUnblockEmail()).toContain(credentials.email);
 
       //Unblock the email
-      await login.unblock(credentials.email);
+      const unblockCode = await target.emailClient.getUnblockCode(
+        credentials.email
+      );
+      await login.unblock(unblockCode);
 
       //Verify confirm code header
       await expect(login.signUpCodeHeader).toBeVisible();
 
-      await login.fillOutSignInCode(credentials.email);
+      const verifyCode = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(verifyCode);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);
@@ -144,7 +153,11 @@ test.describe('severity-2 #smoke', () => {
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
-      await secondaryEmail.addSecondaryEmail(blockedEmail);
+      await secondaryEmail.fillOutEmail(blockedEmail);
+      const verifyCode: string = await target.emailClient.getVerifySecondCode(
+        blockedEmail
+      );
+      await secondaryEmail.fillOutVerificationCode(verifyCode);
       await settings.secondaryEmail.makePrimaryButton.click();
       credentials.email = blockedEmail;
       await settings.signOut();
@@ -157,7 +170,8 @@ test.describe('severity-2 #smoke', () => {
       expect(await login.getUnblockEmail()).toContain(blockedEmail);
 
       //Unblock the email
-      await login.unblock(blockedEmail);
+      const unblockCode = await target.emailClient.getUnblockCode(blockedEmail);
+      await login.unblock(unblockCode);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -145,7 +145,10 @@ test.describe('severity-2 #smoke', () => {
       await expect(login.signUpCodeHeader).toBeVisible();
 
       //Fill the code and submit
-      await login.fillOutSignUpCode(credentials.email);
+      const code = await target.emailClient.getVerifyShortCode(
+        credentials.email
+      );
+      await login.fillOutSignUpCode(code);
 
       //Verify logged in on Settings page
       expect(await login.isUserLoggedIn()).toBe(true);

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -12,6 +12,7 @@ const makeUid = () =>
 test.describe('severity-1 #smoke', () => {
   test.describe('Desktop Sync V3 force auth', () => {
     test('sync v3 with a registered email, no uid', async ({
+      target,
       syncBrowserPages: {
         fxDesktopV3ForceAuth,
         login,
@@ -31,12 +32,16 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.checkWebChannelMessage(
         'fxaccounts:can_link_account'
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await fxDesktopV3ForceAuth.checkWebChannelMessage('fxaccounts:login');
     });
 
     test('sync v3 with a registered email, registered uid', async ({
+      target,
       syncBrowserPages: {
         fxDesktopV3ForceAuth,
         login,
@@ -54,12 +59,16 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.checkWebChannelMessage(
         'fxaccounts:can_link_account'
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await fxDesktopV3ForceAuth.checkWebChannelMessage('fxaccounts:login');
     });
 
     test('sync v3 with a registered email, unregistered uid', async ({
+      target,
       syncBrowserPages: {
         fxDesktopV3ForceAuth,
         login,
@@ -80,12 +89,16 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.checkWebChannelMessage(
         'fxaccounts:can_link_account'
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await fxDesktopV3ForceAuth.checkWebChannelMessage('fxaccounts:login');
     });
 
     test('blocked with an registered email, unregistered uid', async ({
+      target,
       syncBrowserPages: {
         page,
         fxDesktopV3ForceAuth,
@@ -107,7 +120,8 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.checkWebChannelMessage(
         'fxaccounts:can_link_account'
       );
-      await login.unblock(credentials.email);
+      const code = await target.emailClient.getUnblockCode(credentials.email);
+      await login.unblock(code);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await fxDesktopV3ForceAuth.checkWebChannelMessage('fxaccounts:login');
 

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -39,7 +39,10 @@ test.describe('severity-2 #smoke', () => {
       await expect(login.signInCodeHeader).toBeVisible();
 
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
       await login.checkWebChannelMessage(FirefoxCommand.Login);
 
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
@@ -93,7 +96,10 @@ test.describe('severity-2 #smoke', () => {
       await expect(login.signInCodeHeader).toBeVisible();
 
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
       await login.checkWebChannelMessage(FirefoxCommand.Login);
 
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
@@ -130,7 +136,10 @@ test.describe('severity-2 #smoke', () => {
         credentials.email,
         credentials.password
       );
-      await login.fillOutSignInCode(credentials.email);
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await login.fillOutSignInCode(code);
 
       //Go to setting page
       await page.goto(

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -4,7 +4,6 @@
 
 import { getCode } from 'fxa-settings/src/lib/totp';
 import { TestAccountTracker } from '../../lib/testAccountTracker';
-import { EmailHeader, EmailType } from '../../lib/email';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { LoginPage } from '../../pages/login';
@@ -49,10 +48,8 @@ test.describe('severity-2 #smoke', () => {
       await expect(signinTokenCode.successMessage).toContainText(
         /Email re-?sent/
       );
-      const code = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.verifyLoginCode,
-        EmailHeader.signinCode
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
       );
       await signinTokenCode.input.fill(code);
       await signinTokenCode.submit.click();
@@ -76,10 +73,8 @@ test.describe('severity-2 #smoke', () => {
       );
       await login.login(credentials.email, credentials.password);
 
-      const code = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.verifyLoginCode,
-        EmailHeader.signinCode
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
       );
       await signinTokenCode.input.fill(code);
       await signinTokenCode.submit.click();
@@ -111,10 +106,8 @@ test.describe('severity-2 #smoke', () => {
       await expect(signinTokenCode.tooltip).toBeVisible();
       await expect(signinTokenCode.tooltip).toContainText('Invalid or expired');
 
-      const code = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.verifyLoginCode,
-        EmailHeader.signinCode
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
       );
       await signinTokenCode.input.fill(code);
       await signinTokenCode.submit.click();
@@ -144,10 +137,8 @@ test.describe('severity-2 #smoke', () => {
       await login.login(credentials.email, credentials.password);
 
       // Since the account is not verified yet, we'd expect to see the signup code confirmation
-      const code = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.verifyLoginCode,
-        EmailHeader.signinCode
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
       );
       await confirmSignupCode.input.fill(code);
       await confirmSignupCode.submit.click();
@@ -220,11 +211,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await login.login(credentials.email, credentials.password);
 
-      const code = await target.emailClient.waitForEmail(
-        credentials.email,
-        EmailType.unblockCode,
-        EmailHeader.unblockCode
-      );
+      const code = await target.emailClient.getUnblockCode(credentials.email);
       await signinUnblock.input.fill(code);
       await signinUnblock.submit.click();
 

--- a/packages/functional-tests/tests/syncV3/signUp.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUp.spec.ts
@@ -48,7 +48,10 @@ test.describe('severity-1 #smoke', () => {
       // Fix the error
       await login.confirmPassword(credentials.password);
       await login.submit();
-      await login.fillOutSignUpCode(credentials.email);
+      const code = await target.emailClient.getVerifyShortCode(
+        credentials.email
+      );
+      await login.fillOutSignUpCode(code);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
@@ -74,7 +77,8 @@ test.describe('severity-1 #smoke', () => {
 
       // Age textbox is not on the page and click submit
       await login.submit();
-      await login.fillOutSignUpCode(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await login.fillOutSignUpCode(code);
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
 

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -73,7 +73,8 @@ test.describe('severity-1 #smoke', () => {
       await login.CWTSEnginePasswords.click();
       await login.clickSubmit();
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
-      await login.fillOutSignUpCode(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await login.fillOutSignUpCode(code);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
@@ -121,7 +122,8 @@ test.describe('severity-1 #smoke', () => {
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
       await login.noSuchWebChannelMessage(FirefoxCommand.Login);
       await login.clickSubmit();
-      await login.fillOutSignUpCode(email);
+      const code = await target.emailClient.getVerifyShortCode(email);
+      await login.fillOutSignUpCode(code);
       await login.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });


### PR DESCRIPTION
## Because

- we hypothesis that the cause of intermittence in functional tests may be due to uncleared emails and inadequate wait times

## This pull request

- consolidates waiting for emails to the EmailClient
- decouples the EmailClient from POMS
- increases the default timeout from 15 to 45 seconds

## Issue that this pull request solves

Closes: # FXA-9851

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

We expect to see a drop in the number of 'retries' in the Nightly monitoring after this change (see [FxA Functional Test Suite Metrics](https://docs.google.com/spreadsheets/d/1qKwxsSI2RNo-qKZflETtBbyZ9b0ZUB_id2SL17_MmYo/edit#gid=1830381531))