### PR TITLE
task(event-broker): Update profile-change event payload

### DIFF
--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -286,7 +286,6 @@ describe('#integration - AccountResolver', () => {
       data: {
         ts: expect.any(Number),
         uid: USER_1.uid,
-        accountDisabled: true,
       },
     });
   });
@@ -306,7 +305,6 @@ describe('#integration - AccountResolver', () => {
       data: {
         ts: expect.any(Number),
         uid: USER_1.uid,
-        accountDisabled: false,
       },
     });
   });
@@ -451,7 +449,6 @@ describe('#integration - AccountResolver', () => {
       data: {
         ts: expect.any(Number),
         uid: USER_1.uid,
-        locale: 'en-CA',
       },
     });
   });

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -203,7 +203,6 @@ export class AccountResolver {
       data: {
         ts: Date.now() / 1000,
         uid,
-        accountDisabled: true,
       },
     });
     const uidBuffer = uuidTransformer.to(uid);
@@ -232,7 +231,6 @@ export class AccountResolver {
       data: {
         ts: Date.now() / 1000,
         uid,
-        locale,
       },
     });
 
@@ -253,7 +251,6 @@ export class AccountResolver {
       data: {
         ts: Date.now() / 1000,
         uid,
-        accountDisabled: false,
       },
     });
 

--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -114,6 +114,8 @@ const ACCOUNT_PROFILE_GET = {
         - \`locale\` requires \`profile:locale\` scope.
         - \`atLeast18AtReg\` requires \`profile:age_check\` scope.
         - \`authenticationMethods\` and \`authenticatorAssuranceLevel\` require \`profile:amr\` scope.
+        - \`accountDisabledAt\` requires \`profile:account_disabled_at\` scope.
+        - \`accountLockedAt\` requires \`profile:account_locked_at\` scope.
 
       The \`profile\` scope includes all the above sub-scopes.
     `,

--- a/packages/fxa-auth-server/lib/profile/updates.js
+++ b/packages/fxa-auth-server/lib/profile/updates.js
@@ -28,12 +28,6 @@ module.exports = function (log) {
           {},
           {
             uid,
-            email: message.email,
-            locale: message.locale,
-            metricsEnabled: message.metricsEnabled,
-            totpEnabled: message.totpEnabled,
-            accountDisabled: message.accountDisabled,
-            accountLocked: message.accountLocked,
           }
         );
       } catch (err) {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -244,12 +244,6 @@ export class AccountHandler {
     });
     await this.log.notifyAttachedServices('profileDataChange', request, {
       uid: account.uid,
-      email: email,
-      locale: locale,
-      totpEnabled: false,
-      metricsEnabled: true,
-      accountDisabled: false,
-      accountLocked: false,
     });
 
     return { password, password2, account };
@@ -1435,6 +1429,13 @@ export class AccountHandler {
         : null;
     }
 
+    if (scope.contains('profile:account_disabled_at')) {
+      res.accountDisabledAt = account.disabledAt;
+    }
+    if (scope.contains('profile:account_locked_at')) {
+      res.accountLockedAt = account.lockedAt;
+    }
+
     if (
       this.config.subscriptions?.enabled &&
       scope.contains('profile:subscriptions')
@@ -1604,7 +1605,6 @@ export class AccountHandler {
         }),
         this.log.notifyAttachedServices('profileDataChange', request, {
           uid: account.uid,
-          accountLocked: false,
         }),
         this.oauth.removeTokensAndCodes(account.uid),
         this.customs.reset(request, account.email),
@@ -2259,6 +2259,8 @@ export const accountRoutes = (
             profileChangedAt: isA.number().min(0),
             metricsEnabled: isA.boolean().optional(),
             atLeast18AtReg: isA.boolean().allow(null),
+            accountLockedAt: isA.number().optional().allow(null),
+            accountDisabledAt: isA.number().optional().allow(null),
           }),
         },
       },

