### PR TITLE
chore(libs): update tests to use NestJS DI helper

### DIFF
--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -50,10 +50,8 @@ describe('StripeMapperService', () => {
       ],
     }).compile();
 
-    productConfigurationManager = module.get<ProductConfigurationManager>(
-      ProductConfigurationManager
-    );
-    stripeMapper = module.get<StripeMapperService>(StripeMapperService);
+    productConfigurationManager = module.get(ProductConfigurationManager);
+    stripeMapper = module.get(StripeMapperService);
 
     jest
       .spyOn(

--- a/libs/shared/cms/src/lib/queries/eligibility-content-by-offering/factories.ts
+++ b/libs/shared/cms/src/lib/queries/eligibility-content-by-offering/factories.ts
@@ -9,12 +9,24 @@ import {
   EligibilityContentOfferingResult,
   EligibilityContentSubgroupOfferingResult,
   EligibilityContentSubgroupResult,
+  EligibilityContentByOfferingResult,
 } from '.';
 import { StrapiEntityFactory } from '../../factories';
 
 export const EligibilityContentByOfferingQueryFactory = (
   override?: Partial<EligibilityContentByOfferingQuery>
 ): EligibilityContentByOfferingQuery => {
+  return {
+    offerings: {
+      data: [StrapiEntityFactory(EligibilityContentOfferingResultFactory())],
+    },
+    ...override,
+  };
+};
+
+export const EligibilityContentByOfferingResultFactory = (
+  override?: Partial<EligibilityContentByOfferingResult>
+): EligibilityContentByOfferingResult => {
   return {
     offerings: {
       data: [StrapiEntityFactory(EligibilityContentOfferingResultFactory())],

--- a/libs/shared/cms/src/lib/queries/eligibility-content-by-plan-ids/factories.ts
+++ b/libs/shared/cms/src/lib/queries/eligibility-content-by-plan-ids/factories.ts
@@ -10,12 +10,30 @@ import {
   EligibilityPurchaseResult,
   EligibilitySubgroupOfferingResult,
   EligibilitySubgroupResult,
+  type EligibilityContentByPlanIdsResult,
 } from '.';
 import { StrapiEntityFactory } from '../../factories';
 
 export const EligibilityContentByPlanIdsQueryFactory = (
   override?: Partial<EligibilityContentByPlanIdsQuery>
 ): EligibilityContentByPlanIdsQuery => {
+  const data = [StrapiEntityFactory(EligibilityPurchaseResultFactory())];
+  return {
+    purchases: {
+      meta: {
+        pagination: {
+          total: data.length,
+        },
+      },
+      data,
+    },
+    ...override,
+  };
+};
+
+export const EligibilityContentByPlanIdsResultFactory = (
+  override?: Partial<EligibilityContentByPlanIdsResult>
+): EligibilityContentByPlanIdsResult => {
   const data = [StrapiEntityFactory(EligibilityPurchaseResultFactory())];
   return {
     purchases: {


### PR DESCRIPTION
## Because

- Several of our tests were not using the NestJS DI helper or were using the old style.

## This pull request

- Updates a few tests to the new style.

## Issue that this pull request solves

Closes FXA-10174