### PR TITLE
fix(pair): Fix check around isSystemCameraUrl

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/pair/unsupported.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/unsupported.js
@@ -28,7 +28,7 @@ class PairUnsupportedView extends FormView {
     const isMobile = uap.isMobile();
     // Assume the user is on non-Firefox desktop in this case.
     const isDesktopNonFirefox = !isFirefox && !isMobile;
-    const hashParams = this.getHashParams(['channel_id, channel_key']);
+    const hashParams = this.getHashParams(['channel_id', 'channel_key']);
     const isSystemCameraUrl =
       hashParams.channel_id && hashParams.channel_key && isMobile;
 


### PR DESCRIPTION
Because:
* We want a different view to render if this is true, and there was an issue with the check where it was always falsey

This commit:
* Adjusts what's passed into getHashParams

fixes FXA-10443

---

Run `yarn firefox`, change the UA to a mobile UA in dev tools/responsive design mode, and go to `pair/unsupported#channel_id=hello&channel_key=world`