### PR TITLE
fix(sync): Only send canLinkAccount web channel message on desktop sync

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -70,6 +70,14 @@ function mockSyncDesktopV3Integration() {
     wantsKeys: () => true,
   } as Integration;
 }
+function mockSyncOAuthIntegration() {
+  integration = {
+    type: IntegrationType.OAuth,
+    getService: () => MozServices.FirefoxSync,
+    isSync: () => true,
+    wantsKeys: () => true,
+  } as Integration;
+}
 
 function mockWebIntegration() {
   integration = {
@@ -501,9 +509,28 @@ describe('signin container', () => {
       afterEach(() => {
         (firefox.fxaCanLinkAccount as jest.Mock).mockRestore();
       });
-      it('is not called when conditions are not met', async () => {
+      it('is not called when conditions are not met (query param)', async () => {
         // this puts hasLinkedAccount=false in the query params
         // We don't want this called when the user was prompted on email-first
+        mockUseValidateModule();
+        (firefox.fxaCanLinkAccount as jest.Mock).mockImplementationOnce(
+          async () => ({
+            ok: true,
+          })
+        );
+        render([mockGqlAvatarUseQuery()]);
+
+        await waitFor(async () => {
+          await currentSigninProps?.beginSigninHandler(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+          expect(firefox.fxaCanLinkAccount).not.toHaveBeenCalled();
+        });
+      });
+      it('is not called when conditions are not met (oauth integration)', async () => {
+        mockSyncOAuthIntegration();
+        // TODO: when desktop moves to oauth, we must update this logic and test
         mockUseValidateModule();
         (firefox.fxaCanLinkAccount as jest.Mock).mockImplementationOnce(
           async () => ({

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -10,6 +10,7 @@ import {
   useFtlMsgResolver,
   useConfig,
   useSession,
+  isSyncDesktopV3Integration,
 } from '../../models';
 import { MozServices } from '../../lib/types';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
@@ -234,7 +235,7 @@ const SigninContainer = ({
       // warning. The browser will automatically respond with { ok: true } without
       // prompting the user if it matches the email the browser has data for.
       if (
-        integration.isSync() &&
+        isSyncDesktopV3Integration(integration) &&
         queryParamModel.hasLinkedAccount === undefined
       ) {
         const { ok } = await firefox.fxaCanLinkAccount({ email });


### PR DESCRIPTION
Because:
* iOS does not respond to this web channel message, unlike desktop which prompts the user with an alert, and unlike Android, which responds with 'ok: true' automatically

This commit:
* Only sends the web channel message if desktop v3 context is used. We will update this for OAuth desktop before that feature rolls out.

closes FXA-10316