### PR TITLE
feat(libs): convert libs/* projects to use esbuild and swc/jest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -572,7 +572,7 @@ jobs:
   # Runs unit tests in parallel across packages with changes.
   unit-test:
     executor: default-executor
-    resource_class: large
+    resource_class: medium+
     steps:
       - git-checkout
       - restore-workspace

--- a/libs/payments/capability/.swcrc
+++ b/libs/payments/capability/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/payments/capability/jest.config.ts
+++ b/libs/payments/capability/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-capability',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/capability',
 };

--- a/libs/payments/capability/project.json
+++ b/libs/payments/capability/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/capability/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/capability",
-        "tsConfig": "libs/payments/capability/tsconfig.lib.json",
-        "packageJson": "libs/payments/capability/package.json",
         "main": "libs/payments/capability/src/index.ts",
-        "assets": ["libs/payments/capability/*.md"]
+        "outputPath": "dist/libs/payments/capability",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/payments/capability/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/payments/capability/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -29,6 +47,5 @@
         "jestConfig": "libs/payments/capability/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib:payments"]
+  }
 }

--- a/libs/payments/cart/.swcrc
+++ b/libs/payments/cart/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/payments/cart/jest.config.ts
+++ b/libs/payments/cart/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-cart',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/cart',
 };

--- a/libs/payments/cart/project.json
+++ b/libs/payments/cart/project.json
@@ -3,16 +3,33 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/cart/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/cart",
         "main": "libs/payments/cart/src/index.ts",
+        "outputPath": "dist/libs/payments/cart",
+        "outputFileName": "main.js",
         "tsConfig": "libs/payments/cart/tsconfig.lib.json",
-        "packageJson": "libs/payments/cart/package.json",
-        "assets": ["libs/payments/cart/*.md"]
+        "assets": [
+          {
+            "glob": "libs/payments/cart/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -38,6 +55,5 @@
         "testPathPattern": ["\\.in\\.spec\\.ts$"]
       }
     }
-  },
-  "tags": ["scope:shared:lib:payments"]
+  }
 }

--- a/libs/payments/currency/.swcrc
+++ b/libs/payments/currency/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/payments/currency/jest.config.ts
+++ b/libs/payments/currency/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-currency',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/currency',
 };

--- a/libs/payments/currency/project.json
+++ b/libs/payments/currency/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/currency/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/currency",
-        "tsConfig": "libs/payments/currency/tsconfig.lib.json",
-        "packageJson": "libs/payments/currency/package.json",
         "main": "libs/payments/currency/src/index.ts",
-        "assets": ["libs/payments/currency/*.md"]
+        "outputPath": "dist/libs/payments/currency",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/payments/currency/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/payments/currency/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -29,6 +47,5 @@
         "jestConfig": "libs/payments/currency/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib:payments"]
+  }
 }

--- a/libs/payments/eligibility/.swcrc
+++ b/libs/payments/eligibility/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/payments/eligibility/jest.config.ts
+++ b/libs/payments/eligibility/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-eligibility',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/eligibility',
 };

--- a/libs/payments/eligibility/project.json
+++ b/libs/payments/eligibility/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/eligibility/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/eligibility",
-        "tsConfig": "libs/payments/eligibility/tsconfig.lib.json",
-        "packageJson": "libs/payments/eligibility/package.json",
         "main": "libs/payments/eligibility/src/index.ts",
-        "assets": ["libs/payments/eligibility/*.md"]
+        "outputPath": "dist/libs/payments/eligibility",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/payments/eligibility/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/payments/eligibility/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -32,6 +50,5 @@
         "jestConfig": "libs/payments/eligibility/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib:payments"]
+  }
 }

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -1,14 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-const mockStripeUtil = {
-  getSubscribedPrices: jest.fn(),
-  getSubscribedProductIds: jest.fn(),
-};
-
-jest.mock('../../../stripe/src/lib/stripe.util.ts', () => mockStripeUtil);
-
 import { Test, TestingModule } from '@nestjs/testing';
 
 import {
@@ -37,6 +29,11 @@ import {
 } from './eligibility.types';
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
+import * as StripeUtil from '../../../stripe/src/lib/stripe.util';
+
+jest.mock('../../../stripe/src/lib/stripe.util');
+
+const mockStripeUtil = jest.mocked(StripeUtil);
 
 describe('EligibilityService', () => {
   let contentfulManager: ContentfulManager;

--- a/libs/payments/legacy/.swcrc
+++ b/libs/payments/legacy/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/payments/legacy/jest.config.ts
+++ b/libs/payments/legacy/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-legacy',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/legacy',
 };

--- a/libs/payments/legacy/project.json
+++ b/libs/payments/legacy/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/legacy/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/legacy",
-        "tsConfig": "libs/payments/legacy/tsconfig.lib.json",
-        "packageJson": "libs/payments/legacy/package.json",
         "main": "libs/payments/legacy/src/index.ts",
-        "assets": ["libs/payments/legacy/*.md"]
+        "outputPath": "dist/libs/payments/legacy",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/payments/legacy/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/payments/legacy/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -32,6 +50,5 @@
         "jestConfig": "libs/payments/legacy/jest.config.ts"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/payments/paypal/.swcrc
+++ b/libs/payments/paypal/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/payments/paypal/jest.config.ts
+++ b/libs/payments/paypal/jest.config.ts
@@ -1,10 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-paypal',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
+  coverageDirectory: '../../../coverage/libs/payments/paypal',
 };

--- a/libs/payments/paypal/project.json
+++ b/libs/payments/paypal/project.json
@@ -3,16 +3,33 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/paypal/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/paypal",
-        "tsConfig": "libs/payments/paypal/tsconfig.lib.json",
-        "packageJson": "libs/payments/paypal/package.json",
         "main": "libs/payments/paypal/src/index.ts",
-        "assets": ["libs/payments/paypal/*.md"]
+        "outputPath": "dist/libs/payments/paypal",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/payments/paypal/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "libs/payments/paypal/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -38,6 +55,5 @@
         "testPathPattern": ["\\.in\\.spec\\.ts$"]
       }
     }
-  },
-  "tags": ["scope:shared:lib:payments"]
+  }
 }

--- a/libs/payments/stripe/.swcrc
+++ b/libs/payments/stripe/.swcrc
@@ -1,0 +1,14 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}

--- a/libs/payments/stripe/jest.config.ts
+++ b/libs/payments/stripe/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-stripe',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/stripe',
 };

--- a/libs/payments/stripe/project.json
+++ b/libs/payments/stripe/project.json
@@ -3,15 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/payments/stripe/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/payments/stripe",
         "main": "libs/payments/stripe/src/index.ts",
+        "outputPath": "dist/libs/payments/stripe",
+        "outputFileName": "main.js",
         "tsConfig": "libs/payments/stripe/tsconfig.lib.json",
-        "assets": ["libs/payments/stripe/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/payments/stripe/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -40,6 +59,5 @@
         "testPathPattern": ["\\.in\\.spec\\.ts$"]
       }
     }
-  },
-  "tags": ["scope:shared:lib:payments"]
+  }
 }

--- a/libs/payments/stripe/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/invoice.manager.spec.ts
@@ -2,15 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const mockStripeUtil = {
-  stripeInvoiceToFirstInvoicePreviewDTO: jest.fn(),
-};
-
-jest.mock(
-  '../../../stripe/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO',
-  () => mockStripeUtil
-);
-
 import { Test } from '@nestjs/testing';
 
 import { StripeResponseFactory } from './factories/api-list.factory';
@@ -23,6 +14,11 @@ import { StripeClient } from './stripe.client';
 import { MockStripeConfigProvider } from './stripe.config';
 import { InvoicePreviewFactory } from './stripe.factories';
 import { InvoiceManager } from './invoice.manager';
+import * as StripeUtil from '../lib/util/stripeInvoiceToFirstInvoicePreviewDTO';
+
+jest.mock('../lib/util/stripeInvoiceToFirstInvoicePreviewDTO');
+
+const mockStripeUtil = jest.mocked(StripeUtil);
 
 describe('InvoiceManager', () => {
   let invoiceManager: InvoiceManager;

--- a/libs/payments/stripe/src/lib/promotionCode.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/promotionCode.manager.spec.ts
@@ -2,14 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const mockStripeUtil = {
-  checkValidPromotionCode: jest.fn(),
-  checkSubscriptionPromotionCodes: jest.fn(),
-  getSubscribedPrice: jest.fn(),
-};
-
-jest.mock('../lib/stripe.util.ts', () => mockStripeUtil);
-
 import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
 import { Stripe } from 'stripe';
@@ -33,6 +25,11 @@ import { MockStripeConfigProvider } from './stripe.config';
 import { PromotionCodeCouldNotBeAttachedError } from './stripe.error';
 import { STRIPE_PRICE_METADATA } from './stripe.types';
 import { SubscriptionManager } from './subscription.manager';
+import * as StripeUtil from '../lib/stripe.util';
+
+jest.mock('../lib/stripe.util.ts');
+
+const mockStripeUtil = jest.mocked(StripeUtil);
 
 describe('PromotionCodeManager', () => {
   let productManager: ProductManager;

--- a/libs/payments/ui/.swcrc
+++ b/libs/payments/ui/.swcrc
@@ -1,0 +1,30 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "commonjs"
+  },
+  "sourceMaps": true,
+  "exclude": [
+    "jest.config.ts",
+    ".*\\.spec.tsx?$",
+    ".*\\.test.tsx?$",
+    "./src/jest-setup.ts$",
+    "./**/jest-setup.ts$",
+    ".*.js$"
+  ]
+}
+

