### PR TITLE
bug(settings): Allow totp or unblock codes to conduct key stretch upgrade

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
@@ -73,6 +73,13 @@ test.describe('severity-2 #smoke', () => {
       await expect(page).toHaveURL(/settings/);
       await expect(settings.settingsHeading).toBeVisible();
 
+      // Make sure upgrade occurred
+      if (signinVersion.version === 2) {
+        const client = target.createAuthClient(2);
+        const status = await client.getCredentialStatusV2(email);
+        expect(status.currentVersion).toEqual('v2');
+      }
+
       // Delete blocked account, required before teardown
       await removeAccount(target, page, settings, deleteAccount, password);
     });

--- a/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
@@ -72,6 +72,13 @@ test.describe('severity-2 #smoke', () => {
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.totp.status).toHaveText('Enabled');
 
+      // Make sure upgrade occurred
+      if (signinVersion.version === 2) {
+        const client = target.createAuthClient(2);
+        const status = await client.getCredentialStatusV2(email);
+        expect(status.currentVersion).toEqual('v2');
+      }
+
       await settings.disconnectTotp(); // Required before teardown
     });
   }

--- a/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
+++ b/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
@@ -1,0 +1,263 @@
+import { MutationFunction } from '@apollo/client';
+import {
+  CredentialStatus,
+  CredentialStatusResponse,
+  GetAccountKeysResponse,
+  PasswordChangeFinishResponse,
+  PasswordChangeStartResponse,
+} from '../pages/Signin/interfaces';
+import * as Sentry from '@sentry/browser';
+import {
+  getCredentials,
+  getCredentialsV2,
+  getKeysV2,
+  unwrapKB,
+} from 'fxa-auth-client/lib/crypto';
+import { createSaltV2 } from 'fxa-auth-client/lib/salt';
+import { deriveHawkCredentials } from 'fxa-auth-client/lib/hawk';
+import { getHandledError } from './error-utils';
+import { SensitiveDataClient } from './sensitive-data-client';
+
+export type V1Credentials = {
+  authPW: string;
+  unwrapBKey: string;
+};
+
+export type V2Credentials = V1Credentials & {
+  clientSalt: string;
+};
+
+/**
+ * Convenience function for attempting an upgrade and catching any errors that might happen.
+ * Note that this will manually report GQL errors to Sentry.
+ */
+export async function tryFinalizeUpgrade(
+  sessionId: string,
+  sensitiveDataClient: SensitiveDataClient,
+  stage: string,
+  gqlCredentialStatus: MutationFunction<CredentialStatusResponse>,
+  gqlGetWrappedKeys: MutationFunction<GetAccountKeysResponse>,
+  gqlPasswordChangeStart: MutationFunction<PasswordChangeStartResponse>,
+  gqlPasswordChangeFinish: MutationFunction<PasswordChangeFinishResponse>
+) {
+  try {
+    if (sensitiveDataClient.KeyStretchUpgradeData) {
+      const upgradeClient = new GqlKeyStretchUpgrade(
+        stage,
+        gqlCredentialStatus,
+        gqlGetWrappedKeys,
+        gqlPasswordChangeStart,
+        gqlPasswordChangeFinish
+      );
+
+      await upgradeClient.upgrade(
+        sensitiveDataClient.KeyStretchUpgradeData.email,
+        sensitiveDataClient.KeyStretchUpgradeData.v1Credentials,
+        sensitiveDataClient.KeyStretchUpgradeData.v2Credentials,
+        sessionId
+      );
+      return true;
+    }
+  } catch (error) {
+    // NO-OP Don't let a key stretching upgrade issue prevent sign in.
+    // Note that the upgradeClient reports errors to sentry.
+  } finally {
+    // Clear out the state. No reason to keep trying this...
+    // Note that the upgradeClient will report issues to Sentry.
+    sensitiveDataClient.KeyStretchUpgradeData = undefined;
+  }
+  return false;
+}
+
+/**
+ * Handles upgrade process for key stretching
+ */
+export class GqlKeyStretchUpgrade {
+  constructor(
+    private readonly stage: string,
+    private readonly gqlCredentialStatus: MutationFunction<CredentialStatusResponse>,
+    private readonly gqlGetWrappedKeys: MutationFunction<GetAccountKeysResponse>,
+    private readonly gqlPasswordChangeStart: MutationFunction<PasswordChangeStartResponse>,
+    private readonly gqlPasswordChangeFinish: MutationFunction<PasswordChangeFinishResponse>
+  ) {}
+
+  async getCredentials(
+    email: string,
+    password: string,
+    v2Enabled: boolean
+  ): Promise<{
+    v1Credentials: V1Credentials;
+    v2Credentials?: V2Credentials;
+    credentialStatus?: CredentialStatus;
+  }> {
+    const v1Credentials = await getCredentials(email, password);
+    if (v2Enabled) {
+      const credentialStatus = await this.getCredentialsStatus(email);
+      if (credentialStatus) {
+        const v2Credentials = await getCredentialsV2({
+          password,
+          clientSalt: credentialStatus?.clientSalt || createSaltV2(),
+        });
+        return {
+          credentialStatus,
+          v1Credentials,
+          v2Credentials,
+        };
+      }
+    }
+    return {
+      v1Credentials,
+    };
+  }
+
+  async upgrade(
+    email: string,
+    v1Credentials: V1Credentials,
+    v2Credentials: V2Credentials,
+    sessionToken: string
+  ): Promise<boolean> {
+    let result1 = await this.startUpgrade(email, v1Credentials);
+
+    if (result1?.keyFetchToken && result1?.passwordChangeToken) {
+      const result2 = await this.getWrappedKeys(result1.keyFetchToken);
+
+      if (result2?.wrapKB) {
+        await this.finishUpgrade(
+          result2?.wrapKB,
+          result1.passwordChangeToken,
+          v1Credentials,
+          v2Credentials,
+          sessionToken
+        );
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private async getCredentialsStatus(
+    email: string
+  ): Promise<CredentialStatus | undefined> {
+    try {
+      const result = await this.gqlCredentialStatus({
+        variables: {
+          input: email,
+        },
+      });
+      return result.data?.credentialStatus;
+    } catch (error) {
+      Sentry.captureMessage(
+        `Failure to finish v2 key-stretching upgrade. Could not get credential status during ${this.stage}`,
+        {
+          tags: {
+            errno: getHandledError(error).error.errno,
+          },
+        }
+      );
+    }
+    return undefined;
+  }
+
+  private async startUpgrade(email: string, v1Credentials: V1Credentials) {
+    try {
+      const response = await this.gqlPasswordChangeStart({
+        variables: {
+          input: {
+            email: email,
+            oldAuthPW: v1Credentials.authPW,
+          },
+        },
+      });
+      const passwordChangeToken =
+        response.data?.passwordChangeStart?.passwordChangeToken || '';
+      const keyFetchToken =
+        response.data?.passwordChangeStart?.keyFetchToken || '';
+      return {
+        keyFetchToken,
+        passwordChangeToken,
+      };
+    } catch (error) {
+      // If the user enters the wrong password, they will see an invalid password error.
+      // Otherwise something has going wrong and we should show a general error.
+      Sentry.captureMessage(
+        `Failure to finish v2 key-stretching upgrade. Could not start password change during ${this.stage}`,
+        {
+          tags: {
+            errno: getHandledError(error).error.errno,
+          },
+        }
+      );
+    }
+    return undefined;
+  }
+
+  private async getWrappedKeys(keyFetchToken: string) {
+    try {
+      const keysResponse = await this.gqlGetWrappedKeys({
+        variables: {
+          input: keyFetchToken,
+        },
+      });
+      const wrapKB = keysResponse.data?.wrappedAccountKeys.wrapKB || '';
+      return {
+        wrapKB,
+      };
+    } catch (error) {
+      Sentry.captureMessage(
+        `Failure to finish v2 key-stretching upgrade. Could not get wrapped keys during ${this.stage}`,
+        {
+          tags: {
+            errno: getHandledError(error).error.errno,
+          },
+        }
+      );
+    }
+    return undefined;
+  }
+
+  private async finishUpgrade(
+    wrapKb: string,
+    passwordChangeToken: string,
+    v1Credentials: V1Credentials,
+    v2Credentials: V2Credentials,
+    sessionToken: string
+  ): Promise<void> {
+    const kB = unwrapKB(wrapKb, v1Credentials.unwrapBKey);
+    const keys = await getKeysV2({
+      kB,
+      v1: v1Credentials,
+      v2: v2Credentials,
+    });
+    try {
+      const credentials = await deriveHawkCredentials(
+        sessionToken,
+        'sessionToken'
+      );
+
+      const input = {
+        passwordChangeToken: passwordChangeToken,
+        authPW: v1Credentials.authPW,
+        wrapKb: keys.wrapKb,
+        authPWVersion2: v2Credentials.authPW,
+        wrapKbVersion2: keys.wrapKbVersion2,
+        clientSalt: v2Credentials.clientSalt,
+        sessionToken: credentials.id,
+      };
+
+      await this.gqlPasswordChangeFinish({
+        variables: {
+          input,
+        },
+      });
+    } catch (error) {
+      Sentry.captureMessage(
+        `Failure to finish v2 key-stretching upgrade. Could not finish password change during ${this.stage}`,
+        {
+          tags: {
+            errno: getHandledError(error).error.errno,
+          },
+        }
+      );
+    }
+  }
+}

--- a/packages/fxa-settings/src/lib/sensitive-data-client.ts
+++ b/packages/fxa-settings/src/lib/sensitive-data-client.ts
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { V1Credentials, V2Credentials } from './gql-key-stretch-upgrade';
+
 export const AUTH_DATA_KEY = 'auth';
 
 export type SensitiveDataClientData = {
@@ -31,6 +33,15 @@ export class SensitiveDataClient {
    * @private
    */
   private sensitiveData: { [key: string]: object } = {};
+
+  // TODO: Fast follow, use this pattern instead for simpler and better type safety.
+  public KeyStretchUpgradeData:
+    | {
+        email: string;
+        v1Credentials: V1Credentials;
+        v2Credentials: V2Credentials;
+      }
+    | undefined;
 
   /**
    * Create a SensitiveDataClient.

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -138,12 +138,14 @@ export interface SigninFormData {
   password: string;
 }
 
+export interface CredentialStatus {
+  upgradeNeeded: boolean;
+  currentVersion?: string;
+  clientSalt?: string;
+}
+
 export interface CredentialStatusResponse {
-  credentialStatus: {
-    upgradeNeeded: boolean;
-    currentVersion?: string;
-    clientSalt?: string;
-  };
+  credentialStatus: CredentialStatus;
 }
 
 export interface PasswordChangeStartResponse {
@@ -205,7 +207,7 @@ export interface NavigationOptions {
   syncEngines?: {
     offeredEngines: string[];
     declinedEngines: string[];
-  }
+  };
 }
 
 export interface OAuthSigninResult {

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -190,7 +190,10 @@ export function mockGqlBeginSigninMutation(
     service?: string;
     unblockCode?: string;
   },
-  inputOverrides: any = {}
+  inputOverrides: any = {},
+  resultOverrides?: {
+    verified?: boolean;
+  }
 ) {
   const result = opts.keys
     ? createBeginSigninResponse({
@@ -200,6 +203,11 @@ export function mockGqlBeginSigninMutation(
         // unwrapBKey: MOCK_UNWRAP_BKEY,
       })
     : createBeginSigninResponse();
+
+  // Add ability to override result
+  if (resultOverrides?.verified !== undefined) {
+    result.data.signIn.verified = resultOverrides.verified;
+  }
 
   return {
     request: {


### PR DESCRIPTION
## Because

- Users that were required to enter a secondary code weren't getting upgraded.

## This pull request

- Upgrades key stretching when in unblock code flow
- Upgrades key stretching when in totp flow
- Breaks out gql-key-stretch-upgrade module for code reuse
- Won't attempt an upgrade when a session is unverified
- Changes the order operations for upgrade. Previously we always upgraded before login, now we upgrade after, which allows to determine when the session has become verified.

## Issue that this pull request solves

Closes: FXA-10804

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
