### PR TITLE
feat(phone): Add method `available` to RecoveryPhoneService

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -11,6 +11,7 @@ import {
   getConfirmedPhoneNumber,
   registerPhoneNumber,
   removePhoneNumber,
+  hasRecoveryCodes,
 } from './recovery-phone.repository';
 import {
   RecoveryNumberAlreadyExistsError,
@@ -153,5 +154,15 @@ export class RecoveryPhoneManager {
     }
 
     return JSON.parse(data);
+  }
+
+  /**
+   * Check if a user has recovery codes. Recovery codes are required
+   * to set up a recovery phone.
+   *
+   * @param uid The user's unique identifier
+   */
+  async hasRecoveryCodes(uid: string): Promise<boolean> {
+    return hasRecoveryCodes(this.db, Buffer.from(uid, 'hex'));
   }
 }

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.repository.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.repository.ts
@@ -30,3 +30,13 @@ export async function removePhoneNumber(db: AccountDatabase, uid: Buffer) {
 
   return result.numDeletedRows === BigInt(1);
 }
+
+export async function hasRecoveryCodes(db: AccountDatabase, uid: Buffer) {
+  const result = await db
+    .selectFrom('recoveryCodes')
+    .where('uid', '=', uid)
+    .selectAll()
+    .execute();
+
+  return result.length > 0;
+}

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.config.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.config.ts
@@ -2,9 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsArray } from 'class-validator';
+import { IsArray, IsBoolean, IsObject } from 'class-validator';
 
 export class RecoveryPhoneServiceConfig {
   @IsArray()
   public validNumberPrefixes?: Array<string>;
+}
+
+export class RecoveryPhoneConfig {
+  @IsBoolean()
+  public enabled?: boolean;
+
+  @IsArray()
+  public allowedRegions?: Array<string>;
+
+  @IsObject()
+  public sms?: RecoveryPhoneServiceConfig;
 }

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -120,7 +120,9 @@ async function run(config) {
       };
   Container.set(AccountEventsManager, accountEventsManager);
 
-  const accountDatabase = await setupAccountDatabase(config.database.mysql.auth);
+  const accountDatabase = await setupAccountDatabase(
+    config.database.mysql.auth
+  );
   const backupCodeManager = new BackupCodeManager(accountDatabase);
   Container.set('BackupCodeManager', backupCodeManager);
 
@@ -237,7 +239,7 @@ async function run(config) {
     recoveryPhoneManager,
     smsManager,
     otpCodeManager,
-    config.recoveryPhone.sms
+    config.recoveryPhone
   );
   Container.set('RecoveryPhoneService', recoveryPhoneService);
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2109,6 +2109,18 @@ const convictConf = convict({
     },
   },
   recoveryPhone: {
+    enabled: {
+      default: false,
+      doc: 'Enable recovery phone feature',
+      env: 'RECOVERY_PHONE__ENABLED',
+      format: Boolean,
+    },
+    allowedRegions: {
+      default: ['US'],
+      doc: 'Allowed regions for recovery phone',
+      env: 'RECOVERY_PHONE__ALLOWED_REGIONS',
+      format: Array,
+    },
     otp: {
       kind: {
         default: 'recovery-phone-code',


### PR DESCRIPTION
## Because

- We want to check to see if a user can setup a recovery phone

## This pull request

- Adds the `available` method to RecoveryPhoneService
- Adds `hasRecoveryCodes` method to RecoveryPhoneManager
- Adds supporting tests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10444

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
