### PR TITLE
task(functional-tests): Add missing licenses

### DIFF
--- a/packages/functional-tests/lib/ci-reporter.ts
+++ b/packages/functional-tests/lib/ci-reporter.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import path from 'node:path';
 import {
   FullConfig,

--- a/packages/functional-tests/lib/targets/firefoxUserPrefs.ts
+++ b/packages/functional-tests/lib/targets/firefoxUserPrefs.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 const CONFIGS = {
   local: {
     auth: 'http://localhost:9000/v1',

--- a/packages/functional-tests/lib/targets/index.ts
+++ b/packages/functional-tests/lib/targets/index.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { BaseTarget } from './base';
 import { LocalTarget } from './local';
 import { StageTarget } from './stage';
@@ -8,7 +12,7 @@ export const TargetNames = [
   StageTarget.target,
   ProductionTarget.target,
 ] as const;
-export type TargetName = typeof TargetNames[number];
+export type TargetName = (typeof TargetNames)[number];
 
 const targets = {
   [LocalTarget.target]: LocalTarget,

--- a/packages/functional-tests/lib/targets/production.ts
+++ b/packages/functional-tests/lib/targets/production.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { TargetName } from '.';
 import { RemoteTarget } from './remote';
 

--- a/packages/functional-tests/lib/targets/remote.ts
+++ b/packages/functional-tests/lib/targets/remote.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { BaseTarget, Credentials } from './base';
 
 export abstract class RemoteTarget extends BaseTarget {

--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { TargetName } from '.';
 import { RemoteTarget } from './remote';
 

--- a/packages/functional-tests/pages/fourOhFour.ts
+++ b/packages/functional-tests/pages/fourOhFour.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { BaseLayout } from './layout';
 
 export class FourOhFourPage extends BaseLayout {

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Page } from '@playwright/test';
 import { AvatarPage } from './settings/avatar';
 import { BaseTarget } from '../lib/targets/base';

--- a/packages/functional-tests/pages/legal.ts
+++ b/packages/functional-tests/pages/legal.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { BaseLayout } from './layout';
 
 export class LegalPage extends BaseLayout {

--- a/packages/functional-tests/pages/privacy.ts
+++ b/packages/functional-tests/pages/privacy.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { BaseLayout } from './layout';
 
 export class PrivacyPage extends BaseLayout {

--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 

--- a/packages/functional-tests/pages/settings/avatar.ts
+++ b/packages/functional-tests/pages/settings/avatar.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { SettingsLayout } from './layout';
 
 export class AvatarPage extends SettingsLayout {

--- a/packages/functional-tests/pages/settings/changePassword.ts
+++ b/packages/functional-tests/pages/settings/changePassword.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { SettingsLayout } from './layout';
 

--- a/packages/functional-tests/pages/settings/components/dataTrio.ts
+++ b/packages/functional-tests/pages/settings/components/dataTrio.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Page } from '@playwright/test';
 
 export class DataTrioComponent {

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Page } from '@playwright/test';
 import { ConnectedService } from './connectedService';
 

--- a/packages/functional-tests/pages/settings/deleteAccount.ts
+++ b/packages/functional-tests/pages/settings/deleteAccount.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { SettingsLayout } from './layout';
 

--- a/packages/functional-tests/pages/settings/displayName.ts
+++ b/packages/functional-tests/pages/settings/displayName.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { SettingsLayout } from './layout';
 

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect, Page } from '@playwright/test';
 import { BaseLayout } from '../layout';
 

--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { SettingsLayout } from './layout';
 

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import jsQR from 'jsqr';
 import UPNG from 'upng-js';
 import { expect } from '../../lib/fixtures/standard';

--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 import { getReactFeatureFlagUrl } from '../lib/react-flag';

--- a/packages/functional-tests/pages/termsOfService.ts
+++ b/packages/functional-tests/pages/termsOfService.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { BaseLayout } from './layout';
 
 export class TermsOfService extends BaseLayout {

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import type { Project } from '@playwright/test';
 import { PlaywrightTestConfig, defineConfig } from '@playwright/test';
 import * as path from 'path';

--- a/packages/functional-tests/tests/subscription-tests/subscriptionFixtures.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscriptionFixtures.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Page, test as base, expect } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { TestAccountTracker } from '../../lib/testAccountTracker';


### PR DESCRIPTION
## Because

- There were nits in other reviews about missing headers. 
- It'd be nice if headers were just added in

## This pull request

- Adds missing headers in functional tests, where it seems they were often omitted.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The following command is not perfect but does a pretty good job at finding files that don't have headers. `find . -name '*ts' -exec awk 'NR==1&&/^import.*/{print FILENAME}' {} \;`
