### PR TITLE
feat(relay): Add copy to tell users what will happen at service=relay sign-in/sign-up

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/en.ftl
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/en.ftl
@@ -16,3 +16,7 @@ complete-reset-pw-recovery-key-link = Use account recovery key
 # Displayed on the sign in page
 reset-password-complete-banner-heading = Your password has been reset.
 reset-password-complete-banner-message = Don’t forget to generate a new account recovery key from your { -product-mozilla-account } settings to prevent future sign-in issues.
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+complete-reset-password-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.stories.tsx
@@ -18,6 +18,14 @@ export const NoSync = () => (
   <Subject recoveryKeyExists={true} estimatedSyncDeviceCount={0} />
 );
 
+export const OAuthDesktopServiceRelay = () => (
+  <Subject
+    isDesktopServiceRelay={true}
+    estimatedSyncDeviceCount={0}
+    recoveryKeyExists={false}
+  />
+);
+
 export const SyncAndNoRecoveryKey = () => (
   <Subject recoveryKeyExists={false} estimatedSyncDeviceCount={2} />
 );

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -23,6 +23,9 @@ jest.mock('../../../lib/glean', () => ({
   },
 }));
 
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
+
 describe('CompleteResetPassword page', () => {
   beforeEach(() => {
     (GleanMetrics.passwordReset.createNewView as jest.Mock).mockClear();
@@ -69,6 +72,18 @@ describe('CompleteResetPassword page', () => {
       expect(
         screen.queryByRole('link', { name: 'Use account recovery key' })
       ).not.toBeInTheDocument();
+      expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
+    });
+
+    it('renders expected text when service=relay', () => {
+      renderWithLocalizationProvider(
+        <Subject
+          isDesktopServiceRelay={true}
+          estimatedSyncDeviceCount={0}
+          recoveryKeyExists={false}
+        />
+      );
+      screen.getByText(serviceRelayText);
     });
 
     it('renders as expected for account without sync', async () => {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.tsx
@@ -19,6 +19,7 @@ import ResetPasswordWarning from '../../../components/ResetPasswordWarning';
 import { Link, useLocation } from '@reach/router';
 import Banner from '../../../components/Banner';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
+import { useFtlMsgResolver } from '../../../models';
 
 const CompleteResetPassword = ({
   email,
@@ -29,6 +30,7 @@ const CompleteResetPassword = ({
   estimatedSyncDeviceCount,
   recoveryKeyExists,
   integrationIsSync,
+  isDesktopServiceRelay,
 }: CompleteResetPasswordProps) => {
   const location = useLocation();
   const searchParams = location.search;
@@ -37,6 +39,8 @@ const CompleteResetPassword = ({
       ? GleanMetrics.passwordReset.recoveryKeyCreatePasswordView()
       : GleanMetrics.passwordReset.createNewView();
   }, [hasConfirmedRecoveryKey]);
+
+  const ftlMsgResolver = useFtlMsgResolver();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isSyncUser = !!(
@@ -90,9 +94,22 @@ const CompleteResetPassword = ({
       */}
       <input type="email" value={email} className="hidden" readOnly />
 
+      {isDesktopServiceRelay && (
+        <Banner
+          type="info"
+          content={{
+            localizedHeading: ftlMsgResolver.getMsg(
+              'complete-reset-password-desktop-relay',
+              'Firefox will try sending you back to use an email mask after you sign in.'
+            ),
+          }}
+        />
+      )}
+
       <FtlMsg id="complete-reset-pw-header-v2">
-        <h1 className="font-semibold text-xl mt-6">Create a new password</h1>
+        <h2 className="font-semibold text-xl mt-6">Create a new password</h2>
       </FtlMsg>
+
       <section className="mt-2">
         <FormPasswordWithInlineCriteria
           {...{

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
@@ -44,6 +44,7 @@ export interface CompleteResetPasswordProps {
   estimatedSyncDeviceCount?: number;
   recoveryKeyExists?: boolean;
   integrationIsSync: boolean;
+  isDesktopServiceRelay?: boolean;
 }
 
 export type AccountResetData = {

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/mocks.tsx
@@ -20,6 +20,7 @@ export const Subject = ({
   testErrorMessage = '',
   estimatedSyncDeviceCount,
   integrationIsSync = false,
+  isDesktopServiceRelay = false,
 }: Partial<CompleteResetPasswordProps> & {
   testErrorMessage?: string;
 }) => {
@@ -46,6 +47,7 @@ export const Subject = ({
           recoveryKeyExists,
           estimatedSyncDeviceCount,
           integrationIsSync,
+          isDesktopServiceRelay,
         }}
       />
     </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/en.ftl
@@ -16,3 +16,7 @@ signin-recovery-code-back-link = Back
 signin-recovery-code-support-link = Are you locked out?
 # Error displayed in a tooltip when form is submitted witout a code
 signin-recovery-code-required-error = Backup authentication code required
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+signin-recovery-code-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.stories.tsx
@@ -11,7 +11,7 @@ import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { LocationProvider } from '@reach/router';
 import { mockSigninLocationState } from '../mocks';
 import { mockFinishOAuthFlowHandler } from '../../mocks';
-import { mockWebIntegration } from './mocks';
+import { createMockOAuthNativeIntegration, mockWebIntegration } from './mocks';
 import { BeginSigninError } from '../../../lib/error-utils';
 
 export default {
@@ -43,6 +43,15 @@ export const Default = () => (
   <SigninRecoveryCode
     finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
     integration={mockWebIntegration}
+    signinState={mockSigninLocationState}
+    submitRecoveryCode={mockSubmitSuccess}
+  />
+);
+
+export const WithOAuthDesktopServiceRelay = () => (
+  <SigninRecoveryCode
+    finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+    integration={createMockOAuthNativeIntegration(false)}
     signinState={mockSigninLocationState}
     submitRecoveryCode={mockSubmitSuccess}
   />

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import SigninRecoveryCode from '.';
-import { MozServices } from '../../../lib/types';
 import GleanMetrics from '../../../lib/glean';
 import {
   createMockSigninOAuthIntegration,
@@ -18,6 +17,7 @@ import { MOCK_RECOVERY_CODE } from '../../mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { OAUTH_ERRORS } from '../../../lib/oauth';
 import { tryAgainError } from '../../../lib/oauth/hooks';
+import { mockOAuthNativeIntegration } from '../SigninTotpCode/mocks';
 
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
@@ -32,6 +32,9 @@ jest.mock('../../../lib/glean', () => ({
 
 const mockFinishOAuthFlowHandler = jest.fn();
 const mockIntegration = createMockSigninWebIntegration();
+
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
 
 describe('PageSigninRecoveryCode', () => {
   beforeEach(() => {
@@ -70,6 +73,21 @@ describe('PageSigninRecoveryCode', () => {
     screen.getByRole('link', {
       name: /Are you locked out?/,
     });
+    expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
+  });
+
+  it('renders expected text when service=relay', () => {
+    renderWithLocalizationProvider(
+      <LocationProvider>
+        <SigninRecoveryCode
+          finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+          integration={mockOAuthNativeIntegration(false)}
+          signinState={mockSigninLocationState}
+          submitRecoveryCode={jest.fn()}
+        />
+      </LocationProvider>
+    );
+    screen.getByText(serviceRelayText);
   });
 
   describe('metrics', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -173,6 +173,15 @@ const SigninRecoveryCode = ({
         </p>
       </FtlMsg>
 
+      {integration.isDesktopRelay() && (
+        <FtlMsg id="signin-recovery-code-desktop-relay">
+          <p className="text-sm mt-2">
+            Firefox will try sending you back to use an email mask after you
+            sign in.
+          </p>
+        </FtlMsg>
+      )}
+
       <FormVerifyCode
         {...{
           formAttributes,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/mocks.tsx
@@ -36,7 +36,18 @@ export const mockWebIntegration = {
   getService: () => MozServices.Default,
   isSync: () => false,
   wantsKeys: () => false,
+  isDesktopRelay: () => false,
   data: {},
 } as Integration;
+
+export const createMockOAuthNativeIntegration = (isSync = true) =>
+  ({
+    type: IntegrationType.OAuthNative,
+    getService: () => MozServices.FirefoxSync,
+    isSync: () => isSync,
+    wantsKeys: () => false,
+    isDesktopRelay: () => !isSync,
+    data: {},
+  } as Integration);
 
 export * from '../../mocks';

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/en.ftl
@@ -17,3 +17,7 @@ signin-token-code-resend-code-link = Email new code.
 # Error displayed in a tooltip when the form is submitted without a code
 signin-token-code-required-error = Confirmation code required
 signin-token-code-resend-error = Something went wrong. A new code could not be sent.
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+signin-token-code-instruction-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import SigninTokenCode from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { Subject } from './mocks';
+import { createOAuthNativeIntegration, Subject } from './mocks';
 
 export default {
   title: 'Pages/Signin/SigninTokenCode',
@@ -15,3 +15,7 @@ export default {
 } as Meta;
 
 export const Default = () => <Subject />;
+
+export const OAuthDesktopServiceRelay = () => (
+  <Subject integration={createOAuthNativeIntegration(false)} />
+);

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -14,7 +14,7 @@ import { mockAppContext, mockSession } from '../../../models/mocks';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { Session, AppContext } from '../../../models';
 import { SigninTokenCodeProps } from './interfaces';
-import { Subject } from './mocks';
+import { createOAuthNativeIntegration, Subject } from './mocks';
 import { MOCK_SIGNUP_CODE } from '../../Signup/ConfirmSignupCode/mocks';
 import { MOCK_EMAIL, MOCK_OAUTH_FLOW_HANDLER_RESPONSE } from '../../mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
@@ -72,6 +72,9 @@ function mockReactUtilsModule() {
   jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
+
 describe('SigninTokenCode page', () => {
   beforeEach(() => {
     applyDefaultMocks();
@@ -109,6 +112,12 @@ describe('SigninTokenCode page', () => {
 
     // initially hidden
     expect(screen.queryByRole('Code expired?')).not.toBeInTheDocument();
+    expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
+  });
+
+  it('renders expected text when service=relay', () => {
+    render({ integration: createOAuthNativeIntegration(false) });
+    screen.getByText(serviceRelayText);
   });
 
   it('emits a metrics event on render', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -223,6 +223,15 @@ const SigninTokenCode = ({
         </p>
       </FtlMsg>
 
+      {integration.isDesktopRelay() && (
+        <FtlMsg id="signin-token-code-instruction-desktop-relay">
+          <p className="mt-2 text-sm">
+            Firefox will try sending you back to use an email mask after you
+            sign in.
+          </p>
+        </FtlMsg>
+      )}
+
       <FormVerifyCode
         {...{
           formAttributes,

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -31,6 +31,19 @@ export function createMockWebIntegration() {
   };
 }
 
+export function createOAuthNativeIntegration(isSync = true) {
+  return {
+    type: IntegrationType.OAuthNative,
+    getService: () => MozServices.Default,
+    getClientId: () => undefined,
+    isSync: () => isSync,
+    wantsKeys: () => false,
+    isDesktopSync: () => false,
+    isDesktopRelay: () => !isSync,
+    data: {},
+  };
+}
+
 export const createMockSigninLocationState = (
   wantsKeys = false,
   verificationReason?: VerificationReasons

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/en.ftl
@@ -12,3 +12,7 @@ signin-totp-code-other-account-link = Use a different account
 signin-totp-code-recovery-code-link = Trouble entering code?
 # Error displayed in a tooltip when the form is submitted without a code
 signin-totp-code-required-error = Authentication code required
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+signin-totp-code-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -9,8 +9,9 @@ import { LocationProvider } from '@reach/router';
 import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { Subject } from './mocks';
+import { mockOAuthNativeIntegration, Subject } from './mocks';
 import { BeginSigninError } from '../../../lib/error-utils';
+import { Integration } from '../../../models';
 
 export default {
   title: 'Pages/Signin/SigninTotpCode',
@@ -21,6 +22,7 @@ export default {
 const storyWithProps = (props: {
   submitTotpCode: () => Promise<{ status: boolean; error?: BeginSigninError }>;
   serviceName: MozServices;
+  integration?: Integration;
 }) => {
   const story = () => (
     <LocationProvider>
@@ -35,6 +37,14 @@ export const Default = storyWithProps({
     status: true,
   }),
   serviceName: MozServices.Default,
+});
+
+export const WithOAuthDesktopServiceRelay = storyWithProps({
+  submitTotpCode: async () => ({
+    status: true,
+  }),
+  serviceName: MozServices.FirefoxSync,
+  integration: mockOAuthNativeIntegration(false),
 });
 
 export const WithRelyingParty = storyWithProps({

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -14,7 +14,7 @@ import {
   AuthUiError,
   AuthUiErrors,
 } from '../../../lib/auth-errors/auth-errors';
-import { Subject } from './mocks';
+import { mockOAuthNativeIntegration, Subject } from './mocks';
 import { MOCK_OAUTH_FLOW_HANDLER_RESPONSE } from '../../mocks';
 import {
   createMockSigninOAuthIntegration,
@@ -58,6 +58,9 @@ jest.mock('@reach/router', () => ({
   useLocation: () => mockLocation(),
 }));
 
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
+
 describe('Sign in with TOTP code page', () => {
   // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
   // TODO: in FXA-6461
@@ -85,6 +88,14 @@ describe('Sign in with TOTP code page', () => {
     screen.getByRole('button', { name: 'Confirm' });
     screen.getByRole('link', { name: 'Use a different account' });
     screen.getByRole('link', { name: 'Trouble entering code?' });
+    expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
+  });
+
+  it('renders expected service=relay text', () => {
+    renderWithLocalizationProvider(
+      <Subject integration={mockOAuthNativeIntegration(false)} />
+    );
+    screen.getByText(serviceRelayText);
   });
 
   it('shows the relying party in the header when a service name is provided', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -160,6 +160,15 @@ export const SigninTotpCode = ({
         </FtlMsg>
       </div>
 
+      {integration.isDesktopRelay() && (
+        <FtlMsg id="signin-totp-code-desktop-relay">
+          <p className="mt-2 mb-4 text-sm">
+            Firefox will try sending you back to use an email mask after you
+            sign in.
+          </p>
+        </FtlMsg>
+      )}
+
       {bannerError && (
         <Banner type="error" content={{ localizedHeading: bannerError }} />
       )}

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -23,6 +23,16 @@ const mockWebIntegration = {
   isDesktopRelay: () => false,
 } as Integration;
 
+export const mockOAuthNativeIntegration = (isSync = true) =>
+  ({
+    type: IntegrationType.OAuthNative,
+    getService: () => MozServices.FirefoxSync,
+    isSync: () => isSync,
+    wantsKeys: () => false,
+    isDesktopRelay: () => !isSync,
+    data: {},
+  } as Integration);
+
 export const MOCK_TOTP_LOCATION_STATE = {
   email: MOCK_EMAIL,
   uid: MOCK_UID,

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/en.ftl
@@ -12,3 +12,7 @@ signin-unblock-code-incorrect-length = Authorization code must contain 8 charact
 signin-unblock-code-incorrect-format-2 = Authorization code can only contain letters and/or numbers
 signin-unblock-resend-code-button = Not in inbox or spam folder? Resend
 signin-unblock-support-link = Why is this happening?
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+signin-unblock-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
@@ -16,7 +16,10 @@ import {
 } from '../../mocks';
 import VerificationMethods from '../../../constants/verification-methods';
 import VerificationReasons from '../../../constants/verification-reasons';
-import { createMockSigninWebIntegration } from '../mocks';
+import {
+  createMockSigninOAuthNativeSyncIntegration,
+  createMockSigninWebIntegration,
+} from '../mocks';
 
 export default {
   title: 'Pages/Signin/SigninUnblock',
@@ -53,6 +56,21 @@ export const Default = () => (
       hasPassword={true}
       finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
       integration={createMockSigninWebIntegration()}
+      signinWithUnblockCode={mockSuccessResponse}
+      resendUnblockCodeHandler={mockResendSuccessResponse}
+    />
+  </LocationProvider>
+);
+export const WithOAuthDesktopServiceRelay = () => (
+  <LocationProvider>
+    <SigninUnblock
+      email={MOCK_EMAIL}
+      hasLinkedAccount={false}
+      hasPassword={true}
+      finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+      integration={createMockSigninOAuthNativeSyncIntegration({
+        isSync: false,
+      })}
       signinWithUnblockCode={mockSuccessResponse}
       resendUnblockCodeHandler={mockResendSuccessResponse}
     />

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -15,6 +15,7 @@ import {
   createBeginSigninResponse,
   createBeginSigninResponseError,
   createMockSigninOAuthIntegration,
+  createMockSigninOAuthNativeSyncIntegration,
   createMockSigninWebIntegration,
 } from '../mocks';
 import GleanMetrics from '../../../lib/glean';
@@ -54,6 +55,9 @@ const hasLinkedAccount = false;
 const hasPassword = true;
 let signinWithUnblockCode = jest.fn();
 let resendUnblockCodeHandler = jest.fn();
+
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
 
 const renderWithSuccess = (
   finishOAuthFlowHandler = jest
@@ -128,6 +132,17 @@ describe('SigninUnblock', () => {
       name: 'Not in inbox or spam folder? Resend',
     });
     screen.getByRole('link', { name: /Why is this happening/ });
+    expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
+  });
+
+  it('renders expected text when service=relay', () => {
+    renderWithSuccess(
+      undefined,
+      createMockSigninOAuthNativeSyncIntegration({
+        isSync: false,
+      })
+    );
+    screen.getByText(serviceRelayText);
   });
 
   it('emits the expected metrics on render', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -220,6 +220,16 @@ export const SigninUnblock = ({
           Check your email for the authorization code sent to {email}.
         </p>
       </FtlMsg>
+
+      {integration.isDesktopRelay() && (
+        <FtlMsg id="signin-unblock-desktop-relay">
+          <p className="text-sm mt-2">
+            Firefox will try sending you back to use an email mask after you
+            sign in.
+          </p>
+        </FtlMsg>
+      )}
+
       <FormVerifyCode
         {...{
           formAttributes,

--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -16,3 +16,7 @@ signin-header = Sign in
 signin-use-a-different-account-link = Use a different account
 signin-forgot-password-link = Forgot password?
 signin-password-button-label = Password
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+signin-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -67,8 +67,12 @@ export const NoLinkedAccountAndNoPassword = storyWithProps({
   hasPassword: false,
 });
 
-export const NoThirdPartyAuthBecauseSyncWithPassword = storyWithProps({
+export const SignInToSync = storyWithProps({
   hasLinkedAccount: true,
   hasPassword: true,
   integration: createMockSigninOAuthNativeSyncIntegration(),
+});
+
+export const SignInToOAuthDesktopRelay = storyWithProps({
+  integration: createMockSigninOAuthNativeSyncIntegration({ isSync: false }),
 });

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -105,6 +105,9 @@ jest.mock('@reach/router', () => ({
   useLocation: () => mockLocation(),
 }));
 
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
+
 // TODO: Once https://mozilla-hub.atlassian.net/browse/FXA-6461 is resolved, we can
 // add the l10n tests back in. Right now, they can't handle embedded tags.
 
@@ -203,6 +206,7 @@ describe('Signin component', () => {
         privacyAndTermsRendered();
         resetPasswordLinkRendered();
         differentAccountLinkRendered();
+        expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
       });
 
       it('does not render third party auth for sync, emits expected Glean event', () => {
@@ -419,9 +423,9 @@ describe('Signin component', () => {
                   unwrapBKey: MOCK_UNWRAP_BKEY,
                 })
               );
-              const integration = createMockSigninOAuthNativeSyncIntegration(
-                IntegrationType.SyncDesktopV3
-              );
+              const integration = createMockSigninOAuthNativeSyncIntegration({
+                type: IntegrationType.SyncDesktopV3,
+              });
               render({ beginSigninHandler, integration });
               enterPasswordAndSubmit();
               await waitFor(() => {
@@ -610,6 +614,7 @@ describe('Signin component', () => {
                 integration,
                 finishOAuthFlowHandler,
               });
+              screen.getByText(serviceRelayText);
               enterPasswordAndSubmit();
               await waitFor(() => {
                 // Ensure it's not called with keyFetchToken or unwrapBKey, or services: { sync: {} }

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -371,6 +371,15 @@ const Signin = ({
           <Avatar className={avatarClassNames} />
         )}
         <div className="my-5 text-base break-all text-center">{email}</div>
+
+        {isDesktopRelay && (
+          <FtlMsg id="signin-desktop-relay">
+            <p className="mt-2 mb-4 text-sm">
+              Firefox will try sending you back to use an email mask after you
+              sign in.
+            </p>
+          </FtlMsg>
+        )}
       </div>
       {!hasLinkedAccountAndNoPassword && (
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -109,18 +109,19 @@ export function createMockSigninWebIntegration(): SigninIntegration {
   };
 }
 
-export function createMockSigninOAuthNativeSyncIntegration(
-  type = IntegrationType.OAuthNative
-): SigninIntegration {
+export function createMockSigninOAuthNativeSyncIntegration({
+  type = IntegrationType.OAuthNative,
+  isSync = true,
+}: { type?: IntegrationType; isSync?: boolean } = {}): SigninIntegration {
   return {
     type,
-    isSync: () => true,
+    isSync: () => isSync,
     wantsKeys: () => true,
     getService: () => MozServices.FirefoxSync,
     getClientId: () => MOCK_CLIENT_ID,
     data: {},
     isDesktopSync: () => true,
-    isDesktopRelay: () => false,
+    isDesktopRelay: () => !isSync,
   };
 }
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/en.ftl
@@ -20,3 +20,7 @@ confirm-signup-code-resend-code-link = Email new code.
 confirm-signup-code-success-alert = Account confirmed successfully
 # Error displayed in tooltip.
 confirm-signup-code-is-required-error = Confirmation code is required
+# Message to user after they were redirected to the Mozilla account sign-in page in a new browser
+# tab. Firefox will attempt to send the user back to their original tab to use an email mask after
+# they successfully sign in or sign up for a Mozilla account to receive a free email mask.
+confirm-signup-code-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ConfirmSignupCode from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { Subject } from './mocks';
+import { createMockOAuthNativeIntegration, Subject } from './mocks';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
@@ -36,6 +36,12 @@ export const WithSuccess = () => (
 export const WithErrors = () => (
   <AppContext.Provider value={mockAppContext({ account: accountWithErrors })}>
     <Subject />
+  </AppContext.Provider>
+);
+
+export const OAuthDesktopServiceRelay = () => (
+  <AppContext.Provider value={mockAppContext({ account: accountWithSuccess })}>
+    <Subject integration={createMockOAuthNativeIntegration(false)} />
   </AppContext.Provider>
 );
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -114,6 +114,9 @@ function renderWithSession({
   );
 }
 
+const serviceRelayText =
+  'Firefox will try sending you back to use an email mask after you sign in.';
+
 describe('ConfirmSignupCode page', () => {
   // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
   // TODO: in FXA-6461
@@ -258,6 +261,15 @@ describe('ConfirmSignupCode page', () => {
         expect(fxaOAuthLoginSpy).not.toHaveBeenCalled();
       });
     });
+
+    it('does not show service=relay text', () => {
+      renderWithSession({
+        session,
+        integration,
+        finishOAuthFlowHandler: jest.fn(),
+      });
+      expect(screen.queryByText(serviceRelayText)).not.toBeInTheDocument();
+    });
   });
 
   describe('OAuth native integration', () => {
@@ -295,6 +307,7 @@ describe('ConfirmSignupCode page', () => {
         integration,
         finishOAuthFlowHandler: mockFinishOAuthFlowHandler,
       });
+      screen.getByText(serviceRelayText);
       submit();
 
       await waitFor(() => {

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -67,6 +67,7 @@ const ConfirmSignupCode = ({
 
   const navigate = useNavigate();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
+  const isDesktopRelay = integration.isDesktopRelay();
 
   useEffect(() => {
     GleanMetrics.signupConfirmation.view();
@@ -203,7 +204,7 @@ const ConfirmSignupCode = ({
             const { to } = getSyncNavigate(location.search);
             hardNavigate(to);
             return;
-          } else if (integration.isDesktopRelay()) {
+          } else if (isDesktopRelay) {
             firefox.fxaOAuthLogin({
               action: 'signup',
               code,
@@ -293,6 +294,15 @@ const ConfirmSignupCode = ({
           Enter the code that was sent to {email} within 5 minutes.
         </p>
       </FtlMsg>
+
+      {isDesktopRelay && (
+        <FtlMsg id="confirm-signup-code-desktop-relay">
+          <p className="mt-2 text-sm">
+            Firefox will try sending you back to use an email mask after you
+            sign in.
+          </p>
+        </FtlMsg>
+      )}
 
       <FormVerifyCode
         {...{

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -45,7 +45,7 @@ export interface ConfirmSignupCodeFormData {
 
 export type ConfirmSignupCodeBaseIntegration = Pick<
   Integration,
-  'type' | 'data' | 'getService' | 'getClientId'
+  'type' | 'data' | 'getService' | 'getClientId' | 'isDesktopRelay'
 >;
 
 export type ConfirmSignupCodeOAuthIntegration = Pick<

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -41,6 +41,7 @@ export function createMockWebIntegration({
     data: { uid: MOCK_UID, redirectTo },
     getService: () => MozServices.Default,
     getClientId: () => undefined,
+    isDesktopRelay: () => false,
   };
 }
 


### PR DESCRIPTION
Because:
* a11y recommended we tell the user what will happen at the last step of their sign-in or sign-up process near the CTA

This commit:
* Adds recommended copy above confirm_signup_code, signin, signin_totp_code, signin_recovery_code, signin_token_code, signin_unblock_code, and complete_reset_password for isDesktopRelay flows, since users can be at their final step on any of these pages

fixes FXA-10827

---

Launch dev-launcher with oauth desktop (see readme) and change the `service` param to `relay` to see the new copy on the modified pages.