### PR TITLE
feat(payments-next): fail ci on startup error

### DIFF
--- a/_dev/docker/ci/Dockerfile
+++ b/_dev/docker/ci/Dockerfile
@@ -38,6 +38,8 @@ RUN npx playwright install --with-deps firefox chromium webkit;
 # Runs functional tests in our CI. Needs minimal install. Assumes
 # workspace will be restored into the project folder.
 FROM cimg/node:20.11-browsers as functional-test-runner
+RUN sudo apt-get update && sudo apt-get install -y \
+    python3-venv
 WORKDIR /home/circleci
 COPY --chown=circleci:circleci --from=playwright-install /home/circleci/.cache/ms-playwright .cache/ms-playwright/
 COPY --chown=circleci:circleci project project

--- a/apps/payments/next/Gruntfile.js
+++ b/apps/payments/next/Gruntfile.js
@@ -32,6 +32,7 @@ module.exports = function (grunt) {
       nestapp: {
         options: {
           url: 'http://localhost:3035/api/dev/nestapp/restart',
+          timeout: 60 * 1000, // 60 seconds
         },
       },
     },

--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -104,5 +104,5 @@
       }
     }
   },
-  "tags": ["app", "payments", "type:sp3"]
+  "tags": ["app", "payments", "type:sp3", "payments-next"]
 }

--- a/packages/functional-tests/scripts/start-services.sh
+++ b/packages/functional-tests/scripts/start-services.sh
@@ -27,4 +27,17 @@ CI=false NODE_ENV=test npx nx run-many \
     fxa-settings \
     > ~/.pm2/logs/startup.log
 
+
+# Temporary manual step while docker image is updated
+sudo apt-get update && sudo apt-get install -y \
+    python3-venv
+
+# Start payments-next if necessary
+CI=false NODE_ENV=test npx nx affected \
+    -t start \
+    --parallel=1 \
+    --verbose \
+    --exclude='*,!tag:payments-next' \
+    >> ~/.pm2/logs/startup.log
+
 npx pm2 ls


### PR DESCRIPTION
## Because

- A nestapp error in payments-next currenly causes a silent failure in CI. Meaning CI will pass even though payments-next will fail to start up.

## This pull request

- Adds payments-next to functional tests startup

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).