### PR TITLE
fix(fxa-settings): Show correct email for signin after reset

### DIFF
--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -133,12 +133,14 @@ describe('InlineTotpSetupContainer', () => {
   });
 
   describe('redirects away', () => {
-    it('redirects when user is not signed in', () => {
+    it('redirects when user is not signed in', async () => {
       render({ isSignedIn: false });
       const location = mockLocationHook();
-      expect(mockNavigateHook).toHaveBeenCalledWith(
-        `/signup${location.search}`,
-        { state: undefined }
+      await waitFor(() =>
+        expect(mockNavigateHook).toHaveBeenCalledWith(
+          `/signup${location.search}`,
+          { state: undefined }
+        )
       );
     });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -93,24 +93,15 @@ const CompleteResetPasswordContainer = ({
     'Don’t forget to generate a new account recovery key from your Mozilla account settings to prevent future sign-in issues.'
   );
 
-  const signInNavigationDestination = (email: string) =>
-    location.search?.includes('email')
-      ? // if the session is not verified (e.g., 2FA verification is required), navigate to the sign-in page
-        '/signin'
-      : // if user started directly from the reset password page without passing GO (index),
-        // the email needs to be added to query params to avoid redirecting to the index page
-        `/signin?email=${encodeURIComponent(email)}`;
-
   const handleNavigationWithRecoveryKey = (
     state: Record<string, any>,
     hasVerifiedSession: boolean
   ) => {
     if (!hasVerifiedSession) {
-      const destination = signInNavigationDestination(state.email);
-
-      return navigateWithQuery(destination, {
+      return navigateWithQuery('/signin', {
         replace: true,
         state: {
+          email,
           fancyBannerSuccessMessage: {
             heading: successBannerMessageHeading,
             message: successBannerMessageMessage,
@@ -144,10 +135,11 @@ const CompleteResetPasswordContainer = ({
       return navigateWithQuery(SETTINGS_PATH, { replace: true });
     }
 
-    const destination = signInNavigationDestination(email);
-    return navigateWithQuery(destination, {
+    // if the session is not verified (e.g., 2FA verification is required), navigate to the sign-in page
+    return navigateWithQuery('/signin', {
       replace: true,
       state: {
+        email,
         bannerSuccessMessage: localizedSuccessMessage,
       },
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
@@ -18,8 +18,6 @@ import {
   createMockSyncIntegration,
 } from './mocks';
 
-import { act } from 'react-dom/test-utils';
-
 import { MozServices } from '../../../lib/types';
 
 let integration: Integration;
@@ -166,9 +164,7 @@ describe('SigninPushCode container', () => {
 
       it('redirects to totp screen if user has totp enabled', async () => {
         mockHasTotpAuthClient = true;
-        await act(async () => {
-          await render();
-        });
+        render();
 
         await waitFor(() => {
           expect(mockNavigate).toBeCalledWith('/signin_totp_code', {
@@ -179,9 +175,7 @@ describe('SigninPushCode container', () => {
 
       it('does not redirect with totp false', async () => {
         mockHasTotpAuthClient = false;
-        await act(async () => {
-          await render();
-        });
+        render();
 
         await waitFor(() => {
           expect(mockNavigate).not.toBeCalled();
@@ -198,20 +192,20 @@ describe('SigninPushCode container', () => {
     it('sends push notification', async () => {
       mockSessionStatus = 'false';
       mockLocationState = createMockSigninLocationState();
-      await act(async () => {
-        await render();
-      });
-      expect(mockSendLoginPushRequest).toBeCalled();
+      render();
+
+      await waitFor(() => expect(mockSendLoginPushRequest).toBeCalled());
     });
 
     it('navigates when session verified', async () => {
       mockSessionStatus = 'verified';
       mockLocationState = createMockSigninLocationState();
-      await act(async () => {
-        await render();
-      });
-      expect(ReactUtils.hardNavigate).toBeCalledWith(
-        '/pair?showSuccessMessage=true'
+      render();
+
+      await waitFor(() =>
+        expect(ReactUtils.hardNavigate).toBeCalledWith(
+          '/pair?showSuccessMessage=true'
+        )
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -15,7 +15,6 @@ import { screen, waitFor } from '@testing-library/react';
 import { MOCK_EMAIL, MOCK_STORED_ACCOUNT } from '../../mocks';
 import { createMockWebIntegration } from '../../../lib/integrations/mocks';
 import { createMockSigninLocationState } from './mocks';
-import { act } from 'react-dom/test-utils';
 
 let integration: Integration;
 
@@ -157,9 +156,7 @@ describe('SigninTokenCode container', () => {
 
       it('redirects to totp screen if user has totp enabled', async () => {
         mockHasTotpAuthClient = true;
-        await act(async () => {
-          await render();
-        });
+        render();
 
         await waitFor(() => {
           expect(mockNavigate).toBeCalledWith('/signin_totp_code', {
@@ -170,9 +167,7 @@ describe('SigninTokenCode container', () => {
 
       it('does not redirect with totp false', async () => {
         mockHasTotpAuthClient = false;
-        await act(async () => {
-          await render();
-        });
+        render();
 
         await waitFor(() => {
           expect(mockNavigate).not.toBeCalled();

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -302,12 +302,12 @@ describe('signin container', () => {
         });
         expect(SigninModule.default).toBeCalled();
       });
-      it('query param state takes precedence over router state', async () => {
+      it('router state takes precendence over query param state', async () => {
         mockUseValidateModule();
         mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
         render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
-          expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
+          expect(currentSigninProps?.email).toBe(MOCK_ROUTER_STATE_EMAIL);
         });
         expect(SigninModule.default).toBeCalled();
       });
@@ -451,7 +451,9 @@ describe('signin container', () => {
         mockGqlBeginSigninMutation({ keys: false }),
       ]);
 
-      expect(currentSigninProps).toBeDefined();
+      await waitFor(() => {
+        expect(currentSigninProps).toBeDefined();
+      });
       const handlerResult = await currentSigninProps?.beginSigninHandler(
         MOCK_EMAIL,
         MOCK_PASSWORD

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -150,12 +150,17 @@ const SigninContainer = ({
   const [accountStatus, setAccountStatus] = useState({
     hasLinkedAccount:
       // TODO: in FXA-9177, retrieve hasLinkedAccount and hasPassword from Apollo cache (not state)
-      queryParamModel.hasLinkedAccount || hasLinkedAccountFromLocationState,
-    hasPassword: queryParamModel.hasPassword || hasPasswordFromLocationState,
+      hasLinkedAccountFromLocationState !== undefined
+        ? hasLinkedAccountFromLocationState
+        : queryParamModel.hasLinkedAccount,
+    hasPassword:
+      hasPasswordFromLocationState !== undefined
+        ? hasPasswordFromLocationState
+        : queryParamModel.hasPassword,
   });
   const { hasLinkedAccount, hasPassword } = accountStatus;
 
-  const email = queryParamModel.email || emailFromLocationState;
+  const email = emailFromLocationState || queryParamModel.email;
 
   const { sessionToken, uid } = getAccountInfo(email);
 


### PR DESCRIPTION
## Because

* We want to make sure that the email shown after redirect to signin from reset password with 2FA is correct
* If another account was signed into Sync or a different emails was included in query params, that email would be shown after redirect

## This pull request

* Include the email in location state when navigating to signin after password reset with unverified session
* Prioritize email from location state vs query params on sign in
* Cleanup warnings for a few unit tests

## Issue that this pull request solves

Closes: #FXA-10557

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We should also validate and clean unused query params, but I'll file a separate issue for that.
