### PR TITLE
fix(sync): Adjust conditions for sending can_link_account on signin

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -19,6 +19,7 @@ auth-error-155 = TOTP token not found
 auth-error-159 = Invalid account recovery key
 auth-error-183-2 = Invalid or expired confirmation code
 auth-error-999 = Unexpected error
+auth-error-1001 = Login attempt cancelled
 auth-error-1002 = Session expired. Sign in to continue.
 auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different


### PR DESCRIPTION
Because:
* In the 'account disconnected' Sync state, users are now taken to /signin instead of /force_auth, so our logic needed to be updated

This commit:
* Adjusts the logic for when we send the message. Only send if the user didn't first hit content-server (we will know based on a temporary query param until email-first is converted to React). The browser decides when to automatically respond with ok: true or prompt the user
* Displays an error message when the user cancels

closes FXA-10176