### PR TITLE
fix(settings): Add missing error l10n and fix bugs with password create/change

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
@@ -4,9 +4,14 @@
 
 import 'mutationobserver-shim';
 import React from 'react';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { SETTINGS_PATH } from '../../../constants';
-import { mockAppContext, renderWithRouter } from '../../../models/mocks';
+import {
+  mockAppContext,
+  mockSettingsContext,
+  renderWithRouter,
+} from '../../../models/mocks';
+
 import PageChangePassword from '.';
 import {
   logViewEvent,
@@ -14,12 +19,15 @@ import {
   usePageViewEvent,
 } from '../../../lib/metrics';
 import { AppContext, Account } from '../../../models';
+import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import {
   inputCurrentPassword,
   inputNewPassword,
   inputVerifyPassword,
 } from '../../FormPassword/index.test';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 
+jest.mock('../../../models/AlertBarInfo');
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
@@ -38,16 +46,19 @@ const account = {
   changePassword: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
 
-const render = async () => {
+const settingsContext = mockSettingsContext();
+
+const render = async (mockAccount = account) => {
   renderWithRouter(
-    <AppContext.Provider value={mockAppContext({ account })}>
-      <PageChangePassword />
+    <AppContext.Provider value={mockAppContext({ account: mockAccount })}>
+      <SettingsContext.Provider value={settingsContext}>
+        <PageChangePassword />
+      </SettingsContext.Provider>
     </AppContext.Provider>
   );
 };
 
 const changePassword = async () => {
-  await render();
   await inputCurrentPassword('quuz');
   await inputNewPassword('testotesto');
   await inputVerifyPassword('testotesto');
@@ -56,44 +67,89 @@ const changePassword = async () => {
   });
 };
 
-it('renders', async () => {
-  await render();
-  expect(screen.getByTestId('flow-container')).toBeInTheDocument();
-  screen.getByLabelText('Enter current password');
-  expect(screen.getByTestId('nav-link-reset-password')).toBeInTheDocument();
-});
-
-it('emits a metrics event on render', async () => {
-  await render();
-  expect(usePageViewEvent).toHaveBeenCalledWith('settings.change-password');
-});
-
-it('emits a metrics event on success', async () => {
-  await changePassword();
-  expect(logViewEvent).toHaveBeenCalledWith(
-    settingsViewName,
-    'change-password.success'
-  );
-});
-
-it('shows an error when old and new password are the same', async () => {
-  await render();
-  await inputCurrentPassword('testotesto');
-  await inputNewPassword('testotesto');
-  await inputVerifyPassword('testotesto');
-  await act(async () => {
-    fireEvent.click(screen.getByTestId('save-password-button'));
+describe('PageChangePassword', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
-  expect(screen.getByTestId('tooltip')).toBeInTheDocument();
-  expect(screen.getByTestId('tooltip')).toHaveTextContent(
-    'new password must be different'
-  );
-});
+  it('renders', async () => {
+    await render();
+    expect(screen.getByTestId('flow-container')).toBeInTheDocument();
+    screen.getByLabelText('Enter current password');
+    expect(screen.getByTestId('nav-link-reset-password')).toBeInTheDocument();
+  });
 
-it('redirects on success', async () => {
-  await changePassword();
-  expect(mockNavigate).toHaveBeenCalledWith(SETTINGS_PATH + '#password', {
-    replace: true,
+  it('emits a metrics event on render', async () => {
+    await render();
+    expect(usePageViewEvent).toHaveBeenCalledWith('settings.change-password');
+  });
+
+  it('emits a metrics event on success', async () => {
+    await render();
+    await changePassword();
+    expect(logViewEvent).toHaveBeenCalledWith(
+      settingsViewName,
+      'change-password.success'
+    );
+  });
+
+  it('shows an error when old and new password are the same', async () => {
+    await render();
+    await inputCurrentPassword('testotesto');
+    await inputNewPassword('testotesto');
+    await inputVerifyPassword('testotesto');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('save-password-button'));
+    });
+
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveTextContent(
+      'new password must be different'
+    );
+  });
+
+  it('shows an incorrect password error message in tooltip', async () => {
+    const mockAccount = {
+      primaryEmail: {
+        email: 'test@example.com',
+      },
+      changePassword: jest
+        .fn()
+        .mockRejectedValue(AuthUiErrors.INCORRECT_PASSWORD),
+    } as unknown as Account;
+    await render(mockAccount);
+    await changePassword();
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveTextContent(
+      'Incorrect password'
+    );
+  });
+
+  it('shows an unexpected error message in alertBar when error is unknown', async () => {
+    const mockAccount = {
+      primaryEmail: {
+        email: 'test@example.com',
+      },
+      changePassword: jest.fn().mockRejectedValue({ error: 'bloop' }),
+    } as unknown as Account;
+    await render(mockAccount);
+    await changePassword();
+    await waitFor(() =>
+      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1)
+    );
+    expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledWith(
+      'Unexpected error'
+    );
+  });
+
+  it('redirects on success', async () => {
+    await render();
+    await changePassword();
+    await waitFor(() =>
+      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1)
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(SETTINGS_PATH + '#password', {
+      replace: true,
+    });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.test.tsx
@@ -163,6 +163,9 @@ describe('PageCreatePassword', () => {
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(SETTINGS_PATH + '#password', {
       replace: true,
+      state: {
+        wantsUnlinkProviderId: undefined,
+      },
     });
     expect(alertBarInfo.success).toHaveBeenCalledTimes(1);
     expect(alertBarInfo.success).toHaveBeenCalledWith('Password set');
@@ -177,12 +180,15 @@ describe('PageCreatePassword', () => {
         wantsUnlinkProviderId: LinkedAccountProviderIds.Google,
       };
       await createPassword();
-      expect(mockNavigate).toHaveBeenCalledWith(SETTINGS_PATH + '#password', {
-        replace: true,
-        state: {
-          wantsUnlinkProviderId: LinkedAccountProviderIds.Google,
-        },
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        SETTINGS_PATH + '#linked-account',
+        {
+          replace: true,
+          state: {
+            wantsUnlinkProviderId: LinkedAccountProviderIds.Google,
+          },
+        }
+      );
     });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
@@ -54,10 +54,13 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
     alertBar.success(
       ftlMsgResolver.getMsg('pw-create-success-alert-2', 'Password set')
     );
-    navigate(SETTINGS_PATH + '#password', {
-      replace: true,
-      ...(wantsUnlinkProviderId ? { state: { wantsUnlinkProviderId } } : {}),
-    });
+    navigate(
+      SETTINGS_PATH + (wantsUnlinkProviderId ? '#linked-account' : '#password'),
+      {
+        replace: true,
+        state: { wantsUnlinkProviderId },
+      }
+    );
   }, [alertBar, ftlMsgResolver, navigate, wantsUnlinkProviderId]);
 
   const onFormSubmit = useCallback(

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -303,6 +303,10 @@ const ERRORS = {
     errno: 204,
     message: 'System unavailable, try again soon',
   },
+  CANNOT_CREATE_PASSWORD: {
+    errno: 206,
+    message: 'Can not create password, password already set',
+  },
   SERVICE_UNAVAILABLE: {
     errno: 998,
     message: 'System unavailable, try again soon',

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -19,6 +19,7 @@ auth-error-139 = Secondary email must be different than your account email
 auth-error-155 = TOTP token not found
 auth-error-159 = Invalid account recovery key
 auth-error-183-2 = Invalid or expired confirmation code
+auth-error-206 = Can not create password, password already set
 auth-error-999 = Unexpected error
 auth-error-1001 = Login attempt cancelled
 auth-error-1002 = Session expired. Sign in to continue.


### PR DESCRIPTION
## Because

* "Can not create password, password already set" error was not localized, and therefore replaced with "Unexpected error" in UI
* After setting a password on create_password, was not navigated back to settings
* On error with changing the password, the error shown was always "incorrect password", no matter the actual error (e.g., throttling)

## This pull request

* Add l10n for auth error 206
* Update navigation on create_password to ensure it correctly navigates to settings (and doesn't redirect to change password) after successfully setting a password without request to unlink account
* Validate that no regression for showing the unlink account modal after creating a password, when the initial user request was to unlink a third party account
* Update error handling on change_password to show the relevant error and only show "incorrect password" in tooltip if that is the actual error

## Issue that this pull request solves

Closes: #FXA-10866

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
