### PR TITLE
feat(payments-ui): Add error messaging for invalid email input

### DIFF
--- a/libs/payments/ui/src/lib/client/components/SignInForm/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/SignInForm/en.ftl
@@ -1,5 +1,7 @@
 signin-form-continue-button = Continue
 signin-form-email-input = Enter your email
+signin-form-email-input-missing = Please enter your email
+signin-form-email-input-invalid = Please provide a valid email
 
 next-new-user-subscribe-product-updates-mdnplus = I’d like to receive product news and updates from { -product-mdn-plus } and { -brand-mozilla }
 next-new-user-subscribe-product-updates-mozilla = I’d like to receive product news and updates from { -brand-mozilla }

--- a/libs/payments/ui/src/lib/client/components/SignInForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SignInForm/index.tsx
@@ -55,9 +55,24 @@ export const SignInForm = ({ newsletterLabel }: SignInFormProps) => {
             className="w-full border rounded-md border-black/30 p-3 placeholder:text-grey-500 placeholder:font-normal focus:border focus:!border-black/30 focus:!shadow-[0_0_0_3px_rgba(10,132,255,0.3)] focus-visible:outline-none data-[invalid=true]:border-alert-red data-[invalid=true]:text-alert-red data-[invalid=true]:shadow-inputError"
             type="email"
             data-testid="email"
+            required
             aria-required
           />
         </Form.Control>
+        <Form.Message match="valueMissing">
+          <Localized id="signin-form-email-input-missing">
+            <p className="mt-1 text-alert-red" role="alert">
+              Please enter your email
+            </p>
+          </Localized>
+        </Form.Message>
+        <Form.Message match="typeMismatch">
+          <Localized id="signin-form-email-input-invalid">
+            <p className="mt-1 text-alert-red" role="alert">
+              Please provide a valid email
+            </p>
+          </Localized>
+        </Form.Message>
       </Form.Field>
 
       <Form.Field


### PR DESCRIPTION
## This pull request

- adds error message for invalid email input

## Issue that this pull request solves

Closes: FXA-10546

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Missing email
<img width="581" alt="Screenshot 2024-10-25 at 2 53 10 PM" src="https://github.com/user-attachments/assets/5c9e04c4-1870-4e74-8c3d-671f00cfc1f3">

Invalid email
<img width="582" alt="Screenshot 2024-10-25 at 2 52 37 PM" src="https://github.com/user-attachments/assets/9042e0bf-9fb2-4d7c-a8d7-8cbe6026a880">
