### PR TITLE
feat(totp): Add backend methods for 2FA before password reset

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1799,6 +1799,50 @@ export default class AuthClient {
     return this.sessionGet('/totp/exists', sessionToken, headers);
   }
 
+  async checkTotpTokenExistsWithPasswordForgotToken(
+    token: hexstring,
+    headers?: Headers
+  ): Promise<{ exists: boolean; verified: boolean }> {
+    return this.hawkRequest(
+      'GET',
+      '/totp/exists',
+      token,
+      tokenType.passwordForgotToken,
+      null,
+      headers
+    );
+  }
+
+  async checkTotpTokenCodeWithPasswordForgotToken(
+    token: hexstring,
+    code: string,
+    headers?: Headers
+  ): Promise<{ success: boolean }> {
+    return this.hawkRequest(
+      'POST',
+      '/totp/verify',
+      token,
+      tokenType.passwordForgotToken,
+      { code },
+      headers
+    );
+  }
+
+  async consumeRecoveryCodeWithPasswordForgotToken(
+    token: hexstring,
+    code: string,
+    headers?: Headers
+  ): Promise<{ success: boolean }> {
+    return this.hawkRequest(
+      'POST',
+      '/totp/verify/recoveryCode',
+      token,
+      tokenType.passwordForgotToken,
+      { code },
+      headers
+    );
+  }
+
   async sendLoginPushRequest(
     sessionToken: hexstring,
     headers?: Headers

--- a/packages/fxa-auth-server/docs/swagger/totp-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/totp-api.ts
@@ -38,9 +38,33 @@ const TOTP_EXISTS_GET = {
   description: '/totp/exists',
   notes: [
     dedent`
-      🔒 Authenticated with session token
+      🔒 Authenticated with session token or password forgot token
 
       Checks to see if the user has a TOTP token.
+    `,
+  ],
+};
+
+const TOTP_VERIFY_POST = {
+  ...TAGS_TOTP,
+  description: '/totp/verify',
+  notes: [
+    dedent`
+      🔒 Authenticated with password forgot token
+
+      Checks to see if a TOTP code is valid. This is used when a user is resetting their password.
+    `,
+  ],
+};
+
+const TOTP_VERIFY_RECOVERY_CODE_POST = {
+  ...TAGS_TOTP,
+  description: '/totp/verify/recoveryCode',
+  notes: [
+    dedent`
+      🔒 Authenticated with password forgot token
+
+      Checks to see if a Recovery code is valid. If the code is valid, it will be consumed and deleted. This is used when a user is resetting their password.
     `,
   ],
 };
@@ -62,6 +86,8 @@ const API_DOCS = {
   TOTP_CREATE_POST,
   TOTP_DESTROY_POST,
   TOTP_EXISTS_GET,
+  TOTP_VERIFY_POST,
+  TOTP_VERIFY_RECOVERY_CODE_POST,
 };
 
 export default API_DOCS;

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -16,6 +16,8 @@ const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const { Container } = require('typedi');
 const { AccountEventsManager } = require('../account-events');
 
+const RECOVERY_CODE_SANE_MAX_LENGTH = 20;
+
 module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
   const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
 
@@ -208,7 +210,10 @@ module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
       options: {
         ...TOTP_DOCS.TOTP_EXISTS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: [
+            'multiStrategySessionToken',
+            'multiStrategyPasswordForgotToken',
+          ],
         },
         response: {
           schema: isA.object({
@@ -238,6 +243,111 @@ module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
             throw err;
           }
         }
+      },
+    },
+    {
+      method: 'POST',
+      path: '/totp/verify',
+      options: {
+        ...TOTP_DOCS.TOTP_VERIFY_POST,
+        auth: {
+          strategy: 'passwordForgotToken',
+        },
+        validate: {
+          payload: isA.object({
+            code: isA
+              .string()
+              .max(32)
+              .regex(validators.DIGITS)
+              .required()
+              .description(DESCRIPTION.codeTotp),
+          }),
+        },
+        response: {
+          schema: isA.object({
+            success: isA.boolean(),
+          }),
+        },
+      },
+      handler: async function (request) {
+        log.begin('totp.verify', request);
+
+        const code = request.payload.code;
+        const passwordForgotToken = request.auth.credentials;
+        const email = passwordForgotToken.email;
+
+        await customs.check(request, email, 'verifyTotpCode');
+
+        try {
+          const totpRecord = await db.totpToken(passwordForgotToken.uid);
+          const sharedSecret = totpRecord.sharedSecret;
+
+          // Default options for TOTP
+          const otpOptions = {
+            encoding: 'hex',
+            step: config.step,
+            window: config.window,
+          };
+
+          const isValidCode = otpUtils.verifyOtpCode(
+            code,
+            sharedSecret,
+            otpOptions
+          );
+
+          return {
+            success: isValidCode,
+          };
+        } catch (err) {
+          if (err.errno === errors.ERRNO.TOTP_TOKEN_NOT_FOUND) {
+            return { success: false };
+          } else {
+            throw err;
+          }
+        }
+      },
+    },
+    {
+      method: 'POST',
+      path: '/totp/verify/recoveryCode',
+      options: {
+        ...TOTP_DOCS.TOTP_VERIFY_RECOVERY_CODE_POST,
+        auth: {
+          strategy: 'passwordForgotToken',
+        },
+        validate: {
+          payload: isA.object({
+            // Validation here is done with BASE_36 superset to be backwards compatible...
+            // Ideally all backup authentication codes are Crockford Base32.
+            code: validators.recoveryCode(
+              RECOVERY_CODE_SANE_MAX_LENGTH,
+              validators.BASE_36
+            ),
+          }),
+        },
+        response: {
+          schema: isA.object({
+            remaining: isA.number(),
+          }),
+        },
+      },
+      handler: async function (request) {
+        log.begin('totp.verify.recoveryCode', request);
+
+        const code = request.payload.code;
+        const passwordForgotToken = request.auth.credentials;
+        const email = passwordForgotToken.email;
+
+        await customs.check(request, email, 'verifyRecoveryCode');
+
+        const { remaining } = await db.consumeRecoveryCode(
+          passwordForgotToken.uid,
+          code
+        );
+
+        return {
+          remaining,
+        };
       },
     },
     {
@@ -311,7 +421,7 @@ module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
 
           await profileClient.deleteCache(uid);
           await log.notifyAttachedServices('profileDataChange', request, {
-            uid
+            uid,
           });
         }
 


### PR DESCRIPTION
## Because

- We need to add a few backend methods to check 2FA status

## This pull request

- Adds new routes that are authenicated with a `passwordForgotToken` to verify code and recovery code

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10513

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I could not reuse our existing routes to check for 2FA code and recovery code. There was to many session specific things which did not make sense (metrics, verify session). This approach is a little cleaner and simplier than to try to fit it in.
