### PR TITLE
fix(pocket): Do not inline Pocket SVG due to text logo rendering issue

### DIFF
--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -475,6 +475,8 @@ To do this with Tailwind, you'll need to add a class to the `backgroundImage` ob
 
 Sometimes it makes sense to let a network request fetch SVGs that are heavy/large and are used across multiple pages for faster rendering after the initial request. While our builds bust our asset caches, if an SVG persists from page to page, it can be more performant to download the image once and let the browser cache it for use across multiple pages, at least until the next release. The Mozilla and Firefox logo are good examples of this.
 
+Out of caution, we also do not inline SVGs that have text inside of them because this appears to possibly cause rendering issues with the SVG for unknown reasons.
+
 This can be done with either an image `src` or a background-image with `url`.
 
 ```javascript

--- a/packages/fxa-settings/src/components/CardHeader/index.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { ReactElement } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { MozServices } from '../../lib/types';
-import { ReactComponent as PocketTextLogo } from '@fxa/shared/assets/images/pocket-text-logo.svg';
+import PocketTextLogo from '@fxa/shared/assets/images/pocket-text-logo.svg';
 
 // NOTE: this component is heavily tested in components that use it and has complete line
 // coverage. However, we may file an issue out of FXA-6589 to add more explicit coverage.
@@ -115,11 +115,12 @@ function isBasicWithCustomSubheading(
 const serviceLogos: {
   [key in MozServices]?: ReactElement;
 } = {
+  // This is not inlined because text inside of an SVG can have rendering problems
   [MozServices.Pocket]: (
-    <PocketTextLogo
+    <img
+      src={PocketTextLogo}
+      alt={MozServices.Pocket}
       className="inline w-22 ps-0.5"
-      aria-label={MozServices.Pocket}
-      role="img"
     />
   ),
 };

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -914,7 +914,7 @@ describe('Signin', () => {
         />
       );
 
-      const pocketLogo = screen.getByLabelText('Pocket');
+      const pocketLogo = screen.getByAltText('Pocket');
       expect(pocketLogo).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Because:
* In production the SVG is not rendering properly

This commit:
* Sends a network request for the image instead of inlining the SVG

---

Storybook on this branch:
<img width="666" alt="image" src="https://github.com/user-attachments/assets/28d6abcb-a012-4c8c-b73d-e88eef618658">
