### PR TITLE
task(settings): Stop using window.addEventListener for web channel messages

### DIFF
--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -15,6 +15,9 @@ const eventDetailLinkAccount = createCustomEventDetail(
     ok: true,
   }
 );
+const eventDetailFxaLogin = createCustomEventDetail(FirefoxCommand.Login, {
+  ok: true,
+});
 
 test.describe('severity-1 #smoke', () => {
   test.describe('signup react', () => {
@@ -82,6 +85,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.fillOutSignupForm(password, AGE_21);
 
+      await signup.respondToWebChannelMessage(eventDetailFxaLogin);
       await signup.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(page).toHaveURL(/confirm_signup_code/);
 


### PR DESCRIPTION
## Because

- We saw positive results from doing the same thing for the CanLinkAcocunt web channel message

## This pull request

- Updates the FxaLogin web channel message

## Issue that this pull request solves

Closes: FXA-10074

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
