### PR TITLE
task(settings,functional-tests): Review use of webchannel messages

### DIFF
--- a/packages/functional-tests/lib/channels.ts
+++ b/packages/functional-tests/lib/channels.ts
@@ -11,17 +11,57 @@ export enum FirefoxCommand {
   ChangePassword = 'fxaccounts:change_password',
 }
 
-export type CustomEventDetail = ReturnType<typeof createCustomEventDetail>;
+export const FF_OAUTH_CLIENT_ID = '5882386c6d801776';
 
-export function createCustomEventDetail(
-  command: FirefoxCommand,
-  data: Record<string, any>
-) {
-  return {
-    id: 'account_updates',
-    message: {
-      command,
-      data,
-    },
+export type FxaStatusRequest = {};
+export type OAuthLoginRequest = {};
+export type LogoutRequest = {};
+export type LoginRequest = {};
+export type LinkAccountRequest = {};
+export type ChangePasswordRequest = {};
+
+export type FirefoxCommandRequest =
+  | FxaStatusRequest
+  | OAuthLoginRequest
+  | LogoutRequest
+  | LoginRequest
+  | LinkAccountRequest
+  | ChangePasswordRequest;
+
+export type FxAStatusResponse = {
+  id: 'account_updates';
+  message: {
+    command: FirefoxCommand.FxAStatus;
+    data: {
+      signedInUser: null | {
+        email?: string;
+        sessionToken?: string;
+        uid?: string;
+        verified?: boolean;
+      };
+      clientId: string;
+      capabilities: {
+        multiService: boolean;
+        pairing: boolean;
+        choose_what_to_sync?: boolean;
+        engines: string[];
+      };
+    };
   };
-}
+};
+
+export type LinkAccountResponse = {
+  id: 'account_updates';
+  message: {
+    command: FirefoxCommand.LinkAccount;
+    data: {
+      ok: boolean;
+    };
+  };
+};
+
+export type FirefoxCommandResponse = LinkAccountResponse | FxAStatusResponse;
+export const FirefoxCommandsWithResponses = [
+  FirefoxCommand.LinkAccount,
+  FirefoxCommand.FxAStatus,
+];

--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import AuthClient, {
+  CredentialStatus,
   getCredentials,
   getCredentialsV2,
 } from '../../../fxa-auth-client/browser';

--- a/packages/functional-tests/tests/oauth/webchannel.spec.ts
+++ b/packages/functional-tests/tests/oauth/webchannel.spec.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import {
+  FirefoxCommand,
+  FF_OAUTH_CLIENT_ID,
+  FxAStatusResponse,
+} from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
@@ -21,16 +25,23 @@ test.describe('severity-1 #smoke', () => {
         'TODO in FXA-9881: verify FxAStatus webchannel message in React signup flow'
       );
       const { email, password } = testAccountTracker.generateAccountDetails();
-      const customEventDetail = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          capabilities: {
-            choose_what_to_sync: true,
-            engines: ['bookmarks', 'history'],
+
+      const customEventDetail: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            capabilities: {
+              multiService: false,
+              pairing: false,
+              choose_what_to_sync: true,
+              engines: ['bookmarks', 'history'],
+            },
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
           },
-          signedInUser: null,
-        }
-      );
+        },
+      };
 
       await relier.goto('context=oauth_webchannel_v1&automatedBrowser=true');
       await relier.clickEmailFirst();
@@ -56,15 +67,22 @@ test.describe('severity-1 #smoke', () => {
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
-      const customEventDetail = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          capabilities: {
-            engines: ['bookmarks', 'history'],
+      const customEventDetail: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              choose_what_to_sync: true,
+              multiService: false,
+              pairing: true,
+              engines: ['bookmarks', 'history'],
+            },
+            signedInUser: null,
           },
-          signedInUser: null,
-        }
-      );
+        },
+      };
 
       await relier.goto('context=oauth_webchannel_v1&automatedBrowser=true');
       await relier.clickEmailFirst();

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import {
+  FF_OAUTH_CLIENT_ID,
+  FirefoxCommand,
+  FxAStatusResponse,
+} from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import { syncMobileOAuthQueryParams } from '../../lib/query-params';
 
@@ -101,16 +105,22 @@ test.describe('severity-1 #smoke', () => {
       test.fixme(true, 'Fix required as of 2024/06/28 (see FXA-10003).');
       const { email, password } =
         testAccountTracker.generateSignupAccountDetails();
-      const customEventDetail = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          capabilities: {
-            choose_what_to_sync: true,
-            engines: ['bookmarks', 'history'],
+      const customEventDetail: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            signedInUser: null,
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              pairing: false,
+              multiService: false,
+              choose_what_to_sync: true,
+              engines: ['bookmarks', 'history'],
+            },
           },
-          signedInUser: null,
-        }
-      );
+        },
+      };
 
       await signup.goto('/authorization', syncMobileOAuthQueryParams);
 

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -2,22 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import { FirefoxCommand, LinkAccountResponse } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import { syncDesktopV3QueryParams } from '../../lib/query-params';
 
 const AGE_12 = '12';
 const AGE_21 = '21';
 
