### PR TITLE
fix(next): create accountCustomer record on sub

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -120,10 +120,10 @@ export class CheckoutService {
       customer = await this.customerManager.retrieve(stripeCustomerId);
     }
 
-    if (!cart.uid) {
+    if (uid && stripeCustomerId) {
       await this.accountCustomerManager.createAccountCustomer({
-        uid: uid,
-        stripeCustomerId: stripeCustomerId,
+        uid,
+        stripeCustomerId,
       });
     }
 


### PR DESCRIPTION
## Because

- accountCustomer record is not created for uid and stripeCustomerId for a new customer.

## This pull request

- Updates the CheckoutServic to create accountCustomer record when uid and stripeCustomerId exist.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
