### PR TITLE
fix(pairing): Remove the signin link when pairing fails

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/pairing/supplicant-state-machine.js
+++ b/packages/fxa-content-server/app/scripts/models/pairing/supplicant-state-machine.js
@@ -29,10 +29,7 @@ class SupplicantState extends State {
   }
 
   socketError(error) {
-    this.navigate('pair/failure', {
-      error,
-      searchParams: window.location.search,
-    });
+    this.navigate('pair/failure', { error });
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/templates/pair/failure.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/failure.mustache
@@ -12,13 +12,7 @@
         </h1>
       </header>
 
-      <p class="mt-3">{{#t}}The setup couldn’t be completed.{{/t}}{{#showSigninLink}} {{#t}}Please sign in with your email.{{/t}}{{/showSigninLink}}</p>
-
-      {{#showSigninLink}}
-        <div class="button-row">
-          <button class="button primary-button mt-5" id="signin-button" type="button">{{#t}}Sign in{{/t}}</button>
-        </div>
-      {{/showSigninLink}}
+      <p class="mt-3">{{#t}}The setup couldn’t be completed. Please sign in with your email.{{/t}}</p>
 
     </form>
   </section>

--- a/packages/fxa-content-server/app/scripts/views/pair/failure.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/failure.js
@@ -4,33 +4,9 @@
 
 import FormView from '../form';
 import Template from '../../templates/pair/failure.mustache';
-import { assign } from 'underscore';
-import preventDefaultThen from '../decorators/prevent_default_then';
 
 class PairFailureView extends FormView {
   template = Template;
-
-  events = assign(this.events, {
-    'click #signin-button': preventDefaultThen('clickSignin'),
-  });
-
-  setInitialContext(context) {
-    const showSigninLink = !!this.model.get('searchParams');
-    context.set({
-      showSigninLink,
-    });
-  }
-
-  clickSignin() {
-    const params = this.model.get('searchParams');
-
-    // We replace the `email` with `prefillEmail` so that the email
-    // first page gets populated correctly.
-    const email = params.get('email');
-    params.delete('email');
-    params.set('prefillEmail', email);
-    window.location.href = `${window.location.origin}${params}`;
-  }
 }
 
 export default PairFailureView;

--- a/packages/fxa-content-server/app/tests/spec/models/pairing/supplicant-state-machine.js
+++ b/packages/fxa-content-server/app/tests/spec/models/pairing/supplicant-state-machine.js
@@ -84,10 +84,7 @@ describe('models/auth_brokers/pairing/supplicant-state-machine', function () {
       const err = new Error('socker error;');
       state.socketError(err);
       assert.isTrue(
-        state.navigate.calledOnceWith('pair/failure', {
-          error: err,
-          searchParams: '',
-        })
+        state.navigate.calledOnceWith('pair/failure', { error: err })
       );
     });
   });


### PR DESCRIPTION
## Because

- The signin link when pairing fails is flaky

## This pull request

- Removes the signin buton

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10395
Closes: https://mozilla-hub.atlassian.net/browse/FXA-10258
Closes: https://mozilla-hub.atlassian.net/browse/FXA-10409

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
