### PR TITLE
feat(metrics): set available ping metrics during Glean init

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -172,7 +172,7 @@ Start.prototype = {
   },
 
   initializeGlean() {
-    GleanMetrics.initialize(this._config.glean, {
+    return GleanMetrics.initialize(this._config.glean, {
       metrics: this._metrics,
       relier: this._relier,
       user: this._user,

--- a/packages/fxa-content-server/app/tests/spec/lib/glean.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/glean.js
@@ -187,7 +187,8 @@ describe('lib/glean', () => {
     });
 
     it('submits a ping on an event', async () => {
-      await GleanMetrics.registration.view();
+      GleanMetrics.registration.view();
+      await GleanMetrics.isDone();
       sinon.assert.calledOnce(submitPingStub);
     });
 

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -81,6 +81,7 @@ jest.mock('../../lib/glean', () => ({
   default: {
     initialize: jest.fn(),
     getEnabled: jest.fn(),
+    useGlean: jest.fn().mockReturnValue({ enabled: true }),
     accountPref: { view: jest.fn(), promoMonitorView: jest.fn() },
     pageLoad: jest.fn(),
   },

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -161,6 +161,11 @@ export const App = ({
       return;
     }
 
+    // This is in a useMemo because we want Glean to be initialized _before_
+    // other components are rendered.  `useEffect` is called after a component
+    // is rendered, which for this means _after_ all the children components
+    // are rendered and _their `useEffect` hooks are called_.
+
     GleanMetrics.initialize(
       {
         ...config.glean,
@@ -297,10 +302,11 @@ const AuthAndAccountSetupRoutes = ({
   // TODO: MozServices / string discrepancy, FXA-6802
   const serviceName = integration.getServiceName() as MozServices;
   const location = useLocation();
+  const { enabled: gleanEnabled } = GleanMetrics.useGlean();
 
   useEffect(() => {
-    GleanMetrics.pageLoad(location.pathname);
-  }, [location.pathname]);
+    gleanEnabled && GleanMetrics.pageLoad(location.pathname);
+  }, [location.pathname, gleanEnabled]);
 
   return (
     <Router>

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -73,10 +73,11 @@ export const Settings = ({
   }, [account, session]);
 
   const { loading, error } = useInitialSettingsState();
+  const { enabled: gleanEnabled } = GleanMetrics.useGlean();
 
   useEffect(() => {
-    !loading && GleanMetrics.pageLoad(location.pathname);
-  }, [loading, location.pathname]);
+    !loading && gleanEnabled && GleanMetrics.pageLoad(location.pathname);
+  }, [loading, location.pathname, gleanEnabled]);
 
   if (loading) {
     return <LoadingSpinner fullScreen />;

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -166,6 +166,10 @@ describe('lib/glean', () => {
       sinon.assert.notCalled(setEntrypointExperimentStub);
       sinon.assert.notCalled(setEntrypointVariationStub);
     });
+
+    it('returns false for enabed in useGlean', () => {
+      expect(GleanMetrics.useGlean().enabled).toBe(false);
+    });
   });
 
   describe('initialization error', () => {
@@ -209,6 +213,10 @@ describe('lib/glean', () => {
       sinon.assert.notCalled(debugViewTagStub);
       sinon.assert.calledOnce(setEnabledSpy);
       sinon.assert.calledWith(setEnabledSpy, true);
+    });
+
+    it('returns true for enabed in useGlean', () => {
+      expect(GleanMetrics.useGlean().enabled).toBe(true);
     });
 
     it('submits a ping on an event', async () => {


### PR DESCRIPTION
Because:
 - we want to send known metric values in the automatic page load events

This commit:
 - set the available metrics when initializing Glean, before any page load events

