### PR TITLE
fix(oauth-desktop): Don't send up some options to fxaLogin when OAuth sync

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -83,13 +83,17 @@ jest.mock('../../lib/glean', () => ({
   },
 }));
 
-const commonFxaLoginOptions = {
+const oauthCommonFxaLoginOptions = {
   email: MOCK_EMAIL,
-  keyFetchToken: BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.keyFetchToken,
   sessionToken: BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.sessionToken,
   uid: BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.uid,
-  unwrapBKey: BEGIN_SIGNUP_HANDLER_RESPONSE.data.unwrapBKey,
   verified: false,
+};
+
+const commonFxaLoginOptions = {
+  ...oauthCommonFxaLoginOptions,
+  keyFetchToken: BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.keyFetchToken,
+  unwrapBKey: BEGIN_SIGNUP_HANDLER_RESPONSE.data.unwrapBKey,
 };
 
 describe('Signup page', () => {
@@ -636,7 +640,7 @@ describe('Signup page', () => {
             });
 
             expect(fxaLoginSpy).toBeCalledWith({
-              ...commonFxaLoginOptions,
+              ...oauthCommonFxaLoginOptions,
               services: {
                 sync: {
                   declinedEngines: [],
@@ -667,7 +671,7 @@ describe('Signup page', () => {
             });
 
             expect(fxaLoginSpy).toBeCalledWith({
-              ...commonFxaLoginOptions,
+              ...oauthCommonFxaLoginOptions,
               services: {
                 sync: {
                   declinedEngines: ['prefs', 'bookmarks'],
@@ -711,7 +715,7 @@ describe('Signup page', () => {
             });
 
             expect(fxaLoginSpy).toBeCalledWith({
-              ...commonFxaLoginOptions,
+              ...oauthCommonFxaLoginOptions,
               services: {
                 sync: {
                   declinedEngines: offeredEngines,
@@ -787,7 +791,7 @@ describe('Signup page', () => {
         await waitFor(() => {
           // Does not send services: { sync: {...} }
           expect(fxaLoginSpy).toBeCalledWith({
-            ...commonFxaLoginOptions,
+            ...oauthCommonFxaLoginOptions,
           });
         });
 


### PR DESCRIPTION
Because:
* This is causing intermittent issues where desktop thinks it should fetch keys

This commit:
* Does not send keyFetchToken/unwrapBKey if isOAuth is true

fixes FXA-10617

---

This was fixed [here for signin](https://github.com/mozilla/fxa/pull/17744/files#diff-a9a9b44d99bf0ed9a478d27f27cb4071ac2dc6874ead5caea0648f1df9bb25c5R174) a couple of weeks back. I want to DRY this up so we don't have to think about this when sending `fxaLogin`, but I already need to modify the login message in FXA-10614, so I'll create a helper function or make tweaks in `firefox.ts` for that in the other ticket.

To the reviewer - you _probably_ won't be able to reproduce the issue locally. I tried 7 times yesterday and didn't reproduce once, but it's reproducing more in stage/prod (this is a pref in Nightly so there's no user impact).