### PR TITLE
fix(functional): integrate html reporting for smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,6 @@ commands:
           paths:
             - artifacts/blob-report
 
-
   build:
     steps:
       - run:
@@ -656,6 +655,19 @@ jobs:
       - run-playwright-tests:
           project: << parameters.project >>
       - store-artifacts
+      - persist_to_workspace:
+          root: /home/circleci/project
+          paths:
+            - packages/functional-tests/playwright-report
+
+  #create separate job for html reporting for Stage and Prod
+  create-html-report:
+    executor: default-executor
+    steps:
+      - attach_workspace:
+          at: /home/circleci/project
+      - store_artifacts:
+          path: packages/functional-tests/playwright-report
 
   # Runs functional tests using playwright. These tests support splitting
   # and parallel execution.
@@ -871,6 +883,9 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
+      - create-html-report:
+          requires:
+            - Smoke Test Production - Playwright
 
   # Triggered remotely. See .circleci/README.md
   stage_smoke_tests:
@@ -884,6 +899,9 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
+      - create-html-report:
+          requires:
+            - Smoke Test Stage - Playwright
 
   deploy_fxa_image:
     # This workflow can be triggered after a PR lands on main. It requires approval.

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -140,7 +140,7 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutEmailFirstForm(initialEmail);
       await signin.fillOutPasswordForm(newPassword);
 
-      await expect(settings.primaryEmail.status).toHaveText(credentials.email);
+      await expect(settings.settingsHeading).toBeVisible();
 
       // Update which password to use the account cleanup
       credentials.password = newPassword;


### PR DESCRIPTION
## Because

- `severity-1 #smoke › change primary email tests › change primary email, change password, login, change email and login` test was failed in prod once
- Html reporting needed to be added with smoke test in Stage and Prod

## This pull request

- Adds a different expect method for rendering settings page
- integrates html reporting with smoke tests in Stage and Prod

## Issue that this pull request solves

Closes: FXA-10028 FXA-10059

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
