### PR TITLE
fix(glean): Downgrade glean to 5.0.2 instead of 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@google-cloud/pubsub": "^4.3.1",
     "@google-cloud/translate": "^8.2.0",
     "@grpc/grpc-js": "^1.11.1",
-    "@mozilla/glean": "^5.0.3",
+    "@mozilla/glean": "^5.0.2",
     "@nestjs/apollo": "^12.1.0",
     "@nestjs/common": "^10.3.4",
     "@nestjs/config": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12757,19 +12757,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mozilla/glean@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "@mozilla/glean@npm:5.0.3"
-  dependencies:
-    fflate: ^0.8.0
-    tslib: ^2.3.1
-    uuid: ^9.0.0
-  bin:
-    glean: dist/cli/cli.js
-  checksum: 58ec9e831855d57f319738378694ca04b99217c10fee2c370f62624e61ca9b65b799cd16d499cd3cf9a2d18fc1ea512360c10fba2da0af62971e409e43aaa88d
-  languageName: node
-  linkType: hard
-
 "@mrmlnc/readdir-enhanced@npm:^2.2.1":
   version: 2.2.1
   resolution: "@mrmlnc/readdir-enhanced@npm:2.2.1"
@@ -40083,7 +40070,7 @@ fsevents@~2.1.1:
     "@graphql-codegen/typescript": ^4.0.1
     "@graphql-codegen/typescript-document-nodes": ^4.0.1
     "@grpc/grpc-js": ^1.11.1
-    "@mozilla/glean": ^5.0.3
+    "@mozilla/glean": ^5.0.2
     "@nestjs/apollo": ^12.1.0
     "@nestjs/cli": ^10.4.2
     "@nestjs/common": ^10.3.4


### PR DESCRIPTION
## Because

- We use 5.0.2 in fxa-settings, the version mismatch was causing two different Gleans to be initalized

## This pull request

- Updates all Glean to use 5.0.2

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10310

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
Verified locally the error does not show up

```
(Glean.core.Pings.Maker) {
  "metrics": {
    "string": {
      "event.name": "reg_view",
      "account.user_id_sha256": "",
      "relying_party.oauth_client_id": "",
      "relying_party.service": "sync",
      "session.device_type": "desktop",
      "session.entrypoint": "preferences",
      "session.flow_id": "4ee696408490a771af4ca607d6672bce945e360dc047668349c8404c552e6321",
      "utm.campaign": "",
      "utm.content": "",
      "utm.medium": "",
      "utm.source": "",
      "utm.term": "",
      "entrypoint.variation": "",
      "entrypoint.experiment": ""
    }
  },
  "ping_info": {
    "seq": 0,
    "start_time": "2024-08-21T13:55-04:00",
    "end_time": "2024-08-21T13:55-04:00"
  },
  "client_info": {
    "telemetry_sdk_build": "5.0.2",
    "client_id": "a3b19b54-de4d-48fe-a4ac-d0b6b188296c",
    "session_id": "ba1a79cc-3743-410c-9891-4efab1fc947b",
    "session_count": 1,
    "first_run_date": "2024-08-21-04:00",
    "os": "Darwin",
    "os_version": "Unknown",
    "architecture": "Unknown",
    "locale": "en-US",
    "app_build": "Unknown",
    "app_display_version": "0.0.0",
    "app_channel": "development"
  }
} [log.js:15](http://localhost:3030/Users/vijaybudham/Desktop/working2/fxa/node_modules/@mozilla/glean/dist/core/log.js)
(Glean.core.Upload.PingUploadManager) Ping ad36e157-759e-40a8-a63d-f90c62791565 successfully sent 200. [log.js:15](http://localhost:3030/Users/vijaybudham/Desktop/working2/fxa/node_modules/@mozilla/glean/dist/core/log.js)
(Glean.core.Upload.PingUploadManager) Ping a3179ad3-5daa-4ca7-be59-f2645c4a9b3b successfully sent 200. [log.js:15](http://localhost:3030/Users/vijaybudham/Desktop/working2/fxa/node_modules/@mozilla/glean/dist/core/log.js)
(Glean.core.Upload.PingUploadManager) Ping 687c801a-5f67-49f6-8594-c5c2e4781a68 successfully sent 200.
```

Note that we will need a point release for this.
