### PR TITLE
fix(oauth-desktop): Send canLinkAccount if service=sync

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -218,7 +218,10 @@ var OAuthRelier = Relier.extend({
 
     // OAuth reliers are not allowed to specify a service. `service`
     // is used in the verification flow, it'll be set to the `client_id`.
-    if (this.getSearchParam('service')) {
+    if (
+      this.getSearchParam('service') &&
+      this.getSearchParam('service') !== 'sync'
+    ) {
       throw OAuthErrors.toInvalidParameterError('service');
     }
   },

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -10,7 +10,6 @@ import {
   useFtlMsgResolver,
   useConfig,
   useSession,
-  isSyncDesktopV3Integration,
   useSensitiveDataClient,
 } from '../../models';
 import { MozServices } from '../../lib/types';
@@ -242,7 +241,9 @@ const SigninContainer = ({
       // warning. The browser will automatically respond with { ok: true } without
       // prompting the user if it matches the email the browser has data for.
       if (
-        isSyncDesktopV3Integration(integration) &&
+        // NOTE, SYNC-4408 OAuth desktop needs to add `service=sync` as a query parameter
+        // for this to work for OAuth desktop
+        integration.data.service === 'sync' &&
         queryParamModel.hasLinkedAccount === undefined
       ) {
         const { ok } = await firefox.fxaCanLinkAccount({ email });


### PR DESCRIPTION
Because:
* We were only checking for desktopv3 in this case and want to check for desktopv3 and oauth desktop

This commit:
* Modifies the condition to call firefox.fxaCanLinkAccount, updates tests

fixes FXA-10328

---

**NOTE**, what I have here does fix the issue at hand but a more ideal solution (especially considering the Relay work) for this is WIP [in this branch](https://github.com/mozilla/fxa/compare/FXA-10328), but it's not ready yet. I'm going to be reducing points on this and instead creating a follow up ticket to finish that branch out on, which I will also review our oauth desktop tests in (as mentioned in this ticket).

edit: follow up is FXA- 10528