### PR TITLE
bug(settings): Use correct flowId in verifyAccountThirdParty

### DIFF
--- a/libs/shared/metrics/glean/src/lib/metrics.context.ts
+++ b/libs/shared/metrics/glean/src/lib/metrics.context.ts
@@ -29,7 +29,7 @@ export class MetricsContext {
   utmSource?: string;
   utmTerm?: string;
 
-  constructor(queryParams?: Record<string, string>) {
+  constructor(queryParams?: Record<string, string | undefined>) {
     queryParams = queryParams || {};
     this.deviceId = queryParams['deviceId'];
     this.entrypoint = queryParams['entrypoint'];

--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -515,7 +515,7 @@ export function addExperiment(choice: string, group: string) {
  * specific keys but the value is actually a record of all the URL query params.
  */
 export function queryParamsToMetricsContext(
-  queryParams: Record<string, string>
+  queryParams: Record<string, string | undefined>
 ): Partial<MetricsContext> {
   const context = new MetricsContext(queryParams);
   return MetricsContext.prune(context);

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -74,7 +74,7 @@ function mockThirdPartyAuthCallbackIntegration({
     data: { redirectTo: undefined },
     getError: () => getError,
     thirdPartyAuthParams: () => ({ code: 'code', provider: 'provider' }),
-    getFxAParams: () => '?param=value',
+    getFxAParams: () => '?flowId=aaaa&flowBeginTime=1734112296000',
     // TODO, fix this type cast
   } as unknown as ModelsModule.ThirdPartyAuthCallbackIntegration;
 }
@@ -91,7 +91,10 @@ function renderWith(
     flowQueryParams?: QueryParams;
     integration: ModelsModule.Integration;
   } = {
-    flowQueryParams: {},
+    flowQueryParams: {
+      flowId: 'bbbb',
+      flowBeginTime: 1734112296874,
+    },
     integration: mockThirdPartyAuthCallbackIntegration(),
   }
 ) {
@@ -152,12 +155,15 @@ describe('ThirdPartyAuthCallback component', () => {
         'code',
         'provider',
         undefined,
-        expect.any(Object)
+        {
+          flowId: 'aaaa',
+          flowBeginTime: 1734112296000,
+        }
       );
     });
 
     expect(hardNavigateSpy).toBeCalledWith(
-      '/post_verify/third_party_auth/callback?param=value'
+      '/post_verify/third_party_auth/callback?flowId=aaaa&flowBeginTime=1734112296000'
     );
   });
 
@@ -176,7 +182,9 @@ describe('ThirdPartyAuthCallback component', () => {
 
     renderWith({ integration });
 
-    expect(hardNavigateSpy).toBeCalledWith('/?param=value');
+    expect(hardNavigateSpy).toBeCalledWith(
+      '/?flowId=aaaa&flowBeginTime=1734112296000'
+    );
   });
   it('redirects to web redirect', async () => {
     const redirectTo = 'surprisinglyValid!';


### PR DESCRIPTION
## Because

- We encountered a drop in metrics
- We must use the initial flowId we passed to the 3rd party, not the flowId that is generated on page load when the third party directs back to us.

## This pull request

-  Makes sure the relayed flowId and flowBeginTime parameters are used in the metrics context.

## Issue that this pull request solves

Closes: FXA-10851

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
