### PR TITLE
feat(next): add sentry to payments-next

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,6 @@ tmp
 # shared-cms
 libs/shared/cms/src/__generated__/graphql.d.ts
 libs/shared/cms/src/__generated__/graphql.js
+
+# Sentry Config File
+.env.sentry-build-plugin

--- a/apps/payments/next/.env.development
+++ b/apps/payments/next/.env.development
@@ -79,5 +79,18 @@ STATS_D_CONFIG__PREFIX=
 CSP__ACCOUNTS_STATIC_CDN=https://accounts-static.cdn.mozilla.net
 CSP__PAYPAL_API='https://www.sandbox.paypal.com'
 
+# Sentry Config
+SENTRY__SERVER_NAME=fxa-payments-next-server
+SENTRY__AUTH_TOKEN=
+
 # Other
 CONTENT_SERVER_URL=http://localhost:3030
+
+# Nextjs Public Environment Variables
+
+# Sentry Config
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_ENV=local
+NEXT_PUBLIC_SENTRY_CLIENT_NAME=fxa-payments-next-client
+NEXT_PUBLIC_SENTRY_SAMPLE_RATE=1
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=1

--- a/apps/payments/next/.env.production
+++ b/apps/payments/next/.env.production
@@ -75,5 +75,18 @@ STATS_D_CONFIG__PREFIX=
 CSP__ACCOUNTS_STATIC_CDN=https://accounts-static.cdn.mozilla.net
 CSP__PAYPAL_API='https://www.paypal.com'
 
+# Sentry Config
+SENTRY__SERVER_NAME=fxa-payments-next-server
+SENTRY__AUTH_TOKEN=
+
 # Other
 CONTENT_SERVER_URL=https://accounts.firefox.com
+
+# Nextjs Public Environment Variables
+
+# Sentry Config
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_SENTRY_ENV=prod
+NEXT_PUBLIC_SENTRY_CLIENT_NAME=fxa-payments-next-client
+NEXT_PUBLIC_SENTRY_SAMPLE_RATE=1
+NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=1

--- a/apps/payments/next/app/global-error.tsx
+++ b/apps/payments/next/app/global-error.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import NextError from 'next/error';
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        {/* `NextError` is the default Next.js error page component. Its type
+        definition requires a `statusCode` prop. However, since the App Router
+        does not expose status codes for errors, we simply pass 0 to render a
+        generic error message. */}
+        <NextError statusCode={0} />
+      </body>
+    </html>
+  );
+}

--- a/apps/payments/next/config/index.ts
+++ b/apps/payments/next/config/index.ts
@@ -1,7 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import 'reflect-metadata';
 import 'server-only';
 import { Type } from 'class-transformer';
