### PR TITLE
chore(functional_test): update config to run merge reports with test failures in Nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1256,6 +1256,10 @@ workflows:
           projects: --exclude '*,!tag:scope:shared:*'
           requires:
             - Build (nightly)
+      - check-required-jobs-complete:
+          name: Check all required jobs are complete (nightly)
+          requires:
+            - Build (nightly)
       - playwright-functional-tests:
           name: Functional Tests - Playwright (nightly)
           resource_class: xlarge
@@ -1265,7 +1269,7 @@ workflows:
       - playwright-functional-test-report:
           name: Merge Playwright Reports (nightly)
           requires:
-            - Functional Tests - Playwright (nightly)
+            - Check all required jobs are complete (nightly)
       - on-complete:
           name: Tests Complete (nightly)
           stage: Tests (nightly)
@@ -1280,6 +1284,7 @@ workflows:
             - Integration Test - Servers - Auth V2 (nightly)
             - Integration Test - Libraries (nightly)
             - Functional Tests - Playwright (nightly)
+            - Check all required jobs are complete (nightly)
       - build-and-deploy-storybooks:
           name: Deploy Storybooks (nightly)
           requires:


### PR DESCRIPTION
## Because

- Currently CircleCI doesn't let jobs with require parameter to be executed when the previous job fails with a failed status. But we needed to find a workaround for this to be able to generate HTML reports.
- A detailed explanation of the whole workaround is added on [FXA-10298](https://mozilla-hub.atlassian.net/browse/FXA-10298)
- This is for nightly only.

## This pull request

- Created a `waiter` job that will check for all the required job's status and when it's complete it executes the dependent job.
- The `waiter` job is called `check-required-jobs-complete` and the dependent job is `playwright-functional-test-report`


## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-10298]: https://mozilla-hub.atlassian.net/browse/FXA-10298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