### PR TITLE
fix(settings): Remove obsolete 'send download link' link

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/en.ftl
@@ -1,8 +1,7 @@
 ## Connect another device promo
 
 connect-another-fx-mobile = Get { -brand-firefox } on mobile or tablet
-connect-another-find-fx-mobile = Find { -brand-firefox } in the { -google-play } and { -app-store } or
-  <br /><linkExternal>send a download link to your device.</linkExternal>
+connect-another-find-fx-mobile-2 = Find { -brand-firefox } in the { -google-play } and { -app-store }.
 
 # Alt text for Google Play and Apple App store images that will be shown if the image can't be loaded.
 # These images are used to encourage users to download Firefox on their mobile devices.

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
@@ -12,13 +12,8 @@ describe('Connect another device Promo', () => {
   it('renders "fresh load" <ConnectAnotherDevicePromo/> with correct content', async () => {
     renderWithRouter(<ConnectAnotherDevicePromo />);
 
-    expect(
-      await screen.findByText('Get Firefox on mobile or tablet')
-    ).toBeTruthy();
-    expect(await screen.findByTestId('download-link')).toHaveAttribute(
-      'href',
-      'https://www.mozilla.org/firefox/mobile/'
-    );
+    await screen.findByText('Get Firefox on mobile or tablet');
+    await screen.findByText('Find Firefox in the Google Play and App Store.');
     expect(screen.getByTestId('play-store-link')).toHaveAttribute(
       'href',
       'https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox'

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -28,31 +28,9 @@ export function ConnectAnotherDevicePromo() {
         <Localized id="connect-another-fx-mobile">
           <p className="text-sm">Get Firefox on mobile or tablet</p>
         </Localized>
-        <Localized
-          id="connect-another-find-fx-mobile"
-          elems={{
-            br: <br />,
-            linkExternal: (
-              <LinkExternal
-                href="https://www.mozilla.org/firefox/mobile/"
-                className="link-blue"
-                data-testid="download-link"
-              >
-                {' '}
-              </LinkExternal>
-            ),
-          }}
-        >
+        <Localized id="connect-another-find-fx-mobile-2">
           <p className="text-grey-400 text-xs">
-            Find Firefox in the Google Play and App Store or
-            <br />
-            <LinkExternal
-              href="https://www.mozilla.org/firefox/mobile/"
-              className="link-blue"
-              data-testid="download-link"
-            >
-              send a download link to your device.
-            </LinkExternal>
+            Find Firefox in the Google Play and App Store.
           </p>
         </Localized>
       </div>


### PR DESCRIPTION
Because:
* This link no longer allows users to get a text via SMS, so we're removing it

This commit:
* Removes the link and updates copy

fixes FXA-9983

---

While looking at FXA-10049 I remembered this (FXA-9983) recently filed issue and confirmed we don't want this event and want to remove the link.

![image](https://github.com/user-attachments/assets/a7f1c8cb-d519-4a18-98b6-4465937e5ee9)
