### PR TITLE
fix(auth): include bin/ in build-ts script

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -14,7 +14,7 @@
     "build-l10n": "nx l10n-merge && nx l10n-merge-test",
     "build-css": "nx emails-scss",
     "build-ts": "tsc --build && tsc-alias",
-    "build-finalize": "cp -R config public lib scripts bin dist/packages/fxa-auth-server",
+    "build-finalize": "cp -R config public lib scripts dist/packages/fxa-auth-server",
     "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_BUILD=true storybook build && yarn build-storybook-copy-locales && yarn build-storybook-copy-templates",
     "build-storybook-copy-locales": "mkdir -p ./storybook-static/public/locales && cp -R ./public/locales ./storybook-static/public",
     "build-storybook-copy-templates": "mkdir -p ./storybook-static/lib/senders/emails/templates && cp -R ./lib/senders/emails ./storybook-static/lib/senders",

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -13,5 +13,9 @@
     // about these explicit any
     "noImplicitAny": false
   },
-  "include": ["bin/**/*.ts", "lib/**/*.ts", "scripts/**/*.ts"]
+  "include": [
+    "bin/*", // Include bin so that it's included in `build-ts`, specifically for "tsc-alias".
+    "lib/**/*.ts",
+    "scripts/**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Because

- JS files in bin/ directory did not have TS aliases replaced with relative paths.

## This pull request

- Include JS files in bin/ directory in tsconfig, so that it's picked up by tsc-alias during the build-ts script execution.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
