### PR TITLE
fix(oauth-desktop): Call fxaLogin before fxaOAuthLogin with expected data during signin

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -295,7 +295,7 @@
         "id": "5882386c6d801776",
         "hashedSecret": "71b5283536f1f1c331eca2f75c58a5947d7a7ac54164eadb4b33a889afe89fbf",
         "imageUri": "",
-        "redirectUri": "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel",
+        "redirectUri": "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel,http://localhost:3030/oauth/success/5882386c6d801776",
         "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session https://identity.mozilla.com/ids/ecosystem_telemetry",
         "trusted": true,
         "canGrant": true,

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -24,6 +24,7 @@
         "redirectUris": [
           "http://localhost:3030/oauth/success/a2270f727f45f648",
           "http://localhost:3030/oauth/success/1b1a3e44c54fbb58",
+          "http://localhost:3030/oauth/success/5882386c6d801776",
           "urn:ietf:wg:oauth:2.0:oob:pair-auth-webchannel",
           "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel"
         ]

--- a/packages/fxa-dev-launcher/README.md
+++ b/packages/fxa-dev-launcher/README.md
@@ -12,6 +12,8 @@ Available options:
 - `FIREFOX_DEBUGGER=true` - open the [Browser Toolbox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox) on start (NOTE: `false` by default for speed).
 - `FXA_DESKTOP_CONTEXT` - context value for the fxa-content-server: `context=[value]` (NOTE: `fx_desktop_v3` is default).
 
