### PR TITLE
fix(auth): add email logs to Firestore for Admin Panel

### DIFF
--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -15,6 +15,7 @@ import convictConf from '../../config';
 import error from '../../lib/error';
 
 const Profile = require('../profile/client');
+const { AccountEventsManager } = require('../../lib/account-events');
 
 const config = convictConf.getProperties();
 
@@ -74,6 +75,16 @@ export async function setupProcessingTaskObjects(processName: string) {
   } catch (err) {
     log.error('DB.connect', { err: { message: err.message } });
     process.exit(1);
+  }
+
+  if (!Container.has(AccountEventsManager)) {
+    const accountEventsManager = config.accountEvents.enabled
+      ? new AccountEventsManager(database)
+      : {
+          recordEmailEvent: async () => Promise.resolve(),
+          recordSecurityEvent: async () => Promise.resolve(),
+        };
+    Container.set(AccountEventsManager, accountEventsManager);
   }
 
   const currencyHelper = new CurrencyHelper(config);


### PR DESCRIPTION
## This pull request

- some emails (e.g. paymentFailed, subscriptionRenewalReminder, etc) are not being logged to Firestore to display under Email History in Admin Panel

## Issue that this pull request solves

Closes: FXA-10094

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.