### PR TITLE
fix(login): remove webchannel login when at signin token code load

### DIFF
--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -146,7 +146,7 @@ export abstract class BaseLayout {
    * NOTE: Prefer `respondToWebChannelMessage` where possible! This should only be
    * used when we can't attach a listener in time (which respondToWebChannelMessage
    * does) because the event is fired on page load before the listener can attach.
-   * This currently happens on React SignUp which we should revisit when the index
+   * This currently happens on React SignUp and SignIn which we should revisit when the index
    * index page has been converted to React and our event handling moved.
    */
   async sendWebChannelMessage(customEventDetail: CustomEventDetail) {

--- a/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
+import { createCustomEventDetail, FirefoxCommand } from '../../lib/channels';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('connect_another_device', () => {
@@ -25,6 +26,12 @@ test.describe('severity-2 #smoke', () => {
 
       await signinReact.fillOutEmailFirstForm(credentials.email);
       await signinReact.fillOutPasswordForm(credentials.password);
+
+      await signinReact.sendWebChannelMessage(
+        createCustomEventDetail(FirefoxCommand.LinkAccount, {
+          ok: true,
+        })
+      );
 
       await expect(page).toHaveURL(/connect_another_device/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { test, expect } from '../../lib/fixtures/standard';
+import { createCustomEventDetail, FirefoxCommand } from '../../lib/channels';
 
 test.describe('severity-1 #smoke', () => {
   test('react signin to sync and disconnect', async ({
@@ -32,6 +33,12 @@ test.describe('severity-1 #smoke', () => {
 
     await signinReact.fillOutEmailFirstForm(credentials.email);
     await signinReact.fillOutPasswordForm(credentials.password);
+
+    await signinReact.sendWebChannelMessage(
+      createCustomEventDetail(FirefoxCommand.LinkAccount, {
+        ok: true,
+      })
+    );
 
     await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     await connectAnotherDevice.startBrowsingButton.click();

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../lib/fixtures/standard';
+import { createCustomEventDetail, FirefoxCommand } from '../../lib/channels';
+import { EmailHeader, EmailType } from '../../lib/email';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 signin react', () => {
@@ -25,7 +27,57 @@ test.describe('severity-2 #smoke', () => {
       await expect(signinReact.syncSignInHeading).toBeVisible();
       await signinReact.fillOutEmailFirstForm(credentials.email);
       await signinReact.fillOutPasswordForm(credentials.password);
+
+      await signinReact.sendWebChannelMessage(
+        createCustomEventDetail(FirefoxCommand.LinkAccount, {
+          ok: true,
+        })
+      );
+
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
+  });
+
+  test('verified, does need to confirm', async ({
+    target,
+    page,
+    pages: { login, signinReact, settings, deleteAccount },
+    testAccountTracker,
+  }) => {
+    const credentials = await testAccountTracker.signUpSync();
+
+    const syncParams = new URLSearchParams();
+    syncParams.append('context', 'fx_desktop_v3');
+    syncParams.append('service', 'sync');
+    syncParams.append('action', 'email');
+    await signinReact.goto('/', syncParams);
+
+    await signinReact.fillOutEmailFirstForm(credentials.email);
+    await signinReact.fillOutPasswordForm(credentials.password);
+
+    await signinReact.sendWebChannelMessage(
+      createCustomEventDetail(FirefoxCommand.LinkAccount, {
+        ok: true,
+      })
+    );
+
+    await page.waitForURL(/signin_token_code/);
+
+    const code = await target.emailClient.waitForEmail(
+      credentials.email,
+      EmailType.verifyLoginCode,
+      EmailHeader.signinCode
+    );
+
+    await expect(
+      signinReact.page.getByRole('heading', {
+        name: 'Enter confirmation code',
+      })
+    ).toBeVisible();
+
+    await signinReact.codeTextbox.fill(code);
+    await signinReact.confirmButton.click();
+
+    await page.waitForURL(/connect_another_device/);
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -90,7 +90,7 @@ const SigninRecoveryCode = ({
       queryParams: location.search,
     };
 
-    const { error } = await handleNavigation(navigationOptions);
+    const { error } = await handleNavigation(navigationOptions, true);
     if (error) {
       setBannerErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, error));
     }

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -18,13 +18,8 @@ import { Subject } from './mocks';
 import { MOCK_SIGNUP_CODE } from '../../Signup/ConfirmSignupCode/mocks';
 import { MOCK_EMAIL, MOCK_OAUTH_FLOW_HANDLER_RESPONSE } from '../../mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import {
-  createMockSigninOAuthIntegration,
-  createMockSigninSyncIntegration,
-} from '../mocks';
-import { createMockSigninLocationState } from './mocks';
+import { createMockSigninOAuthIntegration } from '../mocks';
 import VerificationReasons from '../../../constants/verification-reasons';
-import firefox from '../../../lib/channels/firefox';
 import { navigate } from '@reach/router';
 
 jest.mock('../../../lib/metrics', () => ({
@@ -120,24 +115,6 @@ describe('SigninTokenCode page', () => {
     render();
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
     expect(GleanMetrics.loginConfirmation.view).toBeCalledTimes(1);
-  });
-
-  describe('fxaLogin webchannel message', () => {
-    let fxaLoginSpy: jest.SpyInstance;
-    beforeEach(() => {
-      fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
-    });
-    it('is sent if Sync integration', () => {
-      const integration = createMockSigninSyncIntegration();
-      render({ integration });
-      expect(fxaLoginSpy).toHaveBeenCalledWith({
-        ...createMockSigninLocationState(integration.wantsKeys()),
-      });
-    });
-    it('is not sent otherwise', () => {
-      render();
-      expect(fxaLoginSpy).not.toBeCalled();
-    });
   });
 
   describe('handleResendCode submission', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -27,7 +27,6 @@ import Banner, {
   ResendEmailSuccessBanner,
 } from '../../../components/Banner';
 import { handleNavigation } from '../utils';
-import firefox from '../../../lib/channels/firefox';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 
@@ -88,24 +87,6 @@ const SigninTokenCode = ({
 
   useEffect(() => {
     GleanMetrics.loginConfirmation.view();
-  }, []);
-
-  useEffect(() => {
-    (async () => {
-      if (integration.isSync()) {
-        await firefox.fxaLogin({
-          email,
-          // keyFetchToken and unwrapBKey should always exist if Sync integration
-          keyFetchToken: keyFetchToken!,
-          unwrapBKey: unwrapBKey!,
-          sessionToken,
-          uid,
-          verified: false,
-        });
-      }
-    })();
-    // Only send webchannel message if sync on initial render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleAnimationEnd = () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -157,7 +157,7 @@ describe('Sign in with TOTP code page', () => {
       let fxaLoginSpy: jest.SpyInstance;
       let hardNavigateSpy: jest.SpyInstance;
       beforeEach(() => {
-        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
+        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
         hardNavigateSpy = jest
           .spyOn(utils, 'hardNavigate')
           .mockImplementation(() => {});

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -338,7 +338,7 @@ describe('Signin', () => {
             let fxaLoginSpy: jest.SpyInstance;
             let hardNavigateSpy: jest.SpyInstance;
             beforeEach(() => {
-              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
+              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
               hardNavigateSpy = jest
                 .spyOn(utils, 'hardNavigate')
                 .mockImplementation(() => {});
@@ -379,10 +379,12 @@ describe('Signin', () => {
 
           describe('OAuth integration', () => {
             let fxaOAuthLoginSpy: jest.SpyInstance;
+            let fxaLoginSpy: jest.SpyInstance;
             let hardNavigateSpy: jest.SpyInstance;
             let finishOAuthFlowHandler: jest.Mock;
             beforeEach(() => {
               fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
+              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
               hardNavigateSpy = jest
                 .spyOn(utils, 'hardNavigate')
                 .mockImplementation(() => {});
@@ -488,6 +490,7 @@ describe('Signin', () => {
               });
               enterPasswordAndSubmit();
               await waitFor(() => {
+                expect(fxaLoginSpy).toHaveBeenCalled();
                 expect(fxaOAuthLoginSpy).toHaveBeenCalled();
                 expect(hardNavigateSpy).toHaveBeenCalledWith(
                   '/connect_another_device?showSuccessMessage=true'

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -66,7 +66,7 @@ export async function handleNavigation(
     // `verified: false`, causing a Sync sign-in issue (see FXA-9837).
     !to?.includes('signin_totp_code')
   ) {
-    firefox.fxaLogin({
+    await firefox.fxaLogin({
       email: navigationOptions.email,
       // keyFetchToken and unwrapBKey should always exist if Sync integration
       keyFetchToken: navigationOptions.signinData.keyFetchToken!,

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -464,7 +464,7 @@ describe('Signup page', () => {
     describe('integrations', () => {
       let fxaLoginSpy: jest.SpyInstance;
       beforeEach(() => {
-        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
+        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
       });
       it('on success with Web integration', async () => {
         const mockBeginSignupHandler = jest


### PR DESCRIPTION
## Because

- We were having intermitant issues when logging in using the React signin and Sync

## This pull request

- Adds an await to the `fxaLogin` message so that the browser has a chance to process it completely
- Updates our functional and unit tests to correctly await

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9836

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
