### PR TITLE
feat(glean): Add 2FA 'these authentication apps' link click event, adjust DataBlock data attrs

### DIFF
--- a/packages/fxa-react/components/LinkExternal/index.tsx
+++ b/packages/fxa-react/components/LinkExternal/index.tsx
@@ -11,6 +11,10 @@ type LinkExternalProps = {
   children: React.ReactNode;
   title?: string;
   'data-testid'?: string;
+  gleanDataAttrs?: {
+    id: string;
+    type?: string;
+  };
   rel?: 'noopener noreferrer' | 'author';
   tabIndex?: number;
   onClick?: () => void;
@@ -23,11 +27,14 @@ export const LinkExternal = ({
   title,
   'data-testid': testid = 'link-external',
   rel = 'noopener noreferrer',
+  gleanDataAttrs,
   tabIndex,
   onClick,
 }: LinkExternalProps) => (
   <a
     data-testid={testid}
+    data-glean-id={gleanDataAttrs?.id}
+    data-glean-type={gleanDataAttrs?.type}
     target="_blank"
     {...{
       className,

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -10,6 +10,7 @@ import { ReactComponent as DownloadIcon } from './download.svg';
 import { ReactComponent as PrintIcon } from './print.svg';
 import { useFtlMsgResolver } from '../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
+import { GleanClickEventType2FA } from '../../lib/types';
 
 export type DownloadContentType =
   | 'Firefox account recovery key'
@@ -29,7 +30,7 @@ export interface GetDataTrioGleanData {
     | 'two_step_auth_codes_copy'
     | 'two_step_auth_codes_print'
     | 'account_pref_recovery_key_copy';
-  type?: 'setup' | 'inline setup' | 'replace';
+  type?: GleanClickEventType2FA;
 }
 
 export type GetDataTrioProps = {
@@ -65,12 +66,8 @@ export const GetDataCopySingleton = ({
         onBlur={() => setTooltipVisible(false)}
         data-testid="databutton-copy"
         className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
-        {...(gleanDataAttrs?.copy && {
-          'data-glean-id': gleanDataAttrs.copy.id,
-        })}
-        {...(gleanDataAttrs?.copy?.type && {
-          'data-glean-type': gleanDataAttrs.copy.type,
-        })}
+        data-glean-id={gleanDataAttrs.copy?.id}
+        data-glean-type={gleanDataAttrs.copy?.type}
       >
         <CopyIcon
           aria-label="Copy"
@@ -106,12 +103,8 @@ export const GetDataCopySingletonInline = ({
           }}
           onBlur={() => setTooltipVisible(false)}
           data-testid="databutton-copy"
-          {...(gleanDataAttrs?.copy && {
-            'data-glean-id': gleanDataAttrs.copy.id,
-          })}
-          {...(gleanDataAttrs?.copy?.type && {
-            'data-glean-type': gleanDataAttrs.copy.type,
-          })}
+          data-glean-id={gleanDataAttrs.copy?.id}
+          data-glean-type={gleanDataAttrs.copy?.type}
           className="-my-3 -me-4 p-3 rounded text-grey-500 bg-transparent border border-transparent hover:bg-grey-100 active:bg-grey-200 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 focus:bg-grey-50"
         >
           <InlineCopyIcon
@@ -190,12 +183,8 @@ export const GetDataTrio = ({
           onBlur={() => {
             setTooltipVisible(false);
           }}
-          {...(gleanDataAttrs?.download && {
-            'data-glean-id': gleanDataAttrs.download.id,
-          })}
-          {...(gleanDataAttrs?.download?.type && {
-            'data-glean-type': gleanDataAttrs.download.type,
-          })}
+          data-glean-id={gleanDataAttrs.download?.id}
+          data-glean-type={gleanDataAttrs.download?.type}
         >
           <DownloadIcon
             aria-label="Download"
@@ -228,12 +217,8 @@ export const GetDataTrio = ({
           onBlur={() => setTooltipVisible(false)}
           data-testid="databutton-print"
           className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-600 focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 hover:bg-grey-50"
-          {...(gleanDataAttrs?.print && {
-            'data-glean-id': gleanDataAttrs.print.id,
-          })}
-          {...(gleanDataAttrs?.print?.type && {
-            'data-glean-type': gleanDataAttrs.print.type,
-          })}
+          data-glean-id={gleanDataAttrs.print?.id}
+          data-glean-type={gleanDataAttrs.print?.type}
         >
           <PrintIcon
             aria-label="Print"

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -21,6 +21,7 @@ import {
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { copyRecoveryCodes } from '../../../lib/totp';
 import { FtlMsg } from 'fxa-react/lib/utils';
+import { GleanClickEventType2FA } from '../../../lib/types';
 
 export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
@@ -151,15 +152,15 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
                   gleanDataAttrs={{
                     download: {
                       id: 'two_step_auth_codes_download',
-                      type: 'replace',
+                      type: GleanClickEventType2FA.replace,
                     },
                     copy: {
                       id: 'two_step_auth_codes_copy',
-                      type: 'replace',
+                      type: GleanClickEventType2FA.replace,
                     },
                     print: {
                       id: 'two_step_auth_codes_print',
-                      type: 'replace',
+                      type: GleanClickEventType2FA.replace,
                     },
                   }}
                 />

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -21,6 +21,7 @@ import { useAsync } from 'react-async-hook';
 import { getErrorFtlId } from '../../../lib/error-utils';
 import DataBlockManual from '../../DataBlockManual';
 import GleanMetrics from '../../../lib/glean';
+import { GleanClickEventType2FA } from '../../../lib/types';
 
 export const metricsPreInPostFix = 'settings.two-step-authentication';
 
@@ -214,6 +215,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                     <LinkExternal
                       className="link-blue"
                       href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                      gleanDataAttrs={{
+                        id: 'two_step_auth_app_link',
+                        type: GleanClickEventType2FA.setup,
+                      }}
                     >
                       {' '}
                     </LinkExternal>
@@ -225,6 +230,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                   <LinkExternal
                     className="link-blue"
                     href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                    gleanDataAttrs={{
+                      id: 'two_step_auth_app_link',
+                      type: GleanClickEventType2FA.setup,
+                    }}
                   >
                     these authentication apps
                   </LinkExternal>
@@ -349,15 +358,15 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 gleanDataAttrs={{
                   download: {
                     id: 'two_step_auth_codes_download',
-                    type: 'setup',
+                    type: GleanClickEventType2FA.setup,
                   },
                   copy: {
                     id: 'two_step_auth_codes_copy',
-                    type: 'setup',
+                    type: GleanClickEventType2FA.setup,
                   },
                   print: {
                     id: 'two_step_auth_codes_print',
-                    type: 'setup',
+                    type: GleanClickEventType2FA.setup,
                   },
                 }}
               />

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -8,6 +8,12 @@ export type GleanClickEventDataAttrs = {
   type?: string;
 };
 
+export enum GleanClickEventType2FA {
+  inline = 'inline setup',
+  setup = 'setup',
+  replace = 'replace',
+}
+
 export enum LinkType {
   'reset-password',
   'signin',

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -17,6 +17,7 @@ import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { InlineRecoverySetupProps } from './interfaces';
 import { getErrorFtlId, getLocalizedErrorMessage } from '../../lib/error-utils';
 import GleanMetrics from '../../lib/glean';
+import { GleanClickEventType2FA } from '../../lib/types';
 
 const InlineRecoverySetup = ({
   oAuthError,
@@ -168,7 +169,7 @@ const InlineRecoverySetup = ({
                 }
                 gleanDataAttrs={{
                   id: 'two_step_auth_enter_code_submit',
-                  type: 'inline setup',
+                  type: GleanClickEventType2FA.inline,
                 }}
               />
               <div className="flex justify-between mt-4">
@@ -218,15 +219,15 @@ const InlineRecoverySetup = ({
               gleanDataAttrs={{
                 download: {
                   id: 'two_step_auth_codes_download',
-                  type: 'inline setup',
+                  type: GleanClickEventType2FA.inline,
                 },
                 copy: {
                   id: 'two_step_auth_codes_copy',
-                  type: 'inline setup',
+                  type: GleanClickEventType2FA.inline,
                 },
                 print: {
                   id: 'two_step_auth_codes_print',
-                  type: 'inline setup',
+                  type: GleanClickEventType2FA.inline,
                 },
               }}
             />

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -14,6 +14,7 @@ import AppLayout from '../../components/AppLayout';
 import Banner, { BannerType } from '../../components/Banner';
 import { InlineTotpSetupProps } from './interfaces';
 import DataBlockManual from '../../components/DataBlockManual';
+import { GleanClickEventType2FA } from '../../lib/types';
 
 export const InlineTotpSetup = ({
   totp,
@@ -83,6 +84,10 @@ export const InlineTotpSetup = ({
                   <LinkExternal
                     className="link-blue text-sm"
                     href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                    gleanDataAttrs={{
+                      id: 'two_step_auth_app_link',
+                      type: GleanClickEventType2FA.inline,
+                    }}
                   >
                     these authentication apps
                   </LinkExternal>
@@ -95,6 +100,10 @@ export const InlineTotpSetup = ({
                 <LinkExternal
                   className="link-blue text-sm"
                   href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                  gleanDataAttrs={{
+                    id: 'two_step_auth_app_link',
+                    type: GleanClickEventType2FA.inline,
+                  }}
                 >
                   these authentication apps
                 </LinkExternal>
@@ -248,7 +257,7 @@ export const InlineTotpSetup = ({
                 {...{ localizedCustomCodeRequiredMessage }}
                 gleanDataAttrs={{
                   id: 'two_step_auth_qr_submit',
-                  type: 'inline setup',
+                  type: GleanClickEventType2FA.inline,
                 }}
               />
               <button className="link-blue text-sm mt-4" onClick={onCancel}>


### PR DESCRIPTION
Because:
* We want metrics for when a user clicks on this link
* Simplifies glean data attrs in DataBlock because the type is string or undefined, and if this is undefined the attribute does not render

This commit:
* Adds the glean attrs on LinkExternal
* Shares 2fa glean data 'type's for consistency

closes FXA-9578
