### PR TITLE
fix(payments-next): Revise import

### DIFF
--- a/apps/payments/next/sentry.client.config.ts
+++ b/apps/payments/next/sentry.client.config.ts
@@ -6,7 +6,7 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import { initSentryForNextjsClient } from '@fxa/shared/sentry/client';
-import { version } from './package.json';
+import packageInfo from './package.json';
 
 const DEFAULT_SAMPLE_RATE = '1';
 const DEFAULT_TRACES_SAMPLE_RATE = '1';
@@ -25,6 +25,6 @@ const sentryConfig = {
 };
 
 initSentryForNextjsClient({
-  release: version,
+  release: packageInfo.version,
   sentry: sentryConfig,
 });

--- a/apps/payments/next/sentry.server.config.ts
+++ b/apps/payments/next/sentry.server.config.ts
@@ -7,7 +7,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import { initSentryForNextjsServer } from '@fxa/shared/sentry';
 import { config } from './config';
-import { version } from './package.json';
+import packageInfo from './package.json';
 
 const sentryConfig = {
   dsn: config.nextPublicSentryDsn,
@@ -19,7 +19,7 @@ const sentryConfig = {
 
 initSentryForNextjsServer(
   {
-    release: version,
+    release: packageInfo.version,
     sentry: sentryConfig,
   },
   console


### PR DESCRIPTION
## This pull request

- prevents log error below: 
```
39|payment | Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
39|payment | 
39|payment | ./sentry.server.config.ts
39|payment | Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
39|payment | 
39|payment | Import trace for requested module:
39|payment | ./sentry.server.config.ts
39|payment |  ⚠ ./sentry.client.config.ts
39|payment | Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
39|payment | 
39|payment | ./sentry.server.config.ts
39|payment | Should not import the named export 'version' (imported as 'version') from default-exporting module (only default export is available soon)
39|payment | 
39|payment | Import trace for requested module:
39|payment | ./sentry.server.config.ts
```

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
