### PR TITLE
fix(glean): Tweak view/submit CAD Glean events

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -225,7 +225,7 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
       cadFirefox.view.record();
       break;
     case 'cad_firefox_choice_view':
-      cadFirefox.view.record();
+      cadFirefox.choiceView.record();
       break;
     case 'cad_firefox_choice_engage':
       cadFirefox.choiceEngage.record({

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -32,6 +32,9 @@ class PairIndexView extends FormView {
   model = new FormNeedsMobile();
 
   submit() {
+    if (this.model.get('needsMobileConfirmed')) {
+      GleanMetrics.cadFirefox.syncDeviceSubmit();
+    }
     this.metrics.flush();
     return this.broker.openPairPreferences();
   }
@@ -88,8 +91,8 @@ class PairIndexView extends FormView {
 
     GleanMetrics.cadFirefox.choiceSubmit({
       reason: needsMobileConfirmed
-        ? GLEAN_EVENT_REASON_HAS_MOBILE
-        : GLEAN_EVENT_REASON_NO_MOBILE,
+        ? GLEAN_EVENT_REASON_NO_MOBILE
+        : GLEAN_EVENT_REASON_HAS_MOBILE,
     });
 
     if (needsMobileConfirmed) {
@@ -97,7 +100,6 @@ class PairIndexView extends FormView {
       // For screen readers/keyboard users, to avoid rereading the Moz logo and CAD header
       this.$('#pair-header-mobile').focus();
     } else {
-      GleanMetrics.cadFirefox.syncDeviceSubmit();
       this.submit();
     }
   }

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -307,9 +307,9 @@ describe('views/pair/index', () => {
           view.$('#set-needs-mobile').click();
 
           sinon.assert.calledWith(submitChoiceEventStub, {
-            reason: 'does not have mobile',
+            reason: 'has mobile',
           });
-          sinon.assert.called(submitSyncDeviceEventStub);
+          sinon.assert.notCalled(submitSyncDeviceEventStub);
           sinon.assert.called(submitSpy);
           sinon.assert.notCalled(viewMobileDownloadEventStub);
         });
@@ -319,8 +319,9 @@ describe('views/pair/index', () => {
           view.$('#set-needs-mobile').click();
 
           sinon.assert.calledWith(submitChoiceEventStub, {
-            reason: 'has mobile',
+            reason: 'does not have mobile',
           });
+          // called on submit
           sinon.assert.notCalled(submitSyncDeviceEventStub);
           sinon.assert.notCalled(submitSpy);
 
@@ -379,11 +380,31 @@ describe('views/pair/index', () => {
   });
 
   describe('submit', () => {
+    let submitSyncDeviceEventStub;
+    beforeEach(() => {
+      submitSyncDeviceEventStub = sinon.stub(
+        GleanMetrics.cadFirefox,
+        'syncDeviceSubmit'
+      );
+    });
+    afterEach(() => {
+      submitSyncDeviceEventStub.restore();
+    });
     it('submits', () => {
       sinon.spy(view.broker, 'openPairPreferences');
       return view.render().then(() => {
         view.submit();
         assert.isTrue(view.broker.openPairPreferences.calledOnce);
+        sinon.assert.notCalled(submitSyncDeviceEventStub);
+      });
+    });
+    it('submits and sends expected Glean event when needsMobileConfirmed is true', () => {
+      sinon.spy(view.broker, 'openPairPreferences');
+      view.model.set('needsMobileConfirmed', true);
+      return view.render().then(() => {
+        view.submit();
+        assert.isTrue(view.broker.openPairPreferences.calledOnce);
+        sinon.assert.calledOnce(submitSyncDeviceEventStub);
       });
     });
   });


### PR DESCRIPTION
Because:
* There are a couple of bugs we want to address with the existing CAD metrics

This commit:
* Swaps the event reason on choice submission, as they were inversed
* Fixes the Glean event map to cad_firefox_choice_view, as it referenced cad_firefox_view
* Only emits the 'cad_firefox_sync_device_submit' event when user reaches the "needs mobile" screen and clicks "Continue to sync"

fixes FXA-9834, fixes FXA-9833, fixes FXA-9832