### PR TITLE
fix(react): Ensure document.body is defined before removing event listener

### DIFF
--- a/packages/fxa-react/lib/hooks.tsx
+++ b/packages/fxa-react/lib/hooks.tsx
@@ -43,7 +43,7 @@ export function useClickOutsideEffect<T>(onClickOutside: Function) {
       }
     };
     document.body.addEventListener('click', onBodyClick);
-    return () => document.body.removeEventListener('click', onBodyClick);
+    return () => document.body?.removeEventListener('click', onBodyClick);
   }, [onClickOutside]);
 
   return insideEl;


### PR DESCRIPTION
Because:
* If users navigate away, document.body might not be defined

This commit:
* Adds an optional '?' chain since 'body' might not exist

fixes FXA-10874