### PR TITLE
fix(bug): Skip session assurance check in device routes

### DIFF
--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -25,7 +25,7 @@ module.exports = (log, db, devices, clientUtils) => {
       options: {
         ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_CLIENTS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategy: 'sessionTokenNoAssurance',
         },
         validate: {
           query: isA.object({

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -99,7 +99,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICE_POST,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenNoAssurance', 'refreshToken'],
         },
         validate: {
           payload: isA
@@ -548,7 +548,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICES_GET,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenNoAssurance', 'refreshToken'],
         },
         validate: {
           query: isA.object({


### PR DESCRIPTION
## Because

- It might cause issues when loading devices on a mobile client

## This pull request

- Falls back to older session auth schem

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
