### PR TITLE
fix(pairing): Give users option to login with email if pair failed

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/pairing/authority.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/pairing/authority.js
@@ -64,6 +64,7 @@ export default class AuthorityBroker extends BaseAuthenticationBroker {
       (response) => {
         if (response.err) {
           this.stateMachine.heartbeatError(response.err);
+          this.stopHeartbeat();
         } else if (response.suppAuthorized) {
           this.notifier.trigger('pair:supp:authorize');
         }

--- a/packages/fxa-content-server/app/scripts/models/pairing/supplicant-state-machine.js
+++ b/packages/fxa-content-server/app/scripts/models/pairing/supplicant-state-machine.js
@@ -13,22 +13,26 @@ class SupplicantState extends State {
     super(attributes, options);
 
     this.pairingChannelClient = options.pairingChannelClient;
-    this.listenTo(this.pairingChannelClient, 'close', () =>
+    this.listenToOnce(this.pairingChannelClient, 'close', () =>
       this.socketClosed()
     );
-    this.listenTo(this.pairingChannelClient, 'error', (error) =>
-      this.socketError(error)
-    );
+    this.listenToOnce(this.pairingChannelClient, 'error', (error) => {
+      return this.socketError(error);
+    });
   }
 
   socketClosed() {
     this.navigate('pair/failure', {
       error: PairingChannelClientErrors.toError('CONNECTION_CLOSED'),
+      searchParams: window.location.search,
     });
   }
 
   socketError(error) {
-    this.navigate('pair/failure', { error });
+    this.navigate('pair/failure', {
+      error,
+      searchParams: window.location.search,
+    });
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/templates/pair/failure.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/failure.mustache
@@ -12,7 +12,14 @@
     <form novalidate>
       <div class="bg-image-pair-fail"></div>
 
-      <p>{{#t}}The setup process was terminated.{{/t}}</p>
+      <p>{{#t}}The setup process was terminated. Please sign in with your email.{{/t}}</p>
+
+      {{#showSigninLink}}
+        <div class="button-row">
+          <button class="button primary-button mt-5" id="signin-button" target="_blank" type="button">{{#t}}Sign in{{/t}}</button>
+        </div>
+      {{/showSigninLink}}
+
     </form>
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/pair/failure.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/failure.js
@@ -4,9 +4,27 @@
 
 import FormView from '../form';
 import Template from '../../templates/pair/failure.mustache';
+import { assign } from 'underscore';
+import preventDefaultThen from '../decorators/prevent_default_then';
 
 class PairFailureView extends FormView {
   template = Template;
+
+  events = assign(this.events, {
+    'click #signin-button': preventDefaultThen('clickSignin'),
+  });
+
+  setInitialContext(context) {
+    const showSigninLink = !!this.model.get('searchParams');
+    context.set({
+      showSigninLink,
+    });
+  }
+
+  clickSignin() {
+    const params = this.model.get('searchParams');
+    window.location.href = `${window.location.origin}${params}`;
+  }
 }
 
 export default PairFailureView;

--- a/packages/fxa-content-server/app/tests/spec/models/pairing/supplicant-state-machine.js
+++ b/packages/fxa-content-server/app/tests/spec/models/pairing/supplicant-state-machine.js
@@ -86,6 +86,7 @@ describe('models/auth_brokers/pairing/supplicant-state-machine', function () {
       assert.isTrue(
         state.navigate.calledOnceWith('pair/failure', {
           error: err,
+          searchParams: '',
         })
       );
     });
@@ -173,8 +174,7 @@ describe('models/auth_brokers/pairing/supplicant-state-machine', function () {
       );
       sinon.spy(state, 'gotoState');
       mockChannelClient.trigger('remote:pair:auth:authorize', {
-        code:
-          'fc46f44802b2a2ce979f39b2187aa1c0fc46f44802b2a2ce979f39b2187aa1c0',
+        code: 'fc46f44802b2a2ce979f39b2187aa1c0fc46f44802b2a2ce979f39b2187aa1c0',
         state: 'state',
       });
 
@@ -256,8 +256,7 @@ describe('models/auth_brokers/pairing/supplicant-state-machine', function () {
       );
       sinon.spy(state, 'gotoState');
       mockChannelClient.trigger('remote:pair:auth:authorize', {
-        code:
-          'fc46f44802b2a2ce979f39b2187aa1c0fc46f44802b2a2ce979f39b2187aa1c0',
+        code: 'fc46f44802b2a2ce979f39b2187aa1c0fc46f44802b2a2ce979f39b2187aa1c0',
         state: 'state',
       });
 


### PR DESCRIPTION
## Because

- When Firefox iOS goes into the background, iOS will close websocket connections based on system resources, this closes the pairing channel and causes it to fail

## This pull request

- Since we can't control what iOS does, the next best option is to give the user an option to login with another method (email/password)

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10056

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2024-07-24 at 10 23 21 AM](https://github.com/user-attachments/assets/1628c798-0e59-4606-ad66-1c0de8f218c3)

## Other information (Optional)

I've filed https://github.com/mozilla-services/channelserver/issues/115 which maybe another option, but would require more effort.
