### PR TITLE
bug(settings): Client name can be undefined

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -106,7 +106,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
         // disconnect all clients/sessions with this name since only unique names
         // are displayed to the user. This is batched into one network request
         // via BatchHttpLink
-        const clientsWithMatchingName = groupedByName[client.name];
+        const clientsWithMatchingName = groupedByName[client.name || 'unknown'];
         const hasMultipleSessions = clientsWithMatchingName.length > 1;
         if (hasMultipleSessions) {
           await Promise.all(
@@ -132,7 +132,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
           hideConfirmDisconnectModal();
           revealAdviceModal();
         } else {
-          const name = client.name;
+          const name = client.name || 'unknown';
           alertBar.success(
             l10n.getString(
               'cs-logged-out-2',
@@ -220,9 +220,9 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
         {!!sortedAndUniqueClients.length &&
           sortedAndUniqueClients.map((client, i) => (
             <Service
-              key={`${client.lastAccessTime}:${client.name}`}
+              key={`${client.lastAccessTime}:${client.name || 'unknown'}`}
               {...{
-                name: client.name,
+                name: client.name || 'unknown',
                 deviceType: client.deviceType,
                 location: client.location,
                 lastAccessTimeFormatted: client.lastAccessTimeFormatted,
@@ -284,7 +284,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
 
               <Localized
                 id="cs-disconnect-sync-content-3"
-                vars={{ device: selectedClient!.name }}
+                vars={{ device: selectedClient?.name || 'unknown' }}
                 elems={{ span: <span className="break-word"></span> }}
               >
                 <p
@@ -292,19 +292,24 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
                   className="my-4 text-center"
                 >
                   Your browsing data will remain on{' '}
-                  <span className="break-word">{selectedClient!.name}</span>,
-                  but it will no longer sync with your account.
+                  <span className="break-word">
+                    {selectedClient?.name || 'unknown'}
+                  </span>
+                  , but it will no longer sync with your account.
                 </p>
               </Localized>
 
               <Localized
                 id="cs-disconnect-sync-reason-3"
-                vars={{ device: selectedClient!.name }}
+                vars={{ device: selectedClient?.name || 'unknown' }}
                 elems={{ span: <span className="break-word"></span> }}
               >
                 <p className="my-4 text-center">
                   What's the main reason for disconnecting{' '}
-                  <span className="break-word">{selectedClient!.name}</span>?
+                  <span className="break-word">
+                    {selectedClient?.name || 'unknown'}
+                  </span>
+                  ?
                 </p>
               </Localized>
               <form

--- a/packages/fxa-settings/src/lib/utilities.test.ts
+++ b/packages/fxa-settings/src/lib/utilities.test.ts
@@ -6,6 +6,7 @@ import {
   constructHrefWithUtm,
   deepMerge,
   isBase32Crockford,
+  isMobileDevice,
   once,
   resetOnce,
   searchParam,
@@ -192,5 +193,18 @@ describe('constructHrefWithUtm', () => {
     const expected =
       'https://example.com?utm_source=moz-account&utm_medium=product-partnership&utm_term=sidebar&utm_content=vpn&utm_campaign=connect-device';
     expect(result).toBe(expected);
+  });
+});
+
+describe('check for mobile device', () => {
+  it('handles typical client', () => {
+    expect(isMobileDevice({ deviceType: 'mobile', name: '' })).toBeTruthy();
+  });
+  it('handles ipad edge case', () => {
+    expect(isMobileDevice({ deviceType: '', name: 'apple ipad' })).toBeTruthy();
+  });
+  it('handles client without name', () => {
+    // See FXA-10326. Somehow an undefined value sneaks in here...
+    expect(isMobileDevice({ deviceType: 'mobile', name: null })).toBeTruthy();
   });
 });

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -96,11 +96,13 @@ export function splitEncodedParams(
     .reduce((newObj, key) => Object.assign(newObj, { [key]: terms[key] }), {});
 }
 
-export function isMobileDevice(client?: AttachedClient) {
+export function isMobileDevice(
+  client?: Pick<AttachedClient, 'deviceType' | 'name'>
+) {
   if (client) {
     return (
       client.deviceType === 'mobile' ||
-      client.name.toLowerCase().includes('ipad')
+      (client.name || '').toLowerCase().includes('ipad')
     );
   }
   return /mobi/i.test(navigator.userAgent);

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -66,13 +66,14 @@ export interface RecoveryKeyBundlePayload {
 }
 
 // TODO: why doesn't this match fxa-graphql-api/src/lib/resolvers/types/attachedClient.ts?
+// DOUBLE TODO: The fact it doeesn't can cuase type safety issues. See FXA-10326
 export interface AttachedClient {
   clientId: string;
   isCurrentSession: boolean;
   userAgent: string;
   deviceType: string | null;
   deviceId: string | null;
-  name: string;
+  name: string | null;
   lastAccessTime: number;
   lastAccessTimeFormatted: string;
   approximateLastAccessTime: number | null;


### PR DESCRIPTION
## Because
- We got a sentry report where client name wasn't defined

## This pull request
- Changes types to reflect grqphql schema, which allows name to be null
- Updates codes accordingly
- Adds fallback for null/undefined client names

## Issue that this pull request solves

Closes: FXA-10326

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

From the sentry issue it appears that the client name can be undefined. In general this shouldn't happen, but our code should still be able to handle this in the event it does occur. I also noticed that there's existing comment about the GQL schema and our client side model don't necessarily match. This is really how this bug originated in the first place. If our types don't match what's on the server, we expose ourselves to these types of bugs. 
