### PR TITLE
task(auth): Add GET /recovery-phone

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1402,7 +1402,7 @@ export class AccountHandler {
       scope = { contains: () => true };
     } else {
       uid = auth.credentials.user;
-      scope = ScopeSet.fromArray(auth.credentials.scope);
+      scope = ScopeSet.fromArray(auth.credentials.scope || []);
     }
 
     const res: Record<string, any> = {};

--- a/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
@@ -16,7 +16,7 @@ export async function handleAuth(
   auth: AuthRequest['auth'],
   fetchEmail = false
 ) {
-  const scope = ScopeSet.fromArray(auth.credentials.scope);
+  const scope = ScopeSet.fromArray(auth.credentials.scope || []);
   if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
@@ -37,7 +37,7 @@ export async function handleAuth(
 }
 
 export function handleUidAuth(auth: AuthRequest['auth']): string {
-  const scope = ScopeSet.fromArray(auth.credentials.scope);
+  const scope = ScopeSet.fromArray(auth.credentials.scope || []);
   if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
@@ -45,7 +45,7 @@ export function handleUidAuth(auth: AuthRequest['auth']): string {
 }
 
 export function handleAuthScoped(auth: AuthRequest['auth'], scopes: string[]) {
-  const scope = ScopeSet.fromArray(auth.credentials.scope);
+  const scope = ScopeSet.fromArray(auth.credentials.scope || []);
   for (const requiredScope of scopes) {
     if (!scope.contains(requiredScope)) {
       throw error.invalidScopes();

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Request, RequestApplicationState } from '@hapi/hapi';
+import { AuthCredentials, Request, RequestApplicationState } from '@hapi/hapi';
 import { Token } from 'typedi';
 import { Logger } from 'mozlog';
 import { ConfigType } from '../config';
@@ -44,11 +44,38 @@ export interface AuthApp extends RequestApplicationState {
   };
 }
 
+// Type declaration for SessionToken found in lib/tokens/session_token.js
+export interface SessionTokenAuthCredential {
+  uid: string;
+  lifetime: number;
+  createdAt: number;
+  email: string | null;
+  emailCode: string | null;
+  emailVerified: boolean;
+  verifierSetAt: number;
+  profileChangedAt: number;
+  keysChangedAt: number;
+  authAt: number;
+  locale: string | null;
+  mustVerify: boolean;
+  tokenVerificationId: string | null;
+  tokenVerified: boolean;
+  verificationMethod: number;
+  verificationMethodValue: string;
+  verifiedAt: number | null;
+  metricsOptOutAt: number | null;
+  providerId: string | null;
+}
+
+export type AuthCredentialsWithScope = AuthCredentials & {
+  scope: string[];
+};
+
 export interface AuthRequest extends Request {
   auth: Request['auth'] & {
     // AuthRequest will always have scopes present provided by
     // the auth-oauth scheme
-    credentials: Request['auth']['credentials'] & { scope: string[] };
+    credentials: AuthCredentialsWithScope | SessionTokenAuthCredential;
   };
   // eslint-disable-next-line no-use-before-define
   log: AuthLogger;

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -47,12 +47,17 @@ describe(`#integration - recovery phone`, function () {
   });
 
   it('confirms a recovery code', async () => {
-    // TODO: Setup test account / twilio emulator
+    // TODO: FXA-10913 Setup test account / twilio emulator
     // TODO: Figure out how to emulate a test code
   });
 
   it('confirms a recovery code', async () => {
-    // TODO: Setup test account / twilio emulator
+    // TODO: FXA-10913 Setup test account / twilio emulator
+    // TODO: Figure out how to emulate a test code
+  });
+
+  it('checks if recovery phone exists', async () => {
+    // TODO: FXA-10913 Setup test account / twilio emulator
     // TODO: Figure out how to emulate a test code
   });
 });


### PR DESCRIPTION
## Because

- We want to provide access to recovery phones that exist and have been confirmed.

## This pull request

- Adds a new end point that checks for the recovery phone
- If session is verified, the response from RecoveryPhoneServices.hasConfirmed is returned.


## Issue that this pull request solves

Closes: FXA-10380

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
