### PR TITLE
chore(functional_test): update config to run merge reports even when tests fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,14 +341,19 @@ commands:
       - run:
           name: Ensure directories
           command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots
+          when: always
       - store_artifacts:
           path: artifacts
+          when: always
       - store_artifacts:
           path: ~/screenshots
+          when: always
       - store_artifacts:
           path: ~/.pm2/logs
+          when: always
       - store_test_results:
           path: artifacts/tests
+          when: always
 
   rename-reports:
     steps:
@@ -367,6 +372,7 @@ commands:
             else
               echo "No report.zip found, skipping rename for this node."
             fi
+            echo "$CIRCLE_WORKFLOW_JOB_ID" > job_id.txt
             echo "Listing contents after renaming:"
             ls -la
           when: always
@@ -721,6 +727,47 @@ jobs:
       - store-artifacts
       - rename-reports
 
+  check-required-jobs-complete:
+    docker:
+      - image: circleci/node
+    resource_class: small
+    steps:
+      - run:
+          name: Wait for required jobs to complete
+          command: |
+            sleep 30
+            mkdir -p artifacts/blob-report
+            while true; do
+              RESPONSE=$(curl -s --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CCI_Token")
+              FUNCTIONAL_TEST_JOB_ID=$(echo $RESPONSE | jq -r '.items[] | select(.status == "running") | select(.name | startswith("Functional Tests")) | .id')
+              if [[ -e artifacts/blob-report/functional_test_job_id.txt ]]; then
+                echo "Job id already set"
+              elif [[ -n "$FUNCTIONAL_TEST_JOB_ID" ]]; then
+                echo "Storing job id, $FUNCTIONAL_TEST_JOB_ID, for later lookup."
+                echo $FUNCTIONAL_TEST_JOB_ID > artifacts/blob-report/functional_test_job_id.txt
+              else
+                echo "No job id located. ($FUNCTIONAL_TEST_JOB_ID)"
+              fi
+              JOB_STATUS=$(echo $RESPONSE | jq -r '.items[] | .name + "-" + .status')
+              echo "ALL JOB_STATUS:"
+              echo $JOB_STATUS
+              PENDING=$(echo $RESPONSE | jq -r '.items[] | select(.status == "blocked" or .status == "running" or .status == "not_running") | select(.name | startswith("Tests Complete") | not) | select(.name | startswith("Merge Playwright Reports") | not) | select(.name | startswith("Check all required jobs are complete") | not ) | .name')
+              echo "PENDING JOBS OF INTEREST:"
+              echo $PENDING
+              if [[ -z "$PENDING" ]]; then
+                echo "All required jobs have now completed"
+                exit 0
+              else
+                echo "Still waiting for jobs to complete..."
+                sleep 1
+              fi
+            done
+      - persist_to_workspace:
+          root: /home/circleci/project
+          paths:
+            - artifacts/blob-report
+          when: always
+
   playwright-functional-test-report:
     executor: default-executor
     steps:
@@ -730,25 +777,39 @@ jobs:
           name: Merge blob Reports
           command: |
             cd artifacts/blob-report
-            echo "Merging blob reports"
-            ls -l
+            JOB_ID=$(cat functional_test_job_id.txt)
+            echo "Fetching reports from circle ci artifact storarge for $JOB_ID"
+            function fetch_report() {
+              echo "Fetching reports-$1.zip"
+              wget https://output.circle-artifacts.com/output/job/${JOB_ID}/artifacts/$1/artifacts/blob-report/reports-$1.zip
+              wgetreturn=$?
+              if [[ $wgetreturn -ne 0 ]]; then
+                echo "Failed to get reports-$1.zip"
+              fi
+            }
+            for i in $(seq 0 7); do
+              fetch_report $i
+            done
+
+            echo "Fetched all reports"
+
             if ls *.zip 1> /dev/null 2>&1; then
+              echo "Merging blob reports"
               npx playwright merge-reports --reporter=blob .
             else
-              echo "No report zip files found, skipping blob merge."
+              echo "No report zip files found, skipping merge."
             fi
       - store_artifacts:
-          path: blob-report
+          path: artifacts/blob-report
       - run:
-          name: Merge html Reports
+          name: Merge HTML Reports
           command: |
             cd artifacts/blob-report
-            echo "Merging HTML reports"
-            ls -l
             if ls *.zip 1> /dev/null 2>&1; then
+              echo "Merging HTML reports"
               npx playwright merge-reports --reporter=html .
             else
-              echo "No report zip files found, skipping HTML merge."
+              echo "No report zip files found, skipping merge."
             fi
       - store_artifacts:
           path: playwright-report
@@ -858,6 +919,10 @@ workflows:
           projects: --exclude '*,!tag:scope:shared:*'
           requires:
             - Build (PR)
+      - check-required-jobs-complete:
+          name: Check all required jobs are complete (PR)
+          requires:
+            - Build (PR)
       - playwright-functional-tests:
           name: Functional Tests - Playwright (PR)
           resource_class: xlarge
@@ -867,7 +932,7 @@ workflows:
       - playwright-functional-test-report:
           name: Merge Playwright Reports (PR)
           requires:
-            - Functional Tests - Playwright (PR)
+            - Check all required jobs are complete (PR)
       - build-and-deploy-storybooks:
           name: Deploy Storybooks (PR)
           requires:
@@ -887,6 +952,7 @@ workflows:
             - Integration Test - Libraries (PR)
             - Functional Tests - Playwright (PR)
             - Deploy Storybooks (PR)
+            - Check all required jobs are complete (PR)
 
   # Triggered remotely. See .circleci/README.md
   production_smoke_tests:


### PR DESCRIPTION
## Because

- Currently CircleCI doesn't let jobs with `require` parameter to be executed when the previous job fails with a failed status. But we needed to find a workaround for this to be able to generate HTML reports.
- A detailed explanation of the whole workaround is added on FXA-10298

## This pull request

- Created a `waiter` job that will check for all the required job's status and when it's complete it executes the dependent job.
- The `waiter` job is called `check-required-jobs-complete` and the dependent job is `playwright-functional-test-report`


## Issue that this pull request solves

Closes: FXA-10298

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There are a few pieces left that will be covered in separate tickets:
- Currently after a test fails, and when re-run from failed is triggered, the merge reports won't run a second time and as it's already marked success for the first run, so technically it isn't failed.
- These needs to be integrated for Nightly and Stage/Prod smoke tests too. Currently we are integrating it just for test pull requests with this PR.(#FXA-10393)

This is the screenshot:

<img width="1135" alt="Screenshot 2024-09-06 at 9 31 56 AM" src="https://github.com/user-attachments/assets/d5192d26-e712-4ea6-84fb-e5a80152c0ff">

<img width="1435" alt="Screenshot 2024-09-06 at 9 32 06 AM" src="https://github.com/user-attachments/assets/a0b93f15-24c8-4558-b2cf-10bbf82bfa46">

<img width="1108" alt="Screenshot 2024-09-06 at 9 32 14 AM" src="https://github.com/user-attachments/assets/588a1001-5fc2-4362-9170-f052abedb5c0">


