### PR TITLE
fix(oauth): Move keyFetchToken and unwrapBKey to sensitiveDataClient

### DIFF
--- a/packages/fxa-settings/src/lib/sensitive-data-client.ts
+++ b/packages/fxa-settings/src/lib/sensitive-data-client.ts
@@ -6,6 +6,20 @@
 
 export const AUTH_DATA_KEY = 'auth';
 
+export type SensitiveDataClientData = {
+  [AUTH_DATA_KEY]: {
+    emailForAuth?: string;
+    authPW?: string;
+    keyFetchToken?: hexstring;
+    unwrapBKey?: hexstring;
+  };
+};
+
+export type SensitiveDataClientAuthKeys = Pick<
+  SensitiveDataClientData[typeof AUTH_DATA_KEY],
+  'keyFetchToken' | 'unwrapBKey'
+>;
+
 /**
  * Class representing a client for handling sensitive data.
  *

--- a/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
@@ -20,6 +20,9 @@ export function isOAuthNativeIntegration(integration: {
 
 export type OAuthIntegration = OAuthWebIntegration | OAuthNativeIntegration;
 
+/**
+ * Check if the integration is OAuthWeb or OAuthNative
+ */
 export function isOAuthIntegration(integration: {
   type: IntegrationType;
 }): integration is OAuthIntegration {

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
@@ -55,6 +55,7 @@ function mockModelsModule() {
   mockSensitiveDataClient.getData = jest.fn().mockReturnValue({
     emailForAuth: 'bloop@gmail.com',
     authPW: MOCK_AUTH_PW,
+    unwrapBKey: MOCK_UNWRAP_BKEY,
   });
 }
 

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
@@ -28,13 +28,16 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state?: SigninLocationState;
   };
-  const { email, uid, sessionToken, unwrapBKey } = location.state || {};
+  const { email, uid, sessionToken } = location.state || {};
 
   const sensitiveDataClient = useSensitiveDataClient();
   const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
