### PR TITLE
feat(metrics): set metrics flow data via data attrs

### DIFF
--- a/packages/fxa-content-server/server/lib/flow-metrics.js
+++ b/packages/fxa-content-server/server/lib/flow-metrics.js
@@ -12,10 +12,9 @@ module.exports = {
    * Create flow data.
    *
    * @param key String
-   * @param userAgent String
    * @returns {{flowBeginTime: number, flowId: string}}
    */
-  create(key, userAgent) {
+  create(key) {
     const salt = crypto.randomBytes(SALT_SIZE).toString('hex');
     return createFlowEventData(key, salt, Date.now());
   },

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -140,10 +140,7 @@ module.exports = function (config) {
     method: 'get',
     path: '/',
     process: async function (req, res) {
-      const flowEventData = flowMetrics.create(
-        FLOW_ID_KEY,
-        req.headers['user-agent']
-      );
+      const flowEventData = flowMetrics.create(FLOW_ID_KEY);
 
       if (NO_LONGER_SUPPORTED_CONTEXTS.has(req.query.context)) {
         return res.redirect(`/update_firefox?${req.originalUrl.split('?')[1]}`);

--- a/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
@@ -106,10 +106,7 @@ module.exports = function (config) {
   };
 
   route.process = function (req, res) {
-    const flowEventData = flowMetrics.create(
-      FLOW_ID_KEY,
-      req.headers['user-agent']
-    );
+    const flowEventData = flowMetrics.create(FLOW_ID_KEY);
     const { flowBeginTime, flowId } = flowEventData;
     const metricsData = req.query || {};
     const beginEvent = {

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -17,7 +17,7 @@
   <meta name="apple-itunes-app" content="app-id=989804926, affiliate-data=ct=smartbanner-fxa" />
 </head>
 
-<body>
+<body data-flow-id="__FLOW_ID__" data-flow-begin-time="__FLOW_BEGIN_TIME__">
   <noscript>Mozilla accounts requires JavaScript.</noscript>
   <div id="root"></div>
 </body>

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -187,7 +187,7 @@ describe('glean', () => {
         channel: config.glean.channel,
       },
       {
-        flowQueryParams: updatedFlowQueryParams,
+        metricsFlow: updatedFlowQueryParams,
         account: mockMetricsQueryAccountGlean,
         userAgent: navigator.userAgent,
         integration: mockIntegration,

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -16,6 +16,7 @@ import { QueryParams } from '../..';
 
 import { currentAccount } from '../../lib/cache';
 import { firefox } from '../../lib/channels/firefox';
+import * as MetricsFlow from '../../lib/metrics-flow';
 import GleanMetrics from '../../lib/glean';
 import * as Metrics from '../../lib/metrics';
 import { LinkType, MozServices } from '../../lib/types';
@@ -105,6 +106,8 @@ export const App = ({
     return data?.account?.metricsEnabled || !isSignedIn;
   }, [metricsLoading, integration, isSignedIn, data?.account?.metricsEnabled]);
   const metricsEnabled = getMetricsEnabled();
+  const metricsFlow = MetricsFlow.init(flowQueryParams);
+  flowQueryParams = { ...flowQueryParams, ...metricsFlow } as QueryParams;
 
   useMemo(() => {
     if (!metricsEnabled || !integration || GleanMetrics.getEnabled()) {
@@ -119,7 +122,7 @@ export const App = ({
         channel: config.glean.channel,
       },
       {
-        flowQueryParams,
+        metricsFlow,
         account: {
           metricsEnabled: data?.account?.metricsEnabled,
           uid: data?.account?.uid,
@@ -133,7 +136,7 @@ export const App = ({
     config.version,
     data?.account?.metricsEnabled,
     data?.account?.uid,
-    flowQueryParams,
+    metricsFlow,
     integration,
     metricsEnabled,
   ]);
@@ -159,6 +162,7 @@ export const App = ({
     data?.account?.recoveryKey,
     isSignedIn,
     flowQueryParams,
+    metricsFlow,
     config,
     metricsLoading,
     metricsEnabled,

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -26,6 +26,7 @@ import * as utm from 'fxa-shared/metrics/glean/web/utm';
 import { Config } from '../config';
 import { FlowQueryParams } from '../..';
 import { WebIntegration, useAccount } from '../../models';
+import { MetricsFlow } from '../metrics-flow';
 
 const sandbox = sinon.createSandbox();
 const mockConfig: Config['glean'] = {
@@ -38,7 +39,7 @@ const mockConfig: Config['glean'] = {
   logPings: false,
   debugViewTag: '',
 };
-let mockFlowQueryParams: FlowQueryParams = {};
+let mockMetricsFlow: MetricsFlow | null = null;
 const mockAccount = {
   metricsEnabled: true,
   recoveryKey: true,
@@ -48,7 +49,7 @@ const mockAccount = {
 let mockUserAgent = '';
 const mockIntegration = { data: {} } as unknown as WebIntegration;
 const mockMetricsContext: GleanMetricsContext = {
-  flowQueryParams: mockFlowQueryParams,
+  metricsFlow: mockMetricsFlow,
   account: mockAccount,
   userAgent: mockUserAgent,
   integration: mockIntegration,
@@ -71,7 +72,10 @@ describe('lib/glean', () => {
     setUtmTermStub: SinonStub;
 
   beforeEach(async () => {
-    mockMetricsContext.flowQueryParams = { flowId: '00ff' };
+    mockMetricsContext.metricsFlow = {
+      flowId: '00ff',
+      flowBeginTime: Date.now(),
+    };
     mockMetricsContext.userAgent = 'ELinks/0.9.3 (textmode; SunOS)';
     mockIntegration.data = {
       clientId: 'abc',
@@ -207,7 +211,7 @@ describe('lib/glean', () => {
     it('sets empty strings as defaults', async () => {
       mockIntegration.data = {};
       mockMetricsContext.userAgent = '';
-      mockMetricsContext.flowQueryParams = {};
+      mockMetricsContext.metricsFlow = null;
       mockMetricsContext.account = undefined;
       GleanMetrics.initialize(
         { ...mockConfig, enabled: true },

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -33,12 +33,12 @@ import {
 } from 'fxa-shared/metrics/glean/web/session';
 import * as sync from 'fxa-shared/metrics/glean/web/sync';
 import * as utm from 'fxa-shared/metrics/glean/web/utm';
-import { FlowQueryParams } from '../..';
 import { Integration } from '../../models';
+import { MetricsFlow } from '../metrics-flow';
 
 type DeviceTypes = 'mobile' | 'tablet' | 'desktop';
 export type GleanMetricsContext = {
-  flowQueryParams: FlowQueryParams;
+  metricsFlow: MetricsFlow | null;
   account?: { uid?: hexstring; metricsEnabled?: boolean };
   userAgent: string;
   integration: Integration;
@@ -144,7 +144,7 @@ const populateMetrics = async (gleanPingMetrics: GleanPingMetrics) => {
 
   deviceType.set(getDeviceType() || '');
   entrypoint.set(metricsContext.integration.data.entrypoint || '');
-  flowId.set(metricsContext.flowQueryParams.flowId || '');
+  flowId.set(metricsContext.metricsFlow?.flowId || '');
 
   utm.campaign.set(metricsContext.integration.data.utmCampaign || '');
   utm.content.set(metricsContext.integration.data.utmContent || '');

--- a/packages/fxa-settings/src/lib/metrics-flow.test.ts
+++ b/packages/fxa-settings/src/lib/metrics-flow.test.ts
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { init } from './metrics-flow';
+
+const flowArg = {
+  flowId: '9999',
+  flowBeginTime: `${Date.now()}`,
+  deviceId: 'psx',
+};
+const flowQueryParam = { flowId: '8888', flowBeginTime: `${Date.now()}` };
+const flowDataAttrParam = {
+  flowId: '7777',
+  flowBeginTime: `${Date.now()}`,
+};
+
+describe('MetricsFlow', () => {
+  describe('init', () => {
+    it('should initialize the metricsFlow model with body data attribues', () => {
+      global.window.document.body.dataset.flowId = flowDataAttrParam.flowId;
+      global.window.document.body.dataset.flowBeginTime =
+        flowDataAttrParam.flowBeginTime;
+      const flowData = init();
+      expect(flowData?.flowId).toEqual(
+        global.window.document.body.dataset.flowId
+      );
+      expect(flowData?.flowBeginTime).toEqual(
+        global.window.document.body.dataset.flowBeginTime
+      );
+      expect(flowData?.deviceId).toBeDefined();
+    });
+
+    it('should initialize the metricsFlow model with URL query parameters', () => {
+      global.window.history.pushState(
+        {},
+        '',
+        `?flowId=${flowQueryParam.flowId}&flowBeginTime=${flowQueryParam.flowBeginTime}`
+      );
+      const flowData = init();
+      expect(flowData?.flowId).toEqual(flowQueryParam.flowId);
+      expect(flowData?.flowBeginTime).toEqual(flowQueryParam.flowBeginTime);
+    });
+
+    it('should initialize the metricsFlow model with the argument', () => {
+      const flowData = init(flowArg);
+      expect(flowData?.flowId).toEqual(flowArg.flowId);
+      expect(flowData?.flowBeginTime).toEqual(flowArg.flowBeginTime);
+      expect(flowData?.deviceId).toEqual(flowArg.deviceId);
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/metrics-flow.ts
+++ b/packages/fxa-settings/src/lib/metrics-flow.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { v4 as uuidv4 } from 'uuid';
+import { searchParams } from './utilities';
+
+export type MetricsFlow = {
+  flowId: string;
+  flowBeginTime: string | number;
+  deviceId?: undefined | string;
+};
+
+let metricsFlow: MetricsFlow | null = null;
+
+function isMetricsFlow(data: any): data is MetricsFlow {
+  return (
+    data?.flowId &&
+    data?.flowBeginTime &&
+    typeof data.flowId === 'string' &&
+    ((typeof data.flowBeginTime === 'string' &&
+      /\d+/.test(data.flowBeginTime)) ||
+      typeof data.flowBeginTime === 'number')
+  );
+}
+
+/**
+ * Initialize the metricsFlow data model.  The order of precedence:
+ *  1. flowData parameter
+ *  2. URL query parameters
+ *  3. body tag data attributes
+ */
+export function init(flowData?: any) {
+  const initWithX = (x: any) => {
+    if (isMetricsFlow(x)) {
+      metricsFlow = {
+        flowId: x.flowId,
+        flowBeginTime: x.flowBeginTime,
+        ...(x.deviceId && { deviceId: x.deviceId }),
+      };
+      return true;
+    }
+    return false;
+  };
+  const initWithArg = () => initWithX(flowData);
+  const initWithQueryParams = () => {
+    const queryParamsMap = searchParams(window.location.search);
+    return initWithX(queryParamsMap);
+  };
+  const initWithDataAttributes = () => initWithX(document.body.dataset);
+
+  initWithArg() || initWithQueryParams() || initWithDataAttributes();
+  maybeSetDeviceId();
+  return getMetricsFlow();
+}
+
+// The "deviceId" was created for Amplitude. It was never persisted. We can
+// generate it here if there isn't one.
+function maybeSetDeviceId() {
+  if (metricsFlow && !metricsFlow?.deviceId) {
+    metricsFlow.deviceId = uuidv4().replace(/-/g, '');
+  }
+}
+
+export function getMetricsFlow() {
+  return metricsFlow;
+}


### PR DESCRIPTION
Because:
 - we need to able to get metrics flow data directly in React/Settings without relying on query params

This commit:
 - injects a flow id and begin time into the HTML of the React page
 - sets the metrics flow data for the app in the precedence of 0) direct argument, 1) query params, 2) body data attrs

