### PR TITLE
Fix key stretch tests

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -68,15 +68,8 @@ test.describe('severity-2 #smoke', () => {
         confirmSignupCode,
       },
       testAccountTracker,
-    }, { project }) => {
+    }) => {
       const config = await configPage.getConfig();
-      test.fixme(
-        project.name !== 'local' &&
-          signupVersion.version === 1 &&
-          resetVersion.version === 2 &&
-          signinVersion.version === 1,
-        'FXA-9742'
-      );
       test.skip(
         config.featureFlags.resetPasswordWithCode !== true,
         'TODO in FXA-9728, remove this config check'

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKeyWithLink.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKeyWithLink.spec.ts
@@ -71,15 +71,8 @@ test.describe('severity-2 #smoke', () => {
         confirmSignupCode,
       },
       testAccountTracker,
-    }, { project }) => {
+    }) => {
       const config = await configPage.getConfig();
-      test.fixme(
-        project.name !== 'local' &&
-          signupVersion.version === 1 &&
-          resetVersion.version === 2 &&
-          signinVersion.version === 1,
-        'FXA-9742'
-      );
       test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'TODO in FXA-9728, remove this file'

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -66,15 +66,8 @@ test.describe('severity-2 #smoke', () => {
         confirmSignupCode,
       },
       testAccountTracker,
-    }, { project }) => {
+    }) => {
       const config = await configPage.getConfig();
-      test.fixme(
-        project.name !== 'local' &&
-          signupVersion.version === 1 &&
-          resetVersion.version === 2 &&
-          signinVersion.version === 2,
-        'FXA-9765'
-      );
       test.skip(
         config.featureFlags.resetPasswordWithCode !== true,
         'TODO in FXA-9728, remove this config check'

--- a/packages/functional-tests/tests/key-stretching-v2/resetPasswordWithLink.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPasswordWithLink.spec.ts
@@ -69,15 +69,8 @@ test.describe('severity-2 #smoke', () => {
         confirmSignupCode,
       },
       testAccountTracker,
-    }, { project }) => {
+    }) => {
       const config = await configPage.getConfig();
-      test.fixme(
-        project.name !== 'local' &&
-          signupVersion.version === 1 &&
-          resetVersion.version === 2 &&
-          signinVersion.version === 2,
-        'FXA-9765'
-      );
       test.skip(
         config.featureFlags.resetPasswordWithCode === true,
         'TODO in FXA-9728 - remove this file'


### PR DESCRIPTION
## Because

- There were some key stretching tests that at one point in time were flaky

## This pull request

- Re-enables these tests

## Issue that this pull request solves

Closes: FXA-9734, FXA-9742, FXA-9765

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
