### PR TITLE
feat(pair/CAD): Implement signed-in '/connect_another_device' and '/pair' mods + redirects

### DIFF
--- a/packages/functional-tests/pages/connectAnotherDevice.ts
+++ b/packages/functional-tests/pages/connectAnotherDevice.ts
@@ -10,10 +10,11 @@ export class ConnectAnotherDevicePage extends BaseLayout {
   readonly selectors = {
     CONNECT_ANOTHER_DEVICE_HEADER: '#fxa-connect-another-device-header',
     CONNECT_ANOTHER_DEVICE_SIGNIN_BUTTON: 'form div a',
-    FXA_CONNECTED_HEADER: '#fxa-connected-heading',
+    FXA_CONNECTED_HEADER: '#cad-header',
     TEXT_INSTALL_FX_DESKTOP: '#install-mobile-firefox-desktop',
     SUCCESS: '.success',
     NOT_NOW: '#cad-not-now',
+    NOT_NOW_PAIR: '#choice-pair-not-now',
   };
 
   get header() {
@@ -48,5 +49,9 @@ export class ConnectAnotherDevicePage extends BaseLayout {
 
   async clickNotNow() {
     return this.page.locator(this.selectors.NOT_NOW).click();
+  }
+
+  async clickNotNowPair() {
+    return this.page.locator(this.selectors.NOT_NOW_PAIR).click();
   }
 }

--- a/packages/functional-tests/tests/misc/recoveryKeyPromo.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromo.spec.ts
@@ -77,8 +77,7 @@ test.describe('recovery key promo', () => {
       const credentials = testAccountTracker.generateSignupAccountDetails();
 
       await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-        { waitUntil: 'load' }
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
       await signup.fillOutEmailForm(credentials.email);
       await signup.fillOutSignupForm(credentials.password, '21');
@@ -89,7 +88,7 @@ test.describe('recovery key promo', () => {
       await login.setCode(code);
       await login.clickSubmit();
 
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
 
     test('not shown if user already has a recovery key', async ({
@@ -100,7 +99,7 @@ test.describe('recovery key promo', () => {
       const credentials = await testAccountTracker.signUp();
 
       // Sign-in without Sync, otw you will get prompted to create a recovery key
-      await page.goto(target.contentServerUrl, { waitUntil: 'load' });
+      await page.goto(target.contentServerUrl);
 
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
@@ -119,13 +118,12 @@ test.describe('recovery key promo', () => {
 
       // Not shown recovery key promo
       await page.goto(
-        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`,
-        { waitUntil: 'load' }
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email`
       );
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
 
     test('can setup recovery key inline after sign-in', async ({
@@ -152,7 +150,7 @@ test.describe('recovery key promo', () => {
       await inlineRecoveryKey.fillOutHint('hint');
       await inlineRecoveryKey.clickFinish();
 
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await expect(connectAnotherDevice.header).toBeEnabled();
     });
 
     test('can setup recovery key inline after email code', async ({
@@ -189,7 +187,8 @@ test.describe('recovery key promo', () => {
       await inlineRecoveryKey.fillOutHint('hint');
       await inlineRecoveryKey.clickFinish();
 
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await page.waitForURL(/connect_another_device/);
+      await expect(connectAnotherDevice.header).toBeAttached();
     });
 
     test('can setup recovery key inline after 2FA', async ({
@@ -236,7 +235,8 @@ test.describe('recovery key promo', () => {
       await inlineRecoveryKey.fillOutHint('hint');
       await inlineRecoveryKey.clickFinish();
 
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await page.waitForURL(/connect_another_device/);
+      await expect(connectAnotherDevice.header).toBeEnabled();
 
       await settings.goto();
       await settings.disconnectTotp(); // Required before teardown
@@ -266,7 +266,8 @@ test.describe('recovery key promo', () => {
       await inlineRecoveryKey.clickDoItLater();
 
       // User taken to connect another device page
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await page.waitForURL(/connect_another_device/);
+      await expect(connectAnotherDevice.header).toBeEnabled();
 
       await connectAnotherDevice.startBrowsingButton.click();
 
@@ -283,7 +284,7 @@ test.describe('recovery key promo', () => {
       );
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
+++ b/packages/functional-tests/tests/postVerify/syncForcePasswordChange.spec.ts
@@ -39,8 +39,8 @@ test.describe('severity-2 #smoke', () => {
       await postVerify.submit();
       credentials.password = newPassword;
 
-      //Verify logged in on connect another device page
-      await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
+      // Verify logged in on connect another device page
+      await expect(connectAnotherDevice.header).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -148,7 +148,7 @@ test.describe('severity-1 #smoke', () => {
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
 
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
       await signup.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
     });
   });

--- a/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('connect_another_device', () => {
-    test('react signin Fx Desktop, load /connect_another_device page', async ({
+    test('react signin Fx Desktop, load /pair page', async ({
       syncBrowserPages: { configPage, connectAnotherDevice, page, signin },
       testAccountTracker,
     }) => {
@@ -26,13 +26,8 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-      await expect(
-        connectAnotherDevice.connectAnotherDeviceButton
-      ).toBeVisible();
-      await expect(connectAnotherDevice.signInButton).toBeHidden();
-      await expect(connectAnotherDevice.success).toBeHidden();
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -34,7 +34,7 @@ test.describe('severity-1 #smoke', () => {
     await signin.fillOutPasswordForm(credentials.password);
 
     await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
-    await connectAnotherDevice.startBrowsingButton.click();
+    await connectAnotherDevice.clickNotNowPair();
     await expect(page).toHaveURL(/settings/, { timeout: 1000 });
 
     await settings.disconnectSync(credentials);

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -93,7 +93,7 @@ test.describe('severity-1 #smoke', () => {
       const code = await getCode(secret);
       await signin.fillOutAuthenticationForm(code);
 
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -91,8 +91,8 @@ test.describe('severity-1 #smoke', () => {
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
 
-      await expect(page).toHaveURL(/connect_another_device/);
-      await expect(page.getByText('You’re signed in to Firefox')).toBeVisible();
+      await expect(page).toHaveURL(/pair/);
+      await expect(page.getByText('Signed in successfully')).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -52,6 +52,6 @@ test.describe('severity-2 #smoke', () => {
 
     await signinTokenCode.fillOutCodeForm(code);
 
-    await expect(page).toHaveURL(/connect_another_device/);
+    await expect(page).toHaveURL(/pair/);
   });
 });

--- a/packages/functional-tests/tests/resetPassword/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPasswordSyncMobile.spec.ts
@@ -50,7 +50,7 @@ test.describe('severity-1 #smoke', () => {
       // new passwowrd works
       await signin.fillOutPasswordForm(newPassword);
 
-      await expect(connectAnotherDevice.header).toBeVisible();
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
       // update password for cleanup function
       credentials.password = newPassword;

--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -23,7 +23,8 @@ test.describe('fxa_status web channel message in Settings', () => {
       `${target.contentServerUrl}/?context=fx_desktop_v3&service=sync`
     );
     const credentials = await signInAccount(signin, testAccountTracker);
-    await expect(connectAnotherDevice.header).toBeVisible();
+    await page.waitForURL(/pair/);
+    await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
     await page.goto(target.contentServerUrl);
     await signin.useDifferentAccountLink.click();
@@ -45,7 +46,7 @@ test.describe('fxa_status web channel message in Settings', () => {
       `${target.contentServerUrl}/?context=fx_desktop_v3&service=sync`
     );
     await signInAccount(signin, testAccountTracker);
-    await expect(connectAnotherDevice.header).toBeVisible();
+    await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
 
     await page.goto(target.contentServerUrl);
     await signin.useDifferentAccountLink.click();

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -19,14 +19,8 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
-      await page.waitForURL(/connect_another_device/);
-
+      await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-      await expect(
-        connectAnotherDevice.connectAnotherDeviceButton
-      ).toBeVisible();
-      await expect(connectAnotherDevice.signInButton).toBeHidden();
-      await expect(connectAnotherDevice.success).toBeHidden();
     });
   });
 });

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -73,7 +73,7 @@ test.describe('severity-1 #smoke', () => {
         credentials.email
       );
       await signinTokenCode.fillOutCodeForm(code);
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await fxDesktopV3ForceAuth.checkWebChannelMessage(FirefoxCommand.Login);
     });
@@ -142,7 +142,7 @@ test.describe('severity-1 #smoke', () => {
       const code = await target.emailClient.getUnblockCode(credentials.email);
       await signinUnblock.fillOutCodeForm(code);
 
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
       await fxDesktopV3ForceAuth.checkWebChannelMessage(FirefoxCommand.Login);
 

--- a/packages/functional-tests/tests/syncV3/oauthSignIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/oauthSignIn.spec.ts
@@ -25,7 +25,7 @@ test.describe('severity-1 #smoke', () => {
       );
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
       await relier.goto();

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -154,7 +154,7 @@ test.describe('severity-2 #smoke', () => {
         credentials.email
       );
       await signinTokenCode.fillOutCodeForm(code);
-      await expect(page).toHaveURL(/connect_another_device/);
+      await expect(page).toHaveURL(/pair/);
 
       await settings.goto();
       //Click Delete account

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -222,8 +222,8 @@ test.describe('severity-2 #smoke', () => {
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
-      //Delete blocked account, required before teardown
-      await connectAnotherDevice.startBrowsingButton.click();
+      // Delete blocked account, required before teardown
+      await connectAnotherDevice.clickNotNowPair();
       await settings.deleteAccountButton.click();
       await deleteAccount.deleteAccount(credentials.password);
 

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -33,8 +33,8 @@ test.describe('severity-2 #smoke', () => {
       await expect(signin.passwordFormHeading).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.fillOutPasswordForm(credentials.password);
-      await expect(page).toHaveURL(/connect_another_device/);
-      await connectAnotherDevice.clickNotNow();
+      await expect(page).toHaveURL(/pair/);
+      await connectAnotherDevice.clickNotNowPair();
 
       //Verify logged in on Settings page
       await expect(settings.settingsHeading).toBeVisible();

--- a/packages/fxa-content-server/app/scripts/lib/user-agent.js
+++ b/packages/fxa-content-server/app/scripts/lib/user-agent.js
@@ -28,8 +28,23 @@ const UserAgent = function (userAgent) {
     },
 
     /**
+     * Check if the device is iOS or Android.
+     *
+     * This does not work for latest iPad, see note above isDesktopFirefoxOnIpad.
+     *
+     * @returns {Boolean}
+     */
+    isMobile() {
+      return this.isIos() || this.isAndroid();
+    },
+
+    /**
      * iPads using FF iOS 13+ send a desktop UA.
      * The OS shows as a Mac, but 'Firefox iOS' in the UA family.
+     *
+     * NOTE, as of at least Sept 2024, this is no longer reliable.
+     * The UA for iPad Safari exactly matches the UA for iPad Firefox
+     * except for "Version" which is unreliable.
      *
      * @returns {Boolean}
      */

--- a/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
@@ -18,7 +18,7 @@
     {{/isSignedIn}}
   {{/showSuccessMessage}}
   <section>
-    <div class="{{graphicId}}" role="img" aria-label="{{#t}}Devices with hearts on their screens{{/t}}"></div>
+    <div class="bg-image-triple-device-hearts" role="img" aria-label="{{#t}}Devices with hearts on their screens{{/t}}"></div>
     {{#showSuccessMessage}}
       {{#isSignedIn}}
         {{#isFirefoxDesktop}}
@@ -65,33 +65,10 @@
           {{/isSignedIn}}
         </p>
       {{/isFirefoxDesktop}}
-      {{#isFirefoxIos}}
-        <!-- user verifies in Fx for iOS, assume they are not signed in -->
-        <p id="signin-fxios">
-          {{#t}}Still adding devices? Sign in to Firefox on another device to complete set-up{{/t}}
-        </p>
-      {{/isFirefoxIos}}
-      {{#isOtherAndroid}}
-        <!-- Another android browser, encourage Fx for Android installation -->
-        <p id="install-mobile-firefox-android">
-          {{#t}}Sign in to Firefox for Android to complete set-up{{/t}}
-        </p>
-      {{/isOtherAndroid}}
-      {{#isOtherIos}}
-        <!-- Safari or Chrome for iOS, encourage installation of Fx -->
-        <p id="install-mobile-firefox-ios">
-          {{#t}}Sign in to Firefox for iOS to complete set-up{{/t}}
-        </p>
-      {{/isOtherIos}}
-      {{#isOther}}
-        <!-- probably some desktop browser -->
-        <p id="install-mobile-firefox-other">
-          {{#isSignIn}}
-            {{#t}}Still adding devices?{{/t}}
-          {{/isSignIn}}
-          {{#t}}Sign in to Firefox on another device to complete set-up{{/t}}
-        </p>
-      {{/isOther}}
+
+      {{#isMobile}}
+        {{{ unsupportedPairHtml }}}
+      {{/isMobile}}
 
       {{^isFirefoxDesktop}}
         <div class="marketing-area"></div>

--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -1,89 +1,76 @@
 
 <div class="card-base">
   <header class="relative">
-    {{#askMobileStatus}}
-      {{#needsMobileConfirmed}}
-        <button id="back-btn" class="me-4 tablet:me-0 tablet:p-4 inline-block tablet:absolute tablet:-start-20 -top-1.5 w-5 h-3.5 p-5 bg-back-arrow bg-auto bg-center bg-no-repeat rtl:transform rtl:-scale-x-100 rounded hover:bg-grey-50 active:bg-grey-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500" aria-label="{{#t}}Back{{/t}}" title="{{#t}}Back{{/t}}"></button>
-      {{/needsMobileConfirmed}}
-      <h1 class="mb-5 text-grey-400 text-base{{#needsMobileConfirmed}} inline-block align-top mt-2 tablet:mt-0{{/needsMobileConfirmed}}" id="cad-header">Connect another device</h1>
+    {{#showSuccessMessage}}
+      <h2 id="fxa-connected-heading" class="w-full text-md font-bold p-3 my-3 rounded bg-green-500 text-gray-900 text-center">{{#t}}Signed in successfully!{{/t}}</h2>
+    {{/showSuccessMessage}}
 
-      {{^needsMobileConfirmed}}
-        <h2 id="pair-header" class="card-header focus:outline-none" tabindex="-1">{{#t}}Sync your Firefox experience{{/t}}</h2>
-      {{/needsMobileConfirmed}}
-      {{#needsMobileConfirmed}}
-        <h2 id="pair-header-mobile" class="card-header focus:outline-none" tabindex="-1">{{#t}}Download Firefox for mobile{{/t}}</h2>
-      {{/needsMobileConfirmed}}
+    {{#needsMobileConfirmed}}
+      <button id="back-btn" class="me-4 tablet:me-0 tablet:p-4 inline-block tablet:absolute tablet:-start-20 -top-1.5 w-5 h-3.5 p-5 bg-back-arrow bg-auto bg-center bg-no-repeat rtl:transform rtl:-scale-x-100 rounded hover:bg-grey-50 active:bg-grey-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500" aria-label="{{#t}}Back{{/t}}" title="{{#t}}Back{{/t}}"></button>
+    {{/needsMobileConfirmed}}
 
-    {{/askMobileStatus}}
-    {{^askMobileStatus}}
-      <h2 id="pair-header" class="card-header" tabindex="-1">{{#t}}Sync Firefox on your phone or tablet{{/t}}</h2>
-    {{/askMobileStatus}}
+    <h1 class="mb-5 text-grey-400 text-base{{#needsMobileConfirmed}} inline-block align-top mt-2 tablet:mt-0{{/needsMobileConfirmed}}" id="cad-header">Connect another device</h1>
+
+    {{^needsMobileConfirmed}}
+      <h2 id="pair-header" class="card-header focus:outline-none" tabindex="-1">{{#t}}Sync your Firefox experience{{/t}}</h2>
+    {{/needsMobileConfirmed}}
+    {{#needsMobileConfirmed}}
+      <h2 id="pair-header-mobile" class="card-header focus:outline-none" tabindex="-1">{{#t}}Download Firefox for mobile{{/t}}</h2>
+    {{/needsMobileConfirmed}}
   </header>
 
   <section>
     <div class="error"></div>
 
-    {{#askMobileStatus}}
-      {{^needsMobileConfirmed}}
-        <p class="my-3 text-base">{{#t}}View your saved passwords, tabs, browsing history and more — across all your devices.{{/t}}</p>
+    {{^needsMobileConfirmed}}
+      <p class="my-3 text-base">{{#t}}View your saved passwords, tabs, browsing history and more — across all your devices.{{/t}}</p>
 
-        <form novalidate id="form-ask-mobile-status">
-          <fieldset>
-            <legend class="mb-4 text-base font-semibold">Select an option to continue:</legend>
-            <div class="input-radio-wrapper">
-              <input class="input-radio" type="radio" id="has-mobile" name="mobile-download">
-              <label class="input-radio-label" for="has-mobile">
-                <div class="pe-3">
-                  <strong class="block mb-2 text-base">{{#t}}I already have Firefox for mobile{{/t}}</strong>{{#t}}Start your sync now if you already have Firefox on your mobile device.{{/t}}
-                </div>
-                <div class="bg-mobile-ff bg-contain bg-center bg-no-repeat w-14"></div>
-              </label>
-            </div>
-            <div class="input-radio-wrapper">
-              <input class="input-radio" type="radio" id="needs-mobile" name="mobile-download" />
-              <label class="input-radio-label" for="needs-mobile">
-                <div class="pe-3">
-                  <strong class="block mb-2 text-base">{{#t}}I don’t have Firefox for mobile{{/t}}</strong>{{#t}}Download Firefox on your mobile device, then start your sync.{{/t}}
-                </div>
-                <div class="bg-mobile-download bg-contain bg-center bg-no-repeat w-14"></div>
-              </label>
-            </fieldset>
-
-          <div class="flex mt-6">
-            <button id="set-needs-mobile" class="cta-primary cta-xl" type="button" disabled>{{#t}}Continue{{/t}}</button>
+      <form novalidate id="form-ask-mobile-status">
+        <fieldset>
+          <legend class="mb-4 text-base font-semibold">Select an option to continue:</legend>
+          <div class="input-radio-wrapper">
+            <input class="input-radio" type="radio" id="has-mobile" name="mobile-download">
+            <label class="input-radio-label" for="has-mobile">
+              <div class="pe-3">
+                <strong class="block mb-2 text-base">{{#t}}I already have Firefox for mobile{{/t}}</strong>{{#t}}Start your sync now if you already have Firefox on your mobile device.{{/t}}
+              </div>
+              <div class="bg-mobile-ff bg-contain bg-center bg-no-repeat w-14"></div>
+            </label>
           </div>
-        </form>
+          <div class="input-radio-wrapper">
+            <input class="input-radio" type="radio" id="needs-mobile" name="mobile-download" />
+            <label class="input-radio-label" for="needs-mobile">
+              <div class="pe-3">
+                <strong class="block mb-2 text-base">{{#t}}I don’t have Firefox for mobile{{/t}}</strong>{{#t}}Download Firefox on your mobile device, then start your sync.{{/t}}
+              </div>
+              <div class="bg-mobile-download bg-contain bg-center bg-no-repeat w-14"></div>
+            </label>
+          </fieldset>
 
-        <p class="mt-5 text-sm text-center"><a id="choice-pair-not-now" class="link-blue" href="/settings">{{#t}}Not now{{/t}}</a></p>
-      {{/needsMobileConfirmed}}
-
-      {{#needsMobileConfirmed}}
-        <p class="text-base mt-2">{{#t}}To sync Firefox on your phone or tablet, you first need to download Firefox for mobile. Here’s how:{{/t}}</>
-        <ol>
-          <li>
-            <p class="text-base mt-5">{{#unsafeTranslate}}<b>Step 1</b>: Download Firefox by scanning this QR code with the camera on your mobile device:{{/unsafeTranslate}}</p>
-            <div class="bg-image-cad-qr-code my-10" role="img" aria-label="{{#t}}QR code (located in the middle of the screen){{/t}}"></div>
-          </li>
-          <li class="text-base mb-5">{{#unsafeTranslate}}<b>Step 2</b>: Select "Continue to sync" to sync your Firefox experience on your mobile device.{{/unsafeTranslate}}</li>
-        </ol>
-
-        <form novalidate>
-          <div class="flex">
-            <button id="start-pairing" class="cta-primary cta-xl" type="submit">{{#t}}Continue to sync{{/t}}</button>
-          </div>
-        </form>
-        <p class="mt-5 text-sm text-center"><a id="pair-not-now" class="link-blue" href="/settings">{{#t}}Not now{{/t}}</a></p>
-      {{/needsMobileConfirmed}}
-    {{/askMobileStatus}}
-
-    {{^askMobileStatus}}
-      <div class="{{graphicId}} mt-5" role="img" aria-label="{{#t}}Devices with hearts on their screens{{/t}}"></div>
-      <p class="mt-5 mb-5 px-16">{{#t}}Take your tabs, bookmarks, and passwords anywhere you use Firefox.{{/t}}</p>
-      <form novalidate>
-        <div class="flex">
-          <button id="start-pairing" class="cta-primary cta-xl" type="submit">{{#t}}Get started{{/t}}</button>
+        <div class="flex mt-6">
+          <button id="set-needs-mobile" class="cta-primary cta-xl" type="button" disabled>{{#t}}Continue{{/t}}</button>
         </div>
       </form>
-    {{/askMobileStatus}}
+
+      <p class="mt-5 text-sm text-center"><a id="choice-pair-not-now" class="link-blue" href="/settings">{{#t}}Not now{{/t}}</a></p>
+    {{/needsMobileConfirmed}}
+
+    {{#needsMobileConfirmed}}
+      <p class="text-base mt-2">{{#t}}To sync Firefox on your phone or tablet, you first need to download Firefox for mobile. Here’s how:{{/t}}</>
+      <ol>
+        <li>
+          <p class="text-base mt-5">{{#unsafeTranslate}}<b>Step 1</b>: Download Firefox by scanning this QR code with the camera on your mobile device:{{/unsafeTranslate}}</p>
+          <div class="bg-image-cad-qr-code my-10" role="img" aria-label="{{#t}}QR code (located in the middle of the screen){{/t}}"></div>
+        </li>
+        <li class="text-base mb-5">{{#unsafeTranslate}}<b>Step 2</b>: Select "Continue to sync" to sync your Firefox experience on your mobile device.{{/unsafeTranslate}}</li>
+      </ol>
+
+      <form novalidate>
+        <div class="flex">
+          <button id="start-pairing" class="cta-primary cta-xl" type="submit">{{#t}}Continue to sync{{/t}}</button>
+        </div>
+      </form>
+      <p class="mt-5 text-sm text-center"><a id="pair-not-now" class="link-blue" href="/settings">{{#t}}Not now{{/t}}</a></p>
+    {{/needsMobileConfirmed}}
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/templates/pair/unsupported.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/unsupported.mustache
@@ -25,7 +25,7 @@
     {{#isMobile}}
       {{#isSystemCameraUrl}}
         <div class="bg-image-pair-fail"></div>
-          <h2 id="pair-unsupported-header" class="card-header" tabindex="-1">{{#t}}Pair using an app{{/t}}</h1>
+          <h2 id="pair-unsupported-header" class="card-header" tabindex="-1">{{#t}}Pair using an app{{/t}}</h2>
         <p class="mt-4">{{#t}}Did you use the system camera? You must pair from within a Firefox app.{{/t}}</p>
       {{/isSystemCameraUrl}}
       {{^isSystemCameraUrl}}
@@ -37,11 +37,9 @@
         {{/isFirefox}}
 
         <div class="bg-image-triple-device-hearts" role="img" aria-label="{{#t}}Devices with hearts on their screens{{/t}}"></div>
+        {{{ unsupportedPairHtml }}}
 
-        <h1 class="card-header">{{#t}}Connecting your mobile device with your Mozilla account{{/t}}</h1>
-        <p class="mt-4 text-base">Open Firefox on your computer, visit <b class="whitespace-nowrap">firefox.com/pair</b>, and follow the on-screen instructions to connect your mobile device.</p>
-        <p class="mt-3"><a href="https://support.mozilla.org/kb/how-do-i-set-sync-my-computer" target="_blank" class="link-blue" data-glean-id="cad_redirect_mobile_learn_more">{{#t}}Learn more{{/t}}</a></p>
-      {{/isSystemCameraUrl}}
+        {{/isSystemCameraUrl}}
     {{/isMobile}}
     {{^isMobile}}
       {{^isDesktopNonFirefox}}

--- a/packages/fxa-content-server/app/scripts/templates/partial/unsupported-pair.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/unsupported-pair.mustache
@@ -1,0 +1,3 @@
+<h1 id="unsupported-header" class="card-header">{{#t}}Connecting your mobile device with your Mozilla account{{/t}}</h1>
+<p class="mt-4 text-base">{{#unsafeTranslate}}Open Firefox on your computer, visit <b class="whitespace-nowrap">firefox.com/pair</b>, and follow the on-screen instructions to connect your mobile device.{{/unsafeTranslate}}</p>
+<p class="mt-3"><a href="https://support.mozilla.org/kb/how-do-i-set-sync-my-computer" target="_blank" class="link-blue" data-glean-id="cad_redirect_mobile_learn_more">{{#t}}Learn more{{/t}}</a></p>

--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -22,6 +22,7 @@ import MarketingMixin from './mixins/marketing-mixin';
 import PairingGraphicsMixin from './mixins/pairing-graphics-mixin';
 import SyncAuthMixin from './mixins/sync-auth-mixin';
 import VerificationReasonMixin from './mixins/verification-reason-mixin';
+import UnsupportedPairTemplate from '../templates/partial/unsupported-pair.mustache';
 
 const entrypoints = Object.keys(Constants)
   .filter((k) => k.endsWith('_ENTRYPOINT'))
@@ -56,6 +57,16 @@ const ConnectAnotherDeviceView = FormView.extend({
     // on whether the url is allowed to be redirected to.
     if (this.getSearchParam('redirect_immediately') === 'true') {
       this.navigate('/settings');
+    }
+
+    // If users are signed in, directly access this page (no query params)
+    // on desktop, redirect them
+    if (
+      this._isSignedIn() &&
+      window.location.search === '' &&
+      !this.getUserAgent().isMobile()
+    ) {
+      this.navigate('/pair');
     }
   },
 
@@ -182,7 +193,9 @@ const ConnectAnotherDeviceView = FormView.extend({
       isSignIn,
       isSignUp,
       pairingUrl,
+      isMobile: this.getUserAgent().isMobile(),
       showSuccessMessage,
+      unsupportedPairHtml: this.renderTemplate(UnsupportedPairTemplate),
     });
   },
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pairing-graphics-mixin.js
@@ -10,7 +10,6 @@
  */
 
 import UserAgentMixin from '../../lib/user-agent-mixin';
-import Constants from '../../lib/constants';
 import UrlMixin from '../../lib/url-mixin';
 
 export default {
@@ -22,21 +21,5 @@ export default {
       return 'bg-image-triple-device-hearts';
     }
     return 'bg-image-cad';
-  },
-
-  /**
-   * Returns true if we believe the current entry points merits that we show the user
-   * a QR code that can be used download firefox on a mobile device.
-   */
-  showDownloadFirefoxQrCode() {
-    const entryPoint = this.getSearchParam('entrypoint');
-    return (
-      entryPoint === Constants.FIREFOX_MENU_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_SYNCED_TABS_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_TABS_SIDEBAR_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_FX_VIEW_ENTRYPOINT ||
-      entryPoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT
-    );
   },
 };

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -65,23 +65,19 @@ class PairIndexView extends FormView {
   }
 
   setInitialContext(context) {
-    // Check the entrypoint. If we aren't in a entrypoint=fxa_app_menu context,
-    // then don't ask if the user needs to download Fx mobile then show QR code.
     const graphicId = this.getGraphicsId();
-    const askMobileStatus = this.showDownloadFirefoxQrCode();
     const needsMobileConfirmed = this.model.get('needsMobileConfirmed');
 
-    if (askMobileStatus) {
-      GleanMetrics.cadFirefox.choiceView();
-    }
     if (needsMobileConfirmed) {
       GleanMetrics.cadFirefox.view();
+    } else {
+      GleanMetrics.cadFirefox.choiceView();
     }
 
     context.set({
       graphicId,
-      askMobileStatus,
       needsMobileConfirmed,
+      showSuccessMessage: this.showSuccessMessage(),
     });
   }
 
@@ -138,6 +134,13 @@ class PairIndexView extends FormView {
   choicePairNotNowHandler() {
     GleanMetrics.cadFirefox.choiceNotnowSubmit();
     return true;
+  }
+
+  showSuccessMessage() {
+    return (
+      !!this.model.get('showSuccessMessage') ||
+      !!this.getSearchParam('showSuccessMessage')
+    );
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/views/pair/unsupported.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/unsupported.js
@@ -8,6 +8,7 @@ import Template from '../../templates/pair/unsupported.mustache';
 import GleanMetrics from '../../lib/glean';
 import UserAgentMixin from '../../lib/user-agent-mixin';
 import UrlMixin from 'lib/url-mixin';
+import UnsupportedPairTemplate from '../../templates/partial/unsupported-pair.mustache';
 
 class PairUnsupportedView extends FormView {
   template = Template;
@@ -24,7 +25,7 @@ class PairUnsupportedView extends FormView {
   setInitialContext(context) {
     const uap = this.getUserAgent();
     const isFirefox = uap.isFirefox();
-    const isMobile = uap.isAndroid() || uap.isIos();
+    const isMobile = uap.isMobile();
     // Assume the user is on non-Firefox desktop in this case.
     const isDesktopNonFirefox = !isFirefox && !isMobile;
     const hashParams = this.getHashParams(['channel_id, channel_key']);
@@ -53,6 +54,7 @@ class PairUnsupportedView extends FormView {
       isSystemCameraUrl,
       escapedMobileDownloadLink,
       showCADHeader: !(isMobile && !isSystemCameraUrl),
+      unsupportedPairHtml: this.renderTemplate(UnsupportedPairTemplate),
     });
   }
 }

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/pairing-graphics-mixin.js
@@ -38,41 +38,4 @@ describe('views/mixins/pairing-graphics-mixin', function () {
       assert.equal(view.getGraphicsId(), 'bg-image-triple-device-hearts');
     });
   });
-
-  describe('showDownloadFirefoxQrCode', () => {
-    it('returns true if entry point is app menu', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => 'fxa_app_menu');
-      assert.equal(view.showDownloadFirefoxQrCode(), true);
-    });
-
-    it('returns true if entry point is preferences', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => 'preferences');
-      assert.equal(view.showDownloadFirefoxQrCode(), true);
-    });
-
-    it('returns true if entry point is synced-tabs', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => 'synced-tabs');
-      assert.equal(view.showDownloadFirefoxQrCode(), true);
-    });
-
-    it('returns true if entry point is side-bar', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => 'tabs-sidebar');
-      assert.equal(view.showDownloadFirefoxQrCode(), true);
-    });
-
-    it('returns true if entry point is fx-view', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => 'fx-view');
-      assert.equal(view.showDownloadFirefoxQrCode(), true);
-    });
-
-    it('returns true if entry point is fxa_discoverability_native', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => 'fx-view');
-      assert.equal(view.showDownloadFirefoxQrCode(), true);
-    });
-
-    it('returns false if entry point is not app menu', () => {
-      sinon.stub(view, 'getSearchParam').callsFake(() => undefined);
-      assert.equal(view.showDownloadFirefoxQrCode(), false);
-    });
-  });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -132,8 +132,6 @@ describe('views/pair/index', () => {
           view.$el.find('#pair-header').text(),
           'Download Firefox on your phone or tablet'
         );
-        assert.ok(view.$el.find('#start-pairing').length);
-        assert.ok(view.$el.find('.bg-image-triple-device-hearts').length);
       });
     });
 
@@ -172,7 +170,6 @@ describe('views/pair/index', () => {
       let viewChoiceEventStub;
       beforeEach(() => {
         viewChoiceEventStub = sinon.stub(GleanMetrics.cadFirefox, 'choiceView');
-        sinon.stub(view, 'showDownloadFirefoxQrCode').callsFake(() => true);
         return view.render();
       });
 
@@ -383,7 +380,6 @@ describe('views/pair/index', () => {
     describe('pairNotNowHandler', () => {
       let notNowEventStub;
       beforeEach(() => {
-        sinon.stub(view, 'showDownloadFirefoxQrCode').callsFake(() => true);
         notNowEventStub = sinon.stub(GleanMetrics.cadFirefox, 'notnowSubmit');
       });
       afterEach(() => {
@@ -395,23 +391,6 @@ describe('views/pair/index', () => {
           view.$('#pair-not-now').click();
           sinon.assert.calledOnce(notNowEventStub);
         });
-      });
-    });
-
-    it('does not ask for mobile status', () => {
-      sinon.stub(view, 'showDownloadFirefoxQrCode').callsFake(() => false);
-      return view.render().then(() => {
-        const heading = view.$('#pair-header');
-        assert.strictEqual(
-          heading.text(),
-          'Sync Firefox on your phone or tablet'
-        );
-
-        const pairButton = view.$('#start-pairing');
-        assert.equal(pairButton.length, 1);
-
-        const qrCode = view.$el.find('.bg-image-cad-qr-code');
-        assert.equal(qrCode.length, 0);
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/pair/unsupported.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/unsupported.js
@@ -55,6 +55,7 @@ describe('views/pair/unsupported', () => {
           isAndroid: () => false,
           isFirefox: () => true,
           isIos: () => true,
+          isMobile: () => true,
         };
       });
       sinon.stub(view, 'getHashParams').callsFake(() => {
@@ -95,6 +96,7 @@ describe('views/pair/unsupported', () => {
           isAndroid: () => false,
           isFirefox: () => true,
           isIos: () => true,
+          isMobile: () => true,
         };
       });
     });
@@ -139,6 +141,7 @@ describe('views/pair/unsupported', () => {
           isAndroid: () => true,
           isFirefox: () => false,
           isIos: () => false,
+          isMobile: () => true,
         };
       });
     });
@@ -180,6 +183,7 @@ describe('views/pair/unsupported', () => {
           isAndroid: () => false,
           isFirefox: () => true,
           isIos: () => false,
+          isMobile: () => false,
         };
       });
     });
@@ -213,6 +217,7 @@ describe('views/pair/unsupported', () => {
           isAndroid: () => false,
           isFirefox: () => false,
           isIos: () => false,
+          isMobile: () => false,
         };
       });
     });

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
@@ -111,7 +111,7 @@ describe('InlineRecoveryKeySetupContainer', () => {
     render(<InlineRecoveryKeySetupContainer />);
 
     expect(hardNavigateSpy).toHaveBeenCalledWith(
-      '/connect_another_device?showSuccessMessage=true'
+      '/pair?showSuccessMessage=true'
     );
     expect(InlineRecoveryKeySetupModule.default).not.toBeCalled();
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
@@ -211,7 +211,7 @@ describe('SigninPushCode container', () => {
         await render();
       });
       expect(ReactUtils.hardNavigate).toBeCalledWith(
-        '/connect_another_device?showSuccessMessage=true'
+        '/pair?showSuccessMessage=true'
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -175,7 +175,7 @@ describe('Sign in with TOTP code page', () => {
         );
         expect(fxaLoginSpy).toHaveBeenCalled();
         expect(hardNavigateSpy).toHaveBeenCalledWith(
-          '/connect_another_device?showSuccessMessage=true'
+          '/pair?showSuccessMessage=true'
         );
       });
       it('is not sent otherwise', async () => {

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -422,7 +422,7 @@ describe('Signin', () => {
                 expect(fxaLoginSpy).toHaveBeenCalled();
               });
               expect(hardNavigateSpy).toHaveBeenCalledWith(
-                '/connect_another_device?showSuccessMessage=true'
+                '/pair?showSuccessMessage=true'
               );
             });
             it('is not sent if user has 2FA enabled', async () => {
@@ -561,7 +561,7 @@ describe('Signin', () => {
                 expect(fxaLoginSpy).toHaveBeenCalled();
                 expect(fxaOAuthLoginSpy).toHaveBeenCalled();
                 expect(hardNavigateSpy).toHaveBeenCalledWith(
-                  '/connect_another_device?showSuccessMessage=true'
+                  '/pair?showSuccessMessage=true'
                 );
               });
             });

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -42,7 +42,7 @@ export function getSyncNavigate(
 
   searchParams.set('showSuccessMessage', 'true');
   return {
-    to: `/connect_another_device?${searchParams}`,
+    to: `/pair?${searchParams}`,
     shouldHardNavigate: true,
   };
 }


### PR DESCRIPTION
This PR is for FXA-10138, but someone else will need to pick it up since I will be in all-day workshops Mon-Wed next week. Please feel free to modify this PR description with the commit message and push over my changes.

This currently covers the first two bullet points in that ticket. See [this note](https://mozilla-hub.atlassian.net/browse/FXA-10427?focusedCommentId=938162) about the iPad comments here.

You'll need to run `yarn firefox` of course to look at these locally. You can modify the user agent in dev tools to see different views.

TODO:
* 3rd bullet point. Look at Figma linked in the epic and pull the "Connecting your mobile device with your Mozilla account" piece of `pair/unsupported` into a partial, and conditionally display it `if this.getUserAgent().isMobile() && this._isSignedIn()`
* 4th & 5th bullet points which sorta cover the same thing. I'm hoping there won't be any messiness with the web channel message bits since we can modify in that `getSyncNavigate` function when we send a message or not on the React side.
* Unit tests & functional tests. We reference `connect_another_device` or the CAD header a lot in our functional tests after sync signin/signup.