### PR TITLE
fix(functional-tests): Await oauth prompt none error

### DIFF
--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -84,11 +84,6 @@ export class RelierPage extends BaseLayout {
     return this.page.locator('.ready .prompt-none').click();
   }
 
-  async promptNoneError() {
-    this.page.locator('.error');
-    return this.page.innerText('.error');
-  }
-
   async clickSubscribe() {
     await this.page
       .getByRole('link', { name: 'Subscribe to Pro (USD)' })

--- a/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/oauth/oauthPromptNone.spec.ts
@@ -33,7 +33,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       //Verify error message
-      expect(await relier.promptNoneError()).toContain('User is not signed in');
+      await expect(page.getByText('User is not signed in')).toBeVisible();
     });
 
     test('fails RP that is not allowed', async ({
@@ -55,9 +55,9 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       //Verify error message
-      expect(await relier.promptNoneError()).toContain(
-        'prompt=none is not enabled for this client'
-      );
+      await expect(
+        page.getByText('prompt=none is not enabled for this client')
+      ).toBeVisible();
     });
 
     test('fails if requesting keys', async ({
@@ -86,9 +86,9 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       //Verify error message
-      expect(await relier.promptNoneError()).toContain(
-        'prompt=none cannot be used when requesting keys'
-      );
+      await expect(
+        page.getByText('prompt=none cannot be used when requesting keys')
+      ).toBeVisible();
     });
 
     test('fails if session is no longer valid', async ({
@@ -119,7 +119,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       //Verify error message
-      expect(await relier.promptNoneError()).toContain('User is not signed in');
+      await expect(page.getByText('User is not signed in')).toBeVisible();
     });
 
     test('fails if account is not verified', async ({
@@ -147,9 +147,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       //Verify error message
-      expect(await relier.promptNoneError()).toContain(
-        'Unverified user or session'
-      );
+      await expect(page.getByText('Unverified user or session')).toBeVisible();
     });
   });
 
@@ -214,9 +212,9 @@ test.describe('severity-1 #smoke', () => {
       await relier.signInPromptNone();
 
       //Verify error message
-      expect(await relier.promptNoneError()).toContain(
-        'A different user is signed in'
-      );
+      await expect(
+        page.getByText('A different user is signed in')
+      ).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## Because

* Error message was not awaited properly causing tests to error in smoke tests

## This pull request

* Await error message without using class selector

## Issue that this pull request solves

Closes: #FXA-9932

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
