### PR TITLE
feat(auth): fixes for Strapi

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -138,7 +138,13 @@ async function run(config) {
     );
     Container.set(PromotionCodeManager, promotionCodeManager);
 
-    if (config.cms.enabled) {
+    if (
+      config.cms.enabled ||
+      (config.cms.strapiClient &&
+        config.cms.strapiClient.graphqlApiUri &&
+        config.cms.strapiClient.apiKey &&
+        config.cms.strapiClient.firestoreCacheCollectionName)
+    ) {
       const strapiClientConfig = config.cms.strapiClient;
       const { graphqlApiUri, apiKey, firestoreCacheCollectionName } =
         strapiClientConfig;


### PR DESCRIPTION
## Because

- We want to spread out any flood of cache resets (unlikely since servers take varying amounts of time to spin up, but possible)
- We want to wait on a pending cachable request between reset periods, simply due to the sheer number of requests that could go through in the interval during a cache reset period.
- We want to enable Strapi in "shadow mode" to log potential mismatches

## This pull request

- Adds a random spread to cache reset interval
- Waits on pending cachable requests
- Enables Strapi in key_server if config is present
