### PR TITLE
fix(shared-cms): re-enable caching decorator

### DIFF
--- a/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
@@ -53,6 +53,7 @@ jest.mock('@type-cacheable/core', () => ({
       return descriptor;
     };
   },
+  setOptions: jest.fn(),
 }));
 
 jest.mock('@fxa/shared/db/type-cacheable', () => ({

--- a/libs/shared/cms/src/lib/strapi.client.spec.ts
+++ b/libs/shared/cms/src/lib/strapi.client.spec.ts
@@ -27,6 +27,7 @@ jest.mock('@type-cacheable/core', () => ({
       return descriptor;
     };
   },
+  setOptions: jest.fn(),
 }));
 
 jest.mock('@fxa/shared/db/type-cacheable', () => ({


### PR DESCRIPTION
## Because

- The caching decorator was disabled in a previous PR (pre-Strapi) due to some issues. I was unable to replicate these issues in the latest Strapi client.

## This pull request

- Re-enables the caching decorator.

## Issue that this pull request solves

Closes FXA-10175