### PR TITLE
Add redirect URIs for Thunderbird sync scope

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -786,7 +786,13 @@ const conf = (module.exports = convict({
           ],
         },
         'https://identity.thunderbird.net/apps/sync': {
-          redirectUris: ['urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel'],
+          redirectUris: [
+            'urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel', // Thunderbird
+            'net.thunderbird.android://mozilla-accounts-redirect', // Thunderbird for Android (release)
+            'net.thunderbird.android.beta://mozilla-accounts-redirect', // Thunderbird for Android (beta)
+            'net.thunderbird.android.daily://mozilla-accounts-redirect', // Thunderbird for Android (daily)
+            'net.thunderbird.android.debug://mozilla-accounts-redirect', // Thunderbird for Android (development/debug build)
+          ],
         },
       },
       doc: 'Validates redirect uris for requested scopes',


### PR DESCRIPTION
## Because

- Thunderbird for Android is using different redirect URIs from Thunderbird (desktop)

## This pull request

- adds those redirect URIs to the allow list of the `https://identity.thunderbird.net/apps/sync` scope

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

See also: https://github.com/thunderbird/thunderbird-android/issues/8031