### PR TITLE
fix(settings): Navigate to signin if uid and sessionToken are missing

### DIFF
--- a/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
+++ b/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
@@ -16,7 +16,7 @@ import {
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
 import { deriveHawkCredentials } from 'fxa-auth-client/lib/hawk';
 import { getHandledError } from './error-utils';
-import { SensitiveDataClient } from './sensitive-data-client';
+import { SensitiveData, SensitiveDataClient } from './sensitive-data-client';
 
 export type V1Credentials = {
   authPW: string;
@@ -41,7 +41,10 @@ export async function tryFinalizeUpgrade(
   gqlPasswordChangeFinish: MutationFunction<PasswordChangeFinishResponse>
 ) {
   try {
-    if (sensitiveDataClient.KeyStretchUpgradeData) {
+    let upgradeData = sensitiveDataClient.getDataType(
+      SensitiveData.Key.KeyStretchUpgrade
+    );
+    if (upgradeData) {
       const upgradeClient = new GqlKeyStretchUpgrade(
         stage,
         gqlCredentialStatus,
@@ -51,9 +54,9 @@ export async function tryFinalizeUpgrade(
       );
 
       await upgradeClient.upgrade(
-        sensitiveDataClient.KeyStretchUpgradeData.email,
-        sensitiveDataClient.KeyStretchUpgradeData.v1Credentials,
-        sensitiveDataClient.KeyStretchUpgradeData.v2Credentials,
+        upgradeData.email,
+        upgradeData.v1Credentials,
+        upgradeData.v2Credentials,
         sessionId
       );
       return true;

--- a/packages/fxa-settings/src/lib/oauth/hooks.tsx
+++ b/packages/fxa-settings/src/lib/oauth/hooks.tsx
@@ -293,7 +293,7 @@ export function useFinishOAuthFlowHandler(
  * memory and the query params won't match after a browser session is restored.
  *
  * TODO: Can we check session storage for if the user just refreshed so we can redirect them
- * to /signin instead of showing an error component? FXA-10707
+ * to /signin instead of showing an error component? FXA-10889
  */
 export function useOAuthKeysCheck(
   integration: Pick<Integration, 'type' | 'wantsKeys'>,

--- a/packages/fxa-settings/src/lib/sensitive-data-client.ts
+++ b/packages/fxa-settings/src/lib/sensitive-data-client.ts
@@ -6,31 +6,87 @@
 
 import { V1Credentials, V2Credentials } from './gql-key-stretch-upgrade';
 
-export const AUTH_DATA_KEY = 'auth';
+export namespace SensitiveData {
+  /**
+   * The keys for the various kinds of data that can be inserted into a `SensitiveData` object.
+   *
+   * @see SensitiveDataClient for implementations.
+   */
+  export enum Key {
+    Auth = 'auth',
+    AccountReset = 'accountResetData',
+    NewRecoveryKey = 'newRecoveryKeyData',
+    Password = 'password',
+    KeyStretchUpgrade = 'keyStretchUpgrade'
+  }
 
-export type SensitiveDataClientData = {
-  [AUTH_DATA_KEY]: {
+  /**
+   * A data type for the various data added through the {@link SensitiveDataClient}.
+   *
+   * N.B. Use a non-nullable type if the values are derived from a hook during initialization.
+   *
+   * @see SensitiveDataClient for implementations.
+   */
+  export type DataMap = {
+    auth?: AuthData;
+    accountResetData?: AccountResetData;
+    newRecoveryKeyData?: NewRecoveryKeyData;
+    password?: Password;
+    keyStretchUpgrade?: KeyStretchUpgradeData;
+  };
+
+  /**
+   * Data inserted for the key {@link Key.Auth}.
+   */
+  export type AuthData = {
     emailForAuth?: string;
     authPW?: string;
     keyFetchToken?: hexstring;
     unwrapBKey?: hexstring;
   };
-};
 
-export type SensitiveDataClientAuthKeys = Pick<
-  SensitiveDataClientData[typeof AUTH_DATA_KEY],
-  'keyFetchToken' | 'unwrapBKey'
->;
+  /**
+   * Data insert for the key {@link Key.Password}.
+   */
+  export type Password = {
+    plainTextPassword: string;
+  };
+
+  /**
+   * Data inserted for the key {@link Key.AccountReset}.
+   */
+  export type AccountResetData = {
+    keyFetchToken: string;
+    unwrapBKey: hexstring;
+  };
+
+  /**
+   * Data inserted for the key {@link Key.NewRecoveryKey}.
+   */
+  export type NewRecoveryKeyData = {
+    recoveryKey: Uint8Array;
+  };
+
+  /**
+   * Data inserted for the key {@link Key.KeyStretchUpgrade}.
+   */
+  export type KeyStretchUpgradeData = {
+    email: string;
+    v1Credentials: V1Credentials;
+    v2Credentials: V2Credentials;
+  };
+}
 
 /**
- * Class representing a client for handling sensitive data.
+ * A client that holds data which should never be persisted.
  *
- * @class
+ * N.B. This data only lives in memory and will always be lost after the document is unloaded. Avoid nullable data where possible.
+ *
+ * @class SensitiveDataClient
  */
 export class SensitiveDataClient {
   /**
-   * Object to store sensitive data.
-   * @private
+   * @deprecated
    */
   private sensitiveData: { [key: string]: object } = {};
 
@@ -44,28 +100,58 @@ export class SensitiveDataClient {
     | undefined;
 
   /**
-   * Create a SensitiveDataClient.
+   * Object to store sensitive data.
+   *
+   * @private
+   */
+  private newSensitiveData: {
+    [key in keyof SensitiveData.DataMap]: SensitiveData.DataMap[key];
+  };
+
+  /**
+   * Create an instance.
+   *
    * @constructor
    */
   constructor() {
     this.sensitiveData = {};
+    this.newSensitiveData = {};
   }
 
   /**
-   * Set data in the sensitiveData object.
-   * @param {string} key - The key under which the data should be stored.
-   * @param {any} value - The data to be stored.
+   * @deprecated Use {@link setDataType} instead.
    */
   setData(key: string, value: any): void {
     this.sensitiveData[key] = value;
   }
 
   /**
-   * Get data from the sensitiveData object.
-   * @param {string} key - The key under which the data is stored.
-   * @return {any} The data stored under the provided key.
+   * Set data in the sensitiveData object.
+   *
+   * @param {SensitiveDataKey} key - The key under which the data should be stored.
+   * @param value - The data to be stored. See {SensitiveData}.
+   */
+  setDataType<T extends SensitiveData.Key>(
+    key: T,
+    value?: SensitiveData.DataMap[T]
+  ): void {
+    this.newSensitiveData[key] = value;
+  }
+
+  /**
+   * @deprecated Use {@link getDataType} instead.
    */
   getData(key: string): any {
     return this.sensitiveData[key];
+  }
+
+  /**
+   * Get data from the sensitiveData object.
+   *
+   * @param {SensitiveDataKey} key - The key under which the data is stored.
+   * @returns The corresponding value to the key in the sensitive data object.
+   */
+  getDataType<T extends SensitiveData.Key>(key: T): SensitiveData.DataMap[T] {
+    return this.newSensitiveData[key];
   }
 }

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
@@ -17,7 +17,7 @@ import {
   MOCK_AUTH_PW,
   MOCK_STORED_ACCOUNT,
 } from '../../pages/mocks';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 import { InlineRecoveryKeySetupProps } from './interfaces';
 import { MOCK_EMAIL } from '../InlineTotpSetup/mocks';
 import { LocationProvider } from '@reach/router';
@@ -37,7 +37,7 @@ jest.mock('fxa-react/lib/utils', () => ({
 }));
 
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.getData = jest.fn();
+mockSensitiveDataClient.getDataType = jest.fn();
 
 function mockModelsModule() {
   mockAuthClient.sessionReauthWithAuthPW = jest
@@ -54,7 +54,7 @@ function mockModelsModule() {
   (ModelsModule.useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
-  mockSensitiveDataClient.getData = jest.fn().mockReturnValue({
+  mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
     emailForAuth: 'bloop@gmail.com',
     authPW: MOCK_AUTH_PW,
     unwrapBKey: MOCK_UNWRAP_BKEY,
@@ -126,7 +126,9 @@ describe('InlineRecoveryKeySetupContainer', () => {
         <InlineRecoveryKeySetupContainer />
       </LocationProvider>
     );
-    expect(mockSensitiveDataClient.getData).toHaveBeenCalledWith(AUTH_DATA_KEY);
+    expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
+      SensitiveData.Key.Auth
+    );
     expect(InlineRecoveryKeySetupModule.default).toBeCalled();
   });
 

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
@@ -13,7 +13,7 @@ import InlineRecoveryKeySetup from '.';
 import { cache, currentAccount } from '../../lib/cache';
 import { generateRecoveryKey } from 'fxa-auth-client/browser';
 import { CreateRecoveryKeyHandler } from './interfaces';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 import { getSyncNavigate } from '../Signin/utils';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { formatRecoveryKey } from '../../lib/utilities';
@@ -31,13 +31,8 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
   const uid = storedLocalAccount?.uid;
 
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
   const { authPW, emailForAuth, unwrapBKey } =
-    (sensitiveData as {
-      emailForAuth?: string;
-      authPW?: string;
-      unwrapBKey?: hexstring;
-    }) || {};
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
   const navigateForward = useCallback(() => {
     setCurrentStep(currentStep + 1);

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
@@ -32,7 +32,7 @@ import {
   useFinishOAuthFlowHandler,
   useOAuthKeysCheck,
 } from '../../lib/oauth/hooks';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 
 let mockLocationState = {};
 const mockSearch = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
@@ -62,7 +62,7 @@ jest.mock('../../lib/oauth/hooks.tsx', () => {
 });
 
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.getData = jest.fn();
+mockSensitiveDataClient.getDataType = jest.fn();
 const mockAuthClient = new AuthClient('http://localhost:9000', {
   keyStretchVersion: 1,
 });
@@ -218,8 +218,8 @@ describe('InlineRecoverySetupContainer', () => {
 
     it('reads data from sensitive data client', () => {
       render();
-      expect(mockSensitiveDataClient.getData).toHaveBeenCalledWith(
-        AUTH_DATA_KEY
+      expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
+        SensitiveData.Key.Auth
       );
     });
 

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -28,10 +28,7 @@ import { TotpStatusResponse } from '../Signin/SigninTokenCode/interfaces';
 import { GET_TOTP_STATUS } from '../../components/App/gql';
 import OAuthDataError from '../../components/OAuthDataError';
 import { isFirefoxService } from '../../models/integrations/utils';
-import {
-  AUTH_DATA_KEY,
-  SensitiveDataClientAuthKeys,
-} from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 
 export const InlineRecoverySetupContainer = ({
   isSignedIn,
@@ -56,9 +53,8 @@ export const InlineRecoverySetupContainer = ({
   const signinRecoveryLocationState = location.state;
   const { totp, ...signinLocationState } = signinRecoveryLocationState || {};
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
   const { keyFetchToken, unwrapBKey } =
-    (sensitiveData as SensitiveDataClientAuthKeys) || {};
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
   const { oAuthKeysCheckError } = useOAuthKeysCheck(
     integration,

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
@@ -24,7 +24,7 @@ import SetPasswordContainer from './container';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../../models/mocks';
 import { act } from '@testing-library/react';
-import { AUTH_DATA_KEY } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 import {
   getSyncEngineIds,
   syncEngineConfigs,
@@ -71,7 +71,7 @@ jest.mock('../../../lib/hooks/useSyncEngines', () => {
 });
 
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.setData = jest.fn();
+mockSensitiveDataClient.setDataType = jest.fn();
 
 const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
@@ -211,11 +211,14 @@ describe('SetPassword container', () => {
       await act(async () => {
         await currentSetPasswordProps?.createPasswordHandler(MOCK_PASSWORD);
       });
-      expect(mockSensitiveDataClient.setData).toBeCalledWith(AUTH_DATA_KEY, {
-        authPW: MOCK_AUTH_PW,
-        emailForAuth: MOCK_EMAIL,
-        unwrapBKey: MOCK_UNWRAP_BKEY,
-      });
+      expect(mockSensitiveDataClient.setDataType).toBeCalledWith(
+        SensitiveData.Key.Auth,
+        {
+          authPW: MOCK_AUTH_PW,
+          emailForAuth: MOCK_EMAIL,
+          unwrapBKey: MOCK_UNWRAP_BKEY,
+        }
+      );
       expect(mockAuthClient.sessionReauthWithAuthPW).toBeCalledWith(
         MOCK_SESSION_TOKEN,
         MOCK_EMAIL,

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -23,7 +23,7 @@ import {
 import useSyncEngines from '../../../lib/hooks/useSyncEngines';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import OAuthDataError from '../../../components/OAuthDataError';
-import { AUTH_DATA_KEY } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { NavigationOptions } from '../../Signin/interfaces';
 import { handleNavigation } from '../../Signin/utils';
 import GleanMetrics from '../../../lib/glean';
@@ -96,7 +96,7 @@ const SetPasswordContainer = ({
             },
           });
 
-          sensitiveDataClient.setData(AUTH_DATA_KEY, {
+          sensitiveDataClient.setDataType(SensitiveData.Key.Auth, {
             // Store for inline recovery key flow
             authPW,
             emailForAuth: email,

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -20,10 +20,7 @@ import OAuthDataError from '../../../components/OAuthDataError';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useEffect, useState } from 'react';
 import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
-import {
-  AUTH_DATA_KEY,
-  SensitiveDataClientAuthKeys,
-} from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 export type SigninPushCodeContainerProps = {
   integration: Integration;
@@ -46,8 +43,8 @@ export const SigninPushCodeContainer = ({
   };
   const signinState = getSigninState(location.state);
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
-  const { unwrapBKey } = (sensitiveData as SensitiveDataClientAuthKeys) || {};
+  const { unwrapBKey } =
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
@@ -20,13 +20,15 @@ import {
   MOCK_STORED_ACCOUNT,
   MOCK_RECOVERY_CODE,
   mockLoadingSpinnerModule,
+  MOCK_UNWRAP_BKEY,
+  MOCK_KEY_FETCH_TOKEN,
 } from '../../mocks';
 import { SigninRecoveryCodeProps } from './interfaces';
 import { mockGqlError, mockSigninLocationState } from '../mocks';
 import { mockConsumeRecoveryCodeUseMutation } from './mocks';
 import { waitFor } from '@testing-library/react';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { AUTH_DATA_KEY } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 let integration: Integration;
 function mockWebIntegration() {
@@ -55,7 +57,6 @@ jest.mock('../../../models', () => {
 
 let currentSigninRecoveryCodeProps: SigninRecoveryCodeProps | undefined;
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.getData = jest.fn();
 function mockSigninRecoveryCodeModule() {
   currentSigninRecoveryCodeProps = undefined;
   jest
@@ -105,6 +106,10 @@ function resetMockSensitiveDataClient() {
   (useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
+  mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
+    keyFetchToken: MOCK_KEY_FETCH_TOKEN,
+    unwrapBKey: MOCK_UNWRAP_BKEY,
+  });
 }
 
 function applyDefaultMocks() {
@@ -165,8 +170,8 @@ describe('SigninRecoveryCode container', () => {
 
     it('reads data from sensitive data client', () => {
       render([]);
-      expect(mockSensitiveDataClient.getData).toHaveBeenCalledWith(
-        AUTH_DATA_KEY
+      expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
+        SensitiveData.Key.Auth
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -24,10 +24,7 @@ import {
 import { ConsumeRecoveryCodeResponse, SubmitRecoveryCode } from './interfaces';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError } from '../../../lib/error-utils';
-import {
-  AUTH_DATA_KEY,
-  SensitiveDataClientAuthKeys,
-} from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 export type SigninRecoveryCodeContainerProps = {
   integration: Integration;
@@ -49,9 +46,9 @@ export const SigninRecoveryCodeContainer = ({
   };
   const signinState = getSigninState(location.state);
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
-  const { keyFetchToken, unwrapBKey } =
-    (sensitiveData as SensitiveDataClientAuthKeys) || {};
+  const { keyFetchToken, unwrapBKey } = sensitiveDataClient.getDataType(
+    SensitiveData.Key.Auth
+  )!;
 
   const { oAuthKeysCheckError } = useOAuthKeysCheck(
     integration,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -4,7 +4,7 @@
 
 import { BeginSigninError } from '../../../lib/error-utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import { SensitiveDataClientAuthKeys } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { MozServices } from '../../../lib/types';
 import { SigninIntegration, SigninLocationState } from '../interfaces';
 
@@ -14,7 +14,7 @@ export type SigninRecoveryCodeProps = {
   serviceName?: MozServices;
   signinState: SigninLocationState;
   submitRecoveryCode: SubmitRecoveryCode;
-} & SensitiveDataClientAuthKeys;
+} & SensitiveData.AuthData;
 
 export type SubmitRecoveryCode = (
   code: string

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -20,10 +20,7 @@ import { SigninLocationState } from '../interfaces';
 import { getSigninState } from '../utils';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { useEffect, useState } from 'react';
-import {
-  AUTH_DATA_KEY,
-  SensitiveDataClientAuthKeys,
-} from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 // The email with token code (verifyLoginCodeEmail) is sent on `/signin`
 // submission if conditions are met.
@@ -40,9 +37,8 @@ const SigninTokenCodeContainer = ({
 
   const signinState = getSigninState(location.state);
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
   const { keyFetchToken, unwrapBKey } =
-    (sensitiveData as SensitiveDataClientAuthKeys) || {};
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
   const authClient = useAuthClient();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
@@ -5,13 +5,13 @@
 import { AccountTotp } from '../../../lib/interfaces';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { SigninIntegration, SigninLocationState } from '../interfaces';
-import { SensitiveDataClientAuthKeys } from './../../../lib/sensitive-data-client';
+import { SensitiveData } from './../../../lib/sensitive-data-client';
 
 export type SigninTokenCodeProps = {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
   signinState: SigninLocationState;
-} & SensitiveDataClientAuthKeys;
+} & SensitiveData.AuthData;
 
 export interface TotpStatusResponse {
   account: {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -38,6 +38,7 @@ import {
   mockLoadingSpinnerModule,
 } from '../../mocks';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 let integration: Integration;
 
@@ -140,7 +141,10 @@ function mockVerifyTotp(success: boolean = true, errorOut: boolean = false) {
 const mockSensitiveDataClient = createMockSensitiveDataClient();
 mockSensitiveDataClient.getData = jest.fn();
 function resetMockSensitiveDataClient() {
-  mockSensitiveDataClient.KeyStretchUpgradeData = undefined;
+  mockSensitiveDataClient.setDataType(
+    SensitiveData.Key.KeyStretchUpgrade,
+    undefined
+  );
   (useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
@@ -192,7 +196,7 @@ describe('signin totp code container', () => {
   });
 
   it('runs keys stretch upgrade when required', async () => {
-    mockSensitiveDataClient.KeyStretchUpgradeData = {
+    mockSensitiveDataClient.setDataType(SensitiveData.Key.KeyStretchUpgrade, {
       email: MOCK_EMAIL,
       v1Credentials: {
         authPW: MOCK_AUTH_PW,
@@ -203,7 +207,7 @@ describe('signin totp code container', () => {
         unwrapBKey: MOCK_UNWRAP_BKEY_V2,
         clientSalt: MOCK_CLIENT_SALT,
       },
-    };
+    });
     await render();
     expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
     const result = await currentPageProps?.submitTotpCode('123456');

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -33,10 +33,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
-import {
-  AUTH_DATA_KEY,
-  SensitiveDataClientAuthKeys,
-} from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { GET_LOCAL_SIGNED_IN_STATUS } from '../../../components/App/gql';
 import {
   CREDENTIAL_STATUS_MUTATION,
@@ -66,9 +63,8 @@ export const SigninTotpCodeContainer = ({
   };
   const signinState = getSigninState(location.state);
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
   const { keyFetchToken, unwrapBKey } =
-    (sensitiveData as SensitiveDataClientAuthKeys) || {};
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
   const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
   const { service } = queryParamModel;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -24,7 +24,7 @@ import {
 } from '../../../lib/error-utils';
 import protectionShieldIcon from '@fxa/shared/assets/images/protection-shield.svg';
 import Banner from '../../../components/Banner';
-import { SensitiveDataClientAuthKeys } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
 
 // TODO: show a banner success message if a user is coming from reset password
@@ -41,7 +41,7 @@ export type SigninTotpCodeProps = {
     totpCode: string
   ) => Promise<{ error?: BeginSigninError; status: boolean }>;
   serviceName?: MozServices;
-} & SensitiveDataClientAuthKeys;
+} & SensitiveData.AuthData;
 
 export const viewName = 'signin-totp-code';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -49,7 +49,7 @@ import {
 import { getCredentials, getCredentialsV2 } from 'fxa-auth-client/lib/crypto';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { SignInOptions } from 'fxa-auth-client/browser';
-import { AUTH_DATA_KEY } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { isFirefoxService } from '../../../models/integrations/utils';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
 
@@ -68,8 +68,10 @@ export const SigninUnblockContainer = ({
   };
 
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
-  const { password } = (sensitiveData as unknown as { password: string }) || {};
+  // We keep the previous non-null assertion on 'password' here because the
+  // flow dictates we definitely have it.
+  const { plainTextPassword: password } =
+    sensitiveDataClient.getDataType(SensitiveData.Key.Password)! || {};
 
   const { email, hasLinkedAccount, hasPassword } = location.state || {};
 
@@ -189,7 +191,7 @@ export const SigninUnblockContainer = ({
 
       return result;
     } finally {
-      sensitiveDataClient.setData(AUTH_DATA_KEY, null);
+      sensitiveDataClient.setDataType(SensitiveData.Key.Auth, undefined);
     }
   };
 

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -55,7 +55,7 @@ import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { Integration } from '../../models';
 import { firefox } from '../../lib/channels/firefox';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../models/mocks';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 import { Constants } from '../../lib/constants';
 
 jest.mock('../../lib/channels/firefox', () => ({
@@ -147,7 +147,7 @@ const mockAuthClient = new AuthClient('http://localhost:9000', {
   keyStretchVersion: 1,
 });
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.setData = jest.fn();
+mockSensitiveDataClient.setDataType = jest.fn();
 
 function mockModelsModule() {
   mockAuthClient.accountStatusByEmail = jest.fn().mockResolvedValue({
@@ -526,12 +526,15 @@ describe('signin container', () => {
           );
         });
 
-        expect(mockSensitiveDataClient.setData).toBeCalledWith(AUTH_DATA_KEY, {
-          authPW: MOCK_AUTH_PW,
-          emailForAuth: MOCK_EMAIL,
-          unwrapBKey: MOCK_UNWRAP_BKEY,
-          keyFetchToken: MOCK_KEY_FETCH_TOKEN,
-        });
+        expect(mockSensitiveDataClient.setDataType).toBeCalledWith(
+          SensitiveData.Key.Auth,
+          {
+            authPW: MOCK_AUTH_PW,
+            emailForAuth: MOCK_EMAIL,
+            unwrapBKey: MOCK_UNWRAP_BKEY,
+            keyFetchToken: MOCK_KEY_FETCH_TOKEN,
+          }
+        );
         expect(mockAuthClient.recoveryKeyExists).toBeCalledWith(
           handlerResult?.data?.signIn.sessionToken,
           MOCK_EMAIL

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -59,7 +59,7 @@ import {
 } from '../../lib/error-utils';
 import { firefox } from '../../lib/channels/firefox';
 import {
-  AUTH_DATA_KEY,
+  SensitiveData,
   SensitiveDataClient,
 } from '../../lib/sensitive-data-client';
 import { Constants } from '../../lib/constants';
@@ -363,11 +363,11 @@ const SigninContainer = ({
             sessionToken
           );
         } else {
-          sensitiveDataClient.KeyStretchUpgradeData = {
+          sensitiveDataClient.setDataType(SensitiveData.Key.KeyStretchUpgrade, {
             email,
             v1Credentials: credentials.v1Credentials,
             v2Credentials: credentials.v2Credentials,
-          };
+          });
         }
       }
 
@@ -579,7 +579,8 @@ export async function trySignIn(
       const unwrapBKey = v2Credentials
         ? v2Credentials.unwrapBKey
         : v1Credentials.unwrapBKey;
-      sensitiveDataClient.setData(AUTH_DATA_KEY, {
+
+      sensitiveDataClient.setDataType(SensitiveData.Key.Auth, {
         // Store for inline recovery key flow
         authPW,
         // Store this in case the email was corrected

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -39,7 +39,7 @@ import {
 import firefox from '../../lib/channels/firefox';
 import { navigate } from '@reach/router';
 import { IntegrationType } from '../../models';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
@@ -86,7 +86,7 @@ jest.mock('../../models', () => {
     ...jest.requireActual('../../models'),
     useSensitiveDataClient: () => {
       return {
-        setData: mockSetData,
+        setDataType: mockSetData,
       };
     },
   };
@@ -674,8 +674,8 @@ describe('Signin component', () => {
         enterPasswordAndSubmit();
         await waitFor(() => {
           expect(sendUnblockEmailHandler).toHaveBeenCalled();
-          expect(mockSetData).toHaveBeenCalledWith(AUTH_DATA_KEY, {
-            password: MOCK_PASSWORD,
+          expect(mockSetData).toHaveBeenCalledWith(SensitiveData.Key.Password, {
+            plainTextPassword: MOCK_PASSWORD,
           });
           expect(mockNavigate).toHaveBeenCalledWith('/signin_unblock', {
             state: {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -35,7 +35,7 @@ import { handleNavigation } from './utils';
 import { useWebRedirect } from '../../lib/hooks/useWebRedirect';
 import { getLocalizedErrorMessage } from '../../lib/error-utils';
 import Banner from '../../components/Banner';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 
 export const viewName = 'signin';
 
@@ -254,8 +254,8 @@ const Signin = ({
               }
 
               // Store password to be used in another component
-              sensitiveDataClient.setData(AUTH_DATA_KEY, {
-                password,
+              sensitiveDataClient.setDataType(SensitiveData.Key.Password, {
+                plainTextPassword: password,
               });
               // navigate only if sending the unblock code email is successful
               navigate('/signin_unblock', {

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -115,7 +115,7 @@ function applyMocks() {
   (ModelsModule.useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
-  mockSensitiveDataClient.getData = jest.fn().mockReturnValue({
+  mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
     keyFetchToken: MOCK_KEY_FETCH_TOKEN,
     unwrapBKey: MOCK_UNWRAP_BKEY,
   });
@@ -292,7 +292,7 @@ describe('confirm-signup-container', () => {
         type: ModelsModule.IntegrationType.OAuthNative,
         wantsKeys: () => true,
       } as Integration;
-      mockSensitiveDataClient.getData = jest.fn().mockReturnValue({
+      mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
         keyFetchToken: undefined,
         unwrapBKey: undefined,
       });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -23,10 +23,7 @@ import { useQuery } from '@apollo/client';
 import { EMAIL_BOUNCE_STATUS_QUERY } from './gql';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { QueryParams } from '../../..';
-import {
-  AUTH_DATA_KEY,
-  SensitiveDataClientAuthKeys,
-} from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 export const POLL_INTERVAL = 5000;
 
@@ -57,9 +54,8 @@ const SignupConfirmCodeContainer = ({
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const sensitiveDataClient = useSensitiveDataClient();
-  const sensitiveData = sensitiveDataClient.getData(AUTH_DATA_KEY);
   const { keyFetchToken, unwrapBKey } =
-    (sensitiveData as SensitiveDataClientAuthKeys) || {};
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
   const { oAuthKeysCheckError } = useOAuthKeysCheck(
     integration,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -7,7 +7,7 @@ import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { Integration, OAuthWebIntegration } from '../../../models';
 import { StoredAccountData } from '../../../lib/storage-utils';
 import { QueryParams } from '../../..';
-import { SensitiveDataClientAuthKeys } from '../../../lib/sensitive-data-client';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 export type LocationState = {
   origin: 'signup' | undefined;
@@ -36,7 +36,7 @@ export type ConfirmSignupCodeProps = {
   offeredSyncEngines?: string[];
   declinedSyncEngines?: string[];
   flowQueryParams: QueryParams;
-} & SensitiveDataClientAuthKeys &
+} & SensitiveData.AuthData &
   RouteComponentProps;
 
 export interface ConfirmSignupCodeFormData {

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -35,7 +35,7 @@ import {
   syncEngineConfigs,
 } from '../../components/ChooseWhatToSync/sync-engines';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../models/mocks';
 import { useSensitiveDataClient } from '../../models';
 
@@ -89,7 +89,7 @@ jest.mock('../../models', () => {
 });
 
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.setData = jest.fn();
+mockSensitiveDataClient.setDataType = jest.fn();
 
 const oauthCommonFxaLoginOptions = {
   email: MOCK_EMAIL,
@@ -354,8 +354,8 @@ describe('Signup page', () => {
       await fillOutForm();
       submit();
       await waitFor(() => {
-        expect(mockSensitiveDataClient.setData).toHaveBeenCalledWith(
-          AUTH_DATA_KEY,
+        expect(mockSensitiveDataClient.setDataType).toHaveBeenCalledWith(
+          SensitiveData.Key.Auth,
           {
             keyFetchToken:
               BEGIN_SIGNUP_HANDLER_RESPONSE.data.signUp.keyFetchToken,

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -37,7 +37,7 @@ import {
 } from '../../models/integrations/client-matching';
 import { SignupFormData, SignupProps } from './interfaces';
 import Banner from '../../components/Banner';
-import { AUTH_DATA_KEY } from '../../lib/sensitive-data-client';
+import { SensitiveData } from '../../lib/sensitive-data-client';
 import { FormSetupAccount } from '../../components/FormSetupAccount';
 
 export const viewName = 'signup';
@@ -206,7 +206,7 @@ export const Signup = ({
         storeAccountData(accountData);
 
         // Set these for use in ConfirmSignupCode
-        sensitiveDataClient.setData(AUTH_DATA_KEY, {
+        sensitiveDataClient.setDataType(SensitiveData.Key.Auth, {
           keyFetchToken: data.signUp.keyFetchToken,
           unwrapBKey: data.unwrapBKey,
         });


### PR DESCRIPTION
## Because

- Adding types to the SensitiveDataClient forces the callers to handle cases when required properties are missing.

## This pull request

- Adds some types to the different data items in the SensitiveDataClient and deprecates the previous wants to add add/get data from it for the general cases.
- Fixes the bug described in FXA-10707 for the specific case.

## Issue that this pull request solves

Closes: FXA-10707

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

In this patch, the uid is nullable so we have to decide how to handle it (i.e. navigate to /signin probably).

## Other information (Optional)

Based on the information found from usages of `setData` and `getData` on the client, I based this change on this data:

### Stored data today

#### Keys

```
sensitiveDataClient.setData
	-> 'auth'
	-> 'accountResetData'
	-> 'newRecoveryKeyData'
	-> 'reset' // we never retrieve data after adding it?
```

#### Value

```
reset = { kB }

accountResetData = { authAt, keyFetchToken, sessionToken, uid, unwrapBKey, verified, email }
accountResetData = { accountResetToken, emailToHashWith, password, recoveryKeyId, kB }

auth = { authPW, emailForAuth, unwrapBKey, keyFetchToken, password }
auth = { keyFetchToken, unwrapBKey }
auth = { emailForAuth, authPW, unwrapBKey }

newRecoveryKeyData = { recoveryKey }
```

---

### Retrieved data today

#### Keys

```
sensitiveDataClient.getData
	-> 'auth'
	-> 'accountResetData'
	-> 'newRecoveryKeyData'
```

#### Value

```
auth = { authPW, emailForAuth, unwrapBKey }
auth = { unwrapBKey }
auth = { keyFetchToken, unwrapBKey }
auth = { password }

accountResetData = { email, uid, sessionToken, keyFetchToken, unwrapBKey, verified }
accountResetData = { uid, sessionToken, keyFetchToken, unwrapBKey }

newRecoveryKeyData = { recoveryKey }
```