### PR TITLE
task(settings): Add more error capture

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { captureException } from '@sentry/browser';
+
 export enum FirefoxCommand {
   AccountDeleted = 'fxaccounts:delete',
   ProfileChanged = 'profile:change',
@@ -317,10 +319,36 @@ export class Firefox extends EventTarget {
   }
 
   fxaLogin(options: FxALoginRequest): void {
+    if (!options.unwrapBKey) {
+      try {
+        throw new Error('Unwrapkey missing from FxALoginRequest');
+      } catch (err) {
+        captureException(err, {
+          extra: {
+            partial: options.email.substring(4),
+            hasKeyFetchToken: !!options.keyFetchToken,
+            hasUnwrapBKey: !!options.unwrapBKey,
+          },
+        });
+      }
+    }
     this.send(FirefoxCommand.Login, options);
   }
 
   fxaLoginSignedInUser(options: FxALoginSignedInUserRequest) {
+    if (!options.unwrapBKey) {
+      try {
+        throw new Error('Unwrapkey missing from FxALoginSignedInUserRequest');
+      } catch (err) {
+        captureException(err, {
+          extra: {
+            partialEmail: options.email.substring(4),
+            hasKeyFetchToken: !!options.keyFetchToken,
+            hasUnwrapBKey: !!options.unwrapBKey,
+          },
+        });
+      }
+    }
     this.send(FirefoxCommand.Login, options);
   }
 

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -443,6 +443,7 @@ describe('signin container', () => {
   describe('beginSigninHandler', () => {
     beforeEach(() => {
       mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
+      mockSentryCaptureMessage.mockReset();
     });
 
     it('runs handler and invokes sign in mutation', async () => {
@@ -786,7 +787,14 @@ describe('signin container', () => {
           expect(handlerResult?.error).toBeDefined();
           expect(handlerResult?.data?.signIn).toBeUndefined();
           expect(mockSentryCaptureMessage).toBeCalledWith(
-            'Failure to finish v2 upgrade. Could not fetch credential status.'
+            'Failure to finish v2 upgrade. Could not fetch credential status.',
+            {
+              extra: {
+                code: undefined,
+                errno: 999,
+                message: 'Unexpected error',
+              },
+            }
           );
         });
       });
@@ -810,7 +818,14 @@ describe('signin container', () => {
           expect(handlerResult?.error).toBeDefined();
           expect(handlerResult?.data?.signIn).toBeUndefined();
           expect(mockSentryCaptureMessage).toBeCalledWith(
-            'Failure to finish v2 upgrade. Could not start password change.'
+            'Failure to finish v2 upgrade. Could not start password change.',
+            {
+              extra: {
+                code: undefined,
+                errno: 999,
+                message: 'Unexpected error',
+              },
+            }
           );
         });
       });
@@ -834,7 +849,6 @@ describe('signin container', () => {
 
           expect(handlerResult?.error?.message).toEqual(mockGqlError().message);
           expect(handlerResult?.data?.signIn).toBeUndefined();
-          expect(mockSentryCaptureMessage).toBeCalledTimes(1);
           expect(mockSentryCaptureMessage).toBeCalledWith(
             'Failure to finish v2 upgrade. Could not get wrapped keys.'
           );
@@ -861,9 +875,15 @@ describe('signin container', () => {
 
           expect(handlerResult?.error?.message).toEqual(mockGqlError().message);
           expect(handlerResult?.data?.signIn).toBeUndefined();
-          expect(mockSentryCaptureMessage).toBeCalledTimes(1);
           expect(mockSentryCaptureMessage).toBeCalledWith(
-            'Failure to finish v2 upgrade. Could not finish password change.'
+            'Failure to finish v2 upgrade. Could not finish password change.',
+            {
+              extra: {
+                code: undefined,
+                errno: 999,
+                message: 'Unexpected error',
+              },
+            }
           );
         });
       });

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -11,6 +11,7 @@ import {
   useConfig,
   useSession,
   useSensitiveDataClient,
+  isOAuthIntegration,
 } from '../../models';
 import { MozServices } from '../../lib/types';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
@@ -266,11 +267,12 @@ const SigninContainer = ({
 
       const service = integration.getService();
 
+      const v2Enabled = keyStretchExp.queryParamModel.isV2(config);
       const { error, unverifiedAccount, v1Credentials, v2Credentials } =
         await tryKeyStretchingUpgrade(
           email,
           password,
-          keyStretchExp.queryParamModel.isV2(config),
+          v2Enabled,
           credentialStatus,
           passwordChangeStart,
           getWrappedKeys,
@@ -300,6 +302,27 @@ const SigninContainer = ({
           };
         }
       );
+      // Sanity Check
+      if (
+        integration.isSync() &&
+        'data' in result &&
+        result.data?.unwrapBKey == null
+      ) {
+        Sentry.captureMessage('Warning missing unwrapBKey after trySignIn', {
+          extra: {
+            v2Enabled,
+            unverifiedAccount,
+            isSync: true,
+            isOAuth: isOAuthIntegration(integration),
+            hasError: 'error' in result,
+            has_unwrapBKey: 'data' in result && !!result.data?.unwrapBKey,
+            has_v1Credentials: !!v1Credentials,
+            has_v1Credentials_unwrapBKey: !!v1Credentials?.unwrapBKey,
+            has_v2Credentials: !!v2Credentials,
+            has_v2Credentials_unwrapBKey: !!v2Credentials?.unwrapBKey,
+          },
+        });
+      }
 
       // Check recovery key status if signin was successful, user is on sync Desktop
       // and they didn't click "Do it later"; this affects navigation.
@@ -527,15 +550,23 @@ export async function tryKeyStretchingUpgrade(
         },
       });
     } catch (error) {
-      Sentry.captureMessage(
-        'Failure to finish v2 upgrade. Could not fetch credential status.'
-      );
-      return {
+      const result = {
         ...getHandledError(error),
         unverifiedAccount,
         v1Credentials,
         v2Credentials,
       };
+      Sentry.captureMessage(
+        'Failure to finish v2 upgrade. Could not fetch credential status.',
+        {
+          extra: {
+            errno: result?.error?.errno,
+            code: result?.error?.code,
+            message: result?.error?.message,
+          },
+        }
+      );
+      return result;
     }
 
     // We might have to upgrade the credentials in place.
@@ -557,17 +588,26 @@ export async function tryKeyStretchingUpgrade(
         keyFetchToken = data?.keyFetchToken || '';
         passwordChangeToken = data?.passwordChangeToken || '';
       } catch (error) {
-        // If the user enters the wrong password, they will see an invalid password error.
-        // Otherwise something has going wrong and we should show a general error.
-        Sentry.captureMessage(
-          'Failure to finish v2 upgrade. Could not start password change.'
-        );
-        return {
+        const result = {
           ...getHandledError(error),
           unverifiedAccount,
           v1Credentials,
           v2Credentials,
         };
+        // Don't include invalid passwords errors.
+        if (result.error?.errno !== 103) {
+          Sentry.captureMessage(
+            'Failure to finish v2 upgrade. Could not start password change.',
+            {
+              extra: {
+                errno: result?.error?.errno,
+                code: result?.error?.code,
+                message: result?.error?.message,
+              },
+            }
+          );
+        }
+        return result;
       }
 
       // Determine wrapKb.
@@ -590,12 +630,24 @@ export async function tryKeyStretchingUpgrade(
             Sentry.captureMessage(
               'Failure to finish v2 upgrade. Could not get wrapped keys.'
             );
-            return {
+            const result = {
               ...getHandledError(error),
               unverifiedAccount,
               v1Credentials,
               v2Credentials,
             };
+            Sentry.captureMessage(
+              'Failure to finish v2 upgrade. Could not get wrapped keys.',
+              {
+                extra: {
+                  unverifiedAccount,
+                  errno: result?.error?.errno,
+                  code: result?.error?.code,
+                  message: result?.error?.message,
+                },
+              }
+            );
+            return result;
           }
         }
       }
@@ -631,15 +683,23 @@ export async function tryKeyStretchingUpgrade(
             },
           });
         } catch (error) {
-          Sentry.captureMessage(
-            'Failure to finish v2 upgrade. Could not finish password change.'
-          );
-          return {
+          const result = {
             ...getHandledError(error),
             unverifiedAccount,
             v1Credentials,
             v2Credentials,
           };
+          Sentry.captureMessage(
+            'Failure to finish v2 upgrade. Could not finish password change.',
+            {
+              extra: {
+                errno: result?.error?.errno,
+                code: result?.error?.code,
+                message: result?.error?.message,
+              },
+            }
+          );
+          return result;
         }
       }
     } else if (credentialStatusData.data?.credentialStatus.clientSalt) {


### PR DESCRIPTION
## Because
- We have a report that a user logs in but is immediately disconnected from sync
- We know from FF logs, that when this happens a keyFetchToken is present, but the unwrapBKey is missing.

## This pull request
- Adds more sentry error capture to try and pinpoint exact condition this occurs under.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Aside from reports in bugzilla, we haven't been able to reproduce through normal usage. Things I've tried:
- I've tried both with the key stretching experiment disabled and enabled.
- I've tried on v1, v2, and v1 upgrading to v2 accounts.
- I've tried on v1 accounts where the primary email was changed.
- I tried on a mac and a windows machine.

Other important things to note:
- All bugzilla reports are coming from Firefox 131 on Windows or Linux. Which is what I've been testing with. (v131.03)
- It's also worth mentioning we have reports of this behavior occurring during a time frame when the key stretching v2 experiment was disabled, so it's possible it isn't directly related to key stretching v2.
- Just as an experiment, I stripped unwrapBKey from the fxaccounts:login message sent by firefox. And sure enough the behavior was exactly as described. So it sure feels like there's an edge case I can't find, but not entirely sure what it is. Hopefully these sentry captures can shed some light on the state that triggers this.

