### PR TITLE
chore: Remove deprecated VSCode extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,7 @@
 {
   "recommendations": [
-    "rbbit.typescript-hero",
-    "waderyan.nodejs-extension-pack",
     "esbenp.prettier-vscode",
-    "rust-lang.rust",
+    "rust-lang.rust-analyzer",
     "ms-azuretools.vscode-docker",
     "ms-vsliveshare.vsliveshare",
     "github.vscode-pull-request-github",


### PR DESCRIPTION
## Because

- VSCode keeps recommending we install these extensions if you don't already have it, but they are deprecated or replaced by others.

## This pull request

- Updates that list with the alternative or removes the others.

## Issue that this pull request solves

FXA-9858

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

