### PR TITLE
refactor(payments): Move processNonZeroInvoice, processZeroInvoice, and processInvoice to InvoiceManager

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -512,6 +512,14 @@ describe('CheckoutService', () => {
         promotionCode: mockPromotionCode,
         priceId: mockPriceId,
       });
+      jest.spyOn(invoiceManager, 'processPayPalInvoice').mockResolvedValue();
+      jest
+        .spyOn(paypalCustomerManager, 'deletePaypalCustomersByUid')
+        .mockResolvedValue(BigInt(1));
+      jest
+        .spyOn(paypalCustomerManager, 'createPaypalCustomer')
+        .mockResolvedValue(mockPaypalCustomer);
+      jest.spyOn(paypalManager, 'cancelBillingAgreement').mockResolvedValue();
       jest
         .spyOn(paypalManager, 'getCustomerPayPalSubscriptions')
         .mockResolvedValue([]);
@@ -519,22 +527,14 @@ describe('CheckoutService', () => {
         .spyOn(paypalManager, 'getOrCreateBillingAgreementId')
         .mockResolvedValue(mockBillingAgreementId);
       jest
+        .spyOn(stripeClient, 'invoicesRetrieve')
+        .mockResolvedValue(mockInvoice);
+      jest
         .spyOn(stripeClient, 'subscriptionsCreate')
         .mockResolvedValue(mockSubscription);
       jest
-        .spyOn(paypalCustomerManager, 'deletePaypalCustomersByUid')
-        .mockResolvedValue(BigInt(1));
-      jest
-        .spyOn(paypalCustomerManager, 'createPaypalCustomer')
-        .mockResolvedValue(mockPaypalCustomer);
-      jest
-        .spyOn(stripeClient, 'invoicesRetrieve')
-        .mockResolvedValue(mockInvoice);
-      jest.spyOn(paypalManager, 'processInvoice').mockResolvedValue();
-      jest
         .spyOn(subscriptionManager, 'cancel')
         .mockResolvedValue(mockSubscription);
-      jest.spyOn(paypalManager, 'cancelBillingAgreement').mockResolvedValue();
     });
 
     describe('success', () => {
@@ -599,7 +599,9 @@ describe('CheckoutService', () => {
       });
 
       it('calls to process the latest invoice', () => {
-        expect(paypalManager.processInvoice).toHaveBeenCalledWith(mockInvoice);
+        expect(invoiceManager.processPayPalInvoice).toHaveBeenCalledWith(
+          mockInvoice
+        );
       });
 
       it('does not cancel the subscription', () => {

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -284,7 +284,7 @@ export class CheckoutService {
       subscription.latest_invoice
     );
     try {
-      this.paypalManager.processInvoice(latestInvoice);
+      this.invoiceManager.processPayPalInvoice(latestInvoice);
     } catch (e) {
       await this.subscriptionManager.cancel(subscription.id);
       await this.paypalManager.cancelBillingAgreement(billingAgreementId);

--- a/libs/payments/stripe/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/invoice.manager.spec.ts
@@ -4,6 +4,7 @@
 
 import { Test } from '@nestjs/testing';
 
+import { CustomerManager } from './customer.manager';
 import { StripeResponseFactory } from './factories/api-list.factory';
 import { StripeCustomerFactory } from './factories/customer.factory';
 import { StripeInvoiceFactory } from './factories/invoice.factory';
@@ -14,6 +15,7 @@ import { StripeClient } from './stripe.client';
 import { MockStripeConfigProvider } from './stripe.config';
 import { InvoicePreviewFactory } from './stripe.factories';
 import { InvoiceManager } from './invoice.manager';
+import { SubscriptionManager } from './subscription.manager';
 import * as StripeUtil from '../lib/util/stripeInvoiceToFirstInvoicePreviewDTO';
 
 jest.mock('../lib/util/stripeInvoiceToFirstInvoicePreviewDTO');
@@ -21,16 +23,26 @@ jest.mock('../lib/util/stripeInvoiceToFirstInvoicePreviewDTO');
 const mockStripeUtil = jest.mocked(StripeUtil);
 
 describe('InvoiceManager', () => {
+  let customerManager: CustomerManager;
   let invoiceManager: InvoiceManager;
   let stripeClient: StripeClient;
+  let subscriptionManager: SubscriptionManager;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [MockStripeConfigProvider, StripeClient, InvoiceManager],
+      providers: [
+        CustomerManager,
+        InvoiceManager,
+        StripeClient,
+        SubscriptionManager,
+        MockStripeConfigProvider,
+      ],
     }).compile();
 
+    customerManager = module.get(CustomerManager);
     invoiceManager = module.get(InvoiceManager);
     stripeClient = module.get(StripeClient);
+    subscriptionManager = module.get(SubscriptionManager);
   });
 
   describe('finalizeWithoutAutoAdvance', () => {
@@ -77,6 +89,75 @@ describe('InvoiceManager', () => {
         taxAddress: mockTaxAddress,
       });
       expect(result).toEqual(mockInvoicePreview);
+    });
+  });
+
+  describe('processInvoice', () => {
+    it('calls processZeroInvoice when amount is less than minimum amount', async () => {
+      const mockInvoice = StripeResponseFactory(
+        StripeInvoiceFactory({
+          amount_due: 0,
+          currency: 'usd',
+        })
+      );
+
+      jest.spyOn(subscriptionManager, 'getMinimumAmount').mockReturnValue(10);
+      jest
+        .spyOn(invoiceManager, 'processPayPalZeroInvoice')
+        .mockResolvedValue(mockInvoice);
+      jest
+        .spyOn(invoiceManager, 'processPayPalNonZeroInvoice')
+        .mockResolvedValue();
+
+      await invoiceManager.processPayPalInvoice(mockInvoice);
+      expect(invoiceManager.processPayPalZeroInvoice).toBeCalledWith(
+        mockInvoice.id
+      );
+      expect(invoiceManager.processPayPalNonZeroInvoice).not.toHaveBeenCalled();
+    });
+
+    it('calls InvoiceManager processNonZeroInvoice when amount is greater than minimum amount', async () => {
+      const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockInvoice = StripeInvoiceFactory({
+        amount_due: 50,
+        currency: 'usd',
+      });
+
+      jest.spyOn(subscriptionManager, 'getMinimumAmount').mockReturnValue(10);
+      jest.spyOn(customerManager, 'retrieve').mockResolvedValue(mockCustomer);
+      jest
+        .spyOn(invoiceManager, 'processPayPalZeroInvoice')
+        .mockResolvedValue(StripeResponseFactory(mockInvoice));
+      jest
+        .spyOn(invoiceManager, 'processPayPalNonZeroInvoice')
+        .mockResolvedValue();
+
+      await invoiceManager.processPayPalInvoice(mockInvoice);
+
+      expect(invoiceManager.processPayPalNonZeroInvoice).toBeCalledWith(
+        mockCustomer,
+        mockInvoice
+      );
+      expect(invoiceManager.processPayPalZeroInvoice).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('processZeroInvoice', () => {
+    it('finalizes invoices with no amount set to zero', async () => {
+      const mockInvoice = StripeResponseFactory(StripeInvoiceFactory());
+
+      jest
+        .spyOn(invoiceManager, 'finalizeWithoutAutoAdvance')
+        .mockResolvedValue(mockInvoice);
+
+      const result = await invoiceManager.processPayPalZeroInvoice(
+        mockInvoice.id
+      );
+
+      expect(result).toEqual(mockInvoice);
+      expect(invoiceManager.finalizeWithoutAutoAdvance).toBeCalledWith(
+        mockInvoice.id
+      );
     });
   });
 });


### PR DESCRIPTION
## This pull request

- [x] Moves processNonZeroInvoice, processZeroInvoice, and processInvoice from PayPalManager to InvoiceManager
- [x] Renames them to processPayPal* accordingly

## Issue that this pull request solves

Closes: FXA-10182

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.