### PR TITLE
feat(glean): Add Glean events for BentoMenu

### DIFF
--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
@@ -3,17 +3,39 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import BentoMenu from '.';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 import { FluentBundle } from '@fluent/bundle';
+import GleanMetrics from '../../../lib/glean';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('../../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    accountPref: {
+      bentoView: jest.fn(),
+      bentoFirefoxDesktop: jest.fn(),
+      bentoFirefoxMobile: jest.fn(),
+      bentoMonitor: jest.fn(),
+      bentoPocket: jest.fn(),
+      bentoRelay: jest.fn(),
+      bentoVpn: jest.fn(),
+    },
+  },
+}));
 
 describe('BentoMenu', () => {
   let bundle: FluentBundle;
   beforeAll(async () => {
     bundle = await getFtlBundle('settings');
   });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const dropDownId = 'drop-down-bento-menu';
 
   it('renders and toggles as expected with default values', () => {
@@ -97,5 +119,109 @@ describe('BentoMenu', () => {
     expect(screen.queryByTestId(dropDownId)).toBeInTheDocument();
     fireEvent.click(container);
     expect(screen.queryByTestId(dropDownId)).not.toBeInTheDocument();
+  });
+
+  describe('metrics', () => {
+    it('logs metrics event for Bento view', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: /Firefox Browser for Desktop/ })
+        ).toBeVisible();
+        expect(GleanMetrics.accountPref.bentoView).toBeCalledTimes(1);
+      });
+    });
+
+    it('logs metrics event for Firefox Desktop link click', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: /Firefox Browser for Desktop/ })
+        ).toBeVisible();
+      });
+      userEvent.click(
+        screen.getByRole('link', { name: /Firefox Browser for Desktop/ })
+      );
+      await waitFor(() => {
+        expect(GleanMetrics.accountPref.bentoFirefoxDesktop).toBeCalledTimes(1);
+      });
+    });
+
+    it('logs metrics event for Firefox Mobile link click', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: /Firefox Browser for Mobile/ })
+        ).toBeVisible();
+      });
+      userEvent.click(
+        screen.getByRole('link', { name: /Firefox Browser for Mobile/ })
+      );
+      await waitFor(() => {
+        expect(GleanMetrics.accountPref.bentoFirefoxMobile).toBeCalledTimes(1);
+      });
+    });
+
+    it('logs metrics event for Monitor link click', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: /Mozilla Monitor/ })
+        ).toBeVisible();
+      });
+      userEvent.click(screen.getByRole('link', { name: /Mozilla Monitor/ }));
+      await waitFor(() => {
+        expect(GleanMetrics.accountPref.bentoMonitor).toBeCalledTimes(1);
+      });
+    });
+
+    it('logs metrics event for Pocket link click', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /Pocket/ })).toBeVisible();
+      });
+      userEvent.click(screen.getByRole('link', { name: /Pocket/ }));
+      await waitFor(() => {
+        expect(GleanMetrics.accountPref.bentoPocket).toBeCalledTimes(1);
+      });
+    });
+
+    it('logs metrics event for Firefox Relay link click', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('link', { name: /Firefox Relay/ })
+        ).toBeVisible();
+      });
+      userEvent.click(screen.getByRole('link', { name: /Firefox Relay/ }));
+      await waitFor(() => {
+        expect(GleanMetrics.accountPref.bentoRelay).toBeCalledTimes(1);
+      });
+    });
+
+    it('logs metrics event for Mozilla VPN link click', async () => {
+      renderWithLocalizationProvider(<BentoMenu />);
+
+      userEvent.click(screen.getByRole('button', { name: /Mozilla products/ }));
+      await waitFor(() => {
+        expect(screen.getByRole('link', { name: /Mozilla VPN/ })).toBeVisible();
+      });
+      userEvent.click(screen.getByRole('link', { name: /Mozilla VPN/ }));
+      await waitFor(() => {
+        expect(GleanMetrics.accountPref.bentoVpn).toBeCalledTimes(1);
+      });
+    });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useState } from 'react';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import LinkExternal from 'fxa-react/components/LinkExternal';
@@ -20,6 +20,7 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { useConfig, useFtlMsgResolver } from '../../../models/hooks';
 import { LINK } from '../../../constants';
 import { constructHrefWithUtm } from '../../../lib/utilities';
