### PR TITLE
fix(glean): Glean metrics were erroring for settings

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -121,7 +121,6 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.13.0",
     "@material-ui/core": "v5.0.0-alpha.24",
-    "@mozilla/glean": "^5.0.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.3",
     "@reach/router": "^1.3.4",
     "@react-pdf/renderer": "^3.1.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12751,19 +12751,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mozilla/glean@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "@mozilla/glean@npm:5.0.2"
-  dependencies:
-    fflate: ^0.8.0
-    tslib: ^2.3.1
-    uuid: ^9.0.0
-  bin:
-    glean: dist/cli/cli.js
-  checksum: 36eb6e3fb92740d2a03c562063858e9d699406bb2853b5b4375dcc60d4b892fa1569f7bc97c36ed77b9c7ef94eb58e52138a035a7237c8e0ac13a4c8d0e9af05
-  languageName: node
-  linkType: hard
-
 "@mozilla/glean@npm:^5.0.3":
   version: 5.0.3
   resolution: "@mozilla/glean@npm:5.0.3"
@@ -39875,7 +39862,6 @@ fsevents@~2.1.1:
     "@emotion/react": ^11.11.1
     "@emotion/styled": ^11.13.0
     "@material-ui/core": v5.0.0-alpha.24
-    "@mozilla/glean": ^5.0.2
     "@pmmmwh/react-refresh-webpack-plugin": ^0.5.3
     "@reach/router": ^1.3.4
     "@react-pdf/renderer": ^3.1.12


### PR DESCRIPTION
## Because

* Glean metrics were not emitted for settings with a console error

## This pull request

* Remove glean from fxa-settings dependencies as follow-up to PR-17470

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
