### PR TITLE
feat(libs): Create NestLogger wrappers

### DIFF
--- a/libs/shared/notifier/src/index.ts
+++ b/libs/shared/notifier/src/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // export * from './lib/notifier.module';
+export * from './lib/notifier.provider';
 export * from './lib/notifier.service';
 export * from './lib/notifier.sns.config';
 export * from './lib/notifier.sns.provider';

--- a/libs/shared/notifier/src/lib/notifier.provider.ts
+++ b/libs/shared/notifier/src/lib/notifier.provider.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LoggerService, Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { StatsDService } from '@fxa/shared/metrics/statsd';
+import { SNS } from 'aws-sdk';
+import { StatsD } from 'hot-shots';
+import { NotifierSnsService } from './notifier.sns.provider';
+import { NotifierService } from './notifier.service';
+
+export const LegacyNotifierServiceProvider: Provider<NotifierService> = {
+  provide: NotifierService,
+  useFactory: (
+    configService: ConfigService,
+    log: LoggerService,
+    sns: SNS,
+    statsd: StatsD | undefined
+  ) => {
+    const config = configService.get('notifier.sns');
+    if (config == null) {
+      throw new Error('Could not locate notifier.sns config');
+    }
+    return new NotifierService(config, log, sns, statsd);
+  },
+  inject: [ConfigService, LOGGER_PROVIDER, NotifierSnsService, StatsDService],
+};

--- a/libs/shared/notifier/src/lib/notifier.sns.config.ts
+++ b/libs/shared/notifier/src/lib/notifier.sns.config.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Provider } from '@nestjs/common';
 import { IsString, IsUrl } from 'class-validator';
 
 export class NotifierSnsConfig {
@@ -11,3 +12,13 @@ export class NotifierSnsConfig {
   @IsUrl()
   public readonly snsTopicEndpoint!: string;
 }
+
+export const MockNotifierSnsConfig = {
+  snsTopicArn: 'arn:aws:sns:us-west-2:123456789012:MyTopic',
+  snsTopicEndpoint: 'http://localhost:4566',
+} satisfies NotifierSnsConfig;
+
+export const MockNotifierSnsConfigProvider = {
+  provide: NotifierSnsConfig,
+  useValue: MockNotifierSnsConfig,
+} satisfies Provider<NotifierSnsConfig>;

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -15,8 +15,10 @@ import { join } from 'path';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import { NotifierService, NotifierSnsFactory } from '@fxa/shared/notifier';
-
+import {
+  LegacyNotifierServiceProvider,
+  NotifierSnsFactory,
+} from '@fxa/shared/notifier';
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -88,7 +90,7 @@ const version = getVersionInfo(__dirname);
       useClass: MozLoggerService,
     },
     NotifierSnsFactory,
-    NotifierService,
+    LegacyNotifierServiceProvider,
     LegacyStatsDProvider,
   ],
 })

--- a/packages/fxa-admin-server/src/gql/gql.module.ts
+++ b/packages/fxa-admin-server/src/gql/gql.module.ts
@@ -5,7 +5,10 @@
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import { NotifierService, NotifierSnsFactory } from '@fxa/shared/notifier';
+import {
+  LegacyNotifierServiceProvider,
+  NotifierSnsFactory,
+} from '@fxa/shared/notifier';
 import { Module } from '@nestjs/common';
 import { BackendModule } from '../backend/backend.module';
 import { DatabaseModule } from '../database/database.module';
@@ -29,7 +32,7 @@ import { RelyingPartyResolver } from './relying-party/relying-party.resolver';
     EmailBounceResolver,
     LegacyStatsDProvider,
     NotifierSnsFactory,
-    NotifierService,
+    LegacyNotifierServiceProvider,
     {
       provide: LOGGER_PROVIDER,
       useClass: MozLoggerService,

--- a/packages/fxa-graphql-api/src/app.module.ts
+++ b/packages/fxa-graphql-api/src/app.module.ts
@@ -5,11 +5,13 @@
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import { NotifierService, NotifierSnsFactory } from '@fxa/shared/notifier';
+import {
+  LegacyNotifierServiceProvider,
+  NotifierSnsFactory,
+} from '@fxa/shared/notifier';
 import { HealthModule } from 'fxa-shared/nestjs/health/health.module';
 
 import { getVersionInfo } from 'fxa-shared/nestjs/version';
-
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -55,7 +57,7 @@ const version = getVersionInfo(__dirname);
     LegacyStatsDProvider,
     MozLoggerService,
     NotifierSnsFactory,
-    NotifierService,
+    LegacyNotifierServiceProvider,
     ComplexityPlugin,
     {
       provide: LOGGER_PROVIDER,

--- a/packages/fxa-graphql-api/src/gql/gql.module.ts
+++ b/packages/fxa-graphql-api/src/gql/gql.module.ts
@@ -11,7 +11,10 @@ import path, { join } from 'path';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import { NotifierService, NotifierSnsFactory } from '@fxa/shared/notifier';
+import {
+  LegacyNotifierServiceProvider,
+  NotifierSnsFactory,
+} from '@fxa/shared/notifier';
 import {
   HttpException,
   MiddlewareConsumer,
@@ -58,8 +61,8 @@ export const GraphQLConfigFactory = async (
     CustomsService,
     LegacyStatsDProvider,
     LegalResolver,
+    LegacyNotifierServiceProvider,
     MozLoggerService,
-    NotifierService,
     NotifierSnsFactory,
     SentryPlugin,
     SessionResolver,

--- a/packages/fxa-graphql-api/src/scripts/must-change-password.ts
+++ b/packages/fxa-graphql-api/src/scripts/must-change-password.ts
@@ -33,7 +33,6 @@ import { batchAccountUpdate } from 'fxa-shared/db/models/auth';
 import { uuidTransformer } from 'fxa-shared/db/transformers';
 import { NotifierService, setupSns } from '@fxa/shared/notifier';
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import { ConfigService } from '@nestjs/config';
 
 const config = Config.getProperties();
 const logger = mozlog(config.log)('must-change-password');
@@ -114,12 +113,13 @@ async function main() {
   );
   const oauthKnex = setupDatabase(config.database.mysql.oauth, logger, metrics);
 
-  const sns = setupSns({
+  const notifierSnsConfig = {
     snsTopicArn: config.notifier.sns.snsTopicArn || '',
     snsTopicEndpoint: config.notifier.sns.snsTopicEndpoint || '',
-  });
+  };
+  const sns = setupSns(notifierSnsConfig);
   const notifier = new NotifierService(
-    Config as unknown as ConfigService,
+    notifierSnsConfig,
     logger as MozLoggerService,
     sns,
     metrics


### PR DESCRIPTION
## Because

- we are using TypedConfig, while NotifierService and ProfileClient are using ConfigService

## This pull request

- [x] creates wrappers for NotifierService and ProfileClient
~~- [ ] adds config for `domain`~~ this will be its own ticket/PR

## Issue that this pull request solves

Closes: FXA-10511

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.