### PR TITLE
bug(settings): Fix storybook typo for SignoutSync

### DIFF
--- a/packages/fxa-settings/src/components/Settings/SignoutSync/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SignoutSync/index.stories.tsx
@@ -3,14 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import SingoutSync from '.';
+import SignoutSync from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 
 export default {
-  title: 'Pages/SingoutSync',
-  component: SingoutSync,
+  title: 'Pages/SignoutSync',
+  component: SignoutSync,
   decorators: [withLocalization],
 } as Meta;
 
-export const Basic = () => <SingoutSync />;
+export const Basic = () => <SignoutSync />;


### PR DESCRIPTION
## Because

- There was a typo

## This pull request

- Fixes typo

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
