### PR TITLE
bug(settings): Force multiple tabs to logout of settings.

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -6,7 +6,12 @@ import React, { useEffect } from 'react';
 import AppLayout from './AppLayout';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import AppErrorDialog from 'fxa-react/components/AppErrorDialog';
-import { useAccount, useConfig, useInitialSettingsState } from '../../models';
+import {
+  useAccount,
+  useConfig,
+  useInitialSettingsState,
+  useSession,
+} from '../../models';
 import { Redirect, Router, RouteComponentProps } from '@reach/router';
 import Head from 'fxa-react/components/Head';
 import PageSettings from './PageSettings';
@@ -24,10 +29,12 @@ import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
 import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
 import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
+import { hardNavigate } from 'fxa-react/lib/utils';
 
 export const Settings = (_: RouteComponentProps) => {
   const config = useConfig();
   const { metricsEnabled, hasPassword } = useAccount();
+  const session = useSession();
 
   useEffect(() => {
     if (config.metrics.navTiming.enabled && metricsEnabled) {
@@ -38,6 +45,16 @@ export const Settings = (_: RouteComponentProps) => {
     config.metrics.navTiming.enabled,
     config.metrics.navTiming.endpoint,
   ]);
+
+  useEffect(() => {
+    function handleWindowFocus() {
+      if (session.isDestroyed) {
+        hardNavigate('/');
+      }
+    }
+    window.addEventListener('focus', handleWindowFocus);
+    return () => window.removeEventListener('focus', handleWindowFocus);
+  }, [session]);
 
   const { loading, error } = useInitialSettingsState();
 

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -1,6 +1,10 @@
 import { ApolloClient, gql, NormalizedCacheObject } from '@apollo/client';
 import AuthClient from 'fxa-auth-client/browser';
-import { sessionToken, clearSignedInAccountUid } from '../lib/cache';
+import {
+  sessionToken,
+  clearSignedInAccountUid,
+  currentAccount,
+} from '../lib/cache';
 import { GET_LOCAL_SIGNED_IN_STATUS } from '../components/App/gql';
 
 export interface SessionData {
@@ -115,6 +119,10 @@ export class Session implements SessionData {
     });
 
     clearSignedInAccountUid();
+  }
+
+  get isDestroyed() {
+    return currentAccount() == null;
   }
 
   async isSessionVerified() {


### PR DESCRIPTION
## Because

- When two tabs are open, logging out of one tab, would not impact the second tab
- Some level interaction would still be possible in the second tab.

## This pull request

- Makes sure that after logging out of one tab, another active tab will also log out
## Issue that this pull request solves

Closes: FXA-9760

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

To test do the following:

1. Log in
2. Right click on tab, select 'duplicate tab'
3. In this tab log out
4. Go back to previous tab
5. Observe that on activation that tab also logs out
