### PR TITLE
fix(metrics): pass the `service` value to the linked account login endpoint

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -124,11 +124,18 @@ const ThirdPartyAuthCallback = ({
     }
 
     try {
+      const fxaParams = integration.getFxAParams();
+      let originalService;
+      if (fxaParams) {
+        const params = new URLSearchParams(fxaParams);
+        originalService =
+          params.get('service') || params.get('client_id') || undefined;
+      }
       const linkedAccount: LinkedAccountData =
         await account.verifyAccountThirdParty(
           thirdPartyOAuthCode,
           provider,
-          undefined,
+          originalService,
           queryParamsToMetricsContext(
             flowQueryParams as unknown as Record<string, string>
           )
@@ -140,8 +147,6 @@ const ThirdPartyAuthCallback = ({
       await storeLinkedAccountData(linkedAccount, totpRequired);
 
       setCurrentAccount(linkedAccount.uid);
-
-      const fxaParams = integration.getFxAParams();
 
       // HACK: Hard navigate is required here to ensure that the new integration
       // is created based off updated search params.


### PR DESCRIPTION
## Because

- Looks like the service value was not being sent in the linked account login endpoint, Glean uses this value to filter out events in the backend

## This pull request

- Grabs the original service/clientId and passes it along the request

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10851

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We would want to get this on a point release to production
