### PR TITLE
chore: add missing deps for glean-generate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 			"moby": "true"
 		},
 		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
-			"packages": "netcat,git,curl,jq,build-essential,pkg-config,libssl-dev,libgmp3-dev,mycli,redis-tools"
+			"packages": "netcat,git,curl,jq,build-essential,pkg-config,libssl-dev,libgmp3-dev,mycli,redis-tools,python3-venv,python3-pip"
 		},
 		"ghcr.io/devcontainers/features/node:1": {},
 		"ghcr.io/dhoeric/features/google-cloud-cli:1": {}


### PR DESCRIPTION
Because:

* glean-generate needs venv and pip to run correctly

This commit:

* Add missing Python venv/pip dependencies.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
