### PR TITLE
bug(settings): Skip checkOauthData for sync

### DIFF
--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -39,6 +39,11 @@ export type FinishOAuthFlowHandlerResult =
   | FinishOAuthFlowHandlerError;
 
 const checkOAuthData = (integration: OAuthIntegration): AuthError | null => {
+  // Weird edge case. See FXA-10029...
+  if (integration.isSync()) {
+    return null;
+  }
+
   // Ensure a redirect was provided or matched. Without this info, we can't relay the
   // oauth code and state on a redirect!
   // clientInfo?.redirectUri has already validated the redirect_uri query param


### PR DESCRIPTION
## Because

- We can hit a state where Firefox will direct a user to sign in and the redirect uri, or client id won't be present
- This state is erroneous, but it'll take a bit for the fix in FF to be released.

## This pull request
- shortCircuits checkOauthData when we are dealing with a sync integration.
- Sync doesn't need to redirect back to a third party anyway, so this is probably okay.

## Issue that this pull request solves

Closes: FXA-10029

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

I had a hard time testing this locally... Testing on stage is needed.
