### PR TITLE
fix(metrics): DENG-3273 Update event names for consistency between `accounts-events` and `events` pings

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -125,7 +125,7 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
     case 'apple_oauth_email_first_start':
       email.appleOauthEmailFirstStart.record();
       break;
-    case 'google_oauth_email_first_start':
+    case 'email_google_oauth_email_first_start':
       email.googleOauthEmailFirstStart.record();
       break;
     case 'reg_cwts_engage':
@@ -292,10 +292,10 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
     case 'third_party_auth_set_password_success':
       thirdPartyAuthSetPassword.success.record();
       break;
-    case 'google_deeplink':
+    case 'third_party_auth_google_deeplink':
       thirdPartyAuth.googleDeeplink.record();
       break;
-    case 'apple_deeplink':
+    case 'third_party_auth_apple_deeplink':
       thirdPartyAuth.appleDeeplink.record();
       break;
   }
@@ -378,7 +378,7 @@ export const GleanMetrics = {
   emailFirst: {
     view: createEventFn('email_first_view'),
     appleOauthStart: createEventFn('apple_oauth_email_first_start'),
-    googleOauthStart: createEventFn('google_oauth_email_first_start'),
+    googleOauthStart: createEventFn('email_google_oauth_email_first_start'),
   },
 
   registration: {
@@ -454,8 +454,8 @@ export const GleanMetrics = {
     success: createEventFn('third_party_auth_set_password_success'),
   },
   thirdPartyAuth: {
-    googleDeeplink: createEventFn('google_deeplink'),
-    appleDeeplink: createEventFn('apple_deeplink'),
+    googleDeeplink: createEventFn('third_party_auth_google_deeplink'),
+    appleDeeplink: createEventFn('third_party_auth_apple_deeplink'),
   },
 };
 

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -344,13 +344,13 @@ describe('lib/glean', () => {
     });
 
     describe('google oauth email first', () => {
-      it('submits a ping with the google_oauth_email_first_start event name', async () => {
+      it('submits a ping with the email_google_oauth_email_first_start event name', async () => {
         GleanMetrics.emailFirst.googleOauthStart();
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
           setEventNameStub,
-          'google_oauth_email_first_start'
+          'email_google_oauth_email_first_start'
         );
       });
     });
@@ -443,18 +443,24 @@ describe('lib/glean', () => {
     });
 
     describe('thirdPartyAuth', () => {
-      it('submits a ping with the google_deeplink event name', async () => {
+      it('submits a ping with the third_party_auth_google_deeplink event name', async () => {
         GleanMetrics.thirdPartyAuth.googleDeeplink();
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
-        sinon.assert.calledWith(setEventNameStub, 'google_deeplink');
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'third_party_auth_google_deeplink'
+        );
       });
 
-      it('submits a ping with the apple_deeplink event name', async () => {
+      it('submits a ping with the third_party_auth_apple_deeplink event name', async () => {
         GleanMetrics.thirdPartyAuth.appleDeeplink();
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
-        sinon.assert.calledWith(setEventNameStub, 'apple_deeplink');
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'third_party_auth_apple_deeplink'
+        );
       });
     });
 

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -515,42 +515,48 @@ describe('lib/glean', () => {
     });
 
     describe('thirdPartyAuth', () => {
-      it('submits a ping with the google_oauth_reg_start event name', async () => {
+      it('submits a ping with the reg_google_oauth_reg_start event name', async () => {
         GleanMetrics.thirdPartyAuth.startGoogleAuthFromReg();
         const spy = sandbox.spy(reg.googleOauthRegStart, 'record');
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
-        sinon.assert.calledWith(setEventNameStub, 'google_oauth_reg_start');
+        sinon.assert.calledWith(setEventNameStub, 'reg_google_oauth_reg_start');
         sinon.assert.calledOnce(spy);
       });
 
-      it('submits a ping with the third_party_auth_login_no_pw_view event name', async () => {
+      it('submits a ping with the login_third_party_auth_login_no_pw_view event name', async () => {
         GleanMetrics.thirdPartyAuth.viewWithNoPasswordSet();
         const spy = sandbox.spy(login.thirdPartyAuthLoginNoPwView, 'record');
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
           setEventNameStub,
-          'third_party_auth_login_no_pw_view'
+          'login_third_party_auth_login_no_pw_view'
         );
         sinon.assert.calledOnce(spy);
       });
 
-      it('submits a ping with the google_oauth_login_start event name', async () => {
+      it('submits a ping with the login_google_oauth_login_start event name', async () => {
         GleanMetrics.thirdPartyAuth.startGoogleAuthFromLogin();
         const spy = sandbox.spy(login.googleOauthLoginStart, 'record');
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
-        sinon.assert.calledWith(setEventNameStub, 'google_oauth_login_start');
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'login_google_oauth_login_start'
+        );
         sinon.assert.calledOnce(spy);
       });
 
-      it('submits a ping with the apple_oauth_login_start event name', async () => {
+      it('submits a ping with the login_apple_oauth_login_start event name', async () => {
         GleanMetrics.thirdPartyAuth.startAppleAuthFromLogin();
         const spy = sandbox.spy(login.appleOauthLoginStart, 'record');
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
-        sinon.assert.calledWith(setEventNameStub, 'apple_oauth_login_start');
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'login_apple_oauth_login_start'
+        );
         sinon.assert.calledOnce(spy);
       });
     });

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -323,19 +323,19 @@ const recordEventMetric = (
     case 'password_reset_view':
       passwordReset.view.record();
       break;
-    case 'google_oauth_reg_start':
+    case 'reg_google_oauth_reg_start':
       reg.googleOauthRegStart.record();
       break;
-    case 'apple_oauth_reg_start':
+    case 'reg_apple_oauth_reg_start':
       reg.appleOauthRegStart.record();
       break;
-    case 'third_party_auth_login_no_pw_view':
+    case 'login_third_party_auth_login_no_pw_view':
       login.thirdPartyAuthLoginNoPwView.record();
       break;
-    case 'google_oauth_login_start':
+    case 'login_google_oauth_login_start':
       login.googleOauthLoginStart.record();
       break;
-    case 'apple_oauth_login_start':
+    case 'login_apple_oauth_login_start':
       login.appleOauthLoginStart.record();
       break;
     case 'cad_firefox_notnow_submit':

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -119,12 +119,12 @@ export const eventsMap = {
   },
 
   thirdPartyAuth: {
-    startGoogleAuthFromReg: 'google_oauth_reg_start',
-    startAppleAuthFromReg: 'apple_oauth_reg_start',
+    startGoogleAuthFromReg: 'reg_google_oauth_reg_start',
+    startAppleAuthFromReg: 'reg_apple_oauth_reg_start',
 
-    viewWithNoPasswordSet: 'third_party_auth_login_no_pw_view',
-    startGoogleAuthFromLogin: 'google_oauth_login_start',
-    startAppleAuthFromLogin: 'apple_oauth_login_start',
+    viewWithNoPasswordSet: 'login_third_party_auth_login_no_pw_view',
+    startGoogleAuthFromLogin: 'login_google_oauth_login_start',
+    startAppleAuthFromLogin: 'login_apple_oauth_login_start',
   },
 
   cadMobilePair: {


### PR DESCRIPTION


## Because

- We want event names in `accounts-events` ping to be consistent with event metric categories and names in `events` ping

## This pull request

- Updates recently added event names for consistency

## Issue that this pull request solves

Closes: issue described in https://mozilla-hub.atlassian.net/browse/DENG-3273?focusedCommentId=907454

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
