### PR TITLE
fix(metrics): DENG-3273 Send cad_ events in events ping

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -9,6 +9,7 @@ import * as cachedLogin from './cachedLogin';
 import * as cadApproveDevice from './cadApproveDevice';
 import * as cadFirefox from './cadFirefox';
 import * as cadMobilePair from './cadMobilePair';
+import * as cadMobilePairUseApp from './cadMobilePairUseApp';
 import * as cad from './cad';
 import * as cadRedirectDesktop from './cadRedirectDesktop';
 import * as email from './email';
@@ -256,14 +257,26 @@ const recordEventMetric = (eventName: string, properties: EventProperties) => {
     case 'cad_firefox_choice_notnow_submit':
       cadFirefox.choiceNotnowSubmit.record();
       break;
+    case 'cad_firefox_notnow_submit':
+      cadFirefox.notnowSubmit.record();
+      break;
     case 'cad_firefox_sync_device_submit':
       cadFirefox.syncDeviceSubmit.record();
       break;
     case 'cad_approve_device_view':
       cadApproveDevice.view.record();
       break;
+    case 'cad_approve_device_submit':
+      cadApproveDevice.submit.record();
+      break;
     case 'cad_mobile_pair_view':
       cadMobilePair.view.record();
+      break;
+    case 'cad_mobile_pair_submit':
+      cadMobilePair.submit.record();
+      break;
+    case 'cad_mobile_pair_use_app_view':
+      cadMobilePairUseApp.view.record();
       break;
     case 'cad_view':
       cad.view.record();


### PR DESCRIPTION
## Because

- Some of the recently added `cad_` events are not sent in `events` ping

## This pull request

- Attempts to send missing events in events ping

## Issue that this pull request solves

Closes: issue described in https://mozilla-hub.atlassian.net/browse/DENG-3273?focusedCommentId=908657

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
