### PR TITLE
task(settings): Add more error capture

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { captureException } from '@sentry/browser';
+
 export enum FirefoxCommand {
   AccountDeleted = 'fxaccounts:delete',
   ProfileChanged = 'profile:change',
@@ -317,10 +319,36 @@ export class Firefox extends EventTarget {
   }
 
   fxaLogin(options: FxALoginRequest): void {
+    if (!options.unwrapBKey) {
+      try {
+        throw new Error('Unwrapkey missing from FxALoginRequest');
+      } catch (err) {
+        captureException(err, {
+          extra: {
+            partial: options.email.substring(4),
+            hasKeyFetchToken: !!options.keyFetchToken,
+            hasUnwrapBKey: !!options.unwrapBKey,
+          },
+        });
+      }
+    }
     this.send(FirefoxCommand.Login, options);
   }
 
   fxaLoginSignedInUser(options: FxALoginSignedInUserRequest) {
+    if (!options.unwrapBKey) {
+      try {
+        throw new Error('Unwrapkey missing from FxALoginSignedInUserRequest');
+      } catch (err) {
+        captureException(err, {
+          extra: {
+            partialEmail: options.email.substring(4),
+            hasKeyFetchToken: !!options.keyFetchToken,
+            hasUnwrapBKey: !!options.unwrapBKey,
+          },
+        });
+      }
+    }
     this.send(FirefoxCommand.Login, options);
   }
 


### PR DESCRIPTION
## Because
- We have a report that a user logs in but is immediately disconnected from sync
- We know from FF logs, that when this happens a keyFetchToken is present, but the unwrapBKey is missing.

## This pull request
- Adds more sentry error capture to try and pinpoint exact condition this occurs under.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Aside from reports in bugzilla, we haven't been able to reproduce through normal usage. Things I've tried:
- I've tried both with the key stretching experiment disabled and enabled.
- I've tried on v1, v2, and v1 upgrading to v2 accounts.
- I tried on a mac and a windows machine.

Other important things to note:
- All bugzilla reports are coming from Firefox 131 on Windows or Linux. Which is what I've been testing with. (v131.03)
- It's also worth mentioning we have reports of this behavior occurring during a time frame when the key stretching v2 experiment was disabled, so it's possible it isn't directly related to key stretching v2.
- Just as an experiment, I stripped unwrapBKey from the fxaccounts:login message sent by firefox. And sure enough the behavior was exactly as described. So it sure feels like there's an edge case I can't find, but not entirely sure what it is. Hopefully these sentry captures can shed some light on the state that triggers this.




