### PR TITLE
fix(auth): One third party auth error, keep the query params on redirect

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -176,7 +176,7 @@ describe('ThirdPartyAuthCallback component', () => {
 
     renderWith({ integration });
 
-    expect(hardNavigateSpy).toBeCalledWith('/');
+    expect(hardNavigateSpy).toBeCalledWith('/?param=value');
   });
   it('redirects to web redirect', async () => {
     const redirectTo = 'surprisinglyValid!';

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -175,7 +175,8 @@ const ThirdPartyAuthCallback = ({
       isVerifyThirdPartyAuth.current = true;
 
       if (integration.getError()) {
-        return hardNavigate('/');
+        const fxaParams = integration.getFxAParams();
+        return hardNavigate(`/${fxaParams.toString()}`);
       }
 
       verifyThirdPartyAuthResponse();


### PR DESCRIPTION
## Because

- We want the user to continue the flow they started

## This pull request

- Keeps the original query params so the user can continue and oauth or sync flow

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10824

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


Any other information that is important to this pull request.
