### PR TITLE
fix(functional-tests): resubscribe successfully with the same coupon after canceling for stripe

### DIFF
--- a/packages/functional-tests/pages/products/index.ts
+++ b/packages/functional-tests/pages/products/index.ts
@@ -83,10 +83,6 @@ export class SubscribePage extends BaseLayout {
       .getByText('Promo Code');
   }
 
-  get totalPrice() {
-    return this.page.getByTestId('total-price');
-  }
-
   get subscriptionErrorHeading() {
     return this.page.getByRole('heading', {
       name: /Error confirming subscription/,

--- a/packages/functional-tests/pages/products/subscriptionManagement.ts
+++ b/packages/functional-tests/pages/products/subscriptionManagement.ts
@@ -73,7 +73,7 @@ export class SubscriptionManagementPage extends BaseLayout {
     return this.page.getByTestId('subscription-item');
   }
 
-  get resubscriptionPrice() {
+  get priceDetailsStandalone() {
     return this.page.getByTestId('price-details-standalone');
   }
 

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -40,16 +40,14 @@ test.describe('severity-2 #smoke', () => {
       // Verify the coupon is applied successfully
       await expect(subscribe.promoCodeAppliedHeading).toBeVisible();
 
-      const total = await subscribe.totalPrice.textContent();
-
-      //Subscribe successfully with Stripe
+      // Subscribe successfully with Stripe
       await subscribe.confirmPaymentCheckbox.check();
       await subscribe.paymentInformation.fillOutCreditCardInfo(VALID_VISA);
       await subscribe.paymentInformation.clickPayNow();
 
       await expect(subscribe.subscriptionConfirmationHeading).toBeVisible();
 
-      //Signin to FxA account
+      // Signin to FxA account
       await signin.goto();
 
       await expect(signin.cachedSigninHeading).toBeVisible();
@@ -62,20 +60,24 @@ test.describe('severity-2 #smoke', () => {
         target
       );
 
-      //Verify no coupon details are visible
+      // Verify no coupon details are visible
       await expect(subscriptionManagement.subscriptionDetails).not.toHaveText(
         'Promo'
       );
 
-      //Cancel subscription and then resubscribe
+      const total =
+        await subscriptionManagement.priceDetailsStandalone.textContent();
+      expect(total).not.toBeNull();
+
+      // Cancel subscription and then resubscribe
       await subscriptionManagement.cancelSubscription();
       await subscriptionManagement.resubscribe();
 
-      //Verify that the resubscription has the same coupon applied
-      const resubscriptionPrice =
-        await subscriptionManagement.resubscriptionPrice.textContent();
-      expect(resubscriptionPrice).toEqual(total);
-      //Verify no coupon details are visible
+      // Verify that the resubscription has the same coupon applied
+      await expect(subscriptionManagement.priceDetailsStandalone).toHaveText(
+        <string>total
+      );
+      // Verify no coupon details are visible
       await expect(subscriptionManagement.subscriptionDetails).not.toHaveText(
         'Promo'
       );


### PR DESCRIPTION
## Because

* the test fails due to the incorrect comparison of the total with the resubscriptionPrice

## This pull request

* fixes the test by comparing resubscriptionPrices

## Issue that this pull request solves

Closes: #FXA-9912

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
