### PR TITLE
fix(payments-next): fix duplicate glean logs

### DIFF
--- a/libs/payments/metrics/src/lib/glean/glean.provider.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.provider.ts
@@ -5,6 +5,8 @@ import { Provider } from '@nestjs/common';
 import { createEventsServerEventLogger } from './__generated__/server_events';
 import { PaymentsGleanConfig } from './glean.config';
 
+const getRandomValue = () => Math.floor(Math.random() * 10000);
+
 export type PaymentsGleanServerEventsLogger = ReturnType<
   typeof createEventsServerEventLogger
 >;
@@ -13,12 +15,19 @@ export const PaymentsGleanProvider = Symbol('GleanServerEventsProvider');
 export const PaymentsGleanFactory: Provider<PaymentsGleanServerEventsLogger> = {
   provide: PaymentsGleanProvider,
   useFactory: (config: PaymentsGleanConfig) => {
+    // In development, we want to have a unique logger name. Without it, each time the
+    // nestapp restarts, a new logger handler is added and  the events will be logged
+    // multiple times, once per handler.
+    const loggerAppName =
+      process.env['NODE_ENV'] === 'development'
+        ? `${config.loggerAppName}-${getRandomValue()}`
+        : config.loggerAppName;
     return createEventsServerEventLogger({
       applicationId: config.applicationId,
       appDisplayVersion: config.version,
       channel: config.channel,
       logger_options: {
-        app: config.loggerAppName,
+        app: loggerAppName,
       },
     });
   },

--- a/libs/shared/db/firestore/src/lib/firestore.provider.ts
+++ b/libs/shared/db/firestore/src/lib/firestore.provider.ts
@@ -46,12 +46,16 @@ export const FirestoreService = Symbol('FIRESTORE');
 export const FirestoreProvider: Provider<Firestore> = {
   provide: FirestoreService,
   useFactory: (config: FirestoreConfig) => {
+    const credentials =
+      config.credentials?.clientEmail && config.credentials?.privateKey
+        ? {
+            client_email: config.credentials?.clientEmail,
+            private_key: config.credentials?.privateKey,
+          }
+        : undefined;
     const firestoreConfig: FirebaseFirestore.Settings = {
       ...config,
-      credentials: {
-        client_email: config.credentials?.clientEmail,
-        private_key: config.credentials?.privateKey,
-      },
+      credentials,
     };
     return setupFirestore(firestoreConfig);
   },


### PR DESCRIPTION
## Because

- In development, while payments-next is running, when the nestapp restarts due to dev changes, the Glean logger adds additional log handlers, resulting in duplicate messages.

## This pull request

- In development only, use a randomized logger name, so that no duplicate log handlers are created.

## Issue that this pull request solves

Closes: #FXA-10450

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
