### PR TITLE
feat(metrics): Fix '2FA QR Code Setup View' to fire on view

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
@@ -133,6 +133,7 @@ describe('step 1', () => {
       'alt',
       expect.stringContaining('JFXE6ULUGM4U4WDHOFVFIRDPKZITATSK')
     );
+    expect(GleanMetrics.accountPref.twoStepAuthQrView).toHaveBeenCalled();
   });
 
   it('does not display the QR code for the unverified', async () => {
@@ -140,6 +141,9 @@ describe('step 1', () => {
       render(account, false);
     });
     expect(screen.queryByTestId('2fa-qr-code')).toBeNull();
+    expect(
+      GleanMetrics.accountPref.twoStepAuthScanCodeLink
+    ).toHaveBeenCalledTimes(0);
   });
 
   it('displays the totp secret', async () => {
@@ -152,15 +156,6 @@ describe('step 1', () => {
 
     expect(screen.getByTestId('manual-code')).toBeInTheDocument();
     expect(GleanMetrics.accountPref.twoStepAuthScanCodeLink).toHaveBeenCalled();
-  });
-
-  it('sends metrics when step 1 is submitted without viewing manual code', async () => {
-    await act(async () => {
-      render();
-    });
-    await submitTotp('867530');
-
-    expect(GleanMetrics.accountPref.twoStepAuthQrView).toHaveBeenCalled();
   });
 });
 

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -184,6 +184,13 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
       GleanMetrics.accountPref.twoStepAuthEnterCodeView();
   }, [recoveryCodesAcknowledged, totpVerified]);
 
+  useEffect(() => {
+    !totpVerified &&
+      showQrCode &&
+      totpInfo.result &&
+      GleanMetrics.accountPref.twoStepAuthQrView();
+  }, [showQrCode, totpInfo.result, totpVerified]);
+
   const moveBack = () => {
     if (!totpVerified) {
       return goHome();
@@ -326,11 +333,6 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 disabled={
                   !totpForm.formState.isDirty || !totpForm.formState.isValid
                 }
-                onClick={() => {
-                  if (showQrCode) {
-                    GleanMetrics.accountPref.twoStepAuthQrView();
-                  }
-                }}
                 data-glean-id="two_step_auth_qr_submit"
                 data-glean-type="setup"
               >


### PR DESCRIPTION
## Because

- The metric was incorrectly added to fire on the 'Continue' button click, but we really want this to fire when the QR code was viewed instead.

## This pull request

- We now fire the Glean metric when the QR code is visible.
- Is a clone of https://github.com/mozilla/fxa/pull/17745 (upstream PR vs fork PR).


## Issue that this pull request solves

Closes: FXA-9573

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).