### PR TITLE
feat(next): Sentry client to respect metrics opt-out

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/checkout/[interval]/[cartId]/layout.tsx
@@ -15,6 +15,7 @@ import {
 } from '@fxa/payments/ui/server';
 import { DEFAULT_LOCALE } from '@fxa/shared/l10n';
 import { config } from 'apps/payments/next/config';
+import { MetricsWrapper } from '@fxa/payments/ui';
 
 // TODO - Replace these placeholders as part of FXA-8227
 export const metadata = {
@@ -54,7 +55,7 @@ export default async function RootLayout({
   const [cms, cart] = await Promise.all([cmsDataPromise, cartDataPromise]);
 
   return (
-    <>
+    <MetricsWrapper cart={cart}>
       <SubscriptionTitle cartState={cart.state} l10n={l10n} />
 
       <section
@@ -114,6 +115,6 @@ export default async function RootLayout({
           showFXALinks={true}
         />
       </div>
-    </>
+    </MetricsWrapper>
   );
 }

--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -44,8 +44,9 @@ export type ResultCart = Readonly<Omit<Cart, 'id' | 'uid'>> & {
   readonly uid?: string;
 };
 
-export type WithUpcomingInvoiceCart = ResultCart & {
+export type WithContextCart = ResultCart & {
   invoicePreview: Invoice;
+  metricsOptedOut: boolean;
 };
 
 export type SetupCart = {

--- a/libs/payments/ui/src/index.ts
+++ b/libs/payments/ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './lib/client/components/PaymentSection';
 export * from './lib/client/components/PurchaseDetails';
 export * from './lib/client/components/SubmitButton';
 export * from './lib/client/components/LoadingSpinner';
+export * from './lib/client/components/MetricsWrapper';
 export * from './lib/client/providers/Providers';
 export * from './lib/utils/helpers';
 export * from './lib/utils/types';

--- a/libs/payments/ui/src/lib/client/components/MetricsWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/MetricsWrapper.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { WithContextCart } from '@fxa/payments/cart';
+import { useEffect } from 'react';
+
+export function MetricsWrapper({
+  cart,
+  children,
+}: {
+  cart?: WithContextCart;
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    cart &&
+      Sentry.getGlobalScope().setTag('metricsOptedOut', cart.metricsOptedOut);
+  }, [cart?.metricsOptedOut]);
+
+  return <>{children}</>;
+}

--- a/libs/shared/sentry/src/lib/next/client.ts
+++ b/libs/shared/sentry/src/lib/next/client.ts
@@ -12,12 +12,7 @@ import { buildSentryConfig } from '../config-builder';
 import { Logger } from '../sentry.types';
 import { beforeSend } from '../utils/beforeSend.client';
 
-/**
- * @@todo - To be worked on in FXA-10398
- */
-const sentryEnabled = true;
-
-export function initSentryForNextjsClient(
+export async function initSentryForNextjsClient(
   config: SentryConfigOpts,
   log?: Logger
 ) {
@@ -40,7 +35,7 @@ export function initSentryForNextjsClient(
     Sentry.init({
       ...opts,
       beforeSend: function (event: Sentry.ErrorEvent) {
-        return beforeSend(sentryEnabled, opts, event);
+        return beforeSend(opts, event);
       },
     });
   } catch (e) {

--- a/libs/shared/sentry/src/lib/utils/beforeSend.client.spec.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.client.spec.ts
@@ -16,15 +16,13 @@ const config: SentryConfigOpts = {
   },
 };
 
-const sentryEnabled = true;
-
 describe('beforeSend', () => {
   it('works without request url', () => {
     const data = {
       key: 'value',
     } as unknown as Sentry.ErrorEvent;
 
-    const resultData = beforeSend(sentryEnabled, config, data);
+    const resultData = beforeSend(config, data);
 
     expect(data).toEqual(resultData);
   });
@@ -40,7 +38,7 @@ describe('beforeSend', () => {
       type: undefined,
     } as Sentry.ErrorEvent;
 
-    const resultData = beforeSend(sentryEnabled, config, data);
+    const resultData = beforeSend(config, data);
     expect(resultData?.fingerprint?.[0]).toEqual('errno100');
     expect(resultData?.level).toEqual('info');
   });
@@ -62,7 +60,7 @@ describe('beforeSend', () => {
       },
     };
 
-    const resultData = beforeSend(sentryEnabled, config, badData);
+    const resultData = beforeSend(config, badData);
     expect(resultData?.request?.url).toEqual(goodData.request.url);
   });
 
@@ -88,7 +86,7 @@ describe('beforeSend', () => {
       },
     };
 
-    const resultData = beforeSend(sentryEnabled, config, badData);
+    const resultData = beforeSend(config, badData);
     expect(resultData?.request?.headers?.Referer).toEqual(
       goodData.request.headers.Referer
     );
@@ -125,7 +123,7 @@ describe('beforeSend', () => {
       type: undefined,
     };
 
-    const resultData = beforeSend(sentryEnabled, config, data);
+    const resultData = beforeSend(config, data);
 
     expect(
       resultData?.exception?.values?.[0].stacktrace?.frames?.[0].abs_path
@@ -133,5 +131,27 @@ describe('beforeSend', () => {
     expect(
       resultData?.exception?.values?.[0].stacktrace?.frames?.[1].abs_path
     ).toEqual(goodAbsPath);
+  });
+
+  it('doesn\t send data if metricsOptOut tag is set and true', () => {
+    const data = {
+      key: 'value',
+      tags: {
+        metricsOptedOut: true,
+      },
+    } as unknown as Sentry.ErrorEvent;
+    const resultData = beforeSend(config, data);
+    expect(resultData).toBeNull();
+  });
+
+  it('sends data if metricsOptOut tag is set and false', () => {
+    const data = {
+      key: 'value',
+      tags: {
+        metricsOptedOut: false,
+      },
+    } as unknown as Sentry.ErrorEvent;
+    const resultData = beforeSend(config, data);
+    expect(data).toEqual(resultData);
   });
 });

--- a/libs/shared/sentry/src/lib/utils/beforeSend.client.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.client.ts
@@ -17,12 +17,8 @@ import { tagFxaName } from './tagFxaName';
  *  Modified error object data
  * @private
  */
-export function beforeSend(
-  sentryEnabled: boolean,
-  opts: SentryConfigOpts,
-  event: Sentry.ErrorEvent
-) {
-  if (sentryEnabled === false) {
+export function beforeSend(opts: SentryConfigOpts, event: Sentry.ErrorEvent) {
+  if (event.tags?.metricsOptedOut) {
     return null;
   }
 


### PR DESCRIPTION
## Because

- Currently metrics are still collected from the user via sentry, regardless of their "opt-out" status.

## This pull request

- Checks the user's account status via the cart service, which sets a tag at the top level of the sentry client instance
- If the metricsOptOut tag is set with the value `true`, then sentry does not send events from anywhere on the front end

## Issue that this pull request solves

Closes: [# FXA-10398](https://mozilla-hub.atlassian.net/browse/FXA-10398)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
