### PR TITLE
feat(cart): validate promo code prior to cart actions

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -110,3 +110,12 @@ export class CartEmailNotFoundError extends CartError {
     });
   }
 }
+
+export class CartInvalidPromoCodeError extends CartError {
+  constructor(promoCode: string, cartId?: string) {
+    super('Cart specified promo code does not exist', {
+      cartId,
+      promoCode,
+    });
+  }
+}

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -19,6 +19,7 @@ import {
   SubplatInterval,
   SubscriptionManager,
   TaxAddress,
+  type StripePromotionCode,
 } from '@fxa/payments/stripe';
 import { AccountManager } from '@fxa/shared/account/account';
 import { ProductConfigurationManager } from '@fxa/shared/cms';
@@ -26,6 +27,7 @@ import {
   CartTotalMismatchError,
   CartEligibilityMismatchError,
   CartEmailNotFoundError,
+  CartInvalidPromoCodeError,
 } from './cart.error';
 import { CartManager } from './cart.manager';
 import { CheckoutCustomerData, ResultCart } from './cart.types';
@@ -123,14 +125,13 @@ export class CheckoutService {
 
     // re-validate total amount against upcoming invoice
     // throws cart total mismatch error if no match found
-    const priceId =
-      await this.productConfigurationManager.retrieveStripePriceId(
-        cart.offeringConfigId,
-        cart.interval as SubplatInterval
-      );
+    const price = await this.productConfigurationManager.retrieveStripePrice(
+      cart.offeringConfigId,
+      cart.interval as SubplatInterval
+    );
 
     const upcomingInvoice = await this.invoiceManager.preview({
-      priceId: priceId,
+      priceId: price.id,
       customer: customer,
       taxAddress: taxAddress,
     });
@@ -146,21 +147,33 @@ export class CheckoutService {
     // check if customer already has subscription to price and cancel if they do
     await this.subscriptionManager.cancelIncompleteSubscriptionsToPrice(
       stripeCustomerId,
-      priceId
+      price.id
     );
 
     const enableAutomaticTax = this.customerManager.isTaxEligible(customer);
 
-    const promotionCode = cart.couponCode
-      ? await this.promotionCodeManager.retrieveByName(cart.couponCode, true)
-      : undefined;
+    let promotionCode: StripePromotionCode | undefined;
+    if (cart.couponCode) {
+      try {
+        await this.promotionCodeManager.assertValidPromotionCodeNameForPrice(
+          cart.couponCode,
+          price
+        );
+
+        promotionCode = await this.promotionCodeManager.retrieveByName(
+          cart.couponCode
+        );
+      } catch (e) {
+        throw new CartInvalidPromoCodeError(cart.couponCode, cart.id);
+      }
+    }
 
     return {
       uid: uid,
       customer,
       enableAutomaticTax,
       promotionCode,
-      priceId,
+      price,
     };
   }
 
@@ -177,7 +190,7 @@ export class CheckoutService {
     paymentMethodId: string,
     customerData: CheckoutCustomerData
   ) {
-    const { customer, enableAutomaticTax, promotionCode, priceId } =
+    const { customer, enableAutomaticTax, promotionCode, price } =
       await this.prePaySteps(cart, customerData);
 
     await this.paymentMethodManager.attach(paymentMethodId, {
@@ -201,7 +214,7 @@ export class CheckoutService {
         promotion_code: promotionCode?.id,
         items: [
           {
-            price: priceId,
+            price: price.id,
           },
         ],
       },
@@ -245,7 +258,7 @@ export class CheckoutService {
     customerData: CheckoutCustomerData,
     token?: string
   ) {
-    const { uid, customer, enableAutomaticTax, promotionCode, priceId } =
+    const { uid, customer, enableAutomaticTax, promotionCode, price } =
       await this.prePaySteps(cart, customerData);
 
     const paypalSubscriptions =
@@ -273,7 +286,7 @@ export class CheckoutService {
         promotion_code: promotionCode?.id,
         items: [
           {
-            price: priceId,
+            price: price.id,
           },
         ],
       },

--- a/libs/payments/stripe/src/lib/stripe.util.spec.ts
+++ b/libs/payments/stripe/src/lib/stripe.util.spec.ts
@@ -17,8 +17,8 @@ import {
 import { PromotionCodeCouldNotBeAttachedError } from './stripe.error';
 import { STRIPE_PRICE_METADATA, STRIPE_PRODUCT_METADATA } from './stripe.types';
 import {
-  checkSubscriptionPromotionCodes,
-  checkValidPromotionCode,
+  assertSubscriptionPromotionCodes,
+  assertValidPromotionCode,
   getSubscribedPrice,
   getSubscribedPrices,
   getSubscribedProductIds,
@@ -31,11 +31,11 @@ describe('util', () => {
       const mockPromoCode = StripePromotionCodeFactory();
 
       expect(() =>
-        checkSubscriptionPromotionCodes(mockPromoCode, mockPrice, undefined)
+        assertSubscriptionPromotionCodes(mockPromoCode, mockPrice, undefined)
       ).toThrowError(PromotionCodeCouldNotBeAttachedError);
     });
 
-    it('returns true if only subscription price provided', async () => {
+    it('does not throw if only subscription price provided', async () => {
       const mockPromoCode = StripePromotionCodeFactory({
         code: 'promo_code1',
       });
@@ -46,15 +46,12 @@ describe('util', () => {
         },
       });
 
-      const result = checkSubscriptionPromotionCodes(
-        mockPromoCode,
-        mockPrice,
-        undefined
-      );
-      expect(result).toEqual(true);
+      expect(() =>
+        assertSubscriptionPromotionCodes(mockPromoCode, mockPrice, undefined)
+      ).not.toThrow();
     });
 
-    it('returns true if promotion code is included in promotion codes for product', async () => {
+    it('does not throw if promotion code is included in promotion codes for product', async () => {
       const mockPrice = StripePriceFactory({
         metadata: {
           [STRIPE_PRICE_METADATA.PROMOTION_CODES]:
@@ -71,12 +68,9 @@ describe('util', () => {
         code: 'promo_code1',
       });
 
-      const result = checkSubscriptionPromotionCodes(
-        mockPromoCode,
-        mockPrice,
-        mockProduct
-      );
-      expect(result).toEqual(true);
+      expect(() =>
+        assertSubscriptionPromotionCodes(mockPromoCode, mockPrice, mockProduct)
+      ).not.toThrow();
     });
   });
 
@@ -84,7 +78,7 @@ describe('util', () => {
     it('throws error if there is no promotion code', async () => {
       const mockPromotionCode = StripeResponseFactory(undefined);
 
-      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+      expect(() => assertValidPromotionCode(mockPromotionCode)).toThrowError(
         PromotionCodeCouldNotBeAttachedError
       );
     });
@@ -94,7 +88,7 @@ describe('util', () => {
         active: false,
       });
 
-      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+      expect(() => assertValidPromotionCode(mockPromotionCode)).toThrowError(
         PromotionCodeCouldNotBeAttachedError
       );
     });
@@ -106,7 +100,7 @@ describe('util', () => {
         }),
       });
 
-      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+      expect(() => assertValidPromotionCode(mockPromotionCode)).toThrowError(
         PromotionCodeCouldNotBeAttachedError
       );
     });
@@ -117,18 +111,17 @@ describe('util', () => {
         expires_at: expiredTime,
       });
 
-      expect(() => checkValidPromotionCode(mockPromotionCode)).toThrowError(
+      expect(() => assertValidPromotionCode(mockPromotionCode)).toThrowError(
         PromotionCodeCouldNotBeAttachedError
       );
     });
 
-    it('returns true if the promotion code is valid', async () => {
+    it('does not throw if the promotion code is valid', async () => {
       const mockPromotionCode = StripePromotionCodeFactory({
         active: true,
       });
 
-      const result = checkValidPromotionCode(mockPromotionCode);
-      expect(result).toEqual(true);
+      expect(() => assertValidPromotionCode(mockPromotionCode)).not.toThrow();
     });
   });
 

--- a/libs/payments/stripe/src/lib/stripe.util.ts
+++ b/libs/payments/stripe/src/lib/stripe.util.ts
@@ -11,7 +11,7 @@ import {
 import { PromotionCodeCouldNotBeAttachedError } from './stripe.error';
 import { STRIPE_PRICE_METADATA, STRIPE_PRODUCT_METADATA } from './stripe.types';
 
-export const checkSubscriptionPromotionCodes = (
+export const assertSubscriptionPromotionCodes = (
   code: StripePromotionCode,
   price: StripePrice,
   product?: StripeProduct
@@ -43,10 +43,9 @@ export const checkSubscriptionPromotionCodes = (
       }
     );
   }
-  return true;
 };
 
-export const checkValidPromotionCode = (code: StripePromotionCode) => {
+export const assertValidPromotionCode = (code: StripePromotionCode) => {
   const nowSecs = Date.now() / 1000;
   if (
     !code ||
@@ -61,7 +60,6 @@ export const checkValidPromotionCode = (code: StripePromotionCode) => {
         promotionId: code.id,
       }
     );
-  return true;
 };
 
 export const getSubscribedPrice = (subscription: StripeSubscription) => {

--- a/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
@@ -523,7 +523,7 @@ describe('productConfigurationManager', () => {
     });
   });
 
-  describe('retrieveStripePriceId', () => {
+  describe('retrieveStripePrice', () => {
     it('returns plan based on offeringId and interval', async () => {
       const mockPrice = StripeResponseFactory(StripePriceFactory());
       const mockInterval = SubplatInterval.Monthly;
@@ -545,11 +545,11 @@ describe('productConfigurationManager', () => {
         .spyOn(priceManager, 'retrieveByInterval')
         .mockResolvedValue(mockPrice);
 
-      const result = await productConfigurationManager.retrieveStripePriceId(
+      const result = await productConfigurationManager.retrieveStripePrice(
         mockOffering.apiIdentifier,
         mockInterval
       );
-      expect(result).toEqual(mockPrice.id);
+      expect(result).toEqual(mockPrice);
     });
 
     it('throws error if no plans are found', async () => {
@@ -566,7 +566,7 @@ describe('productConfigurationManager', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        productConfigurationManager.retrieveStripePriceId(
+        productConfigurationManager.retrieveStripePrice(
           mockOffering.apiIdentifier,
           mockInterval
         )

--- a/libs/shared/cms/src/lib/product-configuration.manager.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.ts
@@ -222,7 +222,7 @@ export class ProductConfigurationManager {
     return planIds;
   }
 
-  async retrieveStripePriceId(
+  async retrieveStripePrice(
     offeringConfigId: string,
     interval: SubplatInterval
   ) {
@@ -232,6 +232,6 @@ export class ProductConfigurationManager {
       interval
     );
     if (!price) throw new ProductConfigError('Plan not found');
-    return price.id;
+    return price;
   }
 }


### PR DESCRIPTION
## Because

- We don't want carts to be able to proceed with actions with invalid coupon codes

## This pull request

- Adds validation so that an invalid coupon code doesn't result in the customer getting invisibly charged more than they saw in the checkout ui.

## Issue that this pull request solves

Closes FXA-10173