### PR TITLE
chore(metrics): remove the switch to call event metrics in auth-server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ commands:
     steps:
       - run:
           name: Linting
-          command: npx nx affected --base=main --head=$CIRCLE_SHA1 --parallel=2 -t lint
+          command: npx nx affected --base=main --head=$CIRCLE_SHA1 --parallel=1 -t lint
 
   compile:
     steps:


### PR DESCRIPTION
Because:
 - it's unwieldy

This commit:
 - calls the metric event record method based on the string event name

