### PR TITLE
fix(tests): Mock `Date.now()` in cloud scheduler tests

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/cloud-scheduler.js
+++ b/packages/fxa-auth-server/test/local/routes/cloud-scheduler.js
@@ -50,6 +50,12 @@ describe('CloudSchedulerHandler', function () {
       cloudSchedulerHandler,
       'processAccountDeletionInRange'
     );
+
+    sinon.stub(Date, 'now').returns(new Date('2023-01-01T00:00:00Z').getTime());
+  });
+
+  afterEach(() => {
+    Date.now.restore();
   });
 
   describe('deleteUnverifiedAccounts', () => {


### PR DESCRIPTION
## Because

- These tests were flaky

## This pull request

- Mocks `Date.now()` so it won't be flaky

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10140

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
