### PR TITLE
chore(functional_test): run playwright functional tests in chromium browser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,6 +336,32 @@ commands:
             RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
             UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
 
+  run-playwright-tests-chromium:
+    parameters:
+      project:
+        type: string
+    steps:
+      - run:
+          name: Running Playwright tests
+          # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
+          command: |
+            npx nx build fxa-auth-client
+            cd packages/functional-tests/tests
+            TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
+            cd ..
+            echo $TEST_FILES | circleci tests run --command="xargs yarn playwright test --project=<< parameters.project >>-chromium $GREP" --verbose --split-by=timings --timings-type=classname
+          environment:
+            NODE_OPTIONS: --dns-result-order=ipv4first
+            JEST_JUNIT_OUTPUT_DIR: ./artifacts/tests
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: true
+            PLAYWRIGHT_BLOB_OUTPUT_DIR: ./artifacts/blob-report
+            PW_TEST_HTML_REPORT_OPEN: never
+            ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
+            PAYMENTS_DOMAIN: << pipeline.parameters.payments-domain >>
+            ACCOUNTS_API_DOMAIN: << pipeline.parameters.accounts-api-domain >>
+            RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
+            UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
+
   store-artifacts:
     steps:
       - run:
@@ -367,12 +393,41 @@ commands:
             echo "Listing contents before renaming:"
             ls -la
             if [ -f report.zip ]; then
-              mv report.zip reports-${CIRCLE_NODE_INDEX}.zip
-              echo "Renamed report.zip to reports-${CIRCLE_NODE_INDEX}.zip"
+              mv report.zip reports-${CIRCLE_NODE_INDEX}-firefox.zip
+              echo "Renamed report.zip to reports-${CIRCLE_NODE_INDEX}-firefox.zip"
             else
               echo "No report.zip found, skipping rename for this node."
             fi
-            echo "$CIRCLE_WORKFLOW_JOB_ID" > job_id.txt
+            echo "$CIRCLE_WORKFLOW_JOB_ID" > job_id_firefox.txt
+            echo "Listing contents after renaming:"
+            ls -la
+          when: always
+      - store_artifacts:
+          path: artifacts/blob-report
+      - persist_to_workspace:
+          root: /home/circleci/project
+          paths:
+            - artifacts/blob-report
+
+
+  rename-reports-chromium:
+    steps:
+      - run:
+          name: Rename Reports
+          command: |
+            mkdir -p artifacts/blob-report && mkdir -p artifacts/playwright-report
+            echo "Starting rename reports step"
+            cd artifacts/blob-report || { echo "Directory artifacts/blob-report not found"; exit 1; }
+            echo "Current directory: $(pwd)"
+            echo "Listing contents before renaming:"
+            ls -la
+            if [ -f report.zip ]; then
+              mv report.zip reports-${CIRCLE_NODE_INDEX}-chromium.zip
+              echo "Renamed report.zip to reports-${CIRCLE_NODE_INDEX}-chromium.zip"
+            else
+              echo "No report.zip found, skipping rename for this node."
+            fi
+            echo "$CIRCLE_WORKFLOW_JOB_ID" > job_id_chromium.txt
             echo "Listing contents after renaming:"
             ls -la
           when: always
@@ -727,6 +782,37 @@ jobs:
       - store-artifacts
       - rename-reports
 
+  playwright-functional-tests-chromium:
+    parameters:
+      resource_class:
+        type: string
+        default: large
+      parallelism:
+        type: integer
+        default: 4
+    executor: functional-test-executor
+    resource_class: << parameters.resource_class >>
+    parallelism: << parameters.parallelism >>
+    steps:
+      - git-checkout
+      - restore-workspace
+      - run:
+          name: Add localhost
+          command: |
+            sudo tee -a /etc/hosts \<<<'127.0.0.1 localhost'
+            sudo cat /etc/hosts
+      - wait-for-infrastructure
+      - run:
+          name: Start services for playwright tests
+          command: ./packages/functional-tests/scripts/start-services.sh
+          environment:
+            NODE_ENV: test
+      - run-playwright-tests-chromium:
+          project: local
+      - store-artifacts
+      - rename-reports-chromium
+
+  # Currently HTML reports are being generated for Firefox tests only hence we are only using firefox functional test job id below
   check-required-jobs-complete:
     docker:
       - image: circleci/node
