### PR TITLE
feat(recovery): fetch recovery key status with passwordForgotToken

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -775,6 +775,20 @@ export default class AuthClient {
     );
   }
 
+  async passwordForgotRecoveryKeyStatus(
+    passwordForgotToken: hexstring,
+    headers?: Headers
+  ) {
+    return this.hawkRequest(
+      'POST',
+      '/recoveryKey/exists',
+      passwordForgotToken,
+      tokenType.passwordForgotToken,
+      null,
+      headers
+    );
+  }
+
   // TODO: Once password reset react is 100% and stable in production
   // we can remove this.
   async accountReset(
@@ -1903,17 +1917,6 @@ export default class AuthClient {
       headers
     );
   }
-
-  // TODO: Review in FXA-7400 - possibly convert to POST to pass payload instead of using param, and enforce rate limiting
-  // async getRecoveryKeyHint(
-  //   sessionToken: hexstring | undefined,
-  //   email?: string
-  // ): Promise<{ hint: string | null }> {
-  //   if (sessionToken) {
-  //     return this.sessionGet('/recoveryKey/hint', sessionToken);
-  //   }
-  //   return this.request('GET', `/recoveryKey/hint?email=${email}`);
-  // }
 
   async updateRecoveryKeyHint(
     sessionToken: hexstring,

--- a/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
@@ -34,8 +34,8 @@ const RECOVERYKEY_EXISTS_POST = {
   ...TAGS_RECOVERY_KEY,
   description: '/recoveryKey/exists',
   notes: [
-    '🔒🔓 Optionally authenticated with session token',
-    'This route checks to see if given user has setup an account recovery key. When used during the password reset flow, an email can be provided (instead of a sessionToken) to check for the status. However, when using an email, the request is rate limited.',
+    '🔒🔓 Authenticated with session token or password-forgot token',
+    'This route checks to see if given user has setup an account recovery key. When used during the password reset flow, a password-forgot token to check for the status.',
   ],
 };
 

--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -1087,13 +1087,9 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     return RecoveryKey.update({ uid, recoveryKeyId, enabled });
   };
 
