### PR TITLE
bug(settings): Hint disappears after navigating back to page

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.tsx
@@ -219,6 +219,7 @@ const AccountRecoveryConfirmKey = ({
               emailToHashWith,
               estimatedSyncDeviceCount,
               recoveryKeyExists,
+              recoveryKeyHint,
               token,
               uid,
             }}
@@ -238,6 +239,7 @@ const AccountRecoveryConfirmKey = ({
               emailToHashWith,
               estimatedSyncDeviceCount,
               recoveryKeyExists,
+              recoveryKeyHint,
               token,
               uid,
             }}


### PR DESCRIPTION
## Because

- After navigating back to the AccountRecoveryConfirmKey page from the complete_reset_password reset page, the recovery key hint would be missing.

## This pull request

- Makes sure the recoveryKeyHint is set in location state

## Issue that this pull request solves

Closes: FXA-10728

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

https://github.com/user-attachments/assets/fc1131fa-42b4-44de-99cd-e54916e2253f


## Other information (Optional)

Tests were not added. It's actually a navigation issue so unit tests aren't applicable and it seems overkill to add a functional test for this bug.
