### PR TITLE
fix: avoid env vars due to dependabot bug

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,6 @@
 enableGlobalCache: true
 
-nmMode: ${DC_NMMODE:-hardlinks-global}
+nmMode: hardlinks-global
 
 nodeLinker: node-modules
 


### PR DESCRIPTION
Because:

* Dependabot is running yarn in a manner that breaks the env var replacmeent in .yarnrc.yml.

This commit:

* Removes the env var replacement in .yarnrc.yml.

Closes FXA-10002

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
