### PR TITLE
feat(sync): Implement browser service=relay logic and UX

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/reliers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/base.js
@@ -38,6 +38,16 @@ var Relier = Backbone.Model.extend({
   },
 
   /**
+   * Check if the relier is OAuth desktop (desktop only for now)
+   * with service=relay; this is a "sync optional" flow
+   *
+   * @returns {Boolean}
+   */
+  isOAuthNativeRelay() {
+    return false;
+  },
+
+  /**
    * Check if the relier should offer Sync
    *
    * @returns {Boolean}

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -169,7 +169,14 @@ var OAuthRelier = Relier.extend({
   },
 
   isSync() {
-    return this.get('serviceName') === Constants.RELIER_SYNC_SERVICE_NAME;
+    return (
+      this.get('serviceName') === Constants.RELIER_SYNC_SERVICE_NAME &&
+      !this.isOAuthNativeRelay()
+    );
+  },
+
+  isOAuthNativeRelay() {
+    return this.get('service') === 'relay';
   },
 
   _isVerificationFlow() {
@@ -216,11 +223,12 @@ var OAuthRelier = Relier.extend({
       this.set('email', this.get('loginHint'));
     }
 
-    // OAuth reliers are not allowed to specify a service. `service`
-    // is used in the verification flow, it'll be set to the `client_id`.
+    // OAuth reliers (at the moment, only oauth desktop) are only allowed to
+    // specify 'sync' or 'relay' as the service.
     if (
       this.getSearchParam('service') &&
-      this.getSearchParam('service') !== 'sync'
+      this.getSearchParam('service') !== 'sync' &&
+      this.getSearchParam('service') !== 'relay'
     ) {
       throw OAuthErrors.toInvalidParameterError('service');
     }

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -10,19 +10,29 @@
       </p>
       {{/isSync}}
       {{^isSync}}
-        <h1 id="fxa-enter-email-header" class="card-header">
-          {{#t}}Enter your email{{/t}}
-          <span class="block text-sm font-body font-normal mt-1" id="subheader">
-            {{#serviceLogo}}
-              <!-- L10N: For languages structured like English, the phrase can read "to continue to" with Pocket image following -->
-              {{#unsafeTranslate}}Continue to <div class="graphic %(serviceLogo)s">%(serviceName)s</div>{{/unsafeTranslate}}
-            {{/serviceLogo}}
-            {{^serviceLogo}}
-              <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->
-              {{#t}}Continue to %(serviceName)s{{/t}}
-            {{/serviceLogo}}
-          </span>
-        </h1>
+        {{^isOAuthNativeRelay}}
+          <h1 id="fxa-enter-email-header" class="card-header">
+            {{#t}}Enter your email{{/t}}
+            <span class="block text-sm font-body font-normal mt-1" id="subheader">
+              {{#serviceLogo}}
+                <!-- L10N: For languages structured like English, the phrase can read "to continue to" with Pocket image following -->
+                {{#unsafeTranslate}}Continue to <div class="graphic %(serviceLogo)s">%(serviceName)s</div>{{/unsafeTranslate}}
+              {{/serviceLogo}}
+              {{^serviceLogo}}
+                <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->
+                {{#t}}Continue to %(serviceName)s{{/t}}
+              {{/serviceLogo}}
+            </span>
+          </h1>
+        {{/isOAuthNativeRelay}}
+        {{#isOAuthNativeRelay}}
+          <h1 id="fxa-enter-email-header" class="card-header">
+            {{#t}}Create an email mask{{/t}}
+          </h1>
+          <p class="mt-1 mb-9 text-grey-600" id="subheader">
+            {{#t}}Please provide the email address where you’d like to forward emails from your masked email.{{/t}}
+          </p>
+        {{/isOAuthNativeRelay}}
       {{/isSync}}
   </header>
 
@@ -44,10 +54,14 @@
     </form>
 
     {{^isSync}}
-      {{{ unsafeThirdPartyAuthHTML }}}
+      {{^isOAuthNativeRelay}}
+        {{{ unsafeThirdPartyAuthHTML }}}
+      {{/isOAuthNativeRelay}}
     {{/isSync}}
 
-    <div class="text-xs text-grey-500 mb-0 mt-5">
+    <div class="text-xs text-grey-500 mb-0
+    {{#isOAuthNativeRelay}}mt-8{{/isOAuthNativeRelay}}
+    {{^isOAuthNativeRelay}}mt-5{{/isOAuthNativeRelay}}">
       {{#isSync}}
         <p id="firefox-family-services" class="mb-2">
           {{#t}}A Mozilla account also unlocks access to more privacy-protecting products from Mozilla.{{/t}}

--- a/packages/fxa-content-server/app/scripts/views/mixins/service-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/service-mixin.js
@@ -33,6 +33,7 @@ export default {
       serviceName: subscriptionProductName || serviceName,
       serviceLogo,
       isSync: this.relier.isSync(),
+      isOAuthNativeRelay: this.relier.isOAuthNativeRelay(),
     });
   },
 

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -275,6 +275,36 @@ describe('views/index', () => {
             );
           });
         });
+
+        describe('isOAuthNativeRelay', () => {
+          beforeEach(() => {
+            relier.set({
+              action: 'email',
+              service: 'relay',
+            });
+            sinon.stub(relier, 'isOAuthNativeRelay').callsFake(() => true);
+          });
+          it('renders expected text when service=relay', () => {
+            return view.render().then(() => {
+              assert.include(
+                view.$(Selectors.HEADER).text(),
+                'Create an email mask'
+              );
+              assert.include(
+                view.$(Selectors.SUB_HEADER).text(),
+                'Please provide the email address where you’d like to forward emails from your masked email.'
+              );
+            });
+          });
+
+          it('does not render FF family or third party auth buttons when service=relay', () => {
+            return view.render().then(() => {
+              assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 0);
+              assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.GOOGLE), 0);
+              assert.lengthOf(view.$(Selectors.THIRD_PARTY_AUTH.APPLE), 0);
+            });
+          });
+        });
       });
 
       describe('fallback behavior', () => {

--- a/packages/fxa-dev-launcher/README.md
+++ b/packages/fxa-dev-launcher/README.md
@@ -12,7 +12,7 @@ Available options:
 - `FIREFOX_DEBUGGER=true` - open the [Browser Toolbox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox) on start (NOTE: `false` by default for speed).
 - `FXA_DESKTOP_CONTEXT` - context value for the fxa-content-server: `context=[value]` (NOTE: `fx_desktop_v3` is default).
 
-Tip: run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 yarn firefox` to test the OAuth Desktop flow.
+Tip: run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 yarn firefox` (from the repo root) to test the OAuth Desktop flow. Run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 FIREFOX_BIN=/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox yarn firefox` to test the OAuth Desktop flow (for MacOS) on Nightly.
 
 ### Basic Usage Example in OS X
 

--- a/packages/fxa-settings/src/components/Banner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.stories.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import Banner, { BannerType } from '.';
+import Banner, { BannerType, FancyBanner } from '.';
 import { Meta } from '@storybook/react';
 import AppLayout from '../AppLayout';
 import { Subject } from './mocks';
@@ -42,5 +42,14 @@ export const Error = () => (
 export const DismissibleInfo = () => (
   <AppLayout>
     <Subject />
+  </AppLayout>
+);
+export const FancySuccess = () => (
+  <AppLayout>
+    <FancyBanner
+      type={BannerType.success}
+      message={{ heading: 'Fancy heading', message: 'Fancy message' }}
+      children={''}
+    />
   </AppLayout>
 );

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -128,7 +128,7 @@ export const FancyBanner = (
     <Banner {...{ ...props, additionalClassNames: 'text-left' }}>
       <div className="flex flex-row gap-x-1">
         <div className="basis-1/5 place-self-center">{icon}</div>
-        <div className="">
+        <div>
           <h2 className="text-base">{props.message.heading}</h2>
           <p className="font-normal">{props.message.message}</p>
         </div>

--- a/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
+++ b/packages/fxa-settings/src/components/TermsPrivacyAgreement/index.tsx
@@ -10,132 +10,131 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 export type TermsPrivacyAgreementProps = {
   isPocketClient?: boolean;
   isMonitorClient?: boolean;
+  marginClassName?: string;
 };
 
 const TermsPrivacyAgreement = ({
   isPocketClient = false,
   isMonitorClient = false,
+  marginClassName = 'mt-5',
 }: TermsPrivacyAgreementProps) => {
-  if (isPocketClient || isMonitorClient) {
-    return (
-      <div className="text-grey-500 mt-5 text-xs">
-        <FtlMsg id="terms-privacy-agreement-intro-2">
-          <p>By proceeding, you agree to the:</p>
-        </FtlMsg>
-        <ul>
-          {isPocketClient && (
-            <FtlMsg
-              id="terms-privacy-agreement-pocket-2"
-              elems={{
-                pocketTos: (
+  return (
+    <div className={`text-grey-500 text-xs ${marginClassName}`}>
+      {isPocketClient || isMonitorClient ? (
+        <>
+          <FtlMsg id="terms-privacy-agreement-intro-2">
+            <p>By proceeding, you agree to the:</p>
+          </FtlMsg>
+          <ul>
+            {isPocketClient && (
+              <FtlMsg
+                id="terms-privacy-agreement-pocket-2"
+                elems={{
+                  pocketTos: (
+                    <LinkExternal
+                      className="link-grey"
+                      href="https://getpocket.com/tos/"
+                    >
+                      Terms of Service
+                    </LinkExternal>
+                  ),
+                  pocketPrivacy: (
+                    <LinkExternal
+                      className="link-grey"
+                      href="https://getpocket.com/privacy/"
+                    >
+                      Privacy Notice
+                    </LinkExternal>
+                  ),
+                }}
+              >
+                <li>
+                  Pocket{' '}
                   <LinkExternal
                     className="link-grey"
                     href="https://getpocket.com/tos/"
                   >
                     Terms of Service
-                  </LinkExternal>
-                ),
-                pocketPrivacy: (
+                  </LinkExternal>{' '}
+                  and{' '}
                   <LinkExternal
                     className="link-grey"
                     href="https://getpocket.com/privacy/"
                   >
                     Privacy Notice
                   </LinkExternal>
-                ),
-              }}
-            >
-              <li>
-                Pocket{' '}
-                <LinkExternal
-                  className="link-grey"
-                  href="https://getpocket.com/tos/"
-                >
-                  Terms of Service
-                </LinkExternal>{' '}
-                and{' '}
-                <LinkExternal
-                  className="link-grey"
-                  href="https://getpocket.com/privacy/"
-                >
-                  Privacy Notice
-                </LinkExternal>
-              </li>
-            </FtlMsg>
-          )}
-          {isMonitorClient && (
-            <FtlMsg
-              id="terms-privacy-agreement-monitor-3"
-              elems={{
-                mozSubscriptionTosLink: (
+                </li>
+              </FtlMsg>
+            )}
+            {isMonitorClient && (
+              <FtlMsg
+                id="terms-privacy-agreement-monitor-3"
+                elems={{
+                  mozSubscriptionTosLink: (
+                    <LinkExternal
+                      className="link-grey"
+                      href="https://www.mozilla.org/about/legal/terms/subscription-services/"
+                    >
+                      Terms of Service
+                    </LinkExternal>
+                  ),
+                  mozSubscriptionPrivacyLink: (
+                    <LinkExternal
+                      className="link-grey"
+                      href="https://www.mozilla.org/privacy/subscription-services/"
+                    >
+                      Privacy Notice
+                    </LinkExternal>
+                  ),
+                }}
+              >
+                <li>
+                  Mozilla Subscription Services{' '}
                   <LinkExternal
                     className="link-grey"
                     href="https://www.mozilla.org/about/legal/terms/subscription-services/"
                   >
                     Terms of Service
-                  </LinkExternal>
-                ),
-                mozSubscriptionPrivacyLink: (
+                  </LinkExternal>{' '}
+                  and{' '}
                   <LinkExternal
                     className="link-grey"
                     href="https://www.mozilla.org/privacy/subscription-services/"
                   >
                     Privacy Notice
                   </LinkExternal>
+                </li>
+              </FtlMsg>
+            )}
+            <FtlMsg
+              id="terms-privacy-agreement-mozilla"
+              elems={{
+                mozillaAccountsTos: (
+                  <Link className="link-grey" to="/legal/terms">
+                    Terms of Service
+                  </Link>
+                ),
+                mozillaAccountsPrivacy: (
+                  <Link className="link-grey" to="/legal/privacy">
+                    Privacy Notice
+                  </Link>
                 ),
               }}
             >
               <li>
-                Mozilla Subscription Services{' '}
-                <LinkExternal
-                  className="link-grey"
-                  href="https://www.mozilla.org/about/legal/terms/subscription-services/"
-                >
-                  Terms of Service
-                </LinkExternal>{' '}
-                and{' '}
-                <LinkExternal
-                  className="link-grey"
-                  href="https://www.mozilla.org/privacy/subscription-services/"
-                >
-                  Privacy Notice
-                </LinkExternal>
-              </li>
-            </FtlMsg>
-          )}
-          {/* Included for both Pocket and Monitor */}
-          <FtlMsg
-            id="terms-privacy-agreement-mozilla"
-            elems={{
-              mozillaAccountsTos: (
+                Mozilla Accounts{' '}
                 <Link className="link-grey" to="/legal/terms">
                   Terms of Service
-                </Link>
-              ),
-              mozillaAccountsPrivacy: (
+                </Link>{' '}
+                and{' '}
                 <Link className="link-grey" to="/legal/privacy">
                   Privacy Notice
                 </Link>
-              ),
-            }}
-          >
-            <li>
-              Mozilla Accounts{' '}
-              <Link className="link-grey" to="/legal/terms">
-                Terms of Service
-              </Link>{' '}
-              and{' '}
-              <Link className="link-grey" to="/legal/privacy">
-                Privacy Notice
-              </Link>
-            </li>
-          </FtlMsg>
-        </ul>
-      </div>
-    );
-  } else {
-    return (
-      <div className="text-grey-500 mt-5 text-xs">
+              </li>
+            </FtlMsg>
+          </ul>
+        </>
+      ) : (
         <FtlMsg
           id="terms-privacy-agreement-default-2"
           elems={{
@@ -163,9 +162,9 @@ const TermsPrivacyAgreement = ({
             .
           </p>
         </FtlMsg>
-      </div>
-    );
-  }
+      )}
+    </div>
+  );
 };
 
 export default TermsPrivacyAgreement;

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -117,6 +117,10 @@ export type FxAOAuthLogin = {
   // For sync oauth signup
   declinedSyncEngines?: string[];
   offeredSyncEngines?: string[];
+  // For sync optional flows (currently only Relay)
+  services?: {
+    relay: {};
+  };
 };
 
 // ref: https://searchfox.org/mozilla-central/rev/82828dba9e290914eddd294a0871533875b3a0b5/services/fxaccounts/FxAccountsWebChannel.sys.mjs#230

