### PR TITLE
task(basket): Update user lookup API

### DIFF
--- a/packages/fxa-admin-server/src/newsletters/basket.service.ts
+++ b/packages/fxa-admin-server/src/newsletters/basket.service.ts
@@ -43,7 +43,7 @@ export class BasketService {
       throw new Error('No API key configured!');
     }
 
-    const url = getUrl(this.basketUrl, '/news/lookup-user/', {
+    const url = getUrl(this.basketUrl, '/api/v1/users/lookup/', {
       email,
       'api-key': this.config.basketApiKey,
     });


### PR DESCRIPTION
## Because

Basket is migrating APIs. FxA uses basket's user lookup API to get basket tokens. This API works identically to the prior API, just the behind the scenes has changed.

