### PR TITLE
fix(fxa-settings): Enable sync after password reset

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -102,6 +102,12 @@ export type FxALoginSignedInUserRequest = {
   uid: hexstring;
   unwrapBKey: string;
   verified: boolean;
+  services?: {
+    sync: {
+      offeredEngines?: string[];
+      declinedEngines?: string[];
+    };
+  };
 };
 
 export type FxAOAuthLogin = {

--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/CompleteResetPassword/container.tsx
@@ -127,6 +127,9 @@ const CompleteResetPasswordContainer = ({
         uid: accountResetData.uid,
         unwrapBKey: accountResetData.unwrapBKey,
         verified: accountResetData.verified,
+        services: {
+          sync: {},
+        },
       });
     }
   };


### PR DESCRIPTION
## Because

* Sync was disabled after resetting password during a sync sign in

## This pull request

* Add services to the FxaLoginSignedInUserRequest webchannel message used by reset password

## Issue that this pull request solves

Closes: #FXA-9870

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