+Tip: run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 yarn firefox` to test the OAuth Desktop flow.
+
 ### Basic Usage Example in OS X
 
 - Download node.js

--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -116,6 +116,12 @@ const fxaProfile = {
   'webchannel.allowObject.urlWhitelist': fxaEnv.content.slice(0, -1),
   'browser.tabs.firefox-view': true,
   'identity.fxaccounts.autoconfig.uri': fxaEnv.content,
+  // TODO in FXA-9872, make oauth_webchannel_v1 the default context and
+  // change these values for fx_desktop_v3. (Also, update the README note)
+  ...(process.env.FXA_DESKTOP_CONTEXT === 'oauth_webchannel_v1' && {
+    'identity.fxaccounts.oauth.enabled': true,
+    'identity.fxaccounts.contextParam': 'oauth_webchannel_v1',
+  }),
 };
 
 // Configuration for local sync development

--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -18,7 +18,7 @@ export function hardNavigate(
   // If there are any query params in the href, we automatically include them in the new url.
   const url = new URL(href, window.location.origin);
 
-  if (includeCurrentQueryParams) {
+  if (includeCurrentQueryParams && window.location.search) {
     const currentSearchParams = new URLSearchParams(window.location.search);
     currentSearchParams.forEach((value, key) => {
       if (!url.searchParams.has(key)) {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -91,7 +91,10 @@ const SigninRecoveryCode = ({
       queryParams: location.search,
     };
 
-    const { error } = await handleNavigation(navigationOptions, true);
+    const { error } = await handleNavigation(navigationOptions, {
+      handleFxaLogin: true,
+      handleFxaOAuthLogin: true,
+    });
     if (error) {
       setBannerErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, error));
     }

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -254,7 +254,9 @@ describe('SigninTokenCode page', () => {
 
         await expectSuccessGleanEvents();
         expect(hardNavigateSpy).toHaveBeenCalledWith(
-          '/post_verify/password/force_password_change'
+          '/post_verify/password/force_password_change',
+          {},
+          true
         );
       });
       // it('with sync integration', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -160,7 +160,10 @@ const SigninTokenCode = ({
 
         await GleanMetrics.isDone();
 
-        const { error: navError } = await handleNavigation(navigationOptions);
+        const { error: navError } = await handleNavigation(navigationOptions, {
+          handleFxaLogin: false,
+          handleFxaOAuthLogin: true,
+        });
         if (navError) {
           const localizedError = getLocalizedErrorMessage(
             ftlMsgResolver,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -131,7 +131,10 @@ export const SigninTotpCode = ({
         showInlineRecoveryKeySetup,
       };
 
-      const { error } = await handleNavigation(navigationOptions, true);
+      const { error } = await handleNavigation(navigationOptions, {
+        handleFxaLogin: true,
+        handleFxaOAuthLogin: true,
+      });
       if (error) {
         setBannerError(getLocalizedErrorMessage(ftlMsgResolver, error));
       }

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -132,10 +132,10 @@ const SigninUnblock = ({
         queryParams: location.search,
       };
 
-      const { error: navError } = await handleNavigation(
-        navigationOptions,
-        true
-      );
+      const { error: navError } = await handleNavigation(navigationOptions, {
+        handleFxaLogin: true,
+        handleFxaOAuthLogin: true,
+      });
       if (navError) {
         setBannerErrorMessage(
           getLocalizedErrorMessage(ftlMsgResolver, navError)

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -298,6 +298,10 @@ const SigninContainer = ({
       if (
         'data' in result &&
         result.data &&
+        // NOTE, Oauth desktop needs to add `service=sync` as a query parameter for this
+        // to take users to the inline recovery key flow (SYNC-4408). (We may want
+        // check for client ID to determine oauth desktop instead, TBD slight refactor for
+        // FXA-10313).
         options.service === 'sync' &&
         config.featureFlags?.recoveryCodeSetupOnSyncSignIn === true &&
         localStorage.getItem(

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -208,10 +208,10 @@ const Signin = ({
           showInlineRecoveryKeySetup: data.showInlineRecoveryKeySetup,
         };
 
-        const { error: navError } = await handleNavigation(
-          navigationOptions,
-          true
-        );
+        const { error: navError } = await handleNavigation(navigationOptions, {
+          handleFxaLogin: true,
+          handleFxaOAuthLogin: true,
+        });
         if (navError) {
           setBannerError(getLocalizedErrorMessage(ftlMsgResolver, navError));
         }

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -107,9 +107,11 @@ export function createMockSigninWebIntegration(): SigninIntegration {
   };
 }
 
-export function createMockSigninSyncIntegration(): SigninIntegration {
+export function createMockSigninSyncIntegration(
+  type = IntegrationType.OAuth
+): SigninIntegration {
   return {
-    type: IntegrationType.OAuth,
+    type,
     isSync: () => true,
     wantsKeys: () => true,
     getService: () => MozServices.FirefoxSync,

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -13,21 +13,23 @@ import { currentAccount } from '../../lib/cache';
 import firefox from '../../lib/channels/firefox';
 import { AuthError } from '../../lib/oauth';
 import GleanMetrics from '../../lib/glean';
+import { OAuthData } from '../../lib/oauth/hooks';
 
 interface NavigationTarget {
   to: string;
-  state?: SigninLocationState;
+  locationState?: SigninLocationState;
   shouldHardNavigate?: boolean;
+  oauthData?: OAuthData;
   error?: undefined;
 }
 interface NavigationTargetError {
   to?: undefined;
-  state?: undefined;
+  locationState?: undefined;
   shouldHardNavigate?: undefined;
+  oauthData?: undefined;
   error: AuthError;
 }
 
-// TODO: don't hard navigate once ConnectAnotherDevice is converted to React
 export function getSyncNavigate(
   queryParams: string,
   showInlineRecoveryKeySetup?: boolean
@@ -43,86 +45,111 @@ export function getSyncNavigate(
   searchParams.set('showSuccessMessage', 'true');
   return {
     to: `/pair?${searchParams}`,
+    // TODO: don't hard navigate once Pair is converted to React
     shouldHardNavigate: true,
   };
 }
 
 // In Backbone and React, 'confirm_signup_code' and 'signin_token_code' send key
-// and token data up to Sync with fxa_login and then the CAD page (currently
+// and token data up to Sync with fxa_login and then the CAD/pair page (currently
 // Backbone) completes the signin with fxa_status.
 //
 // In Backbone happy path signin (session is verified after signin) as well as
 // Backbone 'signin_totp_code' and `signin_unblock`, we send key/token data up on
-// the CAD page itself with an fxa_status message. We don't want to do this with
-// React signin until CAD is converted to React because we'd need to pass this
+// the CAD/pair page itself with an fxa_status message. We don't want to do this with
+// React signin until CAD/pair is converted to React because we'd need to pass this
 // data back to Backbone. This means temporarily we need to send the sync data up
-// _before_ we hard navigate to CAD in these flows.
+// _before_ we hard navigate to CAD/pair in these flows.
 export async function handleNavigation(
   navigationOptions: NavigationOptions,
-  tempHandleSyncLogin = false
+  {
+    handleFxaLogin = false,
+    handleFxaOAuthLogin = false,
+  }: { handleFxaLogin?: boolean; handleFxaOAuthLogin?: boolean } = {}
 ) {
-  const { to, state, shouldHardNavigate, error } = await getNavigationTarget(
-    navigationOptions
-  );
-  if (error) {
-    return { error };
+  const { integration } = navigationOptions;
+  const isOAuth = isOAuthIntegration(integration);
+  const isSync = integration.isSync();
+
+  if (!navigationOptions.signinData.verified) {
+    const { to, locationState } =
+      getUnverifiedNavigationTarget(navigationOptions);
+    if (
+      isSync &&
+      handleFxaLogin &&
+      // If the _next page_ is `signin_totp_code`, we don't want to send this
+      // because we end up sending it twice with the first message containing
+      // `verified: false`, causing a Sync sign-in issue (see FXA-9837).
+      !to?.includes('signin_totp_code')
+    ) {
+      sendFxaLogin(navigationOptions);
+    }
+    performNavigation({ to, locationState });
+    return { error: undefined };
   }
 
   if (
-    tempHandleSyncLogin &&
-    navigationOptions.integration.isSync() &&
-    // If the _next page_ is `signin_totp_code`, we also don't want to send this
-    // because we end up sending it twice with the first message containing
-    // `verified: false`, causing a Sync sign-in issue (see FXA-9837).
-    !to?.includes('signin_totp_code')
+    navigationOptions.signinData.verificationReason ===
+    VerificationReasons.CHANGE_PASSWORD
   ) {
-    firefox.fxaLogin({
-      email: navigationOptions.email,
-      // keyFetchToken and unwrapBKey should always exist if Sync integration
-      keyFetchToken: navigationOptions.signinData.keyFetchToken!,
-      unwrapBKey: navigationOptions.unwrapBKey!,
-      sessionToken: navigationOptions.signinData.sessionToken,
-      uid: navigationOptions.signinData.uid,
-      verified: navigationOptions.signinData.verified,
-      // This is necessary or the user will be signed in but Sync will be 'off'
-      services: {
-        sync: {},
-      },
-    });
+    // TODO in FXA-6653: remove hardNavigate when this route is converted to React
+    hardNavigate('/post_verify/password/force_password_change', {}, true);
+    return { error: undefined };
   }
 
-  if (shouldHardNavigate) {
-    // Hard navigate to RP, or (temp until CAD is Reactified) CAD
-    hardNavigate(to);
-  } else if (state) {
-    navigate(to, { state });
-  } else {
-    navigate(to);
+  if (isSync && handleFxaLogin) {
+    // This _must_ be sent before fxaOAuthLogin for Desktop OAuth flow.
+    // Mobile doesn't care about this message (see FXA-10388)
+    sendFxaLogin(navigationOptions);
   }
+
+  if (!isOAuth) {
+    const { to, locationState, shouldHardNavigate } =
+      await getNonOAuthNavigationTarget(navigationOptions);
+    performNavigation({ to, locationState, shouldHardNavigate });
+    return { error: undefined };
+  }
+
+  // Note that OAuth redirect can only be obtained when the session is verified,
+  // otherwise oauth/authorization endpoint throws an "unconfirmed session" error
+  if (isOAuth) {
+    const { to, locationState, oauthData, shouldHardNavigate, error } =
+      await getOAuthNavigationTarget(navigationOptions);
+
+    if (error) {
+      return { error };
+    }
+    if (isSync && handleFxaOAuthLogin && oauthData) {
+      firefox.fxaOAuthLogin({
+        action: 'signin',
+        code: oauthData.code,
+        redirect: oauthData.redirect,
+        state: oauthData.state,
+      });
+    }
+    performNavigation({ to, locationState, shouldHardNavigate });
+  }
+
   return { error: undefined };
 }
 
-const getNavigationTarget = async ({
-  email,
-  signinData,
-  unwrapBKey,
-  integration,
-  finishOAuthFlowHandler,
-  redirectTo,
-  queryParams = '',
-  showInlineRecoveryKeySetup,
-}: NavigationOptions): Promise<NavigationTarget | NavigationTargetError> => {
-  const isOAuth = isOAuthIntegration(integration);
+const createSigninLocationState = (
+  navigationOptions: NavigationOptions
+): SigninLocationState => {
   const {
-    verified,
-    verificationReason,
-    verificationMethod,
-    keyFetchToken,
-    uid,
-    sessionToken,
-  } = signinData;
-
-  const createSigninLocationState = (): SigninLocationState => ({
+    email,
+    signinData: {
+      uid,
+      sessionToken,
+      verified,
+      verificationMethod,
+      verificationReason,
+      keyFetchToken,
+    },
+    unwrapBKey,
+    showInlineRecoveryKeySetup,
+  } = navigationOptions;
+  return {
     email,
     uid,
     sessionToken,
@@ -132,91 +159,131 @@ const getNavigationTarget = async ({
     keyFetchToken,
     unwrapBKey,
     showInlineRecoveryKeySetup,
+  };
+};
+
+function sendFxaLogin(navigationOptions: NavigationOptions) {
+  const isOAuth = isOAuthIntegration(navigationOptions.integration);
+  firefox.fxaLogin({
+    email: navigationOptions.email,
+    sessionToken: navigationOptions.signinData.sessionToken,
+    uid: navigationOptions.signinData.uid,
+    verified: navigationOptions.signinData.verified,
+    // Do not send these values if OAuth. Mobile doesn't care about this message, and
+    // sending these values can cause intermittent sync disconnect issues in oauth desktop.
+    ...(!isOAuth && {
+      // keyFetchToken and unwrapBKey should always exist if Sync integration
+      keyFetchToken: navigationOptions.signinData.keyFetchToken!,
+      unwrapBKey: navigationOptions.unwrapBKey!,
+    }),
+    // This is necessary or the user will be signed in but Sync will be 'off'
+    services: {
+      sync: {},
+    },
   });
+}
 
-  const getUnverifiedNav = () => {
-    const getUnverifiedNavTo = () => {
-      // TODO in FXA-9177 Consider storing state in Apollo cache instead of location state
-      if (
-        ((verificationReason === VerificationReasons.SIGN_IN ||
-          verificationReason === VerificationReasons.CHANGE_PASSWORD) &&
-          verificationMethod === VerificationMethods.TOTP_2FA) ||
-        (isOAuth && integration.wantsTwoStepAuthentication())
-      ) {
-        return `/signin_totp_code${queryParams}`;
-      } else if (verificationReason === VerificationReasons.SIGN_UP) {
-        return `/confirm_signup_code${queryParams}`;
-      }
-      return `/signin_token_code${queryParams}`;
-    };
+const getUnverifiedNavigationTarget = (
+  navigationOptions: NavigationOptions
+) => {
+  const { verificationReason, verificationMethod } =
+    navigationOptions.signinData;
+  const { integration, queryParams } = navigationOptions;
+  const isOAuth = isOAuthIntegration(integration);
 
-    return { to: getUnverifiedNavTo(), state: createSigninLocationState() };
+  const getUnverifiedNavTo = () => {
+    // TODO in FXA-9177 Consider storing state in Apollo cache instead of location state
+    if (
+      ((verificationReason === VerificationReasons.SIGN_IN ||
+        verificationReason === VerificationReasons.CHANGE_PASSWORD) &&
+        verificationMethod === VerificationMethods.TOTP_2FA) ||
+      (isOAuth && integration.wantsTwoStepAuthentication())
+    ) {
+      return `/signin_totp_code${queryParams || ''}`;
+    } else if (verificationReason === VerificationReasons.SIGN_UP) {
+      return `/confirm_signup_code${queryParams || ''}`;
+    }
+    return `/signin_token_code${queryParams || ''}`;
   };
 
-  if (!verified) {
-    return getUnverifiedNav();
+  return {
+    to: getUnverifiedNavTo(),
+    locationState: createSigninLocationState(navigationOptions),
+  };
+};
+
+function performNavigation({
+  to,
+  shouldHardNavigate = false,
+  locationState,
+}: Pick<NavigationTarget, 'to' | 'locationState' | 'shouldHardNavigate'>) {
+  if (shouldHardNavigate) {
+    // Hard navigate to RP, or (temp until CAD/pair is Reactified)
+    hardNavigate(to);
+  } else if (locationState) {
+    navigate(to, { state: locationState });
+  } else {
+    navigate(to);
   }
+}
 
-  if (verificationReason === VerificationReasons.CHANGE_PASSWORD) {
-    return {
-      to: `/post_verify/password/force_password_change${
-        (queryParams.length > 1 && queryParams) || ''
-      }`,
-      // TODO in FXA-6653: remove shouldHardNavigate when this route is converted to React
-      shouldHardNavigate: true,
-    };
-  }
-
-  // OAuth redirect can only be obtained when the session is verified
-  // otherwise oauth/authorization endpoint throws an "unconfirmed session" error
-  if (isOAuth) {
-    const { error, redirect, code, state } = await finishOAuthFlowHandler(
-      uid,
-      sessionToken,
-      keyFetchToken,
-      unwrapBKey
-    );
-    if (error) {
-      if (
-        error.errno === AuthUiErrors.TOTP_REQUIRED.errno ||
-        error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
-      ) {
-        GleanMetrics.login.error({ event: { reason: error.message } });
-        return {
-          to: `/inline_totp_setup${queryParams}`,
-          state: createSigninLocationState(),
-        };
-      }
-      return { error };
-    }
-
-    if (integration.isSync()) {
-      firefox.fxaOAuthLogin({
-        action: 'signin',
-        code,
-        redirect,
-        state,
-      });
-      return {
-        ...getSyncNavigate(queryParams, showInlineRecoveryKeySetup),
-        state: createSigninLocationState(),
-      };
-    }
-    return { to: redirect, shouldHardNavigate: true };
-  }
-
+const getNonOAuthNavigationTarget = async (
+  navigationOptions: NavigationOptions
+): Promise<NavigationTarget> => {
+  const { integration, queryParams, showInlineRecoveryKeySetup, redirectTo } =
+    navigationOptions;
   if (integration.isSync()) {
     return {
       ...getSyncNavigate(queryParams, showInlineRecoveryKeySetup),
-      state: createSigninLocationState(),
+      locationState: createSigninLocationState(navigationOptions),
     };
   }
-
   if (redirectTo) {
     return { to: redirectTo, shouldHardNavigate: true };
   }
-
   return { to: '/settings' };
+};
+
+const getOAuthNavigationTarget = async (
+  navigationOptions: NavigationOptions
+): Promise<NavigationTarget | NavigationTargetError> => {
+  const locationState = createSigninLocationState(navigationOptions);
+  const { error, redirect, code, state } =
+    await navigationOptions.finishOAuthFlowHandler(
+      navigationOptions.signinData.uid,
+      navigationOptions.signinData.sessionToken,
+      navigationOptions.signinData.keyFetchToken,
+      navigationOptions.unwrapBKey
+    );
+  if (error) {
+    if (
+      error.errno === AuthUiErrors.TOTP_REQUIRED.errno ||
+      error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
+    ) {
+      GleanMetrics.login.error({ event: { reason: error.message } });
+      return {
+        to: `/inline_totp_setup${navigationOptions.queryParams || ''}`,
+        locationState,
+      };
+    }
+    return { error };
+  }
+
+  if (navigationOptions.integration.isSync()) {
+    return {
+      ...getSyncNavigate(
+        navigationOptions.queryParams,
+        locationState.showInlineRecoveryKeySetup
+      ),
+      oauthData: {
+        code,
+        redirect,
+        state,
+      },
+      locationState,
+    };
+  }
+  return { to: redirect, shouldHardNavigate: true };
 };
 
 export function getSigninState(


### PR DESCRIPTION
Because:
* We want to support the new oauth desktop flow, and there is a bug during signin because we were sending fxaOAuthLogin first

This commit:
* Refactors signin/utils to swap the order these web channel messages fire
* Fixes an additional intermittent bug for 2FA and new account signins caused by sending keyFetchToken and unwrapBKey
* Adds oauth desktop config
* Renames oauthCode to oauthData in oauth hook

fixes FXA-10388

---

Most of this was already accounted for in page-level tests. I'm going to be taking a better look at our test coverage in FXA-10328 next.

Test this by running `yarn firefox` for our desktop v3 flow and `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 yarn firefox` for the oauth desktop flow. Check out a standard Sync signin (requires email code), a new Sync account signin (no code), and 2FA signin. Users should be fully logged into Sync.