### PR TITLE
fix(content): Email from subscriptions redirect not passed to react

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -422,7 +422,7 @@ var BaseView = Backbone.View.extend({
   _reAuthPage() {
     if (this.relier && this.relier.get('email')) {
       // setting the email here ensures that React signin can pick up on this email
-      this.user.set('email', this.relier.get('email'));
+      this.user.set('emailFromIndex', this.relier.get('email'));
       return 'force_auth';
     }
     // Until email-first is fully the default, this is


### PR DESCRIPTION
## Because

- Email address is lost when accessing the “here” link from “Automatic renewal notice” email with the force experiment parameter added

## This pull request

- Set the email on emailFromIndex instead of email to ensure it is passed to React force_auth/signin

## Issue that this pull request solves

Closes: #FXA-9975

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

If a renewal notice is not available for testing, these steps may be an adequate scenario for testing:

### Pre-requisites

- Have an account with an active subscription (e.g., added from 123done);
- Sign out of account and clear local storage (localhost:30330/clear)

### Steps
- Go to localhost:3030/subscriptions with React experiment params and account email as param
e.g. with an account created for test@gmail.com:
`http://localhost:3030/subscriptions?forceExperiment=generalizedReactApp&forceExperimentGroup=react&email=test%40gmail.com`

### Expected result

With this PR: redirected to signin with password (prompt to enter password for test@gmail.com), then redirected to subscriptions after sign in

Before this PR: redirected to index page (prompt to enter email), then redirected to subscriptions after sign in