--- a/libs/payments/ui/jest.config.ts
+++ b/libs/payments/ui/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'payments-ui',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/ui',
 };

--- a/libs/shared/account/account/.swcrc
+++ b/libs/shared/account/account/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/account/account/jest.config.ts
+++ b/libs/shared/account/account/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-account-account',
   preset: '../../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/account/account',
 };

--- a/libs/shared/account/account/project.json
+++ b/libs/shared/account/account/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/account/account/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/account/account",
-        "tsConfig": "libs/shared/account/account/tsconfig.lib.json",
-        "packageJson": "libs/shared/account/account/package.json",
         "main": "libs/shared/account/account/src/index.ts",
-        "assets": ["libs/shared/account/account/*.md"]
+        "outputPath": "dist/libs/shared/account/account",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/account/account/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/account/account/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -30,6 +48,5 @@
         "testPathPattern": ["\\.in\\.spec\\.ts$"]
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/cloud-tasks/.swcrc
+++ b/libs/shared/cloud-tasks/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/cloud-tasks/jest.config.ts
+++ b/libs/shared/cloud-tasks/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'cloud-tasks',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/cloud-tasks',
 };

--- a/libs/shared/cloud-tasks/project.json
+++ b/libs/shared/cloud-tasks/project.json
@@ -3,15 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/cloud-tasks/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/cloud-tasks",
         "main": "libs/shared/cloud-tasks/src/index.ts",
