### PR TITLE
fix(functional-tests): subscription coupon tests failing on stage

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
@@ -10,10 +10,6 @@ test.describe('severity-2 #smoke', () => {
     test('apply an expired coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
-      test.fixme(
-        project.name !== 'local',
-        'Fix required as of 2024/05/13 (see FXA-9689).'
-      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
@@ -15,10 +15,6 @@ test.describe('severity-2 #smoke', () => {
     test('apply an invalid coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
-      test.fixme(
-        project.name !== 'local',
-        'Fix required as of 2024/05/13 (see FXA-9689).'
-      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
@@ -67,10 +67,6 @@ test.describe('severity-2 #smoke', () => {
     test('remove a coupon and verify', async ({
       pages: { relier, subscribe },
     }, { project }) => {
-      test.fixme(
-        project.name !== 'local',
-        'Fix required as of 2024/05/13 (see FXA-9689).'
-      );
       test.skip(
         project.name === 'production',
         'test plan not available in prod'


### PR DESCRIPTION
## Because

- on the stage environment applying coupons fails with the error message 'An error occured processing the code. Please try again.' indicating that we've hit a rate limit. Since adding fixmes improvements restricting the number of retries and updating tests to use auto-awaiting asserts have been implemented.

## This pull request

- removes the fixmes to see if rate limiting is still an issue

## Issue that this pull request solves

Closes: # FXA-9689

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
