### PR TITLE
refactor(payments): Move getCustomerPayPalSubscriptions to SubscriptionManager

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -521,9 +521,6 @@ describe('CheckoutService', () => {
         .mockResolvedValue(mockPaypalCustomer);
       jest.spyOn(paypalManager, 'cancelBillingAgreement').mockResolvedValue();
       jest
-        .spyOn(paypalManager, 'getCustomerPayPalSubscriptions')
-        .mockResolvedValue([]);
-      jest
         .spyOn(paypalManager, 'getOrCreateBillingAgreementId')
         .mockResolvedValue(mockBillingAgreementId);
       jest
@@ -535,6 +532,9 @@ describe('CheckoutService', () => {
       jest
         .spyOn(subscriptionManager, 'cancel')
         .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'getCustomerPayPalSubscriptions')
+        .mockResolvedValue([]);
     });
 
     describe('success', () => {
@@ -548,7 +548,7 @@ describe('CheckoutService', () => {
 
       it('fetches the customers paypal subscriptions', async () => {
         expect(
-          paypalManager.getCustomerPayPalSubscriptions
+          subscriptionManager.getCustomerPayPalSubscriptions
         ).toHaveBeenCalledWith(mockCustomer.id);
       });
 

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -241,7 +241,9 @@ export class CheckoutService {
       await this.prePaySteps(cart, customerData);
 
     const paypalSubscriptions =
-      await this.paypalManager.getCustomerPayPalSubscriptions(customer.id);
+      await this.subscriptionManager.getCustomerPayPalSubscriptions(
+        customer.id
+      );
 
     const billingAgreementId =
       await this.paypalManager.getOrCreateBillingAgreementId(

--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -9,8 +9,6 @@ import {
   InvoiceManager,
   MockStripeConfigProvider,
   StripeClient,
-  StripeCustomerFactory,
-  StripeSubscriptionFactory,
   SubscriptionManager,
 } from '@fxa/payments/stripe';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
@@ -35,7 +33,6 @@ describe('PayPalManager', () => {
   let paypalManager: PayPalManager;
   let paypalClient: PayPalClient;
   let paypalCustomerManager: PaypalCustomerManager;
-  let subscriptionManager: SubscriptionManager;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -55,7 +52,6 @@ describe('PayPalManager', () => {
 
     paypalManager = moduleRef.get(PayPalManager);
     paypalClient = moduleRef.get(PayPalClient);
-    subscriptionManager = moduleRef.get(SubscriptionManager);
     paypalCustomerManager = moduleRef.get(PaypalCustomerManager);
   });
 
@@ -307,41 +303,6 @@ describe('PayPalManager', () => {
         paypalManager.getCustomerBillingAgreementId(uid)
       ).rejects.toBeInstanceOf(PaypalCustomerMultipleRecordsError);
     });
-  });
-
-  describe('getCustomerPayPalSubscriptions', () => {
-    it('return customer subscriptions where collection method is send_invoice', async () => {
-      const mockPayPalSubscription = StripeSubscriptionFactory({
-        collection_method: 'send_invoice',
-        status: 'active',
-      });
-
-      const mockCustomer = StripeCustomerFactory();
-
-      const expected = [mockPayPalSubscription];
-
-      jest
-        .spyOn(subscriptionManager, 'listForCustomer')
-        .mockResolvedValue([mockPayPalSubscription]);
-
-      const result = await paypalManager.getCustomerPayPalSubscriptions(
-        mockCustomer.id
-      );
-      expect(result).toEqual(expected);
-    });
-  });
-
-  it('returns empty array when no subscriptions', async () => {
-    const mockCustomer = StripeCustomerFactory();
-
-    jest
-      .spyOn(subscriptionManager, 'listForCustomer')
-      .mockResolvedValueOnce([]);
-
-    const result = await paypalManager.getCustomerPayPalSubscriptions(
-      mockCustomer.id
-    );
-    expect(result).toEqual([]);
   });
 
   describe('getPayPalAmountStringFromAmountInCents', () => {

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -4,10 +4,7 @@
 
 import { Injectable } from '@nestjs/common';
 
-import {
-  ACTIVE_SUBSCRIPTION_STATUSES,
-  SubscriptionManager,
-} from '@fxa/payments/stripe';
+import { SubscriptionManager } from '@fxa/payments/stripe';
 import { PayPalClient } from './paypal.client';
 import { BillingAgreement, BillingAgreementStatus } from './paypal.types';
 import { PaypalCustomerMultipleRecordsError } from './paypalCustomer/paypalCustomer.error';
@@ -118,19 +115,6 @@ export class PayPalManager {
       throw new PaypalCustomerMultipleRecordsError(uid);
 
     return firstRecord.billingAgreementId;
-  }
-
-  // TODO: This should be moved to the subscription manager
-  async getCustomerPayPalSubscriptions(customerId: string) {
-    const subscriptions = await this.subscriptionManager.listForCustomer(
-      customerId
-    );
-    if (!subscriptions) return [];
-    return subscriptions.filter(
-      (sub) =>
-        ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status) &&
-        sub.collection_method === 'send_invoice'
-    );
   }
 
   /*

--- a/libs/payments/stripe/src/lib/subscription.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/subscription.manager.spec.ts
@@ -160,6 +160,41 @@ describe('SubscriptionManager', () => {
     });
   });
 
+  describe('getCustomerPayPalSubscriptions', () => {
+    it('return customer subscriptions where collection method is send_invoice', async () => {
+      const mockPayPalSubscription = StripeSubscriptionFactory({
+        collection_method: 'send_invoice',
+        status: 'active',
+      });
+
+      const mockCustomer = StripeCustomerFactory();
+
+      const expected = [mockPayPalSubscription];
+
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockPayPalSubscription]);
+
+      const result = await subscriptionManager.getCustomerPayPalSubscriptions(
+        mockCustomer.id
+      );
+      expect(result).toEqual(expected);
+    });
+  });
+
+  it('returns empty array when no subscriptions', async () => {
+    const mockCustomer = StripeCustomerFactory();
+
+    jest
+      .spyOn(subscriptionManager, 'listForCustomer')
+      .mockResolvedValueOnce([]);
+
+    const result = await subscriptionManager.getCustomerPayPalSubscriptions(
+      mockCustomer.id
+    );
+    expect(result).toEqual([]);
+  });
+
   describe('getLatestPaymentIntent', () => {
     it('fetches the latest payment intent for the subscription', async () => {
       const mockSubscription = StripeResponseFactory(

--- a/libs/payments/stripe/src/lib/subscription.manager.ts
+++ b/libs/payments/stripe/src/lib/subscription.manager.ts
@@ -7,7 +7,10 @@ import { Stripe } from 'stripe';
 
 import { StripeClient } from './stripe.client';
 import { StripeSubscription } from './stripe.client.types';
-import { STRIPE_MINIMUM_CHARGE_AMOUNTS } from './stripe.constants';
+import {
+  ACTIVE_SUBSCRIPTION_STATUSES,
+  STRIPE_MINIMUM_CHARGE_AMOUNTS,
+} from './stripe.constants';
 import { StripeNoMinimumChargeAmountAvailableError } from './stripe.error';
 
 @Injectable()
@@ -63,6 +66,16 @@ export class SubscriptionManager {
         await this.client.subscriptionsCancel(sub.id);
       }
     }
+  }
+
+  async getCustomerPayPalSubscriptions(customerId: string) {
+    const subscriptions = await this.listForCustomer(customerId);
+    if (!subscriptions) return [];
+    return subscriptions.filter(
+      (sub) =>
+        ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status) &&
+        sub.collection_method === 'send_invoice'
+    );
   }
 
   async getLatestPaymentIntent(subscription: StripeSubscription) {


### PR DESCRIPTION
## This pull request

- Move getCustomerPayPalSubscriptions from PaypalManager to SubscriptionManager to match our responsibility-driven structure.

## Issue that this pull request solves

Closes: FXA-10181

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
