### PR TITLE
fix(bugs): Send low recovery codes email when consuming during password reset

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -200,7 +200,7 @@ module.exports = (log, db, config, customs, mailer, glean) => {
           );
         }
 
-        await Promise.all(mailerPromises);
+        await Promise.allSettled(mailerPromises);
 
         log.info('account.recoveryCode.verified', { uid });
 


### PR DESCRIPTION
## Because

- We don't want a user to get locked out of account if they run out of recovery codes

## This pull request

- Emails the user to let them know a code was consumed (and how many remaining), also emails user if they have "low" amount

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10555

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
