### PR TITLE
fix(metrics): DENG-3273 Update third_party_auth login event names for consistency between accounts-events and events pings

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -228,13 +228,13 @@ const createEventFn =
         case 'access_token_checked':
           gleanServerEventLogger.recordAccessTokenChecked(commonMetrics);
           break;
-        case 'google_login_complete':
+        case 'third_party_auth_google_login_complete':
           gleanServerEventLogger.recordThirdPartyAuthGoogleLoginComplete({
             ...commonMetrics,
             linking: metricsData?.reason === 'linking',
           });
           break;
-        case 'apple_login_complete':
+        case 'third_party_auth_apple_login_complete':
           gleanServerEventLogger.recordThirdPartyAuthAppleLoginComplete({
             ...commonMetrics,
             linking: metricsData?.reason === 'linking',
@@ -311,8 +311,12 @@ export function gleanMetrics(config: ConfigType) {
     },
 
     thirdPartyAuth: {
-      googleLoginComplete: createEventFn('google_login_complete'),
-      appleLoginComplete: createEventFn('apple_login_complete'),
+      googleLoginComplete: createEventFn(
+        'third_party_auth_google_login_complete'
+      ),
+      appleLoginComplete: createEventFn(
+        'third_party_auth_apple_login_complete'
+      ),
       setPasswordComplete: createEventFn(
         'third_party_auth_set_password_complete'
       ),

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -521,7 +521,10 @@ describe('Glean server side events', () => {
         });
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
-        assert.equal(metrics['event_name'], 'google_login_complete');
+        assert.equal(
+          metrics['event_name'],
+          'third_party_auth_google_login_complete'
+        );
         assert.equal(metrics['event_reason'], 'linking');
         sinon.assert.calledOnce(recordThirdPartyAuthGoogleLoginCompleteStub);
         assert.isTrue(
@@ -534,7 +537,10 @@ describe('Glean server side events', () => {
         await glean.thirdPartyAuth.googleLoginComplete(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
-        assert.equal(metrics['event_name'], 'google_login_complete');
+        assert.equal(
+          metrics['event_name'],
+          'third_party_auth_google_login_complete'
+        );
         assert.equal(metrics['event_reason'], '');
         sinon.assert.calledOnce(recordThirdPartyAuthGoogleLoginCompleteStub);
         assert.isFalse(
@@ -554,7 +560,10 @@ describe('Glean server side events', () => {
         });
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
-        assert.equal(metrics['event_name'], 'apple_login_complete');
+        assert.equal(
+          metrics['event_name'],
+          'third_party_auth_apple_login_complete'
+        );
         assert.equal(metrics['event_reason'], 'linking');
         sinon.assert.calledOnce(recordThirdPartyAuthAppleLoginCompleteStub);
         assert.isTrue(
@@ -567,7 +576,10 @@ describe('Glean server side events', () => {
         await glean.thirdPartyAuth.appleLoginComplete(request);
         sinon.assert.calledOnce(recordStub);
         const metrics = recordStub.args[0][0];
-        assert.equal(metrics['event_name'], 'apple_login_complete');
+        assert.equal(
+          metrics['event_name'],
+          'third_party_auth_apple_login_complete'
+        );
         assert.equal(metrics['event_reason'], '');
         sinon.assert.calledOnce(recordThirdPartyAuthAppleLoginCompleteStub);
         assert.isFalse(


### PR DESCRIPTION

## Because

- We want event names in accounts-events ping to be consistent with event metric categories and names in events ping

## This pull request

- Updates recently added event names for consistency

## Issue that this pull request solves

Closes: Closes: issue similar to described in https://mozilla-hub.atlassian.net/browse/DENG-3273?focusedCommentId=907454

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
