### PR TITLE
fix(fxa-shared): failure to injest all unit test results in CI

### DIFF
--- a/packages/fxa-shared/test/oauth/scopes.js
+++ b/packages/fxa-shared/test/oauth/scopes.js
@@ -134,7 +134,10 @@ describe('oauth/scopes:', () => {
     ];
 
     INVALID_SCOPE_VALUES.forEach((source) => {
-      it(`scope "${source}" is invalid`, () => {
+      // Invalid characters, when used in test names, cause test result
+      // injestion errors in CI
+      const printSafeSource = source.replace(/\0/g, '\\0');
+      it(`scope "${printSafeSource}" is invalid`, () => {
         assert.throws(
           () => scopes.fromString(source),
           Error,


### PR DESCRIPTION
## Because

- An invalid token in the JUnit XML report for fxa_shared I believe is causing test result ingestion to fail in CI, resulting in 200-300 test statuses not being reported.
    - this error is on line 786 of a test xml file that has 1493 lines, all the tests before it are included in CircleCI reporting and all the tests after are not, so i think it's reading sequentially and giving up when it encounters the invalid token

## This pull request

- makes the invalid token print safe for reporting

## Issue that this pull request solves

Closes: # FXA-10279

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
