### PR TITLE
feat(metrics): Update the Glean name for `third_party_auth_set_password` metrics

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -253,16 +253,16 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
     case 'cad_mobile_pair_view':
       cadMobilePair.view.record();
       break;
-    case 'set_password_third_party_auth_view':
+    case 'third_party_auth_set_password_view':
       setPasswordThirdPartyAuth.view.record();
       break;
-    case 'set_password_third_party_auth_engage':
+    case 'third_party_auth_set_password_engage':
       setPasswordThirdPartyAuth.engage.record();
       break;
-    case 'set_password_third_party_auth_submit':
+    case 'third_party_auth_set_password_submit':
       setPasswordThirdPartyAuth.submit.record();
       break;
-    case 'set_password_third_party_auth_success':
+    case 'third_party_auth_set_password_success':
       setPasswordThirdPartyAuth.success.record();
       break;
   }
@@ -378,10 +378,10 @@ export const GleanMetrics = {
     view: createEventFn('cad_approve_device_view'),
   },
   setPasswordThirdPartyAuth: {
-    view: createEventFn('set_password_third_party_auth_view'),
-    engage: createEventFn('set_password_third_party_auth_engage'),
-    submit: createEventFn('set_password_third_party_auth_submit'),
-    success: createEventFn('set_password_third_party_auth_success'),
+    view: createEventFn('third_party_auth_set_password_view'),
+    engage: createEventFn('third_party_auth_set_password_engage'),
+    submit: createEventFn('third_party_auth_set_password_submit'),
+    success: createEventFn('third_party_auth_set_password_success'),
   },
 };
 

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -457,40 +457,40 @@ describe('lib/glean', () => {
       });
     });
 
-    describe('set_password_third_party_auth', () => {
-      it('submits a ping with the set_password_third_party_auth_view event name', async () => {
+    describe('third_party_auth_set_password', () => {
+      it('submits a ping with the third_party_auth_set_password_view event name', async () => {
         await GleanMetrics.setPasswordThirdPartyAuth.view();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
           setEventNameStub,
-          'set_password_third_party_auth_view'
+          'third_party_auth_set_password_view'
         );
       });
 
-      it('submits a ping with the set_password_third_party_auth_engage event name', async () => {
+      it('submits a ping with the third_party_auth_set_password_engage event name', async () => {
         await GleanMetrics.setPasswordThirdPartyAuth.engage();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
           setEventNameStub,
-          'set_password_third_party_auth_engage'
+          'third_party_auth_set_password_engage'
         );
       });
 
-      it('submits a ping with the set_password_third_party_auth_submit event name', async () => {
+      it('submits a ping with the third_party_auth_set_password_submit event name', async () => {
         await GleanMetrics.setPasswordThirdPartyAuth.submit();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
           setEventNameStub,
-          'set_password_third_party_auth_submit'
+          'third_party_auth_set_password_submit'
         );
       });
 
-      it('submits a ping with the set_password_third_party_auth_success event name', async () => {
+      it('submits a ping with the third_party_auth_set_password_success event name', async () => {
         await GleanMetrics.setPasswordThirdPartyAuth.success();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
           setEventNameStub,
-          'set_password_third_party_auth_success'
+          'third_party_auth_set_password_success'
         );
       });
     });

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1300,7 +1300,7 @@ cad_mobile_pair:
     data_sensitivity:
       - interaction
 
-set_password_third_party_auth:
+third_party_auth_set_password:
   view:
     type: event
     description: |


### PR DESCRIPTION
## Because

- We want to track these events

## This pull request

- Updates the name since the work was done in https://mozilla-hub.atlassian.net/browse/FXA-9116

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9821
Closes: https://mozilla-hub.atlassian.net/browse/FXA-9822
Closes: https://mozilla-hub.atlassian.net/browse/FXA-9823
Closes: https://mozilla-hub.atlassian.net/browse/FXA-9824

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I didn't realize when I worked on the ticket that I made separate issues for each of this. The work was done in https://mozilla-hub.atlassian.net/browse/FXA-9116. This PR just updates the name to match what we have in https://docs.google.com/spreadsheets/d/1DgohA2JG8gvFOjk_8zUHOi6DSDSPzqCCwoNVvirDpkA/edit#gid=1073857271
