### PR TITLE
Add support for subscription coupon via route param

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -192,6 +192,7 @@ describe('CartService', () => {
         taxAddress,
         currency: mockResolvedCurrency,
         eligibilityStatus: CartEligibilityStatus.CREATE,
+        couponCode: args.promoCode,
       });
       expect(result).toEqual(mockResultCart);
     });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -138,6 +138,7 @@ export class CartService {
       taxAddress,
       currency,
       eligibilityStatus: cartEligibilityStatus,
+      couponCode: args.promoCode,
     });
 
     return cart;

--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
@@ -10,6 +10,8 @@ import { ButtonVariant } from '../BaseButton';
 import { SubmitButton } from '../SubmitButton';
 import { updateCartAction } from '../../../actions/updateCart';
 import { getFallbackTextByFluentId } from '../../../utils/error-ftl-messages';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 interface WithCouponProps {
   cartId: string;
@@ -75,6 +77,14 @@ const WithoutCoupon = ({
       couponCode: promotionCode,
     });
   }
+  const routeCoupon = useSearchParams().get('coupon') || undefined;
+  useEffect(() => {
+    if (routeCoupon) {
+      const formData = new FormData();
+      formData.set('coupon', routeCoupon);
+      formAction(formData);
+    }
+  }, []);
 
   const [error, formAction] = useFormState(applyCoupon, null);
 
@@ -94,6 +104,7 @@ const WithoutCoupon = ({
               data-testid="coupon-input"
               placeholder="Enter code"
               disabled={readOnly}
+              defaultValue={routeCoupon}
             />
           </Localized>
           <div>


### PR DESCRIPTION
validation done, removing comments

## Because

- Current coupons need to be manually entered by user. Links to initiate a subscription checkout flow currently can't contain coupon information.

## This pull request

- Passes `coupon` route parameter to the stripe cart.
- Works with [FXA-10439](https://mozilla-hub.atlassian.net/browse/FXA-10439), which handles coupon information display.

## Issue that this pull request solves

Closes: # [FXA-7831](https://mozilla-hub.atlassian.net/browse/FXA-7831)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Validated against stripe by enabling hacktheplanet coupon code for one of the test VPN subscription prices: https://dashboard.stripe.com/test/prices/price_1OUAavBVqmGyQTMazqzrIjcz


[FXA-10439]: https://mozilla-hub.atlassian.net/browse/FXA-10439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FXA-7831]: https://mozilla-hub.atlassian.net/browse/FXA-7831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