### PR TITLE
fix(settings): Styling tweak to add spacing between links on mobile

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -413,11 +413,11 @@ const Signin = ({
 
       <TermsPrivacyAgreement {...{ isPocketClient, isMonitorClient }} />
 
-      <div className="flex justify-between mt-5">
+      <div className="flex flex-col mt-5 tablet:justify-between tablet:flex-row">
         <FtlMsg id="signin-use-a-different-account-link">
           <a
             href="/"
-            className="text-sm link-blue"
+            className="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
             onClick={(e) => {
               e.preventDefault();
               GleanMetrics.login.diffAccountLinkClick();
@@ -446,7 +446,7 @@ const Signin = ({
               to={`/reset_password${
                 location?.search ? `/${location?.search}` : ''
               }`}
-              className="text-sm link-blue"
+              className="text-sm link-blue mx-auto tablet:mx-0"
               onClick={() =>
                 !isPasswordNeededRef.current
                   ? GleanMetrics.cachedLogin.forgotPassword()


### PR DESCRIPTION
## Because

* There was no spacing between Use a different account and Forgot password? links on mobile sign in page

## This pull request

* Tweak styling to show links on separate lines for mobile

## Issue that this pull request solves

Closes: #FXA-10305

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:

![image](https://github.com/user-attachments/assets/728ad185-ad68-4d5f-bfba-e25184729ed1)

After:

![image](https://github.com/user-attachments/assets/6b1912bd-a61f-43e3-b6c4-0bcdc509d0d5)

## Other information (Optional)

Any other information that is important to this pull request.