-import { IsString, ValidateNested, IsDefined, IsUrl } from 'class-validator';
+import {
+  IsString,
+  ValidateNested,
+  IsDefined,
+  IsUrl,
+  IsNumber,
+  IsOptional,
+} from 'class-validator';
 import {
   RootConfig as NestAppRootConfig,
   validate,
@@ -18,6 +29,14 @@ class CspConfig {
 class PaypalConfig {
   @IsString()
   clientId!: string;
+}
+
+class SentryServerConfig {
+  @IsString()
+  serverName!: string;
+
+  @IsString()
+  authToken!: string;
 }
 
 class AuthJSConfig {
@@ -47,6 +66,11 @@ export class PaymentsNextConfig extends NestAppRootConfig {
   @IsDefined()
   csp!: CspConfig;
 
+  @Type(() => SentryServerConfig)
+  @ValidateNested()
+  @IsDefined()
+  sentry!: SentryServerConfig;
+
   @IsString()
   authSecret!: string;
 
@@ -55,6 +79,29 @@ export class PaymentsNextConfig extends NestAppRootConfig {
 
   @IsUrl({ require_tld: false })
   contentServerUrl!: string;
+
+  /**
+   * Nextjs Public Environment Variables
+   */
+
+  /**
+   * Sentry Config
+   */
+  @IsOptional()
+  @IsString()
+  nextPublicSentryDsn?: string;
+
+  @IsString()
+  nextPublicSentryEnv!: string;
+
+  @IsString()
+  nextPublicSentryClientName!: string;
+
+  @IsNumber()
+  nextPublicSentrySampleRate!: number;
+
+  @IsNumber()
+  nextPublicSentryTracesSampleRate!: number;
 }
 
 export const config = validate(process.env, PaymentsNextConfig);

--- a/apps/payments/next/instrumentation.ts
+++ b/apps/payments/next/instrumentation.ts
@@ -1,5 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
     const { getApp } = await import('@fxa/payments/ui/server');
 
     await getApp().initialize();

--- a/apps/payments/next/next.config.js
+++ b/apps/payments/next/next.config.js
@@ -6,6 +6,7 @@
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { composePlugins, withNx } = require('@nx/next');
+const { withSentryConfig } = require('@sentry/nextjs');
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -22,6 +23,8 @@ const nextConfig = {
       '@nestjs/core',
       '@nestjs/common',
       '@nestjs/websockets',
+      '@nestjs/graphql',
+      '@nestjs/mapped-types',
       'class-transformer',
       'class-validator',
       'hot-shots',
@@ -50,9 +53,54 @@ const nextConfig = {
   },
 };
 
+/**
+ * @type {import('@sentry/nextjs').SentryBuildOptions}
+ **/
+const sentryOptions = {
+  // For all available options, see:
+  // https://github.com/getsentry/sentry-webpack-plugin#options
+
+  org: "mozilla",
+  project: "fxa-payments-next",
+
+  // Enable source maps
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
+  // Only print logs for uploading source maps in CI
+  silent: !process.env.CI,
+
+  // For all available options, see:
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+
+  // Upload a larger set of source maps for prettier stack traces (increases build time)
+  widenClientFileUpload: true,
+
+  // Automatically annotate React components to show their full name in breadcrumbs and session replay
+  reactComponentAnnotation: {
+    enabled: true,
+  },
+
+  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+  // This can increase your server load as well as your hosting bill.
+  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+  // side errors will fail.
+  tunnelRoute: "/monitoring",
+
+  // Hides source maps from generated client bundles
+  hideSourceMaps: true,
+
+  // Automatically tree-shake Sentry logger statements to reduce bundle size
+  disableLogger: true,
+}
+
+// Use withSentryConfig to wrap the next config
+const sentryEnhancedConfig = (passedConfig) =>
+  withSentryConfig(passedConfig, sentryOptions);
+
 const plugins = [
   // Add more Next.js plugins to this list if needed.
   withNx,
+  sentryEnhancedConfig,
 ];
 
 module.exports = composePlugins(...plugins)(nextConfig);

--- a/apps/payments/next/package.json
+++ b/apps/payments/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payments-next",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "scripts": {
     "start": "next start"
   }

--- a/apps/payments/next/sentry.client.config.ts
+++ b/apps/payments/next/sentry.client.config.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This file configures the initialization of Sentry on the client.
+// The config you add here will be used whenever a users loads a page in their browser.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+import { initSentryForNextjsClient } from '@fxa/shared/sentry/client';
+import { version } from './package.json';
+
+const DEFAULT_SAMPLE_RATE = '1';
+const DEFAULT_TRACES_SAMPLE_RATE = '1';
+
+const sentryConfig = {
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  env: process.env.NEXT_PUBLIC_SENTRY_ENV,
+  clientName: process.env.NEXT_PUBLIC_SENTRY_CLIENT_NAME,
+  sampleRate: parseInt(
+    process.env.NEXT_PUBLIC_SENTRY_SAMPLE_RATE || DEFAULT_SAMPLE_RATE
+  ),
+  tracesSampleRate: parseInt(
+    process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE ||
+      DEFAULT_TRACES_SAMPLE_RATE
+  ),
+};
+
+initSentryForNextjsClient({
+  release: version,
+  sentry: sentryConfig,
+});

--- a/apps/payments/next/sentry.server.config.ts
+++ b/apps/payments/next/sentry.server.config.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+import { initSentryForNextjsServer } from '@fxa/shared/sentry';
+import { config } from './config';
+import { version } from './package.json';
+
+const sentryConfig = {
+  dsn: config.nextPublicSentryDsn,
+  env: config.nextPublicSentryEnv,
+  serverName: config.sentry.serverName,
+  sampleRate: config.nextPublicSentrySampleRate,
+  tracesSampleRate: config.nextPublicSentryTracesSampleRate,
+};
+
+initSentryForNextjsServer(
+  {
+    release: version,
+    sentry: sentryConfig,
+  },
+  console
+);

--- a/libs/payments/ui/src/lib/config.utils.ts
+++ b/libs/payments/ui/src/lib/config.utils.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import set from 'set-value';
 import { plainToInstance, ClassConstructor } from 'class-transformer';
 import { validateSync } from 'class-validator';

--- a/libs/shared/sentry/src/client.ts
+++ b/libs/shared/sentry/src/client.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './lib/next/client';

--- a/libs/shared/sentry/src/index.ts
+++ b/libs/shared/sentry/src/index.ts
@@ -8,3 +8,4 @@ export * from './lib/nest/sentry.constants';
 export * from './lib/reporting';
 export * from './lib/node';
 export * from './lib/browser';
+export * from './lib/next/server';

--- a/libs/shared/sentry/src/lib/next/client.ts
+++ b/libs/shared/sentry/src/lib/next/client.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This file configures the initialization of Sentry on the client.
+// The config you add here will be used whenever a users loads a page in their browser.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import * as Sentry from '@sentry/nextjs';
+import { SentryConfigOpts } from '../models/SentryConfigOpts';
+import { buildSentryConfig } from '../config-builder';
+import { Logger } from '../sentry.types';
+import { beforeSend } from '../utils/beforeSend.client';
+
+/**
+ * @@todo - To be worked on in FXA-10398
+ */
+const sentryEnabled = true;
+
+export function initSentryForNextjsClient(
+  config: SentryConfigOpts,
+  log?: Logger
+) {
+  if (!log) {
+    log = console;
+  }
+
+  if (!config?.sentry?.dsn) {
+    log.error('No Sentry dsn provided');
+    return;
+  }
+
+  // We want sentry to be disabled by default... This is because we only emit data
+  // for users that 'have opted in'. A subsequent call to 'enable' is needed to ensure
+  // that sentry events only flow under the proper circumstances.
+  //disable();
+
+  const opts = buildSentryConfig(config, log);
+  try {
+    Sentry.init({
+      ...opts,
+      integrations: [
+        Sentry.browserTracingIntegration({
+          enableInp: true,
+        }),
+      ],
+      beforeSend: function (event: Sentry.ErrorEvent) {
+        return beforeSend(sentryEnabled, opts, event);
+      },
+    });
+  } catch (e) {
+    log.error(e);
+  }
+}

--- a/libs/shared/sentry/src/lib/next/server.ts
+++ b/libs/shared/sentry/src/lib/next/server.ts
@@ -2,22 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/nextjs';
 import { ErrorEvent } from '@sentry/types';
-import { ExtraErrorData } from '@sentry/integrations';
-import { SentryConfigOpts } from './models/SentryConfigOpts';
-import { buildSentryConfig } from './config-builder';
-import { tagFxaName } from './reporting';
-import { Logger } from './sentry.types';
+import { SentryConfigOpts } from '../models/SentryConfigOpts';
+import { buildSentryConfig } from '../config-builder';
+import { Logger } from '../sentry.types';
+import { tagFxaName } from '../utils/tagFxaName';
 
-export type ExtraOpts = {
+type ExtraOpts = {
   integrations?: any[];
   eventFilters?: Array<(event: ErrorEvent, hint: any) => ErrorEvent>;
 };
 
-export type InitSentryOpts = SentryConfigOpts & ExtraOpts;
+type InitSentryOpts = SentryConfigOpts & ExtraOpts;
 
-export function initSentry(config: InitSentryOpts, log: Logger) {
+export function initSentryForNextjsServer(config: InitSentryOpts, log: Logger) {
   if (!config?.sentry?.dsn) {
     log.error('No Sentry dsn provided. Cannot start sentry');
     return;
@@ -40,7 +39,7 @@ export function initSentry(config: InitSentryOpts, log: Logger) {
 
   const integrations = [
     // Default
-    new ExtraErrorData({ depth: 5 }),
+    Sentry.extraErrorDataIntegration({ depth: 5 }),
 
     // Custom Integrations
     ...(config.integrations || []),
@@ -49,7 +48,6 @@ export function initSentry(config: InitSentryOpts, log: Logger) {
   try {
     Sentry.init({
       // Defaults Options
-      instrumenter: 'otel',
       normalizeDepth: 6,
       maxValueLength: 500,
 

--- a/libs/shared/sentry/src/lib/utils/beforeSend.client.spec.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.client.spec.ts
@@ -1,0 +1,137 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { SentryConfigOpts } from '../models/SentryConfigOpts';
+import { beforeSend } from './beforeSend.client';
+import * as Sentry from '@sentry/nextjs';
+
+const config: SentryConfigOpts = {
+  release: 'v0.0.0',
+  sentry: {
+    dsn: 'https://public:private@host:8080/1',
+    env: 'test',
+    clientName: 'fxa-shared-testing',
+    sampleRate: 0,
+  },
+};
+
+const sentryEnabled = true;
+
+describe('beforeSend', () => {
+  it('works without request url', () => {
+    const data = {
+      key: 'value',
+    } as unknown as Sentry.ErrorEvent;
+
+    const resultData = beforeSend(sentryEnabled, config, data);
+
+    expect(data).toEqual(resultData);
+  });
+
+  it('fingerprints errno', () => {
+    const data = {
+      request: {
+        url: 'https://example.com',
+      },
+      tags: {
+        errno: '100',
+      },
+      type: undefined,
+    } as Sentry.ErrorEvent;
+
+    const resultData = beforeSend(sentryEnabled, config, data);
+    expect(resultData?.fingerprint?.[0]).toEqual('errno100');
+    expect(resultData?.level).toEqual('info');
+  });
+
+  it('properly erases sensitive information from url', () => {
+    const url = 'https://accounts.firefox.com/complete_reset_password';
+    const badQuery =
+      '?token=foo&code=bar&email=some%40restmail.net&service=sync';
+    const goodQuery = '?token=VALUE&code=VALUE&email=VALUE&service=sync';
+    const badData = {
+      request: {
+        url: url + badQuery,
+      },
+    } as Sentry.ErrorEvent;
+
+    const goodData = {
+      request: {
+        url: url + goodQuery,
+      },
+    };
+
+    const resultData = beforeSend(sentryEnabled, config, badData);
+    expect(resultData?.request?.url).toEqual(goodData.request.url);
+  });
+
+  it('properly erases sensitive information from referrer', () => {
+    const url = 'https://accounts.firefox.com/complete_reset_password';
+    const badQuery =
+      '?token=foo&code=bar&email=some%40restmail.net&service=sync';
+    const goodQuery = '?token=VALUE&code=VALUE&email=VALUE&service=sync';
+    const badData = {
+      request: {
+        headers: {
+          Referer: url + badQuery,
+        },
+      },
+      type: undefined,
+    } as Sentry.ErrorEvent;
+
+    const goodData = {
+      request: {
+        headers: {
+          Referer: url + goodQuery,
+        },
+      },
+    };
+
+    const resultData = beforeSend(sentryEnabled, config, badData);
+    expect(resultData?.request?.headers?.Referer).toEqual(
+      goodData.request.headers.Referer
+    );
+  });
+
+  it('properly erases sensitive information from abs_path', () => {
+    const url = 'https://accounts.firefox.com/complete_reset_password';
+    const badCulprit = 'https://accounts.firefox.com/scripts/57f6d4e4.main.js';
+    const badAbsPath =
+      'https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=a@a.com&service=sync&resume=barbar';
+    const goodAbsPath =
+      'https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE&service=sync&resume=VALUE';
+    const data = {
+      culprit: badCulprit,
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  abs_path: badAbsPath, // eslint-disable-line camelcase
+                },
+                {
+                  abs_path: badAbsPath, // eslint-disable-line camelcase
+                },
+              ],
+            },
+          },
+        ],
+      },
+      request: {
+        url,
+      },
+      type: undefined,
+    };
+
+    const resultData = beforeSend(sentryEnabled, config, data);
+
+    expect(
+      resultData?.exception?.values?.[0].stacktrace?.frames?.[0].abs_path
+    ).toEqual(goodAbsPath);
+    expect(
+      resultData?.exception?.values?.[0].stacktrace?.frames?.[1].abs_path
+    ).toEqual(goodAbsPath);
+  });
+});

--- a/libs/shared/sentry/src/lib/utils/beforeSend.client.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.client.ts
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Change to @sentry/browser after upgrade to Sentry 8
+import * as Sentry from '@sentry/nextjs';
+import { cleanUpQueryParam } from './cleanUpQueryParam';
+import { SentryConfigOpts } from '../models/SentryConfigOpts';
+import { tagFxaName } from './tagFxaName';
+
+/**
+ * function that gets called before data gets sent to error metrics
+ *
+ * @param {Object} event
+ *  Error object data
+ * @returns {Object} data
+ *  Modified error object data
+ * @private
+ */
+export function beforeSend(
+  sentryEnabled: boolean,
+  opts: SentryConfigOpts,
+  event: Sentry.ErrorEvent
+) {
+  if (sentryEnabled === false) {
+    return null;
+  }
+
+  if (event.request) {
+    if (event.request.url) {
+      event.request.url = cleanUpQueryParam(event.request.url);
+    }
+
+    if (event.tags) {
+      // if this is a known errno, then use grouping with fingerprints
+      // Docs: https://docs.sentry.io/hosted/learn/rollups/#fallback-grouping
+      if (event.tags.errno) {
+        event.fingerprint = ['errno' + (event.tags.errno as number)];
+        // if it is a known error change the error level to info.
+        event.level = 'info';
+      }
+    }
+
+    if (event.exception?.values) {
+      event.exception.values.forEach((value: Sentry.Exception) => {
+        if (value.stacktrace && value.stacktrace.frames) {
+          value.stacktrace.frames.forEach((frame: { abs_path?: string }) => {
+            if (frame.abs_path) {
+              frame.abs_path = cleanUpQueryParam(frame.abs_path); // eslint-disable-line camelcase
+            }
+          });
+        }
+      });
+    }
+
+    if (event.request.headers?.Referer) {
+      event.request.headers.Referer = cleanUpQueryParam(
+        event.request.headers.Referer
+      );
+    }
+  }
+
+  event = tagFxaName(event, opts.sentry?.clientName || opts.sentry?.serverName);
+  return event;
+}

--- a/libs/shared/sentry/src/lib/utils/cleanUpQueryParam.spec.ts
+++ b/libs/shared/sentry/src/lib/utils/cleanUpQueryParam.spec.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { cleanUpQueryParam } from './cleanUpQueryParam';
+
+describe('cleanUpQueryParam', () => {
+  it('properly erases sensitive information', () => {
+    const fixtureUrl1 =
+      'https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=some%40restmail.net';
+    const expectedUrl1 =
+      'https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE';
+    const resultUrl1 = cleanUpQueryParam(fixtureUrl1);
+
+    expect(resultUrl1).toEqual(expectedUrl1);
+  });
+
+  it('properly erases sensitive information, keeps allowed fields', () => {
+    const fixtureUrl2 =
+      'https://accounts.firefox.com/signup?client_id=foo&service=sync';
+    const expectedUrl2 =
+      'https://accounts.firefox.com/signup?client_id=foo&service=sync';
+    const resultUrl2 = cleanUpQueryParam(fixtureUrl2);
+
+    expect(resultUrl2).toEqual(expectedUrl2);
+  });
+
+  it('properly returns the url when there is no query', () => {
+    const expectedUrl = 'https://accounts.firefox.com/signup';
+    const resultUrl = cleanUpQueryParam(expectedUrl);
+
+    expect(resultUrl).toEqual(expectedUrl);
+  });
+});

--- a/libs/shared/sentry/src/lib/utils/cleanUpQueryParam.ts
+++ b/libs/shared/sentry/src/lib/utils/cleanUpQueryParam.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Query parameters we allow to propagate to sentry
+ */
+const ALLOWED_QUERY_PARAMETERS = [
+  'automatedBrowser',
+  'client_id',
+  'context',
+  'entrypoint',
+  'keys',
+  'migration',
+  'redirect_uri',
+  'scope',
+  'service',
+  'setting',
+  'style',
+];
+
+/**
+ * Overwrites sensitive query parameters with a dummy value.
+ *
+ * @param url
+ * @returns url
+ */
+export function cleanUpQueryParam(url = '') {
+  const urlObj = new URL(url);
+
+  if (!urlObj.search.length) {
+    return url;
+  }
+
+  // Iterate the search parameters.
+  urlObj.searchParams.forEach((_, key) => {
+    if (!ALLOWED_QUERY_PARAMETERS.includes(key)) {
+      // if the param is a PII (not allowed) then reset the value.
+      urlObj.searchParams.set(key, 'VALUE');
+    }
+  });
+
+  return urlObj.href;
+}

--- a/libs/shared/sentry/src/lib/utils/tagFxaName.ts
+++ b/libs/shared/sentry/src/lib/utils/tagFxaName.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** Adds fxa.name to data.tags */
+export function tagFxaName(data: any, name?: string) {
+  data.tags = data.tags || {};
+  data.tags['fxa.name'] = name || 'unknown';
+  return data;
+}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@radix-ui/react-tooltip": "^1.1.2",
     "@sentry/browser": "^7.113.0",
     "@sentry/integrations": "^7.113.0",
+    "@sentry/nextjs": "^8",
     "@sentry/node": "^7.113.0",
     "@sentry/opentelemetry-node": "^7.113.0",
     "@swc/helpers": "0.5.11",
@@ -276,7 +277,8 @@
     "tap/typescript": "^4.5.2",
     "terser:>4.0.0 <5": ">=4.8.1",
     "terser:>5 <6": ">=5.14.2",
-    "underscore": ">=1.13.2"
+    "underscore": ">=1.13.2",
+    "@sentry/types": "^7.113.0"
   },
   "packageManager": "yarn@3.3.0",
   "_moduleAliases": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -61,6 +61,7 @@
       "@fxa/shared/pem-jwk": ["libs/shared/pem-jwk/src/index.ts"],
       "@fxa/shared/react": ["libs/shared/react/src/index.ts"],
       "@fxa/shared/sentry": ["libs/shared/sentry/src/index.ts"],
+      "@fxa/shared/sentry/client": ["libs/shared/sentry/src/client.ts"],
       "@fxa/vendored/common-password-list": [
         "libs/vendored/common-password-list/src/index.ts"
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -12284,6 +12284,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
+  checksum: 05df4f2538b3b0f998ea4c1cd34574d0feba216fa5d4ccaef0187d12abf82eafe6021cec8b49f9bb4d90f2ba4582ccc581e72986a5fcf4176ae0cfeb04cf52ec
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
   resolution: "@jridgewell/trace-mapping@npm:0.3.9"
@@ -13967,6 +13974,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api-logs@npm:0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/api-logs@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/api": ^1.0.0
+  checksum: 500cd35527580732921d198bd7007224402cb89fef791f0b64bea839c9f2ad796d54486ee9aee0ee6422ded3963cba793408086eda0adfec2bd1d66f9114d96c
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/api@npm:^1.0.0":
   version: 1.0.0
   resolution: "@opentelemetry/api@npm:1.0.0"
@@ -13978,6 +13994,13 @@ __metadata:
   version: 1.7.0
   resolution: "@opentelemetry/api@npm:1.7.0"
   checksum: 2398cbe65f199c3a7050125b3ad9c835f789bb0a616665e9c7f4475a29ac8334b6a3c15f38db48d345b522180c41c00b04cc174cd0eeffba98eb4874a565fa7e
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/api@npm:^1.8, @opentelemetry/api@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@opentelemetry/api@npm:1.9.0"
+  checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
   languageName: node
   linkType: hard
 
@@ -14051,6 +14074,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/context-async-hooks@npm:^1.25.1":
+  version: 1.26.0
+  resolution: "@opentelemetry/context-async-hooks@npm:1.26.0"
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: f0fe5bfa3aeed99fbe7d6f6157e3bcc2e4450850a62ef60e551812f3e5aa72cb81e38de8c4e1b6934c93e18579a503664597f78e7e7d9904e271f59c939a3e02
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/context-zone-peer-dep@npm:1.23.0, @opentelemetry/context-zone-peer-dep@npm:^1.23.0":
   version: 1.23.0
   resolution: "@opentelemetry/context-zone-peer-dep@npm:1.23.0"
@@ -14112,6 +14144,28 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   checksum: 88aa733364c42f90a61a6efc8b5138dcfed4763f3a0692d957d506a6fe49db943169a0631ad762ac7569723faf5eaca092d6590eca1ad8ff77583fb10512a06b
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/core@npm:1.25.1"
+  dependencies:
+    "@opentelemetry/semantic-conventions": 1.25.1
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: ba1672fde4a1cfd9b55bf6070db71b808702fe59c4a70cda52a6156b2c813827954a6b4d3c3641283d394ff75a69b6359a0487459b4d26cd7d714ab3d21bc780
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/core@npm:1.26.0, @opentelemetry/core@npm:^1.25.1":
+  version: 1.26.0
+  resolution: "@opentelemetry/core@npm:1.26.0"
+  dependencies:
+    "@opentelemetry/semantic-conventions": 1.27.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: e5b06b4d69605927b850109c6b898f00a6a921171b3bf62335a4e00b9a170c1b93ddef6d7f8cc480a551faeaf81074b594f4462a91d4fbc4b313e64ff9ebd717
   languageName: node
   linkType: hard
 
@@ -14279,6 +14333,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-connect@npm:0.38.0":
+  version: 0.38.0
+  resolution: "@opentelemetry/instrumentation-connect@npm:0.38.0"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+    "@types/connect": 3.4.36
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 4dff447ff9a7ee2ca94872d904df260213e8e05b27742713f8dce35593ec8f52bcb07adfb7730e7b208b8b49566e032cdee316f0ccea405e42ffc5804d222750
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-connect@npm:^0.35.0":
   version: 0.35.0
   resolution: "@opentelemetry/instrumentation-connect@npm:0.35.0"
@@ -14344,6 +14412,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-express@npm:0.41.1":
+  version: 0.41.1
+  resolution: "@opentelemetry/instrumentation-express@npm:0.41.1"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: fe2939ab377cc4b1c6dfe77cae6d23156ccd227cc9984bf03eb5f108fa048815d6dd0be9a8240bb3bd053a271789c9928a9e544725e2e099709e9b2c60d456f0
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-express@npm:^0.37.0":
   version: 0.37.0
   resolution: "@opentelemetry/instrumentation-express@npm:0.37.0"
@@ -14354,6 +14435,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 048021e4a9ea063e3c477d17555aeb6133ca5b69addd92c83a27d5297112cb1f0601db44aed93e96e3fb893ce30afd73b9bcfc704741bfa72738af0226ab9426
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-fastify@npm:0.38.0":
+  version: 0.38.0
+  resolution: "@opentelemetry/instrumentation-fastify@npm:0.38.0"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 3cd7996398d783397782fc327a336e37b1eaabee6c9d8a25daa15d86cf6634408bc790e67207548dcae61f064a4a85780d9ae51bc31414bd61e0291d22a8d3f8
   languageName: node
   linkType: hard
 
@@ -14384,6 +14478,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-fs@npm:0.14.0":
+  version: 0.14.0
+  resolution: "@opentelemetry/instrumentation-fs@npm:0.14.0"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: cc6b90e9496bddbbc992adf3cb585b728260e6b22d35e48720e06505e2477e962bd1b62d9d1bf331c877c04ce7b393d87d2f61a3ade08519b73252a342351bf0
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-fs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@opentelemetry/instrumentation-fs@npm:0.11.0"
@@ -14406,6 +14512,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: ce26f2157b36f0232c5d3a61f9800bbac96b10a28602f67cb81650d792565649d23e16a62e37cf9b87d8a8c8054d7b88158ba0c38870a4a7dbce37d5e880f320
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-graphql@npm:0.42.0":
+  version: 0.42.0
+  resolution: "@opentelemetry/instrumentation-graphql@npm:0.42.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: cae523cf75312457dc176a1ae2e4157b41025c5d01d8174467c8a62f8031c3a90151888fcdd804778183f58618ec320a24fe78f5bb0a1a72a119dc37245be676
   languageName: node
   linkType: hard
 
@@ -14432,6 +14549,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-hapi@npm:0.40.0":
+  version: 0.40.0
+  resolution: "@opentelemetry/instrumentation-hapi@npm:0.40.0"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 71ff845ca2376b5f1cf7514d649f829044dec6486e784351a26278afc092a1cd90eb0eaf34ab79afcae9244e8b126d6059ac0c7c286743ceb8e12126cf7e0255
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-hapi@npm:^0.36.0":
   version: 0.36.0
   resolution: "@opentelemetry/instrumentation-hapi@npm:0.36.0"
@@ -14446,6 +14576,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-http@npm:0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/instrumentation-http@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/core": 1.25.1
+    "@opentelemetry/instrumentation": 0.52.1
+    "@opentelemetry/semantic-conventions": 1.25.1
+    semver: ^7.5.2
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 67a31e14d9ee4da745b7529777c1525f717b2ddf09f2a9247acaa9677f32e4a863d8f0712c95917fdbe74d8211cf650065bb3a95ef2fdd9f81630e063cbc2d4f
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-http@npm:^0.50.0":
   version: 0.50.0
   resolution: "@opentelemetry/instrumentation-http@npm:0.50.0"
@@ -14457,6 +14601,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 54e48c8f03d82bf6dd5eacac40670833d11053e2c076b426e56908dca8fa9613a14983038d7ec8d9d8546737f25b4fde40d4d92134695cb5924d2497f6bc87a9
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-ioredis@npm:0.42.0":
+  version: 0.42.0
+  resolution: "@opentelemetry/instrumentation-ioredis@npm:0.42.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/redis-common": ^0.36.2
+    "@opentelemetry/semantic-conventions": ^1.23.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: ae4804732b4380007b09ba11051aae927da0c53cd74d556916a838fb4de4f3c2aa7156bc05c4f34e6669411835604a4587822b2b585c51042e502d0e5079c143
   languageName: node
   linkType: hard
 
@@ -14483,6 +14640,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: e4a8359ac6685633794cd9f248ea57d1843e92e5f97dad8c7da7717caabf35ecfc3d7385d512a2edab45d19e674f79cb38ef0ec017bc99a1865230169229e404
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-koa@npm:0.42.0":
+  version: 0.42.0
+  resolution: "@opentelemetry/instrumentation-koa@npm:0.42.0"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 4e41f4b1c2abb4d31151ae3b5999af3247affa99fadcf87ff542a8523f108275d83a54057d79453ff56bc40938a622803562db87c826bfac9f99fb409207c6fd
   languageName: node
   linkType: hard
 
@@ -14525,6 +14695,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-mongodb@npm:0.46.0":
+  version: 0.46.0
+  resolution: "@opentelemetry/instrumentation-mongodb@npm:0.46.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/sdk-metrics": ^1.9.1
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: fab5db536e2e95177a0ae0975bd8b9fc76f2d59bf89a6023547ba39071b97789859e1ac0582f86498a263611403a70b5f543b025207180770c07e178b04af5ad
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-mongodb@npm:^0.42.0":
   version: 0.42.0
   resolution: "@opentelemetry/instrumentation-mongodb@npm:0.42.0"
@@ -14535,6 +14718,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: f87c6ce9dd05af6e9c2e86b117d79a908f883c977f9de1d0f9000e5945765e686cedad9b0ab6775c1fcb846cb51cdac0e88b617efdf1ade89ad5fdc2d3af44c0
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-mongoose@npm:0.40.0":
+  version: 0.40.0
+  resolution: "@opentelemetry/instrumentation-mongoose@npm:0.40.0"
+  dependencies:
+    "@opentelemetry/core": ^1.8.0
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 3ee4cdee6afc93b313f013ef35a2d4829244e463dceea9229c71e0d4c9d398051986978591d253129f83ec75c5417837d068c1408296faa6d5566a53a8683270
   languageName: node
   linkType: hard
 
@@ -14551,6 +14747,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-mysql2@npm:0.40.0":
+  version: 0.40.0
+  resolution: "@opentelemetry/instrumentation-mysql2@npm:0.40.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+    "@opentelemetry/sql-common": ^0.40.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: acdb9883d1ab92d0bfbe507736888cc0b0d7b25c3d24c27b51add17abceff4bf15988a3cd2e54b93256f28bbc65aa172f116df9277545143e20e8d7b497e2e63
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-mysql2@npm:^0.37.0":
   version: 0.37.0
   resolution: "@opentelemetry/instrumentation-mysql2@npm:0.37.0"
@@ -14564,6 +14773,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-mysql@npm:0.40.0":
+  version: 0.40.0
+  resolution: "@opentelemetry/instrumentation-mysql@npm:0.40.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+    "@types/mysql": 2.15.22
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 6eeba06f7507ab9086ef18b9e37802f12ac0a9f6182d4aba3aaf71a3e0f0759cb51c044247653eb8e359383d922a12a0fc0f129b2982bae17910462450cdb189
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-mysql@npm:^0.37.0":
   version: 0.37.0
   resolution: "@opentelemetry/instrumentation-mysql@npm:0.37.0"
@@ -14574,6 +14796,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: ff70e3fc7f54df420d18709df9c10062031d6fe8ad3affc8f02c13bc6897b2227a5ebb04cc60441799fe3113ecd8bedfc332f86d8f1c4dce432653fef90970ef
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-nestjs-core@npm:0.39.0":
+  version: 0.39.0
+  resolution: "@opentelemetry/instrumentation-nestjs-core@npm:0.39.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.23.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 4394754ce3ef4747e39a59a602c744112f9d6d3ee7ef43a51f1562a977a8e2bb2944687d3dd199f0a5941517e71a84ff9ea9ce183d94b63a3311e9de6ac8e09c
   languageName: node
   linkType: hard
 
@@ -14601,6 +14835,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation-pg@npm:0.43.0":
+  version: 0.43.0
+  resolution: "@opentelemetry/instrumentation-pg@npm:0.43.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/semantic-conventions": ^1.22.0
+    "@opentelemetry/sql-common": ^0.40.1
+    "@types/pg": 8.6.1
+    "@types/pg-pool": 2.0.4
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: d255806b9e5ffd449b7ab3c7c072e919ad8a18118cdf5aec636d89a89d9ac63ef282f280d3b2dd7fa9c57e748fc0c9b38294911bf1aaff35e821079aaeacbd82
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/instrumentation-pg@npm:^0.40.0":
   version: 0.40.0
   resolution: "@opentelemetry/instrumentation-pg@npm:0.40.0"
@@ -14624,6 +14873,19 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
   checksum: 0c2137cf5c14d370ecbed24590a344f055b52ee5bf4e359f48f24e0bc68922ce91fa8c7afa016f52e897a4e5f108a3d86a6db59a549028088de4f69a5986ef08
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation-redis-4@npm:0.41.0":
+  version: 0.41.0
+  resolution: "@opentelemetry/instrumentation-redis-4@npm:0.41.0"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.52.0
+    "@opentelemetry/redis-common": ^0.36.2
+    "@opentelemetry/semantic-conventions": ^1.22.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 1809e3badea5ee5fff0d0a1e7a8204d4a6cf29e0e3b41677fba8eabb444cca62b88f815c5682bc5a827e3ff4ed2c186ed1965d0b2e0b9d1043130a410ee57b50
   languageName: node
   linkType: hard
 
@@ -14758,6 +15020,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/instrumentation@npm:0.52.1, @opentelemetry/instrumentation@npm:^0.49 || ^0.50 || ^0.51 || ^0.52.0, @opentelemetry/instrumentation@npm:^0.52.0, @opentelemetry/instrumentation@npm:^0.52.1":
+  version: 0.52.1
+  resolution: "@opentelemetry/instrumentation@npm:0.52.1"
+  dependencies:
+    "@opentelemetry/api-logs": 0.52.1
+    "@types/shimmer": ^1.0.2
+    import-in-the-middle: ^1.8.1
+    require-in-the-middle: ^7.1.1
+    semver: ^7.5.2
+    shimmer: ^1.2.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: e8b4f202dc9355ca46714349a5e1663346e162f79706eed38015edf38fc536330fde4cc19ed7d3d6b03258c890c1dc0ba6d658d7aac3f41f1803bd03699d2701
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/instrumentation@npm:^0.46.0":
+  version: 0.46.0
+  resolution: "@opentelemetry/instrumentation@npm:0.46.0"
+  dependencies:
+    "@types/shimmer": ^1.0.2
+    import-in-the-middle: 1.7.1
+    require-in-the-middle: ^7.1.1
+    semver: ^7.5.2
+    shimmer: ^1.2.1
+  peerDependencies:
+    "@opentelemetry/api": ^1.3.0
+  checksum: 9589058da858eeb99b52ba191f93d82b3076b83f4a6cb745666fa742ce7fab8a219fd96a2f2bfad9609984d7462aedbaafa266a1ec3abca57964fdda0e43f5d6
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/otlp-exporter-base@npm:0.50.0":
   version: 0.50.0
   resolution: "@opentelemetry/otlp-exporter-base@npm:0.50.0"
@@ -14861,6 +15154,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/redis-common@npm:^0.36.2":
+  version: 0.36.2
+  resolution: "@opentelemetry/redis-common@npm:0.36.2"
+  checksum: b0a6f2c2dc64ba3b655ed944a5a33715d00365865e6f498005527a4ad6c40ca0e7b8ac531791b6d5abfbab9b22d9c6aa1cd8bcc851a7634dfb381ad2d5061b0d
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/resource-detector-alibaba-cloud@npm:^0.28.8":
   version: 0.28.8
   resolution: "@opentelemetry/resource-detector-alibaba-cloud@npm:0.28.8"
@@ -14945,6 +15245,18 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   checksum: e780d34f8107cdd2853aab3c0c680a817da54d9c6020bba9b8a6b8e7b637487592d87440e5c4f09a10dfad7aededde34532e0e337a5c2d441bf26dd921836cfc
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/resources@npm:1.26.0, @opentelemetry/resources@npm:^1.25.1":
+  version: 1.26.0
+  resolution: "@opentelemetry/resources@npm:1.26.0"
+  dependencies:
+    "@opentelemetry/core": 1.26.0
+    "@opentelemetry/semantic-conventions": 1.27.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: f70b0fdf4fb00c950bc30084818c92a5339f1be5d709bd681ab14453e877d6bb9f700324b8e65a0eabfeea618d01ed071abf9088e00fa0bf7f3305b1abad22cb
   languageName: node
   linkType: hard
 
@@ -15060,6 +15372,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/sdk-trace-base@npm:^1.22, @opentelemetry/sdk-trace-base@npm:^1.25.1":
+  version: 1.26.0
+  resolution: "@opentelemetry/sdk-trace-base@npm:1.26.0"
+  dependencies:
+    "@opentelemetry/core": 1.26.0
+    "@opentelemetry/resources": 1.26.0
+    "@opentelemetry/semantic-conventions": 1.27.0
+  peerDependencies:
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
+  checksum: a4f4ddf644fd0d79b2bd49e4377143688d2aa657643a470d8bed6696f26817598fb4e9f16ba2d8c237292af56f06eec56594a7b4cc417d4ea7e490a45a22113b
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/sdk-trace-node@npm:1.23.0, @opentelemetry/sdk-trace-node@npm:^1.23.0":
   version: 1.23.0
   resolution: "@opentelemetry/sdk-trace-node@npm:1.23.0"
@@ -15130,6 +15455,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/semantic-conventions@npm:1.25.1":
+  version: 1.25.1
+  resolution: "@opentelemetry/semantic-conventions@npm:1.25.1"
+  checksum: fea418a4b09c55121c6da11c49dd2105116533838c484aead17e8acf8029dad711e145849812f9c61f9e48fad8e2b6cf103d2c18847ca993032ce9b27c2f863d
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/semantic-conventions@npm:1.27.0, @opentelemetry/semantic-conventions@npm:^1.17.0, @opentelemetry/semantic-conventions@npm:^1.23.0, @opentelemetry/semantic-conventions@npm:^1.25.1":
+  version: 1.27.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.27.0"
+  checksum: 26d85f8d13c8c64024f7a84528cff41d56afc9829e7ff8a654576404f8b2c1a9c264adcc6fa5a9551bacdd938a4a464041fa9493e0a722e5605f2c2ae6752398
+  languageName: node
+  linkType: hard
+
 "@opentelemetry/semantic-conventions@npm:1.7.0":
   version: 1.7.0
   resolution: "@opentelemetry/semantic-conventions@npm:1.7.0"
@@ -15166,6 +15505,17 @@ __metadata:
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
   checksum: 65249c13f160a9f2d2e408bc2c33a90f47d1721b8280c9f087d722fe0d0bfed01289c165b3f668e6c512d4fe2da9a858d25bbe906e667cd12a4aedcbe9da4e1c
+  languageName: node
+  linkType: hard
+
+"@opentelemetry/sql-common@npm:^0.40.1":
+  version: 0.40.1
+  resolution: "@opentelemetry/sql-common@npm:0.40.1"
+  dependencies:
+    "@opentelemetry/core": ^1.1.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+  checksum: 23529740531937dee137c9680dbd2f7abf6a7d7340fbd48d309707601fa6255a5e8c2626c8e1c285b49c0b3429f2b3a8e6cbf7f7240820ecfeb52e2ba5ed6740
   languageName: node
   linkType: hard
 
@@ -15488,6 +15838,17 @@ __metadata:
   bin:
     jsonlint: lib/cli.js
   checksum: 8daf8c54fc394d5243778e7c9ea796084a9486367659146d9370c002e0004e732811fd905fc376a07fbdd1191db8bc0cefb62ca7f9f9e5ce55bca79b34f6686b
+  languageName: node
+  linkType: hard
+
+"@prisma/instrumentation@npm:5.18.0":
+  version: 5.18.0
+  resolution: "@prisma/instrumentation@npm:5.18.0"
+  dependencies:
+    "@opentelemetry/api": ^1.8
+    "@opentelemetry/instrumentation": ^0.49 || ^0.50 || ^0.51 || ^0.52.0
+    "@opentelemetry/sdk-trace-base": ^1.22
+  checksum: a61892e7e5ed501002947bbccc1a275d52ac42f13a69a3192c1ceef086014e45cb9cac1787f8d589556e8c48cb5d7d3a355b3710c9094d62b276147b3527c411
   languageName: node
   linkType: hard
 
@@ -16749,6 +17110,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/plugin-commonjs@npm:26.0.1":
+  version: 26.0.1
+  resolution: "@rollup/plugin-commonjs@npm:26.0.1"
+  dependencies:
+    "@rollup/pluginutils": ^5.0.1
+    commondir: ^1.0.1
+    estree-walker: ^2.0.2
+    glob: ^10.4.1
+    is-reference: 1.2.1
+    magic-string: ^0.30.3
+  peerDependencies:
+    rollup: ^2.68.0||^3.0.0||^4.0.0
+  peerDependenciesMeta:
+    rollup:
+      optional: true
+  checksum: 88d1349cc2cda4ad6193cce901356e4c14a830497fc01c91f38c94a871b203ffe657b29c9a98cd16787e3a6a8b45169dd0b471cb36d26d645478a177c958779a
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-node-resolve@npm:^11.2.1":
   version: 11.2.1
   resolution: "@rollup/plugin-node-resolve@npm:11.2.1"
@@ -16855,6 +17235,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/browser-utils@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry-internal/browser-utils@npm:8.28.0"
+  dependencies:
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: 33cb061158204781cfea9a5d2ea1af3c38ebc06bbd6c8ffbacfea564de4ba8adc2d47d70bc51f0cba7b1135ce5e6846ff63b2a601ce314ae4e49a5c8c5b7fb8a
+  languageName: node
+  linkType: hard
+
 "@sentry-internal/feedback@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry-internal/feedback@npm:7.113.0"
@@ -16863,6 +17254,17 @@ __metadata:
     "@sentry/types": 7.113.0
     "@sentry/utils": 7.113.0
   checksum: 093c7683971455406db1c1d09ba2356d315dc5a8653aac5dd975e953cea2681a172e7bd47077b3e6e9a7ad7c1c063bee6c948e8c91a9ae077c07122284695357
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/feedback@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry-internal/feedback@npm:8.28.0"
+  dependencies:
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: e767624ef5b94037ec6457fabf23f105eb6fc945665edcd7dc1fd0a139ad93ccc3aafc0406fdb5a6d37ef6b6209423dfbab4ba288da362a69fc60aa7fbd62cb8
   languageName: node
   linkType: hard
 
@@ -16878,6 +17280,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/replay-canvas@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry-internal/replay-canvas@npm:8.28.0"
+  dependencies:
+    "@sentry-internal/replay": 8.28.0
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: a652a9427c0de7d6b406bdc0af299e92d556feb60f867707f49e46083c82afa6938e900c598c5dcdf5153d5382f3a05ca6537fd8448f10ca8a084b54bdafa614
+  languageName: node
+  linkType: hard
+
+"@sentry-internal/replay@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry-internal/replay@npm:8.28.0"
+  dependencies:
+    "@sentry-internal/browser-utils": 8.28.0
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: 02833baf0ef4e6c1970cfb22679f2604b6f98f2ff58cd0e98620156ada41446ffd16a5b81208ddce4f941180161bc9826364038227bd2b010d565a7af3fbf535
+  languageName: node
+  linkType: hard
+
 "@sentry-internal/tracing@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry-internal/tracing@npm:7.113.0"
@@ -16886,6 +17312,28 @@ __metadata:
     "@sentry/types": 7.113.0
     "@sentry/utils": 7.113.0
   checksum: 4078b79d4351ba16c13152830107b57934fc47cce26988cc6dd64671b60ab67189049d90a71bd10c4ddbd4600c6879ad257f84fef2dc5be446d4e980e7b58f9e
+  languageName: node
+  linkType: hard
+
+"@sentry/babel-plugin-component-annotate@npm:2.22.3":
+  version: 2.22.3
+  resolution: "@sentry/babel-plugin-component-annotate@npm:2.22.3"
+  checksum: 8dccbe700ffdd4cbdbcf2466d342fba40b3619aef06aa855205a9fa09707a92e80cb401cd341bed1ebe77d28b96fd11a06a6e78ba12b8045b52201f89cb6eced
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/browser@npm:8.28.0"
+  dependencies:
+    "@sentry-internal/browser-utils": 8.28.0
+    "@sentry-internal/feedback": 8.28.0
+    "@sentry-internal/replay": 8.28.0
+    "@sentry-internal/replay-canvas": 8.28.0
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: 712e05b178624dec7f0c6d981a7065ee0f0034b293ac22a4f0b9e1ea63656463f9505473e9953eba1e64409db7aa7105a64b5726e14560b7e0f1197a2fd4e46b
   languageName: node
   linkType: hard
 
@@ -16905,6 +17353,108 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/bundler-plugin-core@npm:2.22.3":
+  version: 2.22.3
+  resolution: "@sentry/bundler-plugin-core@npm:2.22.3"
+  dependencies:
+    "@babel/core": ^7.18.5
+    "@sentry/babel-plugin-component-annotate": 2.22.3
+    "@sentry/cli": ^2.33.1
+    dotenv: ^16.3.1
+    find-up: ^5.0.0
+    glob: ^9.3.2
+    magic-string: 0.30.8
+    unplugin: 1.0.1
+  checksum: cbf7befb78ecf2c1cd0af9b22c26acb7da63c030309452172a34146e834c644dcd24538eedfa6e4296c51bbf46fd1ab50c2b2f108d26c16d8169b7eb29f1e53c
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-darwin@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-darwin@npm:2.35.0"
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm64@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-linux-arm64@npm:2.35.0"
+  conditions: (os=linux | os=freebsd) & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-arm@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-linux-arm@npm:2.35.0"
+  conditions: (os=linux | os=freebsd) & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-i686@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-linux-i686@npm:2.35.0"
+  conditions: (os=linux | os=freebsd) & (cpu=x86 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-linux-x64@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-linux-x64@npm:2.35.0"
+  conditions: (os=linux | os=freebsd) & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-i686@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-win32-i686@npm:2.35.0"
+  conditions: os=win32 & (cpu=x86 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@sentry/cli-win32-x64@npm:2.35.0":
+  version: 2.35.0
+  resolution: "@sentry/cli-win32-x64@npm:2.35.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@sentry/cli@npm:^2.33.1":
+  version: 2.35.0
+  resolution: "@sentry/cli@npm:2.35.0"
+  dependencies:
+    "@sentry/cli-darwin": 2.35.0
+    "@sentry/cli-linux-arm": 2.35.0
+    "@sentry/cli-linux-arm64": 2.35.0
+    "@sentry/cli-linux-i686": 2.35.0
+    "@sentry/cli-linux-x64": 2.35.0
+    "@sentry/cli-win32-i686": 2.35.0
+    "@sentry/cli-win32-x64": 2.35.0
+    https-proxy-agent: ^5.0.0
+    node-fetch: ^2.6.7
+    progress: ^2.0.3
+    proxy-from-env: ^1.1.0
+    which: ^2.0.2
+  dependenciesMeta:
+    "@sentry/cli-darwin":
+      optional: true
+    "@sentry/cli-linux-arm":
+      optional: true
+    "@sentry/cli-linux-arm64":
+      optional: true
+    "@sentry/cli-linux-i686":
+      optional: true
+    "@sentry/cli-linux-x64":
+      optional: true
+    "@sentry/cli-win32-i686":
+      optional: true
+    "@sentry/cli-win32-x64":
+      optional: true
+  bin:
+    sentry-cli: bin/sentry-cli
+  checksum: 15e76ad1cb53cc46823aa48ea99844cd9a944d33c2667cbecf1260b564428a7ef47c1ca38e9a9e222e4d697ed7e5892b107a0b00eddc9e740add290cbe0ad1eb
+  languageName: node
+  linkType: hard
+
 "@sentry/core@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry/core@npm:7.113.0"
@@ -16912,6 +17462,16 @@ __metadata:
     "@sentry/types": 7.113.0
     "@sentry/utils": 7.113.0
   checksum: b0f4bdb858bb57291b7f8af0557eceab30fa86c67fc25f6def75f9b5ab5f7dfe57a3776cae0d5287e27654761c463d28938bf225983a6229433733d74d182ff6
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/core@npm:8.28.0"
+  dependencies:
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: 2a37f14b36a68c496050054f952d56e639863257f59ffcccb7aed4b1a35fb063c1ced38a08e89f2bb789124b18b7f955fd78ef8b38408ad91853aa1a5aa51cbb
   languageName: node
   linkType: hard
 
@@ -16924,6 +17484,76 @@ __metadata:
     "@sentry/utils": 7.113.0
     localforage: ^1.8.1
   checksum: ce5c951a8036d56dc80ef298597ed43294e78061ea2dfa7fa048a7f9b8be69989f8404fdc7c9753ccea188d02c10101da1a0537cda5ac36e20ee2e8088934bc7
+  languageName: node
+  linkType: hard
+
+"@sentry/nextjs@npm:^8":
+  version: 8.28.0
+  resolution: "@sentry/nextjs@npm:8.28.0"
+  dependencies:
+    "@opentelemetry/instrumentation-http": 0.52.1
+    "@opentelemetry/semantic-conventions": ^1.25.1
+    "@rollup/plugin-commonjs": 26.0.1
+    "@sentry/core": 8.28.0
+    "@sentry/node": 8.28.0
+    "@sentry/opentelemetry": 8.28.0
+    "@sentry/react": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+    "@sentry/vercel-edge": 8.28.0
+    "@sentry/webpack-plugin": 2.22.3
+    chalk: 3.0.0
+    resolve: 1.22.8
+    rollup: 3.29.4
+    stacktrace-parser: ^0.1.10
+  peerDependencies:
+    next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0
+    webpack: ">= 5.0.0"
+  peerDependenciesMeta:
+    webpack:
+      optional: true
+  checksum: 5f2ad54789e9eea667fc42bc7c99253cd4ffe6545a878c03e9d977625fe5bb70e1ce09634e308d510182591726a6e6d749e84362c067ed2e5b984bf71034edc8
+  languageName: node
+  linkType: hard
+
+"@sentry/node@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/node@npm:8.28.0"
+  dependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/context-async-hooks": ^1.25.1
+    "@opentelemetry/core": ^1.25.1
+    "@opentelemetry/instrumentation": ^0.52.1
+    "@opentelemetry/instrumentation-connect": 0.38.0
+    "@opentelemetry/instrumentation-express": 0.41.1
+    "@opentelemetry/instrumentation-fastify": 0.38.0
+    "@opentelemetry/instrumentation-fs": 0.14.0
+    "@opentelemetry/instrumentation-graphql": 0.42.0
+    "@opentelemetry/instrumentation-hapi": 0.40.0
+    "@opentelemetry/instrumentation-http": 0.52.1
+    "@opentelemetry/instrumentation-ioredis": 0.42.0
+    "@opentelemetry/instrumentation-koa": 0.42.0
+    "@opentelemetry/instrumentation-mongodb": 0.46.0
+    "@opentelemetry/instrumentation-mongoose": 0.40.0
+    "@opentelemetry/instrumentation-mysql": 0.40.0
+    "@opentelemetry/instrumentation-mysql2": 0.40.0
+    "@opentelemetry/instrumentation-nestjs-core": 0.39.0
+    "@opentelemetry/instrumentation-pg": 0.43.0
+    "@opentelemetry/instrumentation-redis-4": 0.41.0
+    "@opentelemetry/resources": ^1.25.1
+    "@opentelemetry/sdk-trace-base": ^1.25.1
+    "@opentelemetry/semantic-conventions": ^1.25.1
+    "@prisma/instrumentation": 5.18.0
+    "@sentry/core": 8.28.0
+    "@sentry/opentelemetry": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+    import-in-the-middle: ^1.11.0
+    opentelemetry-instrumentation-fetch-node: 1.2.3
+  dependenciesMeta:
+    opentelemetry-instrumentation-fetch-node:
+      optional: true
+  checksum: 795d81e9257070c9557e79f1b22ba0d042ab5320766860a83e5adf76f0e6b57352b73ccd194a36732da680d5f6ebb041ead435b81bdda676137371cc73ba0723
   languageName: node
   linkType: hard
 
@@ -16956,6 +17586,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/opentelemetry@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/opentelemetry@npm:8.28.0"
+  dependencies:
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.9.0
+    "@opentelemetry/core": ^1.25.1
+    "@opentelemetry/instrumentation": ^0.52.1
+    "@opentelemetry/sdk-trace-base": ^1.25.1
+    "@opentelemetry/semantic-conventions": ^1.25.1
+  checksum: 68421a9df72a9b9203447cbf34ddad74b7bb845d3bbb296e607eb2cddf164deb6ecefa0a78d1ccd324ffdb491df3f6f7a63167c602b22aeef33c9c9f78f7c03c
+  languageName: node
+  linkType: hard
+
+"@sentry/react@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/react@npm:8.28.0"
+  dependencies:
+    "@sentry/browser": 8.28.0
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+    hoist-non-react-statics: ^3.3.2
+  peerDependencies:
+    react: ^16.14.0 || 17.x || 18.x || 19.x
+  checksum: f3c16345aeaa6699fb2ef0dbe9ef2c46cec651740743d69a297093da1ebe6239a65e8a406f60c6841a43e74c21932c5bb055fda0443d469fc1ae2a57a9f5c607
+  languageName: node
+  linkType: hard
+
 "@sentry/replay@npm:7.113.0":
   version: 7.113.0
   resolution: "@sentry/replay@npm:7.113.0"
@@ -16968,10 +17630,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.113.0":
-  version: 7.113.0
-  resolution: "@sentry/types@npm:7.113.0"
-  checksum: 6131e776c274d02b54a261739850bd9f5db100f2616a79aed20e6e3523dc251445006287d5ada4cc50f752ff161e70682e9572b86caeab23e92a0ad6d0495802
+"@sentry/types@npm:^7.113.0":
+  version: 7.119.0
+  resolution: "@sentry/types@npm:7.119.0"
+  checksum: ffb8dcaf1d5c96defe860e663553511e602cd6bfbe63b0c3fd8cba5ec1c3ea9ad47597527f4d9ef314ba1b11bccf89c4d6f50435df7cbfb92f5a398c6c261f0b
   languageName: node
   linkType: hard
 
@@ -16981,6 +17643,39 @@ __metadata:
   dependencies:
     "@sentry/types": 7.113.0
   checksum: 248725dced72b18f02042362a17862ed5440140dd63775d7d4432dd3605de0b50d2ffc6d6d091878915b20697c476dd3b74b60c47294a90cbcd440af9d2a44f6
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/utils@npm:8.28.0"
+  dependencies:
+    "@sentry/types": 8.28.0
+  checksum: e0e70a2076e5ca0110865ec89a84f683531da222cf3fd85020d392da2e8b160fc103066576e21f75039751db9178aacf83be44e6930a9e38c927e279e147ea18
+  languageName: node
+  linkType: hard
+
+"@sentry/vercel-edge@npm:8.28.0":
+  version: 8.28.0
+  resolution: "@sentry/vercel-edge@npm:8.28.0"
+  dependencies:
+    "@sentry/core": 8.28.0
+    "@sentry/types": 8.28.0
+    "@sentry/utils": 8.28.0
+  checksum: 68e5e75bb573863c6ebf9cf0a387531a8557f62cd43d55fc29356693e3b135670f64a0875de73eb4d0c7de2a8f66cbba5b3e928c1a0a761a830c6e3f8d26faee
+  languageName: node
+  linkType: hard
+
+"@sentry/webpack-plugin@npm:2.22.3":
+  version: 2.22.3
+  resolution: "@sentry/webpack-plugin@npm:2.22.3"
+  dependencies:
+    "@sentry/bundler-plugin-core": 2.22.3
+    unplugin: 1.0.1
+    uuid: ^9.0.0
+  peerDependencies:
+    webpack: ">=4.40.0"
+  checksum: f6eb12337e35d6514b750acf6bee75227fec7da142a62b660a864e48a3ece6b7d7e96dc8a3c126ebb650ea8acaa6b423399a31a6f48e59e51708965745d3a3f4
   languageName: node
   linkType: hard
 
@@ -34503,7 +35198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.4.4, dotenv@npm:^16.4.5, dotenv@npm:~16.4.5":
+"dotenv@npm:^16.3.1, dotenv@npm:^16.4.4, dotenv@npm:^16.4.5, dotenv@npm:~16.4.5":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 301a12c3d44fd49888b74eb9ccf9f07a1f5df43f489e7fcb89647a2edcd84c42d6bc349dc8df099cd18f07c35c7b04685c1a4f3e6a6a9e6b30f8d48c15b7f49c
@@ -40105,6 +40800,7 @@ fsevents@~2.1.1:
     "@radix-ui/react-tooltip": ^1.1.2
     "@sentry/browser": ^7.113.0
     "@sentry/integrations": ^7.113.0
+    "@sentry/nextjs": ^8
     "@sentry/node": ^7.113.0
     "@sentry/opentelemetry-node": ^7.113.0
     "@storybook/addon-essentials": ^7.6.15
@@ -40788,6 +41484,22 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"glob@npm:^10.4.1":
+  version: 10.4.5
+  resolution: "glob@npm:10.4.5"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^3.1.2
+    minimatch: ^9.0.4
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^1.11.1
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 0bc725de5e4862f9f387fd0f2b274baf16850dcd2714502ccf471ee401803997983e2c05590cb65f9675a3c6f2a58e7a53f9e365704108c6ad3cbf1d60934c4a
+  languageName: node
+  linkType: hard
+
 "glob@npm:^5.0.15, glob@npm:^5.0.3":
   version: 5.0.15
   resolution: "glob@npm:5.0.15"
@@ -40852,6 +41564,18 @@ fsevents@~2.1.1:
     minimatch: ^5.0.1
     once: ^1.3.0
   checksum: 50bcdea19d8e79d8de5f460b1939ffc2b3299eac28deb502093fdca22a78efebc03e66bf54f0abc3d3d07d8134d19a32850288b7440d77e072aa55f9d33b18c5
+  languageName: node
+  linkType: hard
+
+"glob@npm:^9.3.2":
+  version: 9.3.5
+  resolution: "glob@npm:9.3.5"
+  dependencies:
+    fs.realpath: ^1.0.0
+    minimatch: ^8.0.2
+    minipass: ^4.2.4
+    path-scurry: ^1.6.1
+  checksum: 94b093adbc591bc36b582f77927d1fb0dbf3ccc231828512b017601408be98d1fe798fc8c0b19c6f2d1a7660339c3502ce698de475e9d938ccbb69b47b647c84
   languageName: node
   linkType: hard
 
@@ -43383,6 +44107,18 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"import-in-the-middle@npm:^1.11.0, import-in-the-middle@npm:^1.8.1":
+  version: 1.11.0
+  resolution: "import-in-the-middle@npm:1.11.0"
+  dependencies:
+    acorn: ^8.8.2
+    acorn-import-attributes: ^1.9.5
+    cjs-module-lexer: ^1.2.2
+    module-details-from-path: ^1.0.3
+  checksum: 7e7c47e363be9579a4269e1df803be29cd3feb1df2c490b7cdef7c3a7c20f1f5cfa62d7f8de934b73e5c0e98ff07e1f0147b9fc11789a0f160d2893ddcc035ab
+  languageName: node
+  linkType: hard
+
 "import-local@npm:^3.0.2":
   version: 3.0.2
   resolution: "import-local@npm:3.0.2"
@@ -44606,6 +45342,15 @@ fsevents@~2.1.1:
   version: 1.0.2
   resolution: "is-property@npm:1.0.2"
   checksum: 33b661a3690bcc88f7e47bb0a21b9e3187e76a317541ea7ec5e8096d954f441b77a46d8930c785f7fbf4ef8dfd624c25495221e026e50f74c9048fe501773be5
+  languageName: node
+  linkType: hard
+
+"is-reference@npm:1.2.1":
+  version: 1.2.1
+  resolution: "is-reference@npm:1.2.1"
+  dependencies:
+    "@types/estree": "*"
+  checksum: e7b48149f8abda2c10849ea51965904d6a714193d68942ad74e30522231045acf06cbfae5a4be2702fede5d232e61bf50b3183acdc056e6e3afe07fcf4f4b2bc
   languageName: node
   linkType: hard
 
@@ -49544,6 +50289,15 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.3":
+  version: 0.30.11
+  resolution: "magic-string@npm:0.30.11"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.5.0
+  checksum: e041649453c9a3f31d2e731fc10e38604d50e20d3585cd48bc7713a6e2e1a3ad3012105929ca15750d59d0a3f1904405e4b95a23b7e69dc256db3c277a73a3ca
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.5":
   version: 0.30.7
   resolution: "magic-string@npm:0.30.7"
@@ -50603,6 +51357,15 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^8.0.2":
+  version: 8.0.4
+  resolution: "minimatch@npm:8.0.4"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 2e46cffb86bacbc524ad45a6426f338920c529dd13f3a732cc2cf7618988ee1aae88df4ca28983285aca9e0f45222019ac2d14ebd17c1edadd2ee12221ab801a
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^9.0.0":
   version: 9.0.0
   resolution: "minimatch@npm:9.0.0"
@@ -50739,6 +51502,13 @@ fsevents@~2.1.1:
   dependencies:
     yallist: ^4.0.0
   checksum: 57a04041413a3531a65062452cb5175f93383ef245d6f4a2961d34386eb9aa8ac11ac7f16f791f5e8bbaf1dfb1ef01596870c88e8822215db57aa591a5bb0a77
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^4.2.4":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 7f4914d5295a9a30807cae5227a37a926e6d910c03f315930fde52332cf0575dfbc20295318f91f0baf0e6bb11a6f668e30cde8027dea7a11b9d159867a3c830
   languageName: node
   linkType: hard
 
@@ -53523,6 +54293,18 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"opentelemetry-instrumentation-fetch-node@npm:1.2.3":
+  version: 1.2.3
+  resolution: "opentelemetry-instrumentation-fetch-node@npm:1.2.3"
+  dependencies:
+    "@opentelemetry/instrumentation": ^0.46.0
+    "@opentelemetry/semantic-conventions": ^1.17.0
+  peerDependencies:
+    "@opentelemetry/api": ^1.6.0
+  checksum: 1249388c22c5942572895031c7adb355b9563685cc9f773f617a524ca0033f62ad4c904001088a53c433998ca68ce44fe17ed04f04179374f56a5d6b610a9c83
+  languageName: node
+  linkType: hard
+
 "opentracing@npm:^0.14.4":
   version: 0.14.7
   resolution: "opentracing@npm:0.14.7"
@@ -54430,7 +55212,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.11.1":
+"path-scurry@npm:^1.11.1, path-scurry@npm:^1.6.1":
   version: 1.11.1
   resolution: "path-scurry@npm:1.11.1"
   dependencies:
@@ -57052,7 +57834,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0, progress@npm:^2.0.1":
+"progress@npm:^2.0.0, progress@npm:^2.0.1, progress@npm:^2.0.3":
   version: 2.0.3
   resolution: "progress@npm:2.0.3"
   checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
@@ -59977,6 +60759,20 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"rollup@npm:3.29.4":
+  version: 3.29.4
+  resolution: "rollup@npm:3.29.4"
+  dependencies:
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 8bb20a39c8d91130825159c3823eccf4dc2295c9a0a5c4ed851a5bf2167dbf24d9a29f23461a54c955e5506395e6cc188eafc8ab0e20399d7489fb33793b184e
+  languageName: node
+  linkType: hard
+
 "rollup@npm:^2.43.1":
   version: 2.79.1
   resolution: "rollup@npm:2.79.1"
@@ -62166,6 +62962,15 @@ resolve@1.1.7:
   version: 1.2.0
   resolution: "stackframe@npm:1.2.0"
   checksum: 37d659bdd574e118a48c445a9a054a2b8dee6d6ad54eb16c51c7dae622c0f4994b9ff4e47d744aa6cfd14c00b477e145f34db3df78771f3e783ce8f357616d00
+  languageName: node
+  linkType: hard
+
+"stacktrace-parser@npm:^0.1.10":
+  version: 0.1.10
+  resolution: "stacktrace-parser@npm:0.1.10"
+  dependencies:
+    type-fest: ^0.7.1
+  checksum: f4fbddfc09121d91e587b60de4beb4941108e967d71ad3a171812dc839b010ca374d064ad0a296295fed13acd103609d99a4224a25b4e67de13cae131f1901ee
   languageName: node
   linkType: hard
 
@@ -65340,6 +66145,13 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "type-fest@npm:0.7.1"
+  checksum: 5b1b113529d59949d97b76977d545989ddc11b81bb0c766b6d2ccc65473cb4b4a5c7d24f5be2c2bb2de302a5d7a13c1732ea1d34c8c59b7e0ec1f890cf7fc424
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.8.0, type-fest@npm:^0.8.1":
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
@@ -65996,6 +66808,18 @@ resolve@1.1.7:
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
+  languageName: node
+  linkType: hard
+
+"unplugin@npm:1.0.1":
+  version: 1.0.1
+  resolution: "unplugin@npm:1.0.1"
+  dependencies:
+    acorn: ^8.8.1
+    chokidar: ^3.5.3
+    webpack-sources: ^3.2.3
+    webpack-virtual-modules: ^0.5.0
+  checksum: b6bf00dcc79e71cd55d2b4dd39ec7c8ec40b071dc10c14e29095df5dccb13ad0ca1cf14e5da38bb16b8704f8eface750b7a3be9ee7ca2574ce31096ee966b356
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- Be able to use Sentry in Next.js on both the client and the server

## This pull request

- Add Sentry to payments-next using the installation wizard

## Issue that this pull request solves

Closes: #FXA-9998

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).