### PR TITLE
bug(ci): Fix compile and lint jobs for nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1165,17 +1165,17 @@ workflows:
             - Init (nightly)
       - lint:
           name: Lint (nightly)
-          nx_run: ''
+          nx_run: 'run-many'
           requires:
             - Init (nightly)
       - compile:
           name: Compile (nightly)
-          nx_run: ''
+          nx_run: 'run-many'
           requires:
             - Init (nightly)
       - unit-test:
           name: Unit Test (nightly)
-          nx_run: ''
+          nx_run: 'run-many'
           requires:
             - Build (nightly)
       - integration-test:


### PR DESCRIPTION
## Because

- Compile job was failing in nightly
- Lint job was failing in nightly

## This pull request

- Add 'run-many' option, which is required when affected isn't present.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
