### PR TITLE
fix(sync): Check and set sessionToken from browser only when provided

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -119,10 +119,10 @@ export const App = ({
         // be set to true. If there is a user actively signed into the browser,
         // we should try to use that user's account when possible.
         const syncUser = await firefox.requestSignedInUser(
-          integration!.data.context
+          integration.data.context
         );
 
-        if (syncUser) {
+        if (syncUser && syncUser.sessionToken) {
           // If the session is valid, try to set it as the current account
           isValidSession = await session.isValid(syncUser.sessionToken);
           if (isValidSession) {

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -68,7 +68,9 @@ export type FxAStatusResponse = {
 
 export type SignedInUser = {
   email: string;
-  sessionToken: string;
+  // This can be undefined when the browser account
+  // is in an "Account disconnected" state
+  sessionToken: string | undefined;
   uid: string;
   verified: boolean;
 };


### PR DESCRIPTION
Because:
* There's a case where the session token given back from requestSignedInUser is undefined

This commit:
* Makes sure the sessionToken is defined before checking its validity and using it

fixes FXA-10156