### PR TITLE
chore(functional-tests): add a fixme annotation to verify plan change funnel metrics & coupon feature not available when changing plans

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/ui-tests.spec.ts
@@ -19,6 +19,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, settings, signin, subscribe },
       testAccountTracker,
     }, { project }) => {
+      test.fixme(true, 'Fix required as of 2024/07/08 (see FXA-10014).');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'


### PR DESCRIPTION
## Because

- this test is failing causing disruption to CI and development

## This pull request

- adds a fixme annotation until a proper fix can be added

## Issue that this pull request solves

Relates to: #FXA-10014

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
