### PR TITLE
feat(sync): Add initial feature flag for setting up recovery code after Sync sign-in

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -65,6 +65,7 @@
   },
   "featureFlags": {
     "sendFxAStatusOnSettings": true,
-    "resetPasswordWithCode": true
+    "resetPasswordWithCode": true,
+    "recoveryCodeSetupOnSyncSignIn": true
   }
 }

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -103,6 +103,9 @@ const settingsConfig = {
   featureFlags: {
     keyStretchV2: config.get('featureFlags.keyStretchV2'),
     resetPasswordWithCode: config.get('featureFlags.resetPasswordWithCode'),
+    recoveryCodeSetupOnSyncSignIn: config.get(
+      'featureFlags.recoveryCodeSetupOnSyncSignIn'
+    ),
   },
 };
 

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -232,6 +232,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_RESET_PWD_WITH_CODE',
     },
+    recoveryCodeSetupOnSyncSignIn: {
+      default: false,
+      doc: 'Enables setting up a recovery code after a Sync sign in',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN',
+    },
   },
   showReactApp: {
     emailFirstRoutes: {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -89,6 +89,7 @@ export interface Config {
   featureFlags?: {
     keyStretchV2?: boolean;
     resetPasswordWithCode?: boolean;
+    recoveryCodeSetupOnSyncSignIn?: boolean;
   };
 }
 
@@ -166,6 +167,7 @@ export function getDefault() {
     },
     featureFlags: {
       resetPasswordWithCode: false,
+      recoveryCodeSetupOnSyncSignIn: false,
     },
   } as Config;
 }


### PR DESCRIPTION
## Because

- This needs a feature flag

## This pull request

- Adds the feature flag

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10077

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
