### PR TITLE
feat(metrics): Add glean metrics for apple, google, and disconnect settings button

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -7,6 +7,7 @@ import { LinkExternal } from 'fxa-react/components/LinkExternal';
 import { Localized } from '@fluent/react';
 import { getStoreImageByLanguages, StoreType } from './storeImageLoader';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
+import GleanMetrics from '../../../lib/glean';
 
 export function ConnectAnotherDevicePromo() {
   const { navigatorLanguages } = useContext(SettingsContext);
@@ -39,6 +40,7 @@ export function ConnectAnotherDevicePromo() {
           className="self-center"
           data-testid="play-store-link"
           href="https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox"
+          onClick={() => GleanMetrics.accountPref.googlePlaySubmit()}
         >
           <Localized
             id="connect-another-play-store-image"
@@ -54,6 +56,7 @@ export function ConnectAnotherDevicePromo() {
           className="self-center p-2"
           data-testid="app-store-link"
           href="https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926"
+          onClick={() => GleanMetrics.accountPref.appleSubmit()}
         >
           <Localized
             id="connect-another-app-store-image-2"

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -601,6 +601,43 @@ describe('lib/glean', () => {
         );
         sinon.assert.called(spy);
       });
+
+      it('submits a ping with the account_pref_device_signout event name', async () => {
+        GleanMetrics.accountPref.deviceSignout({
+          event: { reason: 'something' },
+        });
+        const spy = sandbox.spy(accountPref.deviceSignout, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_device_signout'
+        );
+        sinon.assert.called(spy);
+        sinon.assert.calledOnce(setEventReasonStub);
+        sinon.assert.calledWith(setEventReasonStub, 'something');
+      });
+
+      it('submits a ping with the account_pref_google_play_submit event name', async () => {
+        GleanMetrics.accountPref.googlePlaySubmit();
+        const spy = sandbox.spy(accountPref.googlePlaySubmit, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_google_play_submit'
+        );
+        sinon.assert.called(spy);
+      });
+
+      it('submits a ping with the account_pref_apple_submit event name', async () => {
+        GleanMetrics.accountPref.appleSubmit();
+        const spy = sandbox.spy(accountPref.appleSubmit, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'account_pref_apple_submit');
+        sinon.assert.called(spy);
+      });
     });
 
     describe('deleteAccount', () => {

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -382,6 +382,17 @@ const recordEventMetric = (
     case 'account_pref_change_password_submit':
       accountPref.changePasswordSubmit.record();
       break;
+    case 'account_pref_device_signout':
+      accountPref.deviceSignout.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_google_play_submit':
+      accountPref.googlePlaySubmit.record();
+      break;
+    case 'account_pref_apple_submit':
+      accountPref.appleSubmit.record();
+      break;
   }
 };
 

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1876,6 +1876,61 @@ account_pref:
     expires: never
     data_sensitivity:
       - interaction
+  device_signout:
+    type: event
+    description: |
+      Click on "Signout" under Connected Services to sign out of device/service
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10043
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: The reason to disconnect the device/service
+        type: string
+  apple_submit:
+    type: event
+    description: |
+      Click on Apple logo to download Firefox on Apple
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10048
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  google_play_submit:
+    type: event
+    description: |
+      Click on Google Play logo to download Firefox on Android
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10047
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 delete_account:
   settings_submit:
     type: event

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -7,6 +7,22 @@
 import EventMetricType from '@mozilla/glean/private/metrics/event';
 
 /**
+ * Click on Apple logo to download Firefox on Apple
+ *
+ * Generated from `account_pref.apple_submit`.
+ */
+export const appleSubmit = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'apple_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Click on "Change" on account settings page to change password for account
  *
  * Generated from `account_pref.change_password_submit`.
@@ -15,6 +31,40 @@ export const changePasswordSubmit = new EventMetricType(
   {
     category: 'account_pref',
     name: 'change_password_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * Click on "Signout" under Connected Services to sign out of device/service
+ *
+ * Generated from `account_pref.device_signout`.
+ */
+export const deviceSignout = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'device_signout',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
+ * Click on Google Play logo to download Firefox on Android
+ *
+ * Generated from `account_pref.google_play_submit`.
+ */
+export const googlePlaySubmit = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'google_play_submit',
     sendInPings: ['events'],
     lifetime: 'ping',
     disabled: false,

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -149,6 +149,9 @@ export const eventsMap = {
     recoveryKeySubmit: 'account_pref_recovery_key_submit',
     twoStepAuthSubmit: 'account_pref_two_step_auth_submit',
     changePasswordSubmit: 'account_pref_change_password_submit',
+    deviceSignout: 'account_pref_device_signout',
+    appleSubmit: 'account_pref_apple_submit',
+    googlePlaySubmit: 'account_pref_google_play_submit',
   },
 
   deleteAccount: {


### PR DESCRIPTION
## Because

- We want metrics to track when user clicks disconnect from settings, and click Apple/Google play store buttons

## This pull request

- Adds those metrics

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10043
Closes: https://mozilla-hub.atlassian.net/browse/FXA-10048
Closes: https://mozilla-hub.atlassian.net/browse/FXA-10047

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
