### PR TITLE
fix(promo): Disable MonitorPlus piece of ProductPromo

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
@@ -35,43 +35,38 @@ const storyWithProps = (
   return story;
 };
 
-export const SettingsWithMonitor = storyWithProps(
+export const SettingsWithNoMonitor = storyWithProps(
   { type: ProductPromoType.Settings },
   {
-    attachedClients: [{ name: MozServices.Monitor }],
+    attachedClients: [],
     subscriptions: [],
   },
-  'Settings with Monitor (resize window)'
+  'Settings, user does not have Monitor (mobile only, resize window)'
 );
-export const SidebarWithMonitor = storyWithProps(
-  { type: ProductPromoType.Sidebar },
-  {
-    attachedClients: [{ name: MozServices.Monitor }],
-    subscriptions: [],
-  },
-  'Sidebar with Monitor (resize window)'
-);
+
 export const SidebarWithNoMonitor = storyWithProps(
   { type: ProductPromoType.Sidebar },
   {
     attachedClients: [],
     subscriptions: [],
   },
-  'Sidebar with no Monitor'
+  'Sidebar, user does not have Monitor (resize window)'
 );
-export const SidebarWithMonitorNoPlus = storyWithProps(
-  { type: ProductPromoType.Sidebar },
+
+export const SettingsWithMonitorNoPlus = storyWithProps(
+  { type: ProductPromoType.Settings, monitorPlusEnabled: true },
   {
     attachedClients: [{ name: MozServices.Monitor }],
     subscriptions: [],
   },
-  'Sidebar with Monitor no Plus'
+  'Settings, user has Monitor but not Plus, MonitorPlus enabled (mobile only, resize window)'
 );
-export const SidebarWithMonitorPlus = storyWithProps(
-  { type: ProductPromoType.Sidebar },
+
+export const SidebarWithMonitorNoPlus = storyWithProps(
+  { type: ProductPromoType.Sidebar, monitorPlusEnabled: true },
   {
     attachedClients: [{ name: MozServices.Monitor }],
-    subscriptions: [{ productName: MozServices.MonitorPlus }],
+    subscriptions: [],
   },
-  'Sidebar with Monitor with Plus'
+  'Sidebar, user has Monitor but not Plus, MonitorPlus enabled (resize window)'
 );

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.test.tsx
@@ -30,6 +30,27 @@ describe('ProductPromo', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  it('renders nothing if user has Monitor but not MonitorPlus, and MonitorPlus Promo is disabled', () => {
+    const services = MOCK_SERVICES.filter((service) =>
+      // TODO: MozServices / string discrepancy, FXA-6802
+      PRODUCT_PROMO_SERVICES.includes(service.name as MozServices)
+    );
+    const account = {
+      attachedClients: services,
+      subscriptions: [],
+    } as unknown as Account;
+
+    const { container } = renderWithLocalizationProvider(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <ProductPromo />
+      </AppContext.Provider>
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(GleanMetrics.accountPref.promoMonitorView).not.toHaveBeenCalled();
+  });
+
   it('renders nothing if user has all products and subscriptions', async () => {
     const services = MOCK_SERVICES.filter((service) =>
       // TODO: MozServices / string discrepancy, FXA-6802
@@ -84,7 +105,7 @@ describe('ProductPromo', () => {
     } as unknown as Account;
     renderWithLocalizationProvider(
       <AppContext.Provider value={mockAppContext({ account })}>
-        <ProductPromo />
+        <ProductPromo monitorPlusEnabled={true} />
       </AppContext.Provider>
     );
 
@@ -112,7 +133,7 @@ describe('ProductPromo', () => {
     } as unknown as Account;
     renderWithLocalizationProvider(
       <AppContext.Provider value={mockAppContext({ account })}>
-        <ProductPromo />
+        <ProductPromo monitorPlusEnabled={true} />
       </AppContext.Provider>
     );
 


### PR DESCRIPTION
Because:
* Monitor Plus is not available for non-US customers and there are UX questions

This commit:
* Hides the MonitorPlus promo temporarily

closes FXA-10289

---

There's a lot of ways we could have sliced this one. I'd love to make this more configurable for other products but we can do that when we get there. I didn't want to just remove the code either, that would have been fine but we've got a meeting scheduled to discuss what to do with Plus, and it's nice keeping the tests and storybook states to show what it'll look like.