### PR TITLE
setup paypal processnonzeroinvoice

### DIFF
--- a/libs/payments/customer/src/lib/error.ts
+++ b/libs/payments/customer/src/lib/error.ts
@@ -92,3 +92,21 @@ export class InvalidPaymentIntentError extends PaymentsCustomerError {
     super('Invalid payment intent');
   }
 }
+
+export class InvalidInvoiceError extends PaymentsCustomerError {
+  constructor() {
+    super('Invalid invoice');
+  }
+}
+
+export class StripePayPalAgreementNotFoundError extends PaymentsCustomerError {
+  constructor(customerId: string) {
+    super(`PayPal agreement not found for Stripe customer ${customerId}`);
+  }
+}
+
+export class PayPalPaymentFailedError extends PaymentsCustomerError {
+  constructor(status?: string) {
+    super(`PayPal payment failed with status ${status ?? 'undefined'}`);
+  }
+}

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -12,6 +12,7 @@ export type InvoicePreview = {
   discountEnd?: number | null;
   discountType?: string;
   number: string | null; // customer-facing invoice identifier
+  paypalTransactionId?: string;
 };
 
 export interface TaxAmount {
@@ -38,6 +39,11 @@ export enum STRIPE_PRODUCT_METADATA {
 export enum STRIPE_SUBSCRIPTION_METADATA {
   Currency = 'currency',
   Amount = 'amount',
+}
+
+export enum STRIPE_INVOICE_METADATA {
+  RetryAttempts = 'paymentAttempts',
+  PaypalTransactionId = 'paypalTransactionId',
 }
 
 export enum SubplatInterval {

--- a/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
+++ b/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { StripeInvoice, StripeUpcomingInvoice } from '@fxa/payments/stripe';
-import { InvoicePreview } from '../types';
+import { InvoicePreview, STRIPE_INVOICE_METADATA } from '../types';
 
 /**
  * Formats a Stripe Invoice to the FirstInvoicePreview DTO format.
@@ -34,5 +34,7 @@ export function stripeInvoiceToInvoicePreviewDTO(
     discountEnd: invoice.discount?.end,
     discountType: invoice.discount?.coupon.duration,
     number: invoice.number,
+    paypalTransactionId:
+      invoice.metadata?.[STRIPE_INVOICE_METADATA.PaypalTransactionId],
   };
 }

--- a/libs/payments/paypal/src/index.ts
+++ b/libs/payments/paypal/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from './lib/paypalCustomer/paypalCustomer.manager';
 export * from './lib/paypalCustomer/paypalCustomer.factories';
+export * from './lib/factories';
 export * from './lib/checkoutToken.manager';
 export * from './lib/paypal.client';
 export * from './lib/paypal.client.config';

--- a/libs/payments/paypal/src/lib/factories.ts
+++ b/libs/payments/paypal/src/lib/factories.ts
@@ -19,6 +19,7 @@ import {
   NVPErrorSeverity,
   TransactionSearchResult,
 } from './paypal.client.types';
+import { ChargeOptions, ChargeResponse } from './paypal.types';
 
 export const NVPBaseResponseFactory = (
   override?: Partial<NVPBaseResponse>
@@ -152,5 +153,35 @@ export const NVPTransactionSearchResponseFactory = (
 ): NVPTransactionSearchResponse => ({
   ...NVPResponseFactory(),
   L: [TransactionSearchResultFactory(), TransactionSearchResultFactory()],
+  ...override,
+});
+
+export const ChargeResponseFactory = (
+  override?: Partial<ChargeResponse>
+): ChargeResponse => ({
+  avsCode: faker.string.alpha(1).toUpperCase(),
+  currencyCode: faker.finance.currencyCode(),
+  cvv2Match: faker.finance.creditCardCVV(),
+  transactionId: faker.string.uuid(),
+  parentTransactionId: faker.string.uuid(),
+  transactionType: 'express-checkout',
+  paymentType: faker.finance.transactionType(),
+  orderTime: faker.date.recent().toISOString(),
+  amount: faker.finance.amount(),
+  paymentStatus: 'Completed',
+  pendingReason: 'none',
+  reasonCode: 'none',
+  ...override,
+});
+
+export const ChargeOptionsFactory = (
+  override?: Partial<ChargeOptions>
+): ChargeOptions => ({
+  amountInCents: faker.number.int({ max: 100000000 }),
+  billingAgreementId: faker.string.uuid(),
+  currencyCode: faker.finance.currencyCode(),
+  idempotencyKey: faker.string.uuid(),
+  invoiceNumber: faker.string.uuid(),
+  taxAmountInCents: faker.number.int({ max: 100000000 }),
   ...override,
 });

--- a/libs/payments/paypal/src/lib/paypal.error.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.error.spec.ts
@@ -4,10 +4,7 @@
 import { faker } from '@faker-js/faker';
 import { MultiError, VError } from 'verror';
 
-import {
-  NVPErrorFactory,
-  NVPErrorResponseFactory,
-} from '../../../../payments/paypal/src/lib/factories';
+import { NVPErrorFactory, NVPErrorResponseFactory } from './factories';
 import { PayPalClientError, PayPalNVPError } from './paypal.error';
 
 describe('PayPal Errors', () => {

--- a/libs/payments/paypal/src/lib/paypal.error.ts
+++ b/libs/payments/paypal/src/lib/paypal.error.ts
@@ -4,6 +4,55 @@
 import { BaseError, BaseMultiError } from '@fxa/shared/error';
 import { NVPErrorResponse } from './paypal.client.types';
 
+/// PayPal error codes
+/**
+ * Error Codes representing an error that is temporary to PayPal
+ * and should be retried again without changes.
+ */
+export const PAYPAL_RETRY_ERRORS = [10014, 10445, 11453, 11612];
+
+/**
+ * Errors Codes representing an error with the customers funding
+ * source, such as the AVS, CVV2, funding, etc. not being valid.
+ *
+ * The customer should be prompted to login to PayPal and fix their
+ * funding source.
+ */
+export const PAYPAL_SOURCE_ERRORS = [
+  10069, 10203, 10204, 10205, 10207, 10210, 10212, 10216, 10417, 10502, 10504,
+  10507, 10525, 10527, 10537, 10546, 10554, 10555, 10556, 10560, 10567, 10600,
+  10601, 10606, 10606, 10748, 10752, 11084, 11091, 11458, 11611, 13109, 13122,
+  15012, 18014,
+];
+
+/**
+ * Error codes representing an error in how we called PayPal and/or
+ * the arguments we passed them. These can only be fixed by fixing our
+ * code.
+ */
+export const PAYPAL_APP_ERRORS = [
+  10004, 10009, 10211, 10213, 10214, 10402, 10406, 10412, 10414, 10443, 10538,
+  10539, 10613, 10747, 10755, 11302, 11452,
+];
+
+/**
+ * Returned when the paypal billing agreement is no longer valid.
+ */
+export const PAYPAL_BILLING_AGREEMENT_INVALID = 10201;
+
+/**
+ * Returned with a transaction if the message sub id was seen before.
+ */
+export const PAYPAL_REPEAT_MESSAGE_SUB_ID = 11607;
+
+/**
+ * Returned with a transaction where the billing agreement was created
+ * with a different business account.
+ *
+ * Should only occur when using multiple dev apps on the same Stripe account.
+ */
+export const PAYPAL_BILLING_TRANSACTION_WRONG_ACCOUNT = 11451;
+
 export class PayPalClientError extends BaseMultiError {
   public raw: string;
   public data: NVPErrorResponse;
@@ -25,6 +74,24 @@ export class PayPalClientError extends BaseMultiError {
       err instanceof PayPalClientError &&
       err.getPrimaryError() instanceof PayPalNVPError
     );
+  }
+
+  static throwPaypalCodeError(err: PayPalClientError) {
+    const primaryError = err.getPrimaryError();
+    const code = primaryError.errorCode;
+    if (!code || PAYPAL_APP_ERRORS.includes(code)) {
+      throw new UnexpectedPayPalErrorCode(err);
+    }
+    if (
+      PAYPAL_SOURCE_ERRORS.includes(code) ||
+      code === PAYPAL_BILLING_AGREEMENT_INVALID
+    ) {
+      throw new PayPalPaymentMethodError(err);
+    }
+    if (PAYPAL_RETRY_ERRORS.includes(code)) {
+      throw new PayPalServiceUnavailableError(err);
+    }
+    throw new UnexpectedPayPalError(err);
   }
 }
 
@@ -50,18 +117,50 @@ export class PayPalNVPError extends BaseError {
   }
 }
 
+export class PaymentsCustomError extends BaseError {
+  constructor(message: string, cause?: Error) {
+    super(message, {
+      cause,
+    });
+  }
+}
+
 export class PaypalBillingAgreementManagerError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
   }
 }
 
