### PR TITLE
feat(phone): Add `removePhoneNumber` to RecoveryPhoneService

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
@@ -118,15 +118,15 @@ describe('RecoveryPhoneManager', () => {
     expect(result).toBe(true);
   });
 
-  it('should return false if no phone number removed', async () => {
+  it('should throw if no phone number removed', async () => {
     const deleteFromSpy = jest.spyOn(db, 'deleteFrom');
     const mockPhone = RecoveryPhoneFactory();
 
-    const result = await recoveryPhoneManager.removePhoneNumber(
-      mockPhone.uid.toString('hex')
-    );
+    const { uid } = mockPhone;
+    await expect(
+      recoveryPhoneManager.removePhoneNumber(uid.toString('hex'))
+    ).rejects.toThrow('Recovery number does not exist');
     expect(deleteFromSpy).toBeCalledWith('recoveryPhones');
-    expect(result).toBe(false);
   });
 
   it('should handle database errors gracefully', async () => {

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -90,7 +90,13 @@ export class RecoveryPhoneManager {
    */
   async removePhoneNumber(uid: string): Promise<boolean> {
     const uidBuffer = Buffer.from(uid, 'hex');
-    return await removePhoneNumber(this.db, uidBuffer);
+    const removed = await removePhoneNumber(this.db, uidBuffer);
+
+    if (!removed) {
+      throw new RecoveryNumberNotExistsError(uid);
+    }
+
+    return true;
   }
 
   /**

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -8,7 +8,10 @@ import { OtpManager } from '@fxa/shared/otp';
 import { SmsManager } from './sms.manager';
 import { RecoveryPhoneServiceConfig } from './recovery-phone.service.config';
 import { RecoveryPhoneManager } from './recovery-phone.manager';
-import { RecoveryNumberNotSupportedError } from './recovery-phone.errors';
+import {
+  RecoveryNumberNotExistsError,
+  RecoveryNumberNotSupportedError,
+} from './recovery-phone.errors';
 
 describe('RecoveryPhoneService', () => {
   const phoneNumber = '+15005551234';
@@ -22,6 +25,7 @@ describe('RecoveryPhoneService', () => {
     storeUnconfirmed: jest.fn(),
     getUnconfirmed: jest.fn(),
     registerPhoneNumber: jest.fn(),
+    removePhoneNumber: jest.fn(),
   };
   const mockOtpManager = { generateCode: jest.fn() };
   const mockRecoveryPhoneServiceConfig = {
@@ -162,6 +166,21 @@ describe('RecoveryPhoneService', () => {
       });
       mockRecoveryPhoneManager.registerPhoneNumber.mockRejectedValue(mockError);
       expect(service.confirmCode(uid, code)).rejects.toEqual(mockError);
+    });
+  });
+
+  describe('removePhoneNumber', () => {
+    it('should remove a phone number', async () => {
+      mockRecoveryPhoneManager.removePhoneNumber.mockResolvedValueOnce(true);
+      const result = await service.removePhoneNumber(uid);
+      expect(result).toBeTruthy();
+      expect(mockRecoveryPhoneManager.removePhoneNumber).toBeCalledWith(uid);
+    });
+
+    it('should throw if phone number not found', () => {
+      const error = new RecoveryNumberNotExistsError(uid);
+      mockRecoveryPhoneManager.removePhoneNumber.mockRejectedValueOnce(error);
+      expect(service.removePhoneNumber(uid)).rejects.toThrow(error);
     });
   });
 });

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -81,4 +81,14 @@ export class RecoveryPhoneService {
     // There was a record matching, the uid / code. The confirmation was successful.
     return true;
   }
+
+  /**
+   * Remove phone number from an account. Each user can only have one associated
+   * phone number.
+   *
+   * @param uid An account id
+   */
+  public async removePhoneNumber(uid: string) {
+    return await this.recoveryPhoneManager.removePhoneNumber(uid);
+  }
 }


### PR DESCRIPTION
## Because

- We need to be able to remove a recovery phone number

## This pull request

- Adds `removePhoneNumber`, which throws error if nothing was removed

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10349

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
