### PR TITLE
task(customs): Alter customs rules for getCredentialStatus action

### DIFF
--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -40,6 +40,7 @@ const ACCOUNT_STATUS_ACTION = {
   accountStatusCheck: true,
   sendUnblockCode: true,
   recoveryKeyExists: true,
+  getCredentialsStatus: true,
 };
 
 // Actions that send an email, and hence might make

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -163,7 +163,7 @@ module.exports = function (fs, path, url, convict) {
       },
       maxAccountStatusCheck: {
         doc: 'Number of account status checks within rateLimitIntervalSeconds before throttling',
-        default: 5,
+        default: 20,
         format: 'nat',
         env: 'MAX_ACCOUNT_STATUS_CHECK',
       },
@@ -414,33 +414,6 @@ module.exports = function (fs, path, url, convict) {
     },
     tracing: tracingConfig,
     userDefinedRateLimitRules: {
-      getCredentialsStatusRules: {
-        actions: {
-          doc: 'Array of actions that this rule should be applied to',
-          default: ['getCredentialsStatus'],
-          format: Array,
-        },
-        limits: {
-          max: {
-            doc: 'max actions during `period` that can occur before rate limit is applied',
-            format: 'nat',
-            default: 120,
-            env: 'GET_CREDENTIALS_STATUS_RULE_MAX',
-          },
-          periodMs: {
-            doc: 'period needed before rate limit is reset',
-            format: 'duration',
-            default: '60 seconds',
-            env: 'GET_CREDENTIALS_STATUS_RULE_PERIOD_MS',
-          },
-          rateLimitIntervalMs: {
-            doc: 'how long rate limit is applied',
-            format: 'duration',
-            default: '15 minutes',
-            env: 'GET_CREDENTIALS_STATUS_RULE_LIMIT_INTERVAL_MS',
-          },
-        },
-      },
       totpCodeRules: {
         actions: {
           doc: 'Array of actions that this rule should be applied to',

--- a/packages/fxa-customs-server/test/remote/user_defined_rules.js
+++ b/packages/fxa-customs-server/test/remote/user_defined_rules.js
@@ -19,16 +19,13 @@ function randomIp() {
 }
 
 const config = require('../../lib/config').getProperties();
-config.userDefinedRateLimitRules.getCredentialsStatusRules.limits.max = 2;
-config.userDefinedRateLimitRules.getCredentialsStatusRules.limits.periodMs = 1000;
-config.userDefinedRateLimitRules.getCredentialsStatusRules.limits.rateLimitIntervalMs = 1000;
 config.userDefinedRateLimitRules.totpCodeRules.limits.periodMs = 1000;
 config.userDefinedRateLimitRules.totpCodeRules.limits.rateLimitIntervalMs = 1000;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.max = 2;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.periodMs = 1000;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.rateLimitIntervalMs = 1000;
 
-const ACTIONS = ['verifyTotpCode', 'verifyTokenCode', 'getCredentialsStatus'];
+const ACTIONS = ['verifyTotpCode', 'verifyTokenCode'];
 
 const testServer = new TestServer(config);
 


### PR DESCRIPTION
## Because

- We've seen an increase in 'unblock sign in' page views, which led to investigating the customs config.
- If a key stretching upgrade occurs, we will trigger a `getCredentialsStatus`, `passwordChange` & `accountLogin` action.
- Therefore we potentially have 3x the number actions during an upgrade scenario.


## This pull request
- Moves the `getCredentialStatus` action into the `ACCOUNT_STATUS_ACTION` set, which more correctly fits the nature of this action.
- The default for `maxAccountStatusCheck` has been increased, because key stretching changes need a bit more overhead for these types of actions.

## Issue that this pull request solves

Closes: FXA-10777

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
