### PR TITLE
fix(settings): Handle multiple signins to settings

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -31,6 +31,8 @@ import PageRecentActivity from './PageRecentActivity';
 import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { SettingsIntegration } from './interfaces';
+import { currentAccount } from '../../lib/cache';
+import { setCurrentAccount } from '../../lib/storage-utils';
 
 export const Settings = ({
   integration,
@@ -38,6 +40,7 @@ export const Settings = ({
   const config = useConfig();
   const { metricsEnabled, hasPassword } = useAccount();
   const session = useSession();
+  const account = useAccount();
 
   useEffect(() => {
     if (config.metrics.navTiming.enabled && metricsEnabled) {
@@ -51,13 +54,16 @@ export const Settings = ({
 
   useEffect(() => {
     function handleWindowFocus() {
+      if (account.uid !== currentAccount()?.uid) {
+        setCurrentAccount(account.uid);
+      }
       if (session.isDestroyed) {
         hardNavigate('/');
       }
     }
     window.addEventListener('focus', handleWindowFocus);
     return () => window.removeEventListener('focus', handleWindowFocus);
-  }, [session]);
+  }, [account, session]);
 
   const { loading, error } = useInitialSettingsState();
 


### PR DESCRIPTION
## Because

* If multiple accounts were signed in on different tabs, operations could be applied to the wrong account
* Current account uid was not correctly updating to reflect the account in use in the focused tab

## This pull request

* On tab focus, check if the account uid matches the current account uid. If not, update current account uid.
* Only check for destroyed session after updating the current account uid to ensure the correct session is signed out on tab focus.

## Issue that this pull request solves

Closes: #FXA-9984

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Steps to reproduce:
1. Sign in to two accounts in different tabs. (do not sign out of either)
2. Add a secondary email to each account.
3. Sign out of each account and sign back in.

Expected result (with this PR):
Secondary email is added to the correct account.

Actual result (without this PR):
Both secondary emails added to the same account.

Also recommend testing signing in to one account on the web (directly at localhost:3030) and a different account with sync (requires a cherry-pick of this fxa-dev-launcher PR: https://github.com/mozilla/fxa/pull/17274 to ensure correct behaviour on sign out from sync)
