### PR TITLE
chore(cleanup): DRY up service checks, comment/dev-launcher README tweak

### DIFF
--- a/packages/fxa-dev-launcher/README.md
+++ b/packages/fxa-dev-launcher/README.md
@@ -7,7 +7,6 @@ Available options:
 
 - `FXA_ENV=local` or `latest` or `stable` or `stage` or `content` (NOTE: `local` is default).
 - `DISABLE_E10S=true` - add this flag to turn off E10S. (NOTE: `false` by default).
-- `FXA_DESKTOP_CONTEXT` - `context=` value. (NOTE: `fx_desktop_v2` is default).
 - `FIREFOX_BIN=/Applications/FirefoxNightly.app/Contents/MacOS/firefox-bin npm start`
 - `FIREFOX_DEBUGGER=true` - open the [Browser Toolbox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox) on start (NOTE: `false` by default for speed).
 - `FXA_DESKTOP_CONTEXT` - context value for the fxa-content-server: `context=[value]` (NOTE: `fx_desktop_v3` is default).

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -119,7 +119,7 @@ export type FxAOAuthLogin = {
   code: string;
   redirect: string;
   state: string;
-  // OAuth desktop looks at the syc engine list in fxaLogin.
+  // OAuth desktop looks at the sync engine list in fxaLogin.
   // OAuth mobile currently looks at fxaOAuthLogin, but should
   // eventually move to look at fxaLogin as well to prevent FXA-10596.
   declinedSyncEngines?: string[];

--- a/packages/fxa-settings/src/models/integrations/base-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/base-integration.ts
@@ -172,11 +172,11 @@ export abstract class Integration<
     return undefined;
   }
 
