### PR TITLE
task(content,settings): Reference l10n files on CDN

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -39,6 +39,10 @@ const settingsConfig = {
   env,
   version: config.get('version'),
   marketingEmailPreferencesUrl: config.get('marketing_email.preferences_url'),
+  l10n: {
+    strict: false,
+    baseUrl: config.get('l10n.baseUrl'),
+  },
   metrics: {
     navTiming: {
       enabled: config.get('statsd.enabled'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -997,6 +997,13 @@ const conf = (module.exports = convict({
     doc: 'The path where deployment specific resources will be sought (keys, etc), and logs will be kept.',
     env: 'VAR_PATH',
   },
+  l10n: {
+    baseUrl: {
+      default: '/settings/locales',
+      doc: 'The path (or url) where ftl files are held.',
+      env: 'L10N_BASE_URL',
+    },
+  },
 }));
 
 // At the time this file is required, we'll determine the "process name" for this proc

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -54,7 +54,7 @@ try {
   render(
     <React.StrictMode>
       <AppLocalizationProvider
-        baseDir="/settings/locales"
+        baseDir={config.l10n.baseUrl}
         userLocales={navigator.languages}
       >
         <AppErrorBoundary>

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -10,6 +10,7 @@ export interface Config {
   env: string;
   l10n: {
     strict: boolean;
+    baseUrl: string;
   };
   marketingEmailPreferencesUrl: string;
   metrics: {
@@ -96,6 +97,7 @@ export function getDefault() {
     env: 'development',
     l10n: {
       strict: false,
+      baseUrl: '/settings/locales',
     },
     marketingEmailPreferencesUrl: 'https://basket.mozilla.org/fxa/',
     metrics: {


### PR DESCRIPTION
## Because

- With the CDN changes, l10n was broken
- We want to reference .ftl on the cdn

## This pull request

- Adds config so we can target the location of the l10n files

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

*Important!* There are accompanying web-infra changes required for these changes.
