### PR TITLE
fix(next): resolve package import version warnings

### DIFF
--- a/apps/payments/next/next.config.js
+++ b/apps/payments/next/next.config.js
@@ -7,6 +7,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { composePlugins, withNx } = require('@nx/next');
 const { withSentryConfig } = require('@sentry/nextjs');
+const { version } = require('./package.json');
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -16,6 +17,9 @@ const nextConfig = {
     // Set this to true if you would like to use SVGR
     // See: https://github.com/gregberge/svgr
     svgr: false,
+  },
+  env: {
+    version,
   },
   experimental: {
     instrumentationHook: true,

--- a/apps/payments/next/sentry.client.config.ts
+++ b/apps/payments/next/sentry.client.config.ts
@@ -6,7 +6,6 @@
 // The config you add here will be used whenever a users loads a page in their browser.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import { initSentryForNextjsClient } from '@fxa/shared/sentry/client';
-import { version } from './package.json';
 
 const DEFAULT_SAMPLE_RATE = '1';
 const DEFAULT_TRACES_SAMPLE_RATE = '1';
@@ -25,6 +24,6 @@ const sentryConfig = {
 };
 
 initSentryForNextjsClient({
-  release: version,
+  release: process.env.version,
   sentry: sentryConfig,
 });

--- a/apps/payments/next/sentry.server.config.ts
+++ b/apps/payments/next/sentry.server.config.ts
@@ -7,7 +7,6 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import { initSentryForNextjsServer } from '@fxa/shared/sentry';
 import { config } from './config';
-import { version } from './package.json';
 
 const sentryConfig = {
   dsn: config.nextPublicSentryDsn,
@@ -19,7 +18,7 @@ const sentryConfig = {
 
 initSentryForNextjsServer(
   {
-    release: version,
+    release: process.env.version,
     sentry: sentryConfig,
   },
   console


### PR DESCRIPTION
## Because

- Importing package.json in sentry config files resulted in build warning 'Should not import the named export'

## This pull request

- Add package version as env var added to js bundle by nextjs

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
