### PR TITLE
test(functional): add fixme to signin cached test failing in Stage

### DIFF
--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -172,6 +172,7 @@ test.describe('severity-2 #smoke', () => {
       syncBrowserPages: { page, settings, signin },
       testAccountTracker,
     }) => {
+      test.fixme(true, 'TODO in FXA-10064, need to fix redirection issue');
       const credentials = await testAccountTracker.signUp();
       const syncCredentials = await signInSyncAccount(
         target,


### PR DESCRIPTION
## Because

- The `severity-2 #smoke › signin cached › sign in once, use a different account` test has been failing in Stage for past 2 runs

## This pull request

- Adds fixme with the ticket number to the test

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