--- a/packages/fxa-auth-server/lib/routes/sign.js
+++ b/packages/fxa-auth-server/lib/routes/sign.js
@@ -181,7 +181,6 @@ module.exports = (log, signer, db, domain, devices, config) => {
               {},
               {
                 uid: sessionToken.uid,
-                locale: request.app.acceptLanguage,
               }
             );
             // meh on the result

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -137,7 +137,6 @@ export class StripeHandler {
     await this.push.notifyProfileUpdated(uid, devices);
     this.log.notifyAttachedServices('profileDataChange', request, {
       uid,
-      email,
     });
   }
 

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -160,7 +160,6 @@ module.exports = (log, db, mailer, customs, config, glean) => {
           {},
           {
             uid,
-            totpEnabled: false,
           }
         );
 
@@ -309,7 +308,6 @@ module.exports = (log, db, mailer, customs, config, glean) => {
 
           await log.notifyAttachedServices('profileDataChange', request, {
             uid: sessionToken.uid,
-            totpEnabled: true,
           });
         }
 

--- a/packages/fxa-auth-server/test/local/profile/updates.js
+++ b/packages/fxa-auth-server/test/local/profile/updates.js
@@ -85,12 +85,6 @@ describe('profile updates', () => {
             {},
             {
               uid,
-              email,
-              locale,
-              metricsEnabled,
-              totpEnabled,
-              accountDisabled,
-              accountLocked,
             }
           )
         );

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -938,12 +938,6 @@ describe('/account/create', () => {
       eventData = mockLog.notifier.send.getCall(1).args[0];
       assert.equal(eventData.event, 'profileDataChange');
       assert.equal(eventData.data.uid, uid);
-      assert.equal(eventData.data.email, 'foo@gmail.com');
-      assert.equal(eventData.data.locale, 'en-US');
-      assert.equal(eventData.data.totpEnabled, false);
-      assert.equal(eventData.data.metricsEnabled, true);
-      assert.equal(eventData.data.accountDisabled, false);
-      assert.equal(eventData.data.accountLocked, false);
 
       assert.equal(
         mockLog.activityEvent.callCount,
@@ -1159,12 +1153,6 @@ describe('/account/create', () => {
       eventData = mockLog.notifier.send.getCall(1).args[0];
       assert.equal(eventData.event, 'profileDataChange');
       assert.equal(eventData.data.uid, uid);
-      assert.equal(eventData.data.email, 'foo@gmail.com');
-      assert.equal(eventData.data.locale, 'en-US');
-      assert.equal(eventData.data.totpEnabled, false);
-      assert.equal(eventData.data.metricsEnabled, true);
-      assert.equal(eventData.data.accountDisabled, false);
-      assert.equal(eventData.data.accountLocked, false);
 
       assert.equal(
         mockLog.activityEvent.callCount,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -505,7 +505,7 @@ describe('DirectStripeRoutes', () => {
         directStripeRoutesInstance.log.notifyAttachedServices.calledOnceWith(
           'profileDataChange',
           VALID_REQUEST,
-          { uid: UID, email: TEST_EMAIL }
+          { uid: UID }
         ),
         'Expected log.notifyAttachedServices to be called'
       );

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -138,7 +138,6 @@ describe('totp', () => {
           'first argument was event name'
         );
         assert.equal(args[2].uid, 'uid');
-        assert.equal(args[2].totpEnabled, false);
 
         assert.equal(
           db.verifyTokensWithMethod.callCount,

--- a/packages/fxa-event-broker/README.md
+++ b/packages/fxa-event-broker/README.md
@@ -44,21 +44,29 @@ should terminate user login sessions that were established prior to the event.
 
 ### Profile Change
 
-Sent when a user has changed their profile data in some manner. Updates to their
-profile may include a new primary email address, display name, or 2FA status. This
-event does not include what changed and the profile data a service has access to
-may not show any changes if the data changed was outside the OAuth scope the service
-was granted.
+Sent when a user has changed their profile data in some manner. Changes to any of the following user data will trigger this event.
 
-Services should update any cached profile data they hold about the user.
+- Display Name - This can be changed on the account settings page
+- Email Address - This can be changed on the settings page by updating the primary email address
+- Profile Image - This can be changed on the settings page
+- Metrics Collection Enabled - This can be changed on the account settings page through the ‘Help Improve Mozilla Accounts’ option in the `Data Collection and Use` section.
+- Locale - This can be changed through the admin panel, and represents their language preference.
+- Totp Enabled - This can be changed through the admin panel.
+- Account Disabled - This can be changed through the admin panel.
+- Account Locked - This can be changed through the admin panel. The state can be changed back to unlocked once a user accepts an account reset.
+- A change to subscription state - There's several ways this can occur but in general this happens when signing up for or canceling subscriptions.
+
+When the event fires, it has the following structure:
 
 - Event Identifier
   - `https://schemas.accounts.firefox.com/event/profile-change`
 - Event Payload
   - [Profile Event Identifier]
-    - email
-      - The new primary email address for the given user (sub)
-      - This property will be undefined if the email hasn't changed
+    - uid {string} (required) - The account’s unique identifier
+
+It’s important to note that this event does not indicate what changed. Rather, it merely signals that services should update any cached profile data
+they have for this user. Furthermore, it’s possible that the data which changed was outside the OAuth scope the service was granted, in which case
+the service might not have privileges to access what was changed.
 
 ### Example Profile Change Event
 
@@ -70,7 +78,7 @@ Services should update any cached profile data they hold about the user.
      "jti": "e19ed6c5-4816-4171-aa43-56ffe80dbda1",
      "events": {
        "https://schemas.accounts.firefox.com/event/profile-change": {
-         "email": "example@mozilla.com"
+         "uid": "cd1181e0532c45cb989a7c234641468e"
        }
      }
 

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -489,7 +489,6 @@ describe('#integration - AccountResolver', () => {
           data: {
             ts: expect.any(Number),
             uid: USER_1.uid,
-            metricsEnabled: false,
           },
         });
       });
@@ -509,7 +508,6 @@ describe('#integration - AccountResolver', () => {
           data: {
             ts: expect.any(Number),
             uid: USER_1.uid,
-            metricsEnabled: true,
           },
         });
       });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -466,7 +466,6 @@ export class AccountResolver {
       data: {
         ts: Date.now() / 1000,
         uid,
-        metricsEnabled: input.state === 'in',
       },
     });
 

--- a/packages/fxa-graphql-api/src/scripts/must-change-password.ts
+++ b/packages/fxa-graphql-api/src/scripts/must-change-password.ts
@@ -147,7 +147,6 @@ async function main() {
         data: {
           ts: Date.now() / 1000,
           uid,
-          accountLocked: true,
         },
       });
     }

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -27,6 +27,8 @@ module.exports = {
       'profile:subscriptions',
       'profile:age_check',
       /* openid-connect scope */ 'email',
+      'profile:account_disabled_at',
+      'profile:account_locked_at',
     ],
   },
   response: {
@@ -40,6 +42,8 @@ module.exports = {
       profileChangedAt: Joi.number().optional(),
       metricsEnabled: Joi.boolean().optional(),
       atLeast18AtReg: Joi.boolean().allow(null),
+      accountLockedAt: Joi.number().optional().allow(null),
+      accountDisabledAt: Joi.number().optional().allow(null),
     }),
   },
   handler: async function _core_profile(req) {
@@ -120,6 +124,12 @@ module.exports = {
               result.atLeast18AtReg = body.atLeast18AtReg
                 ? body.atLeast18AtReg
                 : null;
+            }
+            if (typeof body.accountLockedAt === 'number') {
+              result.accountLockedAt = body.accountLockedAt;
+            }
+            if (typeof body.accountDisabledAt === 'number') {
+              result.accountDisabledAt = body.accountDisabledAt;
             }
             return resolve(result);
           }

--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -75,6 +75,8 @@ module.exports = {
 
       //openid-connect
       sub: Joi.string().allow(null),
+      accountDisabledAt: Joi.number().optional(),
+      accountLockedAt: Joi.number().optional(),
     }),
   },
   handler: async function profile(req, h) {

--- a/packages/fxa-shared/db/models/auth/account.ts
+++ b/packages/fxa-shared/db/models/auth/account.ts
@@ -30,6 +30,7 @@ const selectFields = [
   'verifierSetAt',
   'createdAt',
   'locale',
+  'lockedAt',
   raw(
     'COALESCE(profileChangedAt, verifierSetAt, createdAt) AS profileChangedAt'
   ),


### PR DESCRIPTION
## Because

- We want to simplify the profile change event

## This pull request

- Makes it such that profile events only transmit the uid in the event payload
- Adds `accountDisabledAt` and `accountLockedAt` to the /v1/profile endpoint.

## Issue that this pull request solves

Closes: FXA-10154

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
