### PR TITLE
chore(l10n): Replace hardcoded Firefox with brand term

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/en.ftl
@@ -3,6 +3,6 @@
 
 signin-push-code-heading-w-default-service = Verify this login <span>to continue to account settings</span>
 signin-push-code-heading-w-custom-service = Verify this login <span>to continue to { $serviceName }</span>
-signin-push-code-instruction = Please check your other devices and approve this login from your Firefox browser.
+signin-push-code-instruction = Please check your other devices and approve this login from your { -brand-firefox } browser.
 signin-push-code-did-not-recieve = Didn’t receive the notification?
 signin-push-code-send-email-link = Email code


### PR DESCRIPTION
## Because:

- A string landed with a hard coded brand term for Firefox

## This pull request

- Replaces the hardcoded string with the correct brand term

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).