### PR TITLE
feat(next): add __version__ route for next app

### DIFF
--- a/apps/payments/next/app/%5F_version__/route.ts
+++ b/apps/payments/next/app/%5F_version__/route.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  return NextResponse.json({ body: { version: process.env.version } });
+}


### PR DESCRIPTION
## Because

- other applications have a __version__ route, but the payments-next app does not

## This pull request

- adds a GET /__version__ endpoint, which returns the version as described in apps/payments/next/package.json

## Issue that this pull request solves

Closes: # [FXA-8295](https://mozilla-hub.atlassian.net/browse/FXA-8295)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

[FXA-8295]: https://mozilla-hub.atlassian.net/browse/FXA-8295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