### PR TITLE
fix(functional-tests): Address isolation issues caused by sync tests

### DIFF
--- a/packages/functional-tests/pages/baseTokenCode.ts
+++ b/packages/functional-tests/pages/baseTokenCode.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 
 export abstract class BaseTokenCodePage extends BaseLayout {
@@ -38,6 +39,7 @@ export abstract class BaseTokenCodePage extends BaseLayout {
   async fillOutCodeForm(code: string) {
     this.checkPath();
     await this.codeInput.fill(code);
+    await expect(this.codeInput).toHaveValue(code);
     await this.submitButton.click();
   }
 }

--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -65,6 +65,34 @@ export class SignupPage extends BaseLayout {
     return this.page.getByLabel('History', { exact: true });
   }
 
+  get CWTSEnginePasswords() {
+    return this.page.getByLabel('Passwords', { exact: true });
+  }
+
+  get CWTSEngineAddons() {
+    return this.page.getByLabel('Add-ons', { exact: true });
+  }
+
+  get CWTSEngineOpenTabs() {
+    return this.page.getByLabel('Open Tabs', { exact: true });
+  }
+
+  get CWTSEnginePreferences() {
+    return this.page.getByLabel('Preferences', { exact: true });
+  }
+
+  get CWTSEngineCreditCards() {
+    return this.page.getByLabel('Payment Methods', { exact: true });
+  }
+
+  get CWTSEngineAddresses() {
+    return this.page.getByLabel('Addresses', { exact: true });
+  }
+
+  get CWTSDoNotSync() {
+    return this.page.getByLabel('Do not sync', { exact: true });
+  }
+
   // for backwards compatibility with Backbone
   // not currently implemented in React, see FXA-8827
   get permissionsHeading() {

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -52,13 +52,9 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('signin', async ({
-      pages: { signin, relier, page },
+      syncBrowserPages: { signin, relier, page },
       testAccountTracker,
     }) => {
-      test.fixme(
-        true,
-        'TODO in FXA-9914, look into isolation issue, this test might be causing following tests to fail'
-      );
       const credentials = await testAccountTracker.signUp();
       const customEventDetail = createCustomEventDetail(
         FirefoxCommand.FxAStatus,

--- a/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/forceAuth.spec.ts
@@ -13,9 +13,8 @@ test.describe('force auth react', () => {
   });
 
   test('displays signin with registered email', async ({
-    page,
     target,
-    pages: { signin },
+    syncBrowserPages: { page, signin },
     testAccountTracker,
   }) => {
     const credentials = await testAccountTracker.signUp();
@@ -35,9 +34,8 @@ test.describe('force auth react', () => {
   });
 
   test('redirects to signup with unregistered email', async ({
-    page,
     target,
-    pages: { configPage, signup },
+    syncBrowserPages: { configPage, page, signup },
   }) => {
     const config = await configPage.getConfig();
     test.skip(config.showReactApp.signUpRoutes !== true);

--- a/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { test, expect } from '../../lib/fixtures/standard';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('connect_another_device', () => {

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -52,13 +52,16 @@ test.describe('severity-1 #smoke', () => {
     });
 
     test('add totp, login with sync', async ({
-      pages: { connectAnotherDevice, settings, totp, page, signin, signup },
+      syncBrowserPages: {
+        connectAnotherDevice,
+        settings,
+        totp,
+        page,
+        signin,
+        signup,
+      },
       testAccountTracker,
     }) => {
-      test.fixme(
-        true,
-        'TODO in FXA-9914, look into isolation issue, this test might be causing following tests to fail. Possibly needs syncBrowserPage fixture.'
-      );
       const credentials = await testAccountTracker.signUp();
 
       await signin.goto();

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -53,13 +53,9 @@ test.describe('severity-1 #smoke', () => {
 
     test('signup sync desktop v3, verify account', async ({
       target,
-      syncBrowserPages: { confirmSignupCode, page, signup, login },
+      syncBrowserPages: { confirmSignupCode, page, signup },
       testAccountTracker,
     }) => {
-      test.fixme(
-        true,
-        'TODO in FXA-9914, look into isolation issue, this test might be causing following tests to fail'
-      );
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
       test.fixme(true, 'Fix required as of 2024/03/18 (see FXA-9306).');
@@ -74,23 +70,23 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.respondToWebChannelMessage(eventDetailLinkAccount);
       await signup.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-      await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
+      await signup.checkWebChannelMessage(FirefoxCommand.LinkAccount);
 
       // Sync desktop v3 includes "default" engines plus the ones provided via web channel
       // See sync-engines.ts comments
-      await expect(login.CWTSEngineHeader).toBeVisible();
-      await expect(login.CWTSEngineBookmarks).toBeVisible();
-      await expect(login.CWTSEngineHistory).toBeVisible();
-      await expect(login.CWTSEnginePasswords).toBeVisible();
-      await expect(login.CWTSEngineAddons).toBeVisible();
-      await expect(login.CWTSEngineOpenTabs).toBeVisible();
-      await expect(login.CWTSEnginePreferences).toBeVisible();
-      await expect(login.CWTSEngineCreditCards).toBeVisible();
-      await expect(login.CWTSEngineAddresses).toBeHidden();
+      await expect(signup.CWTSEngineHeader).toBeVisible();
+      await expect(signup.CWTSEngineBookmarks).toBeVisible();
+      await expect(signup.CWTSEngineHistory).toBeVisible();
+      await expect(signup.CWTSEnginePasswords).toBeVisible();
+      await expect(signup.CWTSEngineAddons).toBeVisible();
+      await expect(signup.CWTSEngineOpenTabs).toBeVisible();
+      await expect(signup.CWTSEnginePreferences).toBeVisible();
+      await expect(signup.CWTSEngineCreditCards).toBeVisible();
+      await expect(signup.CWTSEngineAddresses).toBeHidden();
 
       await signup.fillOutSignupForm(password, AGE_21);
 
-      await login.checkWebChannelMessage(FirefoxCommand.Login);
+      await signup.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
@@ -33,8 +32,7 @@ test.describe('severity-2 #smoke', () => {
 
   test('verified, does need to confirm', async ({
     target,
-    page,
-    pages: { signin, signinTokenCode },
+    syncBrowserPages: { page, signin, signinTokenCode },
     testAccountTracker,
   }) => {
     const credentials = await testAccountTracker.signUpSync();

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/oauthResetPasswordSyncMobile.spec.ts
@@ -19,14 +19,9 @@ test.describe('severity-1 #smoke', () => {
 
     test('reset password through Sync mobile', async ({
       target,
-      page,
-      pages: { connectAnotherDevice, resetPassword, signin },
+      syncBrowserPages: { page, connectAnotherDevice, resetPassword, signin },
       testAccountTracker,
     }) => {
-      test.fixme(
-        true,
-        'TODO in FXA-9914, look into isolation issue, this test might be causing following tests to fail'
-      );
       const credentials = await testAccountTracker.signUp();
       const newPassword = testAccountTracker.generatePassword();
 

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPassword.spec.ts
@@ -64,8 +64,7 @@ test.describe('severity-1 #smoke', () => {
 
     test('reset password through Sync mobile', async ({
       target,
-      page,
-      pages: { signin, resetPassword },
+      syncBrowserPages: { page, signin, resetPassword },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPasswordSyncMobile.spec.ts
@@ -21,8 +21,7 @@ test.describe('severity-1 #smoke', () => {
 
     test('reset password through Sync mobile', async ({
       target,
-      page,
-      pages: { signin, resetPassword },
+      syncBrowserPages: { page, signin, resetPassword },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -101,8 +101,7 @@ test.describe('severity-2 #smoke', () => {
 
     test('with bounced email', async ({
       target,
-      page,
-      pages: { signin },
+      syncBrowserPages: { page, signin },
       testAccountTracker,
     }) => {
       test.fixme(


### PR DESCRIPTION
## Because

- Tests were failing in parallel runs, but passing in isolation
- Appears to mainly be caused by missing syncBrowserPages fixture in sync-related tests

## This pull request

- Applies `syncBrowserPages` where it was missing 

## Issue that this pull request solves

Closes: [FXA-9914](https://mozilla-hub.atlassian.net/browse/FXA-9914)

[FXA-9914]: https://mozilla-hub.atlassian.net/browse/FXA-9914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