### PR TITLE
feat(next): respect metrics opt-out flag

### DIFF
--- a/libs/shared/db/mysql/account/src/index.ts
+++ b/libs/shared/db/mysql/account/src/index.ts
@@ -6,6 +6,7 @@ export * from './lib/associated-types';
 export * from './lib/kysely-types';
 export {
   CartFactory,
+  AccountFactory,
   AccountCustomerFactory,
   PaypalCustomerFactory,
 } from './lib/factories';

--- a/libs/shared/db/mysql/account/src/lib/factories.ts
+++ b/libs/shared/db/mysql/account/src/lib/factories.ts
@@ -4,7 +4,12 @@
 
 import { faker } from '@faker-js/faker';
 
-import { AccountCustomer, NewCart, PaypalCustomer } from './associated-types';
+import {
+  Account,
+  AccountCustomer,
+  NewCart,
+  PaypalCustomer,
+} from './associated-types';
 import { CartEligibilityStatus, CartState } from './kysely-types';
 
 export const CartFactory = (override?: Partial<NewCart>): NewCart => ({
@@ -36,6 +41,51 @@ export const CartFactory = (override?: Partial<NewCart>): NewCart => ({
   amount: faker.number.int(10000),
   version: 0,
   eligibilityStatus: faker.helpers.enumValue(CartEligibilityStatus),
+  ...override,
+});
+
+const getHexBuffer = (length: number, prefix = ''): Buffer => {
+  return Buffer.from(
+    faker.string.hexadecimal({
+      length,
+      prefix,
+      casing: 'lower',
+    }),
+    'hex'
+  );
+};
+
+export const AccountFactory = (override?: Partial<Account>): Account => ({
+  uid: getHexBuffer(32),
+  createdAt: faker.date.recent().getTime(),
+  email: faker.internet.email(),
+  normalizedEmail: faker.internet.email().toLocaleLowerCase(),
+  emailCode: getHexBuffer(16),
+  emailVerified: 1,
+  verifierVersion: 1,
+  kA: getHexBuffer(32),
+  wrapWrapKb: Buffer.from(
+    faker.string.hexadecimal({
+      length: 32,
+      prefix: '',
+      casing: 'lower',
+    }),
+    'hex'
+  ),
+  wrapWrapKbVersion2: getHexBuffer(32),
+  authSalt: getHexBuffer(32),
+  verifyHash: getHexBuffer(32),
+  verifierSetAt: faker.date.recent().getTime(),
+  verifyHashVersion2: getHexBuffer(32),
+  locale: 'en-US',
+  lockedAt: null,
+  profileChangedAt: null,
+  keysChangedAt: null,
+  ecosystemAnonId: faker.string.numeric(),
+  disabledAt: null,
+  metricsOptOutAt: null,
+  clientSalt: null,
+  atLeast18AtReg: 1,
   ...override,
 });
 


### PR DESCRIPTION
## Because

- Currently glean logs data on users irrespective of if they have opted out of metrics collection

## This pull request

- Checks `metricsOptOutAt` field on db user, and prevents logging if the field is set
- Adds `AccountFactory` to the factories.ts file for use in tests

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).