### PR TITLE
fix(functional-tests): failures due to rate limiting in coupon tests

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect, test } from '../../../lib/fixtures/standard';
 import { Coupon } from '../../../pages/products';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test expired', () => {

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
@@ -2,34 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { VALID_VISA } from '../../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../../lib/targets/base';
-import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
-import { SettingsPage } from '../../../pages/settings';
-import { SigninPage } from '../../../pages/signin';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test forever discount', () => {
     test('subscribe successfully with a forever discount coupon', async ({
-      target,
       page,
-      pages: { relier, settings, signin, subscribe },
-      testAccountTracker,
+      pages: { relier, signin, subscribe },
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -62,23 +49,14 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('subscribe with credit card and use coupon', async ({
-      target,
       page,
-      pages: { relier, settings, signin, subscribe },
-      testAccountTracker,
+      pages: { relier, signin, subscribe },
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -104,21 +82,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
@@ -2,13 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { VALID_VISA } from '../../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../../lib/targets/base';
-import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
-import { SettingsPage } from '../../../pages/settings';
-import { SigninPage } from '../../../pages/signin';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test invalid', () => {
@@ -44,23 +40,14 @@ test.describe('severity-2 #smoke', () => {
     });
 
     test('subscribe successfully with an invalid coupon', async ({
-      target,
       page,
-      pages: { relier, settings, signin, subscribe },
-      testAccountTracker,
+      pages: { relier, signin, subscribe },
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -91,21 +78,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
@@ -2,34 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { VALID_VISA } from '../../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../../lib/targets/base';
-import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
-import { SettingsPage } from '../../../pages/settings';
-import { SigninPage } from '../../../pages/signin';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('coupon test one time discount', () => {
     test('subscribe with a one time discount coupon', async ({
-      target,
       page,
-      pages: { relier, settings, signin, subscribe },
-      testAccountTracker,
+      pages: { relier, signin, subscribe },
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe12Month();
 
@@ -96,21 +83,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
@@ -2,14 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { VALID_MASTERCARD, VALID_VISA } from '../../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../../lib/targets/base';
-import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
 import { SubscriptionManagementPage } from '../../../pages/products/subscriptionManagement';
-import { SettingsPage } from '../../../pages/settings';
-import { SigninPage } from '../../../pages/signin';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('payment', () => {
@@ -17,20 +13,12 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { relier, subscribe, settings, signin },
-      testAccountTracker,
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -71,21 +59,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -2,14 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { VALID_VISA } from '../../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../../lib/targets/base';
-import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
 import { SubscriptionManagementPage } from '../../../pages/products/subscriptionManagement';
-import { SettingsPage } from '../../../pages/settings';
-import { SigninPage } from '../../../pages/signin';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('resubscription test', () => {
@@ -17,20 +13,12 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { relier, subscribe, settings, signin },
-      testAccountTracker,
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe6Month();
 
@@ -84,21 +72,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -2,30 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../../lib/fixtures/standard';
 import { MetricsObserver } from '../../../lib/metrics';
 import { VALID_VISA } from '../../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../../lib/targets/base';
-import { TestAccountTracker } from '../../../lib/testAccountTracker';
 import { Coupon } from '../../../pages/products';
-import { SettingsPage } from '../../../pages/settings';
-import { SigninPage } from '../../../pages/signin';
+import { expect, test } from '../subscriptionFixtures';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('ui functionality', () => {
     test('verify plan change funnel metrics & coupon feature not available when changing plans', async ({
-      target,
-      page,
-      pages: { relier, settings, signin, subscribe },
-      testAccountTracker,
+      pages: { relier, subscribe },
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-
-      await signInAccount(target, page, settings, signin, testAccountTracker);
-
       const metricsObserver = new MetricsObserver(subscribe);
       metricsObserver.startTracking();
 
@@ -89,21 +79,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/subscription-tests/subscriptionFixtures.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscriptionFixtures.ts
@@ -1,0 +1,47 @@
+import { Page, test as base, expect } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { SettingsPage } from '../../pages/settings';
+import { SigninPage } from '../../pages/signin';
+
+export const test = base.extend<{ credentials: Credentials }>({
+  // Signin is pre-requisite for all subscription tests
+  // In order to avoid failures due to coupon rate limiting by IP, we signin so
+  // that rate limiting is applied on an account basis
+  credentials: [
+    async (
+      { target, page, pages: { settings, signin }, testAccountTracker },
+      use
+    ) => {
+      const credentials = await signInAccount(
+        target,
+        page,
+        settings,
+        signin,
+        testAccountTracker
+      );
+
+      await use(credentials);
+    },
+    { auto: true },
+  ],
+});
+export { expect } from '../../lib/fixtures/standard';
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  settings: SettingsPage,
+  signin: SigninPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(target.contentServerUrl);
+  await signin.fillOutEmailFirstForm(credentials.email);
+  await signin.fillOutPasswordForm(credentials.password);
+
+  await expect(page).toHaveURL(/settings/);
+  await expect(settings.settingsHeading).toBeVisible();
+
+  return credentials;
+}

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -2,18 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { SettingsPage } from '../..//pages/settings';
-import { Page, expect, test } from '../../lib/fixtures/standard';
 import { VALID_VISA } from '../../lib/paymentArtifacts';
-import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SubscriptionManagementPage } from '../../pages/products/subscriptionManagement';
 import {
   App,
   SubscriptionSupportPage,
   Topic,
 } from '../../pages/products/support';
-import { SigninPage } from '../../pages/signin';
+import { expect, test } from './subscriptionFixtures';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('support form without valid session', () => {
@@ -31,12 +27,10 @@ test.describe('severity-1 #smoke', () => {
 
   test.describe('support form without active subscriptions', () => {
     test('go to support form, redirects to subscription management, then back to settings', async ({
-      page,
       target,
-      pages: { settings, signin },
-      testAccountTracker,
+      page,
+      pages: { settings },
     }) => {
-      await signInAccount(target, page, settings, signin, testAccountTracker);
       await page.goto(`${target.contentServerUrl}/support`);
 
       await expect(page).toHaveURL(/settings/);
@@ -54,21 +48,12 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { relier, subscribe, settings, signin },
-      testAccountTracker,
+      credentials,
     }, { project }) => {
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
       );
-
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
-
       await relier.goto();
       await relier.clickSubscribe();
 
@@ -112,21 +97,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-
-  await expect(page).toHaveURL(/settings/);
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}


### PR DESCRIPTION
## Because

- coupon tests are failing in stage due to IP rate limiting

## This pull request

* adds signin as a pre-requisite to coupon tests 
  * since all subscription tests now require signin, the steps have been encapsulated in an automatic fixture to reduce code duplication (subscriptionFixtures.ts)
  * without signin rate limiting is measured per IP, with signin it is measured per account. Since tests have isolated accounts, signing in should add the resilience we need. 

## Issue that this pull request solves

Closes # FXA-10045

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
