### PR TITLE
fix(docker): using inputs.<input> for workflow input validation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
       - id: determine
         run: |
           # workflow_dispatch
-          if [[ "${{ github.event.inputs.git_tag }}" != "" ]]; then
+          if [[ "${{ inputs.git_tag }}" != "" ]]; then
             echo "tag=${{ github.event.inputs.git_tag }}" >> $GITHUB_OUTPUT
           # push
           elif [[ "${{ github.ref }}" != "" ]]; then


### PR DESCRIPTION
## Because
- This job did not successfully detect the `git_tag` input when called as a `workflow_call` event: https://github.com/mozilla/fxa/actions/runs/10600680735/job/29378760414

## This pull request
- This changes the input validation from `github.event.inputs.git_tag` to `inputs.git_tag`. The latter appears to pick up inputs from `workflow_call`, `workflow_dispatch` triggers: https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context

## Issue that this pull request solves

Closes: N/A (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
