### PR TITLE
task(settings): Add reg_age_invalid glean metric

### DIFF
--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -191,6 +191,9 @@ const recordEventMetric = (
     case 'reg_success_view':
       reg.successView.record();
       break;
+    case 'reg_age_invalid':
+      reg.ageInvalid.record();
+      break;
     case 'login_view':
       login.view.record();
       break;

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.test.tsx
@@ -10,9 +10,17 @@ import CannotCreateAccount, { viewName } from '.';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
 import { REACT_ENTRYPOINT } from '../../constants';
+import GleanMetrics from '../../lib/glean';
 
 jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
+}));
+
+jest.mock('../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    registration: { ageInvalid: jest.fn() },
+  },
 }));
 
 describe('CannotCreateAccount', () => {
@@ -37,5 +45,6 @@ describe('CannotCreateAccount', () => {
       'href',
       'https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy'
     );
+    expect(GleanMetrics.registration.ageInvalid).toBeCalledTimes(1);
   });
 });

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.tsx
@@ -10,6 +10,7 @@ import CardHeader from '../../components/CardHeader';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { usePageViewEvent } from '../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../constants';
+import GleanMetrics from '../../lib/glean';
 
 export const viewName = 'cannot-create-account';
 
@@ -21,6 +22,7 @@ const CannotCreateAccount = (_: RouteComponentProps) => {
    * Alternatively, do we want to always open this in the same tab since users are locked out?
    */
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
+  GleanMetrics.registration.ageInvalid();
   return (
     <AppLayout>
       {/* Span is temporary until sign up tests are converted to playwright */}

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1185,6 +1185,25 @@ reg:
     expires: never
     data_sensitivity:
       - interaction
+  age_invalid:
+    type: event
+    description: |
+      Indicates the user entered an age in the "Age" section that is 13 or below. If
+      they do this, they encounter a page that does not let them continue to register
+      their account.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-9421
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 
 cad_firefox:
   view:

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -40,6 +40,7 @@ export const eventsMap = {
     success: 'reg_submit_success',
     complete: 'reg_success_view',
     cwts: 'reg_cwts_engage',
+    ageInvalid: 'reg_age_invalid',
   },
 
   signupConfirmation: {

--- a/packages/fxa-shared/metrics/glean/web/reg.ts
+++ b/packages/fxa-shared/metrics/glean/web/reg.ts
@@ -7,6 +7,24 @@
 import EventMetricType from '@mozilla/glean/private/metrics/event';
 
 /**
+ * Indicates the user entered an age in the "Age" section that is 13 or below. If
+ * they do this, they encounter a page that does not let them continue to register
+ * their account.
+ *
+ * Generated from `reg.age_invalid`.
+ */
+export const ageInvalid = new EventMetricType(
+  {
+    category: 'reg',
+    name: 'age_invalid',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * User interacted with the Sync "Choose What to Sync" options during account
  * registration.
  *


### PR DESCRIPTION
## Because

- We want a metric recorded when a user enters an invalid age

## This pull request

- Creates the reg_age_invalid glean metric
- Fires the event on the cannot_create_account page

## Issue that this pull request solves

Closes: FXA-9421

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Test instructions

- Signup for an account
- Enter email
- Enter passwords
- For age enter 10
- Click Continue
- Observe the page saying 'You must meet certain age requirements to create a ⁨Mozilla account⁩.'
- Observe that the reg_invalid_age metric was fired
