### PR TITLE
fix(ci): add python3-venv to mono image

### DIFF
--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     git-core \
     python3-setuptools \
     python3-dev \
+    python3-venv \
     build-essential \
     zip \
     jq \


### PR DESCRIPTION
## Because

- Glean glinter needs python3-venv.

## This pull request

- Adds python3-venv to circleci mono image used during fxa image create

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).