### PR TITLE
fix(emails): Dont use `session.isSessionVerified` in modal since it causes re-render

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
@@ -67,13 +67,7 @@ export const ModalVerifySession = ({
       if (session.verified) {
         onCompleted && onCompleted();
       } else {
-        let sessionVerified = false;
-        sessionVerified = await session.isSessionVerified();
-        if (sessionVerified) {
-          onCompleted && onCompleted();
-        } else {
-          session.sendVerificationCode();
-        }
+        await session.sendVerificationCode();
       }
     };
 


### PR DESCRIPTION
## Because

- Calling `session.isSessionVerified` updates the apollo cache of session info, which I think causes a render of the component

## This pull request

- Removes that check and uses the current value `session.verified` to send email

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9835

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I tried removing the depencies on the `useEffect` hook, which in theory should make the component render once, it didn't :/ 
