### PR TITLE
fix(react): Handle case where user cancels third party auth login

### DIFF
--- a/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory-flags.ts
@@ -155,7 +155,12 @@ export class DefaultIntegrationFlags implements IntegrationFlags {
 
     const code = this.searchParam('code');
     if (!code) {
-      return false;
+      // If user clicks cancel from the third party auth provider,
+      // the error param will be present in the url.
+      const error = this.searchParam('error');
+      if (!error) {
+        return false;
+      }
     }
 
     try {

--- a/packages/fxa-settings/src/models/integrations/third-party-auth-callback-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/third-party-auth-callback-integration.test.ts
@@ -14,6 +14,7 @@ describe('models/integrations/third-party-auth-callback-integration', function (
     data = new GenericData({});
     data.set('code', 'test-code');
     data.set('provider', 'apple');
+    data.set('error', 'access_denied');
     const state = encodeURIComponent('https://example.com?param=value');
     data.set('state', state);
     model = new ThirdPartyAuthCallbackIntegration(data);
@@ -34,5 +35,10 @@ describe('models/integrations/third-party-auth-callback-integration', function (
   it('should return FxA params from state', () => {
     const fxaParams = model.getFxAParams();
     expect(fxaParams).toBe('?param=value');
+  });
+
+  it('should return error if exists', () => {
+    const error = model.getError();
+    expect(error).toBe('access_denied');
   });
 });

--- a/packages/fxa-settings/src/models/integrations/third-party-auth-callback-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/third-party-auth-callback-integration.ts
@@ -29,6 +29,7 @@ export class ThirdPartyAuthCallbackIntegrationData extends BaseIntegrationData {
   @bind()
   state: string | undefined;
 
+  @IsOptional()
   @IsString()
   @bind()
   code: string | undefined;
@@ -37,6 +38,11 @@ export class ThirdPartyAuthCallbackIntegrationData extends BaseIntegrationData {
   @IsString()
   @bind()
   provider: string | undefined;
+
+  @IsOptional()
+  @IsString()
+  @bind()
+  error: string | undefined;
 }
 
 export interface ThirdPartyAuthCallbackIntegrationFeatures
@@ -72,5 +78,9 @@ export class ThirdPartyAuthCallbackIntegration extends BaseIntegration<ThirdPart
     }
 
     return '';
+  }
+
+  getError() {
+    return this.data.error;
   }
 }

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -102,6 +102,7 @@ describe('ThirdPartyAuthCallback component', () => {
     const mockIntegration = {
       thirdPartyAuthParams: () => ({ code: 'code', provider: 'provider' }),
       getFxAParams: () => '?param=value',
+      getError: () => undefined,
     };
     (useIntegration as jest.Mock).mockReturnValue(mockIntegration);
 
@@ -133,5 +134,30 @@ describe('ThirdPartyAuthCallback component', () => {
     expect(hardNavigateSpy).toBeCalledWith(
       '/post_verify/third_party_auth/callback?param=value'
     );
+  });
+
+  it('redirects to signin on third party auth error', async () => {
+    const mockAccount = {};
+    (useAccount as jest.Mock).mockReturnValue(mockAccount);
+
+    const mockIntegration = {
+      getError: () => 'access_denied',
+    };
+    (useIntegration as jest.Mock).mockReturnValue(mockIntegration);
+
+    (
+      isThirdPartyAuthCallbackIntegration as unknown as jest.Mock
+    ).mockReturnValue(true);
+
+    const mockFinishOAuthFlowHandler = jest.fn();
+    (useFinishOAuthFlowHandler as jest.Mock).mockReturnValue({
+      finishOAuthFlowHandler: mockFinishOAuthFlowHandler,
+    });
+
+    renderWith({
+      flowQueryParams: {},
+    });
+
+    expect(hardNavigateSpy).toBeCalledWith('/');
   });
 });

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -171,6 +171,11 @@ const ThirdPartyAuthCallback = ({
     }
     if (isThirdPartyAuthCallbackIntegration(integration)) {
       isVerifyThirdPartyAuth.current = true;
+
+      if (integration.getError()) {
+        return hardNavigate('/');
+      }
+
       verifyThirdPartyAuthResponse();
     }
   }, [integration, verifyThirdPartyAuthResponse]);


### PR DESCRIPTION
## Because

- The user could be stuck in a loading spinner if they canceled third party auth login

## This pull request

- Checks for the error param and redirects back to login page if found

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10818

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