+import GleanMetrics from '../../../lib/glean';
 
 export const BentoMenu = () => {
   const [isRevealed, setRevealed] = useState(false);
@@ -32,6 +33,12 @@ export const BentoMenu = () => {
 
   const { env } = useConfig();
   const ftlMsgResolver = useFtlMsgResolver();
+
+  useEffect(() => {
+    if (isRevealed) {
+      GleanMetrics.accountPref.bentoView();
+    }
+  }, [isRevealed]);
 
   const bentoMenuTitle = ftlMsgResolver.getMsg(
     'bento-menu-title-3',
@@ -126,6 +133,9 @@ export const BentoMenu = () => {
                       data-testid="desktop-link"
                       href={desktopLink}
                       className="block p-2 ps-6 hover:bg-grey-100"
+                      onClick={() =>
+                        GleanMetrics.accountPref.bentoFirefoxDesktop()
+                      }
                     >
                       <div className={iconClassNames}>
                         <img src={desktopIcon} alt="" />
@@ -140,6 +150,9 @@ export const BentoMenu = () => {
                       data-testid="mobile-link"
                       href={mobileLink}
                       className="block p-2 ps-6 hover:bg-grey-100"
+                      onClick={() =>
+                        GleanMetrics.accountPref.bentoFirefoxMobile()
+                      }
                     >
                       <div className={iconClassNames}>
                         <img src={mobileIcon} alt="" />
@@ -154,6 +167,7 @@ export const BentoMenu = () => {
                       data-testid="monitor-link"
                       href={monitorLink}
                       className="block p-2 ps-6 hover:bg-grey-100"
+                      onClick={() => GleanMetrics.accountPref.bentoMonitor()}
                     >
                       <div className={iconClassNames}>
                         <img src={monitorIcon} alt="" />
@@ -166,6 +180,7 @@ export const BentoMenu = () => {
                       data-testid="relay-link"
                       href={relayLink}
                       className="block p-2 ps-6 hover:bg-grey-100"
+                      onClick={() => GleanMetrics.accountPref.bentoRelay()}
                     >
                       <div className={iconClassNames}>
                         <img src={relayIcon} alt="" />
@@ -180,6 +195,7 @@ export const BentoMenu = () => {
                       data-testid="vpn-link"
                       href={vpnLink}
                       className="block p-2 ps-6 hover:bg-grey-100"
+                      onClick={() => GleanMetrics.accountPref.bentoVpn()}
                     >
                       <div className={iconClassNames}>
                         <img src={vpnIcon} alt="" />
@@ -192,6 +208,7 @@ export const BentoMenu = () => {
                       data-testid="pocket-link"
                       href="https://app.adjust.com/hr2n0yz?redirect_macos=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&redirect_windows=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447"
                       className="block p-2 ps-6 hover:bg-grey-100"
+                      onClick={() => GleanMetrics.accountPref.bentoPocket()}
                     >
                       <div className={iconClassNames}>
                         <img src={pocketIcon} alt="" />

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -749,6 +749,75 @@ describe('lib/glean', () => {
         );
         sinon.assert.called(spy);
       });
+
+      it('submits a ping with the account_pref_bento_view event name', async () => {
+        GleanMetrics.accountPref.bentoView();
+        const spy = sandbox.spy(accountPref.bentoView, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'account_pref_bento_view');
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_bento_firefox_desktop event name', async () => {
+        GleanMetrics.accountPref.bentoFirefoxDesktop();
+        const spy = sandbox.spy(accountPref.bentoFirefoxDesktop, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_bento_firefox_desktop'
+        );
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_bento_firefox_mobile event name', async () => {
+        GleanMetrics.accountPref.bentoFirefoxMobile();
+        const spy = sandbox.spy(accountPref.bentoFirefoxMobile, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'account_pref_bento_firefox_mobile'
+        );
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_bento_monitor event name', async () => {
+        GleanMetrics.accountPref.bentoMonitor();
+        const spy = sandbox.spy(accountPref.bentoMonitor, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'account_pref_bento_monitor');
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_bento_pocket event name', async () => {
+        GleanMetrics.accountPref.bentoPocket();
+        const spy = sandbox.spy(accountPref.bentoPocket, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'account_pref_bento_pocket');
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_bento_relay event name', async () => {
+        GleanMetrics.accountPref.bentoRelay();
+        const spy = sandbox.spy(accountPref.bentoRelay, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'account_pref_bento_relay');
+        sinon.assert.calledOnce(spy);
+      });
+
+      it('submits a ping with the account_pref_bento_vpn event name', async () => {
+        GleanMetrics.accountPref.bentoVpn();
+        const spy = sandbox.spy(accountPref.bentoVpn, 'record');
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'account_pref_bento_vpn');
+        sinon.assert.calledOnce(spy);
+      });
     });
 
     describe('deleteAccount', () => {

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -432,6 +432,27 @@ const recordEventMetric = (
     case 'account_pref_help':
       accountPref.help.record();
       break;
+    case 'account_pref_bento_view':
+      accountPref.bentoView.record();
+      break;
+    case 'account_pref_bento_firefox_desktop':
+      accountPref.bentoFirefoxDesktop.record();
+      break;
+    case 'account_pref_bento_firefox_mobile':
+      accountPref.bentoFirefoxMobile.record();
+      break;
+    case 'account_pref_bento_monitor':
+      accountPref.bentoMonitor.record();
+      break;
+    case 'account_pref_bento_pocket':
+      accountPref.bentoPocket.record();
+      break;
+    case 'account_pref_bento_relay':
+      accountPref.bentoRelay.record();
+      break;
+    case 'account_pref_bento_vpn':
+      accountPref.bentoVpn.record();
+      break;
     case 'delete_account_settings_submit':
       deleteAccount.settingsSubmit.record();
       break;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2173,6 +2173,125 @@ account_pref:
       reason:
         description: What plan user is using `free` or `plus`
         type: string
+  bento_view:
+    type: event
+    description: |
+      User clicks on the bento menu at the top of the account settings page
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  bento_firefox_desktop:
+    type: event
+    description: |
+      User clicks on Firefox Browser for Desktop in the bento menu
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  bento_firefox_mobile:
+    type: event
+    description: |
+      User clicks on Firefox Browser for Mobile in the bento menu
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  bento_monitor:
+    type: event
+    description: |
+      User clicks on Mozilla Monitor in the bento menu
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  bento_relay:
+    type: event
+    description: |
+      User clicks on Firefox Relay in the bento menu
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  bento_vpn:
+    type: event
+    description: |
+      User clicks on Mozilla VPN in the bento menu
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  bento_pocket:
+    type: event
+    description: |
+      User clicks on Pocket in the bento menu
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10219
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 
 delete_account:
   settings_submit:

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -61,6 +61,118 @@ export const appleUnlinkSubmitConfirm = new EventMetricType<{
 );
 
 /**
+ * User clicks on Firefox Browser for Desktop in the bento menu
+ *
+ * Generated from `account_pref.bento_firefox_desktop`.
+ */
+export const bentoFirefoxDesktop = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_firefox_desktop',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on Firefox Browser for Mobile in the bento menu
+ *
+ * Generated from `account_pref.bento_firefox_mobile`.
+ */
+export const bentoFirefoxMobile = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_firefox_mobile',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on Mozilla Monitor in the bento menu
+ *
+ * Generated from `account_pref.bento_monitor`.
+ */
+export const bentoMonitor = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_monitor',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on Pocket in the bento menu
+ *
+ * Generated from `account_pref.bento_pocket`.
+ */
+export const bentoPocket = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_pocket',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on Firefox Relay in the bento menu
+ *
+ * Generated from `account_pref.bento_relay`.
+ */
+export const bentoRelay = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_relay',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on the bento menu at the top of the account settings page
+ *
+ * Generated from `account_pref.bento_view`.
+ */
+export const bentoView = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicks on Mozilla VPN in the bento menu
+ *
+ * Generated from `account_pref.bento_vpn`.
+ */
+export const bentoVpn = new EventMetricType(
+  {
+    category: 'account_pref',
+    name: 'bento_vpn',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Click on "Change" on account settings page to change password for account
  *
  * Generated from `account_pref.change_password_submit`.

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -174,6 +174,13 @@ export const eventsMap = {
     help: 'account_pref_help',
     promoMonitorView: 'account_pref_promo_monitor_view',
     promoMonitorSubmit: 'account_pref_promo_monitor_submit',
+    bentoView: 'account_pref_bento_view',
+    bentoFirefoxDesktop: 'account_pref_bento_firefox_desktop',
+    bentoFirefoxMobile: 'account_pref_bento_firefox_mobile',
+    bentoMonitor: 'account_pref_bento_monitor',
+    bentoPocket: 'account_pref_bento_pocket',
+    bentoRelay: 'account_pref_bento_relay',
+    bentoVpn: 'account_pref_bento_vpn',
   },
 
   deleteAccount: {


### PR DESCRIPTION
## Because

- We want to track views of the bento menu and clicks on suggested product links

## This pull request

- Add new Glean events and implement in fxa-settings, add unit tests

## Issue that this pull request solves

Closes: #FXA-10219

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
