### PR TITLE
task(FXA-10804): Fast-follow apply upgrade process to signin token code

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Page, expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget } from '../../lib/targets/base';
+import { SettingsPage } from '../../pages/settings';
+import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
+
+/**
+ * These tests represent various permutations between interacting with V1 and V2
+ * key stretched passwords. We need to ensure that operations are interchangeable!
+ */
+test.describe('severity-2 #smoke', () => {
+  type Version = { version: 1 | 2; query: string };
+  type TestCase = { signinVersion: Version };
+  const v1: Version = { version: 1, query: '' };
+  const v2: Version = { version: 2, query: 'stretch=2' };
+  const TestCases: TestCase[] = [{ signinVersion: v1 }, { signinVersion: v2 }];
+
+  for (const { signinVersion } of TestCases) {
+    test(`signs up as v1, sign in within token code, signs  as v${signinVersion.version}`, async ({
+      page,
+      target,
+      pages: {
+        settings,
+        signin,
+        connectAnotherDevice,
+        deleteAccount,
+        signinTokenCode,
+      },
+      testAccountTracker,
+    }, {}) => {
+      const { email, password } = await testAccountTracker.signUpSync();
+      await page.goto(
+        `${target.contentServerUrl}?context=fx_desktop_v3&service=sync&action=email&${signinVersion.query}`
+      );
+      await signin.fillOutEmailFirstForm(email);
+      await signin.fillOutPasswordForm(password);
+
+      await expect(page).toHaveURL(/signin_token_code/);
+      await expect(signinTokenCode.heading).toBeVisible();
+      const code = await target.emailClient.getVerifyLoginCode(email);
+      await signinTokenCode.fillOutCodeForm(code);
+
+      await expect(page).toHaveURL(/pair/);
+      await connectAnotherDevice.clickNotNowPair();
+
+      await expect(page).toHaveURL(/settings/);
+
+      // Make sure upgrade occurred
+      if (signinVersion.version === 2) {
+        const client = target.createAuthClient(2);
+        const status = await client.getCredentialStatusV2(email);
+        expect(status.currentVersion).toEqual(`v2`);
+      }
+
+      await removeAccount(target, page, settings, deleteAccount, password);
+    });
+  }
+});
+
+async function removeAccount(
+  target: BaseTarget,
+  page: Page,
+  settings: SettingsPage,
+  deleteAccount: DeleteAccountPage,
+  password: string
+) {
+  await settings.goto();
+  await settings.deleteAccountButton.click();
+  await deleteAccount.deleteAccount(password);
+
+  await expect(page).toHaveURL(`${target.baseUrl}?delete_account_success=true`);
+  await expect(page.getByText('Account deleted successfully')).toBeVisible();
+}

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -248,11 +248,15 @@ describe('SigninTokenCode page', () => {
         expect(GleanMetrics.isDone).toBeCalledTimes(1);
       }
       it('default behavior', async () => {
+        const mockOnSessionVerified = jest.fn().mockResolvedValue(true);
         session = mockSession();
-        render();
+        render({
+          onSessionVerified: mockOnSessionVerified,
+        });
         submitCode();
 
         await expectSuccessGleanEvents();
+        expect(mockOnSessionVerified).toHaveBeenCalledTimes(1);
         expect(navigate).toHaveBeenCalledWith('/settings');
       });
       it('when verificationReason is a force password change', async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -36,6 +36,7 @@ const SigninTokenCode = ({
   signinState,
   keyFetchToken,
   unwrapBKey,
+  onSessionVerified,
 }: SigninTokenCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const session = useSession();
@@ -129,6 +130,9 @@ const SigninTokenCode = ({
       try {
         await session.verifySession(code);
 
+        // Attempt to finish any key stretching upgrades
+        await onSessionVerified(sessionToken);
+
         // TODO: Bounced email redirect to `/signin_bounced`. Try
         // reaching signin_token_code in one browser and deleting the account
         // in another. You reach the "Sorry. We've locked your account" screen
@@ -190,6 +194,7 @@ const SigninTokenCode = ({
       unwrapBKey,
       verificationReason,
       showInlineRecoveryKeySetup,
+      onSessionVerified,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
@@ -11,6 +11,7 @@ export type SigninTokenCodeProps = {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
   signinState: SigninLocationState;
+  onSessionVerified: (sessionId: string) => Promise<void>;
 } & SensitiveData.AuthData;
 
 export interface TotpStatusResponse {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/mocks.tsx
@@ -65,6 +65,7 @@ export const Subject = ({
   finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   integration = createMockWebIntegration(),
   verificationReason = undefined,
+  onSessionVerified = async () => {},
 }: Partial<SigninTokenCodeProps> & {
   verificationReason?: VerificationReasons;
 }) => {
@@ -74,6 +75,7 @@ export const Subject = ({
         {...{
           finishOAuthFlowHandler,
           integration,
+          onSessionVerified,
         }}
         signinState={createMockSigninLocationState(
           integration.wantsKeys(),


### PR DESCRIPTION
## Because
- We already landed a PR for 10804 that does this for totp and unblock codes. In that review, another place where this could be done was spotted.
- We didn't want to block a release, so this is being done as a fast follow.

## This pull request

- Adds the ability to upgrade key stretching after providing a signin token code
- Adds functional tests to validate the upgrade.

## Issue that this pull request solves

Closes: 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
