### PR TITLE
feat(scripts): update IAP subscription check on inactive uids script

### DIFF
--- a/packages/fxa-auth-server/lib/payments/iap/apple-app-store/apple-iap.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/apple-app-store/apple-iap.ts
@@ -22,9 +22,11 @@ export class AppleIAP {
     this.firestore = Container.get(AuthFirestore);
     const { authFirestore } = Container.get(AppConfig);
     this.prefix = `${authFirestore.prefix}iap-`;
-    const purchasesDbRef = this.firestore.collection(
-      `${this.prefix}app-store-purchases`
-    );
+    const purchasesDbRef = this.purchasesDbRef();
     this.purchaseManager = new PurchaseManager(purchasesDbRef, appStoreHelper);
+  }
+
+  purchasesDbRef() {
+    return this.firestore.collection(`${this.prefix}app-store-purchases`);
   }
 }

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/play-billing.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/play-billing.ts
@@ -35,13 +35,15 @@ export class PlayBilling {
     });
     this.prefix = `${config.authFirestore.prefix}iap-`;
     this.firestore = Container.get(AuthFirestore);
-    const purchasesDbRef = this.firestore.collection(
-      `${this.prefix}play-purchases`
-    );
+    const purchasesDbRef = this.purchaseDbRef();
     this.purchaseManager = new PurchaseManager(
       purchasesDbRef,
       playDeveloperApiClient
     );
     this.userManager = new UserManager(purchasesDbRef, this.purchaseManager);
+  }
+
+  purchaseDbRef() {
+    return this.firestore.collection(`${this.prefix}play-purchases`);
   }
 }

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/user-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/user-manager.ts
@@ -56,7 +56,6 @@ export class UserManager extends UserManagerBase {
 
     try {
       // Create query to fetch possibly active subscriptions from Firestore
-      // Create query to fetch possibly active subscriptions from Firestore
       let query = this.purchasesDbRef
         .where('formOfPayment', '==', GOOGLE_PLAY_FORM_OF_PAYMENT)
         .where('skuType', '==', SkuType.SUBS)

--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/lib.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/lib.ts
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  Account,
+  AccountCustomers,
+  Email,
+  SecurityEvent,
+  SessionToken as SessionTokenOrm,
+} from 'fxa-shared/db/models/auth';
+import { SessionToken } from 'fxa-shared/connected-services/models/SessionToken';
+import { EVENT_NAMES } from 'fxa-shared/db/models/auth/security-event';
+
+export const setDateToUTC = (someDate: number) => {
+  const utcDate = new Date(someDate);
+  utcDate.setUTCHours(0, 0, 0, 0);
+  return utcDate;
+};
+
+export const emailUidsQuery = (activeByDateTimestamp) =>
+  Email.query()
+    .distinct('uid')
+    .where('verifiedAt', '>=', activeByDateTimestamp)
+    .as('emailUids');
+
+export const sessionTokenUidsQuery = (activeByDateTimestamp) =>
+  SessionTokenOrm.query()
+    .distinct('uid')
+    .where('lastAccessTime', '>=', activeByDateTimestamp)
+    .as('sessionTokenUids');
+
+export const securityEventUidsQuery = (activeByDateTimestamp) =>
+  SecurityEvent.query()
+    .distinct('uid')
+    .where('createdAt', '>=', activeByDateTimestamp)
+    .whereIn('nameId', [
+      EVENT_NAMES['account.login'],
+      EVENT_NAMES['account.password_reset_success'],
+      EVENT_NAMES['account.password_changed'],
+    ])
+    .as('securityEventUids');
+
+export const accountCustomerUidsQuery = () =>
+  AccountCustomers.query().select('uid').as('accountCustomerUids');
+
+export const accountWhereAndOrderByQueryBuilder = (
+  startDateTimestamp,
+  endDateTimestamp,
+  activeByDateTimestamp
+) => {
+  const emailUids = emailUidsQuery(activeByDateTimestamp);
+  const sessionTokenUids = sessionTokenUidsQuery(activeByDateTimestamp);
+  const securityEventUids = securityEventUidsQuery(activeByDateTimestamp);
+  const accountCustomerUids = accountCustomerUidsQuery();
+
+  return Account.query()
+    .leftJoin(emailUids, 'emailUids.uid', 'accounts.uid')
+    .leftJoin(sessionTokenUids, 'sessionTokenUids.uid', 'accounts.uid')
+    .leftJoin(securityEventUids, 'securityEventUids.uid', 'accounts.uid')
+    .leftJoin(accountCustomerUids, 'accountCustomerUids.uid', 'accounts.uid')
+    .where('accounts.emailVerified', 1)
+    .where('accounts.createdAt', '>=', startDateTimestamp)
+    .where('accounts.createdAt', '<', endDateTimestamp)
+    .where((builder) => {
+      builder
+        .whereNull('emailUids.uid')
+        .whereNull('sessionTokenUids.uid')
+        .whereNull('securityEventUids.uid')
+        .whereNull('accountCustomerUids.uid');
+    })
+    .orderBy('accounts.createdAt', 'asc')
+    .orderBy('accounts.uid', 'asc');
+};
+
+export type GetTokensFn<T> = (uid: string) => Promise<T[]>;
+
+// this includes the agumented last access time from redis
+export const hasActiveSessionToken = async (
+  tokensFn: GetTokensFn<SessionToken>,
+  uid: string,
+  activeByDateTimestamp: number
+) => {
+  const sessionTokens = await tokensFn(uid);
+  return sessionTokens.some(
+    (token) =>
+      token.lastAccessTime && token.lastAccessTime >= activeByDateTimestamp
+  );
+};
+export const hasActiveRefreshToken = async (
+  tokensFn: GetTokensFn<{ lastUsedAt: number }>,
+  uid: string,
+  activeByDateTimestamp: number
+) => {
+  const refreshTokens = await tokensFn(uid);
+  return refreshTokens.some((t) => t.lastUsedAt >= activeByDateTimestamp);
+};
+export const hasAccessToken = async (
+  tokensFn: GetTokensFn<{ lastUsedAt: number }>,
+  uid: string
+) => {
+  const accessTokens = await tokensFn(uid);
+  return accessTokens.length > 0;
+};


### PR DESCRIPTION
Because:
 - the script was checking for IAP subscriptions on every account in the db results

This commit:
 - builds a set of account uids that might have IAP subscriptions and only check when the account uid is in the set
 - moved some code into a file that will be shared with another script
