### PR TITLE
fix: use working gcloud feature in dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 			"packages": "netcat,git,curl,jq,build-essential,pkg-config,libssl-dev,libgmp3-dev,mycli,redis-tools"
 		},
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/bartventer/arch-devcontainer-features/gcloud-cli:1": {}
+		"ghcr.io/dhoeric/features/google-cloud-cli:1": {}
 	},
 
 	"containerEnv": {


### PR DESCRIPTION
Because:

* The other gcloud feature require arch linux, ours is debian based.

This commit:

* Changes the gcloud feature to one that works with debian based systems.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
