### PR TITLE
fix(bug): Skip session assurance check in /oauth/token route

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -446,7 +446,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
           // XXX TODO: To be able to fully replace the /token route from oauth-server,
           // this route must also be able to accept 'client_secret' as Basic Auth in header.
           mode: 'optional',
-          strategy: 'sessionToken',
+          strategy: 'sessionTokenNoAssurance',
         },
         validate: {
           // Note: the use of 'alternatives' here means that `grant_type` will default to


### PR DESCRIPTION
## Because

- We are getting alot more unverified session errors in this route

## This pull request

- Uses our legacy auth scheme on the route

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10677

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I don't have solid leads on why it was having such a huge increaes in errors, but suspect legacy sessions before 2FA was enabled might be getting tripped. We do have other routes with exceptions so this might have to fall in that category.
