### PR TITLE
fix(auth): missing profile client references

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -33,9 +33,8 @@ import {
   appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO,
   playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO,
 } from '../payments/iap/iap-formatter';
-import { PayPalHelper } from '../payments/paypal/helper';
 import { StripeHelper } from '../payments/stripe';
-import { AuthLogger, AuthRequest, ProfileClient } from '../types';
+import { AuthLogger, AuthRequest } from '../types';
 import { deleteAccountIfUnverified } from './utils/account';
 import emailUtils from './utils/email';
 import requestHelper from './utils/request_helper';
@@ -45,6 +44,7 @@ import { gleanMetrics } from '../metrics/glean';
 import { AccountDeleteManager } from '../account-delete';
 import { uuidTransformer } from 'fxa-shared/db/transformers';
 import { AccountTasks, ReasonForDeletion } from '@fxa/shared/cloud-tasks';
+import { ProfileClient } from '@fxa/profile/client';
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -58,7 +58,6 @@ const MS_ONE_MONTH = MS_ONE_DAY * 30;
 export class AccountHandler {
   private OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS: Set<string>;
 
-  private paypalHelper?: PayPalHelper;
   private otpUtils: any;
   private otpOptions: ConfigType['otp'];
   private skipConfirmationForEmailAddresses: string[];
@@ -94,12 +93,6 @@ export class AccountHandler {
 
     this.otpOptions = config.otp;
 
-    if (
-      stripeHelper &&
-      config.subscriptions?.paypalNvpSigCredentials?.enabled
-    ) {
-      this.paypalHelper = Container.get(PayPalHelper);
-    }
     this.capabilityService = Container.get(CapabilityService);
     this.accountEventsManager = Container.get(AccountEventsManager);
     this.accountDeleteManager = Container.get(AccountDeleteManager);

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -32,8 +32,9 @@ const {
 const {
   deleteAccountIfUnverified,
 } = require('../../../lib/routes/utils/account');
-const { AppConfig, AuthLogger, ProfileClient } = require('../../../lib/types');
+const { AppConfig, AuthLogger } = require('../../../lib/types');
 const defaultConfig = require('../../../config').default.getProperties();
+const { ProfileClient } = require('@fxa/profile/client');
 const glean = mocks.mockGlean();
 const profile = mocks.mockProfile();
 


### PR DESCRIPTION
## Because

- Some code was still referencing the auth-server profile client

## This pull request

- Update code to reference the profile client library

## Issue that this pull request solves

Closes: #FXA-10389

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).