### PR TITLE
bug(graphql-api): Prevent known auth-server errors from percolating.

### DIFF
--- a/libs/shared/sentry/src/lib/reporting.spec.ts
+++ b/libs/shared/sentry/src/lib/reporting.spec.ts
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import * as uuid from 'uuid';
 import { FILTERED } from './pii/filter-actions';
-import { filterObject, isAuthServerError } from './reporting';
+import { filterObject, ignoreError, isAuthServerError } from './reporting';
+import { GraphQLError } from 'graphql';
+import { HttpException } from '@nestjs/common';
 
 describe('detects auth server error', () => {
   it('flags when code and errno are present', () => {
@@ -50,6 +52,50 @@ describe('detects auth server error', () => {
     });
 
     expect(result).toBeFalsy();
+  });
+});
+describe('error ignore policies', () => {
+  it('should ignore known auth server errors', () => {
+    expect(
+      ignoreError({
+        extensions: {
+          code: 100,
+          errno: 100,
+        },
+      })
+    ).toBeTruthy();
+  });
+
+  it('should ignore apollo errors', () => {
+    // Apollo errors should be sent to clients and we don't report them.
+    const err = new GraphQLError('BOOM', {
+      extensions: {
+        code: 'BAD_REQUEST',
+      },
+    });
+    expect(ignoreError(err)).toBeTruthy();
+  });
+
+  it('should ignore non 500 errors', () => {
+    // Non-500s are expected responses for clients and we don't report them.
+    expect(ignoreError(new HttpException('Not Found', 404))).toBeTruthy();
+  });
+
+  it('should ignore errors with originalError specified', () => {
+    // This means we are dealing with a wrapped error, so don't report it.
+    expect(ignoreError({ originalError: { status: 500 } })).toBeTruthy();
+  });
+
+  it('should not ignore general errors', () => {
+    expect(ignoreError(new Error('BOOM'))).toBeFalsy();
+  });
+
+  it('should not ignore things that look like internal server error', () => {
+    expect(ignoreError(new HttpException('BOOM', 500))).toBeFalsy();
+  });
+
+  it('should not ignore an unknown error type', () => {
+    expect(ignoreError({ not: 'typical' })).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
## Because

- We were seeing lots of 'Incorrect Email Case' exceptions showing up in Sentry.

## This pull request

- Suppress known auth server errors

## Issue that this pull request solves

Closes: FXA-100249

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note, this logic is also in place in `sentry.interceptor.ts`. After some manual testing in fxa-graphql-api  it appears that it is needed in both places, since the errors can be reported from either place.
