### PR TITLE
feat(metrics): Add '2FA Can't Scan Code Link' frontend event

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -20,6 +20,7 @@ import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useAsync } from 'react-async-hook';
 import { getErrorFtlId } from '../../../lib/error-utils';
 import DataBlockManual from '../../DataBlockManual';
+import GleanMetrics from '../../../lib/glean';
 
 export const metricsPreInPostFix = 'settings.two-step-authentication';
 
@@ -239,7 +240,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                     type="button"
                     className="mx-auto link-blue text-sm"
                     data-testid="cant-scan-code"
-                    onClick={() => setShowQrCode(false)}
+                    onClick={() => {
+                      setShowQrCode(false);
+                      GleanMetrics.accountPref.twoStepAuthScanCodeLink();
+                    }}
                   >
                     Can't scan code?
                   </button>

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -383,6 +383,9 @@ const recordEventMetric = (
     case 'account_pref_two_step_auth_submit':
       accountPref.twoStepAuthSubmit.record();
       break;
+    case 'account_pref_two_step_auth_scan_code_link':
+      accountPref.twoStepAuthScanCodeLink.record();
+      break;
     case 'account_pref_change_password_submit':
       accountPref.changePasswordSubmit.record();
       break;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1890,6 +1890,23 @@ account_pref:
     expires: never
     data_sensitivity:
       - interaction
+  two_step_auth_scan_code_link:
+    type: event
+    description: |
+      User clicked the "Can't scan code?" link
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10038
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
   change_password_submit:
     type: event
     description: |
@@ -1900,7 +1917,7 @@ account_pref:
       - vzare@mozilla.com
       - fxa-staff@mozilla.com
     bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXA-10040
+      - https://mozilla-hub.atlassian.net/browse/FXA-9577
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -199,6 +199,22 @@ export const secondaryEmailSubmit = new EventMetricType(
 );
 
 /**
+ * User clicked the "Can't scan code?" link
+ *
+ * Generated from `account_pref.two_step_auth_scan_code_link`.
+ */
+export const twoStepAuthScanCodeLink = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'two_step_auth_scan_code_link',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Click on "Add" button on account settings page for adding 2FA to account
  *
  * Generated from `account_pref.two_step_auth_submit`.

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -159,6 +159,7 @@ export const eventsMap = {
     view: 'account_pref_view',
     recoveryKeySubmit: 'account_pref_recovery_key_submit',
     twoStepAuthSubmit: 'account_pref_two_step_auth_submit',
+    twoStepAuthScanCodeLink: 'account_pref_two_step_auth_scan_code_link',
     changePasswordSubmit: 'account_pref_change_password_submit',
     deviceSignout: 'account_pref_device_signout',
     appleSubmit: 'account_pref_apple_submit',


### PR DESCRIPTION
## Because

- We want to know when a user clicks the 'Can't scan code?' button.

## This pull request

- Adds a glean telemetry metric for this button click.

## Issue that this pull request solves

Closes: FXA-9577

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
