### PR TITLE
fix(auth): add cache to legacy mapper

### DIFF
--- a/libs/payments/legacy/src/lib/stripe-mapper.config.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.config.ts
@@ -1,0 +1,17 @@
+import { Provider } from '@nestjs/common';
+import { IsNumber, IsOptional } from 'class-validator';
+
+export class StripeMapperConfig {
+  @IsOptional()
+  @IsNumber()
+  ttl?: number;
+}
+
+export const MockStripeMapperConfig = {
+  ttl: 60,
+} satisfies StripeMapperConfig;
+
+export const MockStripeMapperConfigProvider = {
+  provide: StripeMapperConfig,
+  useValue: MockStripeMapperConfig,
+} satisfies Provider<StripeMapperConfig>;

--- a/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
+++ b/libs/payments/legacy/src/lib/stripe-mapper.service.spec.ts
@@ -24,6 +24,16 @@ import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { StripeMetadataWithCMSFactory } from './factories';
 import { StripeMapperService } from './stripe-mapper.service';
+import { MockStripeMapperConfigProvider } from './stripe-mapper.config';
+
+jest.mock('@type-cacheable/core', () => ({
+  Cacheable: () => {
+    return (target: any, propertyKey: any, descriptor: any) => {
+      return descriptor;
+    };
+  },
+  setOptions: jest.fn(),
+}));
 
 jest.useFakeTimers();
 
@@ -40,6 +50,7 @@ describe('StripeMapperService', () => {
         MockStrapiClientConfigProvider,
         MockFirestoreProvider,
         MockStatsDProvider,
+        MockStripeMapperConfigProvider,
         PriceManager,
         ProductConfigurationManager,
         StrapiClient,

--- a/libs/payments/legacy/src/lib/utils/cacheKeyForMap.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/cacheKeyForMap.spec.ts
@@ -1,0 +1,41 @@
+import { StripePlanFactory } from '@fxa/payments/stripe';
+import { cacheKeyForMap } from './cacheKeyForMap';
+
+describe('cacheKeyForMap', () => {
+  const stripePlan = StripePlanFactory({ id: '1' });
+  const stripePlan2 = StripePlanFactory({ id: '2' });
+  const locale = 'en';
+
+  it('should successfully return cache key', () => {
+    expect(cacheKeyForMap([stripePlan], locale)).toBe(
+      'stripeMapperCache:47983b4bfae739b1284cf74c841547f3a7596551940f337f1e4e51d03ef04585:en'
+    );
+  });
+
+  it('should return different key for locale change', () => {
+    expect(cacheKeyForMap([stripePlan], 'de')).toBe(
+      'stripeMapperCache:47983b4bfae739b1284cf74c841547f3a7596551940f337f1e4e51d03ef04585:de'
+    );
+  });
+
+  describe('multiple plans', () => {
+    const expected =
+      'stripeMapperCache:6254b553f98c4d39dce38c8149d2ed7b09726c4542220f40604ac0caf2047e82:en';
+    it('should return different key for different plans array', () => {
+      expect(cacheKeyForMap([stripePlan, stripePlan2], locale)).toBe(expected);
+    });
+
+    it('should return same key if array order is different', () => {
+      expect(cacheKeyForMap([stripePlan2, stripePlan], locale)).toBe(expected);
+    });
+
+    it('should return same key if plans content is different', () => {
+      expect(
+        cacheKeyForMap(
+          [{ ...stripePlan, product: 'different' }, stripePlan2],
+          locale
+        )
+      ).toBe(expected);
+    });
+  });
+});

--- a/libs/payments/legacy/src/lib/utils/cacheKeyForMap.ts
+++ b/libs/payments/legacy/src/lib/utils/cacheKeyForMap.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'crypto';
+import Stripe from 'stripe';
+
+const CACHE_KEY = 'stripeMapperCache';
+
+export const cacheKeyForMap = function (
+  plans: Stripe.Plan[],
+  acceptLanguage: string
+): string {
+  // Sort variables prior to stringifying to not be caller order dependent
+  const planIds = JSON.stringify(plans.map((plan) => plan.id).sort());
+  const planIdsHash = createHash('sha256')
+    .update(JSON.stringify(planIds))
+    .digest('hex');
+  return `${CACHE_KEY}:${planIdsHash}:${acceptLanguage}`;
+};

--- a/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
@@ -428,6 +428,23 @@ describe('productConfigurationManager', () => {
     });
   });
 
