### PR TITLE
fix(payments): hide paypal on paypal init failure

### DIFF
--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -271,7 +271,7 @@ export const PaypalButton = ({
   }
 
   return (
-    <div data-testid="pay-with-other">
+    <div data-testid="pay-with-other" className={`${!initSuccess && 'hidden'}`}>
       <Localized id="pay-with-heading-paypal-2">
         <p className="pay-with-heading mt-14">Pay with PayPal</p>
       </Localized>


### PR DESCRIPTION
## Because

- When the paypal button fails to load during initialization, for example when there is a PayPal sandbox outage, the subscription checkout page loads into an error, instead of hiding the PayPal button.
- This has resulted in a confusing user experience, as well as causing unrelated functional test failures due to the error page being shown.

## This pull request

- If the PayPal button does not successfully finish it's onInit function, then hide the PayPal button instead of showing an error message.
- If any other PayPal error occurs, continue showing the error page.

## Issue that this pull request solves

Closes: #FXA-9886

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The only way I found to replicate the failure scenario is to manually call the `onError` function before `onInit` completes.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![image](https://github.com/mozilla/fxa/assets/10620585/cbb62580-18a7-436f-9b47-65e87b2d8080)

