### PR TITLE
chore(dev-launcher): Disable password autofill for developer testing

### DIFF
--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -116,6 +116,8 @@ const fxaProfile = {
   'webchannel.allowObject.urlWhitelist': fxaEnv.content.slice(0, -1),
   'browser.tabs.firefox-view': true,
   'identity.fxaccounts.autoconfig.uri': fxaEnv.content,
+  // disable password auto-fill; we typically don't need to test this daily.
+  'signon.rememberSignons': false,
   // TODO in FXA-9872, make oauth_webchannel_v1 the default context and
   // change these values for fx_desktop_v3. (Also, update the README note)
   ...(process.env.FXA_DESKTOP_CONTEXT === 'oauth_webchannel_v1' && {


### PR DESCRIPTION
## Because

- We don't typically need this enabled. Our pages are stable enough that we don't require use to validate it daily.

## This pull request

- Disables password autofill in Firefox with `signon.rememberSignons`.

## Issue that this pull request solves

Closes: FXA-10846

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1392" alt="Screenshot 2024-12-09 at 1 50 24 PM" src="https://github.com/user-attachments/assets/9154f1be-c18a-4176-8ec5-f8cc3614140c">

## Other information (Optional)

n/a