### PR TITLE
fix(metrics): Update viewName for sign-in metrics

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/third-party-auth-mixin.js
@@ -71,7 +71,7 @@ export default {
 
     this.logFlowEvent('google.oauth-start');
 
-    if (this.viewName === 'email-first') {
+    if (this.viewName === 'enter-email') {
       GleanMetrics.emailFirst.googleOauthStart();
     }
 
@@ -133,7 +133,7 @@ export default {
 
     this.logFlowEvent('apple.oauth-start');
 
-    if (this.viewName === 'email-first') {
+    if (this.viewName === 'enter-email') {
       GleanMetrics.emailFirst.appleOauthStart();
     }
 


### PR DESCRIPTION
## Because

- The metrics were behind the wrong view name.

## This pull request

- Updates that to what it should be now.

## Issue that this pull request solves

Closes: [FXA-9809](https://mozilla-hub.atlassian.net/browse/FXA-9809), [FXA-9808](https://mozilla-hub.atlassian.net/browse/FXA-9808)

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

Better tests for this will be covered in FXA-9816 and FXA-9817.


[FXA-9809]: https://mozilla-hub.atlassian.net/browse/FXA-9809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXA-9808]: https://mozilla-hub.atlassian.net/browse/FXA-9808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