### PR TITLE
fix(settings): Handle redirectTo from signin unblock

### DIFF
--- a/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useWebRedirect/index.tsx
@@ -24,19 +24,25 @@ export function useWebRedirect(redirectTo: BaseIntegrationData['redirectTo']) {
   const location = useLocation();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const isValid = () =>
-    redirectTo
-      ? isAllowed(redirectTo, location.href, config.redirectAllowlist)
-      : false;
+  if (!redirectTo) {
+    return;
+  }
 
-  const getLocalizedErrorMessage = () =>
-    ftlMsgResolver.getMsg(
-      getErrorFtlId(AuthUiErrors.INVALID_REDIRECT_TO),
-      AuthUiErrors.INVALID_REDIRECT_TO.message
-    );
+  const isValid = isAllowed(
+    redirectTo,
+    location.href,
+    config.redirectAllowlist
+  );
+
+  const localizedInvalidRedirectError = isValid
+    ? ''
+    : ftlMsgResolver.getMsg(
+        getErrorFtlId(AuthUiErrors.INVALID_REDIRECT_TO),
+        AuthUiErrors.INVALID_REDIRECT_TO.message
+      );
 
   return {
     isValid,
-    getLocalizedErrorMessage,
+    localizedInvalidRedirectError,
   };
 }

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -17,7 +17,7 @@ import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { handleNavigation } from '../../Signin/utils';
 import { QueryParams } from '../../../index';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
-import { MOCK_EMAIL, MOCK_SESSION_TOKEN, MOCK_UID } from '../../mocks';
+import { MOCK_EMAIL, MOCK_SESSION_TOKEN } from '../../mocks';
 
 jest.mock('../../../models', () => ({
   ...jest.requireActual('../../../models'),

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -91,7 +91,7 @@ const ThirdPartyAuthCallback = ({
         },
         integration,
         redirectTo:
-          isWebIntegration(integration) && webRedirectCheck.isValid()
+          isWebIntegration(integration) && webRedirectCheck?.isValid
             ? integration.data.redirectTo
             : '',
         finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -52,7 +52,7 @@ export const SigninPushCodeContainer = ({
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
   const redirectTo =
-    isWebIntegration(integration) && webRedirectCheck.isValid()
+    isWebIntegration(integration) && webRedirectCheck?.isValid
       ? integration.data.redirectTo
       : '';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -51,7 +51,7 @@ const SigninRecoveryCode = ({
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
   const redirectTo =
-    isWebIntegration(integration) && webRedirectCheck.isValid()
+    isWebIntegration(integration) && webRedirectCheck?.isValid
       ? integration.data.redirectTo
       : '';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -58,7 +58,7 @@ const SigninTokenCode = ({
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const redirectTo =
-    isWebIntegration(integration) && webRedirectCheck.isValid()
+    isWebIntegration(integration) && webRedirectCheck?.isValid
       ? integration.data.redirectTo
       : '';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -69,7 +69,7 @@ export const SigninTotpCodeContainer = ({
   );
 
   const redirectTo =
-    isWebIntegration(integration) && webRedirectCheck.isValid()
+    isWebIntegration(integration) && webRedirectCheck?.isValid
       ? integration.data.redirectTo
       : '';
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
@@ -181,6 +181,8 @@ describe('signin unblock container', () => {
   });
 
   it('handles signin with correct code and failure when looking up credential status', async () => {
+    jest.spyOn(global.console, 'warn');
+
     await render([
       {
         ...mockGqlCredentialStatusMutation(),
@@ -204,6 +206,8 @@ describe('signin unblock container', () => {
     expect(result?.data?.signIn?.sessionToken).toBeDefined();
     expect(result?.data?.signIn?.verified).toBeDefined();
     expect(result?.data?.signIn?.metricsEnabled).toBeDefined();
+    // console warning during test execution is also expected here
+    expect(console.warn).toBeCalledWith('Could not get credential status!');
   });
 
   it('handles incorrect unblock code', async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/mocks.tsx
@@ -4,8 +4,7 @@
 
 import { MozServices } from '../../../lib/types';
 import { IntegrationType } from '../../../models';
-import { MOCK_EMAIL, MOCK_AUTH_PW } from '../../mocks';
-import { SigninOAuthIntegration } from '../interfaces';
+import { MOCK_EMAIL, MOCK_AUTH_PW, MOCK_UID } from '../../mocks';
 
 export { CREDENTIAL_STATUS_MUTATION, BEGIN_SIGNIN_MUTATION } from '../gql';
 
@@ -15,6 +14,22 @@ export const MOCK_SIGNIN_UNBLOCK_LOCATION_STATE = {
   hasPassword: true,
   authPW: MOCK_AUTH_PW,
 };
+
+export function createMockWebIntegration({
+  redirectTo = undefined,
+}: { redirectTo?: string } = {}) {
+  return {
+    type: IntegrationType.Web,
+    data: { uid: MOCK_UID, redirectTo },
+    getService: () => MozServices.Default,
+    getClientId: () => undefined,
+    isSync: () => false,
+    wantsKeys: () => false,
+    wantsTwoStepAuthentication: () => false,
+    isDesktopSync: () => false,
+    isDesktopRelay: () => false,
+  };
+}
 
 export function createMockSigninWebSyncIntegration() {
   return {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -143,7 +143,7 @@ const Signin = ({
           },
           integration,
           redirectTo:
-            isWebIntegration(integration) && webRedirectCheck.isValid()
+            isWebIntegration(integration) && webRedirectCheck?.isValid
               ? integration.data.redirectTo
               : '',
           finishOAuthFlowHandler,
@@ -208,7 +208,7 @@ const Signin = ({
           integration,
           finishOAuthFlowHandler,
           redirectTo:
-            isWebIntegration(integration) && webRedirectCheck.isValid()
+            isWebIntegration(integration) && webRedirectCheck?.isValid
               ? integration.data.redirectTo
               : '',
           queryParams: location.search,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -70,6 +70,10 @@ function mockLocation(
   });
 }
 
+function mockReactUtilsModule() {
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
+}
+
 function mockEmailBounceQuery() {
   mockEmailBounceStatusQuery.mockImplementation(() => {
     return {
@@ -134,8 +138,8 @@ function applyMocks() {
       };
     });
   mockLocation();
+  mockReactUtilsModule();
   jest.spyOn(SentryModule.default, 'captureException');
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 
   mockEmailBounceQuery();
 }

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -220,14 +220,14 @@ const ConfirmSignupCode = ({
       } else if (isWebIntegration(integration)) {
         // SubPlat redirect
         if (integration.data.redirectTo) {
-          if (webRedirectCheck.isValid()) {
+          if (webRedirectCheck?.isValid) {
             hardNavigate(integration.data.redirectTo);
-          } else {
+          } else if (webRedirectCheck?.localizedInvalidRedirectError) {
             // Even if the code submission is successful, show the user this error
             // message if the redirect is invalid to match parity with content-server.
             // This may but may be revisited when we look at our signup flows as a whole.
             setLocalizedErrorBannerHeading(
-              webRedirectCheck.getLocalizedErrorMessage()
+              webRedirectCheck.localizedInvalidRedirectError
             );
           }
         } else {


### PR DESCRIPTION
## Because

* redirectTo provided by subscriptions page was not handled on the signin unblock page, so users were bumped out of the subscription flow

## This pull request

* Handle and check redirectTo param on the signin unblock page
* Add unit test
* If provided redirectTo is invalid, navigate to settings with an error message (do not entirely interrupt navigation)

## Issue that this pull request solves

Closes: #FXA-10747

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
