### PR TITLE
bug(settings): Make sure event handler is attached before message is sent

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -349,8 +349,6 @@ export class Firefox extends EventTarget {
   async fxaCanLinkAccount(
     options: FxACanLinkAccount
   ): Promise<FxACanLinkAccountResponse> {
-    this.send(FirefoxCommand.CanLinkAccount, options);
-
     return new Promise((resolve) => {
       const eventHandler = (event: Event) => {
         const firefoxEvent = event as FirefoxEvent;
@@ -362,6 +360,7 @@ export class Firefox extends EventTarget {
         resolve(detail.message?.data as FxACanLinkAccountResponse);
       };
       window.addEventListener('WebChannelMessageToContent', eventHandler);
+      this.send(FirefoxCommand.CanLinkAccount, options);
     });
   }
 


### PR DESCRIPTION

## Because:
- On android mobile this response for 'CanLinkAccount' comes back immediately and no pop up is displayed.
- As result, we potentially have a result, and the eventHandler might not be bound.

## This pull request
- Attach the event handler before sending the message.

## Issue that this pull request solves

Closes: FXA-10057

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is a bit tricky test on mobile at the moment. Final validation is needed on staging.
