### PR TITLE
Revert "bug(settings): Skip checkOauthData for sync"

### DIFF
--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -39,11 +39,6 @@ export type FinishOAuthFlowHandlerResult =
   | FinishOAuthFlowHandlerError;
 
 const checkOAuthData = (integration: OAuthIntegration): AuthError | null => {
-  // Weird edge case. See FXA-10029...
-  if (integration.isSync()) {
-    return null;
-  }
-
   // Ensure a redirect was provided or matched. Without this info, we can't relay the
   // oauth code and state on a redirect!
   // clientInfo?.redirectUri has already validated the redirect_uri query param


### PR DESCRIPTION
Reverts mozilla/fxa#17208

See comment on that PR. This was working for Backbone signin, so we thought the client-side React check could be short-circuited here, but it errors out later in the flow and this wasn't the fix.