### PR TITLE
update reset password button copy

### DIFF
--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -87,7 +87,7 @@ export class ResetPasswordPage extends BaseLayout {
   }
 
   get resetPasswordButton() {
-    return this.page.getByRole('button', { name: 'Reset password' });
+    return this.page.getByRole('button', { name: 'Create new password' });
   }
 
   get passwordResetConfirmationHeading() {

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/en.ftl
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/en.ftl
@@ -10,7 +10,7 @@ form-password-with-inline-criteria-reset-new-password =
   .label = New password
 form-password-with-inline-criteria-confirm-password =
   .label = Re-enter password
-form-password-with-inline-criteria-reset-submit-button = Reset password
+form-password-with-inline-criteria-reset-submit-button-2 = Create new password
 
 form-password-with-inline-criteria-match-error = Passwords do not match
 form-password-with-inline-criteria-sr-too-short-message = Password must contain at least 8 characters.

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
@@ -28,7 +28,7 @@ describe('FormPasswordWithInlineCriteria component', () => {
       screen.getByLabelText('New password');
     });
     screen.getByLabelText('Re-enter password');
-    screen.getByRole('button', { name: 'Reset password' });
+    screen.getByRole('button', { name: 'Create new password' });
   });
 
   it('renders as expected for the signup form type', async () => {

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.tsx
@@ -56,8 +56,8 @@ const getTemplateValues = (passwordFormType: PasswordFormType) => {
         'form-password-with-inline-criteria-confirm-password';
       templateValues.confirmPasswordLabel = 'Re-enter password';
       templateValues.buttonFtlId =
-        'form-password-with-inline-criteria-reset-submit-button';
-      templateValues.buttonText = 'Reset password';
+        'form-password-with-inline-criteria-reset-submit-button-2';
+      templateValues.buttonText = 'Create new password';
       break;
   }
   return templateValues;

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -58,7 +58,7 @@ describe('CompleteResetPassword page', () => {
       expect(screen.getByLabelText('New password')).toBeVisible();
       expect(screen.getByLabelText('Re-enter password')).toBeVisible();
       expect(
-        screen.getByRole('button', { name: 'Reset password' })
+        screen.getByRole('button', { name: 'Create new password' })
       ).toBeVisible();
       expect(screen.getByText('Remember your password?')).toBeVisible();
       const link = screen.getByRole('link', { name: 'Sign in' });
@@ -132,7 +132,7 @@ describe('CompleteResetPassword page', () => {
       expect(screen.getByLabelText('New password')).toBeVisible();
       expect(screen.getByLabelText('Re-enter password')).toBeVisible();
       expect(
-        screen.getByRole('button', { name: 'Reset password' })
+        screen.getByRole('button', { name: 'Create new password' })
       ).toBeVisible();
       expect(screen.getByText('Remember your password?')).toBeVisible();
       const link = screen.getByRole('link', { name: 'Sign in' });
@@ -227,7 +227,7 @@ describe('CompleteResetPassword page', () => {
     await waitFor(() =>
       user.type(screen.getByLabelText('Re-enter password'), MOCK_PASSWORD)
     );
-    const button = screen.getByRole('button', { name: 'Reset password' });
+    const button = screen.getByRole('button', { name: 'Create new password' });
     expect(button).toBeEnabled();
     await waitFor(() => user.click(button));
 


### PR DESCRIPTION
## Because

- New design has "Create new password" button copy

## This pull request

- Update button copy and related tests

## Issue that this pull request solves

Closes: #FXA-10071

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/ecf2bef9-a828-478e-ab81-c10aedc005d7)

## Other information (Optional)

Any other information that is important to this pull request.
