### PR TITLE
feat(react): Tweaks for Third party auth in React

### DIFF
--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -153,16 +153,16 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
       return false;
     }
 
+    const code = this.searchParam('code');
+    if (!code) {
+      return false;
+    }
+
     try {
       const decodedState = decodeURIComponent(state);
       // Maybe check for values in url?
       new URL(decodedState);
     } catch (err) {
-      return false;
-    }
-
-    const code = this.searchParam('code');
-    if (!code) {
       return false;
     }
 

--- a/packages/fxa-settings/src/models/integrations/third-party-auth-callback-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/third-party-auth-callback-integration.ts
@@ -53,7 +53,7 @@ export class ThirdPartyAuthCallbackIntegration extends BaseIntegration<ThirdPart
   thirdPartyAuthParams() {
     const code = this.data.code;
     const providerFromParams = this.data.provider;
-    let provider: AUTH_PROVIDER | undefined;
+    let provider: AUTH_PROVIDER;
     if (providerFromParams === 'apple') {
       provider = AUTH_PROVIDER.APPLE;
     } else {


### PR DESCRIPTION
## Because

- I did't get to address all the code review comments in https://github.com/mozilla/fxa/pull/18053

## This pull request

- Adds review feedback
- Does not use `linkedAccount` data ref, the value does not appear to keep the state on rerender, instead uses the user from the linked account login route

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10812

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
