### PR TITLE
bug(graphql): Fix url for legal docs being fetched by graphql

### DIFF
--- a/packages/fxa-graphql-api/src/backend/legal.service.spec.ts
+++ b/packages/fxa-graphql-api/src/backend/legal.service.spec.ts
@@ -58,7 +58,9 @@ describe('#unit - LegalService', () => {
     const MockConfig: Provider = {
       provide: ConfigService,
       useValue: {
-        get: jest.fn().mockReturnValue('http://localhost:3030'),
+        get: jest
+          .fn()
+          .mockReturnValue('http://localhost:3030/settings/legal-docs'),
       },
     };
     const module: TestingModule = await Test.createTestingModule({

--- a/packages/fxa-graphql-api/src/backend/legal.service.ts
+++ b/packages/fxa-graphql-api/src/backend/legal.service.ts
@@ -8,16 +8,14 @@ import { AppConfig } from '../config';
 import { determineLocale } from '@fxa/shared/l10n';
 import { Injectable } from '@nestjs/common';
 
-const LEGAL_DOCS_PATH = '/settings/legal-docs';
-
 @Injectable()
 export class LegalService {
-  private settingsUrl: string;
+  private legalDocsUrl: string;
 
   constructor(configService: ConfigService<AppConfig>) {
-    this.settingsUrl = configService.get(
-      'settingsUrl'
-    ) as AppConfig['settingsUrl'];
+    this.legalDocsUrl = configService.get(
+      'legalDocsUrl'
+    ) as AppConfig['legalDocsUrl'];
   }
 
   public async getDoc(locale: string, file: string) {
@@ -49,7 +47,7 @@ export class LegalService {
   }
 
   private async tryGetDoc(locale: string, file: string) {
-    const url = `${this.settingsUrl}${LEGAL_DOCS_PATH}/${locale}/${file}.md`;
+    const url = `${this.legalDocsUrl}/${locale}/${file}.md`;
     const resp = await fetch(url);
     const resText = await resp.text();
 
@@ -61,7 +59,7 @@ export class LegalService {
   }
 
   private async getAvailableLocales(file: string) {
-    const url = `${this.settingsUrl}${LEGAL_DOCS_PATH}/${file}_locales.json`;
+    const url = `${this.legalDocsUrl}/${file}_locales.json`;
     const response = await fetch(`${url}`);
 
     if (!response.ok) {

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -58,6 +58,11 @@ const conf = convict({
     default: 'http://localhost:3030',
     env: 'SETTINGS_SERVER_URL',
   },
+  legalDocsUrl: {
+    doc: 'Where legal docs reside',
+    default: 'http://localhost:3030/settings/legal-docs',
+    env: 'SETTINGS_LEGAL_DOCS_URL',
+  },
   database: {
     mysql: {
       auth: makeMySQLConfig('AUTH', 'fxa'),


### PR DESCRIPTION
## Because

- Legal docs weren't loading after switching to the CDN

## This pull request

- Adjust the path where legal docs reside

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

*Imortant!* This will also need web-infra change.
