### PR TITLE
fix(inline-totp): Display totp code for manual entry

### DIFF
--- a/packages/fxa-settings/src/components/DataBlock/mocks.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/mocks.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import React from 'react';
 import DataBlock, { DataBlockProps } from '.';
 import { MOCK_EMAIL } from '../../pages/mocks';
 

--- a/packages/fxa-settings/src/components/DataBlockManual/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DataBlockManual/index.stories.tsx
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import DataBlockManual from '.';
+
+export default {
+  title: 'Components/DataBlockManual',
+  component: DataBlockManual,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Default = () => (
+  <DataBlockManual secret={'MMMMOOOOZZZZIIIILLLLLLLLAAAAYAAY'} />
+);

--- a/packages/fxa-settings/src/components/DataBlockManual/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlockManual/index.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+
+interface DataBlockManualProps {
+  secret: string;
+}
+
+export const formatSecret = (secret: string) => {
+  return secret.toUpperCase().match(/.{4}/g)!.join(' ');
+};
+
+export const DataBlockManual = ({ secret }: DataBlockManualProps) => {
+  return (
+    <p className="my-8 mx-auto font-bold" data-testid="manual-code">
+      {formatSecret(secret)}
+    </p>
+  );
+};
+
+export default DataBlockManual;

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -19,6 +19,7 @@ import { Localized, useLocalization } from '@fluent/react';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useAsync } from 'react-async-hook';
 import { getErrorFtlId } from '../../../lib/error-utils';
+import DataBlockManual from '../../DataBlockManual';
 
 export const metricsPreInPostFix = 'settings.two-step-authentication';
 
@@ -251,9 +252,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <Localized id="tfa-enter-secret-key">
                 <p>Enter this secret key into your authenticator app:</p>
               </Localized>
-              <p className="my-8 mx-auto font-bold" data-testid="manual-code">
-                {totpInfo.result.secret.toUpperCase().match(/.{4}/g)!.join(' ')}
-              </p>
+              <DataBlockManual secret={totpInfo.result.secret} />
             </div>
           )}
           <Localized id="tfa-enter-totp-v2">

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -9,6 +9,7 @@ import InlineTotpSetup from '.';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { MozServices } from '../../lib/types';
 import { MOCK_EMAIL, MOCK_TOTP_TOKEN } from './mocks';
+import { formatSecret } from '../../components/DataBlockManual';
 
 const cancelSetupHandler = jest.fn();
 const verifyCodeHandler = jest.fn();
@@ -93,6 +94,7 @@ describe('InlineTotpSetup', () => {
       name: 'Can’t scan code?',
     });
     await act(async () => await user.click(changeToManualModeButton));
+    screen.getByText(formatSecret(MOCK_TOTP_TOKEN.secret));
     await screen.findByRole('button', { name: 'Scan QR code instead?' });
   });
 

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -13,10 +13,10 @@ import FormVerifyCode from '../../components/FormVerifyCode';
 import AppLayout from '../../components/AppLayout';
 import Banner, { BannerType } from '../../components/Banner';
 import { InlineTotpSetupProps } from './interfaces';
+import DataBlockManual from '../../components/DataBlockManual';
 
 export const InlineTotpSetup = ({
   totp,
-  email,
   serviceName,
   cancelSetupHandler,
   verifyCodeHandler,
@@ -31,7 +31,6 @@ export const InlineTotpSetup = ({
     'inline-totp-setup-code-required-error',
     'Authentication code required'
   );
-  const [secret] = useState<string>();
   const [showIntro, setShowIntro] = useState(true);
   const [showQR, setShowQR] = useState(true);
   const [totpErrorMessage, setTotpErrorMessage] = useState('');
@@ -212,7 +211,7 @@ export const InlineTotpSetup = ({
                       ),
                     }}
                   >
-                    <p className="text-sm m-2">
+                    <p className="text-sm mt-4">
                       Type this secret key into your authentication app.{' '}
                       <button
                         onClick={() => {
@@ -224,9 +223,7 @@ export const InlineTotpSetup = ({
                       </button>
                     </p>
                   </FtlMsg>
-                  <div className="qr-code-container">
-                    <div className="qr-code-text">{secret}</div>
-                  </div>
+                  <DataBlockManual secret={totp.secret} />
                   <FtlMsg id="inline-totp-setup-on-completion-description">
                     <p className="text-sm mb-4">
                       Once complete, it will begin generating authentication


### PR DESCRIPTION
Because:
* We were not properly displaying this code on the inline TOTP page

This commit:
* Creates a new component to share with where we display this code inside Settings, and uses it in both locations
* Adds new component to Storybook, updates test

fixes FXA-9916

---

Before and after:

<img width="400" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/d30c1d4b-e7c2-41eb-8652-16ed7b181182">

<img width="400" alt="image" src="https://github.com/mozilla/fxa/assets/13018240/c0599c10-1372-47cb-ae5b-612c82c7d989">
