### PR TITLE
feat(metrics): Add '2FA QR Code Setup View' frontend Glean event

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
@@ -32,6 +32,7 @@ jest.mock('../../../lib/glean', () => ({
   default: {
     accountPref: {
       twoStepAuthScanCodeLink: jest.fn(),
+      twoStepAuthQrView: jest.fn(),
     },
   },
 }));
@@ -148,6 +149,15 @@ describe('step 1', () => {
 
     expect(screen.getByTestId('manual-code')).toBeInTheDocument();
     expect(GleanMetrics.accountPref.twoStepAuthScanCodeLink).toHaveBeenCalled();
+  });
+
+  it('sends metrics when step 1 is submitted without viewing manual code', async () => {
+    await act(async () => {
+      render();
+    });
+    await submitTotp('867530');
+
+    expect(GleanMetrics.accountPref.twoStepAuthQrView).toHaveBeenCalled();
   });
 });
 

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -303,6 +303,11 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 disabled={
                   !totpForm.formState.isDirty || !totpForm.formState.isValid
                 }
+                onClick={() => {
+                  if (showQrCode) {
+                    GleanMetrics.accountPref.twoStepAuthQrView();
+                  }
+                }}
               >
                 Continue
               </button>

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -386,6 +386,9 @@ const recordEventMetric = (
     case 'account_pref_two_step_auth_scan_code_link':
       accountPref.twoStepAuthScanCodeLink.record();
       break;
+    case 'account_pref_two_step_auth_qr_view':
+      accountPref.twoStepAuthQrView.record();
+      break;
     case 'account_pref_change_password_submit':
       accountPref.changePasswordSubmit.record();
       break;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1907,6 +1907,23 @@ account_pref:
     expires: never
     data_sensitivity:
       - interaction
+  two_step_auth_qr_view:
+    type: event
+    description: |
+      User started the 2FA setup process by viewing step 1 of the funnel, complete with QR code for scanning.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-9573
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
   change_password_submit:
     type: event
     description: |

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -213,6 +213,22 @@ export const twoStepAuthScanCodeLink = new EventMetricType(
   },
   []
 );
+/**
+ * User started the 2FA setup process by viewing step 1 of the funnel, complete
+ * with QR code for scanning.
+ *
+ * Generated from `account_pref.two_step_auth_qr_view`.
+ */
+export const twoStepAuthQrView = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'two_step_auth_qr_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
 
 /**
  * Click on "Add" button on account settings page for adding 2FA to account

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -160,6 +160,7 @@ export const eventsMap = {
     recoveryKeySubmit: 'account_pref_recovery_key_submit',
     twoStepAuthSubmit: 'account_pref_two_step_auth_submit',
     twoStepAuthScanCodeLink: 'account_pref_two_step_auth_scan_code_link',
+    twoStepAuthQrView: 'account_pref_two_step_auth_qr_view',
     changePasswordSubmit: 'account_pref_change_password_submit',
     deviceSignout: 'account_pref_device_signout',
     appleSubmit: 'account_pref_apple_submit',


### PR DESCRIPTION
## Because

- We want to know when a user submits step 1 of the 2FA flow.

## This pull request

- Depends on https://github.com/mozilla/fxa/pull/17298.
- We add telemetry to know the button is clicked.

## Issue that this pull request solves

Closes: FXA-9573

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
