### PR TITLE
feat(tests): Add functional test for inline recovery key and settings promo

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -54,24 +54,30 @@ export const test = base.extend<TestOptions, WorkerOptions>({
     await testAccountTracker.destroyAllAccounts();
   },
 
-  storageState: async ({ target }, use) => {
+  storageState: async ({ target }, use, testInfo) => {
     // This is to store our session without logging in through the ui
+    const localStorageItems = [
+      {
+        name: '__fxa_storage.experiment.generalizedReactApp',
+        value: JSON.stringify({ enrolled: false }),
+      },
+    ];
+
+    // Temporary fix, only set this flag if the test is not a recovery key promo test
+    // Once this is no longer feature flagged, we can update all our test and remove this
+    if (!testInfo.titlePath.includes('recovery key promo')) {
+      localStorageItems.push({
+        name: '__fxa_storage.disable_promo.account-recovery-do-it-later',
+        value: 'true',
+      });
+    }
+
     await use({
       cookies: [],
       origins: [
         {
           origin: target.contentServerUrl,
-          localStorage: [
-            {
-              name: '__fxa_storage.experiment.generalizedReactApp',
-              value: JSON.stringify({ enrolled: false }),
-            },
-            // TODO in FXA-10081
-            {
-              name: '__fxa_storage.disable_promo.account-recovery-do-it-later',
-              value: 'true',
-            },
-          ],
+          localStorage: localStorageItems,
         },
       ],
     });

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -33,6 +33,7 @@ import { SignupPage } from './signup';
 import { SubscribePage } from './products';
 import { TermsOfService } from './termsOfService';
 import { TotpPage } from './settings/totp';
+import { InlineRecoveryKey } from './inlineRecoveryKey';
 
 export function create(page: Page, target: BaseTarget) {
   return {
@@ -47,6 +48,7 @@ export function create(page: Page, target: BaseTarget) {
     forceAuth: new ForceAuthPage(page, target),
     fourOhFour: new FourOhFourPage(page, target),
     fxDesktopV3ForceAuth: new FxDesktopV3ForceAuthPage(page, target),
+    inlineRecoveryKey: new InlineRecoveryKey(page, target),
     legal: new LegalPage(page, target),
     login: new LoginPage(page, target),
     page,

--- a/packages/functional-tests/pages/inlineRecoveryKey.ts
+++ b/packages/functional-tests/pages/inlineRecoveryKey.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseLayout } from './layout';
+
+export class InlineRecoveryKey extends BaseLayout {
+  readonly path = 'inline_recovery_key_setup';
+
+  async getHeader() {
+    const header = this.page.getByText('Secure your account');
+    await header.waitFor();
+    return header;
+  }
+
+  getBannerCreateLink() {
+    return this.page.getByTestId('submit_create_recovery_key');
+  }
+
+  async getInlineRecoveryHeader() {
+    const header = this.page.getByRole('heading', {
+      name: 'Secure your account',
+    });
+    await header.waitFor();
+    return header;
+  }
+
+  fillOutHint(value: string) {
+    return this.page
+      .getByRole('textbox', { name: 'Enter a hint (optional)' })
+      .fill(value);
+  }
+
+  clickFinish() {
+    return this.page.getByRole('button', { name: 'Finish' }).click();
+  }
+
+  clickDownloadAndContinue() {
+    return this.page
+      .getByRole('button', { name: 'Download and continue' })
+      .click();
+  }
+
+  clickCreateRecoveryKey() {
+    return this.page
+      .getByRole('button', { name: 'Create account recovery key' })
+      .click();
+  }
+
+  clickDoItLater() {
+    return this.page.getByRole('button', { name: 'Do it later' }).click();
+  }
+}

--- a/packages/functional-tests/tests/misc/recoveryKeyPromo.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromo.spec.ts
@@ -1,0 +1,285 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test } from '../../lib/fixtures/standard';
+import { getCode } from 'packages/fxa-settings/src/lib/totp';
+
+test.describe('recovery key promo', () => {
+  test.describe('settings banner', () => {
+    test('can setup recovery key from settings promo banner', async ({
+      target,
+      pages: { page, inlineRecoveryKey, signin, settings, recoveryKey },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.recoveryKey.status).toHaveText('Not Set');
+
+      await inlineRecoveryKey.getBannerCreateLink().click();
+
+      await recoveryKey.acknowledgeInfoForm();
+      await recoveryKey.fillOutConfirmPasswordForm(credentials.password);
+
+      await expect(recoveryKey.recoveryKeyCreatedHeading).toBeVisible();
+
+      // Notification banner is no longer visible
+      await expect(inlineRecoveryKey.getBannerCreateLink()).not.toBeVisible();
+    });
+
+    test('can dismiss', async ({
+      target,
+      pages: { page, inlineRecoveryKey, signin, settings, recoveryKey },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.recoveryKey.status).toHaveText('Not Set');
+
+      await inlineRecoveryKey.getBannerCreateLink().click();
+
+      await recoveryKey.acknowledgeInfoForm();
+      await recoveryKey.fillOutConfirmPasswordForm(credentials.password);
+
+      await expect(recoveryKey.recoveryKeyCreatedHeading).toBeVisible();
+
+      // Notification banner is no longer visible
+      await expect(inlineRecoveryKey.getBannerCreateLink()).not.toBeVisible();
+    });
+  });
+
+  test.describe('inline', () => {
+    test.beforeEach(async ({ pages: { configPage } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.featureFlags.recoveryCodeSetupOnSyncSignIn !== true,
+        'inline recovery key setup is not enabled'
+      );
+    });
+
+    test('not shown after signup', async ({
+      target,
+      syncBrowserPages: { page, signup, login, connectAnotherDevice },
+      testAccountTracker,
+    }) => {
+      const credentials = testAccountTracker.generateSignupAccountDetails();
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
+        { waitUntil: 'load' }
+      );
+      await signup.fillOutEmailForm(credentials.email);
+      await signup.fillOutSignupForm(credentials.password, '21');
+
+      const code = await target.emailClient.getVerifyShortCode(
+        credentials.email
+      );
+      await login.setCode(code);
+      await login.clickSubmit();
+
+      await expect(connectAnotherDevice.header).toBeVisible();
+    });
+
+    test('not shown if user already has a recovery key', async ({
+      target,
+      pages: { page, signin, connectAnotherDevice, settings, recoveryKey },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      // Sign-in without Sync, otw you will get prompted to create a recovery key
+      await page.goto(target.contentServerUrl, { waitUntil: 'load' });
+
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await settings.recoveryKey.createButton.click();
+      await recoveryKey.acknowledgeInfoForm();
+      await recoveryKey.fillOutConfirmPasswordForm(credentials.password);
+      await recoveryKey.clickDownload();
+      await recoveryKey.finishButton.click();
+
+      // Verify status as 'enabled'
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.recoveryKey.status).toHaveText('Enabled');
+
+      await settings.signOut();
+
+      // Not shown recovery key promo
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
+        { waitUntil: 'load' }
+      );
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await expect(connectAnotherDevice.header).toBeVisible();
+    });
+
+    test('can setup recovery key inline after sign-in', async ({
+      target,
+      syncBrowserPages: {
+        page,
+        inlineRecoveryKey,
+        signin,
+        connectAnotherDevice,
+      },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await inlineRecoveryKey.getInlineRecoveryHeader();
+      await inlineRecoveryKey.clickCreateRecoveryKey();
+      await inlineRecoveryKey.clickDownloadAndContinue();
+      await inlineRecoveryKey.fillOutHint('hint');
+      await inlineRecoveryKey.clickFinish();
+
+      await expect(connectAnotherDevice.header).toBeVisible();
+    });
+
+    test('can setup recovery key inline after email code', async ({
+      target,
+      syncBrowserPages: {
+        page,
+        inlineRecoveryKey,
+        signin,
+        signinTokenCode,
+        connectAnotherDevice,
+      },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUpSync();
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/signin_token_code/);
+      await expect(signinTokenCode.heading).toBeVisible();
+
+      const code = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+
+      await signinTokenCode.fillOutCodeForm(code);
+
+      await inlineRecoveryKey.getInlineRecoveryHeader();
+      await inlineRecoveryKey.clickCreateRecoveryKey();
+      await inlineRecoveryKey.clickDownloadAndContinue();
+      await inlineRecoveryKey.fillOutHint('hint');
+      await inlineRecoveryKey.clickFinish();
+
+      await expect(connectAnotherDevice.header).toBeVisible();
+    });
+
+    test('can setup recovery key inline after 2FA', async ({
+      target,
+      syncBrowserPages: {
+        page,
+        inlineRecoveryKey,
+        signin,
+        settings,
+        connectAnotherDevice,
+        totp,
+      },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      // Sign-in without Sync, otw you will get prompted to create a recovery key
+      await page.goto(target.contentServerUrl, { waitUntil: 'load' });
+
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await expect(settings.settingsHeading).toBeVisible();
+      await settings.totp.addButton.click();
+      const { secret } = await totp.fillOutTotpForms();
+      await expect(settings.totp.status).toHaveText('Enabled');
+      await settings.signOut();
+
+      // Now attempt to sign-in with Sync, you will get prompted for 2FA and then enabling recovery key
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/signin_totp_code/);
+
+      const code = await getCode(secret);
+      await signin.fillOutAuthenticationForm(code);
+
+      await inlineRecoveryKey.getInlineRecoveryHeader();
+      await inlineRecoveryKey.clickCreateRecoveryKey();
+      await inlineRecoveryKey.clickDownloadAndContinue();
+      await inlineRecoveryKey.fillOutHint('hint');
+      await inlineRecoveryKey.clickFinish();
+
+      await expect(connectAnotherDevice.header).toBeVisible();
+
+      await settings.goto();
+      await settings.disconnectTotp(); // Required before teardown
+    });
+
+    test('click do it later', async ({
+      target,
+      syncBrowserPages: {
+        page,
+        inlineRecoveryKey,
+        signin,
+        settings,
+        connectAnotherDevice,
+      },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await inlineRecoveryKey.getInlineRecoveryHeader();
+
+      await inlineRecoveryKey.clickDoItLater();
+
+      // User taken to connect another device page
+      await expect(connectAnotherDevice.header).toBeVisible();
+
+      await connectAnotherDevice.startBrowsingButton.click();
+
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.recoveryKey.status).toHaveText('Not Set');
+
+      await settings.signOut();
+
+      // Attempting to navigate back to the inline recovery key page,
+      // it should redirect to the connect another device page since they user
+      // clicked "do it later"
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
+      );
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await expect(connectAnotherDevice.header).toBeVisible();
+    });
+  });
+});

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -123,6 +123,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.recoveryKey.status).toHaveText('Enabled');
 
+      await settings.goto();
+
       await settings.recoveryKey.deleteButton.click();
 
       await expect(settings.recoveryKeyModalHeading).toBeVisible();

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -19,7 +19,8 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
-      await expect(page).toHaveURL(/connect_another_device/);
+      await page.waitForURL(/connect_another_device/);
+
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await expect(
         connectAnotherDevice.connectAnotherDeviceButton

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -140,10 +140,6 @@ test.describe('severity-2 #smoke', () => {
       },
       testAccountTracker,
     }) => {
-      test.skip(
-        true,
-        'TODO in FXA-10081, functional tests for inline recovery key setup'
-      );
       const credentials = await testAccountTracker.signUpSync();
 
       await page.goto(

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -88,10 +88,6 @@ test.describe('severity-2 #smoke', () => {
       syncBrowserPages: { page, signin, connectAnotherDevice, signinTokenCode },
       testAccountTracker,
     }) => {
-      test.skip(
-        true,
-        'TODO in FXA-10081, functional tests for inline recovery key setup'
-      );
       // Simulate a new sign up that requires a signin verification code.
       const credentials = await testAccountTracker.signUpSync({
         lang: 'en',

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -14,10 +14,6 @@ test.describe('severity-2 #smoke', () => {
       syncBrowserPages: { page, settings, signin, connectAnotherDevice },
       testAccountTracker,
     }) => {
-      test.skip(
-        true,
-        'TODO in FXA-10081, functional tests for inline recovery key setup'
-      );
       const credentials = await testAccountTracker.signUp();
       const syncCredentials = await signInSyncAccount(
         target,

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -55,6 +55,9 @@ module.exports = function (config) {
   const FEATURE_FLAGS_RESET_PWD_WITH_CODE = config.get(
     'featureFlags.resetPasswordWithCode'
   );
+  const FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN = config.get(
+    'featureFlags.recoveryCodeSetupOnSyncSignIn'
+  );
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
   const GLEAN_UPLOAD_ENABLED = config.get('glean.uploadEnabled');
@@ -114,6 +117,8 @@ module.exports = function (config) {
     featureFlags: {
       sendFxAStatusOnSettings: FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS,
       resetPasswordWithCode: FEATURE_FLAGS_RESET_PWD_WITH_CODE,
+      recoveryCodeSetupOnSyncSignIn:
+        FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
     },
     glean: {
       // feature toggle

--- a/packages/fxa-settings/src/components/NotificationPromoBanner/index.tsx
+++ b/packages/fxa-settings/src/components/NotificationPromoBanner/index.tsx
@@ -100,6 +100,7 @@ const NotificationPromoBanner = ({
         <Link
           className="cta-neutral cta-base cta-base-p text-base tablet:mr-8 tablet:text-sm tablet:self-center transition-standard -mt-1 mobileLandscape:mt-0"
           to={`${route}${location.search}`}
+          data-testid={`submit_${metricsKey}`}
           data-glean-id={`account_banner_${metricsKey}_submit`}
         >
           {ctaText}


### PR DESCRIPTION
## Because

- We want to add functional tests for the recovery key inline flow

## This pull request

- Adds functional tests
- Sets a localstorage flag so that it is disabled for all other functional tests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10081

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This is blocked by https://mozilla-hub.atlassian.net/browse/FXA-10079, but I should be able to get it close while that issue is still being worked.
