### PR TITLE
feat(glean): Add frontend glean events for settings profile CTAs

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Profile/index.tsx
@@ -8,6 +8,7 @@ import { UnitRow } from '../UnitRow';
 import { UnitRowSecondaryEmail } from '../UnitRowSecondaryEmail';
 import { HomePath } from '../../../constants';
 import { FtlMsg } from 'fxa-react/lib/utils';
+import GleanMetrics from '../../../lib/glean';
 
 export const Profile = forwardRef<HTMLDivElement>((_, ref) => {
   const { avatar, primaryEmail, displayName } = useAccount();
@@ -45,6 +46,9 @@ export const Profile = forwardRef<HTMLDivElement>((_, ref) => {
             headerValue={displayName}
             headerValueClassName="break-all"
             route="/settings/display_name"
+            ctaOnClickAction={() =>
+              GleanMetrics.accountPref.displayNameSubmit()
+            }
             prefixDataTestId="display-name"
           />
         </FtlMsg>

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -10,6 +10,7 @@ import ModalVerifySession from '../ModalVerifySession';
 import { ButtonIconTrash, ButtonIconReload } from '../ButtonIcon';
 import { Localized, useLocalization } from '@fluent/react';
 import { HomePath } from '../../../constants';
+import GleanMetrics from '../../../lib/glean';
 
 type UnitRowSecondaryEmailContentAndActionsProps = {
   secondary: Email;
@@ -136,6 +137,7 @@ export const UnitRowSecondaryEmail = () => {
         prefixDataTestId="secondary-email"
         headerValue={null}
         route={`${HomePath}/emails`}
+        ctaOnClickAction={() => GleanMetrics.accountPref.secondaryEmailSubmit()}
         {...{
           alertBarRevealed: alertBar.visible,
         }}

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -578,6 +578,30 @@ describe('lib/glean', () => {
         sinon.assert.calledOnce(spy);
       });
 
+      it('submits a ping with the account_pref_display_name_submit event name', async () => {
+        GleanMetrics.accountPref.displayNameSubmit();
+        const spy = sandbox.spy(accountPref.displayNameSubmit, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_display_name_submit'
+        );
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_secondary_email_submit event name', async () => {
+        GleanMetrics.accountPref.secondaryEmailSubmit();
+        const spy = sandbox.spy(accountPref.secondaryEmailSubmit, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_secondary_email_submit'
+        );
+        sinon.assert.calledOnce(spy);
+      });
+
       it('submits a ping with the account_pref_two_step_auth_submit event name', async () => {
         GleanMetrics.accountPref.twoStepAuthSubmit();
         const spy = sandbox.spy(accountPref.twoStepAuthSubmit, 'record');

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -358,6 +358,12 @@ const recordEventMetric = (
     case 'account_pref_recovery_key_submit':
       accountPref.recoveryKeySubmit.record();
       break;
+    case 'account_pref_two_step_auth_submit':
+      accountPref.twoStepAuthSubmit.record();
+      break;
+    case 'account_pref_change_password_submit':
+      accountPref.changePasswordSubmit.record();
+      break;
     case 'account_pref_google_unlink_submit':
       accountPref.googleUnlinkSubmit.record({
         reason: gleanPingMetrics?.event?.['reason'] || '',
@@ -378,6 +384,23 @@ const recordEventMetric = (
         reason: gleanPingMetrics?.event?.['reason'] || '',
       });
       break;
+    case 'account_pref_device_signout':
+      accountPref.deviceSignout.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_google_play_submit':
+      accountPref.googlePlaySubmit.record();
+      break;
+    case 'account_pref_apple_submit':
+      accountPref.appleSubmit.record();
+      break;
+    case 'account_pref_display_name_submit':
+      accountPref.displayNameSubmit.record();
+      break;
+    case 'account_pref_secondary_email_submit':
+      accountPref.secondaryEmailSubmit.record();
+      break;
     case 'delete_account_settings_submit':
       deleteAccount.settingsSubmit.record();
       break;
@@ -395,23 +418,6 @@ const recordEventMetric = (
       break;
     case 'delete_account_password_submit':
       deleteAccount.passwordSubmit.record();
-      break;
-    case 'account_pref_two_step_auth_submit':
-      accountPref.twoStepAuthSubmit.record();
-      break;
-    case 'account_pref_change_password_submit':
-      accountPref.changePasswordSubmit.record();
-      break;
-    case 'account_pref_device_signout':
-      accountPref.deviceSignout.record({
-        reason: gleanPingMetrics?.event?.['reason'] || '',
-      });
-      break;
-    case 'account_pref_google_play_submit':
-      accountPref.googlePlaySubmit.record();
-      break;
-    case 'account_pref_apple_submit':
-      accountPref.appleSubmit.record();
       break;
   }
 };

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1852,7 +1852,7 @@ account_pref:
       - vzare@mozilla.com
       - fxa-staff@mozilla.com
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXA-10039
+      - https://mozilla-hub.atlassian.net/browse/FXA-10038
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
@@ -1869,7 +1869,41 @@ account_pref:
       - vzare@mozilla.com
       - fxa-staff@mozilla.com
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXA-10039
+      - https://mozilla-hub.atlassian.net/browse/FXA-10040
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  display_name_submit:
+    type: event
+    description: |
+      Click on "Add" or "Change" on account settings page to add or change display name
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10041
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  secondary_email_submit:
+    type: event
+    description: |
+      Click on "Add" button on account settings page to add secondary email
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10042
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -95,6 +95,23 @@ export const deviceSignout = new EventMetricType<{
 );
 
 /**
+ * Click on "Add" or "Change" on account settings page to add or change display
+ * name
+ *
+ * Generated from `account_pref.display_name_submit`.
+ */
+export const displayNameSubmit = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'display_name_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Click on Google Play logo to download Firefox on Android
  *
  * Generated from `account_pref.google_play_submit`.
@@ -158,6 +175,22 @@ export const recoveryKeySubmit = new EventMetricType(
   {
     category: 'account_pref',
     name: 'recovery_key_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * Click on "Add" button on account settings page to add secondary email
+ *
+ * Generated from `account_pref.secondary_email_submit`.
+ */
+export const secondaryEmailSubmit = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'secondary_email_submit',
     sendInPings: ['events'],
     lifetime: 'ping',
     disabled: false,

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -156,6 +156,8 @@ export const eventsMap = {
     googleUnlinkSubmitConfirm: 'account_pref_google_unlink_submit_confirm',
     appleUnlinkSubmit: 'account_pref_apple_unlink_submit',
     appleUnlinkSubmitConfirm: 'account_pref_apple_unlink_submit_confirm',
+    displayNameSubmit: 'account_pref_display_name_submit',
+    secondaryEmailSubmit: 'account_pref_secondary_email_submit',
   },
 
   deleteAccount: {


### PR DESCRIPTION
## Because

* We want to track metrics for clicks to add/change display name and add a secondary email

## This pull request

* Adds and implements glean events account_pref_display_name_submit and account_pref_secondary_email_submit

## Issue that this pull request solves

Closes: #FXA-10041, FXA-10042

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
