### PR TITLE
refactor(metrics): replace outdated package

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/context.js
+++ b/packages/fxa-auth-server/lib/metrics/context.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const bufferEqualConstantTime = require('buffer-equal-constant-time');
 const crypto = require('crypto');
 const HEX_STRING = require('../routes/validators').HEX_STRING;
 const isA = require('joi');
@@ -299,7 +298,7 @@ module.exports = function (log, config) {
     );
     const flowSignatureBytes = Buffer.from(flowSignature, 'hex');
     const expectedSignatureBytes = calculateFlowSignatureBytes(metadata);
-    if (!bufferEqualConstantTime(flowSignatureBytes, expectedSignatureBytes)) {
+    if (!crypto.timingSafeEqual(flowSignatureBytes, expectedSignatureBytes)) {
       return logInvalidContext(this, 'invalid signature');
     }
 

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -79,7 +79,6 @@
     "app-store-server-api": "^0.7.0",
     "aws-sdk": "^2.1664.0",
     "buf": "0.1.1",
-    "buffer-equal-constant-time": "1.0.1",
     "cldr-core": "^44.1.0",
     "commander": "2.18.0",
     "convict": "^6.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39539,7 +39539,6 @@ fsevents@~2.1.1:
     babel-loader: ^9.1.3
     binary-split: 1.0.5
     buf: 0.1.1
-    buffer-equal-constant-time: 1.0.1
     chai: ^4.3.6
     chai-as-promised: ^7.1.1
     cldr-core: ^44.1.0


### PR DESCRIPTION
Because:

* buffer-equal-constant-time is no longer supported and is used in a single place

This commit:
* Replaces it with crypto.timingSafeEqual()

Fixes FXA-10266