+        "outputPath": "dist/libs/shared/cloud-tasks",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/cloud-tasks/tsconfig.lib.json",
-        "assets": ["libs/shared/cloud-tasks/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/cloud-tasks/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -31,6 +50,5 @@
         "jestConfig": "libs/shared/cloud-tasks/jest.config.ts"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/shared/contentful/.swcrc
+++ b/libs/shared/contentful/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/contentful/jest.config.ts
+++ b/libs/shared/contentful/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-contentful',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/contentful',
 };

--- a/libs/shared/contentful/package.json
+++ b/libs/shared/contentful/package.json
@@ -1,10 +1,4 @@
 {
   "name": "@fxa/shared/contentful",
-  "version": "0.0.1",
-  "dependencies": {
-    "tslib": "^2.3.0"
-  },
-  "type": "commonjs",
-  "main": "./src/index.js",
-  "typings": "./src/index.d.ts"
+  "version": "0.0.1"
 }

--- a/libs/shared/contentful/project.json
+++ b/libs/shared/contentful/project.json
@@ -3,6 +3,7 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/contentful/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "codegen": {
       "executor": "nx:run-commands",
@@ -11,13 +12,31 @@
       }
     },
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/contentful",
         "main": "libs/shared/contentful/src/index.ts",
+        "outputPath": "dist/libs/shared/contentful",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/contentful/tsconfig.lib.json",
-        "assets": ["libs/shared/contentful/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/contentful/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -37,6 +56,5 @@
         "jestConfig": "libs/shared/contentful/jest.config.ts"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/shared/db/firestore/.swcrc
+++ b/libs/shared/db/firestore/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/db/firestore/jest.config.ts
+++ b/libs/shared/db/firestore/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-db-firestore',
   preset: '../../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/db/firestore',
 };

--- a/libs/shared/db/firestore/project.json
+++ b/libs/shared/db/firestore/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/db/firestore/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/db/firestore",
-        "tsConfig": "libs/shared/db/firestore/tsconfig.lib.json",
-        "packageJson": "libs/shared/db/firestore/package.json",
         "main": "libs/shared/db/firestore/src/index.ts",
-        "assets": ["libs/shared/db/firestore/*.md"]
+        "outputPath": "dist/libs/shared/db/firestore",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/db/firestore/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/db/firestore/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -36,6 +54,5 @@
         }
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/db/mysql/account/.swcrc
+++ b/libs/shared/db/mysql/account/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/db/mysql/account/jest.config.ts
+++ b/libs/shared/db/mysql/account/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-db-mysql-account',
   preset: '../../../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../../../coverage/libs/shared/db/mysql/account',
 };

--- a/libs/shared/db/mysql/account/project.json
+++ b/libs/shared/db/mysql/account/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/db/mysql/account/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/db/mysql/account",
-        "tsConfig": "libs/shared/db/mysql/account/tsconfig.lib.json",
-        "packageJson": "libs/shared/db/mysql/account/package.json",
         "main": "libs/shared/db/mysql/account/src/index.ts",
-        "assets": ["libs/shared/db/mysql/account/*.md"]
+        "outputPath": "dist/libs/shared/db/mysql/account",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/db/mysql/account/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/db/mysql/account/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -29,6 +47,5 @@
         "jestConfig": "libs/shared/db/mysql/account/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/db/mysql/core/.swcrc
+++ b/libs/shared/db/mysql/core/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/db/mysql/core/jest.config.ts
+++ b/libs/shared/db/mysql/core/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-db-mysql-core',
   preset: '../../../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../../../coverage/libs/shared/db/mysql/core',
 };

--- a/libs/shared/db/mysql/core/project.json
+++ b/libs/shared/db/mysql/core/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/db/mysql/core/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/db/mysql/core",
-        "tsConfig": "libs/shared/db/mysql/core/tsconfig.lib.json",
-        "packageJson": "libs/shared/db/mysql/core/package.json",
         "main": "libs/shared/db/mysql/core/src/index.ts",
-        "assets": ["libs/shared/db/mysql/core/*.md"]
+        "outputPath": "dist/libs/shared/db/mysql/core",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/db/mysql/core/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/db/mysql/core/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -29,6 +47,5 @@
         "jestConfig": "libs/shared/db/mysql/core/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/db/type-cacheable/.swcrc
+++ b/libs/shared/db/type-cacheable/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/db/type-cacheable/jest.config.ts
+++ b/libs/shared/db/type-cacheable/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-db-type-cacheable',
   preset: '../../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/db/type-cacheable',
 };

--- a/libs/shared/db/type-cacheable/project.json
+++ b/libs/shared/db/type-cacheable/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/db/type-cacheable/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/db/type-cacheable",
-        "tsConfig": "libs/shared/db/type-cacheable/tsconfig.lib.json",
-        "packageJson": "libs/shared/db/type-cacheable/package.json",
         "main": "libs/shared/db/type-cacheable/src/index.ts",
-        "assets": ["libs/shared/db/type-cacheable/*.md"]
+        "outputPath": "dist/libs/shared/db/type-cacheable",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/db/type-cacheable/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/db/type-cacheable/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -36,6 +54,5 @@
         }
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/error/.swcrc
+++ b/libs/shared/error/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/error/jest.config.ts
+++ b/libs/shared/error/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-error',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/error',
 };

