### PR TITLE
feat(next): Add generic server action for glean

### DIFF
--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -18,6 +18,7 @@ import { GetPayPalCheckoutTokenArgs } from './validators/GetPayPalCheckoutTokenA
 import { RestartCartActionArgs } from './validators/RestartCartActionArgs';
 import { SetupCartActionArgs } from './validators/SetupCartActionArgs';
 import { UpdateCartActionArgs } from './validators/UpdateCartActionArgs';
+import { EventName, RecordGleanEvent } from './validators/RecordGleanEvent';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -116,5 +117,30 @@ export class NextJSActionsService {
     );
 
     return offering;
+  }
+
+  /**
+   * @@todo: Emit event using Emittery. To be added as part of FXA-10087
+   */
+  async recordGleanEvent(args: RecordGleanEvent) {
+    new Validator().validateOrReject(args);
+
+    // Temporary ignore until Emittery logic is added
+    //eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { eventName, commonMetrics, ...restOfArgs } = args;
+
+    switch (eventName) {
+      case EventName.PAY_SETUP_ENGAGE: {
+        //Note: This is a dummy implementation and will likely be changed as part of a future ticket.
+        //emitter.emit('pay_setup:engage', {
+        //  commonMetrics,
+        //  ...restOfArgs.paySetupEngageMetrics
+        //});
+        break;
+      }
+      default: {
+        throw new Error(`Event ${args.eventName} not supported`);
+      }
+    }
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/RecordGleanEvent.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RecordGleanEvent.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Type } from 'class-transformer';
+import { IsEnum, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+/**
+ * @@todo: Temporary location. Move enum to Emittery implementation added as part of FXA-10087
+ */
+export enum EventName {
+  PAY_SETUP_ENGAGE = 'pay_setup - engage',
+}
+
+enum CheckoutType {
+  WITH_ACCOUNT = 'with-account',
+  WITHOUT_ACCOUNT = 'without-account',
+}
+
+/**
+ * Metrics specifc for the pay_setup - engage event
+ */
+class PaySetupEngageMetrics {
+  @IsEnum(CheckoutType)
+  checkoutType!: CheckoutType;
+}
+
+/**
+ * Common metrics that can be found on all events
+ */
+class CommonMetrics {
+  @IsOptional()
+  @IsString()
+  priceId?: string;
+
+  @IsOptional()
+  @IsString()
+  productId?: string;
+
+  @IsOptional()
+  @IsString()
+  utmCampaign?: string;
+
+  @IsOptional()
+  @IsString()
+  utmContent?: string;
+
+  @IsOptional()
+  @IsString()
+  utmMedium?: string;
+
+  @IsOptional()
+  @IsString()
+  utmReferrer?: string;
+
+  @IsOptional()
+  @IsString()
+  utmSource?: string;
+
+  @IsOptional()
+  @IsString()
+  utmTerm?: string;
+}
+
+export class RecordGleanEvent {
+  @IsEnum(EventName)
+  eventName!: EventName;
+
+  @Type(() => CommonMetrics)
+  @ValidateNested()
+  commonMetrics!: CommonMetrics;
+
+  @IsOptional()
+  @Type(() => PaySetupEngageMetrics)
+  @ValidateNested()
+  paySetupEngageMetrics?: PaySetupEngageMetrics;
+}


### PR DESCRIPTION
## Because

- To simplify the Glean implementation payments-next will only make use of Glean server side events. In cases were client events are required, a server action will be called to record the glean event.

## This pull request

- Adds a generic server action that can be used client side to record any glean event.

## Issue that this pull request solves

Closes: #FXA-9999

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).