### PR TITLE
fix(functional-tests): Reset password with code tests failing on stage

### DIFF
--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/oauthResetPassword.spec.ts
@@ -84,7 +84,9 @@ test.describe('severity-1 #smoke', () => {
           `access_type=offline` +
           `&client_id=${target.relierClientID}` +
           `&pkce_client_id=38a6b9b3a65a1871` +
-          `&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth` +
+          `&redirect_uri=${encodeURIComponent(
+            target.relierUrl + '/api/oauth'
+          )}` +
           `&scope=profile%20openid` +
           `&action=signin` +
           `&state=12eeaba43cc7548bf1f6b478b9de95328855b46df1e754fe94b21036c41c9cba`

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/resetPasswordRecoveryKey.spec.ts
@@ -58,9 +58,6 @@ test.describe('severity-1 #smoke', () => {
       await resetPasswordReact.goto();
 
       await resetPasswordReact.fillOutEmailForm(credentials.email);
-      await expect(
-        resetPasswordReact.confirmResetPasswordHeading
-      ).toBeVisible();
 
       const code = await target.emailClient.getResetPasswordCode(
         credentials.email


### PR DESCRIPTION
## Because

* Two tests were failing smoke tests

## This pull request

* Fix the PKCE test by using the correct url by environment (removed stray localhost)
* Fix failing assertion that was causing email check to fail

## Issue that this pull request solves

Closes: #FXA-9800

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