--- a/libs/shared/error/package.json
+++ b/libs/shared/error/package.json
@@ -1,5 +1,4 @@
 {
   "name": "@fxa/shared/error",
-  "version": "0.0.1",
-  "type": "commonjs"
+  "version": "0.0.1"
 }

--- a/libs/shared/error/project.json
+++ b/libs/shared/error/project.json
@@ -3,15 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/error/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/error",
         "main": "libs/shared/error/src/index.ts",
+        "outputPath": "dist/libs/shared/error",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/error/tsconfig.lib.json",
-        "assets": ["libs/shared/error/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/error/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -28,6 +47,5 @@
         "jestConfig": "libs/shared/error/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/geodb/.swcrc
+++ b/libs/shared/geodb/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/geodb/jest.config.ts
+++ b/libs/shared/geodb/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-geodb',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/geodb',
 };

--- a/libs/shared/geodb/package.json
+++ b/libs/shared/geodb/package.json
@@ -1,7 +1,4 @@
 {
   "name": "@fxa/shared/geodb",
-  "version": "0.0.1",
-  "type": "commonjs",
-  "main": "./src/index.js",
-  "typings": "./src/index.d.ts"
+  "version": "0.0.1"
 }

--- a/libs/shared/geodb/project.json
+++ b/libs/shared/geodb/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/geodb/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/geodb",
-        "tsConfig": "libs/shared/geodb/tsconfig.lib.json",
-        "packageJson": "libs/shared/geodb/package.json",
         "main": "libs/shared/geodb/src/index.ts",
-        "assets": ["libs/shared/geodb/*.md"]
+        "outputPath": "dist/libs/shared/geodb",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/geodb/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/geodb/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test-unit": {
@@ -22,6 +40,5 @@
         "jestConfig": "libs/shared/geodb/jest.config.ts"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/shared/l10n/.swcrc
+++ b/libs/shared/l10n/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/l10n/package.json
+++ b/libs/shared/l10n/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/shared/l10n",
-  "version": "0.0.1",
-  "dependencies": {
-    "tslib": "^2.3.0"
-  },
-  "type": "commonjs",
-  "main": "./src/index.js"
+  "version": "0.0.1"
 }

--- a/libs/shared/l10n/project.json
+++ b/libs/shared/l10n/project.json
@@ -3,15 +3,35 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/l10n/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/l10n",
         "main": "libs/shared/l10n/src/index.ts",
+        "outputPath": "dist/libs/shared/l10n",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/l10n/tsconfig.lib.json",
-        "assets": ["libs/shared/l10n/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/l10n/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node",
+        "format": ["cjs", "esm"]
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -31,6 +51,5 @@
         "jestConfig": "libs/shared/l10n/jest.config.ts"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/shared/log/.swcrc
+++ b/libs/shared/log/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/log/jest.config.ts
+++ b/libs/shared/log/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-log',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/log',
 };

--- a/libs/shared/log/project.json
+++ b/libs/shared/log/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/log/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/log",
-        "tsConfig": "libs/shared/log/tsconfig.lib.json",
-        "packageJson": "libs/shared/log/package.json",
         "main": "libs/shared/log/src/index.ts",
-        "assets": ["libs/shared/log/*.md"]
+        "outputPath": "dist/libs/shared/log",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/log/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/log/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -29,6 +47,5 @@
         "jestConfig": "libs/shared/log/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/metrics/statsd/.swcrc
+++ b/libs/shared/metrics/statsd/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/metrics/statsd/jest.config.ts
+++ b/libs/shared/metrics/statsd/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-metrics-statsd',
   preset: '../../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/metrics/statsd',
 };

--- a/libs/shared/metrics/statsd/project.json
+++ b/libs/shared/metrics/statsd/project.json
@@ -3,16 +3,34 @@
   "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/metrics/statsd/src",
   "projectType": "library",
+  "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/metrics/statsd",
-        "tsConfig": "libs/shared/metrics/statsd/tsconfig.lib.json",
-        "packageJson": "libs/shared/metrics/statsd/package.json",
         "main": "libs/shared/metrics/statsd/src/index.ts",
-        "assets": ["libs/shared/metrics/statsd/*.md"]
+        "outputPath": "dist/libs/shared/metrics/statsd",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/metrics/statsd/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/metrics/statsd/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -29,6 +47,5 @@
         "jestConfig": "libs/shared/metrics/statsd/jest.config.ts"
       }
     }
-  },
-  "tags": ["scope:shared:lib"]
+  }
 }

--- a/libs/shared/mozlog/.swcrc
+++ b/libs/shared/mozlog/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/mozlog/jest.config.ts
+++ b/libs/shared/mozlog/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-mozlog',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/mozlog',
 };

--- a/libs/shared/mozlog/project.json
+++ b/libs/shared/mozlog/project.json
@@ -6,13 +6,31 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/mozlog",
         "main": "libs/shared/mozlog/src/index.ts",
+        "outputPath": "dist/libs/shared/mozlog",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/mozlog/tsconfig.lib.json",
-        "assets": ["libs/shared/mozlog/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/mozlog/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {

--- a/libs/shared/notifier/.swcrc
+++ b/libs/shared/notifier/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/notifier/jest.config.ts
+++ b/libs/shared/notifier/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'notifier',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/notifier',
 };

