### PR TITLE
fix(settings): Fix error message if account deletion fails

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -18,8 +18,9 @@ import { Localized } from '@fluent/react';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
-import { getErrorFtlId } from '../../../lib/error-utils';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import GleanMetrics from '../../../lib/glean';
+import { useFtlMsgResolver } from '../../../models/hooks';
 
 type FormData = {
   password: string;
@@ -104,6 +105,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   );
   const navigate = useNavigate();
   const alertBar = useAlertBar();
+  const ftlMsgResolver = useFtlMsgResolver();
   const goHome = useCallback(() => window.history.back(), []);
 
   const account = useAccount();
@@ -143,11 +145,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
         );
         hardNavigate('/', { delete_account_success: true }, true);
       } catch (e) {
-        const localizedError = l10n.getString(
-          getErrorFtlId(AuthUiErrors.INCORRECT_PASSWORD),
-          null,
-          AuthUiErrors.INCORRECT_PASSWORD.message
-        );
+        const localizedError = getLocalizedErrorMessage(ftlMsgResolver, e);
         if (e.errno === AuthUiErrors.INCORRECT_PASSWORD.errno) {
           setErrorText(localizedError);
           setValue('password', '');
@@ -157,7 +155,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
         }
       }
     },
-    [account, l10n, setErrorText, setValue, alertBar]
+    [account, setErrorText, setValue, alertBar, ftlMsgResolver]
   );
 
   const handleConfirmChange =


### PR DESCRIPTION
## Because

* Incorrect password error was shown for all errors with account deletion

## This pull request

* Show correct localized error message
* Show in tooltip if incorrect password, otherwise use alertBar

## Issue that this pull request solves

Issue: #FXA-10392

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is only a partial fix for the reported error - it only fixes the message but not cause of the error (I have not been able to reproduce).