### PR TITLE
bug(auth): Typescript not checking all files

### DIFF
--- a/packages/fxa-auth-server/lib/l10n/index.ts
+++ b/packages/fxa-auth-server/lib/l10n/index.ts
@@ -66,22 +66,22 @@ class Localizer {
     return generateBundles;
   }
 
-  async getLocalizerDeps(acceptLanguage: string) {
-    const currentLocales = parseAcceptLanguage(acceptLanguage);
-    const selectedLocale = determineLocale(acceptLanguage);
+  async getLocalizerDeps(acceptLanguage?: string) {
+    const currentLocales = parseAcceptLanguage(acceptLanguage || '');
+    const selectedLocale = determineLocale(acceptLanguage || '');
     const messages = await this.fetchMessages(currentLocales);
     const generateBundles = this.createBundleGenerator(messages);
     return { currentLocales, messages, generateBundles, selectedLocale };
   }
 
-  async setupDomLocalizer(acceptLanguage: string) {
+  async setupDomLocalizer(acceptLanguage?: string) {
     const { currentLocales, generateBundles, selectedLocale } =
       await this.getLocalizerDeps(acceptLanguage);
     const l10n = new DOMLocalization(currentLocales, generateBundles);
     return { l10n, selectedLocale };
   }
 
-  async setupLocalizer(acceptLanguage: string) {
+  async setupLocalizer(acceptLanguage?: string) {
     const { currentLocales, generateBundles, selectedLocale } =
       await this.getLocalizerDeps(acceptLanguage);
     const l10n = new Localization(currentLocales, generateBundles);

--- a/packages/fxa-auth-server/lib/metrics/glean/index.ts
+++ b/packages/fxa-auth-server/lib/metrics/glean/index.ts
@@ -26,7 +26,7 @@ type MetricsData = {
   uid?: string;
   reason?: string;
   oauthClientId?: string;
-  scopes?: string;
+  scopes?: string | Array<string>;
 };
 
 type AdditionalMetricsCallback = (
@@ -265,7 +265,7 @@ export function gleanMetrics(config: ConfigType) {
           scopes: metrics.scopes
             ? Array.isArray(metrics.scopes)
               ? metrics.scopes.sort().join(',')
-              : metrics.scopes
+              : metrics.scopes.split(',').sort().join(',')
             : '',
         }),
       }),
@@ -304,6 +304,8 @@ export function gleanMetrics(config: ConfigType) {
     },
   };
 }
