### PR TITLE
fix(login): fix sync login issue with react

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
@@ -27,12 +27,6 @@ test.describe('severity-2 #smoke', () => {
       await signinReact.fillOutEmailFirstForm(credentials.email);
       await signinReact.fillOutPasswordForm(credentials.password);
 
-      await signinReact.sendWebChannelMessage(
-        createCustomEventDetail(FirefoxCommand.LinkAccount, {
-          ok: true,
-        })
-      );
-
       await expect(page).toHaveURL(/connect_another_device/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await expect(

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -34,12 +34,6 @@ test.describe('severity-1 #smoke', () => {
     await signinReact.fillOutEmailFirstForm(credentials.email);
     await signinReact.fillOutPasswordForm(credentials.password);
 
-    await signinReact.sendWebChannelMessage(
-      createCustomEventDetail(FirefoxCommand.LinkAccount, {
-        ok: true,
-      })
-    );
-
     await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     await connectAnotherDevice.startBrowsingButton.click();
     await expect(page).toHaveURL(/settings/, { timeout: 1000 });

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -94,12 +94,6 @@ test.describe('severity-1 #smoke', () => {
       const code = await getCode(secret);
       await signinReact.fillOutAuthenticationForm(code);
 
-      await signinReact.sendWebChannelMessage(
-        createCustomEventDetail(FirefoxCommand.LinkAccount, {
-          ok: true,
-        })
-      );
-
       await expect(page).toHaveURL(/connect_another_device/);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -28,12 +28,6 @@ test.describe('severity-2 #smoke', () => {
       await signinReact.fillOutEmailFirstForm(credentials.email);
       await signinReact.fillOutPasswordForm(credentials.password);
 
-      await signinReact.sendWebChannelMessage(
-        createCustomEventDetail(FirefoxCommand.LinkAccount, {
-          ok: true,
-        })
-      );
-
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
   });
@@ -54,12 +48,6 @@ test.describe('severity-2 #smoke', () => {
 
     await signinReact.fillOutEmailFirstForm(credentials.email);
     await signinReact.fillOutPasswordForm(credentials.password);
-
-    await signinReact.sendWebChannelMessage(
-      createCustomEventDetail(FirefoxCommand.LinkAccount, {
-        ok: true,
-      })
-    );
 
     await page.waitForURL(/signin_token_code/);
 

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -79,11 +79,12 @@ export type SignedInUser = {
 
 export type FxALoginRequest = {
   email: string;
-  keyFetchToken: hexstring;
   sessionToken: hexstring;
   uid: hexstring;
-  unwrapBKey: string;
   verified: boolean;
+  keyFetchToken?: hexstring;
+  unwrapBKey?: string;
+  verifiedCanLinkAccount?: boolean;
   services?: {
     sync: {
       offeredEngines?: string[];


### PR DESCRIPTION
## Because

- I think part of the issue with Sync was getting two login webchannel messages, the other part was not specifiying services in the message

## This pull request

- Removes test code that could make false positive results
- Adds login message when `signin_token_page` is loaded only
- Adds empty services on login message

## Issue that this pull request solves

Closes: 

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)


