### PR TITLE
chore(config): Set default Glean uploadEnabled option to true

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -26,7 +26,7 @@ const sandbox = sinon.createSandbox();
 const mockConfig = {
   enabled: false,
   applicationId: 'testo',
-  uploadEnabled: false,
+  uploadEnabled: true,
   appDisplayVersion: '9001',
   channel: 'test',
   serverEndpoint: 'https://metrics.example.io/',

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -370,7 +370,7 @@ const conf = (module.exports = convict({
       format: String,
     },
     uploadEnabled: {
-      default: false,
+      default: true,
       env: 'GLEAN_UPLOAD_ENABLED',
       format: Boolean,
     },

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -150,7 +150,7 @@ export function getDefault() {
     glean: {
       enabled: false,
       applicationId: 'accounts_frontend_dev',
-      uploadEnabled: false,
+      uploadEnabled: true,
       channel: 'development',
       serverEndpoint: 'https://incoming.telemetry.mozilla.org',
       logPings: false,

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -36,7 +36,7 @@ const sandbox = sinon.createSandbox();
 const mockConfig: Config['glean'] = {
   enabled: false,
   applicationId: 'testo',
-  uploadEnabled: false,
+  uploadEnabled: true,
   appDisplayVersion: '9001',
   channel: 'test',
   serverEndpoint: 'https://metrics.example.io/',


### PR DESCRIPTION
Because:
* This must be enabled for automatic Glean click events and is already set to true for stage and prod

This commit:
* Updates the default config option from false to true for dev env

---

Context is [here](https://github.com/mozilla/fxa/pull/17446#discussion_r1727700988) + a recent Slack thread.