### PR TITLE
feat(newsletters): Update default newsletter slug for SubPlat

### DIFF
--- a/packages/fxa-payments-server/src/lib/newsletter.test.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.test.ts
@@ -27,7 +27,7 @@ describe('lib/newsletter', () => {
     it('resolves to undefined on success with default newsletter slug', async () => {
       await expect(handleNewsletterSignup()).resolves.toBe(undefined);
       expect(apiSignupForNewsletter).toHaveBeenCalledWith({
-        newsletters: ['mozilla-accounts'],
+        newsletters: ['mozilla-and-you'],
       });
     });
 

--- a/packages/fxa-payments-server/src/lib/newsletter.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.ts
@@ -9,7 +9,7 @@ import sentry from './sentry';
 export const FXA_NEWSLETTER_SIGNUP_ERROR: GeneralError = {
   code: 'fxa_newsletter_signup_error',
 };
-const DEFAULT_NEWSLETTER_SLUG = 'mozilla-accounts';
+const DEFAULT_NEWSLETTER_SLUG = 'mozilla-and-you';
 
 export async function handleNewsletterSignup(
   productMetadata?: ProductMetadata

--- a/packages/fxa-shared/subscriptions/validation.ts
+++ b/packages/fxa-shared/subscriptions/validation.ts
@@ -26,7 +26,7 @@ export const subscriptionProductMetadataBaseValidator = Joi.object({
   newsletterSlug: commaArray
     .optional()
     .items(
-      Joi.valid('mozilla-accounts', 'security-privacy-news', 'hubs', 'mdnplus')
+      Joi.valid('mozilla-and-you', 'security-privacy-news', 'hubs', 'mdnplus')
     ),
   newsletterLabelTextCode: Joi.string()
     .optional()


### PR DESCRIPTION
Because:
* We want the default case for the switch statement handling newsletters to be shown across products, and a newsletter slug update was requested for this

This commit:
* Updates the default newsletter slug in SubPlat and updates test

fixes the SubPlat side of FXA-10027, minus the Stripe dashboard label update