-  const { authPW, emailForAuth } =
-    (sensitiveData as unknown as { emailForAuth: string; authPW: string }) ||
-    {};
+  const { authPW, emailForAuth, unwrapBKey } =
+    (sensitiveData as {
+      emailForAuth?: string;
+      authPW?: string;
+      unwrapBKey?: hexstring;
+    }) || {};
 
   const navigateForward = useCallback(() => {
     setCurrentStep(currentStep + 1);
@@ -44,7 +47,9 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
     (
         uid: string,
         sessionToken: string,
-        unwrapBKey: string
+        unwrapBKey: string,
+        emailForAuth: string,
+        authPW: string
       ): (() => Promise<CreateRecoveryKeyHandler>) =>
       async () => {
         try {
@@ -93,7 +98,7 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
           };
         }
       },
-    [authClient, emailForAuth, authPW, navigateForward, ftlMsgResolver]
+    [authClient, navigateForward, ftlMsgResolver]
   );
 
   const updateRecoveryHint = useCallback(
@@ -124,7 +129,9 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
   const createRecoveryKeyHandler = createRecoveryKey(
     uid,
     sessionToken,
-    unwrapBKey
+    unwrapBKey,
+    emailForAuth,
+    authPW
   );
   const updateRecoveryHintHandler = updateRecoveryHint(sessionToken);
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -7,7 +7,12 @@ import SigninPushCode from '.';
 import { MozServices } from '../../../lib/types';
 import { getSigninState, handleNavigation } from '../utils';
 import { SigninLocationState } from '../interfaces';
-import { Integration, isWebIntegration, useAuthClient } from '../../../models';
+import {
+  Integration,
+  isWebIntegration,
+  useAuthClient,
+  useSensitiveDataClient,
+} from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
@@ -15,6 +20,10 @@ import OAuthDataError from '../../../components/OAuthDataError';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useEffect, useState } from 'react';
 import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import {
+  AUTH_DATA_KEY,
+  SensitiveDataClientAuthKeys,
+} from '../../../lib/sensitive-data-client';
 
 export type SigninPushCodeContainerProps = {
   integration: Integration;
@@ -35,8 +44,10 @@ export const SigninPushCodeContainer = ({
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: SigninLocationState;
   };
-
   const signinState = getSigninState(location.state);
+  const sensitiveDataClient = useSensitiveDataClient();
+  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
+  const { unwrapBKey } = (sensitiveData as SensitiveDataClientAuthKeys) || {};
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
@@ -82,7 +93,7 @@ export const SigninPushCodeContainer = ({
     const navigationOptions = {
       email: signinState.email,
       signinData: { ...signinState, verified: true },
-      unwrapBKey: signinState.unwrapBKey,
+      unwrapBKey,
       integration,
       finishOAuthFlowHandler,
       queryParams: location.search,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -32,6 +32,8 @@ const SigninRecoveryCode = ({
   serviceName,
   signinState,
   submitRecoveryCode,
+  keyFetchToken,
+  unwrapBKey,
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
   useEffect(() => {
     GleanMetrics.loginBackupCode.view();
@@ -63,15 +65,8 @@ const SigninRecoveryCode = ({
     submitButtonText: 'Confirm',
   };
 
-  const {
-    email,
-    sessionToken,
-    uid,
-    verificationMethod,
-    verificationReason,
-    keyFetchToken,
-    unwrapBKey,
-  } = signinState;
+  const { email, sessionToken, uid, verificationMethod, verificationReason } =
+    signinState;
 
   const onSuccessNavigate = useCallback(async () => {
     const navigationOptions = {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -4,6 +4,7 @@
 
 import { BeginSigninError } from '../../../lib/error-utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
+import { SensitiveDataClientAuthKeys } from '../../../lib/sensitive-data-client';
 import { MozServices } from '../../../lib/types';
 import { SigninIntegration, SigninLocationState } from '../interfaces';
 
@@ -13,7 +14,7 @@ export type SigninRecoveryCodeProps = {
   serviceName?: MozServices;
   signinState: SigninLocationState;
   submitRecoveryCode: SubmitRecoveryCode;
-};
+} & SensitiveDataClientAuthKeys;
 
 export type SubmitRecoveryCode = (
   code: string

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -34,6 +34,8 @@ const SigninTokenCode = ({
   finishOAuthFlowHandler,
   integration,
   signinState,
+  keyFetchToken,
+  unwrapBKey,
 }: SigninTokenCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const session = useSession();
@@ -44,8 +46,6 @@ const SigninTokenCode = ({
     uid,
     sessionToken,
     verificationReason,
-    keyFetchToken,
-    unwrapBKey,
     showInlineRecoveryKeySetup,
   } = signinState;
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
@@ -5,12 +5,13 @@
 import { AccountTotp } from '../../../lib/interfaces';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { SigninIntegration, SigninLocationState } from '../interfaces';
+import { SensitiveDataClientAuthKeys } from './../../../lib/sensitive-data-client';
 
-export interface SigninTokenCodeProps {
+export type SigninTokenCodeProps = {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
   signinState: SigninLocationState;
-}
+} & SensitiveDataClientAuthKeys;
 
 export interface TotpStatusResponse {
   account: {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -20,7 +20,9 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import SigninTotpCodeContainer from './container';
 import { MozServices } from '../../../lib/types';
 import { createMockWebIntegration } from '../SigninTokenCode/mocks';
-import { Integration } from '../../../models';
+import { Integration, useSensitiveDataClient } from '../../../models';
+import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../../models/mocks';
+
 import {
   MOCK_NON_TOTP_LOCATION_STATE,
   MOCK_TOTP_LOCATION_STATE,
@@ -60,6 +62,7 @@ jest.mock('../../../models', () => {
   return {
     ...jest.requireActual('../../../models'),
     useAuthClient: jest.fn(),
+    useSensitiveDataClient: jest.fn(),
   };
 });
 
@@ -119,6 +122,13 @@ function mockVerifyTotp(success: boolean = true, errorOut: boolean = false) {
     },
   ]);
 }
+const mockSensitiveDataClient = createMockSensitiveDataClient();
+mockSensitiveDataClient.getData = jest.fn();
+function restMockSensitiveDataClient() {
+  (useSensitiveDataClient as jest.Mock).mockImplementation(
+    () => mockSensitiveDataClient
+  );
+}
 
 function applyDefaultMocks() {
   jest.resetAllMocks();
@@ -131,6 +141,7 @@ function applyDefaultMocks() {
   mockReachRouter(MOCK_TOTP_LOCATION_STATE);
   mockVerifyTotp();
   mockWebIntegration();
+  restMockSensitiveDataClient();
 }
 
 describe('signin totp code container', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../../lib/error-utils';
 import protectionShieldIcon from '@fxa/shared/assets/images/protection-shield.svg';
 import Banner from '../../../components/Banner';
+import { SensitiveDataClientAuthKeys } from '../../../lib/sensitive-data-client';
 
 // TODO: show a banner success message if a user is coming from reset password
 // in FXA-6491. This differs from content-server where currently, users only
@@ -39,7 +40,7 @@ export type SigninTotpCodeProps = {
     totpCode: string
   ) => Promise<{ error?: BeginSigninError; status: boolean }>;
   serviceName?: MozServices;
-};
+} & SensitiveDataClientAuthKeys;
 
 export const viewName = 'signin-totp-code';
 
@@ -49,7 +50,8 @@ export const SigninTotpCode = ({
   redirectTo,
   signinState,
   submitTotpCode,
-  serviceName,
+  keyFetchToken,
+  unwrapBKey,
 }: SigninTotpCodeProps & RouteComponentProps) => {
   const location = useLocation();
 
@@ -63,8 +65,6 @@ export const SigninTotpCode = ({
     sessionToken,
     verificationMethod,
     verificationReason,
-    keyFetchToken,
-    unwrapBKey,
     showInlineRecoveryKeySetup,
   } = signinState;
 

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -46,6 +46,7 @@ import {
   mockGqlPasswordChangeStartMutation,
   MOCK_FLOW_ID,
   MOCK_CLIENT_ID,
+  MOCK_KEY_FETCH_TOKEN,
 } from './mocks';
 import AuthClient from 'fxa-auth-client/browser';
 import VerificationMethods from '../../constants/verification-methods';
@@ -177,6 +178,7 @@ function mockModelsModule() {
     },
   }));
 }
+
 // Call this when testing local storage
 function mockCurrentAccount(storedAccount = { uid: '123' }) {
   jest.spyOn(CacheModule, 'currentAccount').mockReturnValue(storedAccount);
@@ -519,6 +521,8 @@ describe('signin container', () => {
         expect(mockSensitiveDataClient.setData).toBeCalledWith(AUTH_DATA_KEY, {
           authPW: MOCK_AUTH_PW,
           emailForAuth: MOCK_EMAIL,
+          unwrapBKey: MOCK_UNWRAP_BKEY,
+          keyFetchToken: MOCK_KEY_FETCH_TOKEN,
         });
         expect(mockAuthClient.recoveryKeyExists).toBeCalledWith(
           handlerResult?.data?.signIn.sessionToken,

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -706,11 +706,13 @@ export async function trySignIn(
           ? v2Credentials.unwrapBKey
           : v1Credentials.unwrapBKey;
 
-      // Store for inline recovery key flow
       sensitiveDataClient.setData(AUTH_DATA_KEY, {
+        // Store for inline recovery key flow
         authPW,
         // Store this in case the email was corrected
         emailForAuth: email,
+        unwrapBKey,
+        keyFetchToken: data.signIn.keyFetchToken,
       });
 
       return {

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -39,6 +39,7 @@ import {
 import firefox from '../../lib/channels/firefox';
 import { navigate } from '@reach/router';
 import { IntegrationType } from '../../models';
+import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
 
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
@@ -173,7 +174,7 @@ function differentAccountLinkRendered() {
   screen.getByRole('link', { name: 'Use a different account' });
 }
 
-describe('Signin', () => {
+describe('Signin component', () => {
   // let bundle: FluentBundle;
   // beforeAll(async () => {
   //   bundle = await getFtlBundle('settings');
@@ -380,8 +381,6 @@ describe('Signin', () => {
                     uid: MOCK_UID,
                     sessionToken: MOCK_SESSION_TOKEN,
                     verified: true,
-                    keyFetchToken: MOCK_KEY_FETCH_TOKEN,
-                    unwrapBKey: MOCK_UNWRAP_BKEY,
                     showInlineRecoveryKeySetup: true,
                     verificationMethod: 'email-otp',
                     verificationReason: VerificationReasons.SIGN_IN,
@@ -502,8 +501,6 @@ describe('Signin', () => {
                     verified: false,
                     verificationReason: 'signup',
                     verificationMethod: 'email-otp',
-                    keyFetchToken: MOCK_KEY_FETCH_TOKEN,
-                    unwrapBKey: MOCK_UNWRAP_BKEY,
                   },
                 });
               });
@@ -672,7 +669,7 @@ describe('Signin', () => {
         enterPasswordAndSubmit();
         await waitFor(() => {
           expect(sendUnblockEmailHandler).toHaveBeenCalled();
-          expect(mockSetData).toHaveBeenCalledWith('auth', {
+          expect(mockSetData).toHaveBeenCalledWith(AUTH_DATA_KEY, {
             password: MOCK_PASSWORD,
           });
           expect(mockNavigate).toHaveBeenCalledWith('/signin_unblock', {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -36,6 +36,7 @@ import { handleNavigation } from './utils';
 import { useWebRedirect } from '../../lib/hooks/useWebRedirect';
 import { getLocalizedErrorMessage } from '../../lib/error-utils';
 import Banner from '../../components/Banner';
+import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
 
 export const viewName = 'signin';
 
@@ -254,7 +255,7 @@ const Signin = ({
               }
 
               // Store password to be used in another component
-              sensitiveDataClient.setData('auth', {
+              sensitiveDataClient.setData(AUTH_DATA_KEY, {
                 password,
               });
               // navigate only if sending the unblock code email is successful

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -213,8 +213,6 @@ export interface SigninLocationState {
   verified: boolean;
   verificationMethod?: VerificationMethods;
   verificationReason?: VerificationReasons;
-  keyFetchToken?: hexstring;
-  unwrapBKey?: hexstring;
   showInlineRecoveryKeySetup?: boolean;
 }
 

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -149,9 +149,7 @@ const createSigninLocationState = (
       verified,
       verificationMethod,
       verificationReason,
-      keyFetchToken,
     },
-    unwrapBKey,
     showInlineRecoveryKeySetup,
   } = navigationOptions;
   return {
@@ -161,8 +159,6 @@ const createSigninLocationState = (
     verified,
     verificationMethod,
     verificationReason,
-    keyFetchToken,
-    unwrapBKey,
     showInlineRecoveryKeySetup,
   };
 };
@@ -178,8 +174,8 @@ function sendFxaLogin(navigationOptions: NavigationOptions) {
     // sending these values can cause intermittent sync disconnect issues in oauth desktop.
     ...(!isOAuth && {
       // keyFetchToken and unwrapBKey should always exist if Sync integration
-      keyFetchToken: navigationOptions.signinData.keyFetchToken!,
-      unwrapBKey: navigationOptions.unwrapBKey!,
+      keyFetchToken: navigationOptions.signinData.keyFetchToken,
+      unwrapBKey: navigationOptions.unwrapBKey,
     }),
     services: navigationOptions.integration.isDesktopRelay()
       ? { relay: {} }

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -177,11 +177,8 @@ const ConfirmSignupCode = ({
           const { redirect, code, state, error } = await finishOAuthFlowHandler(
             uid,
             sessionToken,
-            // yes, non-null operator is gross, but it's temporary.
-            // see note in container component / router.js for this page, once
-            // we've converted the index page we can remove
-            keyFetchToken!,
-            unwrapBKey!
+            keyFetchToken,
+            unwrapBKey
           );
           if (error) {
             setLocalizedErrorBannerHeading(

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -7,6 +7,7 @@ import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { Integration, OAuthWebIntegration } from '../../../models';
 import { StoredAccountData } from '../../../lib/storage-utils';
 import { QueryParams } from '../../..';
+import { SensitiveDataClientAuthKeys } from '../../../lib/sensitive-data-client';
 
 export type LocationState = {
   origin: 'signup' | undefined;
@@ -35,7 +36,7 @@ export type ConfirmSignupCodeProps = {
   offeredSyncEngines?: string[];
   declinedSyncEngines?: string[];
   flowQueryParams: QueryParams;
-} & Pick<LocationState, 'keyFetchToken' | 'unwrapBKey'> &
+} & SensitiveDataClientAuthKeys &
   RouteComponentProps;
 
 export interface ConfirmSignupCodeFormData {

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -43,6 +43,7 @@ import {
   isOAuthNativeIntegrationSync,
   isSyncDesktopV3Integration,
   useFtlMsgResolver,
+  useSensitiveDataClient,
 } from '../../models';
 import {
   isClientMonitor,
@@ -50,6 +51,7 @@ import {
 } from '../../models/integrations/client-matching';
 import { SignupFormData, SignupProps } from './interfaces';
 import Banner from '../../components/Banner';
+import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
 
 export const viewName = 'signup';
 
@@ -59,6 +61,7 @@ export const Signup = ({
   beginSignupHandler,
   webChannelEngines,
 }: SignupProps) => {
+  const sensitiveDataClient = useSensitiveDataClient();
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
   useEffect(() => {
@@ -244,6 +247,12 @@ export const Signup = ({
         // this allows the recent account to be used for /signin
         storeAccountData(accountData);
 
+        // Set these for use in ConfirmSignupCode
+        sensitiveDataClient.setData(AUTH_DATA_KEY, {
+          keyFetchToken: data.signUp.keyFetchToken,
+          unwrapBKey: data.unwrapBKey,
+        });
+
         const getOfferedSyncEngines = () =>
           getSyncEngineIds(offeredSyncEngineConfigs || []);
 
@@ -303,8 +312,6 @@ export const Signup = ({
           state: {
             origin: 'signup',
             selectedNewsletterSlugs,
-            keyFetchToken: data.signUp.keyFetchToken,
-            unwrapBKey: data.unwrapBKey,
             // Sync desktop v3 sends a web channel message up on Signup
             // while OAuth Sync does on confirm signup
             ...(isSyncOAuth && {
@@ -338,6 +345,7 @@ export const Signup = ({
       localizedValidAgeError,
       isDesktopRelay,
       isOAuth,
+      sensitiveDataClient,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -61,7 +61,12 @@ export type SignupOAuthIntegration = Pick<
 
 export type SignupBaseIntegration = Pick<
   BaseIntegration,
-  'type' | 'isSync' | 'getService' | 'isDesktopRelay' | 'wantsKeys' | 'getClientId'
+  | 'type'
+  | 'isSync'
+  | 'getService'
+  | 'isDesktopRelay'
+  | 'wantsKeys'
+  | 'getClientId'
 >;
 
 export interface SignupFormData {


### PR DESCRIPTION
Because:
* It's better practice to store these in memory, and this causes a problem on session restart in oauth desktop

This commit:
* Moves keyFetchToken and unwrapBKey off of location state and into sensitiveDataClient

closes FXA-10709, closes FXA-10529