### PR TITLE
feat(delete): Add notice marketing email notice on delete account page

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/en.ftl
@@ -35,6 +35,7 @@ delete-account-continue-button = Continue
 delete-account-password-input =
  .label = Enter password
 pocket-delete-notice = If you subscribe to Pocket Premium, please make sure that you <a>cancel your subscription</a> before deleting your account.
+pocket-delete-notice-marketing = To stop receiving marketing emails from Mozilla Corporation and Mozilla Foundation, you must <a>request deletion of your marketing data.</a>
 
 delete-account-cancel-button = Cancel
 delete-account-delete-button-2 = Delete

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -239,6 +239,28 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                 before deleting your account.
               </p>
             </Localized>
+            <Localized
+              id="pocket-delete-notice-marketing"
+              elems={{
+                a: (
+                  <LinkExternal
+                    href="https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0"
+                    data-testid="link-marketing-delete-notice"
+                    className="link-blue"
+                  >
+                    request deletion of your marketing data.
+                  </LinkExternal>
+                ),
+              }}
+            >
+              <p className="mb-4">
+                To stop receiving marketing emails from Mozilla Corporation and
+                Mozilla Foundation, you must{' '}
+                <a href="#todo-change-to-button">
+                  request deletion of your marketing data.
+                </a>{' '}
+              </p>
+            </Localized>
             <Localized id="delete-account-acknowledge">
               <p className="mb-4">
                 Please acknowledge that by deleting your account:


### PR DESCRIPTION
## Because

- Users think they are removed from marketing emails when they delete their account

## This pull request

- Adds a notice for the user that these emails are not unsubscribed and they have to do another step. `To stop receiving marketing emails from Mozilla Corporation and Mozilla Foundation, you must [request deletion of your marketing data](https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0).`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10187

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="483" alt="Screenshot 2024-07-29 at 12 35 04 PM" src="https://github.com/user-attachments/assets/8f300443-a7d8-43e9-93d3-079361018ddb">


## Other information (Optional)

Any other information that is important to this pull request.
