### PR TITLE
fix(metrics): always use the metrics flow data in `Metrics` model when redirecting in third party auth

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -73,6 +73,14 @@ export default {
     // We stash originating location in the Google state oauth param
     // because we will need it to use it to log the user into FxA
     const currentParams = new URLSearchParams(this.window.location.search);
+
+    if (this.metrics) {
+      const metrics = this.metrics.getFlowEventMetadata();
+      currentParams.append('flowId', metrics.flowId);
+      currentParams.append('flowBeginTime', metrics.flowBeginTime);
+      currentParams.append('deviceId', metrics.deviceId);
+    }
+
     currentParams.delete('deeplink');
 
     const state = encodeURIComponent(
@@ -121,6 +129,14 @@ export default {
     this.logFlowEvent('apple.oauth-start');
 
     const currentParams = new URLSearchParams(this.window.location.search);
+
+    if (this.metrics) {
+      const metrics = this.metrics.getFlowEventMetadata();
+      currentParams.append('flowId', metrics.flowId);
+      currentParams.append('flowBeginTime', metrics.flowBeginTime);
+      currentParams.append('deviceId', metrics.deviceId);
+    }
+
     currentParams.delete('deeplink');
 
     const state = encodeURIComponent(

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/third-party-auth-mixin.js
@@ -78,6 +78,11 @@ describe('views/mixins/third-party-auth-mixin', function () {
       user,
     });
     sinon.spy(notifier, 'trigger');
+    sinon.stub(metrics, 'getFlowEventMetadata').callsFake(() => ({
+      flowId: '123',
+      flowBeginTime: '456',
+      deviceId: '789',
+    }));
     await view.render();
   });
 
@@ -146,6 +151,8 @@ describe('views/mixins/third-party-auth-mixin', function () {
 
     assert.isTrue(view.logFlowEvent.calledWith('google.oauth-start'));
 
+    assert.isTrue(metrics.getFlowEventMetadata.calledOnce);
+
     assert.isTrue(mockForm.setAttribute.calledWith('method', 'GET'));
     assert.isTrue(
       mockForm.setAttribute.calledWith(
@@ -167,7 +174,7 @@ describe('views/mixins/third-party-auth-mixin', function () {
       mockInput,
       'state',
       encodeURIComponent(
-        `${windowMock.location.origin}${windowMock.location.pathname}?`
+        `${windowMock.location.origin}${windowMock.location.pathname}?flowId=123&flowBeginTime=456&deviceId=789`
       )
     );
     assertInputEl(mockInput, 'access_type', 'offline');
@@ -188,6 +195,8 @@ describe('views/mixins/third-party-auth-mixin', function () {
     view.appleSignIn();
 
     assert.isTrue(view.logFlowEvent.calledWith('apple.oauth-start'));
+
+    assert.isTrue(metrics.getFlowEventMetadata.calledOnce);
 
     assert.isTrue(mockForm.setAttribute.calledWith('method', 'GET'));
     assert.isTrue(
@@ -210,7 +219,7 @@ describe('views/mixins/third-party-auth-mixin', function () {
       mockInput,
       'state',
       encodeURIComponent(
-        `${windowMock.location.origin}${windowMock.location.pathname}?`
+        `${windowMock.location.origin}${windowMock.location.pathname}?flowId=123&flowBeginTime=456&deviceId=789`
       )
     );
     assertInputEl(mockInput, 'access_type', 'offline');

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as AppleLogo } from './apple-logo.svg';
 
 import { useConfig } from '../../models';
 import { ReactElement } from 'react-markdown/lib/react-markdown';
+import { useMetrics } from '../../lib/metrics';
 
 export type ThirdPartyAuthProps = {
   onContinueWithGoogle?: FormEventHandler<HTMLFormElement>;
@@ -125,9 +126,11 @@ const ThirdPartySignInForm = ({
   buttonText: ReactElement;
   onSubmit?: FormEventHandler<HTMLFormElement>;
 }) => {
+  const { logViewEventOnce } = useMetrics();
   const stateRef = useRef<HTMLInputElement>(null);
 
   function onClick() {
+    logViewEventOnce(`flow.${party}`, 'oauth-start');
     stateRef.current!.value = getState();
   }
 


### PR DESCRIPTION
## Because

- Some metrics did not have corresponding complete events for third party auth
- If flowId was not provided in the query string, none would be used

## This pull request

- Always defer to using the flowId in the metrics model when redirecting in third party auth, this id is either pulled from query params or generated if not present

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9564
Closes: https://mozilla-hub.atlassian.net/browse/FXA-9767

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I ran through this locally and the flowId stays consistent throughout the third party auth login. No changes are needed in React since it always gets a flowId sent to its views from content-server.

| Component          | Operation       | Event Type                                 | Time           | User ID                        | Device ID                         | Session ID        | App Version | Language | OS Name | OS Version | User Properties                                                                                                                                                                   |
|--------------------|-----------------|--------------------------------------------|----------------|--------------------------------|-----------------------------------|-------------------|-------------|----------|---------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| fxa-content-server | amplitudeEvent  | fxa_third_party_auth - view                | 1718298775581  | N/A                            | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en-US    | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0"}                                                     |
| fxa-content-server | amplitudeEvent  | fxa_email_first - view                     | 1718298775585  | N/A                            | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en-US    | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0"}                                                     |
| fxa-content-server | amplitudeEvent  | fxa_third_party_auth - google_oauth_start  | 1718298776701  | N/A                            | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en-US    | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0"}                                                     |
| fxa-auth-server    | amplitudeEvent  | fxa_login - success                        | 1718298782014  | cd8225ea77e24be9bedefec53c12152c | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en-US    | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0"}                                                     |
| fxa-auth-server    | amplitudeEvent  | fxa_login - complete                       | 1718298782014  | cd8225ea77e24be9bedefec53c12152c | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en-US    | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0"}                                                     |
| fxa-content-server | amplitudeEvent  | fxa_third_party_auth - google_signin_complete | 1718298782039  | N/A                            | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en-US    | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0"}                                                     |
| fxa-content-server | amplitudeEvent  | fxa_pref - view                            | 1718298782427  | cd8225ea77e24be9bedefec53c12152c | 9bad25e8d66f4515aa655fe0c698731b | 1718298775386     | 0.0         | en       | Mac OS X | 10.15      | {"flow_id":"6aad924bb39934ced850a8b7c0e3c6b087a60af145a014bd56ee486d28d96731","ua_browser":"Firefox","ua_version":"126.0","$append":{"account_recovery":false,"emails":false,"two_step_authentication":false}} |
