### PR TITLE
feat(newsletters): Add back mozilla-accounts slug to SubPlat default

### DIFF
--- a/packages/fxa-payments-server/src/lib/newsletter.test.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.test.ts
@@ -27,7 +27,7 @@ describe('lib/newsletter', () => {
     it('resolves to undefined on success with default newsletter slug', async () => {
       await expect(handleNewsletterSignup()).resolves.toBe(undefined);
       expect(apiSignupForNewsletter).toHaveBeenCalledWith({
-        newsletters: ['mozilla-and-you'],
+        newsletters: ['mozilla-and-you', 'mozilla-accounts'],
       });
     });
 

--- a/packages/fxa-payments-server/src/lib/newsletter.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.ts
@@ -9,14 +9,14 @@ import sentry from './sentry';
 export const FXA_NEWSLETTER_SIGNUP_ERROR: GeneralError = {
   code: 'fxa_newsletter_signup_error',
 };
-const DEFAULT_NEWSLETTER_SLUG = 'mozilla-and-you';
+const DEFAULT_NEWSLETTER_SLUGS = ['mozilla-and-you', 'mozilla-accounts'];
 
 export async function handleNewsletterSignup(
   productMetadata?: ProductMetadata
 ) {
   const newsletterSlugs: string[] = productMetadata?.newsletterSlug
     ? productMetadata?.newsletterSlug.split(',')
-    : [DEFAULT_NEWSLETTER_SLUG];
+    : DEFAULT_NEWSLETTER_SLUGS;
 
   try {
     await apiSignupForNewsletter({

--- a/packages/fxa-shared/subscriptions/validation.ts
+++ b/packages/fxa-shared/subscriptions/validation.ts
@@ -26,7 +26,13 @@ export const subscriptionProductMetadataBaseValidator = Joi.object({
   newsletterSlug: commaArray
     .optional()
     .items(
-      Joi.valid('mozilla-and-you', 'security-privacy-news', 'hubs', 'mdnplus')
+      Joi.valid(
+        'mozilla-accounts',
+        'mozilla-and-you',
+        'security-privacy-news',
+        'hubs',
+        'mdnplus'
+      )
     ),
   newsletterLabelTextCode: Joi.string()
     .optional()


### PR DESCRIPTION
Because:
* We want to support both default newsletters

This commit:
* Adds back previously removed 'mozilla-accounts' slug

---

Note, haven't tested this locally yet.