### PR TITLE
fix(react): Redirect back to SubPlat during 3rd party auth

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -317,7 +317,7 @@ const AuthAndAccountSetupRoutes = ({
       {/* Post verify */}
       <ThirdPartyAuthCallback
         path="/post_verify/third_party_auth/callback/*"
-        {...{ flowQueryParams }}
+        {...{ flowQueryParams, integration }}
       />
       <SetPasswordContainer
         path="/post_verify/third_party_auth/set_password/*"


### PR DESCRIPTION
Because:
* Users should be redirected back to SubPlat if they started in a SubPlat flow when signing in through 3rd party auth

This commit:
* Checks the redirectTo with our useWebRedirect hook and passes this into handleNavigation accordingly

fixes FXA-10822
