### PR TITLE
fix(metrics): resolve the event metric method at server start

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -122,9 +122,11 @@ const createEventFn =
   // accessible in the calling scope but difficult/not possible to get from any
   // context attached to the request.
 
+  (eventName: string, options?: GleanEventFnOptions) => {
+    // Resolve the Glean event metric method
+    const method = getMetricMethod(eventName);
 
-    (eventName: string, options?: GleanEventFnOptions) =>
-    async (req: AuthRequest, metricsData?: MetricsData) => {
+    return async (req: AuthRequest, metricsData?: MetricsData) => {
       // where the function is called the request object is likely to be declared
       // to be AuthRequest, so we do a cast here.
       const request = req as unknown as MetricsRequest;
@@ -166,7 +168,6 @@ const createEventFn =
       }
 
       // new style Glean events with event metric type
-      const method = getMetricMethod(eventName);
       const moreMetrics = options?.additionalMetrics
         ? options.additionalMetrics({
             ...commonMetrics,
@@ -181,6 +182,7 @@ const createEventFn =
         event_reason: eventReason,
       });
     };
+  };
 
 const extraKeyReasonCb = (metrics: Record<string, any>) => ({
   reason: metrics.reason,

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -36,6 +36,8 @@ const recordThirdPartyAuthGoogleRegCompleteStub = sinon.stub();
 const recordThirdPartyAuthAppleRegCompleteStub = sinon.stub();
 const recordThirdPartyAuthSetPasswordCompleteStub = sinon.stub();
 const recordAccountDeleteCompleteStub = sinon.stub();
+const recordPasswordResetEmailConfirmationSentStub = sinon.stub();
+const recordPasswordResetEmailConfirmationSuccessStub = sinon.stub();
 
 const { gleanMetrics, logErrorWithGlean } = proxyquire.load(
   '../../../lib/metrics/glean',
@@ -78,6 +80,10 @@ const { gleanMetrics, logErrorWithGlean } = proxyquire.load(
         recordThirdPartyAuthSetPasswordComplete:
           recordThirdPartyAuthSetPasswordCompleteStub,
         recordAccountDeleteComplete: recordAccountDeleteCompleteStub,
+        recordPasswordResetEmailConfirmationSent:
+          recordPasswordResetEmailConfirmationSentStub,
+        recordPasswordResetEmailConfirmationSuccess:
+          recordPasswordResetEmailConfirmationSuccessStub,
       }),
     },
   }


### PR DESCRIPTION
Because:
 - for the auth server backend Glean events, we resolve the event metric method based on the string event name
   - but we currently do that in the created function for the event

This commit:
 - resolves the method during the initial function creation for the event functions, e.g. during server startup

