### PR TITLE
feat(sync): Remove 'desktop only' restriction to send can_link_account

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -16,7 +16,6 @@ import ScopedKeys from 'lib/crypto/scoped-keys';
 import WebChannel from '../../lib/channels/web';
 import SyncEngines from '../sync-engines';
 import ConnectAnotherDeviceBehavior from '../../views/behaviors/connect-another-device';
-import UserAgentMixin from '../../lib/user-agent-mixin';
 
 const ALLOWED_LOGIN_FIELDS = ['email', 'sessionToken', 'uid', 'verified'];
 
@@ -76,17 +75,11 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
     );
   },
 
-  // Note this was mostly copied from the Sync broker (fx_desktop_v3), but
-  // also checks that the UA matches Firefox desktop since this broker is
-  // also used for mobile. We probably want to support this in mobile in
-  // the future but while Android responds with 'ok: true' automatically,
-  // we only very recently landed changes for iOS to respond automatically
-  // as well, so for now this only sends for oauth desktop. See FXA-10316
+  // Note this was mostly copied from the Sync broker (fx_desktop_v3).
   beforeSignIn(account) {
     const email = account.get('email');
-    const uap = this.getUserAgent();
 
-    if (this._verifiedCanLinkEmail === email || !uap.isFirefoxDesktop()) {
+    if (this._verifiedCanLinkEmail === email) {
       // This user has already been asked and responded that
       // they want to link the account. Do not ask again or
       // else the user sees the "can link account" browser
@@ -286,6 +279,6 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
   },
 });
 
-Cocktail.mixin(OAuthWebChannelBroker, ChannelMixin, UserAgentMixin);
+Cocktail.mixin(OAuthWebChannelBroker, ChannelMixin);
 
 export default OAuthWebChannelBroker;

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -314,9 +314,6 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
       broker.fetch();
       // setTimeout due to async nature of the messages
       setTimeout(() => {
-        sinon.stub(broker, 'getUserAgent').returns({
-          isFirefoxDesktop: () => true,
-        });
         return broker.beforeSignIn(account).then(() => {
           assert.isTrue(metrics.flush.calledOnce);
           assert.isTrue(channelMock.request.calledOnceWith('can_link_account'));
@@ -331,34 +328,12 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
       broker.fetch();
       // setTimeout due to async nature of the messages
       setTimeout(() => {
-        sinon.stub(broker, 'getUserAgent').returns({
-          isFirefoxDesktop: () => true,
-        });
         return broker
           .beforeSignIn(account)
           .then(() => broker.beforeSignIn(account))
           .then(() => {
             assert.isTrue(channelMock.request.calledOnce);
             assert.isTrue(channelMock.request.calledWith('can_link_account'));
-          });
-      });
-    });
-
-    it('does not call can_link_account if isFirefoxDesktop is false', () => {
-      channelMock.request = sinon.spy(() => Promise.resolve({ ok: true }));
-
-      createAuthBroker();
-      broker.fetch();
-      // setTimeout due to async nature of the messages
-      setTimeout(() => {
-        sinon.stub(broker, 'getUserAgent').returns({
-          isFirefoxDesktop: () => false,
-        });
-        return broker
-          .beforeSignIn(account)
-          .then(() => broker.beforeSignIn(account))
-          .then(() => {
-            assert.isTrue(channelMock.request.notCalled);
           });
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -75,6 +75,7 @@ function mockSyncDesktopV3Integration() {
     wantsKeys: () => true,
     data: { service: 'sync' },
     isDesktopSync: () => true,
+    isDesktopRelay: () => false,
   } as Integration;
 }
 function mockOAuthWebIntegration(
@@ -88,6 +89,7 @@ function mockOAuthWebIntegration(
     wantsKeys: () => true,
     data,
     isDesktopSync: () => false,
+    isDesktopRelay: () => false,
   } as Integration;
 }
 
@@ -99,6 +101,7 @@ function mockOAuthNativeIntegration() {
     isSync: () => true,
     wantsKeys: () => true,
     isDesktopSync: () => true,
+    isDesktopRelay: () => false,
   } as Integration;
 }
 
@@ -110,6 +113,7 @@ function mockWebIntegration() {
     isSync: () => false,
     wantsKeys: () => false,
     isDesktopSync: () => false,
+    isDesktopRelay: () => false,
     data: {},
   } as Integration;
 }

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -248,7 +248,10 @@ const SigninContainer = ({
       // warning. The browser will automatically respond with { ok: true } without
       // prompting the user if it matches the email the browser has data for.
       if (
-        integration.isDesktopSync() &&
+        // Currently for email-first, we send this if `context=oauth_webchannel_v1`.
+        // Let's check that here too (TBD if we want this for isDesktopRelay; if not,
+        // we'll remove).
+        (integration.isSync() || integration.isDesktopRelay()) &&
         queryParamModel.hasLinkedAccount === undefined
       ) {
         const { ok } = await firefox.fxaCanLinkAccount({ email });


### PR DESCRIPTION
Because:
* iOS and Android now support responding with ok: true automatically

This commit:
* Makes conditions for when we send this more consistent

closes FXA-10638

---

~I'm thinking we should wait for Mark's response [here](https://mozilla.slack.com/archives/C07MSPY85LN/p1729892740422919) where I ask what our plan is for `isDesktopRelay`; I can either remove my comment in Signin or go ahead and implement any changes here, I'll mark this as a draft in the meantime.~

Mark said this is good for now, so I'm going to just leave it open and also leave the comment unless someone requests I remove it. Mark says we'll probably be revisiting this soon when we discuss third party auth buttons + `service=sync` integration.