### PR TITLE
bug(content): Fix broken source maps

### DIFF
--- a/packages/fxa-content-server/grunttasks/build.js
+++ b/packages/fxa-content-server/grunttasks/build.js
@@ -84,5 +84,9 @@ module.exports = function (grunt) {
     // use error pages from en as the static error pages. Comes last
     // to ensure static resources are loaded using cache busting URLs
     'copy:error_pages',
+
+    // copy fxa-settings. note this has already been webpacked. we don't need
+    // run it through webpack again.
+    'copy:settings',
   ]);
 };

--- a/packages/fxa-content-server/grunttasks/copy.js
+++ b/packages/fxa-content-server/grunttasks/copy.js
@@ -82,5 +82,11 @@ module.exports = function (grunt) {
       expand: true,
       src: ['main.css', 'tailwind.out.css'],
     },
+    settings: {
+      expand: true,
+      cwd: '<%= yeoman.app %>/../../fxa-settings/build',
+      dest: '<%= yeoman.dist %>/settings/',
+      src: '**/*',
+    },
   });
 };

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -6,7 +6,6 @@
 const webpack = require('webpack');
 const path = require('path');
 const config = require('./server/lib/configuration').getProperties();
-const CopyPlugin = require('copy-webpack-plugin');
 
 const ENV = config.env;
 const webpackConfig = {
@@ -227,15 +226,6 @@ const webpackConfig = {
     // dynamically loaded routes cause the .md file to be read and a
     // warning to be displayed on the console. Just ignore them.
     new webpack.IgnorePlugin({ resourceRegExp: /\.md$/ }),
-    new CopyPlugin({
-      patterns: [
-        {
-          context: path.resolve(__dirname, '../fxa-settings/build'),
-          from: '**',
-          to: '../settings',
-        },
-      ],
-    }),
     new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'] }),
     new webpack.ProvidePlugin({
       process: 'process/browser',


### PR DESCRIPTION
## Because

- Source maps weren't showing up on stage, yet were being deployed.
- The files in `fxa-settings/build` were effectively being webpacked twice.
- The ending comment, `//# sourceMapURL=` was being stripped off when webpacked the second time.

## This pull request

- Just copies over the files from `settings/build` without sending them through webpack.

## Issue that this pull request solves

Closes: FXA-9972

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

This will not close the related issue, FXA-9225, but does help a bit. I also tried fixing FXA-9225, but the additional web pack plugin sentry adds didn't work out of the box.
