### PR TITLE
feat(newsletters): Update first checkbox slug and copy

### DIFF
--- a/packages/fxa-settings/src/components/ChooseNewsletters/en.ftl
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/en.ftl
@@ -4,8 +4,8 @@
 # Prompt above a checklist of newsletters
 choose-newsletters-prompt-2 = Get more from { -brand-mozilla }:
 # Newsletter checklist item
-choose-newsletters-option-security-privacy =
-  .label = Security & privacy news and updates
+choose-newsletters-option-latest-news =
+  .label = Get our latest news and product updates
 # Newsletter checklist item
 choose-newsletters-option-test-pilot =
   .label = Early access to test new products

--- a/packages/fxa-settings/src/components/ChooseNewsletters/newsletters.ts
+++ b/packages/fxa-settings/src/components/ChooseNewsletters/newsletters.ts
@@ -16,18 +16,18 @@ export type Newsletter = {
 
 export const newsletters: Newsletter[] = [
   {
-    label: 'Security & privacy news and updates',
-    slug: ['security-privacy-news', 'mozilla-accounts'],
-    ftlId: 'choose-newsletters-option-security-privacy',
-  },
-  {
-    label: 'Early access to test new products',
-    slug: ['test-pilot'],
-    ftlId: 'choose-newsletters-option-test-pilot',
+    label: 'Get our latest news and product updates',
+    slug: ['mozilla-and-you', 'mozilla-accounts'],
+    ftlId: 'choose-newsletters-option-latest-news',
   },
   {
     label: 'Action alerts to reclaim the internet',
     slug: ['mozilla-foundation'],
     ftlId: 'choose-newsletters-option-reclaim-the-internet',
+  },
+  {
+    label: 'Early access to test new products',
+    slug: ['test-pilot'],
+    ftlId: 'choose-newsletters-option-test-pilot',
   },
 ];

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -459,10 +459,10 @@ describe('Signup page', () => {
               // we expect three newsletter options, but 4 slugs should be passed
               // because the first newsletter checkbox subscribes the user to 2 newsletters
               selectedNewsletterSlugs: [
-                'security-privacy-news',
+                'mozilla-and-you',
                 'mozilla-accounts',
-                'test-pilot',
                 'mozilla-foundation',
+                'test-pilot',
               ],
               unwrapBKey: MOCK_UNWRAP_BKEY,
             },

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -273,11 +273,10 @@ export const Signup = ({
           GleanMetrics.registration.marketing({
             standard: {
               marketing: {
+                news: selectedNewsletterSlugs.indexOf('mozilla-and-you') >= 0,
                 take_action:
-                  selectedNewsletterSlugs.indexOf('security-privacy-news') >= 0,
-                testing: selectedNewsletterSlugs.indexOf('test-pilot') >= 0,
-                news:
                   selectedNewsletterSlugs.indexOf('mozilla-foundation') >= 0,
+                testing: selectedNewsletterSlugs.indexOf('test-pilot') >= 0,
               },
             },
           });


### PR DESCRIPTION
Because:
* We want updated copy and a new slug

This commit:
* Adjusts the copy and updates the 'security-privacy-news' slug to 'mozilla-and-you'
* Moves the MoFo checkbox to be the second checkbox
* Adjusts Glean marketing event

closes FXA-10027

---
A few notes:
* This new slug is already available in auth-server validators.
* I'm currently awaiting confirmation on if we want to remove the `mozilla-accounts` slug. I left it for now and just replaced `security-privacy-news` with `mozilla-and-you`
* On the SubPlat side, it looks like we pull what slug to display [from the Stripe metadata](https://github.com/mozilla/fxa/blob/175bf0e64fa08561ffc86a5a5053749d234e0556/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx#L91-L92), and the new requested copy already exists as the "default" option and in their FTL file. Awaiting confirmation we don't need code changes here