### PR TITLE
fix(react): Update apollo cache after doing a successful totp code verify

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -31,6 +31,7 @@ import {
   AUTH_DATA_KEY,
   SensitiveDataClientAuthKeys,
 } from '../../../lib/sensitive-data-client';
+import { GET_LOCAL_SIGNED_IN_STATUS } from '../../../components/App/gql';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
@@ -82,6 +83,20 @@ export const SigninTotpCodeContainer = ({
             code,
             service,
           },
+        },
+        update: (cache, { data }) => {
+          if (data?.verifyTotp.success) {
+            // Update the Apollo cache with the new signed in status
+            const cacheData = cache.readQuery({
+              query: GET_LOCAL_SIGNED_IN_STATUS,
+            });
+            if (cacheData) {
+              cache.writeQuery({
+                query: GET_LOCAL_SIGNED_IN_STATUS,
+                data: { isSignedIn: true },
+              });
+            }
+          }
         },
       });
 


### PR DESCRIPTION
## Because

- We would get prompted to login again if the cache was not set

## This pull request

- Updates the signed in state in apollo cache if the user verifies a totp code

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10751

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Found this while working through https://github.com/mozilla/fxa/pull/18057. I think it makes sense to pull into a different PR since it fixes https://mozilla-hub.atlassian.net/browse/FXA-10751. We should consider uplifting it.

Testing steps: 

1. Login with third party auth, enable 2FA, log out
2. Login with localhost:3030, click third party auth, enter creds

You should be taken directly to settings after.
