### PR TITLE
fix(docker): Use git tag from lookup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,13 +49,13 @@ jobs:
       GCP_PROJECT_ID: moz-fx-fxa-prod
       IMAGE: fxa-mono
       RUN_ID: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      TAG: ${{ needs.tag.outputs.TAG }}
+      GIT_TAG: ${{ needs.tag.outputs.TAG }}
     needs:
       - tag
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ env.GIT_TAG }}
 
       - uses: actions/setup-node@v4
         with:
@@ -87,7 +87,7 @@ jobs:
         with:
           context: .
           file: _dev/docker/mono/Dockerfile
-          tags: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE}}:${{ env.TAG }}
+          tags: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE}}:${{ env.GIT_TAG }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/_scripts/create-version-json.sh
+++ b/_scripts/create-version-json.sh
@@ -13,7 +13,7 @@ if [[ "${CIRCLECI}" == "true" ]]; then
 elif [[ "${GITHUB_ACTIONS}" == "true" ]]; then
   printf '{"version":{"hash":"%s","version":"%s","source":"https://github.com/%s","build":"%s/%s/actions/runs/%s"}}\n' \
     "${GITHUB_SHA}" \
-    "${GITHUB_REF_NAME}" \
+    "${GIT_TAG}" \
     "${GITHUB_REPOSITORY}" \
     "${GITHUB_SERVER_URL}" \
     "${GITHUB_REPOSITORY}" \


### PR DESCRIPTION
The `GITHUB_REF_NAME` variable only works for tags pushed by developers.
When calling the docker.yml workflow from tag-release.yml, the contents
of `GITHUB_REF_NAME` is `main`, the branch that the GitHub Action is
running on. This will fix the version output for x.y.0 tags created by
tag-release.yml.
