### PR TITLE
feat(next): add a generic loading page

### DIFF
--- a/apps/payments/next/app/[locale]/loading.tsx
+++ b/apps/payments/next/app/[locale]/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingSpinner } from '@fxa/payments/ui';
+
+export default function GenericLoading() {
+  return (
+    <div className="flex justify-center items-center fixed inset-0">
+      <LoadingSpinner className="h-10" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Because

- Display a loading state to customers while navigating between pages.

## This pull request

- Adds a `loading.tsx` to the root routes of the Next app

## Issue that this pull request solves

Closes: #FXA-7574

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

<img width="1134" alt="image" src="https://github.com/user-attachments/assets/fd994fd2-b558-442b-949c-ac5daf49b8b1">

