### PR TITLE
fix(password reset): stop prompting for unverified 2fa during reset

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
@@ -128,7 +128,8 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
         hint: recoveryKeyHint,
         estimatedSyncDeviceCount,
       } = await checkForRecoveryKey(token);
-      const { exists: totpExists } = await checkForTotp(token);
+      const totpStatus = await checkForTotp(token);
+      const totpExists = totpStatus.exists && totpStatus.verified;
 
       handleNavigation(
         code,


### PR DESCRIPTION
Because:
 - when an account has an unverified 2fa and the user opt to not use the recovery key, we should not prompt for the TOTP during password reset

This commit:
 - ensures that 2fa is enabled, exists and verified, for the account
