### PR TITLE
task(CAD): Update 'Start browsing' to 'Manage your account'

### DIFF
--- a/packages/functional-tests/pages/connectAnotherDevice.ts
+++ b/packages/functional-tests/pages/connectAnotherDevice.ts
@@ -35,8 +35,8 @@ export class ConnectAnotherDevicePage extends BaseLayout {
     );
   }
 
-  get startBrowsingButton() {
-    return this.page.getByRole('link', { name: 'Start browsing' });
+  get manageYourAccountButton() {
+    return this.page.getByRole('link', { name: 'Manage your account' });
   }
 
   get installFxDesktop() {

--- a/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/connect_another_device.mustache
@@ -60,7 +60,7 @@
               <a id="sync-firefox-devices" href="{{{pairingUrl}}}" class="cta-primary cta-xl" data-flow-event="link.pair" role="button">{{#t}}Connect another device{{/t}}</a>
             </div>
             <div class="mt-5 text-center">
-              <a id="cad-not-now" class="link-blue" href="/settings">{{#t}}Start browsing{{/t}}</a>
+              <a id="cad-not-now" class="link-blue" href="/settings">{{#t}}Manage your account{{/t}}</a>
             </div>
           {{/isSignedIn}}
         </p>

--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -11,7 +11,7 @@
     {{#isSync}}
       <p class="account-ready-service">{{{escapedReadyToSyncText}}}</p>
       <div class="button-row">
-          <button class="primary-button btn-start-browsing">{{#t}}Start browsing{{/t}}</button>
+          <button class="primary-button btn-start-browsing">{{#t}}Manage your account{{/t}}</button>
       </div>
     {{/isSync}}
 

--- a/packages/fxa-content-server/app/tests/spec/views/ready.js
+++ b/packages/fxa-content-server/app/tests/spec/views/ready.js
@@ -212,7 +212,7 @@ describe('views/ready', function () {
       });
     });
 
-    it('shows the `Start browsing` for Sync', () => {
+    it('shows the `Manage your account` for Sync', () => {
       createView(VerificationReasons.SIGN_UP);
       sinon.stub(relier, 'isSync').callsFake(() => true);
 

--- a/packages/fxa-settings/src/components/Ready/en.ftl
+++ b/packages/fxa-settings/src/components/Ready/en.ftl
@@ -2,7 +2,7 @@
 
 reset-password-complete-header = Your password has been reset
 ready-complete-set-up-instruction = Complete setup by entering your new password on your other { -brand-firefox } devices.
-ready-start-browsing-button = Start browsing
+manage-your-account-button = Manage your account
 # This is a string that tells the user they can use whatever service prompted them to reset their password or to verify their email
 # Variables:
 # { $serviceName } represents a product name (e.g., Mozilla VPN) that will be passed in as a variable

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -124,9 +124,9 @@ const Ready = ({
               </p>
             </FtlMsg>
             <div className="flex justify-center mx-auto mt-6">
-              <FtlMsg id="ready-start-browsing-button">
+              <FtlMsg id="manage-your-account-button">
                 <button className="cta-primary cta-xl" onClick={startBrowsing}>
-                  Start browsing
+                  Manage your account
                 </button>
               </FtlMsg>
             </div>

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/index.test.tsx
@@ -73,7 +73,7 @@ describe('ResetPasswordWithRecoveryKeyVerified', () => {
   //   bundle = await getFtlBundle('settings');
   // });
 
-  const startBrowsingText = 'Start browsing';
+  const startBrowsingText = 'Manage your account';
   const signedInText = 'You’re now ready to use account settings';
   const singedOutText = 'Your account is ready!';
   const syncText =

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1727,7 +1727,7 @@ cad:
   startbrowsing_submit:
     type: event
     description: |
-      User clicks "Start browsing" on "Connect another device page"
+      User clicks "Manage your account" on "Connect another device page". This CTA used to be "Start browsing".
     send_in_pings:
       - events
     notification_emails:

--- a/packages/fxa-shared/metrics/glean/web/cad.ts
+++ b/packages/fxa-shared/metrics/glean/web/cad.ts
@@ -7,7 +7,8 @@
 import EventMetricType from '@mozilla/glean/private/metrics/event';
 
 /**
- * User clicks "Start browsing" on "Connect another device page"
+ * User clicks "Manage your account" on "Connect another device page". This CTA
+ * used to be "Start browsing".
  *
  * Generated from `cad.startbrowsing_submit`.
  */


### PR DESCRIPTION
Because:
* 'Start browsing' is confusing since it takes users to account settings

This commit:
* Updates the copy to 'Manage your account'

fixes FXA-10376

---

I realized after I started on this that with our tickets recently landed with the CAD/pair updates, I'm not sure if users will ever see this page. It was pretty quick though and won't hurt to land.