### PR TITLE
fix(tests): Skip Chrome when doing Sync base test

### DIFF
--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -7,6 +7,7 @@
     "compile": "tsc --noEmit",
     "test": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local",
     "test-local": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local",
+    "test-local-chromium": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local-chromium",
     "test-stage": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=stage",
     "test-production": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=production",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -15,7 +15,7 @@ const CI = !!process.env.CI;
 // see .vscode/launch.json
 const DEBUG = !!process.env.DEBUG;
 const SLOWMO = parseInt(process.env.PLAYWRIGHT_SLOWMO || '0');
-const NUM_WORKERS = parseInt(process.env.PLAYWRIGHT_WORKERS || '16');
+const NUM_WORKERS = parseInt(process.env.PLAYWRIGHT_WORKERS || '4');
 
 let workers = NUM_WORKERS || 2,
   maxFailures = 0;

--- a/packages/functional-tests/tests/misc/recoveryKeyPromo.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromo.spec.ts
@@ -57,11 +57,15 @@ test.describe('recovery key promo', () => {
   });
 
   test.describe('inline', () => {
-    test.beforeEach(async ({ pages: { configPage } }) => {
+    test.beforeEach(async ({ pages: { configPage } }, { project }) => {
       const config = await configPage.getConfig();
       test.skip(
         config.featureFlags.recoveryCodeSetupOnSyncSignIn !== true,
         'inline recovery key setup is not enabled'
+      );
+      test.skip(
+        project.name === 'local-chromium',
+        'Sync tests can not run on Chrome'
       );
     });
 

--- a/packages/functional-tests/tests/settings/changeEmailBlocked.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmailBlocked.spec.ts
@@ -41,6 +41,8 @@ test.describe('severity-1 #smoke', () => {
       await expect(page.getByText('Incorrect password')).toBeVisible();
 
       await signin.fillOutPasswordForm(credentials.password);
+      // Fill out unblock
+      await expect(page).toHaveURL(/signin_unblock/);
       await unblockAccount(blockedEmail, target, signinUnblock);
       await expect(settings.settingsHeading).toBeVisible();
       // reset primary email to non-blocked email for account cleanup


### PR DESCRIPTION
## Because

- Sync test should fail in Chrome because it won't always respond with the correct webchannels

## This pull request

- Skips for the local-chrome project
- Adds a new command `yarn test-local-chromium --grep="<some tests>"`  for easier local testing
- Updates the local playwright test workers to 4 because 16 was causing timeout issues (I can't imagine a local machine that can handle 16 playwright test workers at once)
- Fixes an unrelated unblock test

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10445

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
