### PR TITLE
fix(html_report): add if statement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ commands:
     steps:
       - run:
           name: Ensure directories
-          command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots && mkdir -p artifacts/blob-report && mkdir -p artifacts/playwright-report
+          command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots
       - store_artifacts:
           path: artifacts
       - store_artifacts:
@@ -349,8 +349,21 @@ commands:
       - run:
           name: Rename Reports
           command: |
-            cd artifacts/blob-report
-            mv report.zip reports-${CIRCLE_NODE_INDEX}.zip
+            mkdir -p artifacts/blob-report && mkdir -p artifacts/playwright-report
+            echo "Starting rename reports step"
+            cd artifacts/blob-report || { echo "Directory artifacts/blob-report not found"; exit 1; }
+            echo "Current directory: $(pwd)"
+            echo "Listing contents before renaming:"
+            ls -la
+            if [ -f report.zip ]; then
+              mv report.zip reports-${CIRCLE_NODE_INDEX}.zip
+              echo "Renamed report.zip to reports-${CIRCLE_NODE_INDEX}.zip"
+            else
+              echo "No report.zip found, skipping rename for this node."
+            fi
+            echo "Listing contents after renaming:"
+            ls -la
+          when: always
       - store_artifacts:
           path: artifacts/blob-report
       - persist_to_workspace:
@@ -683,12 +696,28 @@ jobs:
           at: /home/circleci/project
       - run:
           name: Merge blob Reports
-          command: ls -l artifacts/blob-report && npx playwright merge-reports --reporter=blob artifacts/blob-report
+          command: |
+            cd artifacts/blob-report
+            echo "Merging blob reports"
+            ls -l
+            if ls *.zip 1> /dev/null 2>&1; then
+              npx playwright merge-reports --reporter=blob .
+            else
+              echo "No report zip files found, skipping blob merge."
+            fi
       - store_artifacts:
           path: blob-report
       - run:
           name: Merge html Reports
-          command: npx playwright merge-reports --reporter=html artifacts/blob-report
+          command: |
+            cd artifacts/blob-report
+            echo "Merging HTML reports"
+            ls -l
+            if ls *.zip 1> /dev/null 2>&1; then
+              npx playwright merge-reports --reporter=html .
+            else
+              echo "No report zip files found, skipping HTML merge."
+            fi
       - store_artifacts:
           path: playwright-report
 


### PR DESCRIPTION
## Because

- The reports were not generating for parallel machines that had failed tests runs.


## This pull request

- Added the `when` parameter to config.yaml file for the 'rename reports' step
- Added condition to rename files when the reports otherwise provide an apt message 
- Added if condition for merging the reports when the report exist otherwise provide an apt message

## Issue that this pull request solves

Closes: FXA-9885 FXA-9979

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
