### PR TITLE
task(auth-server): Fix invalid call

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/key_data.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/key_data.js
@@ -161,7 +161,7 @@ module.exports = ({ log, oauthDB, statsd }) => {
           return await keyDataHandler(req);
         } catch (err) {
           if (err.errno === 101) {
-            throw new AuthError.unknownClientId(req.payload.client_id);
+            throw AuthError.unknownClientId(req.payload.client_id);
           }
           throw err;
         }


### PR DESCRIPTION
## Because

- Trying to a new an object doesn't work, and results in a 'not a constructor' error.

## This pull request

- Removes the erroneous 'new' keyword.

## Issue that this pull request solves

Closes: FXA-9861
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

