### PR TITLE
feat(glean): Add click events for 2FA 'cancel' and 'continue' on inline/setup/replace

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -174,15 +174,19 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
                 type="button"
                 className="cta-neutral cta-base-p mx-2 flex-1"
                 onClick={goHome}
+                data-glean-id="two_step_auth_codes_cancel"
+                data-glean-type="replace"
               >
                 Cancel
               </button>
             </FtlMsg>
-            <FtlMsg id="recovery-key-continue-button">
+            <FtlMsg id="tfa-button-continue">
               <button
                 type="submit"
                 className="cta-neutral mx-2 px-10 py-2"
                 data-testid="ack-recovery-code"
+                data-glean-id="two_step_auth_codes_submit"
+                data-glean-type="replace"
                 onClick={() => {
                   activateStep(2);
                 }}

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -353,6 +353,8 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 type="button"
                 className="cta-neutral cta-base-p mx-2 flex-1"
                 onClick={goHome}
+                data-glean-id="two_step_auth_codes_cancel"
+                data-glean-type="setup"
               >
                 Cancel
               </button>
@@ -363,6 +365,8 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 type="submit"
                 className="cta-primary cta-base-p mx-2 flex-1"
                 onClick={onRecoveryCodesAcknowledged}
+                data-glean-id="two_step_auth_codes_submit"
+                data-glean-type="setup"
               >
                 Continue
               </button>

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -223,6 +223,8 @@ const InlineRecoverySetup = ({
                   type="button"
                   className="cta-neutral mx-2 px-10 py-2 flex-1"
                   onClick={cancelSetupHandler}
+                  data-glean-id="two_step_auth_codes_cancel"
+                  data-glean-type="inline setup"
                 >
                   Cancel
                 </button>
@@ -232,6 +234,8 @@ const InlineRecoverySetup = ({
                   type="button"
                   className="cta-neutral mx-2 px-10 py-2"
                   onClick={continueSetup}
+                  data-glean-id="two_step_auth_codes_submit"
+                  data-glean-type="inline setup"
                 >
                   Continue
                 </button>


### PR DESCRIPTION
Because:
* We want click events for "Cancel" and "Continue" buttons after the backup codes are shown

This commit:
* Adds the events for normal setup, inline setup, and replace

closes FXA-9583, closes FXA-9584