### PR TITLE
fix(settings): Handle invalid code format on 2FA verification

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -29,4 +29,5 @@ auth-error-1010 = Valid password required
 auth-error-1011 = Valid email required
 auth-error-1031 = You must enter your age to sign up
 auth-error-1032 = You must enter a valid age to sign up
+auth-error-1054 = Invalid two-step authentication code
 auth-error-1062 = Invalid redirect

--- a/packages/fxa-settings/src/lib/error-utils.ts
+++ b/packages/fxa-settings/src/lib/error-utils.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { GraphQLError } from 'graphql';
-import * as Sentry from '@sentry/browser'
+import * as Sentry from '@sentry/browser';
 import {
   AuthUiError,
   AuthUiErrorNos,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -192,7 +192,7 @@ describe('signin totp code container', () => {
     expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
     const result = await currentPageProps?.submitTotpCode('123456');
 
-    expect(result?.status).toBeTruthy();
+    expect(result?.error).toBeUndefined();
   });
 
   it('runs keys stretch upgrade when required', async () => {
@@ -212,7 +212,7 @@ describe('signin totp code container', () => {
     expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
     const result = await currentPageProps?.submitTotpCode('123456');
 
-    expect(result?.status).toBeTruthy();
+    expect(result?.error).toBeUndefined();
     expect(tryFinalizeUpgrade).toBeCalled();
   });
 
@@ -223,7 +223,7 @@ describe('signin totp code container', () => {
     expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
 
     const result = await currentPageProps?.submitTotpCode('123456');
-    expect(result?.status).toBeFalsy();
+    expect(result?.error).toEqual(AuthUiErrors.INVALID_TOTP_CODE);
   });
 
   it('handles general error', async () => {
@@ -233,7 +233,6 @@ describe('signin totp code container', () => {
     expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
 
     const result = await currentPageProps?.submitTotpCode('123456');
-    expect(result?.status).toBeFalsy();
     expect(result?.error).toEqual(AuthUiErrors.UNEXPECTED_ERROR);
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/en.ftl
@@ -2,6 +2,7 @@
 ## TOTP (time-based one-time password) is a form of two-factor authentication (2FA).
 ## Users that have set up two-factor authentication land on this page during sign-in.
 
+signin-totp-code-header = Sign in
 signin-totp-code-subheader-v2 = Enter two-step authentication code
 signin-totp-code-instruction-v4 = Check your <strong>authenticator app</strong> to confirm your sign-in.
 signin-totp-code-input-label-v4 = Enter 6-digit code

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -20,7 +20,7 @@ export default {
 } as Meta;
 
 const storyWithProps = (props: {
-  submitTotpCode: () => Promise<{ status: boolean; error?: BeginSigninError }>;
+  submitTotpCode: () => Promise<{ error?: BeginSigninError }>;
   serviceName: MozServices;
   integration?: Integration;
 }) => {
@@ -33,37 +33,25 @@ const storyWithProps = (props: {
 };
 
 export const Default = storyWithProps({
-  submitTotpCode: async () => ({
-    status: true,
-  }),
+  submitTotpCode: async () => ({}),
   serviceName: MozServices.Default,
 });
 
 export const WithOAuthDesktopServiceRelay = storyWithProps({
-  submitTotpCode: async () => ({
-    status: true,
-  }),
+  submitTotpCode: async () => ({}),
   serviceName: MozServices.FirefoxSync,
   integration: mockOAuthNativeIntegration(false),
 });
 
-export const WithRelyingParty = storyWithProps({
-  submitTotpCode: async () => ({
-    status: true,
-  }),
-  serviceName: MozServices.MozillaVPN,
-});
-
 export const WithIncorrectCode = storyWithProps({
   submitTotpCode: async () => ({
-    status: false,
+    error: AuthUiErrors.INVALID_TOTP_CODE as BeginSigninError,
   }),
   serviceName: MozServices.MozillaVPN,
 });
 
-export const WithErrorState = storyWithProps({
+export const WithUnexpectedError = storyWithProps({
   submitTotpCode: async () => ({
-    status: false,
     error: AuthUiErrors.UNEXPECTED_ERROR as BeginSigninError,
   }),
   serviceName: MozServices.MozillaVPN,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/mocks.tsx
@@ -51,9 +51,7 @@ export const MOCK_NON_TOTP_LOCATION_STATE = {
 
 export const mockOauthSigninLocationState = {};
 
-const mockSubmitTotpCode = async () => ({
-  status: true,
-});
+const mockSubmitTotpCode = async () => ({});
 
 export const Subject = ({
   finishOAuthFlowHandler = mockFinishOAuthFlowHandler,


### PR DESCRIPTION
## Because

* Entering an alphanumeric code returned an unexpected error instead of invalid code

## This pull request

* Switch from FormVerifyCode to FormVerifyTotp component
* Add some missing l10n
* Update stories and tests

## Issue that this pull request solves

Closes: #FXA-10072

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
