### PR TITLE
fix(settings): ConfirmResetPassword image cut off on small screens

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPasswordRedesign/ConfirmResetPassword/index.tsx
@@ -58,7 +58,7 @@ const ConfirmResetPassword = ({
       <FtlMsg id="password-reset-flow-heading">
         <p className="text-start text-grey-400 text-sm">Reset your password</p>
       </FtlMsg>
-      <EmailCodeImage />
+      <EmailCodeImage className="mx-auto" />
       <FtlMsg id="confirm-reset-password-with-code-heading">
         <h2 className="card-header text-start my-4">Check your email</h2>
       </FtlMsg>


### PR DESCRIPTION
## Because

- We want the entire image to be visible

## This pull request

- Update styling of the image

## Issue that this pull request solves

Closes: #FXA-9911

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://github.com/mozilla/fxa/assets/22231637/12505663-b60d-47b2-a08d-09b3dc5df2ba)

After:
![image](https://github.com/mozilla/fxa/assets/22231637/3de397ca-24de-41d3-a5b9-a3494d2ad620)

## Other information (Optional)

Any other information that is important to this pull request.
