### PR TITLE
fix(payments-server): Add hover style to Close Button in DialogMessage component

### DIFF
--- a/packages/fxa-payments-server/src/components/DialogMessage/index.scss
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.scss
@@ -47,16 +47,4 @@
       background: $button-background-color-primary-active;
     }
   }
-
-  .modal .dismiss {
-    background: transparent;
-    border: 0;
-    height: 24px;
-    margin: 0;
-    padding: 0;
-    position: absolute;
-    right: 15px;
-    top: 13px;
-    width: 24px;
-  }
 }

--- a/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage/index.tsx
@@ -49,7 +49,7 @@ export const DialogMessage = ({
             <Localized id="close-aria">
               <button
                 data-testid="dialog-dismiss"
-                className="dismiss"
+                className="absolute bg-transparent border-0 cursor-pointer flex items-center justify-center w-6 h-6 m-0 p-0 top-4 right-4 hover:bg-grey-200 hover:rounded focus:border-blue-400 focus:rounded focus:shadow-input-blue-focus after:absolute after:content-[''] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10"
                 aria-label="Close modal"
                 onClick={onDismiss as () => void}
               >


### PR DESCRIPTION
## This pull request

- adds hover-state style to DialogMessage component

## Issue that this pull request solves

Closes: FXA-10633

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
#### Modal
<img width="500" alt="Screenshot 2024-10-28 at 11 38 33 AM" src="https://github.com/user-attachments/assets/e7c8dcef-0cba-458d-8140-88ada1e5984e">

#### Hover
<img width="500" alt="Screenshot 2024-10-28 at 11 36 19 AM" src="https://github.com/user-attachments/assets/51679b6c-48e8-4600-a1cc-8da1b6384f45">

#### Modal
<img width="500" alt="Screenshot 2024-10-28 at 11 38 06 AM" src="https://github.com/user-attachments/assets/4d1f439c-160e-473e-8c86-26d6aeb01844">

#### Hover
<img width="500" alt="Screenshot 2024-10-28 at 11 37 41 AM" src="https://github.com/user-attachments/assets/b470ffb3-351a-4a7d-961f-2164181ca116">