-export class AmountExceedsPayPalCharLimitError extends PaypalBillingAgreementManagerError {
+export class AmountExceedsPayPalCharLimitError extends BaseError {
   constructor(amountInCents: number) {
     super('Amount must be less than 10 characters', {
       info: {
         amountInCents,
       },
     });
+  }
+}
+
+export class UnexpectedPayPalError extends PaymentsCustomError {
+  constructor(error: Error) {
+    super('An unexpected PayPal error occured', error);
+  }
+}
+
+export class UnexpectedPayPalErrorCode extends PaymentsCustomError {
+  constructor(error: Error) {
+    super('Encountered an unexpected PayPal error code', error);
+  }
+}
+
+export class PayPalPaymentMethodError extends PaymentsCustomError {
+  constructor(error: Error) {
+    super('PayPal payment method failed', error);
+  }
+}
+
+export class PayPalServiceUnavailableError extends PaymentsCustomError {
+  constructor(error: Error) {
+    super('PayPal service is temporarily unavailable', error);
   }
 }

--- a/libs/payments/paypal/src/lib/paypal.types.ts
+++ b/libs/payments/paypal/src/lib/paypal.types.ts
@@ -18,3 +18,59 @@ export interface BillingAgreement {
   street2: string;
   zip: string;
 }
+
+export interface ChargeOptions {
+  amountInCents: number;
+  billingAgreementId: string;
+  currencyCode: string;
+  idempotencyKey: string;
+  invoiceNumber: string;
+  ipaddress?: string;
+  taxAmountInCents?: number;
+}
+
+export interface ChargeResponse {
+  avsCode: string;
+  currencyCode: string;
+  cvv2Match: string;
+  transactionId: string;
+  parentTransactionId: string | undefined;
+  transactionType: 'cart' | 'express-checkout';
+  paymentType: string;
+  orderTime: string;
+  amount: string;
+  paymentStatus:
+    | 'None'
+    | 'Canceled-Reversal'
+    | 'Completed'
+    | 'Denied'
+    | 'Expired'
+    | 'Failed'
+    | 'In-Progress'
+    | 'Partially-Refunded'
+    | 'Pending'
+    | 'Refunded'
+    | 'Reversed'
+    | 'Processed'
+    | 'Voided';
+  pendingReason:
+    | 'none'
+    | 'address'
+    | 'authorization'
+    | 'echeck'
+    | 'intl'
+    | 'multi-currency'
+    | 'order'
+    | 'paymentreview'
+    | 'regulatoryreview'
+    | 'unilateral'
+    | 'verify'
+    | 'other';
+  reasonCode:
+    | 'none'
+    | 'chargeback'
+    | 'guarantee'
+    | 'buyer-complaint'
+    | 'refund'
+    | 'other';
+}

--- a/libs/payments/paypal/src/lib/paypalBillingAgreement.spec.ts
+++ b/libs/payments/paypal/src/lib/paypalBillingAgreement.spec.ts
@@ -4,11 +4,6 @@
 import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
 
-import {
-  CustomerManager,
-  InvoiceManager,
-  SubscriptionManager,
-} from '@fxa/payments/customer';
 import { MockStripeConfigProvider, StripeClient } from '@fxa/payments/stripe';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 
@@ -33,8 +28,6 @@ describe('PaypalBillingAgreementManager', () => {
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
-        CustomerManager,
-        InvoiceManager,
         PaypalBillingAgreementManager,
         PayPalClient,
         PaypalCustomerManager,
@@ -42,7 +35,6 @@ describe('PaypalBillingAgreementManager', () => {
         MockStripeConfigProvider,
         MockPaypalClientConfigProvider,
         StripeClient,
-        SubscriptionManager,
       ],
     }).compile();
 

--- a/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.spec.ts
+++ b/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.spec.ts
@@ -7,19 +7,19 @@ import { getPayPalAmountStringFromAmountInCents } from './getPayPalAmountStringF
 
 describe('getPayPalAmountStringFromAmountInCents', () => {
   it('returns correctly formatted string', () => {
-    const amountInCents = 9999999999;
+    const amountInCents = 999999999;
     const expectedResult = (amountInCents / 100).toFixed(2);
 
-    const result = getPayPalAmountStringFromAmountInCents(amountInCents);
+    const result = getPayPalAmountStringFromAmountInCents(amountInCents, 'USD');
 
     expect(result).toEqual(expectedResult);
   });
 
   it('throws an error if number exceeds digit limit', () => {
-    const amountInCents = 12345678910;
+    const amountInCents = 1234567890;
 
     expect(() => {
-      getPayPalAmountStringFromAmountInCents(amountInCents);
+      getPayPalAmountStringFromAmountInCents(amountInCents, 'USD');
     }).toThrow(AmountExceedsPayPalCharLimitError);
   });
 });

--- a/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.ts
+++ b/libs/payments/paypal/src/lib/util/getPayPalAmountStringFromAmountInCents.ts
@@ -7,14 +7,19 @@ import { AmountExceedsPayPalCharLimitError } from '../paypal.error';
 /*
  * Convert amount in cents to paypal AMT string.
  * We use Stripe to manage everything and plans are recorded in an AmountInCents.
- * PayPal AMT field requires a string of 10 characters or less, as documented here:
+ * PayPal AMT field requires a string of 9 characters or less, as documented here:
  * https://developer.paypal.com/docs/nvp-soap-api/do-reference-transaction-nvp/#payment-details-fields
  * https://developer.paypal.com/docs/api/payments/v1/#definition-amount
  */
 export function getPayPalAmountStringFromAmountInCents(
-  amountInCents: number
+  amountInCents: number,
+  currencyCode: string
 ): string {
-  if (amountInCents.toString().length > 10) {
+  // HUF, JPY, TWD do not support decimals.
+  if (['HUF', 'JPY', 'TWD'].includes(currencyCode.toUpperCase())) {
+    return String(amountInCents);
+  }
+  if (amountInCents.toString().length > 9) {
     throw new AmountExceedsPayPalCharLimitError(amountInCents);
   }
   // Left pad with zeros if necessary, so we always get a minimum of 0.01.

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -166,6 +166,28 @@ export class StripeClient {
     return result as StripeResponse<StripeInvoice>;
   }
 
+  async invoicesUpdate(invoiceId: string, params?: Stripe.InvoiceUpdateParams) {
+    const result = await this.stripe.invoices.update(invoiceId, {
+      ...params,
+      expand: undefined,
+    });
+    return result as StripeResponse<StripeInvoice>;
+  }
+
+  async invoicesPay(invoiceId: string) {
+    try {
+      await this.stripe.invoices.pay(invoiceId, {
+        paid_out_of_band: true,
+      });
+    } catch (err) {
+      if (err.message.includes('Invoice is already paid')) {
+        // This was already marked paid, we can ignore the error.
+        return;
+      }
+      throw err;
+    }
+  }
+
   async paymentIntentRetrieve(
     paymentIntentId: string,
     params?: Stripe.PaymentIntentRetrieveParams

--- a/libs/payments/ui/src/lib/client/components/CartPoller/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CartPoller/index.tsx
@@ -32,7 +32,7 @@ export function CartPoller() {
         retries = await pollCart(checkoutParams, retries, stripe);
       } catch (error) {
         console.error(error);
-        throw error;
+        retries += 1;
       }
 
       if (retries > 5) {

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -5,6 +5,7 @@
     "paths": {
       "@fxa/payments/legacy": ["libs/payments/legacy/src/index"],
       "@fxa/payments/stripe": ["libs/payments/stripe/src/index"],
+      "@fxa/payments/paypal": ["libs/payments/paypal/src/index"],
       "@fxa/payments/customer": ["libs/payments/customer/src/index"],
       "@fxa/shared/cms": ["libs/shared/cms/src/index"],
       "@fxa/shared/cloud-tasks": ["libs/shared/cloud-tasks/src/index"],


### PR DESCRIPTION
## Because

- We need to be able to process nonzero PayPal invoices

## This pull request

- Brings in functionality from SP2.5 to allow users to pay for their subscriptions with PayPal

## Issue that this pull request solves

Closes: [# FXA-10189](https://mozilla-hub.atlassian.net/browse/FXA-10189)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
