### PR TITLE
fix(metrics): use Settings' currentAccount directly for uid

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -223,7 +223,6 @@ describe('glean', () => {
       },
       {
         metricsFlow: updatedFlowQueryParams,
-        account: mockMetricsQueryAccountGlean,
         userAgent: navigator.userAgent,
         integration: mockIntegration,
       }

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -176,23 +176,11 @@ export const App = ({
       },
       {
         metricsFlow,
-        account: {
-          metricsEnabled: data?.account?.metricsEnabled,
-          uid: data?.account?.uid,
-        },
         userAgent: navigator.userAgent,
         integration,
       }
     );
-  }, [
-    config.glean,
-    config.version,
-    data?.account?.metricsEnabled,
-    data?.account?.uid,
-    metricsFlow,
-    integration,
-    metricsEnabled,
-  ]);
+  }, [metricsEnabled, integration, config.glean, config.version, metricsFlow]);
 
   useEffect(() => {
     if (!metricsEnabled) {

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -46,11 +46,11 @@ import * as utm from 'fxa-shared/metrics/glean/web/utm';
 import * as entrypointQuery from 'fxa-shared/metrics/glean/web/entrypoint';
 import { Integration } from '../../models';
 import { MetricsFlow } from '../metrics-flow';
+import { currentAccount } from '../../lib/cache';
 
 type DeviceTypes = 'mobile' | 'tablet' | 'desktop';
 export type GleanMetricsContext = {
   metricsFlow: MetricsFlow | null;
-  account?: { uid?: hexstring; metricsEnabled?: boolean };
   userAgent: string;
   integration: Integration;
 };
@@ -132,10 +132,11 @@ const getDeviceType: () => DeviceTypes | void = () => {
 const initMetrics = async () => {
   userId.set('');
   userIdSha256.set('');
+  const account = currentAccount();
   try {
-    if (metricsContext.account?.uid) {
-      userId.set(metricsContext.account.uid);
-      userIdSha256.set(await hashUid(metricsContext.account.uid));
+    if (account?.uid) {
+      userId.set(account.uid);
+      userIdSha256.set(await hashUid(account.uid));
     }
   } catch (e) {
     // noop


### PR DESCRIPTION
Because:
 - the account uid in the Settings Glean metrics context does not change when the user signs in

This commit:
 - uses Settings' currentAccount function to get the account whenever Glean sets a metric with the current account uid

