### PR TITLE
fix: drop messages for client ids with no webhook

### DIFF
--- a/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.spec.ts
+++ b/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.spec.ts
@@ -115,6 +115,12 @@ describe('ClientWebhooksService', () => {
       });
     });
 
+    it('returns whether the client id has a webhook registered', async () => {
+      await service.onApplicationBootstrap();
+      expect(service.hasWebhookRegistered('testClient1')).toBe(true);
+      expect(service.hasWebhookRegistered('testClient3')).toBe(false);
+    });
+
     it('gets errors', async () => {
       await service.onApplicationBootstrap();
       const mockExit = jest.spyOn(process, 'exit').mockImplementation();

--- a/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.ts
+++ b/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.ts
@@ -78,6 +78,17 @@ export class ClientWebhooksService
     });
   }
 
+  // Return whether the given client ID has a webhook registered.
+  hasWebhookRegistered(clientId: string): boolean {
+    return Object.keys(this.webhooks).includes(clientId);
+  }
+
+  // Get the webhook URL for a given client ID.
+  getWebhookForClientId(clientId: string): string | undefined {
+    if (!Object.keys(clientId).includes(clientId)) return undefined;
+    return this.webhooks[clientId];
+  }
+
   onApplicationShutdown(): void {
     this.cancel?.();
   }

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -134,6 +134,13 @@ export class QueueworkerService
    * Publish a message to the pubsub topic for the client.
    */
   private async publishMessage(clientId: string, json: any) {
+    // Ensure clientId is normalized
+    clientId = clientId.toLowerCase();
+    if (!this.clientWebhooks.hasWebhookRegistered(clientId)) {
+      this.log.debug('noWebhookRegistered', { clientId });
+      this.metrics.increment('message.webhookNotFound', { clientId });
+      return;
+    }
     const topicName = this.topicPrefix + clientId;
     if (this.pubsub.isEmulator) {
       const topics = await this.pubsub.getTopics();

--- a/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
+++ b/packages/fxa-event-broker/src/queueworker/sqs.dto.ts
@@ -14,7 +14,7 @@ export const SUBSCRIPTION_UPDATE_EVENT = 'subscription:update';
 export const APPLE_USER_MIGRATION_EVENT = 'appleUserMigration';
 
 // Message schemas
-const HEX_STRING = /^(?:[0-9a-f]{2})+$/;
+const HEX_STRING = /^(?:[0-9a-fA-F]{2})+$/;
 export const CLIENT_ID = joi.string().regex(HEX_STRING);
 
 export const BASE_MESSAGE_SCHEMA = joi


### PR DESCRIPTION
Because:

* We don't want to block the SQS queue or fill the PubSub backlog with messages if the client id has no webhookUrl configured.

This commit:

* Adds a check to the client-webhooks service to drop messages for client ids with no webhookUrl configured.

Closes FXA-10216

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