@@ -739,7 +825,7 @@ jobs:
             mkdir -p artifacts/blob-report
             while true; do
               RESPONSE=$(curl -s --request GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" --header "Circle-Token: $CCI_Token")
-              FUNCTIONAL_TEST_JOB_ID=$(echo $RESPONSE | jq -r '.items[] | select(.status == "running") | select(.name | startswith("Functional Tests")) | .id')
+              FUNCTIONAL_TEST_JOB_ID=$(echo $RESPONSE | jq -r '.items[] | select(.status == "running") | select(.name | startswith("Firefox Functional Tests")) | .id')
               if [[ -e artifacts/blob-report/functional_test_job_id.txt ]]; then
                 echo "Job id already set"
               elif [[ -n "$FUNCTIONAL_TEST_JOB_ID" ]]; then
@@ -786,11 +872,11 @@ jobs:
             JOB_ID=$(cat functional_test_job_id.txt)
             echo "Fetching reports from circle ci artifact storarge for $JOB_ID"
             function fetch_report() {
-              echo "Fetching reports-$1.zip"
-              wget https://output.circle-artifacts.com/output/job/${JOB_ID}/artifacts/$1/artifacts/blob-report/reports-$1.zip
+              echo "Fetching reports-$1-firefox.zip"
+              wget https://output.circle-artifacts.com/output/job/${JOB_ID}/artifacts/$1/artifacts/blob-report/reports-$1-firefox.zip
               wgetreturn=$?
               if [[ $wgetreturn -ne 0 ]]; then
-                echo "Failed to get reports-$1.zip"
+                echo "Failed to get reports-$1-firefox.zip"
               fi
             }
             for i in $(seq 0 7); do
@@ -930,7 +1016,7 @@ workflows:
           requires:
             - Build (PR)
       - playwright-functional-tests:
-          name: Functional Tests - Playwright (PR)
+          name: Firefox Functional Tests - Playwright (PR)
           resource_class: xlarge
           parallelism: 8
           requires:
@@ -956,7 +1042,7 @@ workflows:
             - Integration Test - Servers - Auth (PR)
             - Integration Test - Servers - Auth V2 (PR)
             - Integration Test - Libraries (PR)
-            - Functional Tests - Playwright (PR)
+            - Firefox Functional Tests - Playwright (PR)
             - Deploy Storybooks (PR)
             - Check all required jobs are complete (PR)
 
@@ -1267,7 +1353,13 @@ workflows:
           requires:
             - Build (nightly)
       - playwright-functional-tests:
-          name: Functional Tests - Playwright (nightly)
+          name: Firefox Functional Tests - Playwright (nightly)
+          resource_class: xlarge
+          parallelism: 8
+          requires:
+            - Build (nightly)
+      - playwright-functional-tests-chromium:
+          name: Chromium Functional Tests - Playwright (nightly)
           resource_class: xlarge
           parallelism: 8
           requires:
@@ -1289,8 +1381,9 @@ workflows:
             - Integration Test - Servers - Auth (nightly)
             - Integration Test - Servers - Auth V2 (nightly)
             - Integration Test - Libraries (nightly)
-            - Functional Tests - Playwright (nightly)
+            - Firefox Functional Tests - Playwright (nightly)
             - Check all required jobs are complete (nightly)
+            - Chromium Functional Tests - Playwright (nightly)
       - build-and-deploy-storybooks:
           name: Deploy Storybooks (nightly)
           requires:

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -73,6 +73,21 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
           },
         } as Project)
     ),
+    ...TargetNames.map(
+      (name) =>
+        ({
+          name: `${name}-chromium`,
+          use: {
+            browserName: 'chromium',
+            targetName: name,
+            launchOptions: {
+              headless: !DEBUG,
+              slowMo: SLOWMO,
+            },
+            trace: 'retain-on-failure',
+          },
+        } as Project)
+    ),
   ],
   reporter: CI
     ? [

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -51,8 +51,8 @@ test.describe('severity-2 #smoke', () => {
       credentials,
     }, { project }) => {
       test.skip(
-        project.name === 'production',
-        'no real payment method available in prod'
+        project.name === 'production' || project.name === 'local-chromium',
+        'no real payment method available in prod or local-chromium'
       );
       await relier.goto();
       await relier.clickSubscribe();


### PR DESCRIPTION
## Because

- We need to add `chromium browser` to run our Playwright functional tests in `Nightly`

## This pull request

- Adds `chromium` as a project to the `playwright.config.ts` file
- Adds a different job for `run-playwright-tests-chromium` , `rename-reports-chromium` and a workflow `playwright-functional-tests-chromium` to run these jobs in.
- The `playwright-functional-tests` and `playwright-functional-tests-chromium` runs the firefox tests and chromium tests respectively, and generates separate `test.xml` file and `blob reports` (firefox: `reports-[0-7]-firefox.zip`, chromium: `reports-[0-7]-chromium`)
- Currently, HTML reports are only generated for firefox tests.
- One of the tests in `support.spec.ts` - `go to support form, cancel, redirects to subscription management` is currently failing in `chromium` as the textboxes are not properly loading for the support form in chromium browser. Hence this PR also marks the test as skipped and a separate bug would be created to address the issue and link it with the skip comment.

## Issue that this pull request solves

Closes: FXA-10307 FXA-10308

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note: the pre-req to install the `chromium` browser and deploy the CI images was already addressed in this [PR](https://github.com/mozilla/fxa/pull/17515)
