### PR TITLE
Log account in and navigate to /settings after password reset

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -118,8 +118,9 @@ test.describe('severity-2 #smoke', () => {
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signinVersion.query}`
       );
-      await signin.fillOutEmailFirstForm(email);
-      await signin.fillOutPasswordForm(password);
+      // a successful password reset means that the user is signed in
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await signin.signInButton.click();
 
       await expect(page).toHaveURL(/settings/);
       const keys2 = await _getKeys(

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -98,14 +98,6 @@ test.describe('severity-2 #smoke', () => {
 
       await resetPassword.fillOutNewPasswordForm(password);
 
-      await expect(page).toHaveURL(/reset_password_verified/);
-
-      await page.goto(
-        `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signinVersion.query}`
-      );
-      await signin.fillOutEmailFirstForm(email);
-      await signin.fillOutPasswordForm(password);
-
       await expect(page).toHaveURL(/settings/);
       const keys2 = await _getKeys(
         signinVersion.version,

--- a/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
@@ -43,12 +43,11 @@ test.describe('severity-1 #smoke', () => {
 
       await relier.goto();
       await relier.clickEmailFirst();
-      await signin.fillOutEmailFirstForm(credentials.email);
-      // old password fails
-      await signin.fillOutPasswordForm(credentials.password);
-      await expect(page.getByText('Incorrect password')).toBeVisible();
-      // new passwowrd works
-      await signin.fillOutPasswordForm(newPassword);
+
+      // a successful password reset means that the user is signed in
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await signin.signInButton.click();
+
       await expect(page).toHaveURL(target.relierUrl);
       expect(await relier.isLoggedIn()).toBe(true);
 

--- a/packages/functional-tests/tests/resetPassword/oauthResetPasswordSyncMobile.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPasswordSyncMobile.spec.ts
@@ -11,7 +11,13 @@ test.describe('severity-1 #smoke', () => {
   test.describe('oauth reset password Sync mobile react', () => {
     test('reset password through Sync mobile', async ({
       target,
-      syncBrowserPages: { page, connectAnotherDevice, resetPassword, signin },
+      syncBrowserPages: {
+        page,
+        connectAnotherDevice,
+        resetPassword,
+        signin,
+        settings,
+      },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -32,25 +38,10 @@ test.describe('severity-1 #smoke', () => {
       await resetPassword.fillOutResetPasswordCodeForm(code);
       await resetPassword.fillOutNewPasswordForm(newPassword);
 
-      await expect(page).toHaveURL(/reset_password_verified/);
-      await expect(
-        resetPassword.passwordResetConfirmationHeading
-      ).toBeVisible();
-
-      // TODO in FXA-9561 - Remove this temporary test of sign in with new password
-      await page.goto(
-        `${
-          target.contentServerUrl
-        }/authorization/?${syncMobileOAuthQueryParams.toString()}`
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText(
+        'Your password has been reset'
       );
-      // expect user to be signed in to sync and prompted for cached signin
-      // old password fails
-      await signin.fillOutPasswordForm(credentials.password);
-      await expect(page.getByText('Incorrect password')).toBeVisible();
-      // new passwowrd works
-      await signin.fillOutPasswordForm(newPassword);
-
-      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 
       // update password for cleanup function
       credentials.password = newPassword;

--- a/packages/functional-tests/tests/resetPassword/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword.spec.ts
@@ -27,15 +27,6 @@ test.describe('severity-1 #smoke', () => {
     // Create and submit new password
     await resetPassword.fillOutNewPasswordForm(newPassword);
 
-    // Wait for new page to navigate
-    await expect(page).toHaveURL(/reset_password_verified/);
-
-    await page.goto(target.contentServerUrl);
-
-    await signin.fillOutEmailFirstForm(credentials.email);
-
-    await signin.fillOutPasswordForm(newPassword);
-
     await expect(settings.settingsHeading).toBeVisible();
 
     // Cleanup requires setting this value to correct password

--- a/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
@@ -127,11 +127,10 @@ test.describe('severity-1 #smoke', () => {
       await expect(resetPassword.dataLossWarning).toBeVisible();
       await resetPassword.fillOutNewPasswordForm(newPassword);
 
-      await expect(
-        resetPassword.passwordResetConfirmationHeading
-      ).toBeVisible();
-
-      await signinAccount(credentials.email, newPassword, settings, signin);
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText(
+        'Your password has been reset'
+      );
 
       await expect(settings.recoveryKey.status).toHaveText('Not Set');
 

--- a/packages/functional-tests/tests/resetPassword/syncV3ResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/syncV3ResetPassword.spec.ts
@@ -8,7 +8,7 @@ test.describe('severity-1 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 reset password react', () => {
     test('reset pw for sync user', async ({
       target,
-      syncBrowserPages: { page, resetPassword },
+      syncBrowserPages: { page, resetPassword, settings },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -27,13 +27,10 @@ test.describe('severity-1 #smoke', () => {
       await expect(resetPassword.dataLossWarning).toBeVisible();
       await resetPassword.fillOutNewPasswordForm(newPassword);
 
-      await expect(page).toHaveURL(/reset_password_verified/);
-      await expect(
-        resetPassword.passwordResetConfirmationHeading
-      ).toBeVisible();
-
-      // TODO in FXA-9561 - Verify that the service name is displayed in the "Continue to ${serviceName}" button
-      // This functionality is not yet implemented in the reset password flow
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText(
+        'Your password has been reset'
+      );
 
       // Update credentials file so that account can be deleted as part of test cleanup
       credentials.password = newPassword;

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -95,6 +95,7 @@ export const App = ({
 
   // Determine if user is actually signed in
   const [isSignedIn, setIsSignedIn] = useState<boolean | undefined>(undefined);
+
   useEffect(() => {
     if (!integration) {
       return;

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -773,6 +773,10 @@ export class Account implements AccountData {
       accountReset.unwrapBKeyVersion2 = credentialsV2?.unwrapBKey;
       currentAccount(getStoredAccountData(accountReset));
       sessionToken(accountReset.sessionToken);
+      this.apolloClient.cache.writeQuery({
+        query: GET_LOCAL_SIGNED_IN_STATUS,
+        data: { isSignedIn: true },
+      });
       return accountReset;
     } catch (err) {
       throw getHandledError(err);


### PR DESCRIPTION
Because:
 - the user could have a verified session after successfully resetting
   their password for an account

This commit:
 - logs the account in and take the user to /settings if the session is
   verified and the user did not use a recovery key during the reset
