### PR TITLE
chore(functional): integrate html reporting with Playwright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,8 @@ commands:
             NODE_OPTIONS: --dns-result-order=ipv4first
             JEST_JUNIT_OUTPUT_DIR: ./artifacts/tests
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: true
+            PLAYWRIGHT_BLOB_OUTPUT_DIR: ./artifacts/blob-report
+            PW_TEST_HTML_REPORT_OPEN: never
             ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
             PAYMENTS_DOMAIN: << pipeline.parameters.payments-domain >>
             ACCOUNTS_API_DOMAIN: << pipeline.parameters.accounts-api-domain >>
@@ -332,7 +334,7 @@ commands:
     steps:
       - run:
           name: Ensure directories
-          command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots
+          command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots && mkdir -p artifacts/blob-report && mkdir -p artifacts/playwright-report
       - store_artifacts:
           path: artifacts
       - store_artifacts:
@@ -341,6 +343,21 @@ commands:
           path: ~/.pm2/logs
       - store_test_results:
           path: artifacts/tests
+
+  rename-reports:
+    steps:
+      - run:
+          name: Rename Reports
+          command: |
+            cd artifacts/blob-report
+            mv report.zip reports-${CIRCLE_NODE_INDEX}.zip
+      - store_artifacts:
+          path: artifacts/blob-report
+      - persist_to_workspace:
+          root: /home/circleci/project
+          paths:
+            - artifacts/blob-report
+
 
   build:
     steps:
@@ -657,6 +674,23 @@ jobs:
       - run-playwright-tests:
           project: local
       - store-artifacts
+      - rename-reports
+
+  playwright-functional-test-report:
+    executor: default-executor
+    steps:
+      - attach_workspace:
+          at: /home/circleci/project
+      - run:
+          name: Merge blob Reports
+          command: ls -l artifacts/blob-report && npx playwright merge-reports --reporter=blob artifacts/blob-report
+      - store_artifacts:
+          path: blob-report
+      - run:
+          name: Merge html Reports
+          command: npx playwright merge-reports --reporter=html artifacts/blob-report
+      - store_artifacts:
+          path: playwright-report
 
   build-and-deploy-storybooks:
     executor: default-executor
@@ -771,6 +805,10 @@ workflows:
           parallelism: 8
           requires:
             - Build (PR)
+      - playwright-functional-test-report:
+          name: Merge Playwright Reports (PR)
+          requires:
+            - Functional Tests - Playwright (PR)
       - build-and-deploy-storybooks:
           name: Deploy Storybooks (PR)
           requires:
@@ -1093,6 +1131,10 @@ workflows:
           parallelism: 8
           requires:
             - Build (nightly)
+      - playwright-functional-test-report:
+          name: Merge Playwright Reports (nightly)
+          requires:
+            - Functional Tests - Playwright (nightly)
       - on-complete:
           name: Tests Complete (nightly)
           stage: Tests (nightly)

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -73,6 +73,13 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
             ),
           },
         ],
+        [
+          'blob',
+          {
+            outputDir: path.resolve(__dirname, '../../artifacts/blob-report'),
+          },
+        ],
+        ['html', { open: 'never' }],
       ]
     : 'list',
   workers,


### PR DESCRIPTION
## Because

- We want to integrate inbuilt HTML reporting with Playwright together with blob reporting

## This pull request

- Creates blob reports (.zip) for the test run for each parallel running machine
- Merges the test reports from 8 parallel machines running the tests
- Creates a HTML dashboard to display the functional test run details using the merged .zip file
- Adds an additional `Merge-Report` workflow and `playwright-functional-test-report` job in the config file
- Generates a `playwright-report/index.html` in the artifacts section on CircleCI, clicking which displays the dashboard
- All the above steps are integrated for local PRs and nightly

## Issue that this pull request solves

Closes: FXA-8998 FXA-9857

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1038" alt="Untitled" src="https://github.com/mozilla/fxa/assets/62558650/0a0a24cb-ee24-4c1c-a526-f493ff102bc5">



## Other information (Optional)

Any other information that is important to this pull request.
