### PR TITLE
feat(glean): Add login_diff_account_link_click event to login page

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -173,6 +173,9 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
         reason: properties['reason'] || '',
       });
       break;
+    case 'login_diff_account_link_click':
+      login.diffAccountLinkClick.record();
+      break;
     case 'cached_login_forgot_pwd_submit':
       cachedLogin.forgotPwdSubmit.record();
       break;
@@ -387,6 +390,7 @@ export const GleanMetrics = {
     submit: createEventFn('login_submit'),
     success: createEventFn('login_submit_success'),
     error: createEventFn('login_submit_frontend_error'),
+    diffAccountLinkClick: createEventFn('login_diff_account_link_click'),
   },
 
   cachedLogin: {

--- a/packages/fxa-content-server/app/scripts/lib/glean/login.js
+++ b/packages/fxa-content-server/app/scripts/lib/glean/login.js
@@ -23,6 +23,23 @@ export const appleOauthLoginStart = new EventMetricType(
 );
 
 /**
+ * Event that indicates user clicked on "Use a different account" link on login
+ * page.
+ *
+ * Generated from `login.diff_account_link_click`.
+ */
+export const diffAccountLinkClick = new EventMetricType(
+  {
+    category: 'login',
+    name: 'diff_account_link_click',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Login Email Confirm Attempted
  * Event that indicates a user attempted to confirm email in the login by entering
  * in Code to "confirm" & click button to submit. See the Login + 2FA section

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -33,6 +33,7 @@ const SignInPasswordView = FormView.extend({
   }),
 
   useDifferentAccount() {
+    GleanMetrics.login.diffAccountLinkClick();
     // a user who came from an OAuth relier and was
     // directed directly to /signin will not be able
     // to go back. Send them directly to `/` with the

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -336,11 +336,25 @@ describe('views/sign_in_password', () => {
     });
 
     describe('useDifferentAccount', () => {
+      let loginDiffAccountClickEventStub;
+
+      beforeEach(() => {
+        loginDiffAccountClickEventStub = sinon.stub(
+          GleanMetrics.login,
+          'diffAccountLinkClick'
+        );
+      });
+
+      afterEach(() => {
+        loginDiffAccountClickEventStub.restore();
+      });
+
       it('navigates to `/` with the account', () => {
         sinon.spy(view, 'navigate');
 
         view.useDifferentAccount();
 
+        sinon.assert.calledOnce(loginDiffAccountClickEventStub);
         assert.isTrue(view.navigate.calledOnceWith('/', { account }));
       });
     });

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -221,6 +221,9 @@ const recordEventMetric = (
         reason: gleanPingMetrics?.event?.['reason'] || '',
       });
       break;
+    case 'login_diff_account_link_click':
+      login.diffAccountLinkClick.record();
+      break;
     case 'cached_login_forgot_pwd_submit':
       cachedLogin.forgotPwdSubmit.record();
       break;

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -59,6 +59,7 @@ jest.mock('../../lib/glean', () => ({
       submit: jest.fn(),
       success: jest.fn(),
       error: jest.fn(),
+      diffAccountLinkClick: jest.fn(),
     },
     cachedLogin: {
       forgotPassword: jest.fn(),
@@ -809,6 +810,11 @@ describe('with sessionToken', () => {
           screen.getByRole('link', {
             name: 'Use a different account',
           })
+        );
+      });
+      await waitFor(() => {
+        expect(GleanMetrics.login.diffAccountLinkClick).toHaveBeenCalledTimes(
+          1
         );
       });
       expect(hardNavigateSpy).toHaveBeenCalledWith(

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -408,6 +408,7 @@ const Signin = ({
             className="text-sm link-blue"
             onClick={(e) => {
               e.preventDefault();
+              GleanMetrics.login.diffAccountLinkClick();
               const params = new URLSearchParams(location.search);
               // Tell content-server to stay on index and prefill the email
               params.set('prefillEmail', email);

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -731,6 +731,23 @@ login:
     expires: never
     data_sensitivity:
       - interaction
+  diff_account_link_click:
+    type: event
+    description: |
+      Event that indicates user clicked on "Use a different account" link on login page.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-9570
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 
 password_reset:
   create_new_recovery_key_message_click:

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -56,6 +56,7 @@ export const eventsMap = {
     success: 'login_submit_success',
     error: 'login_submit_frontend_error',
     forgotPassword: 'login_forgot_pwd_submit',
+    diffAccountLinkClick: 'login_diff_account_link_click',
   },
 
   cachedLogin: {

--- a/packages/fxa-shared/metrics/glean/web/login.ts
+++ b/packages/fxa-shared/metrics/glean/web/login.ts
@@ -23,6 +23,23 @@ export const appleOauthLoginStart = new EventMetricType(
 );
 
 /**
+ * Event that indicates user clicked on "Use a different account" link on login
+ * page.
+ *
+ * Generated from `login.diff_account_link_click`.
+ */
+export const diffAccountLinkClick = new EventMetricType(
+  {
+    category: 'login',
+    name: 'diff_account_link_click',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Login Email Confirm Attempted
  * Event that indicates a user attempted to confirm email in the login by entering
  * in Code to "confirm" & click button to submit. See the Login + 2FA section


### PR DESCRIPTION
## Because

- We want to know when users click the "Use a different account" link on the login page.

## This pull request

- Adds a Glean telemetry probe for that link.

## Issue that this pull request solves

Closes: FXA-9570

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
