### PR TITLE
fix(dx): fix the `mysql` yarn command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "yarn workspaces foreach run format",
     "ports": "pm2 jlist | json -a -c 'this.pm2_env.env.PORT' pm2_env.env.PORT name",
     "heroku-postbuild": "yarn workspaces foreach --verbose --include 123done install",
-    "mysql": "docker exec -it $(docker container ls | grep mysql | cut -d' ' -f1) mysql",
+    "mysql": "docker exec -it $(docker container ls | grep mysql | grep 3306 | cut -d' ' -f1) mysql",
     "firefox": "FIREFOX_DEBUGGER=true ./packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs",
     "generate-lockfile": "docker build . -f _dev/docker/ci-lockfile-generator/Dockerfile -t generate-lockfile && docker run generate-lockfile > yarn.lock",
     "l10n:clone": "_scripts/l10n/clone.sh",


### PR DESCRIPTION
Because:
 - we run two mysql containers now

This commit:
 - updates the `mysql` "script" to connect to the container that's listening on the default port for mysql

