### PR TITLE
fix(sync): Send fxaCanLinkAccount in force_auth signin submit

### DIFF
--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -26,18 +26,6 @@ test.describe('severity-1 #smoke', () => {
       target,
       testAccountTracker,
     }) => {
-      const config = await configPage.getConfig();
-      // backbone signin sends a fxaccounts:can_link_account event on signin
-      // but this has been removed for react because we already send up this message on the index page
-      // See discussion here: https://github.com/mozilla/fxa/pull/16622/files#r1538329391
-
-      // TODO in FXA-9868 - determine if wfxaccounts:can_link_account needs to be added in react signin,
-      // if index is bypassed the message might not be sent at all.
-      // it is unclear if this scenario can occur or if the account for force auth with sync will always be
-      // the signed in account (no need to merge sync data)
-
-      test.skip(config.showReactApp.signInRoutes === true, 'FXA-9868');
-
       const credentials = await testAccountTracker.signUpSync();
 
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
@@ -70,9 +58,6 @@ test.describe('severity-1 #smoke', () => {
       target,
       testAccountTracker,
     }) => {
-      const config = await configPage.getConfig();
-      // see comment in first test
-      test.skip(config.showReactApp.signInRoutes === true, 'FXA-9868');
       const credentials = await testAccountTracker.signUpSync();
 
       await fxDesktopV3ForceAuth.open(credentials);
@@ -104,9 +89,6 @@ test.describe('severity-1 #smoke', () => {
       target,
       testAccountTracker,
     }) => {
-      const config = await configPage.getConfig();
-      // see comment in first test
-      test.skip(config.showReactApp.signInRoutes === true, 'FXA-9868');
       const credentials = await testAccountTracker.signUpSync();
       const uid = makeUid();
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -124,6 +124,9 @@ export type FxAOAuthLogin = {
 export type FxACanLinkAccount = {
   email: string;
 };
+type FxACanLinkAccountResponse = {
+  ok: boolean;
+};
 
 const DEFAULT_SEND_TIMEOUT_LENGTH_MS = 5 * 1000; // 5 seconds in milliseconds
 
@@ -343,8 +346,24 @@ export class Firefox extends EventTarget {
     this.send(FirefoxCommand.OAuthLogin, options);
   }
 
-  fxaCanLinkAccount(options: FxACanLinkAccount) {
+  async fxaCanLinkAccount(
+    options: FxACanLinkAccount
+  ): Promise<FxACanLinkAccountResponse> {
     this.send(FirefoxCommand.CanLinkAccount, options);
+
+    return new Promise((resolve) => {
+      const eventHandler = (event: Event) => {
+        const firefoxEvent = event as FirefoxEvent;
+        console.log('firefoxEvent', firefoxEvent);
+        const detail =
+          typeof firefoxEvent.detail === 'string'
+            ? (JSON.parse(firefoxEvent.detail) as FirefoxMessageDetail)
+            : firefoxEvent.detail;
+
+        resolve(detail.message?.data as FxACanLinkAccountResponse);
+      };
+      window.addEventListener('WebChannelMessageToContent', eventHandler);
+    });
   }
 
   async requestSignedInUser(context: string) {

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -354,7 +354,6 @@ export class Firefox extends EventTarget {
     return new Promise((resolve) => {
       const eventHandler = (event: Event) => {
         const firefoxEvent = event as FirefoxEvent;
-        console.log('firefoxEvent', firefoxEvent);
         const detail =
           typeof firefoxEvent.detail === 'string'
             ? (JSON.parse(firefoxEvent.detail) as FirefoxMessageDetail)

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -68,6 +68,7 @@ import {
   getHandledError,
   getLocalizedErrorMessage,
 } from '../../lib/error-utils';
+import firefox from '../../lib/channels/firefox';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -137,6 +138,8 @@ const SigninContainer = ({
     localizedErrorMessage: localizedErrorFromLocationState,
   } = location.state || {};
 
+  const [needsCanLinkAccountWebChannel, setNeedsCanLinkAccountWebChannel] =
+    useState(integration.isSync() && location.pathname.includes('force_auth'));
   const [accountStatus, setAccountStatus] = useState({
     hasLinkedAccount:
       // TODO: in FXA-9177, retrieve hasLinkedAccount and hasPassword from Apollo cache (not state)
@@ -228,6 +231,17 @@ const SigninContainer = ({
 
   const beginSigninHandler: BeginSigninHandler = useCallback(
     async (email: string, password: string) => {
+      if (needsCanLinkAccountWebChannel) {
+        // If we're in the `force_auth` flow, users will not have answered
+        // "Confirm" to the Sync merge warning prompt yet, which is usually
+        // confirmed on email-first submission.
+        const { ok } = await firefox.fxaCanLinkAccount({ email });
+        if (!ok) {
+          return { data: undefined, error: undefined };
+        } else {
+          setNeedsCanLinkAccountWebChannel(false);
+        }
+      }
       const service = integration.getService();
 
       const { error, unverifiedAccount, v1Credentials, v2Credentials } =
@@ -277,6 +291,7 @@ const SigninContainer = ({
       passwordChangeStart,
       wantsKeys,
       flowQueryParams,
+      needsCanLinkAccountWebChannel,
     ]
   );
 


### PR DESCRIPTION
Because:
* In Backbone we ask users to confirm that they want to merge their Sync data on submission of password signin, if the flow is force_auth since they haven't answered the prompt at this point. We want to do the same for React

This commit:
* Modifies the fxaCanLinkAccount web channel message to return a promise waiting for the browser's response, and only proceeds if the user confirms

fixes FXA-9868

---

Our functional tests for force auth covers this case, but I can add a couple of unit tests if we want.

Maybe there's a better way to test this but I launched `fxa-dev-launcher`, then console.logged the [test credentials](https://github.com/mozilla/fxa/blob/7d6ae428b4399ec897e0c87c9e1dc014584028ce/packages/functional-tests/pages/forceAuth/index.ts#L28-L29) and [URL](https://github.com/mozilla/fxa/blob/7d6ae428b4399ec897e0c87c9e1dc014584028ce/packages/functional-tests/pages/forceAuth/index.ts#L56) for these Sync desktop v3 force auth tests, ran one (`yarn test --grep="sync v3 with a registered email, registered uid" --debug`) and copied the URL output into the window dev-launcher opened and added `showReactApp=true` to it.

I saw when running these tests in Backbone this is where we were sending the message (on submit). So long as you answer OK, even if the PW is incorrect we don't re-prompt.