### PR TITLE
fix(scripts): update where conditions on inactive accounts query

### DIFF
--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/get-inactive-account-uids.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/get-inactive-account-uids.ts
@@ -172,8 +172,8 @@ const init = async () => {
       .where((builder) => {
         builder
           .whereNull('emailUids.uid')
-          .orWhereNull('sessionTokenUids.uid')
-          .orWhereNull('securityEventUids.uid');
+          .whereNull('sessionTokenUids.uid')
+          .whereNull('securityEventUids.uid');
       })
       .orderBy('accounts.createdAt', 'asc')
       .orderBy('accounts.uid', 'asc');


### PR DESCRIPTION
Because:
 - an account is considered active when any of the timestamps is at or newer than the active by date

This commit:
 - fixes the sql's where conditions so that any such timestamp filters the account out of the list

