### PR TITLE
task(auth): Fix test timeouts in auth-server integration tests

### DIFF
--- a/packages/fxa-auth-server/scripts/test-remote-quick.js
+++ b/packages/fxa-auth-server/scripts/test-remote-quick.js
@@ -18,7 +18,7 @@ TestServer.start(config, false).then((server) => {
     { stdio: 'inherit' }
   );
 
-  cp.on('close', (code) => {
-    server.stop();
+  cp.on('close', async (code) => {
+    await server.stop();
   });
 });

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -95,26 +95,23 @@ module.exports = (config) => {
     this.unwrapBKeyVersion2 = unwrapBKeyVersion2;
   };
 
-  Client.create = function (origin, email, password, options = {}) {
+  Client.create = async function (origin, email, password, options = {}) {
     const c = new Client(origin, options);
 
     if (options.version === 'V2') {
-      return (async function () {
-        await c.setupCredentials(email, password);
-        await c.setupCredentialsV2(email, password);
+      await c.setupCredentials(email, password);
+      await c.setupCredentialsV2(email, password);
 
-        c.generateNewWrapKb();
-        c.deriveWrapKbVersion2FromKb();
+      c.generateNewWrapKb();
+      c.deriveWrapKbVersion2FromKb();
 
-        await c.createV2();
-
-        return c;
-      })();
+      const result = await c.createV2();
+      return result;
+    } else {
+      await c.setupCredentials(email, password);
+      const result = await c.create(options);
+      return result;
     }
-
-    return c.setupCredentials(email, password).then(() => {
-      return c.create(options);
-    });
   };
 
   Client.login = function (origin, email, password, options) {

--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -16,8 +16,6 @@ const sinon = require('sinon');
 const db = require('../../lib/oauth/db');
 const encrypt = require('fxa-shared/auth/encrypt');
 const config = testServer.config;
-let Server;
-let Server2;
 
 const unique = require('../../lib/oauth/unique');
 const util = require('../../lib/oauth/util');
@@ -128,35 +126,6 @@ function authParams(params, options) {
   return defaults;
 }
 
-function newToken(payload = {}, options = {}) {
-  var ttl = payload.ttl || MAX_TTL_S;
-  delete payload.ttl;
-  mockAssertion().reply(200, options.verifierResponse || VERIFY_GOOD);
-  return Server.api
-    .post({
-      url: '/authorization',
-      payload: authParams(payload, options),
-    })
-    .then(function (res) {
-      assert.equal(res.statusCode, 200);
-      assertSecurityHeaders(res);
-      return Server.api.post({
-        url: '/token',
-        payload: {
-          client_id: options.clientId || clientId,
-          client_secret: options.codeVerifier
-            ? undefined
-            : options.secret || secret,
-          code: res.result.code,
-          code_verifier: options.codeVerifier,
-          ppid_seed: options.ppidSeed,
-          resource: options.resource,
-          ttl: ttl,
-        },
-      });
-    });
-}
-
 function assertInvalidRequestParam(result, param) {
   assert.equal(result.code, 400);
   assert.equal(result.errno, 109);
@@ -187,36 +156,60 @@ function basicAuthHeader(clientId, secret) {
 }
 
 describe('#integration - /v1', function () {
+  this.timeout(60000);
   const VERIFY_FAILURE = '{"status": "failure"}';
   let sandbox;
+  let Server;
+
+  function newToken(payload = {}, options = {}) {
+    var ttl = payload.ttl || MAX_TTL_S;
+    delete payload.ttl;
+    mockAssertion().reply(200, options.verifierResponse || VERIFY_GOOD);
+    return Server.api
+      .post({
+        url: '/authorization',
+        payload: authParams(payload, options),
+      })
+      .then(function (res) {
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        return Server.api.post({
+          url: '/token',
+          payload: {
+            client_id: options.clientId || clientId,
+            client_secret: options.codeVerifier
+              ? undefined
+              : options.secret || secret,
+            code: res.result.code,
+            code_verifier: options.codeVerifier,
+            ppid_seed: options.ppidSeed,
+            resource: options.resource,
+            ttl: ttl,
+          },
+        });
+      });
+  }
 
   before(async function () {
-    this.timeout(30000);
     Server = await testServer.start();
-    return Promise.all([
-      genAssertion(USERID + config.get('oauthServer.browserid.issuer')).then(
-        function (ass) {
-          AN_ASSERTION = ass;
-        }
-      ),
-      db.ping().then(function () {
-        client = clientByName('Mocha');
-        clientId = client.id;
-        assert.equal(encrypt.hash(secret).toString('hex'), client.hashedSecret);
-        assert.equal(
-          encrypt.hash(secretPrevious).toString('hex'),
-          client.hashedSecretPrevious
-        );
-        badSecret = Buffer.from(secret, 'hex').slice();
-        badSecret[badSecret.length - 1] ^= 1;
-        badSecret = badSecret.toString('hex');
-      }),
-    ]);
+    AN_ASSERTION = await genAssertion(
+      USERID + config.get('oauthServer.browserid.issuer')
+    );
+    await db.ping();
+    client = clientByName('Mocha');
+    clientId = client.id;
+    assert.equal(encrypt.hash(secret).toString('hex'), client.hashedSecret);
+    assert.equal(
+      encrypt.hash(secretPrevious).toString('hex'),
+      client.hashedSecretPrevious
+    );
+    badSecret = Buffer.from(secret, 'hex').slice();
+    badSecret[badSecret.length - 1] ^= 1;
+    badSecret = badSecret.toString('hex');
   });
 
   after(async function () {
-    await Server?.close();
-    await Server2?.close();
+    await Server.close();
   });
 
   beforeEach(() => {
@@ -2860,37 +2853,57 @@ describe('#integration - /v1', function () {
       assert.equal(res.result.errno, 115);
     });
 
-    it('should not reject expired tokens from pocket clients', async function () {
+    describe('expired tokens from pocket clients', () => {
       const clientId = '749818d3f2e7857f';
-      config.set('oauthServer.expiration.accessTokenExpiryEpoch', undefined);
-      Server2 = await testServer.start();
-      let res = await newToken(
-        {
-          ttl: 1,
-        },
-        {
-          clientId,
-        }
-      );
+      let accessTokenExpiryEpoch;
 
-      assert.equal(res.statusCode, 200);
-      assertSecurityHeaders(res);
-      assert.equal(res.result.expires_in, 1);
-
-      sandbox.useFakeTimers({
-        now: Date.now() + 1000 * 60 * 60, // 1 hr in future
-        shouldAdvanceTime: true,
+      before(async () => {
+        await Server.close();
+        accessTokenExpiryEpoch = config.get(
+          'oauthServer.expiration.accessTokenExpiryEpoch'
+        );
+        config.set('oauthServer.expiration.accessTokenExpiryEpoch', undefined);
+        Server = await testServer.start();
       });
 
-      res = await Server2.api.post({
-        url: '/verify',
-        payload: {
-          token: res.result.access_token,
-        },
+      after(async () => {
+        await Server.close();
+        config.set(
+          'oauthServer.expiration.accessTokenExpiryEpoch',
+          accessTokenExpiryEpoch
+        );
+        Server = await testServer.start();
       });
 
-      assert.equal(res.statusCode, 200);
-      assertSecurityHeaders(res);
+      it('should not reject expired tokens from pocket clients', async function () {
+        let res = await newToken(
+          {
+            ttl: 1,
+          },
+          {
+            clientId,
+          }
+        );
+
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        assert.equal(res.result.expires_in, 1);
+
+        sandbox.useFakeTimers({
+          now: Date.now() + 1000 * 60 * 60, // 1 hr in future
+          shouldAdvanceTime: true,
+        });
+
+        res = await Server.api.post({
+          url: '/verify',
+          payload: {
+            token: res.result.access_token,
+          },
+        });
+
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+      });
     });
 
     describe('response', function () {

--- a/packages/fxa-auth-server/test/oauth/key-management-scripts.js
+++ b/packages/fxa-auth-server/test/oauth/key-management-scripts.js
@@ -11,10 +11,9 @@ const crypto = require('crypto');
 const rimraf = require('rimraf');
 
 describe('#integration - the signing-key management scripts', function () {
+  this.timeout(60000);
   let runScript;
   let workDir, keyFile, newKeyFile, oldKeyFile;
-
-  this.timeout(30000);
 
   beforeEach(() => {
     const uniqName = crypto.randomBytes(8).toString('hex');

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -21,9 +21,10 @@ const {
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote account create`, function () {
-    this.timeout(50000);
+    this.timeout(60000);
     let server;
-    before(async () => {
+
+    before(async function () {
       config.subscriptions = {
         enabled: true,
         stripeApiKey: 'fake_key',
@@ -52,6 +53,10 @@ const {
         },
       });
       return server;
+    });
+
+    after(async function () {
+      await TestServer.stop(server);
     });
 
     it('unverified account fail when getting keys', () => {
@@ -989,9 +994,7 @@ const {
       assert.equal(kB2, originalKb);
     });
 
-    after(async () => {
-      await TestServer.stop(server);
-    });
+
 
     async function login(email, password, version = '') {
       return await Client.login(config.publicUrl, email, password, {

--- a/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
@@ -15,13 +15,16 @@ const otplib = require('otplib');
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote account create with sign-up code`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   const password = '4L6prUdlLNfxGIoj';
   let server, client, email, emailStatus, emailData;
 
   before(async () => {
     server = await TestServer.start(config);
-    return server;
+  });
+
+  after(async function () {
+    await TestServer.stop(server);
   });
 
   it('create and verify sync account', async () => {
@@ -231,9 +234,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
     });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/account_destroy_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_destroy_tests.js
@@ -13,13 +13,15 @@ const config = require('../../config').default.getProperties();
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote account destroy`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
 
-    before(() => {
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+    before(async function () {
+      server = await TestServer.start(config);
+    });
+
+    after(async function () {
+      await TestServer.stop(server);
     });
 
     it('account destroy', () => {
@@ -115,8 +117,6 @@ const config = require('../../config').default.getProperties();
         });
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/account_locale_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_locale_tests.js
@@ -21,7 +21,7 @@ const key = {
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote account locale`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
 
   before(async () => {

--- a/packages/fxa-auth-server/test/remote/account_login_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_login_tests.js
@@ -17,13 +17,15 @@ const config = require('../../config').default.getProperties();
 describe(`#integration${testOptions.version} - remote account login`, () => {
   let server;
 
-  before(function () {
-    this.timeout(15000);
+  before(async function () {
+    this.timeout(60000);
     config.securityHistory.ipProfiling.allowedRecency = 0;
     config.signinConfirmation.skipForNewAccounts.enabled = false;
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async function () {
+    await TestServer.stop(server);
   });
 
   it('the email is returned in the error on Incorrect password errors', () => {
@@ -37,7 +39,12 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
       testOptions
     )
       .then(() => {
-        return Client.login(config.publicUrl, email, `${password}x`, testOptions);
+        return Client.login(
+          config.publicUrl,
+          email,
+          `${password}x`,
+          testOptions
+        );
       })
       .then(
         () => assert(false),
@@ -50,8 +57,7 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
   });
 
   it('the email is returned in the error on Incorrect email case errors with correct password', () => {
-
-    if (testOptions.version === "V2") {
+    if (testOptions.version === 'V2') {
       // Important!!! This test is no longer applicable for V2 passwords.
       // V1 passwords are encoded with a salt that includes the users
       // email address. As a result, if the user enters a their email
@@ -72,7 +78,12 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
       testOptions
     )
       .then(() => {
-        return Client.login(config.publicUrl, loginEmail, password, testOptions);
+        return Client.login(
+          config.publicUrl,
+          loginEmail,
+          password,
+          testOptions
+        );
       })
       .then(
         () => assert(false),
@@ -110,7 +121,10 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
       testOptions
     )
       .then((c) => {
-        return Client.login(config.publicUrl, email, password, { ...testOptions, keys: false });
+        return Client.login(config.publicUrl, email, password, {
+          ...testOptions,
+          keys: false,
+        });
       })
       .then((c) => {
         assert.equal(c.keyFetchToken, null, 'should not have keyFetchToken');
@@ -199,7 +213,7 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
     )
       .then(() => {
         return Client.login(config.publicUrl, email, 'foo', {
-          ... testOptions,
+          ...testOptions,
           metricsContext: {
             flowId:
               '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
@@ -329,7 +343,7 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
         server.mailbox,
         {
           ...testOptions,
-          keys: true
+          keys: true,
         }
       )
         .then(() => {
@@ -386,8 +400,6 @@ describe(`#integration${testOptions.version} - remote account login`, () => {
     });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 });

--- a/packages/fxa-auth-server/test/remote/account_profile_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_profile_tests.js
@@ -17,7 +17,7 @@ const CLIENT_ID = config.oauthServer.clients.find(
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - fetch user profile data`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
 
   let server, client, email, password;
   before(async () => {

--- a/packages/fxa-auth-server/test/remote/account_reset_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_reset_tests.js
@@ -14,13 +14,16 @@ const config = require('../../config').default.getProperties();
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote account reset`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
     config.signinConfirmation.skipForNewAccounts.enabled = true;
-    before(() => {
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+
+    before(async function () {
+      server = await TestServer.start(config);
+    });
+
+    after(async function () {
+      await TestServer.stop(server);
     });
 
     it('account reset w/o sessionToken', async () => {
@@ -253,10 +256,6 @@ const config = require('../../config').default.getProperties();
       assert.equal(cert1['fxa-uid'], cert2['fxa-uid']);
       assert.ok(cert1['fxa-generation'] < cert2['fxa-generation']);
       assert.ok(cert1['fxa-keysChangedAt'] < cert2['fxa-keysChangedAt']);
-    });
-
-    after(() => {
-      return TestServer.stop(server);
     });
 
     async function resetPassword(client, code, newPassword, options) {

--- a/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
@@ -24,14 +24,17 @@ const mocks = require('../mocks');
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote account signin verification`, function () {
-    this.timeout(30000);
+    this.timeout(60000);
     let server;
-    before(() => {
+
+    before(async () => {
       config.securityHistory.ipProfiling.allowedRecency = 0;
       config.signinConfirmation.skipForNewAccounts.enabled = false;
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+      server = await TestServer.start(config);
+    });
+
+    after(async () => {
+      await TestServer.stop(server);
     });
 
     it('account signin without keys does not set challenge', () => {
@@ -810,8 +813,6 @@ const mocks = require('../mocks');
         });
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/account_status_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_status_tests.js
@@ -14,16 +14,23 @@ const config = require('../../config').default.getProperties();
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote account status`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+  before(async () => {
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('account status with existing account', () => {
-    return Client.create(config.publicUrl, server.uniqueEmail(), 'password', testOptions)
+    return Client.create(
+      config.publicUrl,
+      server.uniqueEmail(),
+      'password',
+      testOptions
+    )
       .then((c) => {
         return c.api.accountStatus(c.uid);
       })
@@ -139,9 +146,7 @@ describe(`#integration${testOptions.version} - remote account status`, function 
       });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/account_unlock_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_unlock_tests.js
@@ -14,16 +14,23 @@ const config = require('../../config').default.getProperties();
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote account unlock`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+  before(async () => {
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('/account/lock is no longer supported', () => {
-    return Client.create(config.publicUrl, server.uniqueEmail(), 'password', testOptions)
+    return Client.create(
+      config.publicUrl,
+      server.uniqueEmail(),
+      'password',
+      testOptions
+    )
       .then((c) => {
         return c.lockAccount();
       })
@@ -38,7 +45,12 @@ describe(`#integration${testOptions.version} - remote account unlock`, function 
   });
 
   it('/account/unlock/resend_code is no longer supported', () => {
-    return Client.create(config.publicUrl, server.uniqueEmail(), 'password', testOptions)
+    return Client.create(
+      config.publicUrl,
+      server.uniqueEmail(),
+      'password',
+      testOptions
+    )
       .then((c) => {
         return c.resendAccountUnlockCode('en');
       })
@@ -53,7 +65,12 @@ describe(`#integration${testOptions.version} - remote account unlock`, function 
   });
 
   it('/account/unlock/verify_code is no longer supported', () => {
-    return Client.create(config.publicUrl, server.uniqueEmail(), 'password', testOptions)
+    return Client.create(
+      config.publicUrl,
+      server.uniqueEmail(),
+      'password',
+      testOptions
+    )
       .then((c) => {
         return c.verifyAccountUnlockCode('bigscaryuid', 'bigscarycode');
       })
@@ -67,9 +84,7 @@ describe(`#integration${testOptions.version} - remote account unlock`, function 
       );
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/attached_clients_tests.js
+++ b/packages/fxa-auth-server/test/remote/attached_clients_tests.js
@@ -21,7 +21,7 @@ const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - attached clients listing`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server, oauthServerDb;
   before(async () => {
     config.lastAccessTimeUpdates = {
@@ -32,6 +32,11 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
     testUtils.disableLogs();
     server = await TestServer.start(config, false);
     oauthServerDb = require('../../lib/oauth/db');
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
+    testUtils.restoreStdoutWrite();
   });
 
   it('correctly lists a variety of attached clients', async () => {
@@ -119,7 +124,12 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
       await tokens.SessionToken.fromHex(client.sessionToken)
     ).id;
 
-    const client2 = await Client.login(config.publicUrl, email, password, testOptions);
+    const client2 = await Client.login(
+      config.publicUrl,
+      email,
+      password,
+      testOptions
+    );
     const device = await client2.updateDevice({
       name: 'test',
       type: 'desktop',
@@ -151,7 +161,12 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
       await tokens.SessionToken.fromHex(client.sessionToken)
     ).id;
 
-    const client2 = await Client.login(config.publicUrl, email, password, testOptions);
+    const client2 = await Client.login(
+      config.publicUrl,
+      email,
+      password,
+      testOptions
+    );
     const otherSessionTokenId = (
       await tokens.SessionToken.fromHex(client2.sessionToken)
     ).id;
@@ -207,10 +222,7 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
     assert.equal(allClients[0].refreshTokenId, null);
   });
 
-  after(async () => {
-    await TestServer.stop(server);
-    testUtils.restoreStdoutWrite();
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/base_path_tests.js
+++ b/packages/fxa-auth-server/test/remote/base_path_tests.js
@@ -13,15 +13,17 @@ const superagent = require('superagent');
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote base path`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server, config;
-  before(() => {
+  before(async () => {
     config = require('../../config').default.getProperties();
     config.publicUrl = 'http://localhost:9000/auth';
 
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   function testVersionRoute(path) {
@@ -76,9 +78,7 @@ describe(`#integration${testOptions.version} - remote base path`, function () {
     testVersionRoute('/__version__')
   );
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/certificate_sign_tests.js
+++ b/packages/fxa-auth-server/test/remote/certificate_sign_tests.js
@@ -21,12 +21,14 @@ const publicKey = {
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote certificate sign`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
-    before(() => {
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+    before(async () => {
+      server = await TestServer.start(config);
+    });
+
+    after(async () => {
+      await TestServer.stop(server);
     });
 
     it('certificate sign', () => {
@@ -316,8 +318,6 @@ const publicKey = {
         );
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/concurrent_tests.js
+++ b/packages/fxa-auth-server/test/remote/concurrent_tests.js
@@ -13,13 +13,16 @@ const config = require('../../config').default.getProperties();
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote concurrent`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
+
+  before(async () => {
     config.verifierVersion = 1;
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('concurrent create requests', () => {
@@ -38,9 +41,7 @@ describe(`#integration${testOptions.version} - remote concurrent`, function () {
       });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/device_tests.js
+++ b/packages/fxa-auth-server/test/remote/device_tests.js
@@ -15,249 +15,281 @@ const mocks = require('../mocks');
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote device`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
+  before(async () => {
     config.lastAccessTimeUpdates = {
       enabled: true,
       sampleRate: 1,
       earliestSaneTimestamp: config.lastAccessTimeUpdates.earliestSaneTimestamp,
     };
 
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('device registration after account creation', () => {
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device 🍓🔥在𝌆',
-        type: 'mobile',
-        availableCommands: { foo: 'bar' },
-        pushCallback: '',
-        pushPublicKey: '',
-        pushAuthKey: '',
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.ok(device.createdAt > 0, 'device.createdAt was set');
-          assert.equal(device.name, deviceInfo.name, 'device.name is correct');
-          assert.equal(device.type, deviceInfo.type, 'device.type is correct');
-          assert.deepEqual(
-            device.availableCommands,
-            deviceInfo.availableCommands,
-            'device.availableCommands is correct'
-          );
-          assert.equal(
-            device.pushCallback,
-            deviceInfo.pushCallback,
-            'device.pushCallback is correct'
-          );
-          assert.equal(
-            device.pushPublicKey,
-            deviceInfo.pushPublicKey,
-            'device.pushPublicKey is correct'
-          );
-          assert.equal(
-            device.pushAuthKey,
-            deviceInfo.pushAuthKey,
-            'device.pushAuthKey is correct'
-          );
-          assert.equal(
-            device.pushEndpointExpired,
-            false,
-            'device.pushEndpointExpired is correct'
-          );
-        })
-        .then(() => {
-          return client.devices();
-        })
-        .then((devices) => {
-          assert.equal(devices.length, 1, 'devices returned one item');
-          assert.equal(
-            devices[0].name,
-            deviceInfo.name,
-            'devices returned correct name'
-          );
-          assert.equal(
-            devices[0].type,
-            deviceInfo.type,
-            'devices returned correct type'
-          );
-          assert.deepEqual(
-            devices[0].availableCommands,
-            deviceInfo.availableCommands,
-            'devices returned correct availableCommands'
-          );
-          assert.equal(
-            devices[0].pushCallback,
-            '',
-            'devices returned empty pushCallback'
-          );
-          assert.equal(
-            devices[0].pushPublicKey,
-            '',
-            'devices returned correct pushPublicKey'
-          );
-          assert.equal(
-            devices[0].pushAuthKey,
-            '',
-            'devices returned correct pushAuthKey'
-          );
-          assert.equal(
-            devices[0].pushEndpointExpired,
-            '',
-            'devices returned correct pushEndpointExpired'
-          );
-          return client.destroyDevice(devices[0].id);
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device 🍓🔥在𝌆',
+          type: 'mobile',
+          availableCommands: { foo: 'bar' },
+          pushCallback: '',
+          pushPublicKey: '',
+          pushAuthKey: '',
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.ok(device.createdAt > 0, 'device.createdAt was set');
+            assert.equal(
+              device.name,
+              deviceInfo.name,
+              'device.name is correct'
+            );
+            assert.equal(
+              device.type,
+              deviceInfo.type,
+              'device.type is correct'
+            );
+            assert.deepEqual(
+              device.availableCommands,
+              deviceInfo.availableCommands,
+              'device.availableCommands is correct'
+            );
+            assert.equal(
+              device.pushCallback,
+              deviceInfo.pushCallback,
+              'device.pushCallback is correct'
+            );
+            assert.equal(
+              device.pushPublicKey,
+              deviceInfo.pushPublicKey,
+              'device.pushPublicKey is correct'
+            );
+            assert.equal(
+              device.pushAuthKey,
+              deviceInfo.pushAuthKey,
+              'device.pushAuthKey is correct'
+            );
+            assert.equal(
+              device.pushEndpointExpired,
+              false,
+              'device.pushEndpointExpired is correct'
+            );
+          })
+          .then(() => {
+            return client.devices();
+          })
+          .then((devices) => {
+            assert.equal(devices.length, 1, 'devices returned one item');
+            assert.equal(
+              devices[0].name,
+              deviceInfo.name,
+              'devices returned correct name'
+            );
+            assert.equal(
+              devices[0].type,
+              deviceInfo.type,
+              'devices returned correct type'
+            );
+            assert.deepEqual(
+              devices[0].availableCommands,
+              deviceInfo.availableCommands,
+              'devices returned correct availableCommands'
+            );
+            assert.equal(
+              devices[0].pushCallback,
+              '',
+              'devices returned empty pushCallback'
+            );
+            assert.equal(
+              devices[0].pushPublicKey,
+              '',
+              'devices returned correct pushPublicKey'
+            );
+            assert.equal(
+              devices[0].pushAuthKey,
+              '',
+              'devices returned correct pushAuthKey'
+            );
+            assert.equal(
+              devices[0].pushEndpointExpired,
+              '',
+              'devices returned correct pushEndpointExpired'
+            );
+            return client.destroyDevice(devices[0].id);
+          });
+      }
+    );
   });
 
   it('device registration without optional parameters', () => {
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device',
-        type: 'mobile',
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.ok(device.createdAt > 0, 'device.createdAt was set');
-          assert.equal(device.name, deviceInfo.name, 'device.name is correct');
-          assert.equal(device.type, deviceInfo.type, 'device.type is correct');
-          assert.equal(
-            device.pushCallback,
-            undefined,
-            'device.pushCallback is undefined'
-          );
-          assert.equal(
-            device.pushPublicKey,
-            undefined,
-            'device.pushPublicKey is undefined'
-          );
-          assert.equal(
-            device.pushAuthKey,
-            undefined,
-            'device.pushAuthKey is undefined'
-          );
-          assert.equal(
-            device.pushEndpointExpired,
-            false,
-            'device.pushEndpointExpired is false'
-          );
-        })
-        .then(() => {
-          return client.devices();
-        })
-        .then((devices) => {
-          assert.equal(devices.length, 1, 'devices returned one item');
-          assert.equal(
-            devices[0].name,
-            deviceInfo.name,
-            'devices returned correct name'
-          );
-          assert.equal(
-            devices[0].type,
-            deviceInfo.type,
-            'devices returned correct type'
-          );
-          assert.equal(
-            devices[0].pushCallback,
-            undefined,
-            'devices returned undefined pushCallback'
-          );
-          assert.equal(
-            devices[0].pushPublicKey,
-            undefined,
-            'devices returned undefined pushPublicKey'
-          );
-          assert.equal(
-            devices[0].pushAuthKey,
-            undefined,
-            'devices returned undefined pushAuthKey'
-          );
-          assert.equal(
-            devices[0].pushEndpointExpired,
-            false,
-            'devices returned false pushEndpointExpired'
-          );
-          return client.destroyDevice(devices[0].id);
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device',
+          type: 'mobile',
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.ok(device.createdAt > 0, 'device.createdAt was set');
+            assert.equal(
+              device.name,
+              deviceInfo.name,
+              'device.name is correct'
+            );
+            assert.equal(
+              device.type,
+              deviceInfo.type,
+              'device.type is correct'
+            );
+            assert.equal(
+              device.pushCallback,
+              undefined,
+              'device.pushCallback is undefined'
+            );
+            assert.equal(
+              device.pushPublicKey,
+              undefined,
+              'device.pushPublicKey is undefined'
+            );
+            assert.equal(
+              device.pushAuthKey,
+              undefined,
+              'device.pushAuthKey is undefined'
+            );
+            assert.equal(
+              device.pushEndpointExpired,
+              false,
+              'device.pushEndpointExpired is false'
+            );
+          })
+          .then(() => {
+            return client.devices();
+          })
+          .then((devices) => {
+            assert.equal(devices.length, 1, 'devices returned one item');
+            assert.equal(
+              devices[0].name,
+              deviceInfo.name,
+              'devices returned correct name'
+            );
+            assert.equal(
+              devices[0].type,
+              deviceInfo.type,
+              'devices returned correct type'
+            );
+            assert.equal(
+              devices[0].pushCallback,
+              undefined,
+              'devices returned undefined pushCallback'
+            );
+            assert.equal(
+              devices[0].pushPublicKey,
+              undefined,
+              'devices returned undefined pushPublicKey'
+            );
+            assert.equal(
+              devices[0].pushAuthKey,
+              undefined,
+              'devices returned undefined pushAuthKey'
+            );
+            assert.equal(
+              devices[0].pushEndpointExpired,
+              false,
+              'devices returned false pushEndpointExpired'
+            );
+            return client.destroyDevice(devices[0].id);
+          });
+      }
+    );
   });
 
   it('device registration with unicode characters in the name', () => {
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        // That's a beta, a CJK character from https://bugzilla.mozilla.org/show_bug.cgi?id=1348298,
-        // and the unicode replacement character in case of mojibake.
-        name: 'Firefox \u5728 \u03b2 test\ufffd',
-        type: 'desktop',
-      };
-      return client
-        .updateDevice(deviceInfo)
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.ok(device.createdAt > 0, 'device.createdAt was set');
-          assert.equal(device.name, deviceInfo.name, 'device.name is correct');
-        })
-        .then(() => {
-          return client.devices();
-        })
-        .then((devices) => {
-          assert.equal(devices.length, 1, 'devices returned one item');
-          assert.equal(
-            devices[0].name,
-            deviceInfo.name,
-            'devices returned correct name'
-          );
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          // That's a beta, a CJK character from https://bugzilla.mozilla.org/show_bug.cgi?id=1348298,
+          // and the unicode replacement character in case of mojibake.
+          name: 'Firefox \u5728 \u03b2 test\ufffd',
+          type: 'desktop',
+        };
+        return client
+          .updateDevice(deviceInfo)
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.ok(device.createdAt > 0, 'device.createdAt was set');
+            assert.equal(
+              device.name,
+              deviceInfo.name,
+              'device.name is correct'
+            );
+          })
+          .then(() => {
+            return client.devices();
+          })
+          .then((devices) => {
+            assert.equal(devices.length, 1, 'devices returned one item');
+            assert.equal(
+              devices[0].name,
+              deviceInfo.name,
+              'devices returned correct name'
+            );
+          });
+      }
+    );
   });
 
   it('device registration without required name parameter', () => {
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      return client.updateDevice({ type: 'mobile' }).then((device) => {
-        assert.ok(device.id, 'device.id was set');
-        assert.ok(device.createdAt > 0, 'device.createdAt was set');
-        assert.equal(device.name, '', 'device.name is empty');
-        assert.equal(device.type, 'mobile', 'device.type is correct');
-      });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        return client.updateDevice({ type: 'mobile' }).then((device) => {
+          assert.ok(device.id, 'device.id was set');
+          assert.ok(device.createdAt > 0, 'device.createdAt was set');
+          assert.equal(device.name, '', 'device.name is empty');
+          assert.equal(device.type, 'mobile', 'device.type is correct');
+        });
+      }
+    );
   });
 
   it('device registration without required type parameter', () => {
     const email = server.uniqueEmail();
     const deviceName = 'test device';
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      return client.updateDevice({ name: 'test device' }).then((device) => {
-        assert.ok(device.id, 'device.id was set');
-        assert.ok(device.createdAt > 0, 'device.createdAt was set');
-        assert.equal(device.name, deviceName, 'device.name is correct');
-      });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        return client.updateDevice({ name: 'test device' }).then((device) => {
+          assert.ok(device.id, 'device.id was set');
+          assert.ok(device.createdAt > 0, 'device.createdAt was set');
+          assert.equal(device.name, deviceName, 'device.name is correct');
+        });
+      }
+    );
   });
 
   it('update device fails with bad callbackUrl', () => {
@@ -274,22 +306,28 @@ describe(`#integration${testOptions.version} - remote device`, function () {
       pushPublicKey: mocks.MOCK_PUSH_KEY,
       pushAuthKey: base64url(crypto.randomBytes(16)),
     };
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      return client
-        .updateDevice(deviceInfo)
-        .then((r) => {
-          assert(false, 'request should have failed');
-        })
-        .catch((err) => {
-          assert.equal(err.code, 400, 'err.code was 400');
-          assert.equal(err.errno, 107, 'err.errno was 107, invalid parameter');
-          assert.equal(
-            err.validation.keys[0],
-            'pushCallback',
-            'bad pushCallback caught in validation'
-          );
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        return client
+          .updateDevice(deviceInfo)
+          .then((r) => {
+            assert(false, 'request should have failed');
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'err.code was 400');
+            assert.equal(
+              err.errno,
+              107,
+              'err.errno was 107, invalid parameter'
+            );
+            assert.equal(
+              err.validation.keys[0],
+              'pushCallback',
+              'bad pushCallback caught in validation'
+            );
+          });
+      }
+    );
   });
 
   it('update device fails with non-normalized callbackUrl', () => {
@@ -306,87 +344,97 @@ describe(`#integration${testOptions.version} - remote device`, function () {
       pushPublicKey: mocks.MOCK_PUSH_KEY,
       pushAuthKey: base64url(crypto.randomBytes(16)),
     };
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      return client
-        .updateDevice(deviceInfo)
-        .then((r) => {
-          assert(false, 'request should have failed');
-        })
-        .catch((err) => {
-          assert.equal(err.code, 400, 'err.code was 400');
-          assert.equal(err.errno, 107, 'err.errno was 107, invalid parameter');
-          assert.equal(
-            err.validation.keys[0],
-            'pushCallback',
-            'bad pushCallback caught in validation'
-          );
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        return client
+          .updateDevice(deviceInfo)
+          .then((r) => {
+            assert(false, 'request should have failed');
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'err.code was 400');
+            assert.equal(
+              err.errno,
+              107,
+              'err.errno was 107, invalid parameter'
+            );
+            assert.equal(
+              err.validation.keys[0],
+              'pushCallback',
+              'bad pushCallback caught in validation'
+            );
+          });
+      }
+    );
   });
 
   it('update device works with stage servers', () => {
     const goodPushCallback = 'https://updates-autopush.stage.mozaws.net';
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device',
-        type: 'mobile',
-        availableCommands: {},
-        pushCallback: goodPushCallback,
-        pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: base64url(crypto.randomBytes(16)),
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.equal(
-            device.pushCallback,
-            deviceInfo.pushCallback,
-            'device.pushCallback is correct'
-          );
-        })
-        .catch((err) => {
-          assert.fail(err, 'request should have worked');
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device',
+          type: 'mobile',
+          availableCommands: {},
+          pushCallback: goodPushCallback,
+          pushPublicKey: mocks.MOCK_PUSH_KEY,
+          pushAuthKey: base64url(crypto.randomBytes(16)),
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.equal(
+              device.pushCallback,
+              deviceInfo.pushCallback,
+              'device.pushCallback is correct'
+            );
+          })
+          .catch((err) => {
+            assert.fail(err, 'request should have worked');
+          });
+      }
+    );
   });
 
   it('update device works with dev servers', () => {
     const goodPushCallback = 'https://updates-autopush.dev.mozaws.net';
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device',
-        type: 'mobile',
-        pushCallback: goodPushCallback,
-        pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: base64url(crypto.randomBytes(16)),
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.equal(
-            device.pushCallback,
-            deviceInfo.pushCallback,
-            'device.pushCallback is correct'
-          );
-        })
-        .catch((err) => {
-          assert.fail(err, 'request should have worked');
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device',
+          type: 'mobile',
+          pushCallback: goodPushCallback,
+          pushPublicKey: mocks.MOCK_PUSH_KEY,
+          pushAuthKey: base64url(crypto.randomBytes(16)),
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.equal(
+              device.pushCallback,
+              deviceInfo.pushCallback,
+              'device.pushCallback is correct'
+            );
+          })
+          .catch((err) => {
+            assert.fail(err, 'request should have worked');
+          });
+      }
+    );
   });
 
   it('update device works with callback urls that :443 as a port', () => {
@@ -395,96 +443,102 @@ describe(`#integration${testOptions.version} - remote device`, function () {
 
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device',
-        type: 'mobile',
-        pushCallback: goodPushCallback,
-        pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: base64url(crypto.randomBytes(16)),
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.equal(
-            device.pushCallback,
-            deviceInfo.pushCallback,
-            'device.pushCallback is correct'
-          );
-        })
-        .catch((err) => {
-          assert.fail(err, 'request should have worked');
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device',
+          type: 'mobile',
+          pushCallback: goodPushCallback,
+          pushPublicKey: mocks.MOCK_PUSH_KEY,
+          pushAuthKey: base64url(crypto.randomBytes(16)),
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.equal(
+              device.pushCallback,
+              deviceInfo.pushCallback,
+              'device.pushCallback is correct'
+            );
+          })
+          .catch((err) => {
+            assert.fail(err, 'request should have worked');
+          });
+      }
+    );
   });
 
   it('update device works with callback urls that :4430 as a port', () => {
     const goodPushCallback = 'https://updates.push.services.mozilla.com:4430';
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device',
-        type: 'mobile',
-        pushCallback: goodPushCallback,
-        pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: base64url(crypto.randomBytes(16)),
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.equal(
-            device.pushCallback,
-            deviceInfo.pushCallback,
-            'device.pushCallback is correct'
-          );
-        })
-        .catch((err) => {
-          assert.fail(err, 'request should have worked');
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device',
+          type: 'mobile',
+          pushCallback: goodPushCallback,
+          pushPublicKey: mocks.MOCK_PUSH_KEY,
+          pushAuthKey: base64url(crypto.randomBytes(16)),
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.equal(
+              device.pushCallback,
+              deviceInfo.pushCallback,
+              'device.pushCallback is correct'
+            );
+          })
+          .catch((err) => {
+            assert.fail(err, 'request should have worked');
+          });
+      }
+    );
   });
 
   it('update device works with callback urls that a custom port', () => {
     const goodPushCallback = 'https://updates.push.services.mozilla.com:10332';
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'test device',
-        type: 'mobile',
-        pushCallback: goodPushCallback,
-        pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: base64url(crypto.randomBytes(16)),
-      };
-      return client
-        .devices()
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices returned no items');
-          return client.updateDevice(deviceInfo);
-        })
-        .then((device) => {
-          assert.ok(device.id, 'device.id was set');
-          assert.equal(
-            device.pushCallback,
-            deviceInfo.pushCallback,
-            'device.pushCallback is correct'
-          );
-        })
-        .catch((err) => {
-          assert.fail(err, 'request should have worked');
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'test device',
+          type: 'mobile',
+          pushCallback: goodPushCallback,
+          pushPublicKey: mocks.MOCK_PUSH_KEY,
+          pushAuthKey: base64url(crypto.randomBytes(16)),
+        };
+        return client
+          .devices()
+          .then((devices) => {
+            assert.equal(devices.length, 0, 'devices returned no items');
+            return client.updateDevice(deviceInfo);
+          })
+          .then((device) => {
+            assert.ok(device.id, 'device.id was set');
+            assert.equal(
+              device.pushCallback,
+              deviceInfo.pushCallback,
+              'device.pushCallback is correct'
+            );
+          })
+          .catch((err) => {
+            assert.fail(err, 'request should have worked');
+          });
+      }
+    );
   });
 
   it('update device fails with bad dev callbackUrl', () => {
@@ -499,40 +553,48 @@ describe(`#integration${testOptions.version} - remote device`, function () {
       pushPublicKey: mocks.MOCK_PUSH_KEY,
       pushAuthKey: base64url(crypto.randomBytes(16)),
     };
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      return client
-        .updateDevice(deviceInfo)
-        .then((r) => {
-          assert(false, 'request should have failed');
-        })
-        .catch((err) => {
-          assert.equal(err.code, 400, 'err.code was 400');
-          assert.equal(err.errno, 107, 'err.errno was 107, invalid parameter');
-          assert.equal(
-            err.validation.keys[0],
-            'pushCallback',
-            'bad pushCallback caught in validation'
-          );
-        });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        return client
+          .updateDevice(deviceInfo)
+          .then((r) => {
+            assert(false, 'request should have failed');
+          })
+          .catch((err) => {
+            assert.equal(err.code, 400, 'err.code was 400');
+            assert.equal(
+              err.errno,
+              107,
+              'err.errno was 107, invalid parameter'
+            );
+            assert.equal(
+              err.validation.keys[0],
+              'pushCallback',
+              'bad pushCallback caught in validation'
+            );
+          });
+      }
+    );
   });
 
   it('device registration ignores deprecated "capabilities" field', () => {
     const email = server.uniqueEmail();
     const password = 'test password';
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      const deviceInfo = {
-        name: 'a very capable device',
-        type: 'desktop',
-        capabilities: [],
-      };
-      return client.updateDevice(deviceInfo).then((device) => {
-        assert.ok(device.id, 'device.id was set');
-        assert.ok(device.createdAt > 0, 'device.createdAt was set');
-        assert.equal(device.name, deviceInfo.name, 'device.name is correct');
-        assert.ok(!device.capabilities, 'device.capabilities was ignored');
-      });
-    });
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        const deviceInfo = {
+          name: 'a very capable device',
+          type: 'desktop',
+          capabilities: [],
+        };
+        return client.updateDevice(deviceInfo).then((device) => {
+          assert.ok(device.id, 'device.id was set');
+          assert.ok(device.createdAt > 0, 'device.createdAt was set');
+          assert.equal(device.name, deviceInfo.name, 'device.name is correct');
+          assert.ok(!device.capabilities, 'device.capabilities was ignored');
+        });
+      }
+    );
   });
 
   it('device registration from a different session', () => {
@@ -643,43 +705,45 @@ describe(`#integration${testOptions.version} - remote device`, function () {
       pushPublicKey: mocks.MOCK_PUSH_KEY,
       pushAuthKey: base64url(crypto.randomBytes(16)),
     };
-    return Client.create(config.publicUrl, email, password, testOptions).then((client) => {
-      return client
-        .updateDevice(deviceInfo)
-        .then(() => {
-          return client.devices();
-        })
-        .then((devices) => {
-          assert.equal(
-            devices[0].pushCallback,
-            deviceInfo.pushCallback,
-            'devices returned correct pushCallback'
-          );
-          assert.equal(
-            devices[0].pushPublicKey,
-            deviceInfo.pushPublicKey,
-            'devices returned correct pushPublicKey'
-          );
-          assert.equal(
-            devices[0].pushAuthKey,
-            deviceInfo.pushAuthKey,
-            'devices returned correct pushAuthKey'
-          );
-          assert.equal(
-            devices[0].pushEndpointExpired,
-            false,
-            'devices returned correct pushEndpointExpired'
-          );
-          return client.updateDevice({
-            id: client.device.id,
-            pushCallback: 'https://updates.push.services.mozilla.com/foo',
+    return Client.create(config.publicUrl, email, password, testOptions).then(
+      (client) => {
+        return client
+          .updateDevice(deviceInfo)
+          .then(() => {
+            return client.devices();
+          })
+          .then((devices) => {
+            assert.equal(
+              devices[0].pushCallback,
+              deviceInfo.pushCallback,
+              'devices returned correct pushCallback'
+            );
+            assert.equal(
+              devices[0].pushPublicKey,
+              deviceInfo.pushPublicKey,
+              'devices returned correct pushPublicKey'
+            );
+            assert.equal(
+              devices[0].pushAuthKey,
+              deviceInfo.pushAuthKey,
+              'devices returned correct pushAuthKey'
+            );
+            assert.equal(
+              devices[0].pushEndpointExpired,
+              false,
+              'devices returned correct pushEndpointExpired'
+            );
+            return client.updateDevice({
+              id: client.device.id,
+              pushCallback: 'https://updates.push.services.mozilla.com/foo',
+            });
+          })
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 107);
+            assert.equal(err.message, 'Invalid parameter in request body');
           });
-        })
-        .then(assert.fail, (err) => {
-          assert.equal(err.errno, 107);
-          assert.equal(err.message, 'Invalid parameter in request body');
-        });
-    });
+      }
+    );
   });
 
   it('invalid public keys are cleanly rejected', () => {
@@ -794,9 +858,7 @@ describe(`#integration${testOptions.version} - remote device`, function () {
     });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
@@ -35,7 +35,7 @@ const UNKNOWN_REFRESH_TOKEN =
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote device with refresh tokens`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let client;
   let db;
   let email;
@@ -44,20 +44,14 @@ describe(`#integration${testOptions.version} - remote device with refresh tokens
   let refreshToken;
   let server;
 
-  before(() => {
+  before(async () => {
     config.lastAccessTimeUpdates = lastAccessTimeUpdates;
     const DB = require('../../lib/db')(config, log, Token);
 
     testUtils.disableLogs();
-    return TestServer.start(config, false)
-      .then((s) => {
-        server = s;
-        return DB.connect(config);
-      })
-      .then((x) => {
-        db = x;
-        oauthServerDb = require('../../lib/oauth/db');
-      });
+    server = await TestServer.start(config, false);
+    db = await DB.connect(config);
+    oauthServerDb = require('../../lib/oauth/db');
   });
 
   after(async () => {

--- a/packages/fxa-auth-server/test/remote/email_validity_tests.js
+++ b/packages/fxa-auth-server/test/remote/email_validity_tests.js
@@ -13,12 +13,14 @@ const config = require('../../config').default.getProperties();
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote email validity`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+  before(async () => {
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('/account/create with a variety of malformed email addresses', () => {
@@ -77,9 +79,7 @@ describe(`#integration${testOptions.version} - remote email validity`, function 
     return Promise.all(emails);
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 

--- a/packages/fxa-auth-server/test/remote/flow_tests.js
+++ b/packages/fxa-auth-server/test/remote/flow_tests.js
@@ -15,15 +15,17 @@ const pubSigKey = JWTool.JWK.fromFile(config.publicKeyFile);
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote flow`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
     let email1;
     config.signinConfirmation.skipForNewAccounts.enabled = true;
-    before(() => {
-      return TestServer.start(config).then((s) => {
-        server = s;
-        email1 = server.uniqueEmail();
-      });
+    before(async () => {
+      server = await TestServer.start(config);
+      email1 = server.uniqueEmail();
+    });
+
+    after(async () => {
+      await TestServer.stop(server);
     });
 
     it('Create account flow', () => {
@@ -112,8 +114,6 @@ const pubSigKey = JWTool.JWK.fromFile(config.publicKeyFile);
         });
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/misc_tests.js
+++ b/packages/fxa-auth-server/test/remote/misc_tests.js
@@ -14,12 +14,13 @@ const config = require('../../config').default.getProperties();
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote misc`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
-    before(() => {
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+    before(async () => {
+      server = await TestServer.start(config);
+    });
+    after(async () => {
+      await TestServer.stop(server);
     });
 
     function testVersionRoute(route) {
@@ -286,8 +287,6 @@ const config = require('../../config').default.getProperties();
         });
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.js
@@ -23,7 +23,7 @@ const MOCK_CODE_CHALLENGE = 'YPhkZqm08uTfwjNSiYcx80-NPT9Zn94kHboQW97KyV0';
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - /oauth/ session token scope`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let client;
   let email;
   let password;

--- a/packages/fxa-auth-server/test/remote/oauth_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.js
@@ -25,7 +25,7 @@ const { decodeJWT } = testUtils;
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - /oauth/ routes`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let client;
     let email;
     let password;

--- a/packages/fxa-auth-server/test/remote/password_change_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_change_tests.js
@@ -20,15 +20,17 @@ function getSessionTokenId(sessionTokenHex) {
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote password change`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
-    before(() => {
+    before(async () => {
       config.securityHistory.ipProfiling.allowedRecency = 0;
       config.signinConfirmation.skipForNewAccounts.enabled = false;
 
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+      server = await TestServer.start(config);
+    });
+
+    after(async () => {
+      await TestServer.stop(server);
     });
 
     it('password change, with unverified session', () => {
@@ -544,8 +546,6 @@ function getSessionTokenId(sessionTokenHex) {
       );
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/password_forgot_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_forgot_tests.js
@@ -2,450 +2,449 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
+ 'use strict';
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
-const url = require('url');
-const Client = require('../client')();
-const TestServer = require('../test_server');
-const crypto = require('crypto');
-const base64url = require('base64url');
+ const chai = require('chai');
+ const chaiAsPromised = require('chai-as-promised');
+ const url = require('url');
+ const Client = require('../client')();
+ const TestServer = require('../test_server');
+ const crypto = require('crypto');
+ const base64url = require('base64url');
 
-const config = require('../../config').default.getProperties();
-const mocks = require('../mocks');
+ const config = require('../../config').default.getProperties();
+ const mocks = require('../mocks');
 
-chai.use(chaiAsPromised);
-const { assert } = chai;
+ chai.use(chaiAsPromised);
+ const { assert } = chai;
 
-[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote password forgot`, function () {
-    this.timeout(15000);
-    let server;
-    before(() => {
-      config.securityHistory.ipProfiling.allowedRecency = 0;
-      config.signinConfirmation.skipForNewAccounts.enabled = true;
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+ [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+   describe(`#integration${testOptions.version} - remote password forgot`, function () {
+     this.timeout(15000);
+     let server;
+     before(async () => {
+       config.securityHistory.ipProfiling.allowedRecency = 0;
+       config.signinConfirmation.skipForNewAccounts.enabled = true;
+       server = await TestServer.start(config)
+     });
+
+     after(async () => {
+      await TestServer.stop(server);
     });
 
-    it('forgot password', () => {
-      const email = server.uniqueEmail();
-      const password = 'allyourbasearebelongtous';
-      const newPassword = 'ez';
-      let wrapKb = null;
-      let kA = null;
-      let client = null;
-      const options = {
-        ...testOptions,
-        keys: true,
-        metricsContext: mocks.generateMetricsContext(),
-      };
-      return Client.createAndVerify(
-        config.publicUrl,
-        email,
-        password,
-        server.mailbox,
-        options
-      )
-        .then((x) => {
-          client = x;
-          return client.keys();
-        })
-        .then((keys) => {
-          wrapKb = keys.wrapKb;
-          kA = keys.kA;
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          assert.equal(
-            emailData.headers['x-flow-begin-time'],
-            options.metricsContext.flowBeginTime,
-            'flow begin time set'
-          );
-          assert.equal(
-            emailData.headers['x-flow-id'],
-            options.metricsContext.flowId,
-            'flow id set'
-          );
-          assert.equal(emailData.headers['x-template-name'], 'recovery');
-          return emailData.headers['x-recovery-code'];
-        })
-        .then((code) => {
-          assert.isRejected(client.resetPassword(newPassword));
-          return resetPassword(client, code, newPassword, undefined, options);
-        })
-        .then(() => {
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          const link = emailData.headers['x-link'];
-          const query = url.parse(link, true).query;
-          assert.ok(query.email, 'email is in the link');
+     it('forgot password', () => {
+       const email = server.uniqueEmail();
+       const password = 'allyourbasearebelongtous';
+       const newPassword = 'ez';
+       let wrapKb = null;
+       let kA = null;
+       let client = null;
+       const options = {
+         ...testOptions,
+         keys: true,
+         metricsContext: mocks.generateMetricsContext(),
+       };
+       return Client.createAndVerify(
+         config.publicUrl,
+         email,
+         password,
+         server.mailbox,
+         options
+       )
+         .then((x) => {
+           client = x;
+           return client.keys();
+         })
+         .then((keys) => {
+           wrapKb = keys.wrapKb;
+           kA = keys.kA;
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForEmail(email);
+         })
+         .then((emailData) => {
+           assert.equal(
+             emailData.headers['x-flow-begin-time'],
+             options.metricsContext.flowBeginTime,
+             'flow begin time set'
+           );
+           assert.equal(
+             emailData.headers['x-flow-id'],
+             options.metricsContext.flowId,
+             'flow id set'
+           );
+           assert.equal(emailData.headers['x-template-name'], 'recovery');
+           return emailData.headers['x-recovery-code'];
+         })
+         .then((code) => {
+           assert.isRejected(client.resetPassword(newPassword));
+           return resetPassword(client, code, newPassword, undefined, options);
+         })
+         .then(() => {
+           return server.mailbox.waitForEmail(email);
+         })
+         .then((emailData) => {
+           const link = emailData.headers['x-link'];
+           const query = url.parse(link, true).query;
+           assert.ok(query.email, 'email is in the link');
 
-          assert.equal(
-            emailData.headers['x-flow-begin-time'],
-            options.metricsContext.flowBeginTime,
-            'flow begin time set'
-          );
-          assert.equal(
-            emailData.headers['x-flow-id'],
-            options.metricsContext.flowId,
-            'flow id set'
-          );
-          assert.equal(emailData.headers['x-template-name'], 'passwordReset');
-        })
-        .then(() => {
-          return upgradeCredentials(email, newPassword);
-        })
-        .then(
-          // make sure we can still login after password reset
-          () => {
-            return Client.login(config.publicUrl, email, newPassword, {
-              ...testOptions,
-              keys: true,
-            });
-          }
-        )
-        .then((x) => {
-          client = x;
-          return client.keys();
-        })
-        .then((keys) => {
-          assert.equal(typeof keys.wrapKb, 'string', 'yep, wrapKb');
-          assert.notEqual(wrapKb, keys.wrapKb, 'wrapKb was reset');
-          assert.equal(kA, keys.kA, 'kA was not reset');
-          assert.equal(typeof client.kB, 'string');
-          assert.equal(client.kB.length, 64, 'kB exists, has the right length');
-        });
-    });
+           assert.equal(
+             emailData.headers['x-flow-begin-time'],
+             options.metricsContext.flowBeginTime,
+             'flow begin time set'
+           );
+           assert.equal(
+             emailData.headers['x-flow-id'],
+             options.metricsContext.flowId,
+             'flow id set'
+           );
+           assert.equal(emailData.headers['x-template-name'], 'passwordReset');
+         })
+         .then(() => {
+           return upgradeCredentials(email, newPassword);
+         })
+         .then(
+           // make sure we can still login after password reset
+           () => {
+             return Client.login(config.publicUrl, email, newPassword, {
+               ...testOptions,
+               keys: true,
+             });
+           }
+         )
+         .then((x) => {
+           client = x;
+           return client.keys();
+         })
+         .then((keys) => {
+           assert.equal(typeof keys.wrapKb, 'string', 'yep, wrapKb');
+           assert.notEqual(wrapKb, keys.wrapKb, 'wrapKb was reset');
+           assert.equal(kA, keys.kA, 'kA was not reset');
+           assert.equal(typeof client.kB, 'string');
+           assert.equal(client.kB.length, 64, 'kB exists, has the right length');
+         });
+     });
 
-    it('forgot password limits verify attempts', () => {
-      let code = null;
-      const email = server.uniqueEmail();
-      const password = 'hothamburger';
-      let client = null;
-      return Client.createAndVerify(
-        config.publicUrl,
-        email,
-        password,
-        server.mailbox,
-        testOptions
-      )
-        .then(() => {
-          client = new Client(config.publicUrl, testOptions);
-          client.email = email;
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(email);
-        })
-        .then((c) => {
-          code = c;
-        })
-        .then(() => {
-          return client.reforgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(email);
-        })
-        .then((c) => {
-          assert.equal(code, c, 'same code as before');
-        })
-        .then(() => {
-          return resetPassword(
-            client,
-            '00000000000000000000000000000000',
-            'password'
-          );
-        })
-        .then(
-          () => {
-            assert(false, 'reset password with bad code');
-          },
-          (err) => {
-            assert.equal(err.tries, 2, 'used a try');
-            assert.equal(
-              err.message,
-              'Invalid confirmation code',
-              'bad attempt 1'
-            );
-          }
-        )
-        .then(() => {
-          return resetPassword(
-            client,
-            '00000000000000000000000000000000',
-            'password'
-          );
-        })
-        .then(
-          () => {
-            assert(false, 'reset password with bad code');
-          },
-          (err) => {
-            assert.equal(err.tries, 1, 'used a try');
-            assert.equal(
-              err.message,
-              'Invalid confirmation code',
-              'bad attempt 2'
-            );
-          }
-        )
-        .then(() => {
-          return resetPassword(
-            client,
-            '00000000000000000000000000000000',
-            'password'
-          );
-        })
-        .then(
-          () => {
-            assert(false, 'reset password with bad code');
-          },
-          (err) => {
-            assert.equal(err.tries, 0, 'used a try');
-            assert.equal(
-              err.message,
-              'Invalid confirmation code',
-              'bad attempt 3'
-            );
-          }
-        )
-        .then(() => {
-          return resetPassword(
-            client,
-            '00000000000000000000000000000000',
-            'password'
-          );
-        })
-        .then(
-          () => {
-            assert(false, 'reset password with invalid token');
-          },
-          (err) => {
-            assert.equal(
-              err.message,
-              'Invalid authentication token: Missing authentication',
-              'token is now invalid'
-            );
-          }
-        );
-    });
+     it('forgot password limits verify attempts', () => {
+       let code = null;
+       const email = server.uniqueEmail();
+       const password = 'hothamburger';
+       let client = null;
+       return Client.createAndVerify(
+         config.publicUrl,
+         email,
+         password,
+         server.mailbox,
+         testOptions
+       )
+         .then(() => {
+           client = new Client(config.publicUrl, testOptions);
+           client.email = email;
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForCode(email);
+         })
+         .then((c) => {
+           code = c;
+         })
+         .then(() => {
+           return client.reforgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForCode(email);
+         })
+         .then((c) => {
+           assert.equal(code, c, 'same code as before');
+         })
+         .then(() => {
+           return resetPassword(
+             client,
+             '00000000000000000000000000000000',
+             'password'
+           );
+         })
+         .then(
+           () => {
+             assert(false, 'reset password with bad code');
+           },
+           (err) => {
+             assert.equal(err.tries, 2, 'used a try');
+             assert.equal(
+               err.message,
+               'Invalid confirmation code',
+               'bad attempt 1'
+             );
+           }
+         )
+         .then(() => {
+           return resetPassword(
+             client,
+             '00000000000000000000000000000000',
+             'password'
+           );
+         })
+         .then(
+           () => {
+             assert(false, 'reset password with bad code');
+           },
+           (err) => {
+             assert.equal(err.tries, 1, 'used a try');
+             assert.equal(
+               err.message,
+               'Invalid confirmation code',
+               'bad attempt 2'
+             );
+           }
+         )
+         .then(() => {
+           return resetPassword(
+             client,
+             '00000000000000000000000000000000',
+             'password'
+           );
+         })
+         .then(
+           () => {
+             assert(false, 'reset password with bad code');
+           },
+           (err) => {
+             assert.equal(err.tries, 0, 'used a try');
+             assert.equal(
+               err.message,
+               'Invalid confirmation code',
+               'bad attempt 3'
+             );
+           }
+         )
+         .then(() => {
+           return resetPassword(
+             client,
+             '00000000000000000000000000000000',
+             'password'
+           );
+         })
+         .then(
+           () => {
+             assert(false, 'reset password with invalid token');
+           },
+           (err) => {
+             assert.equal(
+               err.message,
+               'Invalid authentication token: Missing authentication',
+               'token is now invalid'
+             );
+           }
+         );
+     });
 
-    it('recovery email link', () => {
-      const email = server.uniqueEmail();
-      const password = 'something';
-      let client = null;
-      const options = {
-        ...testOptions,
-        redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
-        service: 'sync',
-      };
-      return Client.create(config.publicUrl, email, password, options)
-        .then((c) => {
-          client = c;
-        })
-        .then(() => {
-          return server.mailbox.waitForEmail(email);
-        })
-        .then(() => {
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          const link = emailData.headers['x-link'];
-          const query = url.parse(link, true).query;
-          assert.ok(query.token, 'uid is in link');
-          assert.ok(query.code, 'code is in link');
-          assert.equal(
-            query.redirectTo,
-            options.redirectTo,
-            'redirectTo is in link'
-          );
-          assert.equal(query.service, options.service, 'service is in link');
-          assert.equal(query.email, email, 'email is in link');
-        });
-    });
+     it('recovery email link', () => {
+       const email = server.uniqueEmail();
+       const password = 'something';
+       let client = null;
+       const options = {
+         ...testOptions,
+         redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
+         service: 'sync',
+       };
+       return Client.create(config.publicUrl, email, password, options)
+         .then((c) => {
+           client = c;
+         })
+         .then(() => {
+           return server.mailbox.waitForEmail(email);
+         })
+         .then(() => {
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForEmail(email);
+         })
+         .then((emailData) => {
+           const link = emailData.headers['x-link'];
+           const query = url.parse(link, true).query;
+           assert.ok(query.token, 'uid is in link');
+           assert.ok(query.code, 'code is in link');
+           assert.equal(
+             query.redirectTo,
+             options.redirectTo,
+             'redirectTo is in link'
+           );
+           assert.equal(query.service, options.service, 'service is in link');
+           assert.equal(query.email, email, 'email is in link');
+         });
+     });
 
-    it('password forgot status with valid token', () => {
-      const email = server.uniqueEmail();
-      const password = 'something';
-      return Client.create(config.publicUrl, email, password, testOptions).then(
-        (c) => {
-          return c
-            .forgotPassword()
-            .then(() => {
-              return c.api.passwordForgotStatus(c.passwordForgotToken);
-            })
-            .then((x) => {
-              assert.equal(x.tries, 3, 'three tries remaining');
-              assert.ok(
-                x.ttl > 0 && x.ttl <= config.tokenLifetimes.passwordForgotToken,
-                'ttl is ok'
-              );
-            });
-        }
-      );
-    });
+     it('password forgot status with valid token', () => {
+       const email = server.uniqueEmail();
+       const password = 'something';
+       return Client.create(config.publicUrl, email, password, testOptions).then(
+         (c) => {
+           return c
+             .forgotPassword()
+             .then(() => {
+               return c.api.passwordForgotStatus(c.passwordForgotToken);
+             })
+             .then((x) => {
+               assert.equal(x.tries, 3, 'three tries remaining');
+               assert.ok(
+                 x.ttl > 0 && x.ttl <= config.tokenLifetimes.passwordForgotToken,
+                 'ttl is ok'
+               );
+             });
+         }
+       );
+     });
 
-    it('password forgot status with invalid token', () => {
-      const client = new Client(config.publicUrl, testOptions);
-      return client.api
-        .passwordForgotStatus(
-          '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
-        )
-        .then(
-          () => assert(false),
-          (err) => {
-            assert.equal(err.errno, 110, 'invalid token');
-          }
-        );
-    });
+     it('password forgot status with invalid token', () => {
+       const client = new Client(config.publicUrl, testOptions);
+       return client.api
+         .passwordForgotStatus(
+           '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
+         )
+         .then(
+           () => assert(false),
+           (err) => {
+             assert.equal(err.errno, 110, 'invalid token');
+           }
+         );
+     });
 
-    it('/password/forgot/verify_code should set an unverified account as verified', () => {
-      const email = server.uniqueEmail();
-      const password = 'something';
-      let client = null;
-      return Client.create(config.publicUrl, email, password, testOptions)
-        .then((c) => {
-          client = c;
-        })
-        .then(() => {
-          return client.emailStatus();
-        })
-        .then((status) => {
-          assert.equal(status.verified, false, 'email unverified');
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(email); // ignore this code
-        })
-        .then(() => {
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(email);
-        })
-        .then((code) => {
-          return client.verifyPasswordResetCode(code);
-        })
-        .then(() => {
-          return client.emailStatus();
-        })
-        .then((status) => {
-          assert.equal(status.verified, true, 'account unverified');
-        });
-    });
+     it('/password/forgot/verify_code should set an unverified account as verified', () => {
+       const email = server.uniqueEmail();
+       const password = 'something';
+       let client = null;
+       return Client.create(config.publicUrl, email, password, testOptions)
+         .then((c) => {
+           client = c;
+         })
+         .then(() => {
+           return client.emailStatus();
+         })
+         .then((status) => {
+           assert.equal(status.verified, false, 'email unverified');
+         })
+         .then(() => {
+           return server.mailbox.waitForCode(email); // ignore this code
+         })
+         .then(() => {
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForCode(email);
+         })
+         .then((code) => {
+           return client.verifyPasswordResetCode(code);
+         })
+         .then(() => {
+           return client.emailStatus();
+         })
+         .then((status) => {
+           assert.equal(status.verified, true, 'account unverified');
+         });
+     });
 
-    it('forgot password with service query parameter', () => {
-      const email = server.uniqueEmail();
-      const options = {
-        ...testOptions,
-        redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
-        serviceQuery: 'sync',
-      };
-      let client;
-      return Client.create(config.publicUrl, email, 'wibble', options)
-        .then((c) => {
-          client = c;
-        })
-        .then(() => {
-          return server.mailbox.waitForEmail(email);
-        })
-        .then(() => {
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          const link = emailData.headers['x-link'];
-          const query = url.parse(link, true).query;
-          assert.equal(
-            query.service,
-            options.serviceQuery,
-            'service is in link'
-          );
-        });
-    });
+     it('forgot password with service query parameter', () => {
+       const email = server.uniqueEmail();
+       const options = {
+         ...testOptions,
+         redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
+         serviceQuery: 'sync',
+       };
+       let client;
+       return Client.create(config.publicUrl, email, 'wibble', options)
+         .then((c) => {
+           client = c;
+         })
+         .then(() => {
+           return server.mailbox.waitForEmail(email);
+         })
+         .then(() => {
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForEmail(email);
+         })
+         .then((emailData) => {
+           const link = emailData.headers['x-link'];
+           const query = url.parse(link, true).query;
+           assert.equal(
+             query.service,
+             options.serviceQuery,
+             'service is in link'
+           );
+         });
+     });
 
-    it('forgot password, then get device list', () => {
-      const email = server.uniqueEmail();
-      const newPassword = 'foo';
-      let client;
-      return Client.createAndVerify(
-        config.publicUrl,
-        email,
-        'bar',
-        server.mailbox,
-        testOptions
-      )
-        .then((c) => {
-          client = c;
-          return client.updateDevice({
-            name: 'baz',
-            type: 'mobile',
-            pushCallback: 'https://updates.push.services.mozilla.com/qux',
-            pushPublicKey: mocks.MOCK_PUSH_KEY,
-            pushAuthKey: base64url(crypto.randomBytes(16)),
-          });
-        })
-        .then(() => {
-          return client.devices();
-        })
-        .then((devices) => {
-          assert.equal(devices.length, 1, 'devices list contains 1 item');
-        })
-        .then(() => {
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(email);
-        })
-        .then((code) => {
-          return resetPassword(client, code, newPassword);
-        })
-        .then(() => {
-          return upgradeCredentials(email, newPassword);
-        })
-        .then(() => {
-          return Client.login(
-            config.publicUrl,
-            email,
-            newPassword,
-            testOptions
-          );
-        })
-        .then((client) => {
-          return client.devices();
-        })
-        .then((devices) => {
-          assert.equal(devices.length, 0, 'devices list is empty');
-        });
-    });
+     it('forgot password, then get device list', () => {
+       const email = server.uniqueEmail();
+       const newPassword = 'foo';
+       let client;
+       return Client.createAndVerify(
+         config.publicUrl,
+         email,
+         'bar',
+         server.mailbox,
+         testOptions
+       )
+         .then((c) => {
+           client = c;
+           return client.updateDevice({
+             name: 'baz',
+             type: 'mobile',
+             pushCallback: 'https://updates.push.services.mozilla.com/qux',
+             pushPublicKey: mocks.MOCK_PUSH_KEY,
+             pushAuthKey: base64url(crypto.randomBytes(16)),
+           });
+         })
+         .then(() => {
+           return client.devices();
+         })
+         .then((devices) => {
+           assert.equal(devices.length, 1, 'devices list contains 1 item');
+         })
+         .then(() => {
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForCode(email);
+         })
+         .then((code) => {
+           return resetPassword(client, code, newPassword);
+         })
+         .then(() => {
+           return upgradeCredentials(email, newPassword);
+         })
+         .then(() => {
+           return Client.login(
+             config.publicUrl,
+             email,
+             newPassword,
+             testOptions
+           );
+         })
+         .then((client) => {
+           return client.devices();
+         })
+         .then((devices) => {
+           assert.equal(devices.length, 0, 'devices list is empty');
+         });
+     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
 
-    async function resetPassword(client, code, newPassword, headers, options) {
-      await client.verifyPasswordResetCode(code, headers, options);
-      await client.resetPassword(newPassword, {}, options);
-    }
+     async function resetPassword(client, code, newPassword, headers, options) {
+       await client.verifyPasswordResetCode(code, headers, options);
+       await client.resetPassword(newPassword, {}, options);
+     }
 
-    async function upgradeCredentials(email, newPassword) {
-      if (testOptions.version === 'V2') {
-        await Client.upgradeCredentials(config.publicUrl, email, newPassword, {
-          version: '',
-          key: true,
-        });
-      }
-    }
-  });
-});
+     async function upgradeCredentials(email, newPassword) {
+       if (testOptions.version === 'V2') {
+         await Client.upgradeCredentials(config.publicUrl, email, newPassword, {
+           version: '',
+           key: true,
+         });
+       }
+     }
+   });
+ });

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -50,18 +50,17 @@ const mockLog = {
 };
 
 describe(`#integration - remote push db`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
 
   let dbServer, db;
-  before(() => {
-    return TestServer.start(config)
-      .then((s) => {
-        dbServer = s;
-        return DB.connect(config);
-      })
-      .then((x) => {
-        db = x;
-      });
+  before(async () => {
+    dbServer = await TestServer.start(config);
+    db = await DB.connect(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(dbServer);
+    await db.close();
   });
 
   it('push db tests', () => {
@@ -179,7 +178,5 @@ describe(`#integration - remote push db`, function () {
       });
   });
 
-  after(() => {
-    return Promise.all([TestServer.stop(dbServer), db.close()]);
-  });
+
 });

--- a/packages/fxa-auth-server/test/remote/recovery_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_code_tests.js
@@ -14,6 +14,8 @@ const BASE_36 = require('../../lib/routes/validators').BASE_36;
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote backup authentication codes`, function () {
+  this.timeout(60000);
+
   let server, client, email, recoveryCodes;
   const recoveryCodeCount = 9;
   const password = 'pssssst';
@@ -22,19 +24,21 @@ describe(`#integration${testOptions.version} - remote backup authentication code
     flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
   };
 
-  this.timeout(10000);
+
 
   otplib.authenticator.options = {
     encoding: 'hex',
     window: 10,
   };
 
-  before(() => {
+  before(async () => {
     config.totp.recoveryCodes.count = recoveryCodeCount;
     config.totp.recoveryCodes.notifyLowCount = recoveryCodeCount - 2;
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   beforeEach(() => {
@@ -248,9 +252,7 @@ describe(`#integration${testOptions.version} - remote backup authentication code
     });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/recovery_email_change_email.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_change_email.js
@@ -15,14 +15,16 @@ const password = 'allyourbasearebelongtous',
 [ {version:""}, {version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote change email`, function () {
-  this.timeout(30000);
+  this.timeout(60000);
 
-  before(() => {
+  before(async () => {
     config = require('../../config').default.getProperties();
     config.securityHistory.ipProfiling = {};
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   beforeEach(() => {
@@ -147,22 +149,29 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
         .then((res) => {
           assert.ok(res, 'ok response');
 
-          if (testOptions.version === "V2") {
+          if (testOptions.version === 'V2') {
             // Note for V2 we can login with new primary email. The password is not encrypted with
             // the original email, so this now works!
-            return Client.login(config.publicUrl, secondEmail, password, testOptions);
-          }
-          else {
-            // Verify account can login with new primary email
-            return Client.login(config.publicUrl, secondEmail, password, testOptions).then(
-              () => {
-                assert.fail(
-                  new Error(
-                    'Should have returned correct email for user to login'
-                  )
-                );
-              }
+            return Client.login(
+              config.publicUrl,
+              secondEmail,
+              password,
+              testOptions
             );
+          } else {
+            // Verify account can login with new primary email
+            return Client.login(
+              config.publicUrl,
+              secondEmail,
+              password,
+              testOptions
+            ).then(() => {
+              assert.fail(
+                new Error(
+                  'Should have returned correct email for user to login'
+                )
+              );
+            });
           }
         })
         .catch((err) => {
@@ -175,7 +184,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
 
           return Client.login(config.publicUrl, err.email, password, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -190,7 +199,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
           assert.ok(res, 'ok response');
           return Client.login(config.publicUrl, email, password, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -201,7 +210,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
           assert.ok(res, 'ok response');
           return Client.login(config.publicUrl, email, newPassword, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -240,18 +249,23 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
           assert.ok(res, 'ok response');
         })
         .then(() => {
-          if (testOptions.version === "V2") {
-            return Client.upgradeCredentials(config.publicUrl, email, newPassword, {
-              originalLoginEmail: secondEmail,
-              version: '',
-              keys: true
-           });
+          if (testOptions.version === 'V2') {
+            return Client.upgradeCredentials(
+              config.publicUrl,
+              email,
+              newPassword,
+              {
+                originalLoginEmail: secondEmail,
+                version: '',
+                keys: true,
+              }
+            );
           }
         })
         .then(() => {
           return Client.login(config.publicUrl, email, newPassword, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -269,7 +283,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
         .then(() => {
           return Client.login(config.publicUrl, email, newPassword, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           })
             .then(() => {
               assert.fail(
@@ -356,7 +370,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
 
     const res = await Client.login(config.publicUrl, client1Email, password, {
       originalLoginEmail: client2Email,
-      ...testOptions
+      ...testOptions,
     });
 
     assert.ok(res, 'ok response');
@@ -399,13 +413,17 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
     });
 
     it('can login', () => {
-
-      if (testOptions.version === "V2") {
+      if (testOptions.version === 'V2') {
         // Note that with V2 logins, you can actually use the secondary email to login. This is
         // due to the fact the salt is now independent of the original email.
-        return Client.login(config.publicUrl, secondEmail, password, testOptions).then((res) => {
-          assert.exists(res.sessionToken)
-        })
+        return Client.login(
+          config.publicUrl,
+          secondEmail,
+          password,
+          testOptions
+        ).then((res) => {
+          assert.exists(res.sessionToken);
+        });
       }
 
       // Verify account can still login with new primary email
@@ -425,7 +443,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
 
           return Client.login(config.publicUrl, err.email, password, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -436,7 +454,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
     it('can change password', () => {
       return Client.login(config.publicUrl, email, password, {
         originalLoginEmail: secondEmail,
-        ...testOptions
+        ...testOptions,
       })
         .then((res) => {
           client = res;
@@ -446,7 +464,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
           assert.ok(res, 'ok response');
           return Client.login(config.publicUrl, email, newPassword, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -471,18 +489,23 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
           assert.ok(res, 'ok response');
         })
         .then(() => {
-          if (testOptions.version === "V2") {
-            return Client.upgradeCredentials(config.publicUrl, email, newPassword, {
-              originalLoginEmail: secondEmail,
-              version: '',
-              keys:true
-            });
+          if (testOptions.version === 'V2') {
+            return Client.upgradeCredentials(
+              config.publicUrl,
+              email,
+              newPassword,
+              {
+                originalLoginEmail: secondEmail,
+                version: '',
+                keys: true,
+              }
+            );
           }
         })
         .then(() => {
           return Client.login(config.publicUrl, email, newPassword, {
             originalLoginEmail: secondEmail,
-            ...testOptions
+            ...testOptions,
           });
         })
         .then((res) => {
@@ -494,7 +517,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
       return client.destroyAccount().then(() => {
         return Client.login(config.publicUrl, email, newPassword, {
           originalLoginEmail: secondEmail,
-          ...testOptions
+          ...testOptions,
         })
           .then(() => {
             assert.fail(
@@ -509,9 +532,7 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
     });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 
   function resetPassword(client, code, newPassword, headers, options) {
     return client.verifyPasswordResetCode(code, headers, options).then(() => {

--- a/packages/fxa-auth-server/test/remote/recovery_email_verify_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_verify_tests.js
@@ -14,12 +14,14 @@ const config = require('../../config').default.getProperties();
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote recovery email verify`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+  before(async () => {
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('create account verify with incorrect code', () => {
@@ -85,9 +87,7 @@ describe(`#integration${testOptions.version} - remote recovery email verify`, fu
       });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -2,385 +2,395 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
+ 'use strict';
 
-const { assert } = require('chai');
-const config = require('../../config').default.getProperties();
-const crypto = require('crypto');
-const TestServer = require('../test_server');
-const Client = require('../client')();
-const { JWTool } = require('@fxa/vendored/jwtool');
+ const { assert } = require('chai');
+ const config = require('../../config').default.getProperties();
+ const crypto = require('crypto');
+ const TestServer = require('../test_server');
+ const Client = require('../client')();
+ const { JWTool } = require('@fxa/vendored/jwtool');
 
-[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote recovery keys`, function () {
-    this.timeout(10000);
+ [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+   describe(`#integration${testOptions.version} - remote recovery keys`, function () {
+     this.timeout(60000);
 
-    let server, client, email;
-    const password = '(-.-)Zzz...';
+     let server, client, email;
+     const password = '(-.-)Zzz...';
 
-    let recoveryKeyId;
-    let recoveryData;
-    let keys;
+     let recoveryKeyId;
+     let recoveryData;
+     let keys;
 
-    function createMockRecoveryKey() {
-      // The auth-server does not care about the encryption details of the recovery data.
-      // To simplify things, we can mock out some random bits to be stored. Check out
-      // /docs/recovery_keys.md for more details on the encryption that a client
-      // could perform.
-      const recoveryCode = crypto.randomBytes(16).toString('hex');
-      const recoveryKeyId = crypto.randomBytes(16).toString('hex');
-      const recoveryKey = crypto.randomBytes(16).toString('hex');
-      const recoveryData = crypto.randomBytes(32).toString('hex');
+     function createMockRecoveryKey() {
+       // The auth-server does not care about the encryption details of the recovery data.
+       // To simplify things, we can mock out some random bits to be stored. Check out
+       // /docs/recovery_keys.md for more details on the encryption that a client
+       // could perform.
+       const recoveryCode = crypto.randomBytes(16).toString('hex');
+       const recoveryKeyId = crypto.randomBytes(16).toString('hex');
+       const recoveryKey = crypto.randomBytes(16).toString('hex');
+       const recoveryData = crypto.randomBytes(32).toString('hex');
 
-      return Promise.resolve({
-        recoveryCode,
-        recoveryData,
-        recoveryKeyId,
-        recoveryKey,
-      });
-    }
+       return Promise.resolve({
+         recoveryCode,
+         recoveryData,
+         recoveryKeyId,
+         recoveryKey,
+       });
+     }
 
-    before(() => {
-      return TestServer.start(config).then((s) => (server = s));
-    });
+     before(async () => {
+       server = await TestServer.start(config);
+     });
 
-    beforeEach(() => {
-      email = server.uniqueEmail();
-      return Client.createAndVerify(
-        config.publicUrl,
-        email,
-        password,
-        server.mailbox,
-        {
-          ...testOptions,
-          keys: true,
-        }
-      )
-        .then((x) => {
-          client = x;
-          assert.ok(client.authAt, 'authAt was set');
+     after(async () => {
+       await TestServer.stop(server);
+     });
 
-          return client.keys();
-        })
-        .then((result) => {
-          keys = result;
+     beforeEach(() => {
+       email = server.uniqueEmail();
+       return Client.createAndVerify(
+         config.publicUrl,
+         email,
+         password,
+         server.mailbox,
+         {
+           ...testOptions,
+           keys: true,
+         }
+       )
+         .then((x) => {
+           client = x;
+           assert.ok(client.authAt, 'authAt was set');
 
-          return createMockRecoveryKey(client.uid, keys.kB).then((result) => {
-            recoveryKeyId = result.recoveryKeyId;
-            recoveryData = result.recoveryData;
-            // Should create account recovery key
-            return client
-              .createRecoveryKey(result.recoveryKeyId, result.recoveryData)
-              .then((res) => assert.ok(res, 'empty response'))
-              .then(() => server.mailbox.waitForEmail(email))
-              .then((emailData) => {
-                assert.equal(
-                  emailData.headers['x-template-name'],
-                  'postAddAccountRecovery'
-                );
-              });
-          });
-        });
-    });
+           return client.keys();
+         })
+         .then((result) => {
+           keys = result;
 
-    it('should get account recovery key', () => {
-      return getAccountResetToken(client, server, email)
-        .then(() => client.getRecoveryKey(recoveryKeyId))
-        .then((res) => {
-          assert.equal(res.recoveryData, recoveryData, 'recoveryData returned');
-        });
-    });
+           return createMockRecoveryKey(client.uid, keys.kB).then((result) => {
+             recoveryKeyId = result.recoveryKeyId;
+             recoveryData = result.recoveryData;
+             // Should create account recovery key
+             return client
+               .createRecoveryKey(result.recoveryKeyId, result.recoveryData)
+               .then((res) => assert.ok(res, 'empty response'))
+               .then(() => server.mailbox.waitForEmail(email))
+               .then((emailData) => {
+                 assert.equal(
+                   emailData.headers['x-template-name'],
+                   'postAddAccountRecovery'
+                 );
+               });
+           });
+         });
+     });
 
-    it('should fail to get unknown account recovery key', () => {
-      return getAccountResetToken(client, server, email)
-        .then(() => client.getRecoveryKey('abce1234567890'))
-        .then(assert.fail, (err) => {
-          assert.equal(err.errno, 159, 'account recovery key is not valid');
-        });
-    });
+     it('should get account recovery key', () => {
+       return getAccountResetToken(client, server, email)
+         .then(() => client.getRecoveryKey(recoveryKeyId))
+         .then((res) => {
+           assert.equal(
+             res.recoveryData,
+             recoveryData,
+             'recoveryData returned'
+           );
+         });
+     });
 
-    async function checkPayloadV2(mutate, restore) {
-      await getAccountResetToken(client, server, email);
-      await client.getRecoveryKey(recoveryKeyId);
-      let err;
-      try {
-        mutate();
-        await client.api.accountResetWithRecoveryKeyV2(
-          client.accountResetToken,
-          client.authPW,
-          client.authPWVersion2,
-          client.wrapKb,
-          client.wrapKbVersion2,
-          client.clientSalt,
-          recoveryKeyId,
-          undefined,
-          {}
-        );
-      } catch (error) {
-        err = error;
-      } finally {
-        restore();
-      }
+     it('should fail to get unknown account recovery key', () => {
+       return getAccountResetToken(client, server, email)
+         .then(() => client.getRecoveryKey('abce1234567890'))
+         .then(assert.fail, (err) => {
+           assert.equal(err.errno, 159, 'account recovery key is not valid');
+         });
+     });
 
-      assert.exists(err);
-      assert.equal(err.errno, 107, 'invalid param');
-    }
+     async function checkPayloadV2(mutate, restore) {
+       await getAccountResetToken(client, server, email);
+       await client.getRecoveryKey(recoveryKeyId);
+       let err;
+       try {
+         mutate();
+         await client.api.accountResetWithRecoveryKeyV2(
+           client.accountResetToken,
+           client.authPW,
+           client.authPWVersion2,
+           client.wrapKb,
+           client.wrapKbVersion2,
+           client.clientSalt,
+           recoveryKeyId,
+           undefined,
+           {}
+         );
+       } catch (error) {
+         err = error;
+       } finally {
+         restore();
+       }
 
-    it('should fail if wrapKb is missing and authPWVersion2 is provided', async function () {
-      if (testOptions.version !== 'V2') {
-        return this.skip();
-      }
-      const temp = client.wrapKb;
-      await checkPayloadV2(
-        () => {
-          client.unwrapBKey = undefined;
-          client.wrapKb = undefined;
-        },
-        () => {
-          client.wrapKb = temp;
-        }
-      );
-    });
+       assert.exists(err);
+       assert.equal(err.errno, 107, 'invalid param');
+     }
 
-    it('should fail if wrapKbVersion2 is missing and authPWVersion2 is provided', async function () {
-      if (testOptions.version !== 'V2') {
-        return this.skip();
-      }
+     it('should fail if wrapKb is missing and authPWVersion2 is provided', async function () {
+       if (testOptions.version !== 'V2') {
+         return this.skip();
+       }
+       const temp = client.wrapKb;
+       await checkPayloadV2(
+         () => {
+           client.unwrapBKey = undefined;
+           client.wrapKb = undefined;
+         },
+         () => {
+           client.wrapKb = temp;
+         }
+       );
+     });
 
-      const temp = client.wrapKbVersion2;
-      await checkPayloadV2(
-        () => {
-          client.wrapKbVersion2 = undefined;
-        },
-        () => {
-          client.wrapKbVersion2 = temp;
-        }
-      );
-    });
+     it('should fail if wrapKbVersion2 is missing and authPWVersion2 is provided', async function () {
+       if (testOptions.version !== 'V2') {
+         return this.skip();
+       }
 
-    it('should fail if clientSalt is missing and authPWVersion2 is provided', async function () {
-      if (testOptions.version !== 'V2') {
-        return this.skip();
-      }
-      const temp = client.clientSalt;
-      await checkPayloadV2(
-        () => {
-          client.clientSalt = undefined;
-        },
-        () => {
-          client.clientSalt = temp;
-        }
-      );
-    });
+       const temp = client.wrapKbVersion2;
+       await checkPayloadV2(
+         () => {
+           client.wrapKbVersion2 = undefined;
+         },
+         () => {
+           client.wrapKbVersion2 = temp;
+         }
+       );
+     });
 
-    it('should fail if recoveryKeyId is missing', function () {
-      if (testOptions.version === 'V2') {
-        return this.skip();
-      }
+     it('should fail if clientSalt is missing and authPWVersion2 is provided', async function () {
+       if (testOptions.version !== 'V2') {
+         return this.skip();
+       }
+       const temp = client.clientSalt;
+       await checkPayloadV2(
+         () => {
+           client.clientSalt = undefined;
+         },
+         () => {
+           client.clientSalt = temp;
+         }
+       );
+     });
 
-      return getAccountResetToken(client, server, email)
-        .then(() => client.getRecoveryKey(recoveryKeyId))
-        .then((res) =>
-          assert.equal(res.recoveryData, recoveryData, 'recoveryData returned')
-        )
-        .then(() =>
-          client.resetAccountWithRecoveryKey(
-            'newpass',
-            keys.kB,
-            undefined,
-            {},
-            { keys: true }
-          )
-        )
-        .then(assert.fail, (err) => {
-          assert.equal(err.errno, 107, 'invalid param');
-        });
-    });
+     it('should fail if recoveryKeyId is missing', function () {
+       if (testOptions.version === 'V2') {
+         return this.skip();
+       }
 
-    it('should fail if wrapKb is missing', function () {
-      if (testOptions.version === 'V2') {
-        return this.skip();
-      }
+       return getAccountResetToken(client, server, email)
+         .then(() => client.getRecoveryKey(recoveryKeyId))
+         .then((res) =>
+           assert.equal(res.recoveryData, recoveryData, 'recoveryData returned')
+         )
+         .then(() =>
+           client.resetAccountWithRecoveryKey(
+             'newpass',
+             keys.kB,
+             undefined,
+             {},
+             { keys: true }
+           )
+         )
+         .then(assert.fail, (err) => {
+           assert.equal(err.errno, 107, 'invalid param');
+         });
+     });
 
-      return getAccountResetToken(client, server, email)
-        .then(() => client.getRecoveryKey(recoveryKeyId))
-        .then((res) =>
-          assert.equal(res.recoveryData, recoveryData, 'recoveryData returned')
-        )
-        .then(() =>
-          client.resetAccountWithRecoveryKey(
-            'newpass',
-            keys.kB,
-            recoveryKeyId,
-            {},
-            { keys: true, undefinedWrapKb: true }
-          )
-        )
-        .then(assert.fail, (err) => {
-          assert.equal(err.errno, 107, 'invalid param');
-        });
-    });
+     it('should fail if wrapKb is missing', function () {
+       if (testOptions.version === 'V2') {
+         return this.skip();
+       }
 
-    it('should reset password while keeping kB', async () => {
-      await getAccountResetToken(client, server, email);
-      let res = await client.getRecoveryKey(recoveryKeyId);
-      assert.equal(res.recoveryData, recoveryData, 'recoveryData returned');
+       return getAccountResetToken(client, server, email)
+         .then(() => client.getRecoveryKey(recoveryKeyId))
+         .then((res) =>
+           assert.equal(res.recoveryData, recoveryData, 'recoveryData returned')
+         )
+         .then(() =>
+           client.resetAccountWithRecoveryKey(
+             'newpass',
+             keys.kB,
+             recoveryKeyId,
+             {},
+             { keys: true, undefinedWrapKb: true }
+           )
+         )
+         .then(assert.fail, (err) => {
+           assert.equal(err.errno, 107, 'invalid param');
+         });
+     });
 
-      const duration = 1000 * 60 * 60 * 24; // 24 hours
-      const publicKey = {
-        algorithm: 'RS',
-        n: '4759385967235610503571494339196749614544606692567785790953934768202714280652973091341316862993582789079872007974809511698859885077002492642203267408776123',
-        e: '65537',
-      };
-      const cert1 = JWTool.unverify(
-        await client.sign(publicKey, duration)
-      ).payload;
+     it('should reset password while keeping kB', async () => {
+       await getAccountResetToken(client, server, email);
+       let res = await client.getRecoveryKey(recoveryKeyId);
+       assert.equal(res.recoveryData, recoveryData, 'recoveryData returned');
 
-      res = await client.resetAccountWithRecoveryKey(
-        'newpass',
-        keys.kB,
-        recoveryKeyId,
-        {},
-        { keys: true }
-      );
-      assert.equal(res.uid, client.uid, 'uid returned');
-      assert.ok(res.sessionToken, 'sessionToken return');
+       const duration = 1000 * 60 * 60 * 24; // 24 hours
+       const publicKey = {
+         algorithm: 'RS',
+         n: '4759385967235610503571494339196749614544606692567785790953934768202714280652973091341316862993582789079872007974809511698859885077002492642203267408776123',
+         e: '65537',
+       };
+       const cert1 = JWTool.unverify(
+         await client.sign(publicKey, duration)
+       ).payload;
 
-      const emailData = await server.mailbox.waitForEmail(email);
-      assert.equal(
-        emailData.headers['x-template-name'],
-        'passwordResetAccountRecovery',
-        'correct template sent'
-      );
+       res = await client.resetAccountWithRecoveryKey(
+         'newpass',
+         keys.kB,
+         recoveryKeyId,
+         {},
+         { keys: true }
+       );
+       assert.equal(res.uid, client.uid, 'uid returned');
+       assert.ok(res.sessionToken, 'sessionToken return');
 
-      res = await client.keys();
-      assert.equal(res.kA, keys.kA, 'kA are equal returned');
-      assert.equal(res.kB, keys.kB, 'kB are equal returned');
+       const emailData = await server.mailbox.waitForEmail(email);
+       assert.equal(
+         emailData.headers['x-template-name'],
+         'passwordResetAccountRecovery',
+         'correct template sent'
+       );
 
-      // Login with new password and check to see kB hasn't changed
-      const c = await Client.login(config.publicUrl, email, 'newpass', {
-        ...testOptions,
-        keys: true,
-      });
-      assert.ok(c.sessionToken, 'sessionToken returned');
-      res = await c.keys();
-      assert.equal(res.kA, keys.kA, 'kA are equal returned');
-      assert.equal(res.kB, keys.kB, 'kB are equal returned');
+       res = await client.keys();
+       assert.equal(res.kA, keys.kA, 'kA are equal returned');
+       assert.equal(res.kB, keys.kB, 'kB are equal returned');
 
-      const cert2 = JWTool.unverify(await c.sign(publicKey, duration)).payload;
+       // Login with new password and check to see kB hasn't changed
+       const c = await Client.login(config.publicUrl, email, 'newpass', {
+         ...testOptions,
+         keys: true,
+       });
+       assert.ok(c.sessionToken, 'sessionToken returned');
+       res = await c.keys();
+       assert.equal(res.kA, keys.kA, 'kA are equal returned');
+       assert.equal(res.kB, keys.kB, 'kB are equal returned');
 
-      assert.equal(cert1['fxa-uid'], cert2['fxa-uid']);
-      assert.ok(cert1['fxa-generation'] < cert2['fxa-generation']);
-      assert.equal(cert1['fxa-keysChangedAt'], cert2['fxa-keysChangedAt']);
-    });
+       const cert2 = JWTool.unverify(await c.sign(publicKey, duration)).payload;
 
-    it('should delete account recovery key', () => {
-      return client.deleteRecoveryKey().then((res) => {
-        assert.ok(res, 'empty response');
-        return client
-          .getRecoveryKeyExists()
-          .then((result) => {
-            assert.equal(result.exists, false, 'account recovery key deleted');
-          })
-          .then(() => server.mailbox.waitForEmail(email))
-          .then((emailData) => {
-            assert.equal(
-              emailData.headers['x-template-name'],
-              'postRemoveAccountRecovery'
-            );
-          });
-      });
-    });
+       assert.equal(cert1['fxa-uid'], cert2['fxa-uid']);
+       assert.ok(cert1['fxa-generation'] < cert2['fxa-generation']);
+       assert.equal(cert1['fxa-keysChangedAt'], cert2['fxa-keysChangedAt']);
+     });
 
-    it('should fail to create account recovery key when one already exists', () => {
-      return createMockRecoveryKey(client.uid, keys.kB).then((result) => {
-        recoveryKeyId = result.recoveryKeyId;
-        recoveryData = result.recoveryData;
-        return client
-          .createRecoveryKey(result.recoveryKeyId, result.recoveryData)
-          .then(assert.fail, (err) => {
-            assert.equal(err.errno, 161, 'correct errno');
-          });
-      });
-    });
+     it('should delete account recovery key', () => {
+       return client.deleteRecoveryKey().then((res) => {
+         assert.ok(res, 'empty response');
+         return client
+           .getRecoveryKeyExists()
+           .then((result) => {
+             assert.equal(result.exists, false, 'account recovery key deleted');
+           })
+           .then(() => server.mailbox.waitForEmail(email))
+           .then((emailData) => {
+             assert.equal(
+               emailData.headers['x-template-name'],
+               'postRemoveAccountRecovery'
+             );
+           });
+       });
+     });
 
-    describe('check account recovery key status', () => {
-      describe('with sessionToken', () => {
-        it('should return true if account recovery key exists and enabled', () => {
-          return client.getRecoveryKeyExists().then((res) => {
-            assert.equal(res.exists, true, 'account recovery key exists');
-          });
-        });
+     it('should fail to create account recovery key when one already exists', () => {
+       return createMockRecoveryKey(client.uid, keys.kB).then((result) => {
+         recoveryKeyId = result.recoveryKeyId;
+         recoveryData = result.recoveryData;
+         return client
+           .createRecoveryKey(result.recoveryKeyId, result.recoveryData)
+           .then(assert.fail, (err) => {
+             assert.equal(err.errno, 161, 'correct errno');
+           });
+       });
+     });
 
-        it("should return false if account recovery key doesn't exist", () => {
-          email = server.uniqueEmail();
-          return Client.createAndVerify(
-            config.publicUrl,
-            email,
-            password,
-            server.mailbox,
-            {
-              ...testOptions,
-              keys: true,
-            }
-          )
-            .then((c) => {
-              client = c;
-              return client.getRecoveryKeyExists();
-            })
-            .then((res) => {
-              assert.equal(
-                res.exists,
-                false,
-                'account recovery key doesnt exists'
-              );
-            });
-        });
+     describe('check account recovery key status', () => {
+       describe('with sessionToken', () => {
+         it('should return true if account recovery key exists and enabled', () => {
+           return client.getRecoveryKeyExists().then((res) => {
+             assert.equal(res.exists, true, 'account recovery key exists');
+           });
+         });
 
-        it('should return false if account recovery key exist but not enabled', async () => {
-          const email2 = server.uniqueEmail();
-          const client2 = await Client.createAndVerify(
-            config.publicUrl,
-            email2,
-            password,
-            server.mailbox,
-            {
-              ...testOptions,
-              keys: true,
-            }
-          );
-          const recoveryKeyMock = await createMockRecoveryKey(
-            client2.uid,
-            keys.kB
-          );
-          let res = await client2.createRecoveryKey(
-            recoveryKeyMock.recoveryKeyId,
-            recoveryKeyMock.recoveryData,
-            false
-          );
-          assert.deepEqual(res, {});
+         it("should return false if account recovery key doesn't exist", () => {
+           email = server.uniqueEmail();
+           return Client.createAndVerify(
+             config.publicUrl,
+             email,
+             password,
+             server.mailbox,
+             {
+               ...testOptions,
+               keys: true,
+             }
+           )
+             .then((c) => {
+               client = c;
+               return client.getRecoveryKeyExists();
+             })
+             .then((res) => {
+               assert.equal(
+                 res.exists,
+                 false,
+                 'account recovery key doesnt exists'
+               );
+             });
+         });
 
-          res = await client2.getRecoveryKeyExists();
-          assert.equal(res.exists, false, 'account recovery key doesnt exists');
-        });
-      });
-    });
+         it('should return false if account recovery key exist but not enabled', async () => {
+           const email2 = server.uniqueEmail();
+           const client2 = await Client.createAndVerify(
+             config.publicUrl,
+             email2,
+             password,
+             server.mailbox,
+             {
+               ...testOptions,
+               keys: true,
+             }
+           );
+           const recoveryKeyMock = await createMockRecoveryKey(
+             client2.uid,
+             keys.kB
+           );
+           let res = await client2.createRecoveryKey(
+             recoveryKeyMock.recoveryKeyId,
+             recoveryKeyMock.recoveryData,
+             false
+           );
+           assert.deepEqual(res, {});
 
-    after(() => {
-      return TestServer.stop(server);
-    });
-  });
+           res = await client2.getRecoveryKeyExists();
+           assert.equal(
+             res.exists,
+             false,
+             'account recovery key doesnt exists'
+           );
+         });
+       });
+     });
 
-  function getAccountResetToken(client, server, email) {
-    return client
-      .forgotPassword()
-      .then(() => server.mailbox.waitForCode(email))
-      .then((code) =>
-        client.verifyPasswordResetCode(
-          code,
-          {},
-          { accountResetWithRecoveryKey: true }
-        )
-      );
-  }
-});
+
+   });
+
+   function getAccountResetToken(client, server, email) {
+     return client
+       .forgotPassword()
+       .then(() => server.mailbox.waitForCode(email))
+       .then((code) =>
+         client.verifyPasswordResetCode(
+           code,
+           {},
+           { accountResetWithRecoveryKey: true }
+         )
+       );
+   }
+ });

--- a/packages/fxa-auth-server/test/remote/security_events.js
+++ b/packages/fxa-auth-server/test/remote/security_events.js
@@ -2,121 +2,119 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
+ 'use strict';
 
-const { assert } = require('chai');
-const Client = require('../client')();
-const TestServer = require('../test_server');
-const config = require('../../config').default.getProperties();
+ const { assert } = require('chai');
+ const Client = require('../client')();
+ const TestServer = require('../test_server');
+ const config = require('../../config').default.getProperties();
 
-function resetPassword(client, code, newPassword, options) {
-  return client.verifyPasswordResetCode(code).then(() => {
-    return client.resetPassword(newPassword, {}, options);
-  });
-}
+ function resetPassword(client, code, newPassword, options) {
+   return client.verifyPasswordResetCode(code).then(() => {
+     return client.resetPassword(newPassword, {}, options);
+   });
+ }
 
-function delay(seconds) {
-  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
-}
+ function delay(seconds) {
+   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+ }
 
-[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote securityEvents`, () => {
-    let server;
+ [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+   describe(`#integration${testOptions.version} - remote securityEvents`, function () {
+     this.timeout(60000);
+     let server;
 
-    before(function () {
-      this.timeout(15000);
-      config.securityHistory.ipProfiling.allowedRecency = 0;
-      config.signinConfirmation.skipForNewAccounts.enabled = false;
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
-    });
+     before(async function () {
+       config.securityHistory.ipProfiling.allowedRecency = 0;
+       config.signinConfirmation.skipForNewAccounts.enabled = false;
+       server = await TestServer.start(config);
+     });
 
-    it('returns securityEvents on creating and login into an account', () => {
-      const email = server.uniqueEmail();
-      const password = 'abcdef';
-      let client;
+     after(async () => {
+       await TestServer.stop(server);
+     });
 
-      return Client.createAndVerify(
-        config.publicUrl,
-        email,
-        password,
-        server.mailbox,
-        testOptions
-      )
-        .then((x) => {
-          client = x;
-          return client.login().then(() => {
-            return delay(1).then(() => {
-              return client.securityEvents();
-            });
-          });
-        })
-        .then((events) => {
-          assert.equal(events.length, 2);
-          assert.equal(events[0].name, 'account.login');
-          assert.isBelow(events[0].createdAt, new Date().getTime());
-          assert.equal(events[0].verified, false);
+     it('returns securityEvents on creating and login into an account', () => {
+       const email = server.uniqueEmail();
+       const password = 'abcdef';
+       let client;
 
-          assert.equal(events[1].name, 'account.create');
-          assert.isBelow(events[1].createdAt, new Date().getTime());
-          assert.equal(events[1].verified, true);
-        });
-    });
+       return Client.createAndVerify(
+         config.publicUrl,
+         email,
+         password,
+         server.mailbox,
+         testOptions
+       )
+         .then((x) => {
+           client = x;
+           return client.login().then(() => {
+             return delay(1).then(() => {
+               return client.securityEvents();
+             });
+           });
+         })
+         .then((events) => {
+           assert.equal(events.length, 2);
+           assert.equal(events[0].name, 'account.login');
+           assert.isBelow(events[0].createdAt, new Date().getTime());
+           assert.equal(events[0].verified, false);
 
-    it('returns security events after account reset w/o keys, with sessionToken', () => {
-      const email = server.uniqueEmail();
-      const password = 'oldPassword';
-      const newPassword = 'newPassword';
-      let client;
+           assert.equal(events[1].name, 'account.create');
+           assert.isBelow(events[1].createdAt, new Date().getTime());
+           assert.equal(events[1].verified, true);
+         });
+     });
 
-      return Client.createAndVerify(
-        config.publicUrl,
-        email,
-        password,
-        server.mailbox,
-        testOptions
-      )
-        .then((x) => {
-          client = x;
-        })
-        .then(() => {
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(email);
-        })
-        .then((code) => {
-          assert.isRejected(client.resetPassword(newPassword));
-          return resetPassword(client, code, newPassword);
-        })
-        .then((response) => {
-          assert.ok(response.sessionToken, 'session token is in response');
-          assert(
-            !response.keyFetchToken,
-            'keyFetchToken token is not in response'
-          );
-          assert.equal(response.verified, true, 'verified is true');
-        })
-        .then(() => {
-          return delay(1).then(() => {
-            return client.securityEvents();
-          });
-        })
-        .then((events) => {
-          assert.equal(events.length, 2);
-          assert.equal(events[0].name, 'account.reset');
-          assert.isBelow(events[0].createdAt, new Date().getTime());
-          assert.equal(events[0].verified, true);
+     it('returns security events after account reset w/o keys, with sessionToken', () => {
+       const email = server.uniqueEmail();
+       const password = 'oldPassword';
+       const newPassword = 'newPassword';
+       let client;
 
-          assert.equal(events[1].name, 'account.create');
-          assert.isBelow(events[1].createdAt, new Date().getTime());
-          assert.equal(events[1].verified, true);
-        });
-    });
+       return Client.createAndVerify(
+         config.publicUrl,
+         email,
+         password,
+         server.mailbox,
+         testOptions
+       )
+         .then((x) => {
+           client = x;
+         })
+         .then(() => {
+           return client.forgotPassword();
+         })
+         .then(() => {
+           return server.mailbox.waitForCode(email);
+         })
+         .then((code) => {
+           assert.isRejected(client.resetPassword(newPassword));
+           return resetPassword(client, code, newPassword);
+         })
+         .then((response) => {
+           assert.ok(response.sessionToken, 'session token is in response');
+           assert(
+             !response.keyFetchToken,
+             'keyFetchToken token is not in response'
+           );
+           assert.equal(response.verified, true, 'verified is true');
+         })
+         .then(() => {
+           return delay(1).then(() => {
+             return client.securityEvents();
+           });
+         })
+         .then((events) => {
+           assert.equal(events.length, 2);
+           assert.equal(events[0].name, 'account.reset');
+           assert.isBelow(events[0].createdAt, new Date().getTime());
+           assert.equal(events[0].verified, true);
 
-    after(() => {
-      return TestServer.stop(server);
-    });
-  });
-});
+           assert.equal(events[1].name, 'account.create');
+           assert.isBelow(events[1].createdAt, new Date().getTime());
+           assert.equal(events[1].verified, true);
+         });
+     });
+   });
+ });

--- a/packages/fxa-auth-server/test/remote/session_tests.js
+++ b/packages/fxa-auth-server/test/remote/session_tests.js
@@ -19,13 +19,14 @@ const publicKey = {
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote session`, function () {
-    this.timeout(15000);
+    this.timeout(60000);
     let server;
     config.signinConfirmation.skipForNewAccounts.enabled = false;
-    before(() => {
-      return TestServer.start(config).then((s) => {
-        server = s;
-      });
+    before(async () => {
+      server = await TestServer.start(config);
+    });
+    after(async () => {
+      await TestServer.stop(server);
     });
 
     describe('destroy', () => {
@@ -609,8 +610,6 @@ const publicKey = {
       });
     });
 
-    after(() => {
-      return TestServer.stop(server);
-    });
+
   });
 });

--- a/packages/fxa-auth-server/test/remote/sign_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/sign_key_tests.js
@@ -10,17 +10,18 @@ const TestServer = require('../test_server');
 const path = require('path');
 
 describe(`#integration - remote sign key`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server;
-  before(() => {
+  before(async () => {
     const config = require('../../config').default.getProperties();
     config.oldPublicKeyFile = path.resolve(
       __dirname,
       '../../config/public-key.json'
     );
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('.well-known/browserid has keys', () => {
@@ -37,7 +38,5 @@ describe(`#integration - remote sign key`, function () {
       });
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -37,7 +37,7 @@ const PRODUCT_NAME = 'All Done Pro';
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote subscriptions:`, function () {
-    this.timeout(10000);
+    this.timeout(60000);
 
     before(async () => {
       config.subscriptions.stripeApiKey = null;
@@ -48,7 +48,7 @@ const PRODUCT_NAME = 'All Done Pro';
     });
 
     describe('config.subscriptions.enabled = true and direct stripe access:', function () {
-      this.timeout(15000);
+      this.timeout(60000);
 
       let client, server, tokens;
       const mockStripeHelper = {};

--- a/packages/fxa-auth-server/test/remote/token_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_code_tests.js
@@ -20,18 +20,19 @@ const {
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote tokenCodes`, function () {
+  this.timeout(60000);
+
   let server, client, email, code;
   const password = 'pssssst';
 
-  this.timeout(10000);
-
-  before(() => {
+  before(async () => {
     Container.set(PlaySubscriptions, {});
     Container.set(AppStoreSubscriptions, {});
+    server = await TestServer.start(config);
+  });
 
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   beforeEach(() => {
@@ -241,9 +242,7 @@ describe(`#integration${testOptions.version} - remote tokenCodes`, function () {
     );
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/remote/token_expiry_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_expiry_tests.js
@@ -22,9 +22,10 @@ function fail() {
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote token expiry`, function () {
-  this.timeout(15000);
+  this.timeout(60000);
   let server, config;
-  before(() => {
+
+  before(async () => {
     config = require('../../config').default.getProperties();
     config.tokenLifetimes.passwordChangeToken = 1;
     config.tokenLifetimes.sessionTokenWithoutDevice = 1;
@@ -32,9 +33,11 @@ describe(`#integration${testOptions.version} - remote token expiry`, function ()
     Container.set(PlaySubscriptions, {});
     Container.set(AppStoreSubscriptions, {});
 
-    return TestServer.start(config).then((s) => {
-      server = s;
-    });
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
   });
 
   it('token expiry', () => {
@@ -73,9 +76,7 @@ describe(`#integration${testOptions.version} - remote token expiry`, function ()
     );
   });
 
-  after(() => {
-    return TestServer.stop(server);
-  });
+
 });
 
 });

--- a/packages/fxa-auth-server/test/scripts/check-users.js
+++ b/packages/fxa-auth-server/test/scripts/check-users.js
@@ -44,9 +44,11 @@ function createRandomEmailAddr(template) {
   return `${Math.random() + template}`;
 }
 
-describe('#integration - scripts/check-users:', async function () {
-  this.timeout(30000);
+describe('#integration - scripts/check-users:', function () {
+  this.timeout(60000);
+
   let server, db, validClient, invalidClient, filename;
+
   before(async () => {
     server = await TestServer.start(config);
     db = await DB.connect(config);


### PR DESCRIPTION
## Because

- After upgrading sentry we were seeing test timeouts
- There were some kinda weird patterns in place for these tests anyways
- Test server wasn't getting cleaned up, and occasionally we'd see port conflicts
- Test server start up is taking longer (presumably because of sentry upgrade?)

## This pull request
- Moves before and after blocks next to each other so setup and tear down are easy to follow
- Makes sure test server start / stop is done in before each blocks
- Increase test timeouts to 60s when test server is used
- Switches to async/await for before and after blocks, which feels less error prone
- Gets rid of module scoped 'server' that test server would fall back to. Tests must keep track of their own servers now!

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