-  DB.prototype.getRecoveryKeyHint = async function (uid) {
-    log.trace('DB.getRecoveryKeyHint', { uid });
-    const data = await RecoveryKey.findByUid(uid);
-    if (!data) {
-      throw error.recoveryKeyNotFound();
-    }
-    return { hint: await RecoveryKey.findHintByUid(uid) };
+  DB.prototype.getRecoveryKeyRecordWithHint = async function (uid) {
+    log.trace('DB.getRecoveryKeyRecordWithHint', { uid });
+    return await RecoveryKey.findRecordWithHintByUid(uid);
   };
 
   DB.prototype.updateRecoveryKeyHint = async function (uid, hint) {

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -846,12 +846,8 @@ module.exports = (config) => {
     return this.api.getRecoveryKey(this.accountResetToken, recoveryKeyId);
   };
 
-  Client.prototype.getRecoveryKeyExists = function (email) {
-    if (!email) {
-      return this.api.getRecoveryKeyExistsWithSession(this.sessionToken);
-    } else {
-      return this.api.getRecoveryKeyExistsWithEmail(email);
-    }
+  Client.prototype.getRecoveryKeyExists = function () {
+    return this.api.getRecoveryKeyExistsWithSession(this.sessionToken);
   };
 
   Client.prototype.deleteRecoveryKey = function () {

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -587,7 +587,7 @@ describe('POST /recoveryKey/exists', () => {
         log,
       };
       return setup(
-        { db: { recoveryData } },
+        { db: { recoveryData, hint: 'so wow much encryption' } },
         {},
         '/recoveryKey/exists',
         requestOptions
@@ -596,6 +596,7 @@ describe('POST /recoveryKey/exists', () => {
 
     it('returned the correct response', () => {
       assert.equal(response.exists, true, 'exists ');
+      assert.equal(response.hint, 'so wow much encryption');
       assert.equal(response.estimatedSyncDeviceCount, 0);
     });
 
@@ -607,9 +608,9 @@ describe('POST /recoveryKey/exists', () => {
       assert.equal(args[1], request);
     });
 
-    it('called db.recoveryKeyExists correctly', () => {
-      assert.equal(db.recoveryKeyExists.callCount, 1);
-      const args = db.recoveryKeyExists.args[0];
+    it('called db.getRecoveryKeyRecordWithHint correctly', () => {
+      assert.equal(db.getRecoveryKeyRecordWithHint.callCount, 1);
+      const args = db.getRecoveryKeyRecordWithHint.args[0];
       assert.equal(args.length, 1);
       assert.equal(args[0], uid);
     });
@@ -707,48 +708,6 @@ describe('POST /recoveryKey/exists', () => {
       assert.equal(response.estimatedSyncDeviceCount, 1);
     });
   });
-
-  describe('should check if account recovery key exists using email', () => {
-    beforeEach(() => {
-      const requestOptions = {
-        payload: { email },
-        log,
-      };
-      return setup(
-        { db: { uid, email, recoveryData } },
-        {},
-        '/recoveryKey/exists',
-        requestOptions
-      ).then((r) => (response = r));
-    });
-
-    it('returned the correct response', () => {
-      assert.deepEqual(response.exists, true, 'exists ');
-    });
-
-    it('called log.begin correctly', () => {
-      assert.equal(log.begin.callCount, 1);
-      const args = log.begin.args[0];
-      assert.equal(args.length, 2);
-      assert.equal(args[0], 'recoveryKeyExists');
-      assert.equal(args[1], request);
-    });
-
-    it('called customs.check correctly', () => {
-      assert.equal(customs.check.callCount, 1);
-      const args = customs.check.args[0];
-      assert.equal(args.length, 3);
-      assert.equal(args[1], email);
-      assert.equal(args[2], 'recoveryKeyExists');
-    });
-
-    it('called db.recoveryKeyExists correctly', () => {
-      assert.equal(db.recoveryKeyExists.callCount, 1);
-      const args = db.recoveryKeyExists.args[0];
-      assert.equal(args.length, 1);
-      assert.equal(args[0], uid);
-    });
-  });
 });
 
 describe('DELETE /recoveryKey', () => {
@@ -844,220 +803,6 @@ describe('DELETE /recoveryKey', () => {
     });
   });
 });
-
-// TODO: FXA-7400 - Enable these tests
-// describe('GET /recoveryKey/hint', () => {
-//   describe('should fail when provided with no session token or email', () => {
-//     beforeEach(() => {
-//       const requestOptions = {
-//         method: 'GET',
-//         log,
-//       };
-//       return setup(
-//         { db: { uid, email, recoveryData, hint } },
-//         {},
-//         '/recoveryKey/hint',
-//         requestOptions
-//       ).then(assert.fail, (err) => (response = err));
-//     });
-
-//     it('returned the correct response', () => {
-//       assert.equal(
-//         response.errno,
-//         errors.ERRNO.MISSING_PARAMETER,
-//         'Missing parameter: email'
-//       );
-//     });
-
-//     it('called log.begin correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         log.begin,
-//         'getRecoveryKeyHint',
-//         request
-//       );
-//     });
-//   });
-
-//   describe('should fail when there is no account associated with the email', () => {
-//     beforeEach(() => {
-//       const requestOptions = {
-//         method: 'GET',
-//         query: { email: email },
-//         log,
-//       };
-//       return setup({}, {}, '/recoveryKey/hint', requestOptions).then(
-//         assert.fail,
-//         (err) => (response = err)
-//       );
-//     });
-
-//     it('returned the correct response', () => {
-//       assert.equal(
-//         response.errno,
-//         errors.ERRNO.ACCOUNT_UNKNOWN,
-//         'Unknown account'
-//       );
-//     });
-
-//     it('called log.begin correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         log.begin,
-//         'getRecoveryKeyHint',
-//         request
-//       );
-//     });
-
-//     it('called customs.check correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         customs.check,
-//         request,
-//         email,
-//         'recoveryKeyExists'
-//       );
-//     });
-//   });
-
-//   describe('should fail for unknown recovery key when provided with a session token', () => {
-//     beforeEach(() => {
-//       const requestOptions = {
-//         method: 'GET',
-//         credentials: { uid, email },
-//         log,
-//       };
-//       return setup(
-//         { db: { uid, email } },
-//         {},
-//         '/recoveryKey/hint',
-//         requestOptions
-//       ).then(assert.fail, (err) => (response = err));
-//     });
-
-//     it('returned the correct response', () => {
-//       assert.equal(
-//         response.errno,
-//         errors.ERRNO.RECOVERY_KEY_NOT_FOUND,
-//         'Account recovery key not found'
-//       );
-//     });
-
-//     it('called log.begin correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         log.begin,
-//         'getRecoveryKeyHint',
-//         request
-//       );
-//     });
-//   });
-
-//   describe('should fail for unknown recovery key when provided with an email', () => {
-//     beforeEach(() => {
-//       const requestOptions = {
-//         method: 'GET',
-//         query: { email: email },
-//         log,
-//       };
-//       return setup(
-//         { db: { uid, email } },
-//         {},
-//         '/recoveryKey/hint',
-//         requestOptions
-//       ).then(assert.fail, (err) => (response = err));
-//     });
-
-//     it('returned the correct response', () => {
-//       assert.equal(
-//         response.errno,
-//         errors.ERRNO.RECOVERY_KEY_NOT_FOUND,
-//         'Account recovery key not found'
-//       );
-//     });
-
-//     it('called log.begin correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         log.begin,
-//         'getRecoveryKeyHint',
-//         request
-//       );
-//     });
-
-//     it('called customs.check correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         customs.check,
-//         request,
-//         email,
-//         'recoveryKeyExists'
-//       );
-//     });
-//   });
-
-//   describe('should retrieve the recovery key hint using sessionToken', () => {
-//     beforeEach(() => {
-//       const requestOptions = {
-//         credentials: { uid, email },
-//         log,
-//       };
-//       return setup(
-//         { db: { recoveryData, hint } },
-//         {},
-//         '/recoveryKey/hint',
-//         requestOptions
-//       ).then((r) => (response = r));
-//     });
-
-//     it('returned the correct response', () => {
-//       assert.deepEqual(response.hint, hint);
-//       sinon.assert.calledOnceWithExactly(db.getRecoveryKeyHint, uid);
-//     });
-
-//     it('called log.begin correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         log.begin,
-//         'getRecoveryKeyHint',
-//         request
-//       );
-//     });
-//   });
-
-//   describe('should retrieve the recovery key hint using email', () => {
-//     beforeEach(async () => {
-//       const requestOptions = {
-//         method: 'GET',
-//         query: { email: email },
-//         log,
-//       };
-//       response = await setup(
-//         { db: { recoveryData, hint, uid, email } },
-//         {},
-//         '/recoveryKey/hint',
-//         requestOptions
-//       );
-//     });
-
-//     it('returned the correct response', () => {
-//       assert.deepEqual(response.hint, hint);
-//       sinon.assert.calledOnceWithExactly(db.getRecoveryKeyHint, uid);
-//     });
-
-//     it('called log.begin correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         log.begin,
-//         'getRecoveryKeyHint',
-//         request
-//       );
-//     });
-
-//     // TODO - FXA-7400 verify that request throws an error and aborts the rest of the call
-//     // if the request is rate-limited
-//     it('called customs.check correctly', () => {
-//       sinon.assert.calledOnceWithExactly(
-//         customs.check,
-//         request,
-//         email,
-//         'recoveryKeyExists'
-//       );
-//     });
-//   });
-// });
 
 describe('POST /recoveryKey/hint', () => {
   describe('should fail for unverified session', () => {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -73,7 +73,7 @@ const DB_METHOD_NAMES = [
   'emailRecord',
   'forgotPasswordVerified',
   'getRecoveryKey',
-  'getRecoveryKeyHint',
+  'getRecoveryKeyRecordWithHint',
   'getSecondaryEmail',
   'keyFetchToken',
   'keyFetchTokenWithVerificationStatus',
@@ -593,7 +593,7 @@ function mockDB(data, errors) {
         recoveryData: data.recoveryData,
       });
     }),
-    getRecoveryKeyHint: sinon.spy(() => {
+    getRecoveryKeyRecordWithHint: sinon.spy(() => {
       return Promise.resolve({ hint: data.hint });
     }),
     recoveryKeyExists: sinon.spy(() => {

--- a/packages/fxa-auth-server/test/remote/password_forgot_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_forgot_tests.js
@@ -18,429 +18,434 @@ const mocks = require('../mocks');
 chai.use(chaiAsPromised);
 const { assert } = chai;
 
-[{version:""},{version:"V2"}].forEach((testOptions) => {
-
-describe(`#integration${testOptions.version} - remote password forgot`, function () {
-  this.timeout(15000);
-  let server;
-  before(() => {
-    config.securityHistory.ipProfiling.allowedRecency = 0;
-    config.signinConfirmation.skipForNewAccounts.enabled = true;
-    return TestServer.start(config).then((s) => {
-      server = s;
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - remote password forgot`, function () {
+    this.timeout(15000);
+    let server;
+    before(() => {
+      config.securityHistory.ipProfiling.allowedRecency = 0;
+      config.signinConfirmation.skipForNewAccounts.enabled = true;
+      return TestServer.start(config).then((s) => {
+        server = s;
+      });
     });
-  });
 
-  it('forgot password', () => {
-    const email = server.uniqueEmail();
-    const password = 'allyourbasearebelongtous';
-    const newPassword = 'ez';
-    let wrapKb = null;
-    let kA = null;
-    let client = null;
-    const options = {
-      ...testOptions,
-      keys: true,
-      metricsContext: mocks.generateMetricsContext(),
-    };
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      options
-    )
-      .then((x) => {
-        client = x;
-        return client.keys();
-      })
-      .then((keys) => {
-        wrapKb = keys.wrapKb;
-        kA = keys.kA;
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(
-          emailData.headers['x-flow-begin-time'],
-          options.metricsContext.flowBeginTime,
-          'flow begin time set'
-        );
-        assert.equal(
-          emailData.headers['x-flow-id'],
-          options.metricsContext.flowId,
-          'flow id set'
-        );
-        assert.equal(emailData.headers['x-template-name'], 'recovery');
-        return emailData.headers['x-recovery-code'];
-      })
-      .then((code) => {
-        assert.isRejected(client.resetPassword(newPassword));
-        return resetPassword(client, code, newPassword, undefined, options);
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        const link = emailData.headers['x-link'];
-        const query = url.parse(link, true).query;
-        assert.ok(query.email, 'email is in the link');
-
-        assert.equal(
-          emailData.headers['x-flow-begin-time'],
-          options.metricsContext.flowBeginTime,
-          'flow begin time set'
-        );
-        assert.equal(
-          emailData.headers['x-flow-id'],
-          options.metricsContext.flowId,
-          'flow id set'
-        );
-        assert.equal(emailData.headers['x-template-name'], 'passwordReset');
-      })
-      .then(() => {
-        return upgradeCredentials(email, newPassword);
-      })
-      .then(
-        // make sure we can still login after password reset
-        () => {
-          return Client.login(config.publicUrl, email, newPassword, {
-            ...testOptions,
-            keys: true,
-          });
-        }
-      )
-      .then((x) => {
-        client = x;
-        return client.keys();
-      })
-      .then((keys) => {
-        assert.equal(typeof keys.wrapKb, 'string', 'yep, wrapKb');
-        assert.notEqual(wrapKb, keys.wrapKb, 'wrapKb was reset');
-        assert.equal(kA, keys.kA, 'kA was not reset');
-        assert.equal(typeof client.kB, 'string');
-        assert.equal(client.kB.length, 64, 'kB exists, has the right length');
-      });
-  });
-
-  it('forgot password limits verify attempts', () => {
-    let code = null;
-    const email = server.uniqueEmail();
-    const password = 'hothamburger';
-    let client = null;
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    )
-      .then(() => {
-        client = new Client(config.publicUrl, testOptions);
-        client.email = email;
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email);
-      })
-      .then((c) => {
-        code = c;
-      })
-      .then(() => {
-        return client.reforgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email);
-      })
-      .then((c) => {
-        assert.equal(code, c, 'same code as before');
-      })
-      .then(() => {
-        return resetPassword(
-          client,
-          '00000000000000000000000000000000',
-          'password'
-        );
-      })
-      .then(
-        () => {
-          assert(false, 'reset password with bad code');
-        },
-        (err) => {
-          assert.equal(err.tries, 2, 'used a try');
-          assert.equal(
-            err.message,
-            'Invalid confirmation code',
-            'bad attempt 1'
-          );
-        }
-      )
-      .then(() => {
-        return resetPassword(
-          client,
-          '00000000000000000000000000000000',
-          'password'
-        );
-      })
-      .then(
-        () => {
-          assert(false, 'reset password with bad code');
-        },
-        (err) => {
-          assert.equal(err.tries, 1, 'used a try');
-          assert.equal(
-            err.message,
-            'Invalid confirmation code',
-            'bad attempt 2'
-          );
-        }
-      )
-      .then(() => {
-        return resetPassword(
-          client,
-          '00000000000000000000000000000000',
-          'password'
-        );
-      })
-      .then(
-        () => {
-          assert(false, 'reset password with bad code');
-        },
-        (err) => {
-          assert.equal(err.tries, 0, 'used a try');
-          assert.equal(
-            err.message,
-            'Invalid confirmation code',
-            'bad attempt 3'
-          );
-        }
-      )
-      .then(() => {
-        return resetPassword(
-          client,
-          '00000000000000000000000000000000',
-          'password'
-        );
-      })
-      .then(
-        () => {
-          assert(false, 'reset password with invalid token');
-        },
-        (err) => {
-          assert.equal(
-            err.message,
-            'The authentication token could not be found',
-            'token is now invalid'
-          );
-        }
-      );
-  });
-
-  it('recovery email link', () => {
-    const email = server.uniqueEmail();
-    const password = 'something';
-    let client = null;
-    const options = {
-      ...testOptions,
-      redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
-      service: 'sync',
-    };
-    return Client.create(config.publicUrl, email, password, options)
-      .then((c) => {
-        client = c;
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then(() => {
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        const link = emailData.headers['x-link'];
-        const query = url.parse(link, true).query;
-        assert.ok(query.token, 'uid is in link');
-        assert.ok(query.code, 'code is in link');
-        assert.equal(
-          query.redirectTo,
-          options.redirectTo,
-          'redirectTo is in link'
-        );
-        assert.equal(query.service, options.service, 'service is in link');
-        assert.equal(query.email, email, 'email is in link');
-      });
-  });
-
-  it('password forgot status with valid token', () => {
-    const email = server.uniqueEmail();
-    const password = 'something';
-    return Client.create(config.publicUrl, email, password, testOptions).then((c) => {
-      return c
-        .forgotPassword()
-        .then(() => {
-          return c.api.passwordForgotStatus(c.passwordForgotToken);
-        })
-        .then((x) => {
-          assert.equal(x.tries, 3, 'three tries remaining');
-          assert.ok(
-            x.ttl > 0 && x.ttl <= config.tokenLifetimes.passwordForgotToken,
-            'ttl is ok'
-          );
-        });
-    });
-  });
-
-  it('password forgot status with invalid token', () => {
-    const client = new Client(config.publicUrl, testOptions);
-    return client.api
-      .passwordForgotStatus(
-        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
-      )
-      .then(
-        () => assert(false),
-        (err) => {
-          assert.equal(err.errno, 110, 'invalid token');
-        }
-      );
-  });
-
-  it('/password/forgot/verify_code should set an unverified account as verified', () => {
-    const email = server.uniqueEmail();
-    const password = 'something';
-    let client = null;
-    return Client.create(config.publicUrl, email, password, testOptions)
-      .then((c) => {
-        client = c;
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, false, 'email unverified');
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email); // ignore this code
-      })
-      .then(() => {
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email);
-      })
-      .then((code) => {
-        return client.verifyPasswordResetCode(code);
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, true, 'account unverified');
-      });
-  });
-
-  it('forgot password with service query parameter', () => {
-    const email = server.uniqueEmail();
-    const options = {
-      ...testOptions,
-      redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
-      serviceQuery: 'sync',
-    };
-    let client;
-    return Client.create(config.publicUrl, email, 'wibble', options)
-      .then((c) => {
-        client = c;
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then(() => {
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        const link = emailData.headers['x-link'];
-        const query = url.parse(link, true).query;
-        assert.equal(query.service, options.serviceQuery, 'service is in link');
-      });
-  });
-
-  it('forgot password, then get device list', () => {
-    const email = server.uniqueEmail();
-    const newPassword = 'foo';
-    let client;
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      'bar',
-      server.mailbox,
-      testOptions
-    )
-      .then((c) => {
-        client = c;
-        return client.updateDevice({
-          name: 'baz',
-          type: 'mobile',
-          pushCallback: 'https://updates.push.services.mozilla.com/qux',
-          pushPublicKey: mocks.MOCK_PUSH_KEY,
-          pushAuthKey: base64url(crypto.randomBytes(16)),
-        });
-      })
-      .then(() => {
-        return client.devices();
-      })
-      .then((devices) => {
-        assert.equal(devices.length, 1, 'devices list contains 1 item');
-      })
-      .then(() => {
-        return client.forgotPassword();
-      })
-      .then(() => {
-        return server.mailbox.waitForCode(email);
-      })
-      .then((code) => {
-        return resetPassword(client, code, newPassword);
-      })
-      .then(() => {
-        return upgradeCredentials(email, newPassword);
-      })
-      .then(() => {
-        return Client.login(config.publicUrl, email, newPassword, testOptions);
-      })
-      .then((client) => {
-        return client.devices();
-      })
-      .then((devices) => {
-        assert.equal(devices.length, 0, 'devices list is empty');
-      });
-  });
-
-  after(() => {
-    return TestServer.stop(server);
-  });
-
-  async function resetPassword(client, code, newPassword, headers, options) {
-    await client.verifyPasswordResetCode(code, headers, options);
-    await client.resetPassword(newPassword, {}, options);
-  }
-
-  async function upgradeCredentials(email, newPassword) {
-    if (testOptions.version === "V2") {
-      await Client.upgradeCredentials(config.publicUrl,
+    it('forgot password', () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+      let wrapKb = null;
+      let kA = null;
+      let client = null;
+      const options = {
+        ...testOptions,
+        keys: true,
+        metricsContext: mocks.generateMetricsContext(),
+      };
+      return Client.createAndVerify(
+        config.publicUrl,
         email,
-        newPassword,
-        {
-          version: '',
-          key:true
+        password,
+        server.mailbox,
+        options
+      )
+        .then((x) => {
+          client = x;
+          return client.keys();
+        })
+        .then((keys) => {
+          wrapKb = keys.wrapKb;
+          kA = keys.kA;
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(
+            emailData.headers['x-flow-begin-time'],
+            options.metricsContext.flowBeginTime,
+            'flow begin time set'
+          );
+          assert.equal(
+            emailData.headers['x-flow-id'],
+            options.metricsContext.flowId,
+            'flow id set'
+          );
+          assert.equal(emailData.headers['x-template-name'], 'recovery');
+          return emailData.headers['x-recovery-code'];
+        })
+        .then((code) => {
+          assert.isRejected(client.resetPassword(newPassword));
+          return resetPassword(client, code, newPassword, undefined, options);
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          const link = emailData.headers['x-link'];
+          const query = url.parse(link, true).query;
+          assert.ok(query.email, 'email is in the link');
+
+          assert.equal(
+            emailData.headers['x-flow-begin-time'],
+            options.metricsContext.flowBeginTime,
+            'flow begin time set'
+          );
+          assert.equal(
+            emailData.headers['x-flow-id'],
+            options.metricsContext.flowId,
+            'flow id set'
+          );
+          assert.equal(emailData.headers['x-template-name'], 'passwordReset');
+        })
+        .then(() => {
+          return upgradeCredentials(email, newPassword);
+        })
+        .then(
+          // make sure we can still login after password reset
+          () => {
+            return Client.login(config.publicUrl, email, newPassword, {
+              ...testOptions,
+              keys: true,
+            });
+          }
+        )
+        .then((x) => {
+          client = x;
+          return client.keys();
+        })
+        .then((keys) => {
+          assert.equal(typeof keys.wrapKb, 'string', 'yep, wrapKb');
+          assert.notEqual(wrapKb, keys.wrapKb, 'wrapKb was reset');
+          assert.equal(kA, keys.kA, 'kA was not reset');
+          assert.equal(typeof client.kB, 'string');
+          assert.equal(client.kB.length, 64, 'kB exists, has the right length');
         });
+    });
+
+    it('forgot password limits verify attempts', () => {
+      let code = null;
+      const email = server.uniqueEmail();
+      const password = 'hothamburger';
+      let client = null;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      )
+        .then(() => {
+          client = new Client(config.publicUrl, testOptions);
+          client.email = email;
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email);
+        })
+        .then((c) => {
+          code = c;
+        })
+        .then(() => {
+          return client.reforgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email);
+        })
+        .then((c) => {
+          assert.equal(code, c, 'same code as before');
+        })
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with bad code');
+          },
+          (err) => {
+            assert.equal(err.tries, 2, 'used a try');
+            assert.equal(
+              err.message,
+              'Invalid confirmation code',
+              'bad attempt 1'
+            );
+          }
+        )
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with bad code');
+          },
+          (err) => {
+            assert.equal(err.tries, 1, 'used a try');
+            assert.equal(
+              err.message,
+              'Invalid confirmation code',
+              'bad attempt 2'
+            );
+          }
+        )
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with bad code');
+          },
+          (err) => {
+            assert.equal(err.tries, 0, 'used a try');
+            assert.equal(
+              err.message,
+              'Invalid confirmation code',
+              'bad attempt 3'
+            );
+          }
+        )
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with invalid token');
+          },
+          (err) => {
+            assert.equal(
+              err.message,
+              'Invalid authentication token: Missing authentication',
+              'token is now invalid'
+            );
+          }
+        );
+    });
+
+    it('recovery email link', () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      let client = null;
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
+        service: 'sync',
+      };
+      return Client.create(config.publicUrl, email, password, options)
+        .then((c) => {
+          client = c;
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          const link = emailData.headers['x-link'];
+          const query = url.parse(link, true).query;
+          assert.ok(query.token, 'uid is in link');
+          assert.ok(query.code, 'code is in link');
+          assert.equal(
+            query.redirectTo,
+            options.redirectTo,
+            'redirectTo is in link'
+          );
+          assert.equal(query.service, options.service, 'service is in link');
+          assert.equal(query.email, email, 'email is in link');
+        });
+    });
+
+    it('password forgot status with valid token', () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      return Client.create(config.publicUrl, email, password, testOptions).then(
+        (c) => {
+          return c
+            .forgotPassword()
+            .then(() => {
+              return c.api.passwordForgotStatus(c.passwordForgotToken);
+            })
+            .then((x) => {
+              assert.equal(x.tries, 3, 'three tries remaining');
+              assert.ok(
+                x.ttl > 0 && x.ttl <= config.tokenLifetimes.passwordForgotToken,
+                'ttl is ok'
+              );
+            });
+        }
+      );
+    });
+
+    it('password forgot status with invalid token', () => {
+      const client = new Client(config.publicUrl, testOptions);
+      return client.api
+        .passwordForgotStatus(
+          '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
+        )
+        .then(
+          () => assert(false),
+          (err) => {
+            assert.equal(err.errno, 110, 'invalid token');
+          }
+        );
+    });
+
+    it('/password/forgot/verify_code should set an unverified account as verified', () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then((c) => {
+          client = c;
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, false, 'email unverified');
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email); // ignore this code
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email);
+        })
+        .then((code) => {
+          return client.verifyPasswordResetCode(code);
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, true, 'account unverified');
+        });
+    });
+
+    it('forgot password with service query parameter', () => {
+      const email = server.uniqueEmail();
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
+        serviceQuery: 'sync',
+      };
+      let client;
+      return Client.create(config.publicUrl, email, 'wibble', options)
+        .then((c) => {
+          client = c;
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          const link = emailData.headers['x-link'];
+          const query = url.parse(link, true).query;
+          assert.equal(
+            query.service,
+            options.serviceQuery,
+            'service is in link'
+          );
+        });
+    });
+
+    it('forgot password, then get device list', () => {
+      const email = server.uniqueEmail();
+      const newPassword = 'foo';
+      let client;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        'bar',
+        server.mailbox,
+        testOptions
+      )
+        .then((c) => {
+          client = c;
+          return client.updateDevice({
+            name: 'baz',
+            type: 'mobile',
+            pushCallback: 'https://updates.push.services.mozilla.com/qux',
+            pushPublicKey: mocks.MOCK_PUSH_KEY,
+            pushAuthKey: base64url(crypto.randomBytes(16)),
+          });
+        })
+        .then(() => {
+          return client.devices();
+        })
+        .then((devices) => {
+          assert.equal(devices.length, 1, 'devices list contains 1 item');
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return server.mailbox.waitForCode(email);
+        })
+        .then((code) => {
+          return resetPassword(client, code, newPassword);
+        })
+        .then(() => {
+          return upgradeCredentials(email, newPassword);
+        })
+        .then(() => {
+          return Client.login(
+            config.publicUrl,
+            email,
+            newPassword,
+            testOptions
+          );
+        })
+        .then((client) => {
+          return client.devices();
+        })
+        .then((devices) => {
+          assert.equal(devices.length, 0, 'devices list is empty');
+        });
+    });
+
+    after(() => {
+      return TestServer.stop(server);
+    });
+
+    async function resetPassword(client, code, newPassword, headers, options) {
+      await client.verifyPasswordResetCode(code, headers, options);
+      await client.resetPassword(newPassword, {}, options);
     }
-  }
 
-});
-
+    async function upgradeCredentials(email, newPassword) {
+      if (testOptions.version === 'V2') {
+        await Client.upgradeCredentials(config.publicUrl, email, newPassword, {
+          version: '',
+          key: true,
+        });
+      }
+    }
+  });
 });

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -364,39 +364,6 @@ const { JWTool } = require('@fxa/vendored/jwtool');
           assert.equal(res.exists, false, 'account recovery key doesnt exists');
         });
       });
-
-      describe('with email', () => {
-        it('should return true if account recovery key exists', () => {
-          return client.getRecoveryKeyExists(email).then((res) => {
-            assert.equal(res.exists, true, 'account recovery key exists');
-          });
-        });
-
-        it("should return false if account recovery key doesn't exist", () => {
-          email = server.uniqueEmail();
-          return Client.createAndVerify(
-            config.publicUrl,
-            email,
-            password,
-            server.mailbox,
-            {
-              ...testOptions,
-              keys: true,
-            }
-          )
-            .then((c) => {
-              client = c;
-              return client.getRecoveryKeyExists(email);
-            })
-            .then((res) => {
-              assert.equal(
-                res.exists,
-                false,
-                "account recovery key doesn't exist"
-              );
-            });
-        });
-      });
     });
 
     after(() => {

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -428,13 +428,6 @@ export class Account implements AccountData {
     );
   }
 
-  async hasRecoveryKey(email: string): Promise<boolean> {
-    // Users may not be logged in (no session token) so we currently can't use GQL here
-    return this.withLoadingStatus(
-      await this.authClient.recoveryKeyExists(sessionToken()!, email)
-    );
-  }
-
   async getAccountStatusByEmail(email: string): Promise<boolean> {
     return this.withLoadingStatus(
       (await this.authClient.accountStatusByEmail(email)).exists

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
@@ -42,7 +42,8 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
     token: string,
     uid: string,
     estimatedSyncDeviceCount?: number,
-    recoveryKeyExists?: boolean
+    recoveryKeyExists?: boolean,
+    recoveryKeyHint?: string
   ) => {
     if (recoveryKeyExists === true) {
       navigate('/account_recovery_confirm_key', {
@@ -52,6 +53,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
           emailToHashWith,
           estimatedSyncDeviceCount,
           recoveryKeyExists,
+          recoveryKeyHint,
           token,
           uid,
         },
@@ -73,16 +75,15 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
     }
   };
 
-  const checkForRecoveryKey = async () => {
+  const checkForRecoveryKey = async (passwordForgotToken: hexstring) => {
     try {
-      const result: RecoveryKeyCheckResult = await authClient.recoveryKeyExists(
-        undefined,
-        email
-      );
+      const result: RecoveryKeyCheckResult =
+        await authClient.passwordForgotRecoveryKeyStatus(passwordForgotToken);
       return result;
     } catch (error) {
       return {
         exist: undefined,
+        hint: undefined,
         estimatedSyncDeviceCount: undefined,
       } as RecoveryKeyCheckResult;
     }
@@ -101,15 +102,19 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
       GleanMetrics.passwordReset.emailConfirmationSubmit();
       const { code, emailToHashWith, token, uid } =
         await authClient.passwordForgotVerifyOtp(email, otpCode, options);
-      const { exists: recoveryKeyExists, estimatedSyncDeviceCount } =
-        await checkForRecoveryKey();
+      const {
+        exists: recoveryKeyExists,
+        hint: recoveryKeyHint,
+        estimatedSyncDeviceCount,
+      } = await checkForRecoveryKey(token);
       handleNavigation(
         code,
         emailToHashWith,
         token,
         uid,
         estimatedSyncDeviceCount,
-        recoveryKeyExists
+        recoveryKeyExists,
+        recoveryKeyHint
       );
     } catch (error) {
       const localizerErrorMessage = getLocalizedErrorMessage(

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/interfaces.ts
@@ -12,6 +12,7 @@ export interface ConfirmResetPasswordLocationState {
 
 export type RecoveryKeyCheckResult = {
   exists?: boolean;
+  hint?: string;
   estimatedSyncDeviceCount?: number;
 };
 

--- a/packages/fxa-shared/db/models/auth/recovery-key.ts
+++ b/packages/fxa-shared/db/models/auth/recovery-key.ts
@@ -93,11 +93,12 @@ export class RecoveryKey extends BaseAuthModel {
     return RecoveryKey.fromDatabaseJson(rows[0]);
   }
 
-  static async findHintByUid(uid: string) {
-    const recoveryKey = await RecoveryKey.query()
+  static async findRecordWithHintByUid(uid: string) {
+    return await RecoveryKey.query()
       .select('hint')
-      .where('uid', uuidTransformer.to(uid));
-    return recoveryKey[0].hint;
+      .where('uid', uuidTransformer.to(uid))
+      .andWhereRaw('enabled = 1')
+      .first();
   }
 
   static async exists(uid: string) {


### PR DESCRIPTION
Because:
 - we want to allow the user to get their recovery key status with the 'passwordForgotToken' they received during the reset password flow

This commit:
 - adds passwordForgotToken to the allowed auth strategies for the /recoveryKey/exists auth-server endpoint
   - updates the auth client to use the passwordForgotToken to access that endpoint
 - returns the recovery key hint along with the exists status
 - passes the hint in Setting when navigating post-reset

Fixes FXA-9398, FXA-7400