### PR TITLE
bug(settings): Signin Unblock was dropping unwrapBKey

### DIFF
--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -179,7 +179,7 @@ export function tryAgainError() {
  */
 export function useFinishOAuthFlowHandler(
   authClient: AuthClient,
-  integration: Integration
+  integration: Pick<Integration, 'clientInfo' | 'type' | 'wantsKeys' | 'data'>
 ): UseFinishOAuthFlowHandlerResult {
   const isSyncOAuth = isOAuthNativeIntegrationSync(integration);
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
@@ -1,0 +1,240 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Mocked Module Imports
+import * as SigninUnblockModule from './index';
+import * as ReachRouterModule from '@reach/router';
+import * as ModelsModule from '../../../models';
+
+// Regular imports
+import { act, screen } from '@testing-library/react';
+import { LocationProvider } from '@reach/router';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import SigninUnblockContainer from './container';
+import { MozServices } from '../../../lib/types';
+
+import {
+  MOCK_AUTH_PW,
+  MOCK_AUTH_PW_V2,
+  MOCK_PASSWORD,
+  MOCK_UNBLOCK_CODE,
+  MOCK_UNWRAP_BKEY,
+  MOCK_UNWRAP_BKEY_V2,
+  mockLoadingSpinnerModule,
+} from '../../mocks';
+import {
+  mockGqlBeginSigninMutation,
+  mockGqlCredentialStatusMutation,
+  mockGqlError,
+} from '../mocks';
+
+import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../../models/mocks';
+
+import { SigninUnblockLocationState, SigninUnblockProps } from './interfaces';
+
+import { QueryParams } from '../../..';
+import { MockedProvider, MockedResponse } from '@apollo/client/testing';
+
+import {
+  createMockSigninWebSyncIntegration,
+  MOCK_SIGNIN_UNBLOCK_LOCATION_STATE,
+} from './mocks';
+import { BeginSigninResult, SigninUnblockIntegration } from '../interfaces';
+
+let integration: SigninUnblockIntegration;
+function mockWebIntegration() {
+  integration = {
+    ...createMockSigninWebSyncIntegration(),
+    clientInfo: undefined,
+  };
+}
+
+let flowQueryParams: QueryParams;
+function mockQueryFlowParameters() {
+  flowQueryParams = {
+    service: 'sync',
+    flowId: '00ff',
+  };
+}
+
+let currentPageProps: SigninUnblockProps | undefined;
+function mockSigninUnblockModule() {
+  currentPageProps = undefined;
+  jest.spyOn(SigninUnblockModule, 'default').mockImplementation((props) => {
+    currentPageProps = props;
+    return <div>signin unblock mock</div>;
+  });
+}
+
+jest.mock('../../../models', () => {
+  return {
+    ...jest.requireActual('../../../models'),
+    useAuthClient: jest.fn(),
+    useSensitiveDataClient: jest.fn(),
+  };
+});
+
+jest.mock('fxa-auth-client/lib/crypto', () => {
+  return {
+    getCredentials: () => ({
+      authPW: MOCK_AUTH_PW,
+      unwrapBKey: MOCK_UNWRAP_BKEY,
+    }),
+    getCredentialsV2: () => ({
+      authPW: MOCK_AUTH_PW_V2,
+      unwrapBKey: MOCK_UNWRAP_BKEY_V2,
+    }),
+  };
+});
+
+let mockNavigate = jest.fn();
+function mockReachRouter(mockLocationState?: SigninUnblockLocationState) {
+  mockNavigate.mockReset();
+  jest.spyOn(ReachRouterModule, 'useLocation').mockImplementation(() => {
+    return {
+      ...global.window.location,
+      pathname: '/signin_unblock',
+      state: mockLocationState,
+    };
+  });
+}
+
+const mockSensitiveDataClient = createMockSensitiveDataClient();
+const mockSensitiveDataClientState: Record<string, any> = {};
+mockSensitiveDataClient.setData = function (key, value) {
+  mockSensitiveDataClientState[key] = value;
+};
+mockSensitiveDataClient.getData = function (key: string) {
+  return mockSensitiveDataClientState[key];
+};
+function mockModelsModule() {
+  mockSensitiveDataClientState['auth'] = { password: MOCK_PASSWORD };
+  (ModelsModule.useSensitiveDataClient as jest.Mock).mockReturnValue(
+    mockSensitiveDataClient
+  );
+}
+
+function applyDefaultMocks() {
+  jest.resetAllMocks();
+  jest.restoreAllMocks();
+  mockSigninUnblockModule();
+  mockLoadingSpinnerModule();
+  mockModelsModule();
+  mockReachRouter(MOCK_SIGNIN_UNBLOCK_LOCATION_STATE);
+  mockWebIntegration();
+  mockQueryFlowParameters();
+}
+
+describe('signin unblock container', () => {
+  beforeEach(() => {
+    applyDefaultMocks();
+  });
+
+  /** Renders the container with a fake page component */
+  async function render(mocks: Array<MockedResponse>) {
+    renderWithLocalizationProvider(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <LocationProvider>
+          <SigninUnblockContainer
+            {...{
+              integration,
+              serviceName: MozServices.Default,
+              flowQueryParams,
+            }}
+          />
+        </LocationProvider>
+      </MockedProvider>
+    );
+
+    await screen.findByText('signin unblock mock');
+    expect(SigninUnblockModule.default).toBeCalled();
+  }
+
+  it('handles signin with correct code', async () => {
+    await render([
+      mockGqlCredentialStatusMutation(),
+      mockGqlBeginSigninMutation(
+        {
+          unblockCode: MOCK_UNBLOCK_CODE,
+          keys: true,
+        },
+        {
+          authPW: MOCK_AUTH_PW_V2,
+        }
+      ),
+    ]);
+
+    let result: BeginSigninResult | undefined;
+    await act(async () => {
+      result = await currentPageProps?.signinWithUnblockCode(MOCK_UNBLOCK_CODE);
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.data).toBeDefined();
+    expect(result?.data?.unwrapBKey).toEqual(MOCK_UNWRAP_BKEY_V2);
+    expect(result?.data?.signIn?.uid).toBeDefined();
+    expect(result?.data?.signIn?.sessionToken).toBeDefined();
+    expect(result?.data?.signIn?.verified).toBeDefined();
+    expect(result?.data?.signIn?.metricsEnabled).toBeDefined();
+  });
+
+  it('handles signin with correct code and failure when looking up credential status', async () => {
+    await render([
+      {
+        ...mockGqlCredentialStatusMutation(),
+        error: mockGqlError(),
+      },
+      mockGqlBeginSigninMutation({
+        unblockCode: MOCK_UNBLOCK_CODE,
+        keys: true,
+      }),
+    ]);
+
+    let result: BeginSigninResult | undefined;
+    await act(async () => {
+      result = await currentPageProps?.signinWithUnblockCode(MOCK_UNBLOCK_CODE);
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.data).toBeDefined();
+    expect(result?.data?.unwrapBKey).toEqual(MOCK_UNWRAP_BKEY);
+    expect(result?.data?.signIn?.uid).toBeDefined();
+    expect(result?.data?.signIn?.sessionToken).toBeDefined();
+    expect(result?.data?.signIn?.verified).toBeDefined();
+    expect(result?.data?.signIn?.metricsEnabled).toBeDefined();
+  });
+
+  it('handles incorrect unblock code', async () => {
+    const wrongCode = '000000';
+    await render([
+      mockGqlCredentialStatusMutation(),
+      {
+        ...(() => {
+          const result = mockGqlBeginSigninMutation(
+            {
+              unblockCode: wrongCode,
+              keys: true,
+            },
+            {
+              authPW: MOCK_AUTH_PW_V2,
+            }
+          );
+          return result;
+        })(),
+        error: mockGqlError(AuthUiErrors.INCORRECT_UNBLOCK_CODE),
+      },
+    ]);
+
+    let result: BeginSigninResult | undefined;
+    await act(async () => {
+      result = await currentPageProps?.signinWithUnblockCode(wrongCode);
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.data).toBeUndefined();
+    expect(result?.error).toBeDefined();
+    expect(result?.error?.errno).toEqual(127);
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -34,7 +34,7 @@ import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const viewName = 'signin-unblock';
 
-const SigninUnblock = ({
+export const SigninUnblock = ({
   email,
   hasLinkedAccount,
   hasPassword,

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/mocks.tsx
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MozServices } from '../../../lib/types';
+import { IntegrationType } from '../../../models';
+import { MOCK_EMAIL, MOCK_AUTH_PW } from '../../mocks';
+import { SigninOAuthIntegration } from '../interfaces';
+
+export { CREDENTIAL_STATUS_MUTATION, BEGIN_SIGNIN_MUTATION } from '../gql';
+
+export const MOCK_SIGNIN_UNBLOCK_LOCATION_STATE = {
+  email: MOCK_EMAIL,
+  hasLinkedAccount: false,
+  hasPassword: true,
+  authPW: MOCK_AUTH_PW,
+};
+
+export function createMockSigninWebSyncIntegration() {
+  return {
+    type: IntegrationType.SyncDesktopV3,
+    isSync: () => true,
+    getService: () => MozServices.FirefoxSync,
+    getClientId: () => undefined,
+    wantsKeys: () => true,
+    wantsTwoStepAuthentication: () => false,
+    data: {},
+    isDesktopSync: () => true,
+    isDesktopRelay: () => false,
+    wantsLogin: () => false,
+  };
+}

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -18,6 +18,20 @@ export interface AvatarResponse {
   };
 }
 
+export type SigninUnblockIntegration = Pick<
+  Integration,
+  | 'type'
+  | 'isSync'
+  | 'getService'
+  | 'getClientId'
+  | 'wantsTwoStepAuthentication'
+  | 'clientInfo'
+  | 'wantsKeys'
+  | 'data'
+  | 'isDesktopSync'
+  | 'isDesktopRelay'
+>;
+
 export type SigninIntegration =
   | Pick<
       Integration,

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -14,7 +14,6 @@ import {
   MOCK_SESSION_TOKEN,
   MOCK_UID,
   MOCK_AVATAR_NON_DEFAULT,
-  MOCK_UNWRAP_BKEY,
   mockFinishOAuthFlowHandler,
   MOCK_CLIENT_ID,
   MOCK_AVATAR_DEFAULT,
@@ -185,13 +184,20 @@ export function mockGqlAvatarUseQuery() {
 }
 
 export function mockGqlBeginSigninMutation(
-  opts: { keys: boolean; originalLoginEmail?: string; service?: 'sync' },
+  opts: {
+    keys: boolean;
+    originalLoginEmail?: string;
+    service?: string;
+    unblockCode?: string;
+  },
   inputOverrides: any = {}
 ) {
   const result = opts.keys
     ? createBeginSigninResponse({
         keyFetchToken: MOCK_KEY_FETCH_TOKEN,
-        unwrapBKey: MOCK_UNWRAP_BKEY,
+        // This doesn't actually come back from the server. We have to 'patch it' with
+        // the current client side credentials after the request comes back.
+        // unwrapBKey: MOCK_UNWRAP_BKEY,
       })
     : createBeginSigninResponse();
 
@@ -215,7 +221,11 @@ export function mockGqlBeginSigninMutation(
   };
 }
 
-export function mockGqlCredentialStatusMutation() {
+export function mockGqlCredentialStatusMutation(overrides?: {
+  upgradeNeeded?: boolean;
+  currentVersion?: 'v1' | 'v2';
+  clientSalt?: string;
+}) {
   return {
     request: {
       query: CREDENTIAL_STATUS_MUTATION,
@@ -227,8 +237,9 @@ export function mockGqlCredentialStatusMutation() {
       data: {
         credentialStatus: {
           upgradeNeeded: true,
-          version: 2,
+          currentVersion: 'v2',
           clientSalt: MOCK_CLIENT_SALT,
+          ...(overrides || {}),
         },
       },
     },


### PR DESCRIPTION
## Because

- We had reports of users getting disconnected from sync
- We had firefox logs showing the unwrapBKey was not being provided by FxA

## This pull request
- Ensures unwrapBKey is provided
- Introduces a test file for SigninUnbock container
- Fixes a bug in our mocks where the credentialStatus.currentVersion wasn't the correct format
- Switches to SigninOAuthIntegration for useFinishOAuthFlowHandler, which is a more accurate and restricted interface.

## Issue that this pull request solves

Closes: FXA-10641 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a follow for the main branch. The issue was also quickly patched on train-285 [here](https://github.com/mozilla/fxa/pull/17923).
