### PR TITLE
feat(payments-cart): Add tax ID to customer and set appliedPromotionCode metadata in CheckoutService postPaySteps

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -182,9 +182,22 @@ export class CheckoutService {
   }
 
   async postPaySteps(cart: ResultCart, subscription: StripeSubscription) {
-    // TODO: Add tax ID to customer
+    const { customer: customerId, currency } = subscription;
+
+    await this.customerManager.setTaxId(customerId, currency);
+
     // TODO: call customerChanged
-    // TODO: save promo code to subscription's metadata
+
+    if (cart.couponCode) {
+      const subscriptionMetadata = {
+        ...subscription.metadata,
+        [STRIPE_CUSTOMER_METADATA.SubscriptionPromotionCode]: cart.couponCode,
+      };
+      await this.subscriptionManager.update(subscription.id, {
+        metadata: subscriptionMetadata,
+      });
+    }
+
     // TODO: call sendFinishSetupEmailForStubAccount
     console.log(cart.id, subscription.id);
   }
@@ -313,7 +326,7 @@ export class CheckoutService {
 
     await this.customerManager.update(customer.id, {
       metadata: {
-        [STRIPE_CUSTOMER_METADATA.PAYPAL_AGREEMENT]: billingAgreementId,
+        [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: billingAgreementId,
       },
     });
 

--- a/libs/payments/stripe/src/lib/promotionCode.manager.spec.ts
+++ b/libs/payments/stripe/src/lib/promotionCode.manager.spec.ts
@@ -407,7 +407,7 @@ describe('PromotionCodeManager', () => {
           StripeSubscriptionItemFactory({
             price: StripePriceFactory({
               metadata: {
-                [STRIPE_PRICE_METADATA.PROMOTION_CODES]: 'promo_code1',
+                [STRIPE_PRICE_METADATA.PromotionCodes]: 'promo_code1',
               },
             }),
           }),
@@ -420,7 +420,7 @@ describe('PromotionCodeManager', () => {
           StripeSubscriptionItemFactory({
             price: StripePriceFactory({
               metadata: {
-                [STRIPE_PRICE_METADATA.PROMOTION_CODES]:
+                [STRIPE_PRICE_METADATA.PromotionCodes]:
                   'promo_code1,promo_code2',
               },
             }),

--- a/libs/payments/stripe/src/lib/stripe.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.types.ts
@@ -18,17 +18,18 @@ export interface TaxAmount {
 }
 
 export enum STRIPE_CUSTOMER_METADATA {
-  PAYPAL_AGREEMENT = 'paypalAgreementId',
+  PaypalAgreement = 'paypalAgreementId',
+  SubscriptionPromotionCode = 'appliedPromotionCode',
 }
 
 export enum STRIPE_PRICE_METADATA {
-  APP_STORE_PRODUCT_IDS = 'appStoreProductIds',
-  PLAY_SKU_IDS = 'playSkuIds',
-  PROMOTION_CODES = 'promotionCodes',
+  AppStoreProductIds = 'appStoreProductIds',
+  PlaySkuIds = 'playSkuIds',
+  PromotionCodes = 'promotionCodes',
 }
 
 export enum STRIPE_PRODUCT_METADATA {
-  PROMOTION_CODES = 'promotionCodes',
+  PromotionCodes = 'promotionCodes',
 }
 
 export enum SubplatInterval {

--- a/libs/payments/stripe/src/lib/util/assertPromotionCodeApplicableToPrice.spec.ts
+++ b/libs/payments/stripe/src/lib/util/assertPromotionCodeApplicableToPrice.spec.ts
@@ -28,7 +28,7 @@ describe('assertPromotionCodeApplicableToPrice', () => {
     });
     const mockPrice = StripePriceFactory({
       metadata: {
-        [STRIPE_PRICE_METADATA.PROMOTION_CODES]:
+        [STRIPE_PRICE_METADATA.PromotionCodes]:
           'promo_code1,promo_code2,promo_code3',
       },
     });
@@ -41,13 +41,13 @@ describe('assertPromotionCodeApplicableToPrice', () => {
   it('does not throw if promotion code is included in promotion codes for product', async () => {
     const mockPrice = StripePriceFactory({
       metadata: {
-        [STRIPE_PRICE_METADATA.PROMOTION_CODES]:
+        [STRIPE_PRICE_METADATA.PromotionCodes]:
           'promo_code1,promo_code2,promo_code3',
       },
     });
     const mockProduct = StripeProductFactory({
       metadata: {
-        [STRIPE_PRODUCT_METADATA.PROMOTION_CODES]:
+        [STRIPE_PRODUCT_METADATA.PromotionCodes]:
           'promo_code1,promo_code2,promo_code3',
       },
     });

--- a/libs/payments/stripe/src/lib/util/assertPromotionCodeApplicableToPrice.ts
+++ b/libs/payments/stripe/src/lib/util/assertPromotionCodeApplicableToPrice.ts
@@ -19,19 +19,19 @@ export const assertPromotionCodeApplicableToPrice = (
   product?: StripeProduct
 ) => {
   const validPromotionCodes: string[] = [];
-  if (price.metadata && price.metadata[STRIPE_PRICE_METADATA.PROMOTION_CODES]) {
+  if (price.metadata && price.metadata[STRIPE_PRICE_METADATA.PromotionCodes]) {
     validPromotionCodes.push(
-      ...price.metadata[STRIPE_PRICE_METADATA.PROMOTION_CODES]
+      ...price.metadata[STRIPE_PRICE_METADATA.PromotionCodes]
         .split(',')
         .map((c) => c.trim())
     );
   }
   if (
     product?.metadata &&
-    product.metadata[STRIPE_PRODUCT_METADATA.PROMOTION_CODES]
+    product.metadata[STRIPE_PRODUCT_METADATA.PromotionCodes]
   ) {
     validPromotionCodes.push(
-      ...product.metadata[STRIPE_PRODUCT_METADATA.PROMOTION_CODES]
+      ...product.metadata[STRIPE_PRODUCT_METADATA.PromotionCodes]
         .split(',')
         .map((c) => c.trim())
     );

--- a/libs/payments/stripe/src/lib/util/isCustomerTaxEligible.spec.ts
+++ b/libs/payments/stripe/src/lib/util/isCustomerTaxEligible.spec.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { isCustomerTaxEligible } from './isCustomerTaxEligible';
+import { StripeCustomerFactory } from '../factories/customer.factory';
+import { faker } from '@faker-js/faker';
+
+describe('isCustomerTaxEligible', () => {
+  it('returns true if customer is tax eligible - not supported', () => {
+    const mockCustomer = StripeCustomerFactory({
+      tax: {
+        location: null,
+        automatic_tax: 'supported',
+        ip_address: faker.internet.ipv4(),
+      },
+    });
+
+    const result = isCustomerTaxEligible(mockCustomer);
+    expect(result).toEqual(true);
+  });
+
+  it('returns true if customer is tax eligible - not collecting', () => {
+    const mockCustomer = StripeCustomerFactory({
+      tax: {
+        location: null,
+        automatic_tax: 'not_collecting',
+        ip_address: faker.internet.ipv4(),
+      },
+    });
+
+    const result = isCustomerTaxEligible(mockCustomer);
+    expect(result).toEqual(true);
+  });
+
+  it('returns false if customer is not tax eligible', () => {
+    const mockCustomer = StripeCustomerFactory({
+      tax: {
+        location: null,
+        automatic_tax: 'failed',
+        ip_address: faker.internet.ipv4(),
+      },
+    });
+
+    const result = isCustomerTaxEligible(mockCustomer);
+    expect(result).toEqual(false);
+  });
+});

--- a/libs/payments/stripe/src/lib/util/isCustomerTaxEligible.ts
+++ b/libs/payments/stripe/src/lib/util/isCustomerTaxEligible.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { StripeCustomer } from '../stripe.client.types';
 
 export const isCustomerTaxEligible = (customer: StripeCustomer) => {


### PR DESCRIPTION
## This pull request

- [x] adds the tax ID to the customer (not related to tax address!) within postPaySteps in CheckoutService.
- [x] sets appliedPromotionCode metadata property on subscriptions if a promo code is used for the checkout
- [x] removes the comments in postPaySteps

## Issue that this pull request solves

Closes: FXA-10159
Closes: FXA-10160

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
