### PR TITLE
feat(tests): Fix 2FA inline setup flow

### DIFF
--- a/packages/functional-tests/pages/relier.ts
+++ b/packages/functional-tests/pages/relier.ts
@@ -119,6 +119,11 @@ export class RelierPage extends BaseLayout {
     return this.page.waitForURL(`${this.target.paymentsServerUrl}/**`);
   }
 
+  async clickRequire2FA() {
+    await this.page.getByText('Sign In (Require 2FA)').click();
+    return this.page.waitForURL(`${this.target.contentServerUrl}/**`);
+  }
+
   async getUrl() {
     const expectedPathRegExp = new RegExp(
       `\\/subscriptions\\/products\\/${this.target.subscriptionConfig.product}\\?plan=${this.target.subscriptionConfig.plan}&service=(\\w+)`,


### PR DESCRIPTION
## Because

- Some users were having issues setting up 2FA in the inline flow
- It appears that the `useEffect` was being called twice and creating then replacing the 2FA device

## This pull request

- Adds a ref so that the async create function only gets called once
- Adds a functional test for the flow

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10583

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I looked at having the create token only be trigger when the user clicks "Continue" but it was turning out to be a big refactor the way the container pattern was setup. 
