### PR TITLE
refactor(payments): Update CheckoutService to use cartId as idempotency key

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -454,18 +454,21 @@ describe('CheckoutService', () => {
       });
 
       it('creates the subscription', async () => {
-        expect(subscriptionManager.create).toHaveBeenCalledWith({
-          customer: mockCustomer.id,
-          automatic_tax: {
-            enabled: true,
-          },
-          promotion_code: mockPromotionCode.id,
-          items: [
-            {
-              price: mockPriceId, // TODO: fetch price from cart after FXA-8893
+        expect(subscriptionManager.create).toHaveBeenCalledWith(
+          {
+            customer: mockCustomer.id,
+            automatic_tax: {
+              enabled: true,
             },
-          ],
-        });
+            promotion_code: mockPromotionCode.id,
+            items: [
+              {
+                price: mockPriceId, // TODO: fetch price from cart after FXA-8893
+              },
+            ],
+          },
+          { idempotencyKey: mockCart.id }
+        );
       });
 
       it('retrieves the latest invoice', () => {
@@ -559,20 +562,23 @@ describe('CheckoutService', () => {
       });
 
       it('creates the subscription', async () => {
-        expect(subscriptionManager.create).toHaveBeenCalledWith({
-          customer: mockCustomer.id,
-          automatic_tax: {
-            enabled: true,
-          },
-          collection_method: 'send_invoice',
-          days_until_due: 1,
-          promotion_code: mockPromotionCode.id,
-          items: [
-            {
-              price: mockPriceId,
+        expect(subscriptionManager.create).toHaveBeenCalledWith(
+          {
+            customer: mockCustomer.id,
+            automatic_tax: {
+              enabled: true,
             },
-          ],
-        });
+            collection_method: 'send_invoice',
+            days_until_due: 1,
+            promotion_code: mockPromotionCode.id,
+            items: [
+              {
+                price: mockPriceId,
+              },
+            ],
+          },
+          { idempotencyKey: mockCart.id }
+        );
       });
 
       it('deletes all paypalCustomers for user by uid', () => {

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -191,19 +191,23 @@ export class CheckoutService {
 
     // TODO: increment statsd for stripe_subscription with payment provider stripe
 
-    const subscription = await this.subscriptionManager.create({
-      customer: customer.id,
-      automatic_tax: {
-        enabled: enableAutomaticTax,
-      },
-      promotion_code: promotionCode?.id,
-      items: [
-        {
-          price: priceId,
+    const subscription = await this.subscriptionManager.create(
+      {
+        customer: customer.id,
+        automatic_tax: {
+          enabled: enableAutomaticTax,
         },
-      ],
-      // TODO: Generate and use idempotency key using util
-    });
+        promotion_code: promotionCode?.id,
+        items: [
+          {
+            price: priceId,
+          },
+        ],
+      },
+      {
+        idempotencyKey: cart.id,
+      }
+    );
 
     const paymentIntent = await this.subscriptionManager.getLatestPaymentIntent(
       subscription
@@ -257,21 +261,25 @@ export class CheckoutService {
 
     // TODO: increment statsd for stripe_subscription with payment provider paypal
     //
-    const subscription = await this.subscriptionManager.create({
-      customer: customer.id,
-      automatic_tax: {
-        enabled: enableAutomaticTax,
-      },
-      collection_method: 'send_invoice',
-      days_until_due: 1,
-      promotion_code: promotionCode?.id,
-      items: [
-        {
-          price: priceId,
+    const subscription = await this.subscriptionManager.create(
+      {
+        customer: customer.id,
+        automatic_tax: {
+          enabled: enableAutomaticTax,
         },
-      ],
-      // TODO: Generate and use idempotency key
-    });
+        collection_method: 'send_invoice',
+        days_until_due: 1,
+        promotion_code: promotionCode?.id,
+        items: [
+          {
+            price: priceId,
+          },
+        ],
+      },
+      {
+        idempotencyKey: cart.id,
+      }
+    );
 
     await this.paypalCustomerManager.deletePaypalCustomersByUid(uid);
     await this.paypalCustomerManager.createPaypalCustomer({

--- a/libs/payments/stripe/src/lib/stripe.client.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
 import { Stripe } from 'stripe';
 
@@ -172,9 +173,12 @@ describe('StripeClient', () => {
 
       mockStripeSubscriptionsCreate.mockResolvedValue(mockResponse);
 
-      const result = await stripeClient.subscriptionsCreate({
-        customer: mockCustomer.id,
-      });
+      const result = await stripeClient.subscriptionsCreate(
+        {
+          customer: mockCustomer.id,
+        },
+        { idempotencyKey: faker.string.uuid() }
+      );
       expect(result).toEqual(mockResponse);
     });
   });

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -83,11 +83,17 @@ export class StripeClient {
     return result as StripeApiList<StripeSubscription>;
   }
 
-  async subscriptionsCreate(params: Stripe.SubscriptionCreateParams) {
-    const result = await this.stripe.subscriptions.create({
-      ...params,
-      expand: undefined,
-    });
+  async subscriptionsCreate(
+    params: Stripe.SubscriptionCreateParams,
+    options?: Stripe.RequestOptions
+  ) {
+    const result = await this.stripe.subscriptions.create(
+      {
+        ...params,
+        expand: undefined,
+      },
+      options
+    );
 
     return result as StripeResponse<StripeSubscription>;
   }

--- a/libs/payments/stripe/src/lib/subscription.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/subscription.manager.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
 
 import {
@@ -125,14 +126,17 @@ describe('SubscriptionManager', () => {
       const params = {
         customer: mockCustomer.id,
       };
+      const options = {
+        idempotencyKey: faker.string.uuid(),
+      };
 
       jest
         .spyOn(stripeClient, 'subscriptionsCreate')
         .mockResolvedValue(mockResponse);
 
-      const result = await subscriptionManager.create(params);
+      const result = await subscriptionManager.create(params, options);
 
-      expect(stripeClient.subscriptionsCreate).toBeCalledWith(params);
+      expect(stripeClient.subscriptionsCreate).toBeCalledWith(params, options);
       expect(result).toEqual(mockResponse);
     });
   });

--- a/libs/payments/stripe/src/lib/subscription.manager.ts
+++ b/libs/payments/stripe/src/lib/subscription.manager.ts
@@ -21,8 +21,11 @@ export class SubscriptionManager {
     return this.client.subscriptionsCancel(subscriptionId);
   }
 
-  async create(params: Stripe.SubscriptionCreateParams) {
-    return this.client.subscriptionsCreate(params);
+  async create(
+    params: Stripe.SubscriptionCreateParams,
+    options?: Stripe.RequestOptions
+  ) {
+    return this.client.subscriptionsCreate(params, options);
   }
 
   async retrieve(subscriptionId: string) {


### PR DESCRIPTION
## This pull request

- updates both method calls for `subscriptionManager.create` by setting cartId as the idempotency key to prevent duplicate subscription creation with a given cart

## Issue that this pull request solves

Closes: FXA-10161

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
