### PR TITLE
revert(sync): Revert await fxaLogin in signin utils

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -66,7 +66,7 @@ export async function handleNavigation(
     // `verified: false`, causing a Sync sign-in issue (see FXA-9837).
     !to?.includes('signin_totp_code')
   ) {
-    await firefox.fxaLogin({
+    firefox.fxaLogin({
       email: navigationOptions.email,
       // keyFetchToken and unwrapBKey should always exist if Sync integration
       keyFetchToken: navigationOptions.signinData.keyFetchToken!,


### PR DESCRIPTION
Because:
* Adding 'await' in front of this waits for the browser to respond. We thought this may fix an intermittent sync signin issue, but instead hangs

This commit:
* Reverts this change