### PR TITLE
fix(settings): Improve code and key input for reset password

### DIFF
--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
@@ -47,7 +47,6 @@ const FormVerifyTotp = ({
       ''
     );
     e.target.value = filteredCode;
-    console.log(e.target.value.length);
     e.target.value.length === codeLength
       ? setIsSubmitDisabled(false)
       : setIsSubmitDisabled(true);
@@ -65,7 +64,6 @@ const FormVerifyTotp = ({
     } else if (!isSubmitDisabled) {
       await verifyCode(code);
     }
-    setIsSubmitDisabled(false);
   };
 
   const getDisabledButtonTitle = () => {

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
@@ -35,7 +35,7 @@ export const RecoveryKeySetupHint = ({
 }: RecoveryKeySetupHintProps) => {
   const [bannerText, setBannerText] = useState<string>();
   const [hintError, setHintError] = useState<string>();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitDisabled, setIsSubmitDisabled] = useState(false);
   const ftlMsgResolver = useFtlMsgResolver();
 
   const { control, getValues, handleSubmit, register } = useForm<FormData>({
@@ -67,7 +67,7 @@ export const RecoveryKeySetupHint = ({
   };
 
   const onSubmit = async ({ hint }: FormData) => {
-    setIsLoading(true);
+    setIsSubmitDisabled(true);
     const trimmedHint = hint.trim();
 
     if (trimmedHint.length === 0) {
@@ -98,8 +98,6 @@ export const RecoveryKeySetupHint = ({
           }
           setBannerText(localizedError);
           logViewEvent(`flow.${viewName}`, 'create-hint.fail', e);
-        } finally {
-          setIsLoading(false);
         }
       }
     }
@@ -116,6 +114,7 @@ export const RecoveryKeySetupHint = ({
       defaultValue: getValues().hint,
     });
     const isTooLong: boolean = hint.length > MAX_HINT_LENGTH;
+
     return (
       <p
         className={classNames('text-end text-xs mt-2', {
@@ -159,7 +158,9 @@ export const RecoveryKeySetupHint = ({
             onChange={() => {
               setHintError(undefined);
               setBannerText(undefined);
+              isSubmitDisabled && setIsSubmitDisabled(false);
             }}
+            maxLength={MAX_HINT_LENGTH}
             {...{ errorText: hintError }}
           />
         </FtlMsg>
@@ -168,7 +169,7 @@ export const RecoveryKeySetupHint = ({
           <button
             className="cta-primary cta-xl w-full mt-6 mb-4"
             type="submit"
-            disabled={isLoading}
+            disabled={isSubmitDisabled}
           >
             Finish
           </button>

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
@@ -95,7 +95,6 @@ const AccountRecoveryConfirmKeyContainer = (_: RouteComponentProps) => {
         ftlMsgResolver,
         error
       );
-      setIsSubmitDisabled(false);
       setErrorMessage(localizedBannerMessage);
     }
   };

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -116,7 +116,7 @@ describe('AccountRecoveryConfirmKey', () => {
         expect(submitButton).toBeDisabled();
       });
 
-      it('with more than 32 characters', async () => {
+      it('with more than 32 characters extra characters are truncated', async () => {
         const user = userEvent.setup();
         renderWithLocalizationProvider(
           <Subject verifyRecoveryKey={mockVerifyRecoveryKey} />
@@ -127,7 +127,8 @@ describe('AccountRecoveryConfirmKey', () => {
         const input = screen.getByRole('textbox');
 
         await waitFor(() => user.type(input, `${MOCK_RECOVERY_KEY}abc`));
-        expect(submitButton).toBeDisabled();
+        expect(input).toHaveValue(MOCK_RECOVERY_KEY);
+        expect(submitButton).toBeEnabled();
       });
 
       it('with invalid Crockford base32', async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/container.tsx
@@ -24,12 +24,6 @@ const ResetPasswordContainer = ({
 
   let localizedErrorMessage = '';
 
-  console.log(
-    queryParamsToMetricsContext(
-      flowQueryParams as unknown as Record<string, string>
-    )
-  );
-
   const requestResetPasswordCode = async (email: string) => {
     const metricsContext = queryParamsToMetricsContext(
       flowQueryParams as unknown as Record<string, string>


### PR DESCRIPTION
## Because

* ConfimResetPassword code submit button was not disabled after an invalid code error
* AccountRecoveryConfirmKey input did not have a character limit
* RecoveryKeySetupHint returned an error when the submitted hint was too long, but submit stayed disabled even after updating the hint

## This pull request

* Set a character limit on the AccountRecoveryConfirmKey and RecoveryKeySetupHint inputs, ensure submit is re-enabled onChange
* Disable the ConfirmResetPassword submit button if the code is invalid

## Issue that this pull request solves

Closes: #FXA-10477, FXA-10481, FXA-10495

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
