### PR TITLE
refactor(payments-paypal): Move getPayPalAmountStringFromAmountInCents to a util

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.spec.ts
@@ -20,10 +20,7 @@ import {
 import { PayPalClient } from './paypal.client';
 import { PayPalManager } from './paypal.manager';
 import { BillingAgreementStatus } from './paypal.types';
-import {
-  AmountExceedsPayPalCharLimitError,
-  PaypalManagerError,
-} from './paypal.error';
+import { PaypalManagerError } from './paypal.error';
 import { PaypalCustomerMultipleRecordsError } from './paypalCustomer/paypalCustomer.error';
 import { ResultPaypalCustomerFactory } from './paypalCustomer/paypalCustomer.factories';
 import { PaypalCustomerManager } from './paypalCustomer/paypalCustomer.manager';
@@ -302,26 +299,6 @@ describe('PayPalManager', () => {
       await expect(
         paypalManager.getCustomerBillingAgreementId(uid)
       ).rejects.toBeInstanceOf(PaypalCustomerMultipleRecordsError);
-    });
-  });
-
-  describe('getPayPalAmountStringFromAmountInCents', () => {
-    it('returns correctly formatted string', () => {
-      const amountInCents = 9999999999;
-      const expectedResult = (amountInCents / 100).toFixed(2);
-
-      const result =
-        paypalManager.getPayPalAmountStringFromAmountInCents(amountInCents);
-
-      expect(result).toEqual(expectedResult);
-    });
-
-    it('throws an error if number exceeds digit limit', () => {
-      const amountInCents = 12345678910;
-
-      expect(() => {
-        paypalManager.getPayPalAmountStringFromAmountInCents(amountInCents);
-      }).toThrow(AmountExceedsPayPalCharLimitError);
     });
   });
 });

--- a/libs/payments/paypal/src/lib/paypal.manager.ts
+++ b/libs/payments/paypal/src/lib/paypal.manager.ts
@@ -8,7 +8,6 @@ import { SubscriptionManager } from '@fxa/payments/stripe';
 import { PayPalClient } from './paypal.client';
 import { BillingAgreement, BillingAgreementStatus } from './paypal.types';
 import { PaypalCustomerMultipleRecordsError } from './paypalCustomer/paypalCustomer.error';
-import { AmountExceedsPayPalCharLimitError } from './paypal.error';
 import { PaypalCustomerManager } from './paypalCustomer/paypalCustomer.manager';
 import { PaypalManagerError } from './paypal.error';
 
@@ -115,23 +114,5 @@ export class PayPalManager {
       throw new PaypalCustomerMultipleRecordsError(uid);
 
     return firstRecord.billingAgreementId;
-  }
-
-  /*
-   * Convert amount in cents to paypal AMT string.
-   * We use Stripe to manage everything and plans are recorded in an AmountInCents.
-   * PayPal AMT field requires a string of 10 characters or less, as documented here:
-   * https://developer.paypal.com/docs/nvp-soap-api/do-reference-transaction-nvp/#payment-details-fields
-   * https://developer.paypal.com/docs/api/payments/v1/#definition-amount
-   */
-  getPayPalAmountStringFromAmountInCents(amountInCents: number): string {
-    if (amountInCents.toString().length > 10) {
-      throw new AmountExceedsPayPalCharLimitError(amountInCents);
-    }
-    // Left pad with zeros if necessary, so we always get a minimum of 0.01.
-    const amountAsString = String(amountInCents).padStart(3, '0');
-    const dollars = amountAsString.slice(0, -2);
-    const cents = amountAsString.slice(-2);
-    return `${dollars}.${cents}`;
   }
 }

--- a/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.spec.ts
+++ b/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.spec.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AmountExceedsPayPalCharLimitError } from '../paypal.error';
+import { getPayPalAmountStringFromAmountInCents } from './getPayPalAmountStringFromAmountInCents';
+
+describe('getPayPalAmountStringFromAmountInCents', () => {
+  it('returns correctly formatted string', () => {
+    const amountInCents = 9999999999;
+    const expectedResult = (amountInCents / 100).toFixed(2);
+
+    const result = getPayPalAmountStringFromAmountInCents(amountInCents);
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  it('throws an error if number exceeds digit limit', () => {
+    const amountInCents = 12345678910;
+
+    expect(() => {
+      getPayPalAmountStringFromAmountInCents(amountInCents);
+    }).toThrow(AmountExceedsPayPalCharLimitError);
+  });
+});

--- a/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.ts
+++ b/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AmountExceedsPayPalCharLimitError } from '../paypal.error';
+
+/*
+ * Convert amount in cents to paypal AMT string.
+ * We use Stripe to manage everything and plans are recorded in an AmountInCents.
+ * PayPal AMT field requires a string of 10 characters or less, as documented here:
+ * https://developer.paypal.com/docs/nvp-soap-api/do-reference-transaction-nvp/#payment-details-fields
+ * https://developer.paypal.com/docs/api/payments/v1/#definition-amount
+ */
+export function getPayPalAmountStringFromAmountInCents(
+  amountInCents: number
+): string {
+  if (amountInCents.toString().length > 10) {
+    throw new AmountExceedsPayPalCharLimitError(amountInCents);
+  }
+  // Left pad with zeros if necessary, so we always get a minimum of 0.01.
+  const amountAsString = String(amountInCents).padStart(3, '0');
+  const dollars = amountAsString.slice(0, -2);
+  const cents = amountAsString.slice(-2);
+  return `${dollars}.${cents}`;
+}


### PR DESCRIPTION
## This pull request

- Moves getPayPalAmountStringFromAmountInCents from PaypalManager to a util folder with the name getPayPalAmountStringFromAmountInCents.ts.

## Issue that this pull request solves

Closes: FXA-10183
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.