+
+export type GleanMetricsType = ReturnType<typeof gleanMetrics>;
 
 const routePathToErrorPingFnMap = {
   '/account/create': 'registration.error',

--- a/packages/fxa-auth-server/lib/payments/iap/apple-app-store/errors.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/apple-app-store/errors.ts
@@ -13,5 +13,6 @@ export class AppStoreRetryableError extends Error {
     super(errorMessage);
     this.name = 'AppStoreRetryableError';
     this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
   }
 }

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -327,7 +327,7 @@ export class StripeHelper extends StripeHelperBase {
    * Fetch all active tax rates.
    */
   async fetchAllTaxRates() {
-    const taxRates = [];
+    const taxRates = new Array<Stripe.TaxRate>();
     for await (const taxRate of this.stripe.taxRates.list({ active: true })) {
       taxRates.push(taxRate);
     }
@@ -1534,7 +1534,7 @@ export class StripeHelper extends StripeHelperBase {
   async *fetchOpenInvoices(
     created: Stripe.InvoiceListParams['created'],
     customerId?: string
-  ) {
+  ): AsyncGenerator<Stripe.Invoice> {
     for await (const invoice of this.stripe.invoices.list({
       customer: customerId,
       limit: 100,
@@ -1907,7 +1907,7 @@ export class StripeHelper extends StripeHelperBase {
       );
     });
     const iapType = getIapPurchaseType(purchases[0]);
-    const purchasedPrices = [];
+    const purchasedPrices = new Array<string>();
     for (const price of prices) {
       const purchaseIds = this.priceToIapIdentifiers(price, iapType);
       if (purchaseIds.some((id) => purchasedIds.includes(id))) {
@@ -2482,7 +2482,7 @@ export class StripeHelper extends StripeHelperBase {
   async formatSubscriptionsForSupport(
     subscriptions: Stripe.ApiList<Stripe.Subscription>
   ) {
-    const subs = [];
+    const subs = new Array<any>();
     for (const sub of subscriptions.data) {
       const plan = singlePlan(sub);
       if (!plan) {
@@ -2503,8 +2503,8 @@ export class StripeHelper extends StripeHelperBase {
       }
       const product_name = product.name;
 
-      let previous_product = null;
-      let plan_changed = null;
+      let previous_product: string | null = null;
+      let plan_changed: number | null = null;
 
       if (sub.metadata.previous_plan_id !== undefined) {
         const previousPlan = await this.findAbbrevPlanById(
@@ -2618,8 +2618,8 @@ export class StripeHelper extends StripeHelperBase {
 
     // if the invoice does not have the deprecated discount property but has a discount ID in discounts
     // expand the discount
-    let discountType = null;
-    let discountDuration = null;
+    let discountType: Stripe.Coupon.Duration | null = null;
+    let discountDuration: number | null = null;
 
     if (invoice.discount) {
       discountType = invoice.discount.coupon.duration;
@@ -2801,7 +2801,7 @@ export class StripeHelper extends StripeHelperBase {
       return [];
     }
 
-    const formattedSubscriptions = [];
+    const formattedSubscriptions = new Array<FormattedSubscriptionForEmail>();
 
     for (const subscription of customer.subscriptions.data) {
       if (ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
@@ -3183,10 +3183,10 @@ export class StripeHelper extends StripeHelperBase {
   }
 
   async extractCustomerDefaultPaymentDetails(customer: Stripe.Customer) {
-    let lastFour = null;
-    let cardType = null;
-    let country = null;
-    let postalCode = null;
+    let lastFour: string | null = null;
+    let cardType: string | null = null;
+    let country: string | null = null;
+    let postalCode: string | null = null;
 
     if (customer.invoice_settings.default_payment_method) {
       // Post-SCA customer with a default PaymentMethod

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -154,7 +154,7 @@ export class AccountHandler {
     );
 
     // Handle authPWVersion2 credentials
-    let password2 = undefined;
+    let password2: any | undefined = undefined;
     let verifyHashVersion2 = undefined;
     let wrapWrapKb = await random.hex(32);
     let wrapWrapKbVersion2 = undefined;
@@ -164,8 +164,8 @@ export class AccountHandler {
         authSalt,
         this.config.verifierVersion
       );
-      verifyHashVersion2 = await password2.verifyHash();
-      wrapWrapKbVersion2 = await password2.wrap(wrapKbVersion2);
+      verifyHashVersion2 = await password2?.verifyHash();
+      wrapWrapKbVersion2 = await password2?.wrap(wrapKbVersion2);
 
       // When version 2 credentials are supplied, the wrapKb will also be supplied.
       // This is necessary to the same kB values are produced for both passwords.

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -94,9 +94,9 @@ module.exports = function (
 
         await customs.check(request, email, 'passwordChange');
 
-        let keyFetchToken = undefined;
-        let keyFetchToken2 = undefined;
-        let passwordChangeToken = undefined;
+        let keyFetchToken: any | undefined = undefined;
+        let keyFetchToken2: any | undefined = undefined;
+        let passwordChangeToken: any | undefined = undefined;
 
         try {
           const emailRecord = await db.accountRecord(email);
@@ -315,7 +315,7 @@ module.exports = function (
 
           // For the time being we store both passwords in the DB. authPW is created
           // with the old quickStretch and authPWVersion2 is created with improved 'quick' stretch.
-          let password2 = undefined;
+          let password2: any | undefined = undefined;
           let verifyHashVersion2 = undefined;
           let wrapWrapKbVersion2 = undefined;
           if (authPWVersion2) {
@@ -325,8 +325,8 @@ module.exports = function (
               verifierVersion,
               2
             );
-            verifyHashVersion2 = await password2.verifyHash();
-            wrapWrapKbVersion2 = await password2.wrap(wrapKbVersion2);
+            verifyHashVersion2 = await password2?.verifyHash();
+            wrapWrapKbVersion2 = await password2?.wrap(wrapKbVersion2);
           }
 
           await db.deletePasswordChangeToken(passwordChangeToken);

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -388,7 +388,7 @@ export class PayPalHandler extends StripeWebhookHandler {
     );
 
     const nowSeconds = msToSec(Date.now());
-    const invoices = [];
+    const invoices = new Array<any>();
     for await (const invoice of this.stripeHelper.fetchOpenInvoices(
       nowSeconds,
       customer.id

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -285,7 +285,13 @@ export class StripeHandler {
     const customer = await this.stripeHelper.fetchCustomer(uid, [
       'subscriptions',
     ]);
-    const activeSubscriptions = [];
+    const activeSubscriptions = new Array<{
+      uid: string;
+      productId: string | Stripe.Product | Stripe.DeletedProduct | null;
+      subscriptionId: string;
+      createdAt: number;
+      cancelledAt: number | null;
+    }>();
 
     if (customer && customer.subscriptions) {
       for (const subscription of customer.subscriptions.data) {
@@ -388,7 +394,7 @@ export class StripeHandler {
       string
     >;
 
-    let customer = undefined;
+    let customer: Stripe.Customer | void = undefined;
     if (request.auth.credentials) {
       const { uid, email } = await handleAuth(this.db, request.auth, true);
       await this.customs.check(request, email, 'previewInvoice');

--- a/packages/fxa-auth-server/lib/senders/emails/mjml-browser-helper.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/mjml-browser-helper.ts
@@ -1,4 +1,4 @@
-type MjIncludeTag = { path: string; inline: boolean; type: string };
+type MjIncludeTag = { path?: string; inline: boolean; type?: string };
 
 /**
  * Important! At the current momement, mjml-browser does not support <mj-include>.
@@ -48,7 +48,7 @@ export function transformMjIncludeTags(mjml: string): string {
 function extractMjIncludeTags(mjml: string): MjIncludeTag[] {
   let chomp = false;
   let include = '';
-  const includes = [];
+  const includes = new Array<MjIncludeTag>();
   mjml
     .replace(/<mj-include/g, ' <mj-include')
     .split(/\n|\s/g)
@@ -96,7 +96,7 @@ function parseMjIncludeTag(include: string): MjIncludeTag {
 
   // Convert relative paths. The requests will now be made to the root
   // of the webserver.
-  res.path = res.path.replace(/\.\//, '/');
+  res.path = res.path?.replace(/\.\//, '/');
 
   return res;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/userDevice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/userDevice/index.stories.ts
@@ -4,7 +4,6 @@
 
 import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
-import { MOCK_USER_INFO_TRUNCATED } from '../userInfo/mocks';
 import {
   MOCK_DEVICE_ALL,
   MOCK_DEVICE_BROWSER,
@@ -24,7 +23,6 @@ const createStory = storyWithProps(
     subject: 'N/A',
     partial: 'userInfo',
     layout: null,
-    ...MOCK_USER_INFO_TRUNCATED,
   }
 );
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
@@ -13,7 +13,7 @@ export default {
 const createStory = storyWithProps(
   'cadReminderSecond',
   'Sent 72 hours after a user clicks "send me a reminder" on the connect another device page.',
-  cadReminderFirst.CadReminderDefault.args.variables
+  cadReminderFirst.CadReminderDefault.args?.variables
 );
 
 export const CadReminderDefault = createStory();

--- a/packages/fxa-auth-server/lib/senders/renderer/bindings-browser.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/bindings-browser.ts
@@ -66,7 +66,14 @@ export class BrowserRendererBindings extends RendererBindings {
     );
   }
 
-  renderEjs(template: string, context: TemplateContext, body?: string) {
+  renderEjs(
+    template: string,
+    context: Pick<
+      TemplateContext,
+      'acceptLanguage' | 'templateValues' | 'layout'
+    >,
+    body?: string
+  ) {
     return ejs.render(template, { ...context, body: body }, this.opts.ejs);
   }
 

--- a/packages/fxa-auth-server/lib/senders/renderer/bindings.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/bindings.ts
@@ -47,7 +47,7 @@ export type TemplateValues = {
 
 // TODO: better typing for 'template' with enums? from _versions.json
 export interface TemplateContext {
-  acceptLanguage: string;
+  acceptLanguage?: string;
   template: string;
   layout?: string;
   templateValues?: TemplateValues;

--- a/packages/fxa-auth-server/lib/senders/renderer/index.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/index.ts
@@ -40,7 +40,7 @@ class Renderer extends Localizer {
   ) {
     // l10n will only be undefined in tests
     if (!l10n) {
-      l10n = (await super.setupLocalizer(context.acceptLanguage)).l10n;
+      l10n = (await super.setupLocalizer(context.acceptLanguage || '')).l10n;
     }
 
     const localizedString =
@@ -61,7 +61,7 @@ class Renderer extends Localizer {
   async renderEmail(templateContext: TemplateContext) {
     const { acceptLanguage, template, layout } = templateContext;
     const { l10n, selectedLocale } = await super.setupDomLocalizer(
-      acceptLanguage
+      acceptLanguage || ''
     );
 
     const context = {
@@ -99,7 +99,7 @@ class Renderer extends Localizer {
     }
 
     const { text, rootElement } = await this.bindings.renderTemplate(
-      template,
+      template || '',
       context,
       layout
     );

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -21,7 +21,7 @@
     "bump-template-versions": "node scripts/template-version-bump",
     "clean": "rimraf dist",
     "clean-up-old-ci-stripe-customers": "node -r esbuild-register ./scripts/clean-up-old-ci-stripe-customers.js --limit 1000",
-    "compile": "tsc --noEmit",
+    "compile": "yarn install-ejs && tsc --noEmit",
     "create-mock-iap": "NODE_ENV=dev FIRESTORE_EMULATOR_HOST=localhost:9090 node -r esbuild-register ./scripts/create-mock-iap-subscriptions.ts",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "glean-generate": "npx glean translate ../fxa-shared/metrics/glean/fxa-backend-pings.yaml ../fxa-shared/metrics/glean/fxa-backend-metrics.yaml -f typescript_server -o lib/metrics/glean",

--- a/packages/fxa-auth-server/scripts/populate-firestore-customers.ts
+++ b/packages/fxa-auth-server/scripts/populate-firestore-customers.ts
@@ -24,7 +24,12 @@ export async function init() {
 
   const options = program.opts();
   const rateLimit = parseInt(options.rateLimit);
-  process.env.NODE_ENV = options.config || 'dev';
+
+  const node_env = process.env.NODE_ENV;
+  if (node_env !== (options.condition || 'dev')) {
+    throw new Error('Unexpected NODE_ENV ' + node_env);
+  }
+
   const { log, stripeHelper } = await setupProcessingTaskObjects(
     'populate-firestore-customers'
   );

--- a/packages/fxa-auth-server/scripts/prune-tokens.ts
+++ b/packages/fxa-auth-server/scripts/prune-tokens.ts
@@ -137,7 +137,7 @@ Exit Codes:
   // Start max session pruning
   if (maxSessions > 0) {
     // Locate large accounts
-    const targetAccounts = [];
+    const targetAccounts = new Array<string>();
     try {
       log.info('finding large accounts', {
         maxSessions,
@@ -268,7 +268,7 @@ Exit Codes:
 
         // Iterate through current set of redis tokens, and remove any that
         // don't exist in the sql database anymore.
-        const orphanedTokens = [];
+        const orphanedTokens = new Array<string>();
         for (const redisSessionTokenId of redisSessionTokenIds) {
           const dbSessionTokens = await SessionToken.findByTokenId(
             redisSessionTokenId

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents/stripe-products-and-plans-converter.ts
@@ -99,7 +99,7 @@ export class StripeProductsAndPlansConverter {
     metadata: Stripe.Product['metadata'],
     metadataKeyPrefix: string
   ): string[] {
-    const metadataValues = [];
+    const metadataValues = new Array<any>();
     for (const [metadataKey, metadataValue] of Object.entries(metadata)) {
       if (metadataKey.startsWith(metadataKeyPrefix)) {
         metadataValues.push(metadataValue);

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -2941,7 +2941,7 @@ describe('lib/senders/emails:', () => {
   describe('mock sendMail method:', () => {
     beforeEach(() => {
       mailer.localize = () => ({ language: 'en' });
-      sinon.stub(mailer.mailer, 'sendMail').callsFake((config, cb) => {
+      sinon.stub(mailer.mailer, 'sendMail').callsFake((_config, cb: any) => {
         cb(null, { resp: 'ok' });
       });
     });
@@ -2971,9 +2971,9 @@ describe('lib/senders/emails:', () => {
   describe('mock failing sendMail method:', () => {
     beforeEach(() => {
       mailer.localize = () => ({});
-      sinon
-        .stub(mailer.mailer, 'sendMail')
-        .callsFake((config, cb) => cb(new Error('Fail')));
+      sinon.stub(mailer.mailer, 'sendMail').callsFake((_config, cb: any) => {
+        cb(new Error('Fail'));
+      });
     });
 
     it('rejects sendMail status', () => {
@@ -2984,7 +2984,7 @@ describe('lib/senders/emails:', () => {
         uid: 'foo',
       };
 
-      return mailer.send(message).then(assert.notOk, (err) => {
+      return mailer.send(message).then(assert.notOk, (err: any) => {
         assert.equal(err.message, 'Fail');
       });
     });
@@ -2992,7 +2992,7 @@ describe('lib/senders/emails:', () => {
 });
 
 describe('mailer constructor:', () => {
-  let mailerConfig, mockLog, mailer;
+  let mailerConfig: any, mockLog: any, mailer: any;
 
   before(async () => {
     mailerConfig = [
@@ -3014,7 +3014,7 @@ describe('mailer constructor:', () => {
       'verificationUrl',
       'verifyLoginUrl',
       'verifyPrimaryEmailUrl',
-    ].reduce((target, key) => {
+    ].reduce((target: any, key) => {
       target[key] = `mock ${key}`;
       return target;
     }, {});

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax-helpers.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax-helpers.ts
@@ -228,6 +228,7 @@ describe('StripeAutomaticTaxConverterHelpers', () => {
         ...mockSubscription,
         automatic_tax: {
           enabled: false,
+          liability: null,
         },
       });
 
@@ -239,6 +240,7 @@ describe('StripeAutomaticTaxConverterHelpers', () => {
         ...mockSubscription,
         automatic_tax: {
           enabled: true,
+          liability: null,
         },
       });
 

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.ts
@@ -596,7 +596,7 @@ describe('StripeAutomaticTaxConverter', () => {
   });
 
   describe('fetchInvoicePreview', () => {
-    let result: Stripe.Invoice;
+    let result: Stripe.Response<Stripe.UpcomingInvoice>;
     let stub: sinon.SinonStub;
 
     beforeEach(async () => {

--- a/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
@@ -365,7 +365,8 @@ describe('CustomerPlanMover', () => {
     it("returns false if the customer does not have a price that's excluded", () => {
       const result = customerPlanMover.isCustomerExcluded([
         {
-          ...subscription1,
+          // TODO: Either provide full mock, or reduce type required isCustomerExcluded
+          ...(subscription1 as unknown as Stripe.Subscription),
         },
       ]);
       expect(result).false;

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -8,12 +8,10 @@
     "checkJs": false,
     "outDir": "./dist",
     "types": ["accept-language", "mocha", "mozlog", "node", "fxa-geodb"],
-    "lib": ["ESNext"]
+    "lib": ["ESNext"],
+    // We should remove this, but for whatever reason, esbuild was not complaining
+    // about these explicit any
+    "noImplicitAny": false
   },
-  "include": [
-    "bin/*",
-    "scripts/**/*.ts",
-    "scripts/delete-account.js",
-    "lib/senders/emails/templates/*/includes.ts"
-  ]
+  "include": ["bin/**/*.ts", "lib/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Because

- While working on FXA-10460, I noticed that auth-server wasn't actually targeting all typescript files for compilation.

## This pull request

- Targets all files
- Fixes ensuing errors

## Issue that this pull request solves

Closes: FXA-10676

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a fast follow to #17938. Also it's good to note that make this PR reasonable in size, `noImplicitAny` was set to false. We can address this at a later point in time. There were enough of these errors that it didn't make sense to fix them here, and to fix them properly actual types should be tracked down.