### PR TITLE
revert react signin full prod flag

### DIFF
--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -200,7 +200,7 @@ test.describe('severity-1 #smoke', () => {
 
       await relier.goto();
       await relier.clickEmailFirst();
-      await expect(page).toHaveURL(/oauth\//);
+      await expect(page).toHaveURL(/oauth\/signin/);
 
       // reload page with React experiment params
       await page.goto(
@@ -208,6 +208,8 @@ test.describe('severity-1 #smoke', () => {
       );
 
       // Cached user detected
+      await expect(page).toHaveURL(/oauth\/signin/);
+      await expect(page.locator('#root')).toBeEnabled();
       await expect(signin.cachedSigninHeading).toBeVisible();
       // Email is prefilled
       await expect(page.getByText(email)).toBeVisible();
@@ -246,6 +248,7 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await signup.fillOutEmailForm(email);
+      await expect(signup.signupFormHeading).toBeVisible();
       await signup.fillOutSignupForm(password, AGE_21);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -80,7 +80,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'inline_totp_setup',
         'inline_recovery_setup',
       ]),
-      fullProdRollout: true,
+      fullProdRollout: false,
     },
 
     signUpRoutes: {


### PR DESCRIPTION
## Because

- Not ready for full prod rollout

## This pull request

- Revert React Signin fullProdRollout flag to false

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
