### PR TITLE
feat(glean): Add unlink account submit and confirm submit events

### DIFF
--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/index.tsx
@@ -27,19 +27,14 @@ export const LinkedAccounts = forwardRef<HTMLDivElement>((_, ref) => {
           <div className="bg-white tablet:rounded-xl shadow px-4 tablet:px-6 pt-7 pb-8">
             <div className="flex justify-between mb-4">
               <Localized id="la-description">
-                <p>
-                  You have linked and authorized access to the following
-                  accounts.
-                </p>
+                <p>You have authorized access to the following accounts.</p>
               </Localized>
             </div>
 
             {linkedAccounts.map((linkedAccount) => (
               <LinkedAccount
-                {...{
-                  key: linkedAccount.providerId,
-                  providerId: linkedAccount.providerId,
-                }}
+                key={linkedAccount.providerId}
+                providerId={linkedAccount.providerId}
               />
             ))}
           </div>

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -590,6 +590,54 @@ describe('lib/glean', () => {
         sinon.assert.called(spy);
       });
 
+      it('submits a ping with the account_pref_google_unlink_submit event name', async () => {
+        GleanMetrics.accountPref.googleUnlinkSubmit();
+        const spy = sandbox.spy(accountPref.googleUnlinkSubmit, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_google_unlink_submit'
+        );
+        sinon.assert.called(spy);
+      });
+      it('submits a ping with the account_pref_apple_unlink_submit event name', async () => {
+        GleanMetrics.accountPref.appleUnlinkSubmit();
+        const spy = sandbox.spy(accountPref.appleUnlinkSubmit, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_apple_unlink_submit'
+        );
+        sinon.assert.called(spy);
+      });
+      it('submits a ping with the account_pref_google_unlink_submit_confirm event name', async () => {
+        GleanMetrics.accountPref.googleUnlinkSubmitConfirm();
+        const spy = sandbox.spy(
+          accountPref.googleUnlinkSubmitConfirm,
+          'record'
+        );
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_google_unlink_submit_confirm'
+        );
+        sinon.assert.called(spy);
+      });
+      it('submits a ping with the account_pref_apple_unlink_submit_confirm event name', async () => {
+        GleanMetrics.accountPref.appleUnlinkSubmitConfirm();
+        const spy = sandbox.spy(accountPref.appleUnlinkSubmitConfirm, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_apple_unlink_submit_confirm'
+        );
+        sinon.assert.called(spy);
+      });
+
       it('submits a ping with the account_pref_change_password_submit event name', async () => {
         GleanMetrics.accountPref.changePasswordSubmit();
         const spy = sandbox.spy(accountPref.changePasswordSubmit, 'record');

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -358,6 +358,26 @@ const recordEventMetric = (
     case 'account_pref_recovery_key_submit':
       accountPref.recoveryKeySubmit.record();
       break;
+    case 'account_pref_google_unlink_submit':
+      accountPref.googleUnlinkSubmit.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_google_unlink_submit_confirm':
+      accountPref.googleUnlinkSubmitConfirm.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_apple_unlink_submit':
+      accountPref.appleUnlinkSubmit.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_apple_unlink_submit_confirm':
+      accountPref.appleUnlinkSubmitConfirm.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
     case 'delete_account_settings_submit':
       deleteAccount.settingsSubmit.record();
       break;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -758,7 +758,7 @@ login:
       - vzare@mozilla.com
       - fxa-staff@mozilla.com
     bugs:
-       - https://mozilla-hub.atlassian.net/browse/FXA-9569
+      - https://mozilla-hub.atlassian.net/browse/FXA-9569
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
@@ -1931,6 +1931,91 @@ account_pref:
     expires: never
     data_sensitivity:
       - interaction
+  google_unlink_submit:
+    type: event
+    description: |
+      The user clicked "Unlink" from account preferences for their Google linked account.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10050
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: If reason is "create_password", the user must set a password before they can confirm the account unlinking.
+        type: string
+  google_unlink_submit_confirm:
+    type: event
+    description: |
+      The user clicked "Unlink" from the confirmation modal for their Google linked account.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10050
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: If reason is "create_password", the user must set a password before they can confirm the account unlinking.
+        type: string
+  apple_unlink_submit:
+    type: event
+    description: |
+      The user clicked "Unlink" from account preferences for their Apple linked account.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10051
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: If reason is "create_password", the user must set a password before they can confirm the account unlinking.
+        type: string
+  apple_unlink_submit_confirm:
+    type: event
+    description: |
+      The user clicked "Unlink" from the confirmation modal for their Apple linked account.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10051
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: If reason is "create_password", the user was taken to the create password page, set a password, and then confirmed the account unlinking.
+        type: string
+
 delete_account:
   settings_submit:
     type: event

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -23,6 +23,44 @@ export const appleSubmit = new EventMetricType(
 );
 
 /**
+ * The user clicked "Unlink" from account preferences for their Apple linked
+ * account.
+ *
+ * Generated from `account_pref.apple_unlink_submit`.
+ */
+export const appleUnlinkSubmit = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'apple_unlink_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
+ * The user clicked "Unlink" from the confirmation modal for their Apple linked
+ * account.
+ *
+ * Generated from `account_pref.apple_unlink_submit_confirm`.
+ */
+export const appleUnlinkSubmitConfirm = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'apple_unlink_submit_confirm',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
  * Click on "Change" on account settings page to change password for account
  *
  * Generated from `account_pref.change_password_submit`.
@@ -70,6 +108,44 @@ export const googlePlaySubmit = new EventMetricType(
     disabled: false,
   },
   []
+);
+
+/**
+ * The user clicked "Unlink" from account preferences for their Google linked
+ * account.
+ *
+ * Generated from `account_pref.google_unlink_submit`.
+ */
+export const googleUnlinkSubmit = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'google_unlink_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
+ * The user clicked "Unlink" from the confirmation modal for their Google linked
+ * account.
+ *
+ * Generated from `account_pref.google_unlink_submit_confirm`.
+ */
+export const googleUnlinkSubmitConfirm = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'google_unlink_submit_confirm',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
 );
 
 /**

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -152,6 +152,10 @@ export const eventsMap = {
     deviceSignout: 'account_pref_device_signout',
     appleSubmit: 'account_pref_apple_submit',
     googlePlaySubmit: 'account_pref_google_play_submit',
+    googleUnlinkSubmit: 'account_pref_google_unlink_submit',
+    googleUnlinkSubmitConfirm: 'account_pref_google_unlink_submit_confirm',
+    appleUnlinkSubmit: 'account_pref_apple_unlink_submit',
+    appleUnlinkSubmitConfirm: 'account_pref_apple_unlink_submit_confirm',
   },
 
   deleteAccount: {


### PR DESCRIPTION
Because:
* We want to track metrics events on Unlink click from settings, and Unlink confirm, with 'create_password' reason if the user needed to first set a password

This commit:
* Adds events account_pref_google_unlink_submit, account_pref_google_unlink_submit_confirm, account_pref_apple_unlink_submit, account_pref_apple_unlink_submit_confirm
* Includes 'reason' in events if user does not have a password set
* Updates some tests and one warning

closes FXA-10050, closes FXA-10051

--

See [Slack thread](https://mozilla.slack.com/archives/C04LVV8V8BA/p1721062687040009) for context around the two extra events and the `reason`.