### PR TITLE
chore(payments-paypal): move getCheckoutToken to CheckoutTokenManager

### DIFF
--- a/libs/payments/paypal/src/index.ts
+++ b/libs/payments/paypal/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from './lib/paypalCustomer/paypalCustomer.manager';
 export * from './lib/paypalCustomer/paypalCustomer.factories';
+export * from './lib/checkoutToken.manager';
 export * from './lib/paypal.client';
 export * from './lib/paypal.client.config';
 export * from './lib/paypal.client.types';

--- a/libs/payments/paypal/src/lib/checkoutToken.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/checkoutToken.manager.spec.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { faker } from '@faker-js/faker';
+import { Test } from '@nestjs/testing';
+
+import { NVPSetExpressCheckoutResponseFactory } from './factories';
+import { PayPalClient } from './paypal.client';
+import { CheckoutTokenManager } from './checkoutToken.manager';
+import { MockPaypalClientConfigProvider } from './paypal.client.config';
+
+describe('CheckoutTokenManager', () => {
+  let checkoutTokenManager: CheckoutTokenManager;
+  let paypalClient: PayPalClient;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MockPaypalClientConfigProvider,
+        CheckoutTokenManager,
+        PayPalClient,
+      ],
+    }).compile();
+
+    checkoutTokenManager = moduleRef.get(CheckoutTokenManager);
+    paypalClient = moduleRef.get(PayPalClient);
+  });
+
+  describe('getCheckoutToken', () => {
+    it('returns token and calls setExpressCheckout with passed options', async () => {
+      const currencyCode = faker.finance.currencyCode();
+      const token = faker.string.uuid();
+      const successfulSetExpressCheckoutResponse =
+        NVPSetExpressCheckoutResponseFactory({
+          TOKEN: token,
+        });
+
+      jest
+        .spyOn(paypalClient, 'setExpressCheckout')
+        .mockResolvedValue(successfulSetExpressCheckoutResponse);
+
+      const result = await checkoutTokenManager.get(currencyCode);
+
+      expect(result).toEqual(successfulSetExpressCheckoutResponse.TOKEN);
+      expect(paypalClient.setExpressCheckout).toBeCalledTimes(1);
+      expect(paypalClient.setExpressCheckout).toBeCalledWith({ currencyCode });
+    });
+  });
+});

--- a/libs/payments/paypal/src/lib/checkoutToken.manager.ts
+++ b/libs/payments/paypal/src/lib/checkoutToken.manager.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable } from '@nestjs/common';
+
+import { PayPalClient } from './paypal.client';
+
+@Injectable()
+export class CheckoutTokenManager {
+  constructor(private client: PayPalClient) {}
+
+  /**
+   * Get a token authorizing transaction to move to the next stage.
+   * If the call to PayPal fails, a PayPalClientError will be thrown.
+   */
+  async get(currencyCode: string) {
+    const response = await this.client.setExpressCheckout({ currencyCode });
+    return response.TOKEN;
+  }
+}

--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -20,7 +20,6 @@ import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import {
   NVPCreateBillingAgreementResponseFactory,
   NVPBAUpdateTransactionResponseFactory,
-  NVPSetExpressCheckoutResponseFactory,
 } from './factories';
 import { PayPalClient } from './paypal.client';
 import { PayPalManager } from './paypal.manager';
@@ -349,27 +348,6 @@ describe('PayPalManager', () => {
       mockCustomer.id
     );
     expect(result).toEqual([]);
-  });
-
-  describe('getCheckoutToken', () => {
-    it('returns token and calls setExpressCheckout with passed options', async () => {
-      const currencyCode = faker.finance.currencyCode();
-      const token = faker.string.uuid();
-      const successfulSetExpressCheckoutResponse =
-        NVPSetExpressCheckoutResponseFactory({
-          TOKEN: token,
-        });
-
-      jest
-        .spyOn(paypalClient, 'setExpressCheckout')
-        .mockResolvedValue(successfulSetExpressCheckoutResponse);
-
-      const result = await paypalManager.getCheckoutToken(currencyCode);
-
-      expect(result).toEqual(successfulSetExpressCheckoutResponse.TOKEN);
-      expect(paypalClient.setExpressCheckout).toBeCalledTimes(1);
-      expect(paypalClient.setExpressCheckout).toBeCalledWith({ currencyCode });
-    });
   });
 
   describe('processZeroInvoice', () => {

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -140,15 +140,6 @@ export class PayPalManager {
   }
 
   /**
-   * Get a token authorizing transaction to move to the next stage.
-   * If the call to PayPal fails, a PayPalClientError will be thrown.
-   */
-  async getCheckoutToken(currencyCode: string) {
-    const response = await this.client.setExpressCheckout({ currencyCode });
-    return response.TOKEN;
-  }
-
-  /**
    * Process an invoice when amount is greater than minimum amount
    */
   async processNonZeroInvoice(

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -11,6 +11,7 @@ import {
   EligibilityService,
 } from '@fxa/payments/eligibility';
 import {
+  CheckoutTokenManager,
   PayPalClient,
   PaypalCustomerManager,
   PayPalManager,
@@ -67,6 +68,7 @@ import { validate } from '../config.utils';
     PayPalClient,
     PaypalCustomerManager,
     PayPalManager,
+    CheckoutTokenManager,
     PriceManager,
     ProductConfigurationManager,
     ProductManager,

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -6,7 +6,7 @@ import { Injectable } from '@nestjs/common';
 import { Validator } from 'class-validator';
 
 import { CartService } from '@fxa/payments/cart';
-import { PayPalManager } from '@fxa/payments/paypal';
+import { CheckoutTokenManager } from '@fxa/payments/paypal';
 import { ProductConfigurationManager } from '@fxa/shared/cms';
 
 import { CheckoutCartWithPaypalActionArgs } from './validators/CheckoutCartWithPaypalActionArgs';
@@ -28,7 +28,7 @@ import { UpdateCartActionArgs } from './validators/UpdateCartActionArgs';
 export class NextJSActionsService {
   constructor(
     private cartService: CartService,
-    private paypalManager: PayPalManager,
+    private checkoutTokenManager: CheckoutTokenManager,
     private productConfigurationManager: ProductConfigurationManager
   ) {}
 
@@ -80,7 +80,7 @@ export class NextJSActionsService {
   async getPayPalCheckoutToken(args: GetPayPalCheckoutTokenArgs) {
     new Validator().validateOrReject(args);
 
-    const token = await this.paypalManager.getCheckoutToken(args.currencyCode);
+    const token = await this.checkoutTokenManager.get(args.currencyCode);
 
     return token;
   }


### PR DESCRIPTION
## Because

- We want to have managers separated by responsibility rather than their implementation/service.

## This pull request

- Moves getCheckoutToken to a CheckoutTokenManager.

## Issue that this pull request solves

Closes: FXA-10184