### PR TITLE
chore(settings): Move remaining SensitveDataClient calls to new function

### DIFF
--- a/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
+++ b/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
@@ -16,7 +16,7 @@ import {
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
 import { deriveHawkCredentials } from 'fxa-auth-client/lib/hawk';
 import { getHandledError } from './error-utils';
-import { SensitiveData, SensitiveDataClient } from './sensitive-data-client';
+import { SensitiveDataClient } from './sensitive-data-client';
 
 export type V1Credentials = {
   authPW: string;
@@ -41,10 +41,7 @@ export async function tryFinalizeUpgrade(
   gqlPasswordChangeFinish: MutationFunction<PasswordChangeFinishResponse>
 ) {
   try {
-    let upgradeData = sensitiveDataClient.getDataType(
-      SensitiveData.Key.KeyStretchUpgrade
-    );
-    if (upgradeData) {
+    if (sensitiveDataClient.KeyStretchUpgradeData) {
       const upgradeClient = new GqlKeyStretchUpgrade(
         stage,
         gqlCredentialStatus,
@@ -54,9 +51,9 @@ export async function tryFinalizeUpgrade(
       );
 
       await upgradeClient.upgrade(
-        upgradeData.email,
-        upgradeData.v1Credentials,
-        upgradeData.v2Credentials,
+        sensitiveDataClient.KeyStretchUpgradeData.email,
+        sensitiveDataClient.KeyStretchUpgradeData.v1Credentials,
+        sensitiveDataClient.KeyStretchUpgradeData.v2Credentials,
         sessionId
       );
       return true;

--- a/packages/fxa-settings/src/lib/sensitive-data-client.ts
+++ b/packages/fxa-settings/src/lib/sensitive-data-client.ts
@@ -4,6 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import { DecryptedRecoveryKeyData } from 'fxa-auth-client/lib/recoveryKey';
 import { V1Credentials, V2Credentials } from './gql-key-stretch-upgrade';
 
 export namespace SensitiveData {
@@ -17,7 +18,7 @@ export namespace SensitiveData {
     AccountReset = 'accountResetData',
     NewRecoveryKey = 'newRecoveryKeyData',
     Password = 'password',
-    KeyStretchUpgrade = 'keyStretchUpgrade'
+    DecryptedRecoveryKey = 'decryptedRecoveryKeyData',
   }
 
   /**
@@ -32,7 +33,7 @@ export namespace SensitiveData {
     accountResetData?: AccountResetData;
     newRecoveryKeyData?: NewRecoveryKeyData;
     password?: Password;
-    keyStretchUpgrade?: KeyStretchUpgradeData;
+    decryptedRecoveryKeyData?: Pick<DecryptedRecoveryKeyData, 'kB'>;
   };
 
   /**
@@ -66,15 +67,6 @@ export namespace SensitiveData {
   export type NewRecoveryKeyData = {
     recoveryKey: Uint8Array;
   };
-
-  /**
-   * Data inserted for the key {@link Key.KeyStretchUpgrade}.
-   */
-  export type KeyStretchUpgradeData = {
-    email: string;
-    v1Credentials: V1Credentials;
-    v2Credentials: V2Credentials;
-  };
 }
 
 /**
@@ -85,12 +77,7 @@ export namespace SensitiveData {
  * @class SensitiveDataClient
  */
 export class SensitiveDataClient {
-  /**
-   * @deprecated
-   */
-  private sensitiveData: { [key: string]: object } = {};
-
-  // TODO: Fast follow, use this pattern instead for simpler and better type safety.
+  // TODO(FXA-10929): Fast follow, use this pattern instead for simpler and better type safety.
   public KeyStretchUpgradeData:
     | {
         email: string;
@@ -104,7 +91,7 @@ export class SensitiveDataClient {
    *
    * @private
    */
-  private newSensitiveData: {
+  private sensitiveData: {
     [key in keyof SensitiveData.DataMap]: SensitiveData.DataMap[key];
   };
 
@@ -115,14 +102,6 @@ export class SensitiveDataClient {
    */
   constructor() {
     this.sensitiveData = {};
-    this.newSensitiveData = {};
-  }
-
-  /**
-   * @deprecated Use {@link setDataType} instead.
-   */
-  setData(key: string, value: any): void {
-    this.sensitiveData[key] = value;
   }
 
   /**
@@ -135,14 +114,7 @@ export class SensitiveDataClient {
     key: T,
     value?: SensitiveData.DataMap[T]
   ): void {
-    this.newSensitiveData[key] = value;
-  }
-
-  /**
-   * @deprecated Use {@link getDataType} instead.
-   */
-  getData(key: string): any {
-    return this.sensitiveData[key];
+    this.sensitiveData[key] = value;
   }
 
   /**
@@ -152,6 +124,6 @@ export class SensitiveDataClient {
    * @returns The corresponding value to the key in the sensitive data object.
    */
   getDataType<T extends SensitiveData.Key>(key: T): SensitiveData.DataMap[T] {
-    return this.newSensitiveData[key];
+    return this.sensitiveData[key];
   }
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
@@ -7,14 +7,18 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import base32Decode from 'base32-decode';
 
 import { decryptRecoveryKeyData } from 'fxa-auth-client/lib/recoveryKey';
-import { useAccount, useSensitiveDataClient } from '../../../models';
-import { useFtlMsgResolver } from '../../../models/hooks';
+import { useAccount } from '../../../models';
+import {
+  useFtlMsgResolver,
+  useSensitiveDataClient,
+} from '../../../models/hooks';
 
 import { AccountRecoveryConfirmKeyLocationState } from './interfaces';
 
 import AccountRecoveryConfirmKey from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
+import { SensitiveData } from '../../../lib/sensitive-data-client';
 
 const AccountRecoveryConfirmKeyContainer = (_: RouteComponentProps) => {
   const [errorMessage, setErrorMessage] = useState('');
@@ -64,7 +68,10 @@ const AccountRecoveryConfirmKeyContainer = (_: RouteComponentProps) => {
       uid
     );
 
-    sensitiveDataClient.setData('reset', { kB });
+    sensitiveDataClient.setDataType(SensitiveData.Key.DecryptedRecoveryKey, {
+      kB,
+    });
+
     navigate('/account_recovery_reset_password', {
       state: {
         accountResetToken: fetchedAccountResetToken,

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -71,11 +71,14 @@ const CompleteResetPasswordContainer = ({
     token,
     accountResetToken,
     emailToHashWith,
-    kB,
     recoveryKeyId,
     recoveryKeyExists,
     estimatedSyncDeviceCount,
   } = location.state as CompleteResetPasswordLocationState;
+
+  const kB = sensitiveDataClient.getDataType(
+    SensitiveData.Key.DecryptedRecoveryKey
+  )?.kB;
 
   const hasConfirmedRecoveryKey = !!(
     accountResetToken &&
@@ -301,13 +304,10 @@ const CompleteResetPasswordContainer = ({
           // we cannot create a new recovery key if the session is not verified
           if (accountResetData.verified) {
             await account.refresh('account');
-            const createRecoveryKeyResult = await account.createRecoveryKey(
-              newPassword
-            );
-            sensitiveDataClient.setData(
-              'newRecoveryKeyData',
-              createRecoveryKeyResult
-            );
+            const recoveryKey = await account.createRecoveryKey(newPassword);
+            sensitiveDataClient.setDataType(SensitiveData.Key.NewRecoveryKey, {
+              recoveryKey,
+            });
           }
 
           handleNavigationWithRecoveryKey(

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/container.tsx
@@ -47,8 +47,13 @@ const ResetPasswordWithRecoveryKeyVerifiedContainer = ({
   const { uid, sessionToken } = currentAccount() || {};
   const { keyFetchToken, unwrapBKey } =
     sensitiveDataClient.getDataType(SensitiveData.Key.AccountReset) || {};
-  const newRecoveryKeyData = sensitiveDataClient.getData('newRecoveryKeyData');
-  const newRecoveryKey = formatRecoveryKey(newRecoveryKeyData.buffer);
+  // We keep the previous non-null assertion on 'newRecoveryKey' here because the
+  // flow dictates we definitely have it. This is not good practice.
+  // TODO: Fix me with FXA-10869.
+  const { recoveryKey } = sensitiveDataClient.getDataType(
+    SensitiveData.Key.NewRecoveryKey
+  )!;
+  const newRecoveryKey = formatRecoveryKey(recoveryKey);
 
   const updateRecoveryKeyHint = useCallback(
     async (hint: string) => account.updateRecoveryKeyHint(hint),

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
@@ -45,7 +45,7 @@ function applyDefaultMocks() {
 }
 
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.setData = jest.fn();
+mockSensitiveDataClient.setDataType = jest.fn();
 let mockHasTotpAuthClient = false;
 let mockSessionStatus = 'verified';
 let mockSendLoginPushRequest = jest.fn().mockResolvedValue({});
@@ -110,7 +110,7 @@ function resetMockSensitiveDataClient() {
   (useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
-  mockSensitiveDataClient.getData = jest.fn().mockReturnValue({
+  mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
     keyFetchToken: MOCK_KEY_FETCH_TOKEN,
     unwrapBKey: MOCK_UNWRAP_BKEY,
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -99,7 +99,7 @@ function resetMockSensitiveDataClient() {
   (useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
-  mockSensitiveDataClient.getData = jest.fn().mockReturnValue({
+  mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
     keyFetchToken: MOCK_KEY_FETCH_TOKEN,
     unwrapBKey: MOCK_UNWRAP_BKEY,
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -139,12 +139,9 @@ function mockVerifyTotp(success: boolean = true, errorOut: boolean = false) {
   ]);
 }
 const mockSensitiveDataClient = createMockSensitiveDataClient();
-mockSensitiveDataClient.getData = jest.fn();
+mockSensitiveDataClient.getDataType = jest.fn();
 function resetMockSensitiveDataClient() {
-  mockSensitiveDataClient.setDataType(
-    SensitiveData.Key.KeyStretchUpgrade,
-    undefined
-  );
+  mockSensitiveDataClient.KeyStretchUpgradeData = undefined;
   (useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
@@ -196,7 +193,7 @@ describe('signin totp code container', () => {
   });
 
   it('runs keys stretch upgrade when required', async () => {
-    mockSensitiveDataClient.setDataType(SensitiveData.Key.KeyStretchUpgrade, {
+    mockSensitiveDataClient.KeyStretchUpgradeData = {
       email: MOCK_EMAIL,
       v1Credentials: {
         authPW: MOCK_AUTH_PW,
@@ -207,7 +204,7 @@ describe('signin totp code container', () => {
         unwrapBKey: MOCK_UNWRAP_BKEY_V2,
         clientSalt: MOCK_CLIENT_SALT,
       },
-    });
+    };
     await render();
     expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
     const result = await currentPageProps?.submitTotpCode('123456');

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
@@ -116,6 +116,7 @@ function mockModelsModule() {
   (ModelsModule.useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
+  mockSensitiveDataClient.KeyStretchUpgradeData = undefined;
   mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
     plainTextPassword: MOCK_PASSWORD,
   });
@@ -186,7 +187,7 @@ describe('signin unblock container', () => {
   });
 
   it('handles signin with with key stretching upgrade', async () => {
-    mockSensitiveDataClient.setDataType(SensitiveData.Key.KeyStretchUpgrade, {
+    mockSensitiveDataClient.KeyStretchUpgradeData = {
       email: MOCK_EMAIL,
       v1Credentials: {
         authPW: MOCK_AUTH_PW,
@@ -197,7 +198,7 @@ describe('signin unblock container', () => {
         unwrapBKey: MOCK_UNWRAP_BKEY_V2,
         clientSalt: MOCK_CLIENT_SALT,
       },
-    });
+    };
 
     await render([
       mockGqlCredentialStatusMutation(),

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -363,11 +363,11 @@ const SigninContainer = ({
             sessionToken
           );
         } else {
-          sensitiveDataClient.setDataType(SensitiveData.Key.KeyStretchUpgrade, {
+          sensitiveDataClient.KeyStretchUpgradeData = {
             email,
             v1Credentials: credentials.v1Credentials,
             v2Credentials: credentials.v2Credentials,
-          });
+          };
         }
       }
 


### PR DESCRIPTION
## Because

- We want to remove the remaining deprecated usages in the SensitiveDataClient.

## This pull request

- Replaces the last few calls to `setData`/`getData` with `setDataType`/`getDataType`.

## Issue that this pull request solves

Closes: FXA-10849

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

n/a

## Other information (Optional)

n/a
