### PR TITLE
feat(recovery): Add functionality of `do it later` in inline recovery key

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
@@ -84,6 +84,7 @@ const FRONTEND_ROUTES = [
   'verify_secondary_email',
   'would_you_like_to_sync',
   'web_channel_example',
+  'inline_recovery_key_setup',
 ];
 
 // The array is converted into a RegExp

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -86,6 +86,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
         'inline_recovery_setup',
         'signin_push_code',
         'signin_push_code_confirm',
+        'inline_recovery_key_setup',
       ]),
       fullProdRollout: true,
     },

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -84,6 +84,7 @@ import ConfirmResetPasswordContainer from '../../pages/ResetPasswordRedesign/Con
 import CompleteResetPasswordWithCodeContainer from '../../pages/ResetPasswordRedesign/CompleteResetPassword/container';
 import AccountRecoveryConfirmKeyContainer from '../../pages/ResetPasswordRedesign/AccountRecoveryConfirmKey/container';
 import SignoutSync from '../Settings/SignoutSync';
+import InlineRecoveryKeySetupContainer from '../../pages/InlineRecoveryKeySetup/container';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -454,6 +455,10 @@ const AuthAndAccountSetupRoutes = ({
       <SigninUnblockContainer
         path="/signin_unblock/*"
         {...{ integration, flowQueryParams }}
+      />
+      <InlineRecoveryKeySetupContainer
+        path="/inline_recovery_key_setup/*"
+        {...{ integration, serviceName }}
       />
 
       {/* Signup */}

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
@@ -61,6 +61,7 @@ export const InlineRecoveryKeySetupCreate = ({
       <button
         className="flex justify-center items-center link-blue text-sm mx-auto"
         onClick={doLaterHandler}
+        data-glean-id="inline_recovery_key_setup_create_do_it_later"
       >
         <FtlMsg id="inline-recovery-key-setup-later-button">Do it later</FtlMsg>
       </button>

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
@@ -12,7 +12,7 @@ export const InlineRecoveryKeySetupCreate = ({
   doLaterHandler,
 }: {
   createRecoveryKeyHandler: () => Promise<void>;
-  doLaterHandler: () => Promise<void>;
+  doLaterHandler: () => void;
 }) => {
   return (
     <>
@@ -58,7 +58,10 @@ export const InlineRecoveryKeySetupCreate = ({
         </button>
       </div>
 
-      <button className="flex justify-center items-center link-blue text-sm mx-auto">
+      <button
+        className="flex justify-center items-center link-blue text-sm mx-auto"
+        onClick={doLaterHandler}
+      >
         <FtlMsg id="inline-recovery-key-setup-later-button">Do it later</FtlMsg>
       </button>
     </>

--- a/packages/fxa-settings/src/components/NotificationPromoBanner/index.test.tsx
+++ b/packages/fxa-settings/src/components/NotificationPromoBanner/index.test.tsx
@@ -18,6 +18,10 @@ jest.mock('@reach/router', () => ({
 }));
 
 describe('NotificationPromoBanner component', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('renders as expected', () => {
     const notificationProps = {
       headerImage: keyImage,

--- a/packages/fxa-settings/src/components/NotificationPromoBanner/index.tsx
+++ b/packages/fxa-settings/src/components/NotificationPromoBanner/index.tsx
@@ -3,6 +3,7 @@ import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { ReactComponent as IconClose } from '@fxa/shared/assets/images/close.svg';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import GleanMetrics from '../../lib/glean';
+import { Constants } from '../../lib/constants';
 
 type NotificationPromoBannerProps = {
   headerImage: string;
@@ -13,6 +14,11 @@ type NotificationPromoBannerProps = {
   dismissKey: string;
   metricsKey: string;
   isVisible: boolean;
+};
+
+const PromoKeys: { [key: string]: string } = {
+  'account-recovery-dismissed':
+    Constants.DISABLE_PROMO_ACCOUNT_RECOVERY_KEY_BANNER,
 };
 
 const NotificationPromoBanner = ({
@@ -34,7 +40,7 @@ const NotificationPromoBanner = ({
   // This value is used to animate the banner out of view when the user dismisses it.
   const [isClosing, setIsClosing] = useState(false);
 
-  const notificationBannerClosedLocalStorageKey = `__fxa_storage.fxa_disable_notification_banner.${dismissKey}`;
+  const notificationBannerClosedLocalStorageKey = PromoKeys[dismissKey];
 
   const [bannerClosed] = useState<string | null>(
     localStorage.getItem(notificationBannerClosedLocalStorageKey)

--- a/packages/fxa-settings/src/lib/constants.ts
+++ b/packages/fxa-settings/src/lib/constants.ts
@@ -189,4 +189,10 @@ export const Constants = {
 
   ENV_DEVELOPMENT: 'development',
   ENV_PRODUCTION: 'production',
+
+  DISABLE_PROMO_ACCOUNT_RECOVERY_KEY_BANNER:
+    '__fxa_storage.fxa_disable_notification_banner.account-recovery-dismissed',
+
+  DISABLE_PROMO_ACCOUNT_RECOVERY_KEY_DO_IT_LATER:
+    '__fxa_storage.disable_promo.account-recovery-do-it-later',
 };

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
@@ -12,7 +12,7 @@ export const InlineRecoveryKeySetupContainer = ({
 }: {
   integration: Integration;
 } & RouteComponentProps) => {
-  const [currentStep, setCurrentStep] = useState<number>(1);
+  const [currentStep] = useState<number>(1);
   const createRecoveryKeyHandler = useCallback(async () => {
     // TODO in FXA-10079
   }, []);

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.tsx
@@ -102,9 +102,7 @@ export const InlineRecoveryKeySetup = ({
       default:
         return (
           <InlineRecoveryKeySetupCreate
-            {...{ createRecoveryKeyHandler }}
-            doLaterHandler={doLaterHandler}
-            data-glean-id="inline_recovery_key_setup_create_do_it_later"
+            {...{ createRecoveryKeyHandler, doLaterHandler }}
           />
         );
     }


### PR DESCRIPTION
## Because

- We want to be able to dismiss this promo

## This pull request

- Adds functionalit to the do it later button
- Sets a localstorage value so that it wont appear again if the user clicked do it later
- Adds glean metric for button click

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10080

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
