### PR TITLE
Bug(settings): Fix for 'stuck' sign in button p2

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -350,18 +350,12 @@ export class Firefox extends EventTarget {
     options: FxACanLinkAccount
   ): Promise<FxACanLinkAccountResponse> {
     return new Promise((resolve) => {
-      const eventHandler = (event: Event) => {
-        const firefoxEvent = event as FirefoxEvent;
-        const detail =
-          typeof firefoxEvent.detail === 'string'
-            ? (JSON.parse(firefoxEvent.detail) as FirefoxMessageDetail)
-            : firefoxEvent.detail;
-
-        resolve(detail.message?.data as FxACanLinkAccountResponse);
+      const eventHandler = (firefoxEvent: any) => {
+        this.removeEventListener(FirefoxCommand.CanLinkAccount, eventHandler);
+        resolve(firefoxEvent.detail || { ok: false });
       };
-      window.addEventListener('WebChannelMessageToContent', eventHandler);
-      // requestAnimationFrame ensures the event listener is added first
-      // otherwise, there is a race condition
+
+      this.addEventListener(FirefoxCommand.CanLinkAccount, eventHandler);
       requestAnimationFrame(() => {
         this.send(FirefoxCommand.CanLinkAccount, options);
       });


### PR DESCRIPTION
## Because
- When signing into sync on Android,  the signin button can become 'stuck'
- Yesterday we uncovered a race condition that seemed to help, but didn't totally fix the problem.
- The event handler in fxaCanLinkAccount was too general and could pick up events that were not intended for it.


## This pull request
- Uses `this.addEventListener(FirefoxCommand.CanLinkAccount` instead of `window.addEventListener('WebChannelMessageToContent'...`
- Doing so ensures that only responses for the CanLinkAccount command are handled.


## Issue that this pull request solves

Closes: FXA-10057

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

Note, we should avoid using `window.addEventListener('WebChannelMessageToContent'`
