### PR TITLE
fix(metrics): Add Google and Apple signin telemetry

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/email.js
+++ b/packages/fxa-content-server/app/scripts/lib/glean/email.js
@@ -7,6 +7,22 @@
 import EventMetricType from '@mozilla/glean/private/metrics/event';
 
 /**
+ * User clicks on the Apple third party link from email first page.
+ *
+ * Generated from `email.apple_oauth_email_first_start`.
+ */
+export const appleOauthEmailFirstStart = new EventMetricType(
+  {
+    category: 'email',
+    name: 'apple_oauth_email_first_start',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Email First Page View
  * A view of the page that prompts the user to enter their email address. From
  * there the user either gets directed to the registration or login flow depending
@@ -18,6 +34,22 @@ export const firstView = new EventMetricType(
   {
     category: 'email',
     name: 'first_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on the Google third party link from email first page.
+ *
+ * Generated from `email.google_oauth_email_first_start`.
+ */
+export const googleOauthEmailFirstStart = new EventMetricType(
+  {
+    category: 'email',
+    name: 'google_oauth_email_first_start',
     sendInPings: ['events'],
     lifetime: 'ping',
     disabled: false,

--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -119,6 +119,12 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
     case 'email_first_view':
       email.firstView.record();
       break;
+    case 'apple_oauth_email_first_start':
+      email.appleOauthEmailFirstStart.record();
+      break;
+    case 'google_oauth_email_first_start':
+      email.googleOauthEmailFirstStart.record();
+      break;
     case 'reg_cwts_engage':
       reg.cwtsEngage.record();
       break;
@@ -319,6 +325,8 @@ export const GleanMetrics = {
 
   emailFirst: {
     view: createEventFn('email_first_view'),
+    appleOauthStart: createEventFn('apple_oauth_email_first_start'),
+    googleOauthStart: createEventFn('google_oauth_email_first_start'),
   },
 
   registration: {

--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import GleanMetrics from '../../lib/glean';
 import SigninMixin from './signin-mixin';
 import Storage from '../../lib/storage';
 import Url from '../../lib/url';
@@ -70,6 +71,10 @@ export default {
 
     this.logFlowEvent('google.oauth-start');
 
+    if (this.viewName === 'email-first') {
+      GleanMetrics.emailFirst.googleOauthStart();
+    }
+
     // We stash originating location in the Google state oauth param
     // because we will need it to use it to log the user into FxA
     const currentParams = new URLSearchParams(this.window.location.search);
@@ -127,6 +132,10 @@ export default {
     this.clearStoredParams();
 
     this.logFlowEvent('apple.oauth-start');
+
+    if (this.viewName === 'email-first') {
+      GleanMetrics.emailFirst.appleOauthStart();
+    }
 
     const currentParams = new URLSearchParams(this.window.location.search);
 

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -327,6 +327,28 @@ describe('lib/glean', () => {
       });
     });
 
+    describe('apple oauth email first', () => {
+      it('submits a ping with the apple_oauth_email_first_start event name', async () => {
+        await GleanMetrics.emailFirst.appleOauthStart();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'apple_oauth_email_first_start'
+        );
+      });
+    });
+
+    describe('google oauth email first', () => {
+      it('submits a ping with the google_oauth_email_first_start event name', async () => {
+        await GleanMetrics.emailFirst.googleOauthStart();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'google_oauth_email_first_start'
+        );
+      });
+    });
+
     describe('registration', () => {
       it('submits a ping with the reg_view event name', async () => {
         await GleanMetrics.registration.view();

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -405,6 +405,40 @@ email:
     expires: never
     data_sensitivity:
       - interaction
+  apple_oauth_email_first_start:
+    type: event
+    description: |
+      User clicks on the Apple third party link from email first page.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-9809
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  google_oauth_email_first_start:
+    type: event
+    description: |
+      User clicks on the Google third party link from email first page.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-9809
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 
 login:
   email_confirmation_submit:


### PR DESCRIPTION
This doesn't seem like the best way for landing these metrics. I believe we should be using glean extras to add the provider to be either `google` or `apple`, but I've been struggling to get the `EventProperties` type checking to add a new property.

Open question: 
- should I add the fxa-settings equivalent in this patch too?
- is the test coverage sufficient?

## This pull request

- Adds `google_oauth_email_first_start` and `apple_oauth_login_start`.

## Issue that this pull request solves

Closes: FXA-9809, FXA-9808

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
