### PR TITLE
add name, email, and image to next jwt

### DIFF
--- a/apps/payments/next/auth.ts
+++ b/apps/payments/next/auth.ts
@@ -25,20 +25,35 @@ export const {
       clientId: config.auth.clientId,
       clientSecret: config.auth.clientSecret,
       token: config.auth.tokenUrl,
+      profile: (profile) => {
+        return {
+          id: profile.uid,
+          name: profile.displayName,
+          email: profile.email,
+          image: profile.avatar,
+        };
+      },
       userinfo: config.auth.userinfoUrl,
     },
   ],
   callbacks: {
-    async session(params: any) {
-      params.session.user.id = params.token.fxaUid;
-      return params.session;
+    async session({ session, token }) {
+      session.user = { ...session.user, ...(token.user as any) };
+      return session;
     },
     async jwt({ token, profile }) {
       // Note profile is only defined once after user sign in.
-      const fxaUid = token.fxaUid || profile?.uid;
+      // const fxaUid = token.fxaUid || profile?.uid;
+      if (profile) {
+        token.user = {
+          id: profile.uid,
+          name: profile.displayName,
+          email: profile.email,
+          image: profile.avatar,
+        };
+      }
       return {
         ...token,
-        fxaUid,
       };
     },
   },


### PR DESCRIPTION
## Because

- SP3 needs access to the users email, profile picture, and display name in order to render up-to-date UIs

## This pull request

- Adds the fields to the userinfo auth context object, which is then set on the jwt

## Issue that this pull request solves

Closes: [FXA-7599](https://mozilla-hub.atlassian.net/browse/FXA-7599)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

[FXA-7599]: https://mozilla-hub.atlassian.net/browse/FXA-7599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