### PR TITLE
remove HTML report job for smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -969,14 +969,6 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
-      - playwright-functional-test-report:
-          requires:
-            - Smoke Test Production - Playwright
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
 
   # Triggered remotely. See .circleci/README.md
   stage_smoke_tests:
@@ -987,14 +979,6 @@ workflows:
           project: stage
           resource_class: xlarge
           parallelism: 8
-          filters:
-            branches:
-              only: /.*/
-            tags:
-              only: /.*/
-      - playwright-functional-test-report:
-          requires:
-            - Smoke Test Stage - Playwright
           filters:
             branches:
               only: /.*/


### PR DESCRIPTION
## Because

- The playwright test report job were failing for smoke tests due to a recent [PR](https://github.com/mozilla/fxa/pull/17537)

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
