### PR TITLE
chore: add mycli, redis, and gcloud to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,9 +12,10 @@
 			"moby": "true"
 		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "netcat,git,curl,jq,build-essential,pkg-config,libssl-dev,libgmp3-dev"
+			"packages": "netcat,git,curl,jq,build-essential,pkg-config,libssl-dev,libgmp3-dev,mycli,redis-tools"
 		},
-		"ghcr.io/devcontainers/features/node:1": {}
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/bartventer/arch-devcontainer-features/gcloud-cli:1": {}
 	},
 
 	"containerEnv": {


### PR DESCRIPTION
Because:

* It's useful having some CLI tooling for the fxa stack installed by default in the devcontainer.

This commit:

* Adds mycli, redis, and gcloud to the devcontainer.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
