### PR TITLE
fix(settings): Ensure product promo glean view event is only emitted …

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
@@ -6,9 +6,6 @@ import React from 'react';
 import ProductPromo, { ProductPromoProps, ProductPromoType } from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { AppContext } from '../../../models';
-import { mockAppContext } from '../../../models/mocks';
-import { MozServices } from '../../../lib/types';
 
 export default {
   title: 'Components/Settings/ProductPromo',
@@ -16,57 +13,29 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-const storyWithProps = (
-  props: ProductPromoProps,
-  account: any,
-  storyName?: string
-) => {
-  const story = () => (
-    <AppContext.Provider
-      value={mockAppContext({
-        account,
-      })}
-    >
-      <ProductPromo {...props} />
-    </AppContext.Provider>
-  );
+const storyWithProps = (props: ProductPromoProps, storyName?: string) => {
+  const story = () => <ProductPromo {...props} />;
 
   if (storyName) story.storyName = storyName;
   return story;
 };
 
-export const SettingsWithNoMonitor = storyWithProps(
+export const MonitorFreeSettings = storyWithProps(
   { type: ProductPromoType.Settings },
-  {
-    attachedClients: [],
-    subscriptions: [],
-  },
-  'Settings, user does not have Monitor (mobile only, resize window)'
+  'MonitorFree promo (Settings, mobile only, resize window)'
 );
 
-export const SidebarWithNoMonitor = storyWithProps(
+export const MonitorFreeSidebar = storyWithProps(
   { type: ProductPromoType.Sidebar },
-  {
-    attachedClients: [],
-    subscriptions: [],
-  },
-  'Sidebar, user does not have Monitor (resize window)'
+  'MonitorFree promo (Sidebar, resize window)'
 );
 
-export const SettingsWithMonitorNoPlus = storyWithProps(
-  { type: ProductPromoType.Settings, monitorPlusEnabled: true },
-  {
-    attachedClients: [{ name: MozServices.Monitor }],
-    subscriptions: [],
-  },
-  'Settings, user has Monitor but not Plus, MonitorPlus enabled (mobile only, resize window)'
+export const MonitorPlusSettings = storyWithProps(
+  { type: ProductPromoType.Settings, showMonitorPlusPromo: true },
+  'MonitorPlus promo (Settings, mobile only, resize window)'
 );
 
-export const SidebarWithMonitorNoPlus = storyWithProps(
-  { type: ProductPromoType.Sidebar, monitorPlusEnabled: true },
-  {
-    attachedClients: [{ name: MozServices.Monitor }],
-    subscriptions: [],
-  },
-  'Sidebar, user has Monitor but not Plus, MonitorPlus enabled (resize window)'
+export const MonitorPlusSidebar = storyWithProps(
+  { type: ProductPromoType.Sidebar, showMonitorPlusPromo: true },
+  'MonitorPlus promo (Sidebar, resize window)'
 );

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
@@ -7,47 +7,29 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import monitorTextLogo from './monitor-text-logo.svg';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import classNames from 'classnames';
-import { MozServices } from '../../../lib/types';
-import { useAccount, useConfig } from '../../../models';
+import { useConfig } from '../../../models';
 import { constructHrefWithUtm } from '../../../lib/utilities';
 import { LINK } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
+import { GleanPingMetrics } from 'fxa-shared/metrics/glean/web';
 
 export enum ProductPromoType {
   Sidebar = 'sidebar',
   Settings = 'settings',
 }
 
-// TODO, remove this and logic. This is temporary until we work out the UX for
-// this. This was left configurable via props for tests and storybook.
-const MONITOR_PLUS_ENABLED = false;
-
 export interface ProductPromoProps {
+  gleanEvent?: GleanPingMetrics;
+  showMonitorPlusPromo?: boolean;
   type?: ProductPromoType;
-  monitorPlusEnabled?: boolean;
 }
 
 export const ProductPromo = ({
+  gleanEvent,
+  showMonitorPlusPromo = false,
   type = ProductPromoType.Sidebar,
-  monitorPlusEnabled = MONITOR_PLUS_ENABLED,
 }: ProductPromoProps) => {
-  const { attachedClients, subscriptions } = useAccount();
   const { env } = useConfig();
-
-  const hasMonitor = attachedClients.some(
-    ({ name }) => name === MozServices.Monitor
-  );
-
-  const hasMonitorPlus = subscriptions.some(
-    ({ productName }) => productName === MozServices.MonitorPlus
-  );
-
-  const showMonitorPlusPromo =
-    hasMonitor && !hasMonitorPlus && monitorPlusEnabled;
-
-  if (hasMonitor && !showMonitorPlusPromo) {
-    return <></>;
-  }
 
   const monitorPromoLink = constructHrefWithUtm(
     env === 'stage' ? LINK.MONITOR_STAGE : LINK.MONITOR,
@@ -66,12 +48,6 @@ export const ProductPromo = ({
     'monitor-plus',
     'settings-promo'
   );
-
-  const gleanEvent = showMonitorPlusPromo
-    ? { event: { reason: 'plus' } }
-    : { event: { reason: 'free' } };
-
-  GleanMetrics.accountPref.promoMonitorView(gleanEvent);
 
   const promoContent = showMonitorPlusPromo ? (
     <>

--- a/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
@@ -4,7 +4,10 @@
 
 import React from 'react';
 import Nav, { NavRefProps } from '../Nav';
-import ProductPromo, { ProductPromoType } from '../ProductPromo';
+import ProductPromo, {
+  ProductPromoProps,
+  ProductPromoType,
+} from '../ProductPromo';
 
 export const SideBar = ({
   profileRef,
@@ -12,7 +15,10 @@ export const SideBar = ({
   connectedServicesRef,
   linkedAccountsRef,
   dataCollectionRef,
-}: NavRefProps) => {
+  gleanEvent,
+  showMonitorPromo = false,
+  showMonitorPlusPromo = false,
+}: NavRefProps & ProductPromoProps & { showMonitorPromo?: boolean }) => {
   // top-[7.69rem] allows the sticky nav header to align exactly with first section heading
   return (
     <div className="fixed desktop:sticky desktop:top-[7.69rem] inset-0 bg-white desktop:bg-transparent w-full mt-19 desktop:mt-0">
@@ -25,7 +31,12 @@ export const SideBar = ({
           dataCollectionRef,
         }}
       />
-      <ProductPromo type={ProductPromoType.Sidebar} />
+      {showMonitorPromo && (
+        <ProductPromo
+          type={ProductPromoType.Sidebar}
+          {...{ gleanEvent, showMonitorPlusPromo }}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Because

* account_pref_promo_monitor_view event was emitted multiple times on load of the settings page because of re-renders and because the component is included twice (in sidebar and in main settings page)

## This pull request

* Move the Glean event logic to the Settings page level

## Issue that this pull request solves

Closes: #* Move the Glean event logic to the Settings page level

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
