### PR TITLE
fix(sync): Use requestAnimationFrame to ensure event handler is attached before event

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -360,7 +360,11 @@ export class Firefox extends EventTarget {
         resolve(detail.message?.data as FxACanLinkAccountResponse);
       };
       window.addEventListener('WebChannelMessageToContent', eventHandler);
-      this.send(FirefoxCommand.CanLinkAccount, options);
+      // requestAnimationFrame ensures the event listener is added first
+      // otherwise, there is a race condition
+      requestAnimationFrame(() => {
+        this.send(FirefoxCommand.CanLinkAccount, options);
+      });
     });
   }
 


### PR DESCRIPTION
Because:
* Android responds immediately to the can_link_account message and we don't appear to always have the event listener attached

This fix:
* Adds requestAnimationFrame, as we have needed to use this a couple of times before for testing when the response back was immediate

fixes FXA-10057