-const eventDetailLinkAccount = createCustomEventDetail(
-  FirefoxCommand.LinkAccount,
-  {
-    ok: true,
-  }
-);
-const eventDetailFxaLogin = createCustomEventDetail(FirefoxCommand.Login, {
-  ok: true,
-});
+const eventDetailLinkAccount: LinkAccountResponse = {
+  id: 'account_updates',
+  message: {
+    command: FirefoxCommand.LinkAccount,
+    data: {
+      ok: true,
+    },
+  },
+};
 
 test.describe('severity-1 #smoke', () => {
   test.describe('signup react', () => {
@@ -85,7 +85,6 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.fillOutSignupForm(password, AGE_21);
 
-      await signup.respondToWebChannelMessage(eventDetailFxaLogin);
       await signup.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(page).toHaveURL(/confirm_signup_code/);
 

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import {
+  FF_OAUTH_CLIENT_ID,
+  FirefoxCommand,
+  FxAStatusResponse,
+} from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
@@ -34,12 +38,23 @@ test.describe('severity-2 #smoke', () => {
         forceUA: uaStrings['desktop_firefox_71'],
         email: credentials.email,
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: credentials.email,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: {
+              email: credentials.email,
+            },
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
       await page.goto(
         `${
           target.contentServerUrl
@@ -62,12 +77,24 @@ test.describe('severity-2 #smoke', () => {
         forceUA: uaStrings['desktop_firefox_71'],
         email: syncCredentials.email,
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: credentials.email,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: {
+              email: credentials.email,
+            },
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${
           target.contentServerUrl

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
@@ -2,7 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import {
+  FF_OAUTH_CLIENT_ID,
+  FirefoxCommand,
+  FxAStatusResponse,
+} from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
@@ -15,12 +19,22 @@ test.describe('severity-2 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: null,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            signedInUser: null,
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
@@ -39,12 +53,25 @@ test.describe('severity-2 #smoke', () => {
         forceUA: uaStrings['desktop_firefox_71'],
         email: credentials.email,
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: credentials.email,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            signedInUser: {
+              email: credentials.email,
+              uid: credentials.uid,
+            },
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
@@ -66,12 +93,22 @@ test.describe('severity-2 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: null,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
@@ -83,12 +120,24 @@ test.describe('severity-2 #smoke', () => {
 
       // Then, sign in the user again, synthesizing the user having signed
       // into Sync after the initial sign in.
-      const eventDetailStatusSignIn = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: credentials.email,
-        }
-      );
+      const eventDetailStatusSignIn: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: {
+              email: credentials.email,
+            },
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
@@ -112,12 +161,23 @@ test.describe('severity-2 #smoke', () => {
         forceUA: uaStrings['desktop_firefox_71'],
         email: syncCredentials.email,
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: credentials.email,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: {
+              email: credentials.email,
+            },
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
       await page.goto(
         `${
           target.contentServerUrl

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -95,7 +95,6 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         uid,
       });
-      await fxDesktopV3ForceAuth.noSuchWebChannelMessage('fxaccounts:logout');
       await signin.fillOutPasswordForm(credentials.password);
       // fails on this chck for react (message not sent)
       await fxDesktopV3ForceAuth.checkWebChannelMessage(
@@ -134,7 +133,6 @@ test.describe('severity-1 #smoke', () => {
       await fxDesktopV3ForceAuth.openWithReplacementParams(credentials, {
         uid,
       });
-      await fxDesktopV3ForceAuth.noSuchWebChannelMessage('fxaccounts:logout');
       await signin.fillOutPasswordForm(credentials.password);
       // fails on this chck for react (message not sent)
       await fxDesktopV3ForceAuth.checkWebChannelMessage(

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import { FirefoxCommand, LinkAccountResponse } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
@@ -21,12 +21,15 @@ test.describe('severity-2 #smoke', () => {
     }) => {
       const credentials = await testAccountTracker.signUpSync();
       const newPassword = testAccountTracker.generatePassword();
-      const customEventDetail = createCustomEventDetail(
-        FirefoxCommand.LinkAccount,
-        {
-          ok: true,
-        }
-      );
+      const customEventDetail: LinkAccountResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.LinkAccount,
+          data: {
+            ok: true,
+          },
+        },
+      };
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
@@ -79,12 +82,15 @@ test.describe('severity-2 #smoke', () => {
     }) => {
       const credentials = await testAccountTracker.signUpSync();
       const newPassword = testAccountTracker.generatePassword();
-      const customEventDetail = createCustomEventDetail(
-        FirefoxCommand.LinkAccount,
-        {
-          ok: true,
-        }
-      );
+      const customEventDetail: LinkAccountResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.LinkAccount,
+          data: {
+            ok: true,
+          },
+        },
+      };
 
       await page.goto(
         `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
@@ -110,7 +116,6 @@ test.describe('severity-2 #smoke', () => {
 
       //Change password
       await settings.password.changeButton.click();
-      await signin.noSuchWebChannelMessage(FirefoxCommand.ChangePassword);
       await changePassword.fillOutChangePassword(
         credentials.password,
         newPassword

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { FirefoxCommand, createCustomEventDetail } from '../../lib/channels';
+import {
+  FF_OAUTH_CLIENT_ID,
+  FirefoxCommand,
+  FxAStatusResponse,
+  LinkAccountResponse,
+} from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
@@ -28,23 +33,33 @@ test.describe('severity-1 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: null,
-          capabilities: {
-            choose_what_to_sync: true,
-            multiService: true,
-            engines: ['history'],
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              pairing: true,
+              choose_what_to_sync: true,
+              multiService: false,
+              engines: ['history'],
+            },
           },
-        }
-      );
-      const eventDetailLinkAccount = createCustomEventDetail(
-        FirefoxCommand.LinkAccount,
-        {
-          ok: true,
-        }
-      );
+        },
+      };
+
+      const eventDetailLinkAccount: LinkAccountResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.LinkAccount,
+          data: {
+            ok: true,
+          },
+        },
+      };
+
       await page.goto(
         `${
           target.contentServerUrl
@@ -88,15 +103,22 @@ test.describe('severity-1 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: null,
-          capabilities: {
-            multiService: false,
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              multiService: false,
+              pairing: false,
+              engines: [],
+            },
           },
-        }
-      );
+        },
+      };
+
       await page.goto(
         `${
           target.contentServerUrl
@@ -120,7 +142,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(login.CWTSDoNotSync).toBeHidden();
       await expect(login.CWTSEngineCreditCards).toBeHidden();
       await login.checkWebChannelMessage(FirefoxCommand.LinkAccount);
-      await login.noSuchWebChannelMessage(FirefoxCommand.Login);
       await login.clickSubmit();
       const code = await target.emailClient.getVerifyShortCode(email);
       await login.fillOutSignUpCode(code);
@@ -138,12 +159,22 @@ test.describe('severity-1 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          signedInUser: null,
-        }
-      );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              pairing: false,
+              multiService: false,
+              engines: [],
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${
           target.contentServerUrl
@@ -174,15 +205,21 @@ test.describe('severity-1 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          capabilities: {
-            engines: [],
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              pairing: false,
+              multiService: false,
+              engines: [],
+            },
           },
-          signedInUser: null,
-        }
-      );
+        },
+      };
       await page.goto(
         `${
           target.contentServerUrl
@@ -213,15 +250,22 @@ test.describe('severity-1 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_58'],
       });
-      const eventDetailStatus = createCustomEventDetail(
-        FirefoxCommand.FxAStatus,
-        {
-          capabilities: {
-            engines: ['creditcards', 'addresses'],
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            signedInUser: null,
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              pairing: false,
+              multiService: false,
+              engines: ['creditcards', 'addresses'],
+            },
           },
-          signedInUser: null,
-        }
-      );
+        },
+      };
+
       await page.goto(
         `${
           target.contentServerUrl

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -157,7 +157,7 @@ describe('Sign in with TOTP code page', () => {
       let fxaLoginSpy: jest.SpyInstance;
       let hardNavigateSpy: jest.SpyInstance;
       beforeEach(() => {
-        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
+        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
         hardNavigateSpy = jest
           .spyOn(utils, 'hardNavigate')
           .mockImplementation(() => {});

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -374,7 +374,7 @@ describe('Signin', () => {
             let fxaLoginSpy: jest.SpyInstance;
             let hardNavigateSpy: jest.SpyInstance;
             beforeEach(() => {
-              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
+              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
               hardNavigateSpy = jest
                 .spyOn(utils, 'hardNavigate')
                 .mockImplementation(() => {});
@@ -420,7 +420,7 @@ describe('Signin', () => {
             let finishOAuthFlowHandler: jest.Mock;
             beforeEach(() => {
               fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
-              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
+              fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
               hardNavigateSpy = jest
                 .spyOn(utils, 'hardNavigate')
                 .mockImplementation(() => {});

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -485,7 +485,7 @@ describe('Signup page', () => {
     describe('integrations', () => {
       let fxaLoginSpy: jest.SpyInstance;
       beforeEach(() => {
-        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin').mockResolvedValue();
+        fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
       });
       it('on success with Web integration', async () => {
         const mockBeginSignupHandler = jest


### PR DESCRIPTION
## Because

- We noticed that some of the usage for webchannels was inconsistent.
- Of the web channel messages we send only FxAStatus and LinkAccount actually return responses.

## This pull request

- Removes implied response from the fxaLogin command that wasn't actually sent by firefox.
- Updates the functional tests to better reflect the actual commands and responses sent by firefox by creating some types. This should avoid mistakes

## Issue that this pull request solves

Closes: FXA-9874

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note this based on the [functional-tests-support-typescript-compilation](https://app.circleci.com/pipelines/github/mozilla/fxa?branch=functional-tests-support-typescript-compilation) branch. To have reliable type checking, this became a prerequisite.
