### PR TITLE
fix(payments-legacy): support cms localization

### DIFF
--- a/libs/payments/legacy/src/lib/stripe-mapper.service.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.ts
@@ -95,13 +95,23 @@ export class StripeMapperService {
         continue;
       }
 
-      const commonContent =
-        cmsConfigData.offering.data.attributes.commonContent;
-      const purchaseDetails = cmsConfigData.purchaseDetails;
+      const commonContentAttributes =
+        cmsConfigData.offering.data.attributes.commonContent.data.attributes;
+      const commonContentAttributesLocalized = commonContentAttributes
+        .localizations.data.length
+        ? commonContentAttributes.localizations.data[0].attributes
+        : commonContentAttributes;
+
+      const purchaseDetailsAttributes =
+        cmsConfigData.purchaseDetails.data.attributes;
+      const purchaseDetailsLocalizedAttributes = purchaseDetailsAttributes
+        .localizations.data.length
+        ? purchaseDetailsAttributes.localizations.data[0].attributes
+        : purchaseDetailsAttributes;
 
       const planMapper = new PlanMapperUtil(
-        commonContent.data.attributes,
-        purchaseDetails.data.attributes,
+        commonContentAttributesLocalized,
+        purchaseDetailsLocalizedAttributes,
         mergedStripeMetadata,
         cmsEnabled
       );

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -148,6 +148,7 @@ async function run(config) {
       const strapiClient = new StrapiClient(strapiClientConfig, firestore);
       const productConfigurationManager = new ProductConfigurationManager(
         strapiClient,
+        priceManager,
         statsd
       );
       Container.set(ProductConfigurationManager, productConfigurationManager);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -50,7 +50,6 @@ const {
 const {
   ProductConfigurationManager,
   PurchaseWithDetailsOfferingContentTransformedFactory,
-  PurchaseDetailsTransformedFactory,
 } = require('@fxa/shared/cms');
 
 const customer1 = require('./fixtures/stripe/customer1.json');
@@ -3426,15 +3425,11 @@ describe('#integration - StripeHelper', () => {
       const newWebIconURL = 'http://strapi.example/webicon';
       const mockCMSConfigUtil = {
         transformedPurchaseWithCommonContentForPlanId: (planId) => {
-          return PurchaseWithDetailsOfferingContentTransformedFactory({
-            purchaseDetails: {
-              data: {
-                attributes: PurchaseDetailsTransformedFactory({
-                  webIcon: newWebIconURL,
-                }),
-              },
-            },
-          });
+          const mockValue =
+            PurchaseWithDetailsOfferingContentTransformedFactory();
+          mockValue.purchaseDetails.data.attributes.webIcon = newWebIconURL;
+          mockValue.purchaseDetails.data.attributes.localizations.data = [];
+          return mockValue;
         },
       };
       const mockProductConfigurationManager = {


### PR DESCRIPTION
## Because

- Legacy mapper was not using localization data from the CMS

## This pull request

- Updated legacy mapper to utilize localization data.

## Issue that this pull request solves

Closes: #FXA-10436

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This can be tested by using the following product and price.
- prod_JYy0wNbTbA5fDv
- price_1OUAavBVqmGyQTMazqzrIjcz

Note that until FXA-10428 is fixed, [the following lines of code](https://github.com/mozilla/fxa/blob/00bc5d2fcbfdcb8d6644d86dcae75933719b4241/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts#L950-L953) need to be deleted or commented out.
```
            .items(
              validators.subscriptionsPlanWithProductConfigValidator,
              validators.subscriptionsPlanWithMetaDataValidator
            ) as any,
```