### PR TITLE
feat(next): paypal createOrder and onApprove hooks

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -55,6 +55,12 @@ export class CartNotUpdatedError extends CartError {
   }
 }
 
+export class CartStateProcessingError extends CartError {
+  constructor(cartId: string, cause: Error) {
+    super('Cart state not changed to processing', { cartId }, cause);
+  }
+}
+
 export class CartStateFinishedError extends CartError {
   constructor() {
     super('Cart state is already finished', {});

--- a/libs/payments/cart/src/lib/cart.manager.in.spec.ts
+++ b/libs/payments/cart/src/lib/cart.manager.in.spec.ts
@@ -123,6 +123,31 @@ describe('CartManager', () => {
     });
   });
 
+  describe('fetchAndValidateCartVersion', () => {
+    it('succeeds', async () => {
+      const cart = await cartManager.fetchAndValidateCartVersion(CART_ID, 0);
+      expect(cart.id).toEqual(CART_ID);
+    });
+
+    it('errors - NotFound', async () => {
+      try {
+        await cartManager.fetchAndValidateCartVersion(RANDOM_ID, 1);
+        fail('Error in fetchCartById');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartNotFoundError);
+      }
+    });
+
+    it('errors - with cart version mismatch', async () => {
+      try {
+        await cartManager.fetchAndValidateCartVersion(CART_ID, 99);
+        fail('Error in fetchCartById');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartVersionMismatchError);
+      }
+    });
+  });
+
   describe('updateFreshCart', () => {
     it('succeeds', async () => {
       const updateItems = UpdateCartFactory({

--- a/libs/payments/cart/src/lib/cart.manager.ts
+++ b/libs/payments/cart/src/lib/cart.manager.ts
@@ -72,7 +72,7 @@ export class CartManager {
    * Fetch a cart from the database by id and validate that the version
    * matches the version passed in.
    */
-  private async fetchAndValidateCartVersion(cartId: string, version: number) {
+  async fetchAndValidateCartVersion(cartId: string, version: number) {
     const cart = await this.fetchCartById(cartId);
 
     if (cart.version !== version) {

--- a/libs/payments/cart/src/lib/checkout.factories.ts
+++ b/libs/payments/cart/src/lib/checkout.factories.ts
@@ -1,0 +1,23 @@
+import {
+  StripeCustomerFactory,
+  StripePriceFactory,
+} from '@fxa/payments/stripe';
+import { PrePayStepsResult } from './checkout.types';
+import { ResultCartFactory } from './cart.factories';
+import { faker } from '@faker-js/faker';
+
+export const PrePayStepsResultFactory = (
+  override?: Partial<PrePayStepsResult>
+): PrePayStepsResult => {
+  const cart = ResultCartFactory();
+
+  return {
+    version: cart.version,
+    uid: faker.string.uuid(),
+    email: cart.email,
+    customer: StripeCustomerFactory(),
+    enableAutomaticTax: true,
+    price: StripePriceFactory(),
+    ...override,
+  };
+};

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -81,6 +81,7 @@ import {
   CartInvalidCurrencyError,
 } from './cart.error';
 import { CheckoutService } from './checkout.service';
+import { PrePayStepsResultFactory } from './checkout.factories';
 
 describe('CheckoutService', () => {
   let accountCustomerManager: AccountCustomerManager;
@@ -451,12 +452,18 @@ describe('CheckoutService', () => {
     beforeEach(async () => {
       jest.spyOn(customerManager, 'setTaxId').mockResolvedValue();
       jest.spyOn(profileClient, 'deleteCache').mockResolvedValue('test');
+      jest.spyOn(cartManager, 'finishCart').mockResolvedValue();
     });
 
     it('success', async () => {
       const mockCart = ResultCartFactory();
 
-      await checkoutService.postPaySteps(mockCart, mockSubscription, mockUid);
+      await checkoutService.postPaySteps(
+        mockCart,
+        mockCart.version,
+        mockSubscription,
+        mockUid
+      );
 
       expect(customerManager.setTaxId).toHaveBeenCalledWith(
         mockSubscription.customer,
@@ -464,6 +471,7 @@ describe('CheckoutService', () => {
       );
 
       expect(privateMethod).toHaveBeenCalled();
+      expect(cartManager.finishCart).toHaveBeenCalled();
     });
 
     it('success - adds coupon code to subscription metadata if it exists', async () => {
@@ -483,7 +491,12 @@ describe('CheckoutService', () => {
         .spyOn(subscriptionManager, 'update')
         .mockResolvedValue(mockUpdatedSubscription);
 
-      await checkoutService.postPaySteps(mockCart, mockSubscription, mockUid);
+      await checkoutService.postPaySteps(
+        mockCart,
+        mockCart.version,
+        mockSubscription,
+        mockUid
+      );
 
       expect(customerManager.setTaxId).toHaveBeenCalledWith(
         mockSubscription.customer,
@@ -526,14 +539,14 @@ describe('CheckoutService', () => {
     const mockPrice = StripePriceFactory();
 
     beforeEach(async () => {
-      jest.spyOn(checkoutService, 'prePaySteps').mockResolvedValue({
-        uid: mockCart.uid as string,
-        customer: mockCustomer,
-        email: faker.internet.email(),
-        enableAutomaticTax: true,
-        promotionCode: mockPromotionCode,
-        price: mockPrice,
-      });
+      jest.spyOn(checkoutService, 'prePaySteps').mockResolvedValue(
+        PrePayStepsResultFactory({
+          uid: mockCart.uid,
+          customer: mockCustomer,
+          promotionCode: mockPromotionCode,
+          price: mockPrice,
+        })
+      );
       jest
         .spyOn(paymentMethodManager, 'attach')
         .mockResolvedValue(mockPaymentMethod);
@@ -646,14 +659,14 @@ describe('CheckoutService', () => {
     const mockPrice = StripePriceFactory();
 
     beforeEach(async () => {
-      jest.spyOn(checkoutService, 'prePaySteps').mockResolvedValue({
-        uid: mockCart.uid as string,
-        customer: mockCustomer,
-        email: faker.internet.email(),
-        enableAutomaticTax: true,
-        promotionCode: mockPromotionCode,
-        price: mockPrice,
-      });
+      jest.spyOn(checkoutService, 'prePaySteps').mockResolvedValue(
+        PrePayStepsResultFactory({
+          uid: mockCart.uid,
+          customer: mockCustomer,
+          promotionCode: mockPromotionCode,
+          price: mockPrice,
+        })
+      );
       jest
         .spyOn(subscriptionManager, 'getCustomerPayPalSubscriptions')
         .mockResolvedValue([]);

--- a/libs/payments/cart/src/lib/checkout.types.ts
+++ b/libs/payments/cart/src/lib/checkout.types.ts
@@ -1,0 +1,14 @@
+import {
+  StripeCustomer,
+  StripePrice,
+  StripePromotionCode,
+} from '@fxa/payments/stripe';
+import { ResultCart } from './cart.types';
+
+export type PrePayStepsResult = Pick<ResultCart, 'version' | 'email'> & {
+  uid: string;
+  customer: StripeCustomer;
+  enableAutomaticTax: boolean;
+  promotionCode?: StripePromotionCode;
+  price: StripePrice;
+};

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
@@ -7,6 +7,7 @@
 import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
 import { CheckoutCartWithPaypalActionArgs } from '../nestapp/validators/CheckoutCartWithPaypalActionArgs';
+import { redirect } from 'next/navigation';
 
 export const checkoutCartWithPaypal = async (
   cartId: string,
@@ -22,4 +23,6 @@ export const checkoutCartWithPaypal = async (
       token,
     })
   );
+
+  redirect('processing');
 };

--- a/libs/payments/ui/src/lib/actions/getPayPalCheckoutToken.ts
+++ b/libs/payments/ui/src/lib/actions/getPayPalCheckoutToken.ts
@@ -8,7 +8,7 @@ import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
 import { GetPayPalCheckoutTokenArgs } from '../nestapp/validators/GetPayPalCheckoutTokenArgs';
 
-export const getPayPalCheckoutToken = async (currencyCode: string) => {
+export const getPayPalCheckoutToken = async (currencyCode?: string | null) => {
   const actionsService = getApp().getActionsService();
 
   const token = await actionsService.getPayPalCheckoutToken(

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -24,6 +24,8 @@ import {
   recordEmitterEventAction,
   checkoutCartWithStripe,
   finalizeCartWithError,
+  getPayPalCheckoutToken,
+  checkoutCartWithPaypal,
 } from '@fxa/payments/ui/actions';
 import { CartErrorReasonId } from '@fxa/shared/db/mysql/account/kysely-types';
 
@@ -256,12 +258,25 @@ export function CheckoutForm({
                 style={{
                   layout: 'horizontal',
                   color: 'gold',
-                  shape: 'pill',
+                  shape: 'rect',
                   label: 'paypal',
                   height: 48,
+                  borderRadius: 6, // This should match 0.375rem
                   tagline: false,
                 }}
                 className="mt-6"
+                createOrder={async () => getPayPalCheckoutToken(cart.currency)}
+                onApprove={async (data: { orderID: string }) => {
+                  await checkoutCartWithPaypal(
+                    cart.id,
+                    cart.version,
+                    {
+                      locale,
+                      displayName: '',
+                    },
+                    data.orderID
+                  );
+                }}
                 onError={async () => {
                   await finalizeCartWithError(
                     cart.id,


### PR DESCRIPTION
## Because

- Submit PayPal checkout to payments-next

## This pull request

- Add logic to PayPal button createOrder and onApprove hooks.

## Issue that this pull request solves

Closes: #FXA-7586

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
