### PR TITLE
chore(git): Gitignore new public/static folders for hashed l10n files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,12 +146,14 @@ packages/fxa-react/**/*.d.ts
 !packages/fxa-react/pm2.config.js
 packages/fxa-react/fxa-content-server-l10n/
 packages/fxa-react/public/locales
+packages/fxa-react/public/static
 packages/fxa-react/test/
 
 # fxa-settings
 packages/fxa-settings/fxa-content-server-l10n/
 packages/fxa-settings/public/static
 packages/fxa-settings/public/locales
+packages/fxa-settings/public/static
 packages/fxa-settings/legal-docs/
 packages/fxa-settings/public/legal-docs
 packages/fxa-settings/test/


### PR DESCRIPTION
Because:

* We don't want to commit these build files

This commit:

* Gitignores the folders

Closes #

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
