### PR TITLE
refactor(payments-paypal): Create PaypalBillingAgreementManager

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -13,9 +13,9 @@ import {
 } from '@fxa/payments/eligibility';
 import {
   MockPaypalClientConfigProvider,
+  PaypalBillingAgreementManager,
   PayPalClient,
   PaypalCustomerManager,
-  PayPalManager,
 } from '@fxa/payments/paypal';
 import {
   AccountCustomerManager,
@@ -84,7 +84,6 @@ describe('CartService', () => {
         CartService,
         CheckoutService,
         ConfigService,
-        MockStrapiClientConfigProvider,
         CustomerManager,
         EligibilityManager,
         EligibilityService,
@@ -96,10 +95,11 @@ describe('CartService', () => {
         MockGeoDBNestFactory,
         MockPaypalClientConfigProvider,
         MockStatsDProvider,
+        MockStrapiClientConfigProvider,
         MockStripeConfigProvider,
+        PaypalBillingAgreementManager,
         PayPalClient,
         PaypalCustomerManager,
-        PayPalManager,
         PriceManager,
         ProductConfigurationManager,
         ProductManager,

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -11,7 +11,6 @@ import {
   AccountCustomerNotFoundError,
   CustomerManager,
   InvoiceManager,
-  PriceManager,
   StripeCustomer,
   SubplatInterval,
   TaxAddress,
@@ -39,7 +38,6 @@ export class CartService {
     private eligibilityService: EligibilityService,
     private geodbManager: GeoDBManager,
     private invoiceManager: InvoiceManager,
-    private priceManager: PriceManager,
     private productConfigurationManager: ProductConfigurationManager
   ) {}
 

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -4,7 +4,10 @@
 
 import { Injectable } from '@nestjs/common';
 import { EligibilityService } from '@fxa/payments/eligibility';
-import { PayPalManager, PaypalCustomerManager } from '@fxa/payments/paypal';
+import {
+  PaypalBillingAgreementManager,
+  PaypalCustomerManager,
+} from '@fxa/payments/paypal';
 import {
   AccountCustomerManager,
   CustomerManager,
@@ -37,8 +40,8 @@ export class CheckoutService {
     private customerManager: CustomerManager,
     private eligibilityService: EligibilityService,
     private invoiceManager: InvoiceManager,
+    private paypalBillingAgreementManager: PaypalBillingAgreementManager,
     private paypalCustomerManager: PaypalCustomerManager,
-    private paypalManager: PayPalManager,
     private productConfigurationManager: ProductConfigurationManager,
     private promotionCodeManager: PromotionCodeManager,
     private stripeClient: StripeClient,
@@ -246,7 +249,7 @@ export class CheckoutService {
       );
 
     const billingAgreementId =
-      await this.paypalManager.getOrCreateBillingAgreementId(
+      await this.paypalBillingAgreementManager.retrieveOrCreateId(
         uid,
         !!paypalSubscriptions.length,
         token
@@ -289,7 +292,7 @@ export class CheckoutService {
       this.invoiceManager.processPayPalInvoice(latestInvoice);
     } catch (e) {
       await this.subscriptionManager.cancel(subscription.id);
-      await this.paypalManager.cancelBillingAgreement(billingAgreementId);
+      await this.paypalBillingAgreementManager.cancel(billingAgreementId);
     }
 
     await this.postPaySteps(cart, subscription);

--- a/libs/payments/paypal/src/index.ts
+++ b/libs/payments/paypal/src/index.ts
@@ -9,6 +9,6 @@ export * from './lib/paypal.client';
 export * from './lib/paypal.client.config';
 export * from './lib/paypal.client.types';
 export * from './lib/paypal.error';
-export * from './lib/paypal.manager';
 export * from './lib/paypal.types';
+export * from './lib/paypalBillingAgreement.manager';
 export * from './lib/util';

--- a/libs/payments/paypal/src/lib/paypal.error.ts
+++ b/libs/payments/paypal/src/lib/paypal.error.ts
@@ -50,18 +50,18 @@ export class PayPalNVPError extends BaseError {
   }
 }
 
-export class PaypalManagerError extends BaseError {
+export class PaypalBillingAgreementManagerError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
   }
 }
 
-export class AmountExceedsPayPalCharLimitError extends PaypalManagerError {
+export class AmountExceedsPayPalCharLimitError extends PaypalBillingAgreementManagerError {
   constructor(amountInCents: number) {
     super('Amount must be less than 10 characters', {
       info: {
-        amountInCents
-      }
+        amountInCents,
+      },
     });
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -12,9 +12,9 @@ import {
 } from '@fxa/payments/eligibility';
 import {
   CheckoutTokenManager,
+  PaypalBillingAgreementManager,
   PayPalClient,
   PaypalCustomerManager,
-  PayPalManager,
 } from '@fxa/payments/paypal';
 import {
   AccountCustomerManager,
@@ -55,6 +55,7 @@ import { validate } from '../config.utils';
     AccountManager,
     CartManager,
     CartService,
+    CheckoutTokenManager,
     CustomerManager,
     CheckoutService,
     EligibilityManager,
@@ -65,10 +66,9 @@ import { validate } from '../config.utils';
     InvoiceManager,
     LocalizerRscFactoryProvider,
     NextJSActionsService,
+    PaypalBillingAgreementManager,
     PayPalClient,
     PaypalCustomerManager,
-    PayPalManager,
-    CheckoutTokenManager,
     PriceManager,
     ProductConfigurationManager,
     ProductManager,


### PR DESCRIPTION
## This pull request

- [x] Moves all billing agreement methods from PaypalManager to PaypalBillingAgreementManager
- [x] Renames to get, create, update, etc. implicit names.
- [x] Updates references to these PaypalManager calls within dependent libraries/managers/services.


## Issue that this pull request solves

Closes: FXA-10180

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
