### PR TITLE
fix(Glean): use the configured app channel for Glean in Settings

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -218,7 +218,7 @@ describe('glean', () => {
         ...config.glean,
         enabled: mockMetricsQueryAccountGlean.metricsEnabled,
         appDisplayVersion: config.version,
-        channel: config.glean.channel,
+        appChannel: config.glean.appChannel,
       },
       {
         metricsFlow: updatedFlowQueryParams,

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -173,7 +173,7 @@ export const App = ({
         ...config.glean,
         enabled: metricsEnabled,
         appDisplayVersion: config.version,
-        channel: config.glean.channel,
+        appChannel: config.glean.appChannel,
       },
       {
         metricsFlow,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -72,7 +72,7 @@ export interface Config {
     applicationId: string;
     uploadEnabled: boolean;
     appDisplayVersion: string;
-    channel: string;
+    appChannel: string;
     serverEndpoint: string;
     logPings: boolean;
     debugViewTag: string;
@@ -153,7 +153,7 @@ export function getDefault() {
       enabled: false,
       applicationId: 'accounts_frontend_dev',
       uploadEnabled: true,
-      channel: 'development',
+      appChannel: 'development',
       serverEndpoint: 'https://incoming.telemetry.mozilla.org',
       logPings: false,
       debugViewTag: '',

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -38,7 +38,7 @@ const mockConfig: Config['glean'] = {
   applicationId: 'testo',
   uploadEnabled: true,
   appDisplayVersion: '9001',
-  channel: 'test',
+  appChannel: 'test',
   serverEndpoint: 'https://metrics.example.io/',
   logPings: false,
   debugViewTag: '',
@@ -195,7 +195,7 @@ describe('lib/glean', () => {
         mockConfig.uploadEnabled,
         {
           appDisplayVersion: mockConfig.appDisplayVersion,
-          channel: mockConfig.channel,
+          channel: mockConfig.appChannel,
           serverEndpoint: mockConfig.serverEndpoint,
           enableAutoPageLoadEvents: true,
           enableAutoElementClickEvents: true,

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -539,7 +539,7 @@ export const GleanMetrics: Pick<
       if (config.enabled) {
         Glean.initialize(config.applicationId, config.uploadEnabled, {
           appDisplayVersion: config.appDisplayVersion,
-          channel: config.channel,
+          channel: config.appChannel,
           serverEndpoint: config.serverEndpoint,
           enableAutoPageLoadEvents: true,
           enableAutoElementClickEvents: true,

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -7,7 +7,7 @@ export type GleanMetricsConfig = {
   applicationId: string;
   uploadEnabled: boolean;
   appDisplayVersion: string;
-  channel: string;
+  appChannel: string;
   serverEndpoint: string;
   logPings: boolean;
   debugViewTag: string;


### PR DESCRIPTION
Because:
 - Glean in Settings was initialized with the default "development" value

This commit:
 - uses the actual configuration value for the app channel

You can verify this locally by setting `GLEAN_APP_CHANNEL` to something other than "development".