### PR TITLE
bug(admin): Use start / stop when reading from flat file

### DIFF
--- a/packages/fxa-admin-server/src/scripts/restore-rk.mjs
+++ b/packages/fxa-admin-server/src/scripts/restore-rk.mjs
@@ -143,8 +143,11 @@ async function main() {
       const result = await mainKnex.raw(
         `SELECT accounts.uid, emails.email, accounts.keysChangedAt
          FROM accounts join emails on accounts.uid = emails.uid and emails.isPrimary
-         WHERE accounts.uid=?`,
-        [uid]
+         WHERE
+          accounts.uid=?
+          AND accounts.keysChangedAt >= (UNIX_TIMESTAMP(DATE(?))*1000)
+          AND accounts.keysChangedAt <= (UNIX_TIMESTAMP(DATE(?))*1000)`,
+        [uid, argv.start, argv.stop]
       );
       if (result[0].length === 1) {
         await processUser(result[0][0]);


### PR DESCRIPTION
## Because

- We might not want to process all users in the flat file

## This pull request

- Applies start stop times to flat file processing

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
