### PR TITLE
fix(glean): Conditionally fire promo view event when Settings view event fires

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, RouteComponentProps } from '@reach/router';
 import Security from '../Security';
 import { Profile } from '../Profile';
@@ -15,14 +15,17 @@ import { SETTINGS_PATH } from 'fxa-settings/src/constants';
 import { Localized } from '@fluent/react';
 import DataCollection from '../DataCollection';
 import GleanMetrics from '../../../lib/glean';
-import ProductPromo, { ProductPromoType } from '../ProductPromo';
+import ProductPromo, {
+  getProductPromoData,
+  ProductPromoType,
+} from '../ProductPromo';
 import SideBar from '../Sidebar';
 import NotificationPromoBanner from '../../NotificationPromoBanner';
 import keyImage from '../../NotificationPromoBanner/key.svg';
 import Head from 'fxa-react/components/Head';
 
 export const PageSettings = (_: RouteComponentProps) => {
-  const { uid, recoveryKey } = useAccount();
+  const { uid, recoveryKey, attachedClients, subscriptions } = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
 
   Metrics.setProperties({
@@ -34,6 +37,23 @@ export const PageSettings = (_: RouteComponentProps) => {
   useEffect(() => {
     GleanMetrics.accountPref.view();
   }, []);
+
+  const [productPromoGleanEventSent, setProductPromoGleanEventSent] =
+    useState(false);
+
+  useEffect(() => {
+    // We want this view event to fire whenever the account settings page view
+    // event fires, if the user is shown the promo.
+    const { gleanEvent, hasAllPromoProducts } = getProductPromoData(
+      attachedClients,
+      subscriptions
+    );
+    if (!hasAllPromoProducts && !productPromoGleanEventSent) {
+      GleanMetrics.accountPref.promoMonitorView(gleanEvent);
+      // Keep track of this because `attachedClients` can change on disconnect
+      setProductPromoGleanEventSent(true);
+    }
+  }, [attachedClients, subscriptions, productPromoGleanEventSent]);
 
   const accountRecoveryNotificationProps = {
     headerImage: keyImage,

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.test.tsx
@@ -6,15 +6,14 @@ import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import ProductPromo, { ProductPromoType } from '.';
 import { Account, AppContext } from '../../../models';
-import { MOCK_SERVICES } from '../ConnectedServices/mocks';
 import { MozServices } from '../../../lib/types';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { mockAppContext } from '../../../models/mocks';
 import GleanMetrics from '../../../lib/glean';
-
-// List all services this component handles
-const PRODUCT_PROMO_SERVICES = [MozServices.Monitor];
-const PRODUCT_PROMO_SUBSCRIPTIONS = [{ productName: MozServices.MonitorPlus }];
+import {
+  ALL_PRODUCT_PROMO_SERVICES,
+  ALL_PRODUCT_PROMO_SUBSCRIPTIONS,
+} from '../../../pages/mocks';
 
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
@@ -32,12 +31,8 @@ describe('ProductPromo', () => {
   });
 
   it('renders nothing if user has Monitor but not MonitorPlus, and MonitorPlus Promo is disabled', () => {
-    const services = MOCK_SERVICES.filter((service) =>
-      // TODO: MozServices / string discrepancy, FXA-6802
-      PRODUCT_PROMO_SERVICES.includes(service.name as MozServices)
-    );
     const account = {
-      attachedClients: services,
+      attachedClients: ALL_PRODUCT_PROMO_SERVICES,
       subscriptions: [],
     } as unknown as Account;
 
@@ -48,17 +43,12 @@ describe('ProductPromo', () => {
     );
 
     expect(container.firstChild).toBeNull();
-    expect(GleanMetrics.accountPref.promoMonitorView).not.toHaveBeenCalled();
   });
 
   it('renders nothing if user has all products and subscriptions', async () => {
-    const services = MOCK_SERVICES.filter((service) =>
-      // TODO: MozServices / string discrepancy, FXA-6802
-      PRODUCT_PROMO_SERVICES.includes(service.name as MozServices)
-    );
     const account = {
-      attachedClients: services,
-      subscriptions: PRODUCT_PROMO_SUBSCRIPTIONS,
+      attachedClients: ALL_PRODUCT_PROMO_SERVICES,
+      subscriptions: ALL_PRODUCT_PROMO_SUBSCRIPTIONS,
     } as unknown as Account;
 
     const { container } = renderWithLocalizationProvider(
@@ -68,7 +58,6 @@ describe('ProductPromo', () => {
     );
 
     expect(container.firstChild).toBeNull();
-    expect(GleanMetrics.accountPref.promoMonitorView).not.toHaveBeenCalled();
   });
   it('renders Monitor promo if user does not have Monitor', async () => {
     const account = {
@@ -89,9 +78,6 @@ describe('ProductPromo', () => {
       'href',
       'https://monitor.mozilla.org/?utm_source=moz-account&utm_medium=product-partnership&utm_term=sidebar&utm_content=monitor-free&utm_campaign=settings-promo'
     );
-    expect(GleanMetrics.accountPref.promoMonitorView).toBeCalledWith({
-      event: { reason: 'free' },
-    });
   });
 
   it('renders Monitor Plus promo if user does not have Monitor Plus', async () => {
@@ -120,9 +106,6 @@ describe('ProductPromo', () => {
       'href',
       'https://monitor.mozilla.org/#pricing?utm_source=moz-account&utm_medium=product-partnership&utm_term=sidebar&utm_content=monitor-plus&utm_campaign=settings-promo'
     );
-    expect(GleanMetrics.accountPref.promoMonitorView).toBeCalledWith({
-      event: { reason: 'plus' },
-    });
   });
 
   it('emits metric when user clicks call to action', async () => {

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -83,6 +83,11 @@ export interface AttachedClient {
   refreshTokenId: string | null;
 }
 
+interface Subscription {
+  created: number;
+  productName: string;
+}
+
 export interface AccountData {
   uid: hexstring;
   displayName: string | null;
@@ -102,10 +107,7 @@ export interface AccountData {
   attachedClients: AttachedClient[];
   linkedAccounts: LinkedAccount[];
   totp: AccountTotp;
-  subscriptions: {
-    created: number;
-    productName: string;
-  }[];
+  subscriptions: Subscription[];
   securityEvents: SecurityEvent[];
 }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCodeConfirm/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCodeConfirm/index.tsx
@@ -26,7 +26,7 @@ export type SigninPushCodeConfirmProps = {
   errorMessage?: string;
 };
 
-const ProductPromotion = () => {
+const Products = () => {
   const products = [
     {
       icon: monitorIcon,
@@ -99,7 +99,7 @@ const LoginApprovedMessage = () => {
           Your login has been approved. Please close this window.
         </p>
       </FtlMsg>
-      <ProductPromotion />
+      <Products />
     </div>
   );
 };

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -66,3 +66,7 @@ export function mockLoadingSpinnerModule() {
 }
 export const MOCK_RECOVERY_KEY = 'ARJDF300TFEPRJ7SFYB8QVNVYT60WWS2';
 export const MOCK_REMOTE_METADATA = JSON.stringify({});
+export const ALL_PRODUCT_PROMO_SERVICES = [{ name: MozServices.Monitor }];
+export const ALL_PRODUCT_PROMO_SUBSCRIPTIONS = [
+  { productName: MozServices.MonitorPlus },
+];


### PR DESCRIPTION
Because:
* We are seeing this event fire too many times, reproducible when navigating around Settings

This commit:
* Creates a shared function for PageSettings and ProductPromo to use to conditionally send the Glean ping and render the component as expected

fixes FXA-10403

---

I think the more ideal fix for this would still be the intersection observer to better tweak when this ping is sent especially in mobile, but we talked about simply having this fire once (if a promo is rendered) whenever the Settings page view event fires despite there being multiple promos rendered (in mobile there's one in nav + in Settings), so that's what this does.

I found that Barry's guess was correct - the Settings page view fires whenever you navigate inside of Settings and then navigate back to Settings, but the promo component was sometimes firing multiple times. I don't know what was causing the re-render but this seemed like the right approach for now instead of trying to pass state/a state setter down into where we're composing the components.

One thing I might not fully understand is why this event seems to send to `events` _and_ `account-events`. I guess this is because of our string metric for 'reason'?