-  getService() {
+  getService(): string | undefined {
     return this.data.service;
   }
 
-  getClientId() {
+  getClientId(): string | undefined {
     return this.data.clientId;
   }
 

--- a/packages/fxa-settings/src/models/integrations/client-matching.ts
+++ b/packages/fxa-settings/src/models/integrations/client-matching.ts
@@ -14,10 +14,10 @@ export const POCKET_CLIENTIDS = [
   '749818d3f2e7857f', // pocket-web
 ];
 
-export const isClientPocket = (clientId: string) => {
-  return POCKET_CLIENTIDS.includes(clientId);
+export const isClientPocket = (clientId?: string) => {
+  return !!(clientId && POCKET_CLIENTIDS.includes(clientId));
 };
 
-export const isClientMonitor = (clientId: string) => {
-  return MONITOR_CLIENTIDS.includes(clientId);
+export const isClientMonitor = (clientId?: string) => {
+  return !!(clientId && MONITOR_CLIENTIDS.includes(clientId));
 };

--- a/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
@@ -39,7 +39,7 @@ export enum OAuthNativeClients {
 /**
  * These come through via data.service (a query parameter).
  */
-enum OAuthNativeServices {
+export enum OAuthNativeServices {
   Sync = 'sync',
   Relay = 'relay',
 }

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -225,7 +225,7 @@ export class OAuthWebIntegration extends BaseIntegration {
     return this.data.service;
   }
 
-  getClientId() {
+  getClientId(): string {
     return this.data.clientId;
   }
 

--- a/packages/fxa-settings/src/models/integrations/utils.test.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.test.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { OAuthNativeServices } from './oauth-native-integration';
+import { isFirefoxService } from './utils';
+
+describe('isFirefoxService', () => {
+  it('should return true for OAuthNativeServices.Sync', () => {
+    const result = isFirefoxService(OAuthNativeServices.Sync);
+    expect(result).toBe(true);
+  });
+
+  it('should return true for OAuthNativeServices.Relay', () => {
+    const result = isFirefoxService(OAuthNativeServices.Relay);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for a service that is not in OAuthNativeServices', () => {
+    const result = isFirefoxService('testo');
+    expect(result).toBe(false);
+  });
+
+  it('should return false for an empty string', () => {
+    const result = isFirefoxService('');
+    expect(result).toBe(false);
+  });
+
+  it('should return false for undefined service', () => {
+    expect(isFirefoxService(undefined)).toBe(false);
+  });
+});

--- a/packages/fxa-settings/src/models/integrations/utils.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { OAuthNativeServices } from './oauth-native-integration';
+
+export function isFirefoxService(service?: string) {
+  return (
+    service === OAuthNativeServices.Sync ||
+    service === OAuthNativeServices.Relay
+  );
+}

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -22,6 +22,7 @@ import { SigninRecoveryLocationState } from './interfaces';
 import { TotpStatusResponse } from '../Signin/SigninTokenCode/interfaces';
 import { GET_TOTP_STATUS } from '../../components/App/gql';
 import OAuthDataError from '../../components/OAuthDataError';
+import { isFirefoxService } from '../../models/integrations/utils';
 
 export const InlineRecoverySetupContainer = ({
   isSignedIn,
@@ -61,13 +62,11 @@ export const InlineRecoverySetupContainer = ({
     const service = integration.getService();
     const clientId = integration.getClientId();
 
-    const isBrowserClient = service === 'sync' || service === 'relay';
-
     const result = await verifyTotp({
       variables: {
         input: {
           code,
-          ...(isBrowserClient ? { service } : { service: clientId }),
+          ...(isFirefoxService(service) ? { service } : { service: clientId }),
         },
       },
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -38,6 +38,7 @@ import { getCredentials, getCredentialsV2 } from 'fxa-auth-client/lib/crypto';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { SignInOptions } from 'fxa-auth-client/browser';
 import { AUTH_DATA_KEY } from '../../../lib/sensitive-data-client';
+import { isFirefoxService } from '../../../models/integrations/utils';
 
 const SigninUnblockContainer = ({
   integration,
@@ -79,15 +80,13 @@ const SigninUnblockContainer = ({
     const service = integration.getService();
     const clientId = integration.getClientId();
 
-    const isBrowserClient = service === 'sync' || service === 'relay';
-
     const options: SignInOptions = signInOptions ?? {
       verificationMethod: VerificationMethods.EMAIL_OTP,
       keys: integration.wantsKeys(),
       // See oauth_client_info in the auth-server for details on service/clientId
       // Sending up the clientId when the user is not signing in to the browser
       // is used to show the correct service name in emails
-      ...(isBrowserClient ? { service } : { service: clientId }),
+      ...(isFirefoxService(service) ? { service } : { service: clientId }),
       unblockCode,
       metricsContext: queryParamsToMetricsContext(
         flowQueryParams as unknown as Record<string, string>

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -75,6 +75,7 @@ import {
   SensitiveDataClient,
 } from '../../lib/sensitive-data-client';
 import { Constants } from '../../lib/constants';
+import { isFirefoxService } from '../../models/integrations/utils';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -265,8 +266,6 @@ const SigninContainer = ({
       const service = integration.getService();
       const clientId = integration.getClientId();
 
-      const isBrowserClient = service === 'sync' || service === 'relay';
-
       const { error, unverifiedAccount, v1Credentials, v2Credentials } =
         await tryKeyStretchingUpgrade(
           email,
@@ -284,7 +283,7 @@ const SigninContainer = ({
         // See oauth_client_info in the auth-server for details on service/clientId
         // Sending up the clientId when the user is not signing in to the browser
         // is used to show the correct service name in emails
-        ...(isBrowserClient ? { service } : { service: clientId }),
+        ...(isFirefoxService(service) ? { service } : { service: clientId }),
         metricsContext: queryParamsToMetricsContext(
           flowQueryParams as ReturnType<typeof searchParams>
         ),

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -41,6 +41,7 @@ import {
   getErrorFtlId,
   getLocalizedErrorMessage,
 } from '../../../lib/error-utils';
+import { isFirefoxService } from '../../../models/integrations/utils';
 
 export const viewName = 'confirm-signup-code';
 
@@ -136,8 +137,6 @@ const ConfirmSignupCode = ({
       const service = integration.getService();
       const clientId = integration.getClientId();
 
-      const isBrowserClient = service === 'sync' || service === 'relay';
-
       const options = {
         ...(hasSelectedNewsletters && { ...{ newsletters } }),
         ...(isOAuthIntegration(integration) && {
@@ -146,7 +145,7 @@ const ConfirmSignupCode = ({
         // See oauth_client_info in the auth-server for details on service/clientId
         // Sending up the clientId when the user is not signing in to the browser
         // is used to show the correct service name in emails
-        ...(isBrowserClient ? { service } : { service: clientId }),
+        ...(isFirefoxService(service) ? { service } : { service: clientId }),
       };
 
       await session.verifySession(code, options);
@@ -212,7 +211,7 @@ const ConfirmSignupCode = ({
 
           if (integration.isSync()) {
             firefox.fxaOAuthLogin({
-              // OAuth desktop looks at the syc engine list in fxaLogin. Oauth
+              // OAuth desktop looks at the sync engine list in fxaLogin. Oauth
               // mobile currently looks at the engines provided here, but should
               // eventually move to look at fxaLogin as well to prevent FXA-10596.
               declinedSyncEngines,

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -37,6 +37,7 @@ import { handleGQLError } from './utils';
 import VerificationMethods from '../../constants/verification-methods';
 import { queryParamsToMetricsContext } from '../../lib/metrics';
 import { QueryParams } from '../..';
+import { isFirefoxService } from '../../models/integrations/utils';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -167,7 +168,6 @@ const SignupContainer = ({
     async (email, password, atLeast18AtReg) => {
       const service = integration.getService();
       const clientId = integration.getClientId();
-      const isBrowserClient = service === 'sync' || service === 'relay';
 
       const options: BeginSignUpOptions = {
         verificationMethod: VerificationMethods.EMAIL_OTP,
@@ -175,7 +175,7 @@ const SignupContainer = ({
         // See oauth_client_info in the auth-server for details on service/clientId
         // Sending up the clientId when the user is not signing in to the browser
         // is used to show the correct service name in emails
-        ...(isBrowserClient ? { service } : { service: clientId }),
+        ...(isFirefoxService(service) ? { service } : { service: clientId }),
         atLeast18AtReg,
         metricsContext: queryParamsToMetricsContext(
           flowQueryParams as unknown as Record<string, string>

--- a/packages/fxa-settings/src/pages/Signup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/mocks.tsx
@@ -33,7 +33,7 @@ export const MOCK_SEARCH_PARAMS = {
 export function createMockSignupWebIntegration(): SignupBaseIntegration {
   return {
     type: IntegrationType.Web,
-    getService: () => Promise.resolve(MozServices.Default),
+    getService: () => undefined,
     getClientId: () => undefined,
     isSync: () => false,
     isDesktopRelay: () => false,
@@ -44,7 +44,7 @@ export function createMockSignupWebIntegration(): SignupBaseIntegration {
 export function createMockSignupSyncDesktopV3Integration(): SignupBaseIntegration {
   return {
     type: IntegrationType.SyncDesktopV3,
-    getService: () => Promise.resolve(MozServices.FirefoxSync),
+    getService: () => 'sync',
     getClientId: () => undefined,
     isSync: () => true,
     isDesktopRelay: () => false,


### PR DESCRIPTION
Because:
* We want to clean up some things that recently landed

This commit:
* Adds a function to check if the service is 'relay' or 'sync', fixes typos, removes redundent option in dev-launcher README

fixes part of FXA-10614