### PR TITLE
 bug(settings): Fix android manage account settings glitch 

### DIFF
--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -27,6 +27,7 @@ import { SessionVerifyCodeInput } from './dto/input/session-verify-code';
 import { ConsumeRecoveryCodePayload } from './dto/payload/consume-recovery-code';
 import { ConsumeRecoveryCodeInput } from './dto/input/consume-recovery-code';
 import { UnverifiedSessionGuard } from '../auth/unverified-session-guard';
+import { validateSessionToken } from '../auth/session-token.strategy';
 
 @Resolver((of: any) => SessionType)
 export class SessionResolver {
@@ -58,6 +59,18 @@ export class SessionResolver {
     return {
       verified: state === 'verified',
     } as SessionType;
+  }
+
+  @Query((returns) => Boolean)
+  async isValidToken(
+    @Args('sessionToken', { nullable: false }) sessionToken: string
+  ) {
+    try {
+      await validateSessionToken(sessionToken);
+      return true;
+    } catch (err) {
+      return false;
+    }
   }
 
   @Query((returns) => SessionStatus)

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/en.ftl
@@ -1,0 +1,2 @@
+signout-sync-header = Session Expired
+signout-sync-session-expired = Sorry, something went wrong. Please sign out from the browser menu and try again.

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.stories.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import SingoutSync from '.';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+
+export default {
+  title: 'Pages/SingoutSync',
+  component: SingoutSync,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Basic = () => <SingoutSync />;

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.test.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import SignoutSync from '.';
+import { screen } from '@testing-library/react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { FluentBundle } from '@fluent/bundle';
+import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
+
+describe('SignoutSync', () => {
+  let bundle: FluentBundle;
+  beforeAll(async () => {
+    bundle = await getFtlBundle('settings');
+  });
+
+  it('renders as expected', () => {
+    renderWithLocalizationProvider(<SignoutSync />);
+    testAllL10n(screen, bundle);
+
+    screen.getByText('Session Expired');
+    screen.getByText(
+      'Sorry, something went wrong. Please sign out from the browser menu and try again.'
+    );
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import CardHeader from '../../CardHeader';
+import AppLayout from '../../AppLayout';
+
+export const viewName = 'legal';
+
+const SignoutSync = (_: RouteComponentProps) => {
+  // TODO: Add button to make this more automatic. We need the android signout fix
+  //       to be rolled out first though.
+
+  return (
+    <AppLayout>
+      <CardHeader
+        headingTextFtlId="signout-sync-header"
+        headingText="Session Expired"
+      />
+      <section className="flex flex-cols items-center">
+        <FtlMsg id="signout-sync-session-expired">
+          <p className="text-sm">
+            Sorry, something went wrong. Please sign out from the browser menu
+            and try again.
+          </p>
+        </FtlMsg>
+      </section>
+    </AppLayout>
+  );
+};
+
+export default SignoutSync;

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -64,6 +64,11 @@ export function currentAccount(
   return all[uid];
 }
 
+export function getAccountByUid(uid: string) {
+  const all = accounts() || {};
+  return all[uid];
+}
+
 export function lastStoredAccount() {
   const all = accounts() || {};
 

--- a/packages/fxa-settings/src/lib/storage-utils.ts
+++ b/packages/fxa-settings/src/lib/storage-utils.ts
@@ -81,5 +81,5 @@ export function setCurrentAccount(uid: string) {
 export function storeAccountData(accountData: StoredAccountData) {
   persistAccount(accountData);
   setCurrentAccount(accountData.uid);
-  sessionToken(accountData.sessionToken);
+  sessionToken(accountData.sessionToken); // Can we remove this? It seems unnecessary...
 }


### PR DESCRIPTION
## Because

- If users sign out in manner where the browser isn't notified, they can end up in a weird state when accessing settings.

## This pull request

- Asks Firefox for the current user
- Checks the current user's session token
- If the current session is token, uses it thereby letting the user access settings
- If the current session is not valid, a message is displayed saying to signout from sync.

## Issue that this pull request solves

Closes: FXA-10029

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Edge where this code becomes active can be hit with these two scenarios:
Local cache cleared behind Firefox’s back

1. Create an account email+1@gmail.com
2. Click firefox menu > Sync and save data
3. Select use email instead
4. Sign in with email+1@gmail.com
5. Provide confirmation code
6. Observe settings page
7. Close settings page
8. In new tab (ie not from sync), go to [accounts.stage.mozaws.net/clear](http://accounts.stage.mozaws.net/clear)
9. Click Firefox menu > [tz@mz.com](mailto:tz@mz.com) > Manage account settings
10. Observe that account settings load now
11. Observe that [tz@mz.com](mailto:tz@mz.com) is the active user

Account signed out behind Firefox’s back

1. Create an account [tz@mz.com](mailto:tz@mz.com)
2. Click firefox menu > Sync and save data
3. Sign in
4. Observe settings page
5. Close window
6. In new tab go [accounts.stage.mozaws.net](http://accounts.stage.mozaws.net/clear)/signin
7. Sign in with [tz@mz.com](mailto:tz@mz.com)
8. Click profile image in top right corner > click signout (This told our server to destroy [tz@mozilla.com](mailto:tz@mz.com)’s session!)
9. Close window
10. Click firefox menu > [tz@mz.com](mailto:tz@mz.com) > Manage account settings (you should be logged in still, and this option should be present)
11. Observe Screen that says ‘Session Expired’ and instructs you to to signout from sync**


** Note that in the future we can make this seamless. At the time of writing, the sign out web channel message isn’t getting picked up by Firefox on android though, so to really sign out of sync, the user must do this themselves. A follow has been filed for this.
