### PR TITLE
task(recovery-phone): Add confirmCode method

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -49,4 +49,31 @@ export class RecoveryPhoneService {
     );
     return true;
   }
+
+  /**
+   * Confirms a UID code. This will also and finalizes the phone number setup if the code provided was
+   * intended for phone number setup.
+   * @param uid An account id
+   * @param code A otp code
+   * @returns True if successful
+   */
+  public async confirmCode(uid: string, code: string) {
+    const data = await this.recoveryPhoneManager.getUnconfirmed(uid, code);
+
+    // If there is no data, it means there's no record of this code being sent to the uid provided
+    if (data == null) {
+      return false;
+    }
+
+    // If this was for a setup operation. Register the phone number to the uid.
+    if (data.isSetup === true) {
+      await this.recoveryPhoneManager.registerPhoneNumber(
+        uid,
+        data.phoneNumber
+      );
+    }
+
+    // There was a record matching, the uid / code. The confirmation was successful.
+    return true;
+  }
 }


### PR DESCRIPTION
## Because
- We want to able to confirm a user's setup code

## This pull request
- Adds a method called confirmCode to the recovery-phone service
- Register the phone number to the account in the event the code provided is valid.

## Issue that this pull request solves

Closes: FXA-10348

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
