### PR TITLE
fix(auth): Set state when navigating with third party auth in React

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -75,13 +75,13 @@ describe('ThirdPartyAuthComponent', () => {
       (await screen.findByTestId('google-signin-form-state')).getAttribute(
         'value'
       )
-    ).toEqual('');
+    ).toEqual('http%3A%2F%2Flocalhost%2F%3F');
 
     expect(
       (await screen.findByTestId('apple-signin-form-state')).getAttribute(
         'value'
       )
-    ).toEqual('');
+    ).toEqual('http%3A%2F%2Flocalhost%2F%3F');
   });
 
   it('submits apple form', async () => {

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -61,7 +61,7 @@ const ThirdPartyAuth = ({
             {...{
               party: 'google',
               ...config.googleAuthConfig,
-              state: '',
+              state: getState(),
               scope: 'openid email profile',
               responseType: 'code',
               accessType: 'offline',
@@ -82,7 +82,7 @@ const ThirdPartyAuth = ({
             {...{
               party: 'apple',
               ...config.appleAuthConfig,
-              state: '',
+              state: getState(),
               scope: 'email',
               responseType: 'code id_token',
               accessType: 'offline',


### PR DESCRIPTION
## Because

- Third party auth fails when logging in with a different email than one already logged in (React)

## This pull request

- Sets the `state` param when lauching auth so that it logs in correct user

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10046

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Testing steps

1. Be enrolled in React signin experiment
2. Log in with a user ( ex a@aa.com)
3. Sign out
4. Log in with Google user
