### PR TITLE
fix(payments-stripe): Cleanup instances that incorrectly expect nullish values returned from client

### DIFF
--- a/libs/payments/stripe/src/lib/price.manager.ts
+++ b/libs/payments/stripe/src/lib/price.manager.ts
@@ -6,10 +6,7 @@ import { Injectable } from '@nestjs/common';
 
 import { StripeClient } from './stripe.client';
 import { StripePrice } from './stripe.client.types';
-import {
-  PlanIntervalMultiplePlansError,
-  PlanNotFoundError,
-} from './stripe.error';
+import { PlanIntervalMultiplePlansError } from './stripe.error';
 import { SubplatInterval } from './stripe.types';
 import { doesPriceMatchSubplatInterval } from './util/doesPriceMatchSubplatInterval';
 
@@ -19,7 +16,6 @@ export class PriceManager {
 
   async retrieve(priceId: string) {
     const price = await this.client.pricesRetrieve(priceId);
-    if (!price) throw new PlanNotFoundError();
     return price;
   }
 

--- a/libs/payments/stripe/src/lib/product.manager.ts
+++ b/libs/payments/stripe/src/lib/product.manager.ts
@@ -5,7 +5,6 @@
 import { Injectable } from '@nestjs/common';
 
 import { StripeClient } from './stripe.client';
-import { ProductNotFoundError } from './stripe.error';
 
 @Injectable()
 export class ProductManager {
@@ -13,7 +12,6 @@ export class ProductManager {
 
   async retrieve(productId: string) {
     const product = await this.client.productsRetrieve(productId);
-    if (!product) throw new ProductNotFoundError();
     return product;
   }
 }

--- a/libs/payments/stripe/src/lib/stripe.error.ts
+++ b/libs/payments/stripe/src/lib/stripe.error.ts
@@ -30,18 +30,6 @@ export class PlanIntervalMultiplePlansError extends StripeError {
   }
 }
 
-export class PlanNotFoundError extends StripeError {
-  constructor() {
-    super('Plan not found');
-  }
-}
-
-export class ProductNotFoundError extends StripeError {
-  constructor() {
-    super('Product not found');
-  }
-}
-
 export class PromotionCodeCouldNotBeAttachedError extends StripeError {
   customerId?: string;
   subscriptionId?: string;


### PR DESCRIPTION
## Because

- several instances incorrectly nullish checks the return value from a stripe call, where the type signature indicates the underlying method cannot return a nullish value.

## This pull request

- cleans up following instances, along with the associated errors:
  - `retrieve` in `PriceManager`
  - `retrieve` in `ProductManager`

## Issue that this pull request solves

Closes: FXA-9620

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.