### PR TITLE
fix(event-broker): use proper check for webhook urls

### DIFF
--- a/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.spec.ts
+++ b/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.spec.ts
@@ -121,6 +121,14 @@ describe('ClientWebhooksService', () => {
       expect(service.hasWebhookRegistered('testClient3')).toBe(false);
     });
 
+    it('returns the webhook url for a client id', async () => {
+      await service.onApplicationBootstrap();
+      expect(service.getWebhookForClientId('testClient1')).toBe(
+        'http://localhost/webhook'
+      );
+      expect(service.getWebhookForClientId('testClient3')).toBe(undefined);
+    });
+
     it('gets errors', async () => {
       await service.onApplicationBootstrap();
       const mockExit = jest.spyOn(process, 'exit').mockImplementation();

--- a/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.ts
+++ b/packages/fxa-event-broker/src/client-webhooks/client-webhooks.service.ts
@@ -85,7 +85,7 @@ export class ClientWebhooksService
 
   // Get the webhook URL for a given client ID.
   getWebhookForClientId(clientId: string): string | undefined {
-    if (!Object.keys(clientId).includes(clientId)) return undefined;
+    if (!this.hasWebhookRegistered(clientId)) return undefined;
     return this.webhooks[clientId];
   }
 


### PR DESCRIPTION
Because:

* The previous check was checking the wrong object, and not finding the webhook url as it should for delivery.

This commit:

* Fixes the check to use the correct object, and now finds the webhook url as it should for delivery.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