--- a/libs/shared/notifier/project.json
+++ b/libs/shared/notifier/project.json
@@ -3,15 +3,34 @@
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "libs/shared/notifier/src",
   "projectType": "library",
+  "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/notifier",
         "main": "libs/shared/notifier/src/index.ts",
+        "outputPath": "dist/libs/shared/notifier",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/notifier/tsconfig.lib.json",
-        "assets": ["libs/shared/notifier/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/notifier/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {
@@ -31,6 +50,5 @@
         "jestConfig": "libs/shared/notifier/jest.config.ts"
       }
     }
-  },
-  "tags": []
+  }
 }

--- a/libs/shared/otp/.swcrc
+++ b/libs/shared/otp/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/otp/jest.config.ts
+++ b/libs/shared/otp/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'otp',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/otp',
 };

--- a/libs/shared/otp/project.json
+++ b/libs/shared/otp/project.json
@@ -6,14 +6,31 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/otp",
-        "tsConfig": "libs/shared/otp/tsconfig.lib.json",
-        "packageJson": "libs/shared/otp/package.json",
         "main": "libs/shared/otp/src/index.ts",
-        "assets": ["libs/shared/otp/*.md"]
+        "outputPath": "dist/libs/shared/otp",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/otp/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/otp/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test-unit": {

--- a/libs/shared/pem-jwk/.swcrc
+++ b/libs/shared/pem-jwk/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/pem-jwk/jest.config.ts
+++ b/libs/shared/pem-jwk/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'pem-jwk',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/pem-jwk',
 };

--- a/libs/shared/pem-jwk/project.json
+++ b/libs/shared/pem-jwk/project.json
@@ -6,14 +6,32 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/pem-jwk",
-        "tsConfig": "libs/shared/pem-jwk/tsconfig.lib.json",
-        "packageJson": "libs/shared/pem-jwk/package.json",
         "main": "libs/shared/pem-jwk/src/index.ts",
-        "assets": ["libs/shared/pem-jwk/*.md"]
+        "outputPath": "dist/libs/shared/pem-jwk",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/shared/pem-jwk/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/pem-jwk/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node",
+        "format": ["cjs", "esm"]
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test-unit": {

--- a/libs/shared/react/jest.config.ts
+++ b/libs/shared/react/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'shared-react',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/react',
 };

--- a/libs/shared/sentry/.swcrc
+++ b/libs/shared/sentry/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/shared/sentry/jest.config.ts
+++ b/libs/shared/sentry/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'sentry',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/sentry',
 };

--- a/libs/shared/sentry/project.json
+++ b/libs/shared/sentry/project.json
@@ -6,13 +6,31 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/shared/sentry",
         "main": "libs/shared/sentry/src/index.ts",
+        "outputPath": "dist/libs/shared/sentry",
+        "outputFileName": "main.js",
         "tsConfig": "libs/shared/sentry/tsconfig.lib.json",
-        "assets": ["libs/shared/sentry/*.md"]
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/shared/sentry/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "lint": {

--- a/libs/vendored/common-password-list/.swcrc
+++ b/libs/vendored/common-password-list/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/vendored/common-password-list/jest.config.ts
+++ b/libs/vendored/common-password-list/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'common-password-list',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/common-password-list',
 };

--- a/libs/vendored/common-password-list/project.json
+++ b/libs/vendored/common-password-list/project.json
@@ -6,14 +6,31 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/vendored/common-password-list",
-        "tsConfig": "libs/vendored/common-password-list/tsconfig.lib.json",
-        "packageJson": "libs/vendored/common-password-list/package.json",
         "main": "libs/vendored/common-password-list/src/index.ts",
-        "assets": ["libs/vendored/common-password-list/*.md"]
+        "outputPath": "dist/libs/vendored/common-password-list",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/vendored/common-password-list/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/vendored/common-password-list/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test-unit": {

--- a/libs/vendored/crypto-relier/.swcrc
+++ b/libs/vendored/crypto-relier/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/vendored/crypto-relier/jest.config.ts
+++ b/libs/vendored/crypto-relier/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'crypto-relier',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/crypto-relier',
 };

--- a/libs/vendored/crypto-relier/project.json
+++ b/libs/vendored/crypto-relier/project.json
@@ -6,14 +6,32 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/vendored/crypto-relier",
-        "tsConfig": "libs/vendored/crypto-relier/tsconfig.lib.json",
-        "packageJson": "libs/vendored/crypto-relier/package.json",
         "main": "libs/vendored/crypto-relier/src/index.ts",
-        "assets": ["libs/vendored/crypto-relier/*.md"]
+        "outputPath": "dist/libs/vendored/crypto-relier",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/vendored/crypto-relier/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/vendored/crypto-relier/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node",
+        "format": ["cjs", "esm"]
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test": {

--- a/libs/vendored/incremental-encoder/.swcrc
+++ b/libs/vendored/incremental-encoder/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/vendored/incremental-encoder/jest.config.ts
+++ b/libs/vendored/incremental-encoder/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'incremental-encoder',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/incremental-encoder',
 };

--- a/libs/vendored/incremental-encoder/project.json
+++ b/libs/vendored/incremental-encoder/project.json
@@ -6,14 +6,31 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/vendored/incremental-encoder",
-        "tsConfig": "libs/vendored/incremental-encoder/tsconfig.lib.json",
-        "packageJson": "libs/vendored/incremental-encoder/package.json",
         "main": "libs/vendored/incremental-encoder/src/index.ts",
