### PR TITLE
feat(phone): Add `unconfirmed` to RecoveryPhoneManager

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -12,11 +12,17 @@ import {
   RecoveryNumberAlreadyExistsError,
   RecoveryNumberInvalidFormatError,
 } from './recovery-phone.errors';
+import { Redis } from 'ioredis';
+
+const RECORD_EXPIRATION_SECONDS = 10 * 60;
 
 @Injectable()
 export class RecoveryPhoneManager {
+  private readonly redisPrefix = 'sms-attempt';
+
   constructor(
-    @Inject(AccountDbProvider) private readonly db: AccountDatabase
+    @Inject(AccountDbProvider) private readonly db: AccountDatabase,
+    @Inject('Redis') private readonly redisClient: Redis
   ) {}
 
   private isE164Format(phoneNumber: string) {
@@ -56,5 +62,61 @@ export class RecoveryPhoneManager {
       }
       throw err;
     }
+  }
+
+  /**
+   * Store phone number data and SMS code for a user.
+   *
+   * @param uid The user's unique identifier
+   * @param code The SMS code to associate with this UID
+   * @param phoneNumber The phone number to store
+   * @param isSetup Flag indicating if this SMS is to set up a number or verify an existing one
+   * @param lookupData Optional lookup data for the phone number
+   */
+  async storeUnconfirmed(
+    uid: string,
+    code: string,
+    phoneNumber: string,
+    isSetup: boolean,
+    lookupData?: Record<string, any>
+  ): Promise<void> {
+    const redisKey = `${this.redisPrefix}:${uid}:${code}`;
+    const data = {
+      phoneNumber,
+      isSetup,
+      lookupData: lookupData ? JSON.stringify(lookupData) : null,
+    };
+
+    await this.redisClient.set(
+      redisKey,
+      JSON.stringify(data),
+      'EX',
+      RECORD_EXPIRATION_SECONDS
+    );
+  }
+
+  /**
+   * Retrieve phone number data for a user using uid and sms code.
+   *
+   * @param uid The user's unique identifier
+   * @param code The SMS code associated with this user
+   * @returns The stored phone number data if found, or null if not found
+   */
+  async getUnconfirmed(
+    uid: string,
+    code: string
+  ): Promise<{
+    phoneNumber: string;
+    isSetup: boolean;
+    lookupData: Record<string, any> | null;
+  } | null> {
+    const redisKey = `${this.redisPrefix}:${uid}:${code}`;
+    const data = await this.redisClient.get(redisKey);
+
+    if (!data) {
+      return null;
+    }
+
+    return JSON.parse(data);
   }
 }


### PR DESCRIPTION
## Because

- We want to store the unconfirmed code in Redis

## This pull request

- Updates the RecoveryPhoneManager to store this code

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10346

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I took a look at adding the `OtpManager` (same one we use for password reset code), but we would need to refactor it a good bit to accept additional data needed for sms. To unblock other stuff, we can add that in a follow up.
