### PR TITLE
fix(payments-stripe): Revises SubscriptionManager.update()

### DIFF
--- a/libs/payments/stripe/src/lib/subscription.manager.ts
+++ b/libs/payments/stripe/src/lib/subscription.manager.ts
@@ -8,6 +8,7 @@ import { Stripe } from 'stripe';
 import { StripeClient } from './stripe.client';
 import { StripeSubscription } from './stripe.client.types';
 import { ACTIVE_SUBSCRIPTION_STATUSES } from './stripe.constants';
+import { STRIPE_CUSTOMER_METADATA } from './stripe.types';
 
 @Injectable()
 export class SubscriptionManager {
@@ -32,6 +33,19 @@ export class SubscriptionManager {
     subscriptionId: string,
     params?: Stripe.SubscriptionUpdateParams
   ) {
+    if (params?.metadata) {
+      const newMetadata = params.metadata;
+      Object.keys(newMetadata).forEach((key) => {
+        if (
+          !Object.values(STRIPE_CUSTOMER_METADATA).includes(
+            key as STRIPE_CUSTOMER_METADATA
+          )
+        ) {
+          throw new Error(`Invalid metadata key: ${key}`);
+        }
+      });
+    }
+
     return this.stripeClient.subscriptionsUpdate(subscriptionId, params);
   }
 


### PR DESCRIPTION
## This pull request

- revises `SubscriptionManager.update()` to set metadata only if keys are included in `STRIPE_CUSTOMER_METADATA`

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