-        "assets": ["libs/vendored/incremental-encoder/*.md"]
+        "outputPath": "dist/libs/vendored/incremental-encoder",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/vendored/incremental-encoder/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/vendored/incremental-encoder/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test-unit": {

--- a/libs/vendored/jwtool/.swcrc
+++ b/libs/vendored/jwtool/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/vendored/jwtool/jest.config.ts
+++ b/libs/vendored/jwtool/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'jwtool',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/jwtool',
 };

--- a/libs/vendored/jwtool/project.json
+++ b/libs/vendored/jwtool/project.json
@@ -6,14 +6,32 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/vendored/jwtool",
-        "tsConfig": "libs/vendored/jwtool/tsconfig.lib.json",
-        "packageJson": "libs/vendored/jwtool/package.json",
         "main": "libs/vendored/jwtool/src/index.ts",
-        "assets": ["libs/vendored/jwtool/*.md"]
+        "outputPath": "dist/libs/vendored/jwtool",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/vendored/jwtool/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/vendored/jwtool/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node",
+        "format": ["cjs", "esm"]
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test-unit": {

--- a/libs/vendored/typesafe-node-firestore/.swcrc
+++ b/libs/vendored/typesafe-node-firestore/.swcrc
@@ -1,0 +1,15 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}
+

--- a/libs/vendored/typesafe-node-firestore/jest.config.ts
+++ b/libs/vendored/typesafe-node-firestore/jest.config.ts
@@ -1,11 +1,30 @@
 /* eslint-disable */
+import { readFileSync } from 'fs';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
 export default {
   displayName: 'typesafe-node-firestore',
   preset: '../../../jest.preset.js',
-  testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/typesafe-node-firestore',
 };

--- a/libs/vendored/typesafe-node-firestore/project.json
+++ b/libs/vendored/typesafe-node-firestore/project.json
@@ -6,14 +6,31 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/libs/vendored/typesafe-node-firestore",
-        "tsConfig": "libs/vendored/typesafe-node-firestore/tsconfig.lib.json",
-        "packageJson": "libs/vendored/typesafe-node-firestore/package.json",
         "main": "libs/vendored/typesafe-node-firestore/src/index.ts",
