### PR TITLE
refactor(payments): Set billing agreement ID on customer metadata

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -514,6 +514,7 @@ describe('CheckoutService', () => {
         promotionCode: mockPromotionCode,
         priceId: mockPriceId,
       });
+      jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
       jest.spyOn(invoiceManager, 'processPayPalInvoice').mockResolvedValue();
       jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
       jest.spyOn(paypalBillingAgreementManager, 'cancel').mockResolvedValue();

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -14,6 +14,7 @@ import {
   InvoiceManager,
   PaymentMethodManager,
   PromotionCodeManager,
+  STRIPE_CUSTOMER_METADATA,
   StripeSubscription,
   SubplatInterval,
   SubscriptionManager,
@@ -280,7 +281,12 @@ export class CheckoutService {
       status: 'active',
       endedAt: null,
     });
-    // TODO: set billingAgreementId on customer metadata (existing is updateCustomerPaypalAgreement)
+
+    await this.customerManager.update(customer.id, {
+      metadata: {
+        [STRIPE_CUSTOMER_METADATA.PAYPAL_AGREEMENT]: billingAgreementId,
+      },
+    });
 
     if (!subscription.latest_invoice) {
       throw new CheckoutError('latest_invoice does not exist on subscription');

--- a/libs/payments/stripe/src/lib/stripe.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.types.ts
@@ -17,6 +17,10 @@ export interface TaxAmount {
   amount: number;
 }
 
+export enum STRIPE_CUSTOMER_METADATA {
+  PAYPAL_AGREEMENT = 'paypalAgreementId',
+}
+
 export enum STRIPE_PRICE_METADATA {
   APP_STORE_PRODUCT_IDS = 'appStoreProductIds',
   PLAY_SKU_IDS = 'playSkuIds',


### PR DESCRIPTION
## This pull request

- sets billing agreement ID on customer metadata within the checkout service in the payWithPaypal method after the billing agreement is created

## Issue that this pull request solves

Closes: FXA-10162

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
