### PR TITLE
feat(2fa): Add metrics for 2FA password reset, add `use different account` link

### DIFF
--- a/packages/functional-tests/tests/resetPassword/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword.spec.ts
@@ -444,14 +444,7 @@ test.describe('severity-1 #smoke', () => {
   test('can reset password with unverified 2FA and skip recovery key', async ({
     page,
     target,
-    pages: {
-      signin,
-      resetPassword,
-      settings,
-      totp,
-      signinTotpCode,
-      recoveryKey,
-    },
+    pages: { signin, resetPassword, settings, totp, recoveryKey },
     testAccountTracker,
   }) => {
     const credentials = await testAccountTracker.signUp();

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/en.ftl
@@ -6,3 +6,4 @@ confirm-totp-reset-password-instruction = Check your authenticator app to reset 
 confirm-totp-reset-password-trouble-code = Trouble entering code?
 confirm-totp-reset-password-confirm-button = Confirm
 confirm-totp-reset-password-input-label = Enter code
+confirm-totp-reset-password-use-different-account = Use a different account

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.tsx
@@ -5,7 +5,7 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import AppLayout from '../../../components/AppLayout';
 import { useFtlMsgResolver } from '../../../models';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import protectionShieldIcon from '@fxa/shared/assets/images/protection-shield.svg';
 import FormVerifyCode, {
   FormAttributes,
@@ -70,11 +70,11 @@ const ConfirmTotpResetPassword = ({
 
           <div className="flex space-x-4">
             <img src={protectionShieldIcon} alt="" />
-            <FtlMsg id="confirm-totp-reset-password-instruction">
-              <p className="my-5 text-md text-start">
+            <p className="my-5 text-md text-start">
+              <FtlMsg id="confirm-totp-reset-password-instruction">
                 Check your download or saved backup recovery code.
-              </p>
-            </FtlMsg>
+              </FtlMsg>
+            </p>
           </div>
 
           <FormVerifyCode
@@ -85,18 +85,22 @@ const ConfirmTotpResetPassword = ({
               viewName: 'confirm-recovery-code-reset-password',
               codeErrorMessage,
               setCodeErrorMessage,
+              gleanDataAttrs: {
+                id: 'reset_password_confirm_recovery_code_submit_button',
+              },
             }}
           />
           <div className="mt-5 link-blue text-sm flex justify-end">
-            <FtlMsg id="confirm-recovery-code-reset-password-trouble-code">
-              <div
-                onClick={() => {
-                  setShowRecoveryCode(false);
-                }}
-              >
+            <div
+              onClick={() => {
+                setShowRecoveryCode(false);
+              }}
+              data-glean-id="reset_password_confirm_recovery_code_trouble_with_code_button"
+            >
+              <FtlMsg id="confirm-recovery-code-reset-password-trouble-code">
                 Back
-              </div>
-            </FtlMsg>
+              </FtlMsg>
+            </div>
           </div>
         </AppLayout>
       ) : (
@@ -115,11 +119,11 @@ const ConfirmTotpResetPassword = ({
 
           <div className="flex space-x-4">
             <img src={protectionShieldIcon} alt="" />
-            <FtlMsg id="confirm-totp-reset-password-instruction">
-              <p className="my-5 text-md text-start">
+            <p className="my-5 text-md text-start">
+              <FtlMsg id="confirm-totp-reset-password-instruction">
                 Check your authenticator app to reset your password.
-              </p>
-            </FtlMsg>
+              </FtlMsg>
+            </p>
           </div>
 
           <FormVerifyCode
@@ -130,18 +134,35 @@ const ConfirmTotpResetPassword = ({
               codeErrorMessage,
               setCodeErrorMessage,
               viewName: 'confirm-totp-reset-password',
+              gleanDataAttrs: {
+                id: 'reset_password_confirm_totp_code_submit_button',
+              },
             }}
           />
-          <div className="mt-5 link-blue text-sm flex justify-end">
-            <FtlMsg id="confirm-totp-reset-password-trouble-code">
-              <button
-                onClick={() => {
-                  setShowRecoveryCode(true);
-                }}
-              >
+          <div className="mt-5 flex justify-between items-center">
+            <button
+              className="link-blue text-sm"
+              data-glean-id="reset_password_confirm_totp_use_different_account_button"
+              onClick={() => {
+                // Navigate to email first page and keep search params
+                hardNavigate('/', {}, true);
+              }}
+            >
+              <FtlMsg id="confirm-totp-reset-password-use-different-account">
+                Use different account
+              </FtlMsg>
+            </button>
+            <button
+              className="link-blue text-sm"
+              onClick={() => {
+                setShowRecoveryCode(true);
+              }}
+              data-glean-id="reset_password_confirm_totp_trouble_with_code_button"
+            >
+              <FtlMsg id="confirm-totp-reset-password-trouble-code">
                 Trouble entering code?
-              </button>
-            </FtlMsg>
+              </FtlMsg>
+            </button>
           </div>
         </AppLayout>
       )}


### PR DESCRIPTION
## Because

- We want to add a few more metrics for 2FA with password reset

## This pull request

- Adds Glean events
  - `reset_password_confirm_recovery_code_submit_button`
  - `reset_password_confirm_recovery_code_trouble_with_code_button`
  - `reset_password_confirm_totp_code_submit_button`
  - `reset_password_confirm_totp_use_different_account_button`
  - `reset_password_confirm_totp_trouble_with_code_button`
- Adds the `Use different account` link

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10558
Closes: https://mozilla-hub.atlassian.net/browse/FXA-10533

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2024-10-18 at 2 47 49 PM](https://github.com/user-attachments/assets/58f1fe69-b1fb-4f22-81c5-149feb50abaf)

## Other information (Optional)

Added a bunch of new Glean metrics for this feature, note that the names are a little different than ticket to match other events and for more clarity.
