### PR TITLE
chore(tests): Add fixme to flaky signup oauth webchannel test

### DIFF
--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -98,6 +98,7 @@ test.describe('severity-1 #smoke', () => {
       syncBrowserPages: { confirmSignupCode, page, login, signup },
       testAccountTracker,
     }) => {
+      test.fixme(true, 'Fix required as of 2024/06/28 (see FXA-10003).');
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
       const customEventDetail = createCustomEventDetail(


### PR DESCRIPTION
Because:
* This test is not reliably passing

This commit:
* Adds a fixme to this test temporarily