-        "assets": ["libs/vendored/typesafe-node-firestore/*.md"]
+        "outputPath": "dist/libs/vendored/typesafe-node-firestore",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/vendored/typesafe-node-firestore/tsconfig.lib.json",
+        "declaration": true,
+        "assets": [
+          {
+            "glob": "libs/vendored/typesafe-node-firestore/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node"
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
       }
     },
     "test": {

--- a/nx.json
+++ b/nx.json
@@ -2,14 +2,8 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "prebuild",
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
+      "dependsOn": ["prebuild", "^build"],
+      "inputs": ["production", "^production"],
       "outputs": [
         "{projectRoot}/*.tsbuildinfo",
         "{projectRoot}/*/.tmp",
@@ -27,75 +21,41 @@
       "cache": true
     },
     "build-storybook": {
-      "dependsOn": [
-        "build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
-      "outputs": [
-        "{projectRoot}/storybook-static"
-      ],
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/storybook-static"],
       "cache": true
     },
     "compile": {
-      "dependsOn": [
-        "^compile"
-      ],
-      "inputs": [
-        "typescript",
-        "^typescript"
-      ],
-      "outputs": [
-        "{projectRoot}/build",
-        "{projectRoot}/dist"
-      ],
+      "dependsOn": ["^compile"],
+      "inputs": ["typescript", "^typescript"],
+      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"],
       "cache": true
     },
     "gql-copy": {
       "dependsOn": [
         {
-          "projects": [
-            "fxa-settings",
-            "fxa-admin-panel"
-          ],
+          "projects": ["fxa-settings", "fxa-admin-panel"],
           "target": "gql-extract"
         }
       ],
-      "inputs": [
-        "typescript",
-        "^typescript"
-      ],
-      "outputs": [
-        "{projectRoot}/src/config/gql/allowlist"
-      ],
+      "inputs": ["typescript", "^typescript"],
+      "outputs": ["{projectRoot}/src/config/gql/allowlist"],
       "cache": true
     },
     "gql-extract": {
       "dependsOn": [],
-      "inputs": [
-        "typescript"
-      ],
-      "outputs": [
-        "{workspaceRoot}/configs/gql/allowlist"
-      ],
+      "inputs": ["typescript"],
+      "outputs": ["{workspaceRoot}/configs/gql/allowlist"],
       "cache": true
     },
     "lint": {
-      "inputs": [
-        "lint",
-        "{workspaceRoot}/.eslintrc.json"
-      ],
-      "outputs": [
-        "{projectRoot}/.eslintcache"
-      ],
+      "inputs": ["lint", "{workspaceRoot}/.eslintrc.json"],
+      "outputs": ["{projectRoot}/.eslintcache"],
       "cache": true
     },
     "prebuild": {
-      "dependsOn": [
-        "gql-copy"
-      ],
+      "dependsOn": ["gql-copy"],
       "inputs": [],
       "outputs": [
         "{projectRoot}/public/locales",
@@ -109,50 +69,23 @@
       "cache": true
     },
     "restart": {
-      "dependsOn": [
-        "build",
-        "^restart"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
+      "dependsOn": ["build", "^restart"],
+      "inputs": ["production", "^production"],
       "outputs": []
     },
     "start": {
-      "dependsOn": [
-        "build",
-        "gen-keys",
-        "^start"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
+      "dependsOn": ["build", "gen-keys", "^start"],
+      "inputs": ["production", "^production"],
       "outputs": []
     },
     "storybook": {
-      "dependsOn": [
-        "build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
-      "outputs": [
-        "{projectRoot}/storybook-static"
-      ]
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/storybook-static"]
     },
     "test": {
-      "inputs": [
-        "production",
-        "^production"
-      ],
-      "dependsOn": [
-        "test-unit",
-        "test-integration",
-        "test-e2e"
-      ],
+      "inputs": ["production", "^production"],
+      "dependsOn": ["test-unit", "test-integration", "test-e2e"],
       "outputs": [
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
@@ -161,13 +94,8 @@
       "cache": true
     },
     "test-e2e": {
-      "dependsOn": [
-        "build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"],
       "outputs": [
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
@@ -175,14 +103,8 @@
       ]
     },
     "test-integration": {
-      "dependsOn": [
-        "build",
-        "gen-keys"
-      ],
-      "inputs": [
-        "test",
-        "^test"
-      ],
+      "dependsOn": ["build", "gen-keys"],
+      "inputs": ["test", "^test"],
       "outputs": [
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
@@ -192,14 +114,8 @@
       "cache": true
     },
     "test-unit": {
-      "dependsOn": [
-        "build",
-        "gen-keys"
-      ],
-      "inputs": [
-        "test",
-        "^test"
-      ],
+      "dependsOn": ["build", "gen-keys"],
+      "inputs": ["test", "^test"],
       "outputs": [
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
@@ -209,11 +125,7 @@
     },
     "@nx/jest:jest": {
       "cache": true,
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ],
+      "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"],
       "options": {
         "passWithNoTests": true
       },
@@ -226,23 +138,23 @@
     },
     "@nx/js:tsc": {
       "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
+    },
+    "@nx/js:swc": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
+    },
+    "@nx/esbuild:esbuild": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"]
     }
   },
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*.*",
-      "sharedGlobals"
-    ],
-    "lint": [
-      "{projectRoot}/**/*.@(js|jsx|ts|tsx)"
-    ],
+    "default": ["{projectRoot}/**/*.*", "sharedGlobals"],
+    "lint": ["{projectRoot}/**/*.@(js|jsx|ts|tsx)"],
     "production": [
       "default",
       "{workspaceRoot}/external/l10n/**/*.@(ftl|po)",
@@ -264,10 +176,7 @@
         "runtime": "tsc -v"
       }
     ],
-    "test": [
-      "default",
-      "{workspaceRoot}/jest.preset.js"
-    ],
+    "test": ["default", "{workspaceRoot}/jest.preset.js"],
     "typescript": [
       "{projectRoot}/**/*.@(ts|tsx)",
       "{projectRoot}/package.json",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "@nestjs/cli": "^10.3.2",
     "@nestjs/schematics": "^10.1.1",
     "@nestjs/testing": "^10.3.4",
+    "@nx/esbuild": "19.3.0",
     "@nx/eslint-plugin": "19.3.0",
     "@nx/jest": "19.3.0",
     "@nx/js": "19.3.0",
@@ -181,6 +182,7 @@
     "@swc-node/register": "1.9.2",
     "@swc/cli": "0.3.12",
     "@swc/core": "1.5.29",
+    "@swc/jest": "^0.2.36",
     "@testing-library/react": "15.0.6",
     "@types/babel__core": "^7",
     "@types/bn.js": "^5",
@@ -275,9 +277,9 @@
   },
   "packageManager": "yarn@3.3.0",
   "_moduleAliases": {
-    "@fxa/vendored/jwtool": "./dist/libs/vendored/jwtool/src/index.js",
-    "@fxa/vendored/crypto-relier": "./dist/libs/vendored/crypto-relier/src/index.js",
-    "@fxa/shared/pem-jwk": "./dist/libs/shared/pem-jwk/src/index.js",
-    "@fxa/shared/l10n": "./dist/libs/shared/l10n/src/index.js"
+    "@fxa/vendored/jwtool": "./dist/libs/vendored/jwtool/main.cjs",
+    "@fxa/vendored/crypto-relier": "./dist/libs/vendored/crypto-relier/main.cjs",
+    "@fxa/shared/pem-jwk": "./dist/libs/shared/pem-jwk/main.cjs",
+    "@fxa/shared/l10n": "./dist/libs/shared/l10n/main.cjs"
   }
 }

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -66,7 +66,7 @@ const webpackConfig = {
       'fast-text-encoding': require.resolve('fast-text-encoding'),
       fxaCryptoDeriver: path.resolve(
         __dirname,
-        '../../dist/libs/vendored/crypto-relier/src/lib/deriver/index.js'
+        '../../dist/libs/vendored/crypto-relier/main.js'
       ),
       fxaPairingChannel: require.resolve(
         'fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10969,6 +10969,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/create-cache-key-function@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/create-cache-key-function@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+  checksum: 681bc761fa1d6fa3dd77578d444f97f28296ea80755e90e46d1c8fa68661b9e67f54dd38b988742db636d26cf160450dc6011892cec98b3a7ceb58cad8ff3aae
+  languageName: node
+  linkType: hard
+
 "@jest/environment@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/environment@npm:27.5.1"
@@ -12697,6 +12706,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nrwl/esbuild@npm:19.3.0":
+  version: 19.3.0
+  resolution: "@nrwl/esbuild@npm:19.3.0"
+  dependencies:
+    "@nx/esbuild": 19.3.0
+  checksum: a9d15f1dfd15dacfe52183018ba42d85072ebb748c398a13c574c77245cd9680f9ecffea45bd921bf2d08bbc808651c4fbedd07e73c0d87e21b1888348443b0c
+  languageName: node
+  linkType: hard
+
 "@nrwl/eslint-plugin-nx@npm:19.3.0":
   version: 19.3.0
   resolution: "@nrwl/eslint-plugin-nx@npm:19.3.0"
@@ -12869,6 +12887,27 @@ __metadata:
   peerDependencies:
     nx: ">= 17 <= 20"
   checksum: 32538ea477361f195aa5af2160371a89169c4a557ea0baccf6b74753817fd983ca976f82b46815c14040301f8ea5d2bae3d979fb1a669bc96966ad5cfa5d77a9
+  languageName: node
+  linkType: hard
+
+"@nx/esbuild@npm:19.3.0":
+  version: 19.3.0
+  resolution: "@nx/esbuild@npm:19.3.0"
+  dependencies:
+    "@nrwl/esbuild": 19.3.0
+    "@nx/devkit": 19.3.0
+    "@nx/js": 19.3.0
+    chalk: ^4.1.0
+    fast-glob: 3.2.7
+    fs-extra: ^11.1.0
+    tsconfig-paths: ^4.1.2
+    tslib: ^2.3.0
+  peerDependencies:
+    esbuild: ~0.19.2
+  peerDependenciesMeta:
+    esbuild:
+      optional: true
+  checksum: de61f4d84ed587fec7e46d8b2731e35d67fecf25bc80d632d1d4093aaefb0709e4b6e012da1d27146e70fee43405d6edf55bbf3fc91595f61ad88155f62e468e
   languageName: node
   linkType: hard
 
@@ -20900,6 +20939,19 @@ __metadata:
   dependencies:
     tslib: ^2.4.0
   checksum: 273fd3f3fc461a92f3790cc551ea054745c6d6959afbe1232e6d7aa1c722bbc114d308aab96bef5c78fc0303c85c7b472ef00e2253251cc89737f3b1af56e5a5
+  languageName: node
+  linkType: hard
+
+"@swc/jest@npm:^0.2.36":
+  version: 0.2.36
+  resolution: "@swc/jest@npm:0.2.36"
+  dependencies:
+    "@jest/create-cache-key-function": ^29.7.0
+    "@swc/counter": ^0.1.3
+    jsonc-parser: ^3.2.0
+  peerDependencies:
+    "@swc/core": "*"
+  checksum: 14f2e696ac093e23dae1e2e57d894bbcde4de6fe80341a26c8d0d8cbae5aae31832f8fa32dc698529f128d19a76aeedf2227f59480de6dab5eb3f30bfdf9b71a
   languageName: node
   linkType: hard
 
@@ -38973,6 +39025,7 @@ fsevents@~2.1.1:
     "@nestjs/schedule": ^4.0.1
     "@nestjs/schematics": ^10.1.1
     "@nestjs/testing": ^10.3.4
+    "@nx/esbuild": 19.3.0
     "@nx/eslint-plugin": 19.3.0
     "@nx/jest": 19.3.0
     "@nx/js": 19.3.0
@@ -39011,6 +39064,7 @@ fsevents@~2.1.1:
     "@swc/cli": 0.3.12
     "@swc/core": 1.5.29
     "@swc/helpers": 0.5.11
+    "@swc/jest": ^0.2.36
     "@testing-library/react": 15.0.6
     "@type-cacheable/core": ^14.0.1
     "@type-cacheable/ioredis-adapter": ^10.0.4
@@ -46754,7 +46808,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"jsonc-parser@npm:3.2.1":
+"jsonc-parser@npm:3.2.1, jsonc-parser@npm:^3.2.0":
   version: 3.2.1
   resolution: "jsonc-parser@npm:3.2.1"
   checksum: 656d9027b91de98d8ab91b3aa0d0a4cab7dc798a6830845ca664f3e76c82d46b973675bbe9b500fae1de37fd3e81aceacbaa2a57884bf2f8f29192150d2d1ef7


### PR DESCRIPTION
## Because

- ts-jest is consuming too much memory during unit test execution

## This pull request

- Replace ts-jest with @swc/jest, which has better memory utilization
- Replace Nx `TSC` build executor with Nx `esbuild` build executor, for better performance.
- Reduce size of unit-test job instance size from large back to medium+

## Issue that this pull request solves

Closes: #FXA-9879

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional information

Updated the Ecosystem docs in this PR https://github.com/mozilla/ecosystem-platform/pull/545

## Screenshots (Optional)

### Payments Cart
#### ts-jest
![image](https://github.com/mozilla/fxa/assets/10620585/5b8d6a56-ec4b-43a7-865d-4a0e2faeb617)

#### @swc/jest
![image](https://github.com/mozilla/fxa/assets/10620585/9f46fde3-3d7c-4865-84ba-2639ca7ec617)

### Payments Stripe
#### ts-jest
![image](https://github.com/mozilla/fxa/assets/10620585/a21858f4-5aae-4ce2-bd73-38fec7fa5e56)

#### @swc/jest
![image](https://github.com/mozilla/fxa/assets/10620585/f7546490-2609-43f5-80c8-27b3b23c953f)

