### PR TITLE
fix(fxa-settings): Ensure confirmation emails are sent for cached signin

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -9,6 +9,7 @@ import {
   useAuthClient,
   useFtlMsgResolver,
   useConfig,
+  useSession,
 } from '../../models';
 import { MozServices } from '../../lib/types';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
@@ -115,6 +116,7 @@ const SigninContainer = ({
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state?: LocationState;
   };
+  const session = useSession();
 
   const { queryParamModel, validationError } =
     useValidatedQueryParams(SigninQueryParams);
@@ -320,6 +322,10 @@ const SigninContainer = ({
           ? VerificationReasons.SIGN_IN
           : VerificationReasons.SIGN_UP;
 
+        if (!verified) {
+          await session.sendVerificationCode();
+        }
+
         return {
           data: {
             verificationMethod,
@@ -342,7 +348,7 @@ const SigninContainer = ({
         return { error };
       }
     },
-    [authClient, uid]
+    [authClient, session, uid]
   );
 
   const sendUnblockEmailHandler = useCallback(


### PR DESCRIPTION
## Because

* Confirmation code emails (either for unverified session or unverified account) were not sent out during cached signin with React (but clicking "Email new code" worked
* We want to ensure that an email is immediately sent out
* We want to match parity with Backbone

## This pull request

* Send out the email during cached signin if the account or session are unverified
* Update the cached signin functional test
* Add a new functional test for unverified signin

## Issue that this pull request solves

Closes: #FXA-9878

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

### Pre-requisites
- Use React params `http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
- Signup for a new account, but *DON'T* confirm it on `confirm_signup_code`

### Steps to test cached sign in (unverified):

- Go back to `http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
- Expect to see a password-less cached signin
- Click "Sign in"

Expected result:

- navigated to /confirm_signup_code
- receive verifyShortCode email (“Confirm your account”)

### Steps to test sign in with password (unverified)
- either from the previous account if it is still unconfirmed or with a new account from pre-requisites
- clear cache at `http://localhost:3030/clear`
- go to `http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
- enter email
- enter password

Expected result:

- navigated to /confirm_signup_code
- receive verifyLoginCode email (“Authorize this sign-in”) --> while this is not ideal vs receiving `verifyShortCode`, it does match parity with Backbone

### Steps to test sign-in confirmation (verified email)

- in local testing, change auth-server config to force sign-in confirmation:
  - set `forceGlobally` to true
  - set `skipForNewAccounts` to false
- sign up for a new account and complete confirmation
- go to `http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
- start sign in but don't confirm
- return to `http://localhost:3030/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
- Expect to see a password-less cached signin
- Click "Sign in"

Expected result:

- navigated to /confirm_signup_code
- receive verifyLoginCode email (“Authorize this sign-in”) 