### PR TITLE
fix nightly issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -751,7 +751,13 @@ jobs:
               JOB_STATUS=$(echo $RESPONSE | jq -r '.items[] | .name + "-" + .status')
               echo "ALL JOB_STATUS:"
               echo $JOB_STATUS
-              PENDING=$(echo $RESPONSE | jq -r '.items[] | select(.status == "blocked" or .status == "running" or .status == "not_running") | select(.name | startswith("Tests Complete") | not) | select(.name | startswith("Merge Playwright Reports") | not) | select(.name | startswith("Check all required jobs are complete") | not ) | .name')
+              PENDING=$(echo $RESPONSE | jq -r '.items[] | select(.status == "blocked" or .status == "running" or .status == "not_running") | select(.name | startswith("Tests Complete") | not) |
+              select(.name | startswith("Merge Playwright Reports") | not) |
+              select(.name | startswith("Deploy Storybooks") | not) |
+              select(.name | startswith("Create FxA Image") | not) |
+              select(.name | startswith("Deploy FxA Image") | not) |
+              select(.name | startswith("Deploy CI Images") | not) |
+              select(.name | startswith("Check all required jobs are complete") | not ) | .name')
               echo "PENDING JOBS OF INTEREST:"
               echo $PENDING
               if [[ -z "$PENDING" ]]; then


### PR DESCRIPTION
## Because

- The `Check all required jobs are complete` waiter job needs additional job present in nightly only to be skipped while fetching the status and trying to proceed because of which `Nightly' job failed in the last run.

[CircleCI job run](https://app.circleci.com/pipelines/github/mozilla/fxa/54100/workflows/ffcc4fa8-84f3-4439-84f5-908da0feacec/jobs/528201)

## This pull request

- Adds the additional job for nightly to be skipped while fetching the status.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
