### PR TITLE
feat(metrics): Add Glean page load events when navigating

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/glean/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/glean/index.ts
@@ -348,6 +348,7 @@ export const GleanMetrics = {
           // Glean does not offer direct control over when metrics are uploaded;
           // this ensures that events are uploaded.
           maxEvents: 1,
+          enableAutoPageLoadEvents: true,
         });
         Glean.setLogPings(config.logPings);
         if (config.debugViewTag) {

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -165,6 +165,7 @@ describe('lib/glean', () => {
           channel: mockConfig.channel,
           serverEndpoint: mockConfig.serverEndpoint,
           maxEvents: 1,
+          enableAutoPageLoadEvents: true,
         }
       );
       sinon.assert.calledWith(logPingsStub, mockConfig.logPings);

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -82,6 +82,7 @@ jest.mock('../../lib/glean', () => ({
     initialize: jest.fn(),
     getEnabled: jest.fn(),
     accountPref: { view: jest.fn() },
+    pageLoad: jest.fn(),
   },
 }));
 

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -258,6 +258,10 @@ const SettingsRoutes = ({
   const location = useLocation();
   const isSync = integration != null ? integration.isSync() : false;
 
+  useEffect(() => {
+    GleanMetrics.pageLoad();
+  }, [location.pathname]);
+
   // If the user is not signed in, they cannot access settings! Direct them accordingly
   if (!isSignedIn) {
     const params = new URLSearchParams(window.location.search);
@@ -302,6 +306,11 @@ const AuthAndAccountSetupRoutes = ({
   const localAccount = currentAccount();
   // TODO: MozServices / string discrepancy, FXA-6802
   const serviceName = integration.getServiceName() as MozServices;
+
+  const location = useLocation();
+  useEffect(() => {
+    GleanMetrics.pageLoad();
+  }, [location.pathname]);
 
   return (
     <Router>

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Glean from '@mozilla/glean/web';
+import * as GleanMetricsAPI from '@mozilla/glean/metrics';
 import { testResetGlean } from '@mozilla/glean/testing';
 import sinon, { SinonStub } from 'sinon';
 
@@ -71,7 +72,8 @@ describe('lib/glean', () => {
     setUtmContentStub: SinonStub,
     setUtmMediumStub: SinonStub,
     setUtmSourceStub: SinonStub,
-    setUtmTermStub: SinonStub;
+    setUtmTermStub: SinonStub,
+    pageLoadStub: SinonStub;
 
   beforeEach(async () => {
     mockMetricsContext.metricsFlow = {
@@ -104,6 +106,8 @@ describe('lib/glean', () => {
     setUtmSourceStub = sandbox.stub(utm.source, 'set');
     setUtmTermStub = sandbox.stub(utm.term, 'set');
     submitPingStub = sandbox.stub(pings.accountsEvents, 'submit');
+    pageLoadStub = sandbox.stub(GleanMetricsAPI.default, 'pageLoad');
+
     await testResetGlean('glean-test');
   });
 
@@ -176,6 +180,7 @@ describe('lib/glean', () => {
           appDisplayVersion: mockConfig.appDisplayVersion,
           channel: mockConfig.channel,
           serverEndpoint: mockConfig.serverEndpoint,
+          enableAutoPageLoadEvents: true,
         }
       );
       sinon.assert.calledWith(logPingsStub, mockConfig.logPings);
@@ -818,6 +823,13 @@ describe('lib/glean', () => {
       GleanMetrics.login.success();
       await GleanMetrics.isDone();
       expect(true).toBeTruthy();
+    });
+  });
+
+  describe('pageLoad', () => {
+    it('resolves', async () => {
+      GleanMetrics.pageLoad();
+      sinon.assert.calledOnce(pageLoadStub);
     });
   });
 });

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Glean from '@mozilla/glean/web';
+import GleanMetricsAPI from '@mozilla/glean/metrics';
 import UAParser from 'ua-parser-js';
 import { Entries } from 'type-fest';
 import {
@@ -61,6 +62,7 @@ type GleanMetricsT = {
   setEnabled: (enabled: boolean) => void;
   getEnabled: () => boolean;
   isDone: () => Promise<void>;
+  pageLoad: () => void;
 } & {
   [k in EventMapKeys]: { [eventKey in keyof EventsMap[k]]: PingFn };
 };
@@ -445,7 +447,7 @@ const createEventFn =
 
 export const GleanMetrics: Pick<
   GleanMetricsT,
-  'initialize' | 'setEnabled' | 'getEnabled' | 'isDone'
+  'initialize' | 'setEnabled' | 'getEnabled' | 'isDone' | 'pageLoad'
 > = {
   initialize: (config: GleanMetricsConfig, context: GleanMetricsContext) => {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1859629
@@ -457,6 +459,7 @@ export const GleanMetrics: Pick<
           appDisplayVersion: config.appDisplayVersion,
           channel: config.channel,
           serverEndpoint: config.serverEndpoint,
+          enableAutoPageLoadEvents: true,
         });
         Glean.setLogPings(config.logPings);
         if (config.debugViewTag) {
@@ -480,6 +483,10 @@ export const GleanMetrics: Pick<
 
   getEnabled: () => {
     return gleanEnabled;
+  },
+
+  pageLoad: () => {
+    GleanMetricsAPI.pageLoad();
   },
 
   /**


### PR DESCRIPTION
## Because

- We want to track these events in Glean

## This pull request

- Adds `pageLoad` events

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-9723

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2024-07-25 at 10 28 15 AM](https://github.com/user-attachments/assets/7c103a35-9d58-470b-a15a-5074419c11c5)

## Other information (Optional)

To test, enable Glean and start navigating through pages.
