### PR TITLE
fix(auth): strapi client cachebust and key server setup

### DIFF
--- a/libs/shared/cms/src/lib/strapi.client.ts
+++ b/libs/shared/cms/src/lib/strapi.client.ts
@@ -152,7 +152,7 @@ export class StrapiClient {
 
   private setupCacheBust() {
     const cacheTTL =
-      this.strapiClientConfig.memCacheTTL || DEFAULT_MEM_CACHE_TTL * 1000;
+      (this.strapiClientConfig.memCacheTTL || DEFAULT_MEM_CACHE_TTL) * 1000;
 
     setInterval(() => {
       this.graphqlMemCache = {};

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -148,6 +148,7 @@ async function run(config) {
       const strapiClient = new StrapiClient(strapiClientConfig, firestore);
       const productConfigurationManager = new ProductConfigurationManager(
         strapiClient,
+        priceManager,
         statsd
       );
       Container.set(ProductConfigurationManager, productConfigurationManager);


### PR DESCRIPTION
## Because

- Running with Strapi-enabled had two issues

## This pull request

- Fixes two issues with Strapi-enabled auth

## Issue that this pull request solves

Closes FXA-10112