### PR TITLE
fix(functional-tests):  remove fixmes from webchannel tests

### DIFF
--- a/packages/functional-tests/pages/login.ts
+++ b/packages/functional-tests/pages/login.ts
@@ -54,10 +54,6 @@ export class LoginPage extends BaseLayout {
     return this.page.getByLabel('Add-ons', { exact: true });
   }
 
-  get CWTSEngineOpenTabs() {
-    return this.page.getByLabel('Open Tabs', { exact: true });
-  }
-
   get CWTSEnginePreferences() {
     return this.page.getByLabel('Preferences', { exact: true });
   }

--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -128,9 +128,4 @@ export class SignupPage extends BaseLayout {
     await this.ageTextbox.fill(age);
     await this.createAccountButton.click();
   }
-
-  async waitForRoot() {
-    const root = this.page.locator('#root');
-    await root.waitFor();
-  }
 }

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -98,7 +98,6 @@ test.describe('severity-1 #smoke', () => {
       syncBrowserPages: { confirmSignupCode, page, login, signup },
       testAccountTracker,
     }) => {
-      test.fixme(true, 'Fix required as of 2024/03/18 (see FXA-9306).');
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
       const customEventDetail = createCustomEventDetail(
@@ -115,30 +114,30 @@ test.describe('severity-1 #smoke', () => {
       await signup.goto('/authorization', syncMobileOAuthQueryParams);
 
       await signup.fillOutEmailForm(email);
-      await page.waitForURL(/signup/, { waitUntil: 'load' });
-      await signup.waitForRoot();
 
       await expect(signup.signupFormHeading).toBeVisible();
 
       await signup.sendWebChannelMessage(customEventDetail);
 
       // Only engines provided via web channel for Sync mobile are displayed
-      await expect(login.CWTSEngineHeader).toBeVisible();
-      await expect(login.CWTSEngineBookmarks).toBeVisible();
-      await expect(login.CWTSEngineHistory).toBeVisible();
-      await expect(login.CWTSEnginePasswords).toBeHidden();
-      await expect(login.CWTSEngineAddons).toBeHidden();
-      await expect(login.CWTSEngineOpenTabs).toBeHidden();
-      await expect(login.CWTSEnginePreferences).toBeHidden();
-      await expect(login.CWTSEngineCreditCards).toBeHidden();
-      await expect(login.CWTSEngineAddresses).toBeHidden();
+      await expect(signup.CWTSEngineHeader).toBeVisible();
+      await expect(signup.CWTSEngineBookmarks).toBeVisible();
+      await expect(signup.CWTSEngineHistory).toBeVisible();
+      await expect(signup.CWTSEnginePasswords).toBeHidden();
+      await expect(signup.CWTSEngineAddons).toBeHidden();
+      await expect(signup.CWTSEngineOpenTabs).toBeHidden();
+      await expect(signup.CWTSEnginePreferences).toBeHidden();
+      await expect(signup.CWTSEngineCreditCards).toBeHidden();
+      await expect(signup.CWTSEngineAddresses).toBeHidden();
 
       await signup.fillOutSignupForm(password, AGE_21);
+
       await expect(page).toHaveURL(/confirm_signup_code/);
+
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
-      await page.waitForURL(/connect_another_device/);
 
+      await expect(page).toHaveURL(/connect_another_device/);
       await signup.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
     });
   });

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -37,12 +37,11 @@ test.describe('severity-1 #smoke', () => {
         testAccountTracker.generateSignupAccountDetails();
 
       await signup.goto();
-
       await signup.fillOutEmailForm(email);
-      await signup.waitForRoot();
-
       await signup.fillOutSignupForm(password, AGE_21);
+
       await expect(page).toHaveURL(/confirm_signup_code/);
+
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
 
@@ -58,17 +57,14 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
-      test.fixme(true, 'Fix required as of 2024/03/18 (see FXA-9306).');
       await signup.goto('/', syncDesktopV3QueryParams);
 
       await signup.fillOutEmailForm(email);
-      await page.waitForURL(/signup/, { waitUntil: 'load' });
-      await signup.waitForRoot();
 
-      // Wait for page to render
-      await expect(page.getByText('Set your password')).toBeVisible();
+      await expect(signup.signupFormHeading).toBeVisible();
 
       await signup.respondToWebChannelMessage(eventDetailLinkAccount);
+
       await signup.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       await signup.checkWebChannelMessage(FirefoxCommand.LinkAccount);
 
@@ -88,10 +84,11 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(page).toHaveURL(/confirm_signup_code/);
+
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
-      await page.waitForURL(/connect_another_device/);
 
+      await expect(page).toHaveURL(/connect_another_device/);
       await expect(page.getByText('You’re signed into Firefox')).toBeVisible();
     });
   });


### PR DESCRIPTION
## Because

- many updates have been made to improve isolation since March and the tests no longer exhibit flake locally

## This pull request

- removes the fixme annotation from: 
  - react-conversion/oauthSignup.spec.ts:96:9 › severity-1 #smoke › signup react › signup oauth webchannel - sync mobile or FF desktop 123+ 
  - react-conversion/signup.spec.ts:53:9 › severity-1 #smoke › signup react › signup sync desktop v3, verify account
- removes waitForRoot from SignupPage
- removes CWTSEngineOpenTabs from LoginPage

## Issue that this pull request solves

Closes: # FXA-9306

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
