### PR TITLE
fix(customs): Use `checkAuthenticated` in `/session/reauth` route

### DIFF
--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -155,7 +155,8 @@ module.exports = function (
 
         const { accountRecord } = await signinUtils.checkCustomsAndLoadAccount(
           request,
-          email
+          email,
+          sessionToken.uid
         );
 
         await signinUtils.checkEmailAddress(

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -112,7 +112,7 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
      *    didSigninUnblock:  whether an unblock code was successfully used
      *  }
      */
-    async checkCustomsAndLoadAccount(request, email) {
+    async checkCustomsAndLoadAccount(request, email, checkAuthenticatedUid) {
       let accountRecord, originalError;
       let didSigninUnblock = false;
 
@@ -125,7 +125,16 @@ module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
           if (forced && forced.test(email)) {
             throw error.requestBlocked(true);
           }
-          await customs.check(request, email, 'accountLogin');
+
+          if (checkAuthenticatedUid) {
+            await customs.checkAuthenticated(
+              request,
+              checkAuthenticatedUid,
+              'accountLogin'
+            );
+          } else {
+            await customs.check(request, email, 'accountLogin');
+          }
         } catch (e) {
           originalError = e;
 

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -175,7 +175,7 @@ describe('/session/reauth', () => {
     log = mocks.mockLog();
     config = {};
     customs = {
-      check: () => {
+      checkAuthenticated: () => {
         return Promise.resolve(true);
       },
     };
@@ -258,7 +258,7 @@ describe('/session/reauth', () => {
       let args = signinUtils.checkCustomsAndLoadAccount.args[0];
       assert.equal(
         args.length,
-        2,
+        3,
         'checkCustomsAndLoadAccount was called with correct number of arguments'
       );
       assert.equal(


### PR DESCRIPTION
## Because

- The route uses a valid session token, we should use `checkAuthenticated` instead of `check` which is typically meant for unauthenticated routes

## This pull request

- Uses `checkAuthenticated` in `/session/reauth` route

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10818

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
