### PR TITLE
fix(auth): disable stripe tax when currency/country incompatible

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -95,10 +95,15 @@ export class PayPalHandler extends StripeWebhookHandler {
         throw error.unknownCustomer(uid);
       }
 
-      const automaticTax =
-        this.stripeHelper.isCustomerStripeTaxEligible(customer);
-
       const { priceId } = request.payload as Record<string, string>;
+      const { currency: planCurrency } =
+        await this.stripeHelper.findAbbrevPlanById(priceId);
+
+      const automaticTax =
+        this.stripeHelper.isCustomerTaxableWithSubscriptionCurrency(
+          customer,
+          planCurrency
+        );
 
       // Make sure to clean up any subscriptions that may be hanging with no payment
       const existingSubscription =

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -433,7 +433,8 @@ describe('subscriptions payPalRoutes', () => {
         authDbModule.getAccountCustomerByUid =
           sinon.fake.resolves(accountCustomer);
         stripeHelper.updateCustomerPaypalAgreement = sinon.fake.resolves({});
-        stripeHelper.isCustomerStripeTaxEligible = sinon.fake.returns(true);
+        stripeHelper.isCustomerTaxableWithSubscriptionCurrency =
+          sinon.fake.returns(true);
         payPalHelper.processInvoice = sinon.fake.resolves({});
         payPalHelper.processZeroInvoice = sinon.fake.resolves({});
       });
@@ -515,7 +516,8 @@ describe('subscriptions payPalRoutes', () => {
             state: 'Ontario',
           },
         };
-        stripeHelper.isCustomerStripeTaxEligible = sinon.fake.returns(false);
+        stripeHelper.isCustomerTaxableWithSubscriptionCurrency =
+          sinon.fake.returns(false);
         const actual = await runTest('/oauth/subscriptions/active/new-paypal', {
           ...requestOptions,
           payload: { token },
@@ -639,7 +641,8 @@ describe('subscriptions payPalRoutes', () => {
         };
         c.subscriptions.data[0].collection_method = 'send_invoice';
         stripeHelper.fetchCustomer = sinon.fake.resolves(c);
-        stripeHelper.isCustomerStripeTaxEligible = sinon.fake.returns(true);
+        stripeHelper.isCustomerTaxableWithSubscriptionCurrency =
+          sinon.fake.returns(true);
         stripeHelper.getCustomerPaypalAgreement =
           sinon.fake.returns(paypalAgreementId);
         payPalHelper.processInvoice = sinon.fake.resolves({});

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -1200,7 +1200,7 @@ describe('DirectStripeRoutes', () => {
 
     it('creates a subscription with a payment method and promotion code', async () => {
       const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
-      directStripeRoutesInstance.stripeHelper.isCustomerStripeTaxEligible.returns(
+      directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         true
       );
       directStripeRoutesInstance.extractPromotionCode = sinon.stub().resolves({
@@ -1226,7 +1226,7 @@ describe('DirectStripeRoutes', () => {
 
     it('creates a subscription with a payment method', async () => {
       const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
-      directStripeRoutesInstance.stripeHelper.isCustomerStripeTaxEligible.returns(
+      directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         true
       );
       const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
@@ -1247,7 +1247,7 @@ describe('DirectStripeRoutes', () => {
 
     it('creates a subscription with a payment method using automatic tax but in an unsupported region', async () => {
       const { sourceCountry, expected } = setupCreateSuccessWithTaxIds();
-      directStripeRoutesInstance.stripeHelper.isCustomerStripeTaxEligible.returns(
+      directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         false
       );
       const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
@@ -1503,7 +1503,7 @@ describe('DirectStripeRoutes', () => {
       );
       const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(customer);
-      directStripeRoutesInstance.stripeHelper.isCustomerStripeTaxEligible.returns(
+      directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         true
       );
       const expected = deepCopy(subscription2);
@@ -1561,7 +1561,7 @@ describe('DirectStripeRoutes', () => {
       );
       const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(customer);
-      directStripeRoutesInstance.stripeHelper.isCustomerStripeTaxEligible.returns(
+      directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         true
       );
       directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI.resolves(


### PR DESCRIPTION
## Because

- We don't want to charge US customers exclusive tax, nor EU customers inclusive tax.

## This pull request

- Enforces that we only enable automatic tax if the customer's tax country matches the currency of the plan.

## Issue that this pull request solves

Closes FXA-10593