+  describe('getSupportedLocale', () => {
+    it('should call strapiClient and return result', async () => {
+      jest.spyOn(strapiClient, 'getLocale').mockResolvedValue('en');
+      const result = await productConfigurationManager.getSupportedLocale('en');
+      expect(result).toEqual('en');
+    });
+
+    it('should reject with error', async () => {
+      jest
+        .spyOn(strapiClient, 'getLocale')
+        .mockRejectedValue(new Error('error'));
+      await expect(
+        productConfigurationManager.getSupportedLocale('en')
+      ).rejects.toThrow();
+    });
+  });
+
   describe('retrieveStripePrice', () => {
     it('returns plan based on offeringId and interval', async () => {
       const mockPrice = StripeResponseFactory(StripePriceFactory());

--- a/libs/shared/cms/src/lib/product-configuration.manager.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.ts
@@ -184,6 +184,10 @@ export class ProductConfigurationManager {
     return planIds;
   }
 
+  async getSupportedLocale(acceptLanguage: string) {
+    return this.strapiClient.getLocale(acceptLanguage);
+  }
+
   async retrieveStripePrice(
     offeringConfigId: string,
     interval: SubplatInterval

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -33,6 +33,7 @@ import { StatsD } from 'hot-shots';
 import Stripe from 'stripe';
 import { FirestoreService } from '../backend/firestore.service';
 import { AppConfig } from '../config';
+import { StripeMapperService } from '@fxa/payments/legacy';
 
 export const StripeFactory: Provider<Stripe> = {
   provide: 'STRIPE',
@@ -122,6 +123,7 @@ export class StripeService extends StripeHelper {
   protected productConfigurationManager?:
     | ProductConfigurationManager
     | undefined;
+  protected stripeMapperService?: StripeMapperService;
 
   constructor(
     configService: ConfigService<AppConfig>,

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2022,6 +2022,14 @@ const convictConf = convict({
       env: 'CMS_ENABLED',
       format: Boolean,
     },
+    legacyMapper: {
+      mapperCacheTTL: {
+        default: 60,
+        doc: 'Strapi client Firestore cache TTL in seconds',
+        env: 'CMS_LEGACY_MAPPER_CACHE_TTL',
+        format: Number,
+      },
+    },
     strapiClient: {
       graphqlApiUri: {
         default: '',

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -83,6 +83,7 @@ import { stripeInvoiceToLatestInvoiceItemsDTO } from './stripe-formatter';
 import { generateIdempotencyKey, roundTime } from './utils';
 import { ProductConfigurationManager } from '@fxa/shared/cms';
 import { reportSentryError, reportSentryMessage } from '../sentry';
+import { StripeMapperService } from '@fxa/payments/legacy';
 
 // Maintains backwards compatibility. Some type defs hoisted to fxa-shared/payments/stripe
 export * from 'fxa-shared/payments/stripe';
@@ -173,6 +174,7 @@ export class StripeHelper extends StripeHelperBase {
   protected override readonly productConfigurationManager?:
     | ProductConfigurationManager
     | undefined;
+  protected override readonly stripeMapperService?: StripeMapperService;
 
   // Note that this isn't quite accurate, as the auth-server logger has some extras
   // attached to it in Hapi.
@@ -242,6 +244,11 @@ export class StripeHelper extends StripeHelperBase {
     if (Container.has(ProductConfigurationManager)) {
       this.productConfigurationManager = Container.get(
         ProductConfigurationManager
+      );
+
+      this.stripeMapperService = new StripeMapperService(
+        this.productConfigurationManager,
+        { ttl: this.config.cms.legacyMapper.mapperCacheTTL }
       );
     }
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -148,6 +148,9 @@ const mockConfig = {
   currenciesToCountries: { ZAR: ['AS', 'CA'] },
   cms: {
     enabled: false,
+    legacyMapper: {
+      mapperCacheTTL: 60,
+    },
   },
 };
 
@@ -3435,6 +3438,7 @@ describe('#integration - StripeHelper', () => {
         getPurchaseWithDetailsOfferingContentByPlanIds: sinon
           .stub()
           .rejects(err),
+        getSupportedLocale: sinon.fake.resolves('en'),
       };
       Container.set(
         ProductConfigurationManager,
@@ -3511,6 +3515,7 @@ describe('#integration - StripeHelper', () => {
       const mockProductConfigurationManager = {
         getPurchaseWithDetailsOfferingContentByPlanIds:
           sinon.fake.resolves(mockCMSConfigUtil),
+        getSupportedLocale: sinon.fake.resolves('en'),
       };
       Container.set(
         ProductConfigurationManager,
@@ -3547,6 +3552,7 @@ describe('#integration - StripeHelper', () => {
       // set container
       const mockProductConfigurationManager = {
         getPurchaseWithDetailsOfferingContentByPlanIds: sinon.fake.resolves(),
+        getSupportedLocale: sinon.fake.resolves('en'),
       };
       Container.set(
         ProductConfigurationManager,


### PR DESCRIPTION
## Because

- The operation mapping Strapi data to Stripe metadata is too expensive for a method that is expected to be fast

## This pull request

- Adds a memory cache decorator to the legacy mapper function

## Issue that this pull request solves

Closes: #FXA-10852

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
