### PR TITLE
fix(content): Set email for force_auth with React signin

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -421,6 +421,8 @@ var BaseView = Backbone.View.extend({
   // specifies an email address, we force the user to use that account.
   _reAuthPage() {
     if (this.relier && this.relier.get('email')) {
+      // setting the email here ensures that React signin can pick up on this email
+      this.user.set('email', this.relier.get('email'));
       return 'force_auth';
     }
     // Until email-first is fully the default, this is


### PR DESCRIPTION
## Because

* If the user reaches a page where they must reauth, for example when following a link from email, we want to suggest the provided email for signin instead of asking the user to re-enter their email (matching parity with backbone)

## This pull request


* When reauth is required and there is a redirect to force_auth, set the email on the user model so it can be picked up when navigating to react

## Issue that this pull request solves

Closes: #FXA-9855

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

One way to test:
1. Have an account created with a product subscription (subscribe to a product via 123Done)
2. Sign out of the account 
3. From the subscription welcome email, look for the "Update billing information" link
a. For backbone: follow the link and observe that redirected to force_auth page to enter password
b. For react, without this PR: paste the link into the search bar and add react params `forceExperiment=generalizedReactApp&forceExperimentGroup=react`. Observe that redirected to index page to re-enter email.
c. For react, with this PR: paste the link into the search bar and add react params `forceExperiment=generalizedReactApp&forceExperimentGroup=react`. Observe that redirected to signin page to enter password (skip index).