### PR TITLE
bug(settings): Emit login enage metric only once

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -224,10 +224,19 @@ describe('Signin', () => {
         render();
         expect(
           fireEvent.input(screen.getByLabelText(/Password/), {
+            target: {
+              value: MOCK_PASSWORD.substring(0, MOCK_PASSWORD.length - 2),
+            },
+          })
+        ).toBeTruthy();
+        expect(
+          fireEvent.input(screen.getByLabelText(/Password/), {
             target: { value: MOCK_PASSWORD },
           })
         ).toBeTruthy();
+
         await waitFor(() => {
+          // Make sure event didn't double fire.
           expect(GleanMetrics.login.engage).toBeCalledTimes(1);
         });
       });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -72,6 +72,7 @@ const Signin = ({
   const [passwordTooltipErrorText, setPasswordTooltipErrorText] =
     useState<string>('');
   const [signinLoading, setSigninLoading] = useState<boolean>(false);
+  const [hasEngaged, setHasEngaged] = useState<boolean>(false);
 
   const isOAuth = isOAuthIntegration(integration);
   const clientId = integration.getService();
@@ -362,7 +363,13 @@ const Signin = ({
               required
               autoFocus
               onChange={() => {
-                GleanMetrics.login.engage();
+                // Only log the engage event once. Note that this text box is autofocused, so
+                // using autofocus wouldn't be a good way to do this.
+                if (hasEngaged === false) {
+                  setHasEngaged(true);
+                  GleanMetrics.login.engage();
+                }
+
                 // clear error tooltip if user types in the field
                 if (passwordTooltipErrorText) {
                   setPasswordTooltipErrorText('');


### PR DESCRIPTION
## Because

- The login engage metric was being emitted too many times

## This pull request

- Ensures the metric can only be emitted once

## Issue that this pull request solves

Closes: FXA-10171

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I tried doing this with focus / blur, but it didn't work well due to the field being auto focused by default.
