### PR TITLE
fix target name and temporarily run-many

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,6 +644,10 @@ jobs:
       - restore-workspace
       - wait-for-infrastructure
       - run:
+          name: Gen keys
+          command: |
+            NODE_ENV=dev npx nx gen-keys fxa-auth-server
+      - run:
           name: Run API Integration Tests
           command: |
             npx nx << parameters.nx_run >> << parameters.parallel >> << parameters.target >> << parameters.projects >>
@@ -847,7 +851,7 @@ workflows:
           name: Integration Test - Servers - Auth V2 (PR)
           nx_run: affected --base=main --head=$CIRCLE_SHA1
           projects: --exclude '*,!tag:scope:server:auth'
-          target: -t integration-test-v2
+          target: -t test-integration-v2
           requires:
             - Build (PR)
       - integration-test:
@@ -1080,7 +1084,7 @@ workflows:
       - integration-test:
           name: Integration Test - Servers - Auth V2
           projects: --exclude '*,!tag:scope:server:auth'
-          target: -t integration-test-v2
+          target: -t test-integration-v2
           filters:
             branches:
               ignore: /.*/
@@ -1197,7 +1201,7 @@ workflows:
       - integration-test:
           name: Integration Test - Servers - Auth V2 (nightly)
           projects: --exclude '*,!tag:scope:server:auth'
-          target: -t integration-test-v2
+          target: -t test-integration-v2
           requires:
             - Build (nightly)
       - integration-test:

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -173,7 +173,7 @@ const { JWTool } = require('@fxa/vendored/jwtool');
       );
     });
 
-    it('should fail if recoveryKeyId is missing', () => {
+    it('should fail if recoveryKeyId is missing', function () {
       if (testOptions.version === 'V2') {
         return this.skip();
       }
@@ -197,7 +197,7 @@ const { JWTool } = require('@fxa/vendored/jwtool');
         });
     });
 
-    it('should fail if wrapKb is missing', () => {
+    it('should fail if wrapKb is missing', function () {
       if (testOptions.version === 'V2') {
         return this.skip();
       }


### PR DESCRIPTION
## Because

- The Integration Test - Servers - Auth V2  job was not producing artifacts

## This pull request

- Corrects a typo in the target name
- Fixes bug where this.skip() cannot be used with fat arrow functions.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
