### PR TITLE
fix(payments-cart): Remove stub account logic

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -117,6 +117,14 @@ export class CartEmailNotFoundError extends CartError {
   }
 }
 
+export class CartUidNotFoundError extends CartError {
+  constructor(cartId: string) {
+    super('Cart uid not found', {
+      cartId,
+    });
+  }
+}
+
 export class CartInvalidPromoCodeError extends CartError {
   constructor(promoCode: string, cartId?: string) {
     super('Cart specified promo code does not exist', {


### PR DESCRIPTION
## This pull request

- Removes logic creating stub account as it is no longer needed with the new signin/up process

## Issue that this pull request solves

Closes: FXA-10550

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.