### PR TITLE
fix(auth): handle missing key comparison in genkeys

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/keys.ts
+++ b/packages/fxa-auth-server/lib/oauth/keys.ts
@@ -82,8 +82,8 @@ if (oldPubJWK) {
     'openid.oldKey must be a valid public key'
   );
   assert.notEqual(
-    currentPrivJWK.kid,
-    oldPubJWK.kid,
+    currentPrivJWK?.kid,
+    oldPubJWK?.kid,
     'openid.key.kid must differ from openid.oldKey.id'
   );
   PRIVATE_JWKS_MAP.set(oldPubJWK.kid, oldPubJWK);


### PR DESCRIPTION
Because:

* The key comparison was requiring the old key to exist.

This commit:

* Handles the case where the old key is missing.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
