### PR TITLE
feat(glean): Add click event for 2fa backup code submit

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -293,6 +293,8 @@ const RecoveryCodeCheck = ({
               !recoveryCodeForm.formState.isDirty ||
               !recoveryCodeForm.formState.isValid
             }
+            data-glean-id="two_step_auth_enter_code_submit"
+            data-glean-type="replace"
           >
             Finish
           </button>

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -418,6 +418,8 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                   !recoveryCodeForm.formState.isDirty ||
                   !recoveryCodeForm.formState.isValid
                 }
+                data-glean-id="two_step_auth_enter_code_submit"
+                data-glean-type="setup"
               >
                 Finish
               </button>

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -157,6 +157,10 @@ const InlineRecoverySetup = ({
                 localizedCustomCodeRequiredMessage={
                   localizedRecoveryCodeRequiredError
                 }
+                gleanDataAttrs={{
+                  id: 'two_step_auth_enter_code_submit',
+                  type: 'inline setup',
+                }}
               />
               <div className="flex justify-between mt-4">
                 <FtlMsg id="inline-recovery-back-link">


### PR DESCRIPTION
Because:
* We are adding glean click events

This commit:
* Adds the click event for inline setup, normal setup, and replace recovery codes, after users submit the recovery code to confirm and finish the flow

closes FXA-10127