### PR TITLE
feat(auth): Update 2FA via push backend api

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1796,6 +1796,38 @@ export default class AuthClient {
     return this.sessionGet('/totp/exists', sessionToken, headers);
   }
 
+  async sendLoginPushRequest(
+    sessionToken: hexstring,
+    headers?: Headers
+  ): Promise<void> {
+    return this.sessionPost(
+      '/session/verify/send_push',
+      sessionToken,
+      {},
+      headers
+    );
+  }
+
+  async verifyLoginPushRequest(
+    email: string,
+    uid: string,
+    tokenVerificationId: string,
+    code: string,
+    headers?: Headers
+  ): Promise<void> {
+    return await this.request(
+      'POST',
+      '/session/verify/verify_push',
+      {
+        email,
+        uid,
+        tokenVerificationId,
+        code,
+      },
+      headers
+    );
+  }
+
   async verifyTotpCode(
     sessionToken: hexstring,
     code: string,

--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -99,10 +99,28 @@ const SESSION_RESEND_CODE_POST = {
   notes: ['🔒 Authenticated with session token'],
 };
 
-const SESSION_VERIFY_SEND_PUSH_POST = {
+const SESSION_SEND_PUSH_POST = {
   ...TAGS_SESSION,
   description: '/session/verify/send_push',
-  notes: ['🔒 Authenticated with session token'],
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Sends a push notification to all push enabled devices to verify current session.
+    `,
+  ],
+};
+
+const SESSION_VERIFY_PUSH_POST = {
+  ...TAGS_SESSION,
+  description: '/session/verify/verify_push',
+  notes: [
+    dedent`
+    🔒 Authenticated with session token
+    
+    Endpoint that accepts a code and tokenVerificationId to verify a session.
+    `,
+  ],
 };
 
 const API_DOCS = {
@@ -112,7 +130,8 @@ const API_DOCS = {
   SESSION_STATUS_GET,
   SESSION_RESEND_CODE_POST,
   SESSION_VERIFY_CODE_POST,
-  SESSION_VERIFY_SEND_PUSH_POST,
+  SESSION_SEND_PUSH_POST,
+  SESSION_VERIFY_PUSH_POST,
 };
 
 export default API_DOCS;


### PR DESCRIPTION
## Because

- I demo this at all hands and it required some backend updates 

## This pull request

- Adds a few tweaks and changes to api
- Only sends 2FA push notification to desktop devices if they support it

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10320

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I would like to land this since it updates are already existing 2FA push functionality.