### PR TITLE
fix(image): Fix issue with Pocket logo in cache signin page

### DIFF
--- a/packages/fxa-settings/src/components/CardHeader/index.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.tsx
@@ -193,9 +193,9 @@ const CardHeader = (props: CardHeaderProps) => {
           : props.subheadingWithCustomServiceFtlId,
       // include `vars={{ serviceName }}` if non-default and no logo
       ...(!isDefaultService && !logo && { vars: { serviceName } }),
-      // include `elems={{ span: logoElem }}` if serviceName is given a logo in serviceLogos
+      // include `elems={{ span: logo }}` if serviceName is given a logo in serviceLogos
       ...(logo && {
-        elems: { span: logoElem },
+        elems: { span: logo },
       }),
     };
 


### PR DESCRIPTION
## Because

- It wasn't rendering the service image

## This pull request

- Removes the extra `span` around the image

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10163

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2024-07-25 at 2 23 48 PM](https://github.com/user-attachments/assets/dc20c2b1-b08c-4172-b44e-a4a6b4ceaf5a)
