### PR TITLE
fix(sync): Send fxaLogout message on settings sign out if sync

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -236,7 +236,7 @@ const SettingsRoutes = ({
     <SettingsContext.Provider value={settingsContext}>
       <ScrollToTop default>
         <Suspense fallback={<LoadingSpinner fullScreen />}>
-          <Settings path="/settings/*" />
+          <Settings path="/settings/*" {...{ integration }} />
         </Suspense>
       </ScrollToTop>
     </SettingsContext.Provider>

--- a/packages/fxa-settings/src/components/BrandMessaging/index.stories.tsx
+++ b/packages/fxa-settings/src/components/BrandMessaging/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { BrandMessagingPortal } from '.';
-import AppLayout from '../Settings/AppLayout';
+import { MockSettingsAppLayout } from '../Settings/AppLayout/mocks';
 
 export default {
   title: 'Components/BrandMessaging',
@@ -15,19 +15,19 @@ export default {
 } as Meta;
 
 export const NoLaunch = () => (
-  <AppLayout>
+  <MockSettingsAppLayout>
     <BrandMessagingPortal viewName="storybook" />
-  </AppLayout>
+  </MockSettingsAppLayout>
 );
 
 export const PreLaunch = () => (
-  <AppLayout>
+  <MockSettingsAppLayout>
     <BrandMessagingPortal mode="prelaunch" viewName="storybook" />
-  </AppLayout>
+  </MockSettingsAppLayout>
 );
 
 export const PostLaunch = () => (
-  <AppLayout>
+  <MockSettingsAppLayout>
     <BrandMessagingPortal mode="postlaunch" viewName="storybook" />
-  </AppLayout>
+  </MockSettingsAppLayout>
 );

--- a/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
@@ -5,33 +5,32 @@
 import React from 'react';
 import { Subject } from './mocks';
 import { LocationProvider } from '@reach/router';
-import AppLayout from '../Settings/AppLayout';
 import FormPassword from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../Settings/AppLayout/mocks';
 
 export default {
   title: 'Components/FormPassword',
   component: FormPassword,
   decorators: [withLocalization],
 } as Meta;
-
 export const WithCurrentPassword = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <div className="max-w-lg mx-auto">
         <Subject />
       </div>
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );
 
 export const WithoutCurrentPassword = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <div className="max-w-lg mx-auto">
         <Subject includeCurrentPw={false} />
       </div>
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AppLayout from './index';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { createMockSettingsIntegration } from '../mocks';
 
 export default {
   title: 'Components/Settings/AppLayout',
@@ -9,8 +10,10 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+const integration = createMockSettingsIntegration();
+
 export const Basic = () => (
-  <AppLayout>
+  <AppLayout {...{ integration }}>
     <p>App content goes here</p>
   </AppLayout>
 );

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.test.tsx
@@ -4,17 +4,17 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
-import AppLayout from '.';
 import { renderWithRouter } from '../../../models/mocks';
 import { HomePath } from '../../../constants';
+import { MockSettingsAppLayout } from './mocks';
 
 it('renders the app with children', async () => {
   const {
     history: { navigate },
   } = renderWithRouter(
-    <AppLayout>
+    <MockSettingsAppLayout>
       <p data-testid="test-child">Hello, world!</p>
-    </AppLayout>
+    </MockSettingsAppLayout>
   );
   await navigate(HomePath);
   expect(screen.getByTestId('app')).toBeInTheDocument();

--- a/packages/fxa-settings/src/components/Settings/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/index.tsx
@@ -7,12 +7,14 @@ import HeaderLockup from '../HeaderLockup';
 import ContentSkip from '../ContentSkip';
 import Footer from 'fxa-react/components/Footer';
 import { AlertBar } from '../AlertBar';
+import { SettingsIntegration } from '../interfaces';
 
 type AppLayoutProps = {
   children: React.ReactNode;
+  integration: SettingsIntegration;
 };
 
-export const AppLayout = ({ children }: AppLayoutProps) => {
+export const AppLayout = ({ children, integration }: AppLayoutProps) => {
   return (
     <div
       className="flex flex-col justify-between min-h-screen"
@@ -20,7 +22,7 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
     >
       <ContentSkip />
       <div id="body-top" className="hidden mobileLandscape:block" />
-      <HeaderLockup />
+      <HeaderLockup {...{ integration }} />
       <div className="max-w-screen-desktopXl flex-1 w-full mx-auto tablet:px-20 desktop:px-12">
         <main id="main" data-testid="main" className="w-full">
           <AlertBar />

--- a/packages/fxa-settings/src/components/Settings/AppLayout/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/AppLayout/mocks.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AppLayout from '.';
+import { createMockSettingsIntegration } from '../mocks';
+
+// Does not follow "Subject" naming convention for clarity because we use
+// this throughout the app and not isolated tests.
+export const MockSettingsAppLayout = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return (
+    <AppLayout integration={createMockSettingsIntegration()}>
+      {children}
+    </AppLayout>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.stories.tsx
@@ -8,6 +8,7 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import DropDownAvatarMenu from '.';
 import { Account, AppContext } from 'fxa-settings/src/models';
 import { mockAppContext, MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
+import { createMockSettingsIntegration } from '../mocks';
 
 export default {
   title: 'Components/Settings/DropDownAvatarMenu',
@@ -34,12 +35,14 @@ const accountWithoutAvatar = {
   },
 } as unknown as Account;
 
+const integration = createMockSettingsIntegration();
+
 const storyWithContext = (account: Partial<Account>) => {
   const context = { account: account as Account };
 
   const story = () => (
     <AppContext.Provider value={mockAppContext(context)}>
-      <DropDownAvatarMenu />
+      <DropDownAvatarMenu {...{ integration }} />
     </AppContext.Provider>
   );
   return story;
@@ -48,4 +51,6 @@ const storyWithContext = (account: Partial<Account>) => {
 export const DefaultNoAvatarOrDisplayName =
   storyWithContext(accountWithoutAvatar);
 
-export const WithAvatarAndDisplayName = () => <DropDownAvatarMenu />;
+export const WithAvatarAndDisplayName = () => (
+  <DropDownAvatarMenu {...{ integration }} />
+);

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
@@ -10,9 +10,15 @@ import { useEscKeydownEffect } from '../../../lib/hooks';
 import { ReactComponent as SignOut } from './sign-out.svg';
 import { logViewEvent, settingsViewName } from '../../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
+import firefox from '../../../lib/channels/firefox';
+import { SettingsIntegration } from '../interfaces';
 
-export const DropDownAvatarMenu = () => {
-  const { displayName, primaryEmail, avatar } = useAccount();
+export const DropDownAvatarMenu = ({
+  integration,
+}: {
+  integration: SettingsIntegration;
+}) => {
+  const { displayName, primaryEmail, avatar, uid } = useAccount();
   const session = useSession();
   const [isRevealed, setRevealed] = useState(false);
   const toggleRevealed = () => setRevealed(!isRevealed);
@@ -32,6 +38,11 @@ export const DropDownAvatarMenu = () => {
     if (session.destroy) {
       try {
         await session.destroy();
+
+        if (integration.isSync()) {
+          firefox.fxaLogout({ uid });
+        }
+
         logViewEvent(settingsViewName, 'signout.success');
         window.location.assign(window.location.origin);
       } catch (e) {

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
@@ -5,11 +5,11 @@
 import React, { useState } from 'react';
 import { FlowRecoveryKeyConfirmPwd } from '.';
 import { Meta } from '@storybook/react';
-import AppLayout from '../AppLayout';
 import { Account, AppContext, useFtlMsgResolver } from '../../../models';
 import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Components/Settings/FlowRecoveryKeyConfirmPwd',
@@ -74,7 +74,7 @@ const StoryWithContext = (account: Account) => {
 
   return (
     <AppContext.Provider value={mockAppContext({ account })}>
-      <AppLayout>
+      <MockSettingsAppLayout>
         <FlowRecoveryKeyConfirmPwd
           {...{
             localizedBackButtonTitle,
@@ -85,7 +85,7 @@ const StoryWithContext = (account: Account) => {
             viewName,
           }}
         />
-      </AppLayout>
+      </MockSettingsAppLayout>
     </AppContext.Provider>
   );
 };

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
@@ -8,6 +8,7 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { HeaderLockup } from '.';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext, MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
+import { createMockSettingsIntegration } from '../mocks';
 
 export default {
   title: 'Components/Settings/HeaderLockup',
@@ -25,12 +26,14 @@ const accountWithoutAvatar = {
   },
 } as unknown as Account;
 
+const integration = createMockSettingsIntegration();
+
 const storyWithContext = (account: Partial<Account>) => {
   const context = { account: account as Account };
 
   const story = () => (
     <AppContext.Provider value={mockAppContext(context)}>
-      <HeaderLockup />
+      <HeaderLockup {...{ integration }} />
     </AppContext.Provider>
   );
   return story;
@@ -38,4 +41,4 @@ const storyWithContext = (account: Partial<Account>) => {
 
 export const WithDefaultAvatar = storyWithContext(accountWithoutAvatar);
 
-export const WithCustomAvatar = () => <HeaderLockup />;
+export const WithCustomAvatar = () => <HeaderLockup {...{ integration }} />;

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.test.tsx
@@ -6,13 +6,16 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import HeaderLockup from '.';
+import { createMockSettingsIntegration } from '../mocks';
 
 // TODO: functional test for `data-testid="header-menu"` to be visible in
 // mobile & tablet but hidden at desktop
 
 describe('HeaderLockup', () => {
   it('renders as expected', () => {
-    renderWithLocalizationProvider(<HeaderLockup />);
+    renderWithLocalizationProvider(
+      <HeaderLockup integration={createMockSettingsIntegration()} />
+    );
     const headerHelp = screen.getByTestId('header-help');
     const headerMenu = screen.getByTestId('header-menu');
 

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.tsx
@@ -13,8 +13,13 @@ import { ReactComponent as Help } from './help.svg';
 import { ReactComponent as Menu } from './menu.svg';
 import { ReactComponent as Close } from './close.svg';
 import Nav from '../Nav';
+import { SettingsIntegration } from '../interfaces';
 
-export const HeaderLockup = () => {
+export const HeaderLockup = ({
+  integration,
+}: {
+  integration: SettingsIntegration;
+}) => {
   const [navRevealedState, setNavState] = useState(false);
   const { l10n } = useLocalization();
   const localizedHelpText = l10n.getString('header-help', null, 'Help');
@@ -78,7 +83,7 @@ export const HeaderLockup = () => {
         />
       </LinkExternal>
       <BentoMenu />
-      <DropDownAvatarMenu />
+      <DropDownAvatarMenu {...{ integration }} />
     </>
   );
 

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.stories.tsx
@@ -10,10 +10,10 @@ import {
 } from 'fxa-settings/src/models/mocks';
 import React from 'react';
 import { Page2faReplaceRecoveryCodes } from '.';
-import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 const session = mockSession(true);
 const account = {
@@ -41,9 +41,9 @@ export default {
 export const Default = () => (
   <LocationProvider>
     <AppContext.Provider value={mockAppContext({ account, session })}>
-      <AppLayout>
+      <MockSettingsAppLayout>
         <Page2faReplaceRecoveryCodes />
-      </AppLayout>
+      </MockSettingsAppLayout>
     </AppContext.Provider>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.stories.tsx
@@ -5,9 +5,9 @@
 import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
-import AppLayout from '../AppLayout';
 import PageAvatar from './';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/Avatar',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageAvatar />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
@@ -5,9 +5,9 @@
 import React from 'react';
 import { PageChangePassword } from '.';
 import { LocationProvider } from '@reach/router';
-import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/ChangePassword',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageChangePassword />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
@@ -4,10 +4,10 @@
 
 import PageCreatePassword from '.';
 import React from 'react';
-import AppLayout from '../AppLayout';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/CreatePassword',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageCreatePassword />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
@@ -5,9 +5,9 @@
 import React from 'react';
 import { PageDeleteAccount } from '.';
 import { LocationProvider } from '@reach/router';
-import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/DeleteAccount',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageDeleteAccount />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.stories.tsx
@@ -5,9 +5,9 @@
 import { LocationProvider } from '@reach/router';
 import React from 'react';
 import { PageDisplayName } from '.';
-import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/DisplayName',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageDisplayName />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
@@ -4,10 +4,10 @@
 
 import React from 'react';
 import { LocationProvider } from '@reach/router';
-import { AppLayout } from '../AppLayout';
 import { PageSecondaryEmailAdd } from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/SecondaryEmailAdd',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageSecondaryEmailAdd />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
@@ -5,9 +5,9 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { PageSecondaryEmailVerify } from '.';
-import { AppLayout } from '../AppLayout';
 import { WindowLocation, LocationProvider } from '@reach/router';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/SecondaryEmailVerify',
@@ -21,8 +21,8 @@ const mockLocation = {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageSecondaryEmailVerify location={mockLocation} />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
@@ -9,7 +9,6 @@ import { PageSettings } from '.';
 import { Config } from '../../../lib/config';
 
 import { LocationProvider } from '@reach/router';
-import AppLayout from '../AppLayout';
 import { isMobileDevice } from '../../../lib/utilities';
 import { mockAppContext, mockEmail, MOCK_ACCOUNT } from '../../../models/mocks';
 import { MOCK_SERVICES } from '../ConnectedServices/mocks';
@@ -17,6 +16,7 @@ import { AppContext } from 'fxa-settings/src/models';
 import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
@@ -63,9 +63,9 @@ const storyWithContext = (
   const story = () => (
     <LocationProvider>
       <AppContext.Provider value={mockAppContext(context)}>
-        <AppLayout>
+        <MockSettingsAppLayout>
           <PageSettings />
-        </AppLayout>
+        </MockSettingsAppLayout>
       </AppContext.Provider>
     </LocationProvider>
   );

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.stories.tsx
@@ -5,9 +5,9 @@
 import { LocationProvider } from '@reach/router';
 import React from 'react';
 import { PageTwoStepAuthentication } from '.';
-import AppLayout from '../AppLayout';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
+import { MockSettingsAppLayout } from '../AppLayout/mocks';
 
 export default {
   title: 'Pages/Settings/TwoStepAuthentication',
@@ -17,8 +17,8 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <AppLayout>
+    <MockSettingsAppLayout>
       <PageTwoStepAuthentication />
-    </AppLayout>
+    </MockSettingsAppLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -17,6 +17,7 @@ import { Config } from '../../lib/config';
 import * as NavTiming from 'fxa-shared/metrics/navigation-timing';
 import { HomePath } from '../../constants';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
+import { Subject, createMockSettingsIntegration } from './mocks';
 
 jest.mock('../../models', () => ({
   ...jest.requireActual('../../models'),
@@ -30,11 +31,7 @@ jest.mock('./ScrollToTop', () => ({
   ),
 }));
 
-const flowQueryParams = {
-  deviceId: 'x',
-  flowBeginTime: 1,
-  flowId: 'x',
-};
+const integration = createMockSettingsIntegration();
 
 describe('performance metrics', () => {
   beforeEach(() => {
@@ -61,7 +58,7 @@ describe('performance metrics', () => {
     } as unknown as Account;
     render(
       <AppContext.Provider value={mockAppContext({ account, config })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>
     );
     expect(NavTiming.observeNavigationTiming).toHaveBeenCalledWith('/foobar');
@@ -78,7 +75,7 @@ describe('performance metrics', () => {
     render(
       <AppContext.Provider value={mockAppContext({ account, config })}>
         <AppContext.Provider value={mockAppContext({ account, config })}>
-          <App {...{ flowQueryParams }} />
+          <Subject />
         </AppContext.Provider>
       </AppContext.Provider>
     );
@@ -97,9 +94,7 @@ describe('App component', () => {
     (useInitialSettingsState as jest.Mock).mockReturnValueOnce({
       loading: true,
     });
-    const { getByLabelText } = renderWithRouter(
-      <App {...{ flowQueryParams }} />
-    );
+    const { getByLabelText } = renderWithRouter(<Subject />);
 
     expect(getByLabelText('Loading…')).toBeInTheDocument();
   });
@@ -108,7 +103,7 @@ describe('App component', () => {
     (useInitialSettingsState as jest.Mock).mockReturnValueOnce({
       error: { message: 'Error' },
     });
-    const { getByRole } = renderWithRouter(<App {...{ flowQueryParams }} />);
+    const { getByRole } = renderWithRouter(<Subject />);
 
     expect(getByRole('heading', { level: 2 })).toHaveTextContent(
       'General application error'
@@ -119,7 +114,9 @@ describe('App component', () => {
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(<Subject />, {
+      route: HomePath,
+    });
 
     await navigate(HomePath);
 
@@ -130,7 +127,7 @@ describe('App component', () => {
     const {
       getByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(<Subject />, { route: HomePath });
 
     await navigate(HomePath + '/display_name');
 
@@ -141,7 +138,9 @@ describe('App component', () => {
     const {
       getAllByTestId,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(<Subject />, {
+      route: HomePath,
+    });
 
     await navigate(HomePath + '/avatar');
 
@@ -155,7 +154,7 @@ describe('App component', () => {
       history: { navigate },
     } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>,
       { route: HomePath }
     );
@@ -172,7 +171,7 @@ describe('App component', () => {
       history: { navigate },
     } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>,
       { route: HomePath }
     );
@@ -189,7 +188,7 @@ describe('App component', () => {
       history: { navigate },
     } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>,
       { route: HomePath }
     );
@@ -206,7 +205,7 @@ describe('App component', () => {
       history: { navigate },
     } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>,
       { route: HomePath }
     );
@@ -223,7 +222,7 @@ describe('App component', () => {
       history: { navigate },
     } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>,
       { route: HomePath }
     );
@@ -240,7 +239,7 @@ describe('App component', () => {
       history: { navigate },
     } = renderWithRouter(
       <AppContext.Provider value={mockAppContext({ session })}>
-        <App {...{ flowQueryParams }} />
+        <Subject />
       </AppContext.Provider>,
       { route: HomePath }
     );
@@ -254,7 +253,9 @@ describe('App component', () => {
     const {
       history,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(<Subject />, {
+      route: HomePath,
+    });
 
     await navigate(HomePath + '/clients');
 
@@ -265,7 +266,9 @@ describe('App component', () => {
     const {
       history,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(<Subject />, {
+      route: HomePath,
+    });
 
     await navigate(HomePath + '/avatar/change');
 
@@ -276,7 +279,7 @@ describe('App component', () => {
     const {
       history,
       history: { navigate },
-    } = renderWithRouter(<App {...{ flowQueryParams }} />, { route: HomePath });
+    } = renderWithRouter(<Subject />, { route: HomePath });
 
     await navigate(HomePath + '/create_password');
     expect(history.location.pathname).toBe('/settings/change_password');
@@ -302,7 +305,7 @@ describe('App component', () => {
             messages={{ en: ['testo: lol'] }}
             reportError={() => {}}
           >
-            <App {...{ flowQueryParams }} />
+            <Subject />
           </AppLocalizationProvider>
         </AppContext.Provider>,
         { route: HomePath }

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -30,8 +30,11 @@ import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
 import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
 import { hardNavigate } from 'fxa-react/lib/utils';
+import { SettingsIntegration } from './interfaces';
 
-export const Settings = (_: RouteComponentProps) => {
+export const Settings = ({
+  integration,
+}: { integration: SettingsIntegration } & RouteComponentProps) => {
   const config = useConfig();
   const { metricsEnabled, hasPassword } = useAccount();
   const session = useSession();
@@ -68,7 +71,7 @@ export const Settings = (_: RouteComponentProps) => {
   }
 
   return (
-    <AppLayout>
+    <AppLayout {...{ integration }}>
       <Head />
       <Router basepath={HomePath}>
         <ScrollToTop default>

--- a/packages/fxa-settings/src/components/Settings/interfaces.ts
+++ b/packages/fxa-settings/src/components/Settings/interfaces.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Integration } from '../../models';
+
+export type SettingsIntegration = Pick<Integration, 'type' | 'isSync'>;

--- a/packages/fxa-settings/src/components/Settings/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/mocks.tsx
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Settings from '.';
+import { IntegrationType } from '../../models';
+import { SettingsIntegration } from './interfaces';
+
+export function createMockSettingsIntegration({
+  type = IntegrationType.Web,
+  isSync = false,
+}: {
+  type?: IntegrationType;
+  isSync?: boolean;
+} = {}): SettingsIntegration {
+  return {
+    type,
+    isSync: () => isSync,
+  };
+}
+
+const flowQueryParams = {
+  deviceId: 'x',
+  flowBeginTime: 1,
+  flowId: 'x',
+};
+
+export const Subject = () => (
+  <Settings
+    {...{ flowQueryParams }}
+    integration={createMockSettingsIntegration()}
+  />
+);


### PR DESCRIPTION
Because:
* Users that sign out from within account settings destroy their session token but we don't tell the browser it's become invalid. Users trying to access settings again in mobile run into a case where we redirect them to oauth signin, causing problems with at least 2FA login in this scenario

This commit:
* Sends the integration down as a prop into DropDownAvatarMenu so we can conditionally send the webchannel message if the flow is Sync
* Adds unit tests, updates all stories/tests/mocks

closes FXA-9919

---

### Info

Product confirmed on Slack that this is the fix we want to implement. In at least iOS there's a menu that still comes up once the command is received for logout, [see video/thread](https://mozilla.slack.com/archives/C4DCECLGJ/p1719270947515019?thread_ts=1719270799.780619&cid=C4DCECLGJ), and our mobile clients will update their response to the command to close this menu. Users caught in this state now are instructed to sign out of the browser and sign back in through the browser, since they're being redirected to `oauth/signin` under the hood, which expects a `client_id` query parameter.

The diff looks large, but the only real change happened in `DropDownAvatarMenu`. The rest is the result of some prop drilling and mock cleanup.

### Testing

The error shown is different in Backbone and React (see ticket). To test this, first reproduce on `main` by following [our instructions](https://mozilla.github.io/ecosystem-platform/reference/mobile-specifics#firefox-for-ios) to set up at least iOS in XCode.` Create an account and enable 2FA (can do this part on desktop), then go into account settings from the browser menu in mobile and sign out through the drop down menu. Close out and try to access settings again in the same way and you'll see the error per the ticket.

In this branch, the error is avoided because on sign out, the user is signed out of the browser. The easiest way to test this for React signin is to turn `signInRoutes.fullProdRollout` to `true` in `react-app/index.js`. This can also be tested in desktop via our `fxa-dev-launcher` command where you should be able to just run `yarn start`, to confirm that the user is signed out of the desktop browser as well on Settings sign out after signing in or signing up for an account in React.