--- a/packages/fxa-settings/src/models/integrations/base-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/base-integration.ts
@@ -105,6 +105,10 @@ export abstract class Integration<
     return false;
   }
 
+  isDesktopRelay() {
+    return false;
+  }
+
   isFirefoxMobileClient() {
     return false;
   }

--- a/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
@@ -37,6 +37,14 @@ export enum OAuthNativeClients {
 }
 
 /**
+ * These come through via data.service (a query parameter).
+ */
+enum OAuthNativeServices {
+  Sync = 'sync',
+  Relay = 'relay',
+}
+
+/**
  * A convenience function for the OAuthNativeIntegration type guard + isSync().
  */
 export const isOAuthNativeIntegrationSync = (
@@ -70,7 +78,17 @@ export class OAuthNativeIntegration extends OAuthWebIntegration {
       this.isFirefoxDesktopClient() &&
       // Sync oauth desktop should always provide a `service=sync` parameter but
       // we'll also default to Sync if it's missing.
-      (this.data.service === undefined || this.data.service === 'sync')
+      (this.data.service === undefined ||
+        this.data.service === OAuthNativeServices.Sync)
+    );
+  }
+
+  // Note, if/when we expand this to other services, possibly consider making a
+  // isSyncOptional method (or whatever name makes sense) instead
+  isDesktopRelay() {
+    return (
+      this.isFirefoxDesktopClient() &&
+      this.data.service === OAuthNativeServices.Relay
     );
   }
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -210,9 +210,11 @@ const CompleteResetPasswordContainer = ({
         uid: accountResetData.uid,
         unwrapBKey: accountResetData.unwrapBKey,
         verified: accountResetData.verified,
-        services: {
-          sync: {},
-        },
+        ...(!integration.isDesktopRelay() && {
+          services: {
+            sync: {},
+          },
+        }),
       });
     }
   };

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -25,6 +25,7 @@ export function createMockWebIntegration() {
     isSync: () => false,
     wantsKeys: () => false,
     isDesktopSync: () => false,
+    isDesktopRelay: () => false,
     data: {},
   };
 }

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -18,7 +18,7 @@ import { Subject } from './mocks';
 import { MOCK_OAUTH_FLOW_HANDLER_RESPONSE } from '../../mocks';
 import {
   createMockSigninOAuthIntegration,
-  createMockSigninSyncIntegration,
+  createMockSigninOAuthNativeSyncIntegration,
 } from '../mocks';
 import { SigninIntegration } from '../interfaces';
 import {
@@ -152,8 +152,7 @@ describe('Sign in with TOTP code page', () => {
       expect(navigate).toHaveBeenCalledWith('/settings');
     });
 
-    // When CAD is converted to React, just test navigation since CAD will handle fxaLogin
-    describe('fxaLogin webchannel message (tempHandleSyncLogin)', () => {
+    describe('fxaLogin webchannel message', () => {
       let fxaLoginSpy: jest.SpyInstance;
       let hardNavigateSpy: jest.SpyInstance;
       beforeEach(() => {
@@ -162,8 +161,8 @@ describe('Sign in with TOTP code page', () => {
           .spyOn(utils, 'hardNavigate')
           .mockImplementation(() => {});
       });
-      it('is sent if Sync integration and navigates to CAD', async () => {
-        const integration = createMockSigninSyncIntegration();
+      it('is sent if Sync integration and navigates to pair', async () => {
+        const integration = createMockSigninOAuthNativeSyncIntegration();
         await waitFor(() =>
           renderAndSubmitTotpCode(
             {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -20,6 +20,7 @@ const mockWebIntegration = {
   getService: () => MozServices.Default,
   isSync: () => false,
   wantsKeys: () => false,
+  isDesktopRelay: () => false,
 } as Integration;
 
 export const MOCK_TOTP_LOCATION_STATE = {

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -9,7 +9,7 @@ import { Meta } from '@storybook/react';
 import {
   Subject,
   createMockSigninOAuthIntegration,
-  createMockSigninSyncIntegration,
+  createMockSigninOAuthNativeSyncIntegration,
 } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { SigninProps } from './interfaces';
@@ -70,5 +70,5 @@ export const NoLinkedAccountAndNoPassword = storyWithProps({
 export const NoThirdPartyAuthBecauseSyncWithPassword = storyWithProps({
   hasLinkedAccount: true,
   hasPassword: true,
-  integration: createMockSigninSyncIntegration(),
+  integration: createMockSigninOAuthNativeSyncIntegration(),
 });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -107,7 +107,8 @@ const Signin = ({
     },
   });
 
-  const hideThirdPartyAuth = integration.isSync() && hasPassword;
+  const hideThirdPartyAuth =
+    (integration.isSync() || integration.isDesktopRelay()) && hasPassword;
 
   useEffect(() => {
     if (!isPasswordNeededRef.current) {

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -21,7 +21,13 @@ export interface AvatarResponse {
 export type SigninIntegration =
   | Pick<
       Integration,
-      'type' | 'isSync' | 'getService' | 'wantsKeys' | 'data' | 'isDesktopSync'
+      | 'type'
+      | 'isSync'
+      | 'getService'
+      | 'wantsKeys'
+      | 'data'
+      | 'isDesktopSync'
+      | 'isDesktopRelay'
     >
   | SigninOAuthIntegration;
 
@@ -35,6 +41,7 @@ export type SigninOAuthIntegration = Pick<
   | 'wantsLogin'
   | 'data'
   | 'isDesktopSync'
+  | 'isDesktopRelay'
 >;
 
 export interface LocationState {

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -105,10 +105,11 @@ export function createMockSigninWebIntegration(): SigninIntegration {
     wantsKeys: () => false,
     data: {},
     isDesktopSync: () => false,
+    isDesktopRelay: () => false,
   };
 }
 
-export function createMockSigninSyncIntegration(
+export function createMockSigninOAuthNativeSyncIntegration(
   type = IntegrationType.OAuthNative
 ): SigninIntegration {
   return {
@@ -118,6 +119,7 @@ export function createMockSigninSyncIntegration(
     getService: () => MozServices.FirefoxSync,
     data: {},
     isDesktopSync: () => true,
+    isDesktopRelay: () => false,
   };
 }
 
@@ -139,6 +141,25 @@ export function createMockSigninOAuthIntegration({
     wantsTwoStepAuthentication: () => false,
     isDesktopSync: () => isSync,
     data: {},
+    isDesktopRelay: () => false,
+  };
+}
+
+export function createMockSigninOAuthNativeIntegration({
+  isSync = true,
+}: {
+  isSync?: boolean;
+} = {}): SigninOAuthIntegration {
+  return {
+    type: IntegrationType.OAuthNative,
+    getService: () => MOCK_CLIENT_ID,
+    isSync: () => isSync,
+    wantsKeys: () => true,
+    wantsLogin: () => false,
+    wantsTwoStepAuthentication: () => false,
+    isDesktopSync: () => isSync,
+    data: {},
+    isDesktopRelay: () => !isSync,
   };
 }
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -262,9 +262,9 @@ describe('ConfirmSignupCode page', () => {
     beforeEach(() => {
       fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
     });
-    const integration = createMockOAuthNativeIntegration();
 
-    it('sends expected web channel messages', async () => {
+    it('sends expected web channel messages when service=sync', async () => {
+      const integration = createMockOAuthNativeIntegration();
       const offeredSyncEngines = ['blabbitybee', 'bloopitybop'];
       const declinedSyncEngines = ['bloopitybop'];
       renderWithSession({
@@ -282,6 +282,25 @@ describe('ConfirmSignupCode page', () => {
           offeredSyncEngines,
           action: 'signup',
           ...MOCK_OAUTH_FLOW_HANDLER_RESPONSE,
+        });
+      });
+    });
+    it('sends expected web channel messages when service=relay', async () => {
+      const integration = createMockOAuthNativeIntegration(false);
+      renderWithSession({
+        session,
+        integration,
+        finishOAuthFlowHandler: mockFinishOAuthFlowHandler,
+      });
+      submit();
+
+      await waitFor(() => {
+        expect(fxaOAuthLoginSpy).toHaveBeenCalledWith({
+          action: 'signup',
+          ...MOCK_OAUTH_FLOW_HANDLER_RESPONSE,
+          services: {
+            relay: {},
+          },
         });
       });
     });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -94,6 +94,16 @@ const ConfirmSignupCode = ({
     'Confirmation code is required'
   );
 
+  function goToSettingsWithAlertSuccess() {
+    alertBar.success(
+      ftlMsgResolver.getMsg(
+        'confirm-signup-code-success-alert',
+        'Account confirmed successfully'
+      )
+    );
+    navigate('/settings', { replace: true });
+  }
+
   async function handleResendCode() {
     try {
       await session.sendVerificationCode();
@@ -207,6 +217,17 @@ const ConfirmSignupCode = ({
             const { to } = getSyncNavigate(location.search);
             hardNavigate(to);
             return;
+          } else if (integration.isDesktopRelay()) {
+            firefox.fxaOAuthLogin({
+              action: 'signup',
+              code,
+              redirect,
+              state,
+              services: {
+                relay: {},
+              },
+            });
+            goToSettingsWithAlertSuccess();
           } else {
             // Navigate to relying party
             hardNavigate(redirect);
@@ -228,13 +249,7 @@ const ConfirmSignupCode = ({
             });
           }
         } else {
-          alertBar.success(
-            ftlMsgResolver.getMsg(
-              'confirm-signup-code-success-alert',
-              'Account confirmed successfully'
-            )
-          );
-          navigate('/settings', { replace: true });
+          goToSettingsWithAlertSuccess();
         }
       }
     } catch (error) {

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -56,6 +56,7 @@ export type ConfirmSignupCodeOAuthIntegration = Pick<
   | 'wantsTwoStepAuthentication'
   | 'isSync'
   | 'getPermissions'
+  | 'isDesktopRelay'
 >;
 
 export type ConfirmSignupCodeIntegration =

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -53,18 +53,22 @@ export function createMockOAuthWebIntegration(
     wantsTwoStepAuthentication: () => false,
     isSync: () => false,
     getPermissions: () => [],
+    isDesktopRelay: () => false,
   };
 }
 
-export function createMockOAuthNativeIntegration(): ConfirmSignupCodeOAuthIntegration {
+export function createMockOAuthNativeIntegration(
+  isSync = true
+): ConfirmSignupCodeOAuthIntegration {
   return {
     type: IntegrationType.OAuthNative,
     data: { uid: MOCK_UID, redirectTo: undefined },
     getRedirectUri: () => MOCK_REDIRECT_URI,
     getService: () => OAuthNativeClients.FirefoxDesktop,
     wantsTwoStepAuthentication: () => false,
-    isSync: () => true,
+    isSync: () => isSync,
     getPermissions: () => [],
+    isDesktopRelay: () => !isSync,
   };
 }
 

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -38,12 +38,12 @@ import * as ReactUtils from 'fxa-react/lib/utils';
 // Typical imports
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';
-import SignupContainer, { SignupContainerIntegration } from './container';
+import SignupContainer from './container';
 import { IntegrationType, useAuthClient } from '../../models';
 import { MozServices } from '../../lib/types';
 import { FirefoxCommand } from '../../lib/channels/firefox';
 import { Constants } from '../../lib/constants';
-import { SignupProps } from './interfaces';
+import { SignupIntegration, SignupProps } from './interfaces';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { GraphQLError } from 'graphql';
 import { ApolloClient } from '@apollo/client';
@@ -57,20 +57,14 @@ import { mockLoadingSpinnerModule, MOCK_FLOW_ID } from '../mocks';
 // Principle, will limit the amount you need to mock. Here, we let the container specify
 // the SignupContainerIntegration interface which is a subset (and therefore compatible)
 // larger and often more specific interfaces like Integration, OAuthIntegration, etc...
-let integration: SignupContainerIntegration;
+let integration: SignupIntegration;
 function mockIntegration() {
   integration = {
     type: IntegrationType.SyncDesktopV3,
     getService: () => MozServices.Default,
     isSync: () => true,
     wantsKeys: () => true,
-    features: {
-      allowUidChange: false,
-      fxaStatus: false,
-      handleSignedInNotification: false,
-      reuseExistingSession: false,
-      supportsPairing: false,
-    },
+    isDesktopRelay: () => false,
   };
 }
 let serviceName: MozServices;

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -5,8 +5,7 @@
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import {
-  Integration,
-  isOAuthNativeIntegrationSync,
+  isOAuthIntegration,
   isSyncDesktopV3Integration,
   useAuthClient,
   useConfig,
@@ -20,6 +19,7 @@ import {
   BeginSignUpOptions,
   BeginSignupHandler,
   BeginSignupResponse,
+  SignupIntegration,
 } from './interfaces';
 import { BEGIN_SIGNUP_MUTATION } from './gql';
 import { useCallback, useEffect, useState } from 'react';
@@ -61,11 +61,6 @@ import { QueryParams } from '../..';
  * If we want to mimic this functionality we can once index is converted.
  */
 
-export type SignupContainerIntegration = Pick<
-  Integration,
-  'type' | 'getService' | 'features' | 'isSync' | 'wantsKeys'
->;
-
 type LocationState = {
   emailStatusChecked?: boolean;
 };
@@ -74,7 +69,7 @@ const SignupContainer = ({
   integration,
   flowQueryParams,
 }: {
-  integration: SignupContainerIntegration;
+  integration: SignupIntegration;
   flowQueryParams: QueryParams;
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
@@ -96,7 +91,8 @@ const SignupContainer = ({
     string[] | undefined
   >();
 
-  const isSyncOAuth = isOAuthNativeIntegrationSync(integration);
+  const isOAuth = isOAuthIntegration(integration);
+  const isSyncOAuth = isOAuth && integration.isSync();
   const isSyncDesktopV3 = isSyncDesktopV3Integration(integration);
   const isSync = integration.isSync();
   const wantsKeys = integration.wantsKeys();

--- a/packages/fxa-settings/src/pages/Signup/en.ftl
+++ b/packages/fxa-settings/src/pages/Signup/en.ftl
@@ -2,6 +2,8 @@
 ## This is the second page of the sign up flow, users have already entered their email
 
 signup-heading = Set your password
+signup-relay-info = A password is needed to securely manage your masked emails and access { -brand-mozilla }’s security tools.
+signup-heading-relay = Create a password
 # This text is displayed in a dismissible info banner and is only displayed to Pocket clients
 # <LinkExternal> leads to https://support.mozilla.org/kb/pocket-firefox-account-migration
 signup-info-banner-for-pocket = Why do I need to create this account? <LinkExternal>Find out here</LinkExternal>

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -8,6 +8,7 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import {
+  createMockSignupOAuthNativeIntegration,
   createMockSignupOAuthWebIntegration,
   createMockSignupSyncDesktopV3Integration,
   mockBeginSignupHandler,
@@ -21,7 +22,6 @@ import {
   POCKET_CLIENTIDS,
 } from '../../models/integrations/client-matching';
 import { getSyncEngineIds } from '../../components/ChooseWhatToSync/sync-engines';
-import { MOCK_CLIENT_ID } from '../mocks';
 
 export default {
   title: 'Pages/Signup',
@@ -67,5 +67,9 @@ export const SyncDesktopV3 = storyWithProps(
 );
 
 export const SyncOAuth = storyWithProps(
-  createMockSignupOAuthWebIntegration(MOCK_CLIENT_ID)
+  createMockSignupOAuthNativeIntegration()
+);
+
+export const OAuthDestkopServiceRelay = storyWithProps(
+  createMockSignupOAuthNativeIntegration(false)
 );

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { HandledError } from '../../lib/error-utils';
-import {
-  BaseIntegration,
-  IntegrationType,
-  OAuthIntegration,
-} from '../../models';
+import { BaseIntegration, OAuthIntegration } from '../../models';
 import { SignupQueryParams } from '../../models/pages/signup';
 import { MetricsContext } from 'fxa-auth-client/browser';
 
@@ -51,19 +47,21 @@ export interface SignupProps {
 
 export type SignupIntegration = SignupOAuthIntegration | SignupBaseIntegration;
 
-export interface SignupOAuthIntegration {
-  type: IntegrationType.OAuthWeb | IntegrationType.OAuthNative;
-  isSync: () => ReturnType<OAuthIntegration['isSync']>;
-  getRedirectUri: () => ReturnType<OAuthIntegration['getRedirectUri']>;
-  saveOAuthState: () => ReturnType<OAuthIntegration['saveOAuthState']>;
-  getService: () => ReturnType<OAuthIntegration['getService']>;
-}
+export type SignupOAuthIntegration = Pick<
+  OAuthIntegration,
+  | 'type'
+  | 'isSync'
+  | 'getRedirectUri'
+  | 'saveOAuthState'
+  | 'getService'
+  | 'isDesktopRelay'
+  | 'wantsKeys'
+>;
 
-export interface SignupBaseIntegration {
-  type: IntegrationType;
-  isSync: () => ReturnType<BaseIntegration['isSync']>;
-  getService: () => ReturnType<BaseIntegration['getService']>;
-}
+export type SignupBaseIntegration = Pick<
+  BaseIntegration,
+  'type' | 'isSync' | 'getService' | 'isDesktopRelay' | 'wantsKeys'
+>;
 
 export interface SignupFormData {
   email: string;

--- a/packages/fxa-settings/src/pages/Signup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/mocks.tsx
@@ -35,6 +35,8 @@ export function createMockSignupWebIntegration(): SignupBaseIntegration {
     type: IntegrationType.Web,
     getService: () => Promise.resolve(MozServices.Default),
     isSync: () => false,
+    isDesktopRelay: () => false,
+    wantsKeys: () => false,
   };
 }
 
@@ -43,6 +45,8 @@ export function createMockSignupSyncDesktopV3Integration(): SignupBaseIntegratio
     type: IntegrationType.SyncDesktopV3,
     getService: () => Promise.resolve(MozServices.FirefoxSync),
     isSync: () => true,
+    isDesktopRelay: () => false,
+    wantsKeys: () => false,
   };
 }
 
@@ -55,19 +59,22 @@ export function createMockSignupOAuthWebIntegration(
     saveOAuthState: () => {},
     getService: () => clientId || MOCK_CLIENT_ID,
     isSync: () => false,
+    isDesktopRelay: () => false,
+    wantsKeys: () => false,
   };
 }
 
 export function createMockSignupOAuthNativeIntegration(
-  clientId?: string,
   isSync = true
 ): SignupOAuthIntegration {
   return {
     type: IntegrationType.OAuthNative,
     getRedirectUri: () => MOCK_REDIRECT_URI,
     saveOAuthState: () => {},
-    getService: () => clientId || MOCK_CLIENT_ID,
+    getService: () => MOCK_CLIENT_ID,
     isSync: () => isSync,
+    isDesktopRelay: () => !isSync,
+    wantsKeys: () => true,
   };
 }
 


### PR DESCRIPTION
Because:
* We want to support this new 'sync optional' flow to allow users to sign into the browser without being signed into Sync, beginning with Relay

This commit:
* Allows service=relay query param with our oauth flow
* Adds logic to content-server reliers/fxa-settings integrations to check for this browser-but-not-Sync Relay case
* Makes conditional email-first UX changes for service=relay
* Makes conditional Signup UX changes for service=relay
* Adjusts web channel messages for fxaLogin and fxaOAuthLogin, for signin and signup

closes FXA-10313, closes FXA-10377

---

This needs to be tested with **latest** Nightly (and then swapping `service=sync` with `service=relay`), see fxa-dev-launcher README with new (in this branch) Nightly command note for oauth desktop.
* Testable through sign up, signin, signin with 2FA, signin token code
* Also double checking that I didn't mess anything up with sync v3 desktop / regular oauth desktop would be nice 🙏 but I can make notes for QA on all this too.