### PR TITLE
fix(functional-tests): Await confirmation of totp setup in tests

### DIFF
--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -27,6 +27,11 @@ test.describe('severity-1 #smoke', () => {
       await settings.goto();
       await settings.totp.addButton.click();
       const { secret } = await totp.fillOutTotpForms();
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText(
+        'Two-step authentication enabled'
+      );
+      await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
       await relier.goto();
       await relier.clickEmailFirst();
@@ -51,6 +56,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.goto();
       await settings.totp.addButton.click();
       await totp.fillOutTotpForms();
+      await expect(settings.totp.status).toHaveText('Enabled');
       await settings.totp.disableButton.click();
       await settings.clickModalConfirm();
 

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithCode/oauthResetPassword.spec.ts
@@ -131,7 +131,8 @@ test.describe('severity-1 #smoke', () => {
       // Goes to settings and enables totp on user's account.
       await expect(settings.settingsHeading).toBeVisible();
       await settings.totp.addButton.click();
-      const totpCredentials = await totp.fillOutTotpForms();
+      const { secret } = await totp.fillOutTotpForms();
+      await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
 
       // Makes sure user is not signed in, and goes to the relier (ie 123done)
@@ -162,7 +163,7 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(page).toHaveURL(/signin_totp_code/);
 
-      const totpCode = await getCode(totpCredentials.secret);
+      const totpCode = await getCode(secret);
       await expect(page).toHaveURL(/signin_totp_code/);
       await signinTotpCode.fillOutCodeForm(totpCode);
 

--- a/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordWithLink/oauthResetPassword.spec.ts
@@ -217,6 +217,7 @@ test.describe('severity-1 #smoke', () => {
       // Goes to settings and enables totp on user's account.
       await settings.totp.addButton.click();
       await totp.fillOutTotpForms();
+      await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
 
       // Makes sure user is not signed in, and goes to the relier (ie 123done)

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -170,6 +170,7 @@ test.describe('severity-2 #smoke', () => {
       await settings.goto();
       await settings.totp.addButton.click();
       const { secret } = await totp.fillOutTotpForms();
+      await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
 
       await page.goto(


### PR DESCRIPTION
## Because

* We were not await confirmation that totp was enabled before signing out of settings in tests
* This could cause a race condition where totp setup was incomplete before sign out, causing flakiness in tests

## This pull request

* Add assertion for totp enabled after forms are filled out

## Issue that this pull request solves

Closes: #FXA-10001

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
