### PR TITLE
feat(2fa): Add /recoveryCodes/exists endpoint

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -9,7 +9,6 @@ import { RecoveryPhoneServiceConfig } from './recovery-phone.service.config';
 import { RecoveryPhoneManager } from './recovery-phone.manager';
 import {
   RecoveryNumberNotExistsError,
-  RecoveryNumberNotSupportedError,
   RecoveryNumberNotSupportedError
 } from './recovery-phone.errors';
 import { MessageInstance } from 'twilio/lib/rest/api/v2010/account/message';

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1926,6 +1926,13 @@ export default class AuthClient {
     );
   }
 
+  async getRecoveryCodesExist(
+    sessionToken: hexstring,
+    headers?: Headers
+  ): Promise<{ hasBackupCodes?: boolean; count?: number }> {
+    return this.sessionGet('/recoveryCodes/exists', sessionToken, headers);
+  }
+
   async consumeRecoveryCode(
     sessionToken: hexstring,
     code: string,

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1187,6 +1187,11 @@ module.exports = (config) => {
     });
   };
 
+  ClientApi.prototype.getRecoveryCodesExist = async function (sessionTokenHex) {
+    const token = await tokens.SessionToken.fromHex(sessionTokenHex);
+    return this.doRequest('GET', `${this.baseURL}/recoveryCodes/exists`, token);
+  };
+
   ClientApi.prototype.consumeRecoveryCode = function (
     sessionTokenHex,
     code,

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -826,6 +826,10 @@ module.exports = (config) => {
     return this.api.replaceRecoveryCodes(this.sessionToken, options);
   };
 
+  Client.prototype.getRecoveryCodesExist = function () {
+    return this.api.getRecoveryCodesExist(this.sessionToken);
+  };
+
   Client.prototype.consumeRecoveryCode = function (code, options = {}) {
     return this.api.consumeRecoveryCode(this.sessionToken, code, options);
   };

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -72,6 +72,7 @@ const DB_METHOD_NAMES = [
   'emailBounces',
   'emailRecord',
   'forgotPasswordVerified',
+  'getRecoveryCodesExist',
   'getRecoveryKey',
   'getRecoveryKeyRecordWithHint',
   'getSecondaryEmail',

--- a/packages/fxa-auth-server/test/remote/recovery_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_code_tests.js
@@ -95,6 +95,16 @@ describe(`#integration${testOptions.version} - remote backup authentication code
     });
   });
 
+  it('can retrieve a count of backup authentication codes', () => {
+    const result = client.getRecoveryCodesExist();
+    assert.equal(result.hasBackupCodes, true, 'recovery codes exist');
+    assert.equal(
+      result.count,
+      recoveryCodeCount,
+      'correct remaining codes'
+    );
+  });
+
   it('should replace backup authentication codes', () => {
     return client
       .replaceRecoveryCodes()

--- a/packages/fxa-auth-server/test/remote/recovery_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_code_tests.js
@@ -24,8 +24,6 @@ describe(`#integration${testOptions.version} - remote backup authentication code
     flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
   };
 
-
-
   otplib.authenticator.options = {
     encoding: 'hex',
     window: 10,
@@ -93,16 +91,6 @@ describe(`#integration${testOptions.version} - remote backup authentication code
       assert.equal(code.length > 1, true, 'correct length');
       assert.equal(BASE_36.test(code), true, 'code is hex');
     });
-  });
-
-  it('can retrieve a count of backup authentication codes', () => {
-    const result = client.getRecoveryCodesExist();
-    assert.equal(result.hasBackupCodes, true, 'recovery codes exist');
-    assert.equal(
-      result.count,
-      recoveryCodeCount,
-      'correct remaining codes'
-    );
   });
 
   it('should replace backup authentication codes', () => {

--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -41,6 +41,7 @@ const ACCOUNT_STATUS_ACTION = {
   sendUnblockCode: true,
   recoveryKeyExists: true,
   getCredentialsStatus: true,
+  checkRecoveryCodesExist: true,
 };
 
 // Actions that send an email, and hence might make

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -179,6 +179,15 @@ describe('#integration - AccountResolver', () => {
         expect(result).toBeTruthy();
       });
 
+      it('resolves backupCodes', async () => {
+        authClient.getRecoveryCodesExist = jest
+          .fn()
+          .mockResolvedValue({ hasBackupCodes: true, count: 10 });
+        const result = await resolver.backupCodes('token', headers);
+        expect(result.hasBackupCodes).toBeTruthy();
+        expect(result.count).toBe(10);
+      });
+
       it('resolves linked accounts with empty array', async () => {
         const user = await Account.findByUid(USER_1.uid);
         const linkedAccounts = resolver.linkedAccounts(user!);

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -818,6 +818,14 @@ export class AccountResolver {
   }
 
   @ResolveField()
+  public backupCodes(
+    @GqlSessionToken() token: string,
+    @GqlXHeaders() headers: Headers
+  ) {
+    return this.authAPI.getRecoveryCodesExist(token, headers);
+  }
+
+  @ResolveField()
   public attachedClients(
     @GqlSessionToken() token: string,
     @GqlXHeaders() headers: Headers

--- a/packages/fxa-graphql-api/src/gql/model/account.ts
+++ b/packages/fxa-graphql-api/src/gql/model/account.ts
@@ -11,6 +11,7 @@ import { Totp } from './totp';
 import { LinkedAccount } from './linkedAccount';
 import { SecurityEvent } from './securityEvent';
 import { RecoveryKey } from './recoveryKey';
+import { BackupCodes } from './backupCodes';
 
 @ObjectType({
   description: "The current authenticated user's Firefox Account record.",
@@ -41,6 +42,9 @@ export class Account {
 
   @Field((type) => Totp)
   public totp!: Totp;
+
+  @Field((type) => BackupCodes)
+  public backupCodes!: BackupCodes;
 
   @Field((type) => RecoveryKey, {
     description: 'Whether the user has had an account recovery key issued.',

--- a/packages/fxa-graphql-api/src/gql/model/backupCodes.ts
+++ b/packages/fxa-graphql-api/src/gql/model/backupCodes.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType({ description: 'Two-factor authentication backup codes.' })
+export class BackupCodes {
+  @Field({ description: 'Whether backup codes exists for the user.' })
+  public hasBackupCodes?: boolean;
+
+  @Field({
+    description: 'The number of remaining backup codes the user has available.',
+  })
+  public count?: number;
+}

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import Modal from '../Modal';
@@ -23,6 +23,7 @@ export const UnitRowTwoStepAuth = () => {
   const {
     totp: { exists, verified },
   } = account;
+  const count = account.backupCodes?.count;
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
   const [secondaryModalRevealed, revealSecondaryModal, hideSecondaryModal] =
     useBooleanState();
@@ -50,6 +51,15 @@ export const UnitRowTwoStepAuth = () => {
       );
     }
   }, [account, hideModal, alertBar, l10n]);
+
+  console.log('Number of backup codes remaining: ', count);
+
+  // TODO in FXA-10206, remove this console log and use the count data for the backup codes subrow
+  useEffect(() => {
+    if (exists && verified) {
+      console.log('Number of backup codes remaining: ', count);
+    }
+  }, [count, exists, verified]);
 
   const conditionalUnitRowProps =
     exists && verified

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import Modal from '../Modal';
@@ -21,9 +21,10 @@ export const UnitRowTwoStepAuth = () => {
   const alertBar = useAlertBar();
   const account = useAccount();
   const {
+    // TODO: use in FXA-10206
+    // backupCodes: { hasBackupCodes, count },
     totp: { exists, verified },
   } = account;
-  const count = account.backupCodes?.count;
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
   const [secondaryModalRevealed, revealSecondaryModal, hideSecondaryModal] =
     useBooleanState();
@@ -51,15 +52,6 @@ export const UnitRowTwoStepAuth = () => {
       );
     }
   }, [account, hideModal, alertBar, l10n]);
-
-  console.log('Number of backup codes remaining: ', count);
-
-  // TODO in FXA-10206, remove this console log and use the count data for the backup codes subrow
-  useEffect(() => {
-    if (exists && verified) {
-      console.log('Number of backup codes remaining: ', count);
-    }
-  }, [count, exists, verified]);
 
   const conditionalUnitRowProps =
     exists && verified

--- a/packages/fxa-settings/src/lib/interfaces.ts
+++ b/packages/fxa-settings/src/lib/interfaces.ts
@@ -13,3 +13,8 @@ export interface AccountTotp {
   exists: boolean;
   verified: boolean;
 }
+
+export interface AccountBackupCodes {
+  hasBackupCodes: boolean;
+  count: number;
+}

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -28,7 +28,11 @@ import {
   GET_LOCAL_SIGNED_IN_STATUS,
   GET_TOTP_STATUS,
 } from '../components/App/gql';
-import { AccountAvatar, AccountTotp } from '../lib/interfaces';
+import {
+  AccountAvatar,
+  AccountBackupCodes,
+  AccountTotp,
+} from '../lib/interfaces';
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
 import { getHandledError } from '../lib/error-utils';
 
@@ -108,6 +112,7 @@ export interface AccountData {
   attachedClients: AttachedClient[];
   linkedAccounts: LinkedAccount[];
   totp: AccountTotp;
+  backupCodes: AccountBackupCodes;
   subscriptions: Subscription[];
   securityEvents: SecurityEvent[];
 }
@@ -186,6 +191,10 @@ export const GET_ACCOUNT = gql`
       totp {
         exists
         verified
+      }
+      backupCodes {
+        hasBackupCodes
+        count
       }
       subscriptions {
         created
@@ -388,6 +397,10 @@ export class Account implements AccountData {
 
   get totpActive() {
     return this.totp.exists && this.totp.verified;
+  }
+
+  get backupCodes() {
+    return this.data.backupCodes;
   }
 
   get attachedClients() {

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -94,6 +94,10 @@ export function defaultAppContext(context?: AppContextValue) {
       exists: true,
       verified: true,
     },
+    backupCodes: {
+      hasBackupCodes: false,
+      count: 0,
+    },
     linkedAccounts: [],
     securityEvents: [],
   };

--- a/packages/fxa-settings/src/models/contexts/SettingsContext.ts
+++ b/packages/fxa-settings/src/models/contexts/SettingsContext.ts
@@ -58,6 +58,10 @@ export const INITIAL_SETTINGS_QUERY = gql`
         exists
         verified
       }
+      backupCodes {
+        hasBackupCodes
+        count
+      }
       subscriptions {
         created
         productName


### PR DESCRIPTION
## Because

* We want to hook up the BackupCodeManager to the front end

## This pull request

* Add new /recoveryCodes/exists route
* Add new handler method that uses the BackupCodeManager to retrieve the count of remaining codes
* Add backup codes to account resolver
* Update fxa-settings account model to include backup codes count

## Issue that this pull request solves

Closes: #FXA-10231

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
