### PR TITLE
fix(functional-test): Cached signin test failing on redirect

### DIFF
--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -82,6 +82,6 @@ export abstract class SettingsLayout extends BaseLayout {
     await this.avatarDropDownMenuToggle.click();
     await this.avatarMenuSignOut.click();
 
-    await expect(this.page).toHaveURL(this.target.baseUrl);
+    await expect(this.page).not.toHaveURL(/settings/);
   }
 }

--- a/packages/functional-tests/tests/signin/signinCached.spec.ts
+++ b/packages/functional-tests/tests/signin/signinCached.spec.ts
@@ -195,10 +195,9 @@ test.describe('severity-2 #smoke', () => {
       await expect(settings.primaryEmail.status).toHaveText(credentials.email);
       await settings.signOut();
 
-      // testing to make sure cached signin comes back after a refresh
-      await page.goto(target.contentServerUrl);
+      await expect(page).toHaveURL(/signin/);
 
-      //Check prefilled email
+      // Check that suggested cached account is the sync account
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
     });
   });


### PR DESCRIPTION
## Because

* Sign in cached, sign in once, use a different account test was failing on the sign out step due to redirect to cached signin

## This pull request

* Update the sign out function to check for redirect away from settings but allow for different destinations (email first or sign in, for example)
* Remove the refresh in the test (not needed) and replace with URL check

## Issue that this pull request solves

Closes: #FXA-10064

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
