### PR TITLE
fix(metrics): enclose the event function options

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -125,6 +125,7 @@ const createEventFn =
   (eventName: string, options?: GleanEventFnOptions) => {
     // Resolve the Glean event metric method
     const method = getMetricMethod(eventName);
+    const eventOptions = options || {};
 
     return async (req: AuthRequest, metricsData?: MetricsData) => {
       // where the function is called the request object is likely to be declared
@@ -141,7 +142,7 @@ const createEventFn =
       const commonMetrics = {
         user_agent: request.headers['user-agent'],
         ip_address:
-          options?.skipClientIp === true ? '' : request.app.clientAddress,
+          eventOptions.skipClientIp === true ? '' : request.app.clientAddress,
         account_user_id_sha256: '',
         relying_party_oauth_client_id: await findOauthClientId(
           request,
@@ -168,8 +169,8 @@ const createEventFn =
       }
 
       // new style Glean events with event metric type
-      const moreMetrics = options?.additionalMetrics
-        ? options.additionalMetrics({
+      const moreMetrics = eventOptions.additionalMetrics
+        ? eventOptions.additionalMetrics({
             ...commonMetrics,
             ...(metricsData || {}),
           })

--- a/packages/fxa-auth-server/test/local/metrics/glean.ts
+++ b/packages/fxa-auth-server/test/local/metrics/glean.ts
@@ -39,7 +39,7 @@ const recordAccountDeleteCompleteStub = sinon.stub();
 const recordPasswordResetEmailConfirmationSentStub = sinon.stub();
 const recordPasswordResetEmailConfirmationSuccessStub = sinon.stub();
 
-const { gleanMetrics, logErrorWithGlean } = proxyquire.load(
+const { gleanMetrics, logErrorWithGlean } = proxyquire(
   '../../../lib/metrics/glean',
   {
     './server_events': {


### PR DESCRIPTION
Because:
 - the options for an event's function was not enclosed with the returned event function in the auth server, leading to the optional callback not being called

This commit:
 - ensure the options for the event function is enclosed with the created event function

Fixes FXA-10169
