### PR TITLE
feat(payments-stripe): Create PaymentMethod manager

### DIFF
--- a/libs/payments/stripe/src/lib/paymentMethod.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/paymentMethod.manager.spec.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Test } from '@nestjs/testing';
+
+import { PaymentMethodManager } from './paymentMethod.manager';
+import { StripeClient } from './stripe.client';
+import { MockStripeConfigProvider } from './stripe.config';
+import { StripeResponseFactory } from './factories/api-list.factory';
+import { StripeCustomerFactory } from './factories/customer.factory';
+import { StripePaymentMethodFactory } from './factories/payment-method.factory';
+
+describe('PaymentMethodManager', () => {
+  let paymentMethodManager: PaymentMethodManager;
+  let stripeClient: StripeClient;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [MockStripeConfigProvider, PaymentMethodManager, StripeClient],
+    }).compile();
+
+    paymentMethodManager = moduleRef.get(PaymentMethodManager);
+    stripeClient = moduleRef.get(StripeClient);
+  });
+
+  describe('attach', () => {
+    it('should attach a payment method to a customer', async () => {
+      const mockCustomer = StripeCustomerFactory();
+      const mockPaymentMethod = StripePaymentMethodFactory();
+      const mockResponse = StripeResponseFactory(mockPaymentMethod);
+
+      jest
+        .spyOn(stripeClient, 'paymentMethodsAttach')
+        .mockResolvedValue(mockResponse);
+
+      const result = await paymentMethodManager.attach(mockPaymentMethod.id, {
+        customer: mockCustomer.id,
+      });
+
+      expect(stripeClient.paymentMethodsAttach).toHaveBeenCalledWith(
+        mockPaymentMethod.id,
+        {
+          customer: mockCustomer.id,
+        }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/libs/payments/stripe/src/lib/paymentMethod.manager.ts
+++ b/libs/payments/stripe/src/lib/paymentMethod.manager.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable } from '@nestjs/common';
+import { Stripe } from 'stripe';
+import { StripeClient } from './stripe.client';
+
+@Injectable()
+export class PaymentMethodManager {
+  constructor(private client: StripeClient) {}
+
+  async attach(
+    paymentMethodId: string,
+    params: Stripe.PaymentMethodAttachParams
+  ) {
+    return this.client.paymentMethodsAttach(paymentMethodId, params);
+  }
+}

--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -11,6 +11,7 @@ import {
 } from './factories/api-list.factory';
 import { StripeCustomerFactory } from './factories/customer.factory';
 import { StripeInvoiceFactory } from './factories/invoice.factory';
+import { StripePaymentMethodFactory } from './factories/payment-method.factory';
 import { StripePriceFactory } from './factories/price.factory';
 import { StripeProductFactory } from './factories/product.factory';
 import { StripePromotionCodeFactory } from './factories/promotion-code.factory';
@@ -34,6 +35,8 @@ const mockStripeInvoicesFinalizeInvoice =
   mockJestFnGenerator<typeof Stripe.prototype.invoices.finalizeInvoice>();
 const mockStripeInvoicesRetrieve =
   mockJestFnGenerator<typeof Stripe.prototype.invoices.retrieve>();
+const mockStripePaymentMethodsAttach =
+  mockJestFnGenerator<typeof Stripe.prototype.paymentMethods.attach>();
 const mockStripePricesRetrieve =
   mockJestFnGenerator<typeof Stripe.prototype.prices.retrieve>();
 const mockStripeProductsRetrieve =
@@ -65,6 +68,9 @@ jest.mock('stripe', () => ({
         finalizeInvoice: mockStripeInvoicesFinalizeInvoice,
         retrieve: mockStripeInvoicesRetrieve,
         retrieveUpcoming: mockStripeRetrieveUpcomingInvoice,
+      },
+      paymentMethods: {
+        attach: mockStripePaymentMethodsAttach,
       },
       prices: {
         retrieve: mockStripePricesRetrieve,
@@ -261,6 +267,25 @@ describe('StripeClient', () => {
         mockInvoice.id,
         {
           auto_advance: false,
+        }
+      );
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('paymentsMethodsAttach', () => {
+    it('attaches payment method to a customer successfully', async () => {
+      const mockCustomer = StripeCustomerFactory();
+      const mockPaymentMethod = StripePaymentMethodFactory();
+      const mockResponse = StripeResponseFactory(mockPaymentMethod);
+
+      mockStripePaymentMethodsAttach.mockResolvedValue(mockResponse);
+
+      const result = await stripeClient.paymentMethodsAttach(
+        mockPaymentMethod.id,
+        {
+          customer: mockCustomer.id,
         }
       );
 


### PR DESCRIPTION
## This pull request

- creates PaymentMethodManager

Closes: FXA-10179

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
