### PR TITLE
chore(Glean): run prettier after generate Glean code

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist",
     "compile": "tsc --noEmit",
     "copy-local-config": "cp server/config/local.json-dist server/config/local.json",
-    "glean-generate": "yarn glean translate ../fxa-shared/metrics/glean/fxa-ui-pings.yaml ../fxa-shared/metrics/glean/fxa-ui-metrics.yaml -f javascript -o app/scripts/lib/glean",
+    "glean-generate": "yarn glean translate ../fxa-shared/metrics/glean/fxa-ui-pings.yaml ../fxa-shared/metrics/glean/fxa-ui-metrics.yaml -f javascript -o app/scripts/lib/glean && prettier --config ../../_dev/.prettierrc --write app/scripts/lib/glean/*.js",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "l10n-create-json": "NODE_OPTIONS=--openssl-legacy-provider grunt l10n-create-json",
     "l10n-prime": "yarn l10n:prime packages/fxa-content-server",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -209,7 +209,7 @@
     "compile": "yarn build-ts",
     "copy-assets": "cp -r ./db/luaScripts ./dist/esm/packages/fxa-shared/db/luaScripts; cp -r ./db/luaScripts ./dist/cjs/packages/fxa-shared/db/luaScripts",
     "copy-sql": "echo '{ \"type\": \"module\" }' > ./dist/esm/packages/fxa-shared/db/package.json && find test -name \\*.sql -exec cp \\{\\} dist/esm/packages/fxa-shared/\\{\\} \\; ; find test -name \\*.sql -exec cp \\{\\} dist/cjs/packages/fxa-shared/\\{\\} \\;",
-    "glean-generate": "yarn glean translate ./metrics/glean/fxa-ui-pings.yaml ./metrics/glean/fxa-ui-metrics.yaml -f typescript -o ./metrics/glean/web",
+    "glean-generate": "yarn glean translate ./metrics/glean/fxa-ui-pings.yaml ./metrics/glean/fxa-ui-metrics.yaml -f typescript -o ./metrics/glean/web && prettier --config ../../_dev/.prettierrc --write ./metrics/glean/web/*.ts",
     "glean-lint": "yarn glean glinter ./metrics/glean/fxa-ui-pings.yaml ./metrics/glean/fxa-ui-metrics.yaml",
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",


### PR DESCRIPTION
Because:
 - the diff looks large because the Glean generated code uses double quotes whereas our code base uses single quotes

This commit:
 - runs the same prettier fix that's part of the pre-commit hook immediately after generating the code
