### PR TITLE
fix(paypal-processor): use initSentry helper

### DIFF
--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -13,6 +13,7 @@ import { PayPalHelper } from '../lib/payments/paypal/helper';
 import { PayPalClient } from '@fxa/payments/paypal';
 import { PaypalProcessor } from '../lib/payments/paypal/processor';
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+import { initSentry } from 'packages/fxa-shared/sentry/node';
 
 const pckg = require('../package.json');
 const config = require('../config').default.getProperties();
@@ -23,8 +24,6 @@ const DEFAULT_LOCK_DURATION_MS = 300000;
  * Used to track whether the script has been requested to exit cleanly and stop processing
  */
 let shutdown = false;
-
-Sentry.init({});
 
 export async function init() {
   // Load program options
@@ -65,6 +64,14 @@ export async function init() {
 
   const { log, database, senders } = await setupProcessingTaskObjects(
     'paypal-processor'
+  );
+
+  initSentry(
+    {
+      ...config,
+      release: pckg.version,
+    },
+    log
   );
 
   const paypalClient = new PayPalClient(

--- a/packages/fxa-shared/sentry/node.ts
+++ b/packages/fxa-shared/sentry/node.ts
@@ -4,7 +4,6 @@
 
 import * as Sentry from '@sentry/node';
 import { ErrorEvent } from '@sentry/types';
-import { ExtraErrorData } from '@sentry/integrations';
 import { SentryConfigOpts } from './models/SentryConfigOpts';
 import { ILogger } from '../log';
 import { tagCriticalEvent, tagFxaName } from './tag';
@@ -38,7 +37,7 @@ export function initSentry(config: InitSentryOpts, log: ILogger) {
 
   const integrations = [
     // Default
-    new ExtraErrorData({ depth: 5 }),
+    Sentry.extraErrorDataIntegration({ depth: 5 }),
 
     // Custom Integrations
     ...(config.integrations || []),


### PR DESCRIPTION
## Because

- Sentry errors logged by the paypal processor did not include additional error information.

## This pull request

- Update paypal processor script to use initSentry, which includes additional Sentry integrations, such as ExtraErrorData.
- Replace deprecated ExtraErrorData integration with Sentry.extraErrorDataIntegration()

## Issue that this pull request solves

Closes: #FXA-9219

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).