### PR TITLE
feat(tests): Add functional tests for Relay

### DIFF
--- a/packages/functional-tests/lib/query-params.ts
+++ b/packages/functional-tests/lib/query-params.ts
@@ -40,6 +40,21 @@ export const syncDesktopOAuthQueryParams = new URLSearchParams({
   service: 'sync',
 });
 
+export const relayDesktopOAuthQueryParams = new URLSearchParams({
+  ...Object.fromEntries(oauthWebchannelV1.entries()),
+  client_id: FF_OAUTH_CLIENT_ID, // Firefox Desktop
+  code_challenge_method: 'S256',
+  code_challenge: '2oc_C4v1qHeefWAGu5LI5oDG1oX4FV_Itc148D8_oQI',
+  // eslint-disable-next-line camelcase
+  keys_jwk:
+    'eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6ImdUejVIWFJfa2pxSFRtMG43ZjhxcDMybVZFaHZ1cGo1dXNUV1h5TWZsb1kiLCJ5IjoiVER5TlhkalhibHZld1pWLVc5MXNDZU9fRWd0NU9WYXhpblBzOEFTQ3owZyJ9',
+  scope:
+    'https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session',
+  state: 'fakestate',
+  automatedBrowser: 'true',
+  service: 'relay',
+});
+
 export const syncDesktopV3QueryParams = new URLSearchParams({
   context: 'fx_desktop_v3',
   service: 'sync',

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { FirefoxCommand } from '../../lib/channels';
+import { expect, test } from '../../lib/fixtures/standard';
+import { relayDesktopOAuthQueryParams } from '../../lib/query-params';
+import { getCode } from 'packages/fxa-settings/src/lib/totp';
+
+const AGE_21 = '21';
+
+test.describe('relay integration', () => {
+  test('signup with Relay desktop', async ({
+    target,
+    syncOAuthBrowserPages: { confirmSignupCode, page, signup },
+    testAccountTracker,
+  }) => {
+    const { email, password } =
+      testAccountTracker.generateSignupAccountDetails();
+
+    await signup.goto('/authorization', relayDesktopOAuthQueryParams);
+
+    await expect(signup.page.getByText('Create an email mask ')).toBeVisible();
+
+    await signup.emailTextbox.fill(email);
+    await signup.submitButton.click();
+
+    await expect(
+      signup.page.getByText(
+        'A password is needed to securely manage your masked emails and access ⁨Mozilla⁩’s security tools.'
+      )
+    ).toBeVisible();
+
+    await signup.passwordTextbox.fill(password);
+    await signup.verifyPasswordTextbox.fill(password);
+    await signup.ageTextbox.fill(AGE_21);
+    await signup.createAccountButton.click();
+
+    await page.waitForURL(/confirm_signup_code/);
+
+    const code = await target.emailClient.getVerifyShortCode(email);
+    await confirmSignupCode.fillOutCodeForm(code);
+
+    await page.waitForURL(/settings/);
+
+    await signup.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+    await signup.checkWebChannelMessage(FirefoxCommand.Login);
+  });
+
+  test('signin with Relay desktop', async ({
+    syncOAuthBrowserPages: { confirmSignupCode, page, signin },
+    testAccountTracker,
+  }) => {
+    const { email, password } = await testAccountTracker.signUp();
+
+    await signin.goto('/authorization', relayDesktopOAuthQueryParams);
+
+    await expect(signin.page.getByText('Create an email mask ')).toBeVisible();
+
+    await signin.fillOutEmailFirstForm(email);
+
+    await signin.fillOutPasswordForm(password);
+
+    await page.waitForURL(/settings/);
+
+    await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+    await signin.checkWebChannelMessage(FirefoxCommand.Login);
+  });
+
+  test('signin with Relay desktop - with confirm email', async ({
+    target,
+    syncOAuthBrowserPages: { signinTokenCode, page, signin },
+    testAccountTracker,
+  }) => {
+    const { email, password } = await testAccountTracker.signUpSync();
+
+    await signin.goto('/authorization', relayDesktopOAuthQueryParams);
+
+    await expect(signin.page.getByText('Create an email mask ')).toBeVisible();
+
+    await signin.fillOutEmailFirstForm(email);
+
+    await signin.fillOutPasswordForm(password);
+
+    await page.waitForURL(/signin_token_code/);
+    const code = await target.emailClient.getVerifyLoginCode(email);
+    await signinTokenCode.fillOutCodeForm(code);
+
+    await page.waitForURL(/settings/);
+
+    await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+    await signin.checkWebChannelMessage(FirefoxCommand.Login);
+  });
+
+  test('signin with Relay desktop - with 2FA', async ({
+    target,
+    syncOAuthBrowserPages: { signinTotpCode, totp, page, signin, settings },
+    testAccountTracker,
+  }) => {
+    const { email, password } = await testAccountTracker.signUp();
+
+    // Sign-in without Sync, otw you will get prompted to create a recovery key
+    await page.goto(target.contentServerUrl, { waitUntil: 'load' });
+
+    await signin.fillOutEmailFirstForm(email);
+    await signin.fillOutPasswordForm(password);
+
+    await expect(settings.settingsHeading).toBeVisible();
+    await settings.totp.addButton.click();
+    const { secret } = await totp.fillOutTotpForms();
+    await expect(settings.totp.status).toHaveText('Enabled');
+    await settings.signOut();
+
+    await signin.goto('/authorization', relayDesktopOAuthQueryParams);
+
+    await expect(signin.page.getByText('Create an email mask ')).toBeVisible();
+
+    await signin.fillOutEmailFirstForm(email);
+
+    await signin.fillOutPasswordForm(password);
+
+    await page.waitForURL(/signin_totp_code/);
+
+    const totpCode = await getCode(secret);
+    await signinTotpCode.fillOutCodeForm(totpCode);
+
+    await page.waitForURL(/settings/);
+
+    await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
+    await signin.checkWebChannelMessage(FirefoxCommand.Login);
+
+    await settings.disconnectTotp(); // Required before teardown
+  });
+});


### PR DESCRIPTION
## Because

- We want functional tests for Relay

## This pull request

- Adds functional tests for signin, signup, signin with email confirm, and signin with 2FA

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10415

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
