### PR TITLE
feat(phone): Add `available` endpoint for checking for recovery phone

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -309,5 +309,30 @@ describe('/recovery-phone', () => {
       });
       assert.equal(mockGlean.twoStepAuthPhoneRemove.success.callCount, 0);
     });
+
+  });
+
+  describe('POST /recovery-phone/available', async () => {
+    it('should return true if user can setup phone number', async () => {
+      mockRecoveryPhoneService.available = sinon.fake.returns(true);
+
+      const resp = await makeRequest({
+        method: 'POST',
+        path: '/recovery-phone/available',
+        credentials: { uid },
+        geo: {
+          location: {
+            countryCode: 'US',
+          },
+        },
+      });
+
+      assert.deepEqual(resp, { available: true });
+      assert.calledOnceWithExactly(
+        mockRecoveryPhoneService.available,
+        uid,
+        'US'
+      );
+    });
   });
 });


### PR DESCRIPTION
## Because

- We want to be able to query whether or not a user can setup recovery phone

## This pull request

- Adds endpoint `/available` endpoint

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10359

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

@dschom Tagging you for review. If looks good please merge since I'll be out!
