### PR TITLE
task(settings): Add event when users engages with login password

### DIFF
--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -239,6 +239,9 @@ const recordEventMetric = (
     case 'login_backup_code_success_view':
       login.backupCodeSuccessView.record();
       break;
+    case 'login_engage':
+      login.engage.record();
+      break;
     case 'cached_login_forgot_pwd_submit':
       cachedLogin.forgotPwdSubmit.record();
       break;

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../models/integrations/client-matching';
 import firefox from '../../lib/channels/firefox';
 import { navigate } from '@reach/router';
+import { text } from 'stream/consumers';
 
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
@@ -60,6 +61,7 @@ jest.mock('../../lib/glean', () => ({
       success: jest.fn(),
       error: jest.fn(),
       diffAccountLinkClick: jest.fn(),
+      engage: jest.fn(),
     },
     cachedLogin: {
       forgotPassword: jest.fn(),
@@ -212,6 +214,18 @@ describe('Signin', () => {
         fireEvent.click(screen.getByText('Forgot password?'));
         await waitFor(() => {
           expect(GleanMetrics.login.forgotPassword).toBeCalledTimes(1);
+        });
+      });
+
+      it('emits an event when password field is focused', async () => {
+        render();
+        expect(
+          fireEvent.input(screen.getByLabelText(/Password/), {
+            target: { value: MOCK_PASSWORD },
+          })
+        ).toBeTruthy();
+        await waitFor(() => {
+          expect(GleanMetrics.login.engage).toBeCalledTimes(1);
         });
       });
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -362,6 +362,7 @@ const Signin = ({
               required
               autoFocus
               onChange={() => {
+                GleanMetrics.login.engage();
                 // clear error tooltip if user types in the field
                 if (passwordTooltipErrorText) {
                   setPasswordTooltipErrorText('');

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -748,6 +748,23 @@ login:
     expires: never
     data_sensitivity:
       - interaction
+  engage:
+    type: event
+    description: |
+      Indicates a user engaged with the password field on login by focusing/clicking/type.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+       - https://mozilla-hub.atlassian.net/browse/FXA-9569
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
   backup_code_view:
     type: event
     description: |

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -59,6 +59,7 @@ export const eventsMap = {
     error: 'login_submit_frontend_error',
     forgotPassword: 'login_forgot_pwd_submit',
     diffAccountLinkClick: 'login_diff_account_link_click',
+    engage: 'login_engage',
   },
 
   cachedLogin: {

--- a/packages/fxa-shared/metrics/glean/web/login.ts
+++ b/packages/fxa-shared/metrics/glean/web/login.ts
@@ -147,6 +147,23 @@ export const emailConfirmationView = new EventMetricType(
 );
 
 /**
+ * Indicates a user engaged with the password field on login by
+ * focusing/clicking/type.
+ *
+ * Generated from `login.engage`.
+ */
+export const engage = new EventMetricType(
+  {
+    category: 'login',
+    name: 'engage',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Login Password Reset Click
  * User clicks on the "Forgot Password" Link.'
  *


### PR DESCRIPTION
## Because

- We want to know when a user interacts with the password field

## This pull request

- Adds the login_engage event
- Fires the event when a user focuses on the password input

## Issue that this pull request solves

Closes: FXA-9569

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Test Instructions

- Create account
- Login
- Focus on password field
- Observe metric
