### PR TITLE
chore(dev): Update sync server in check-ports to 8000

### DIFF
--- a/_scripts/ports.txt
+++ b/_scripts/ports.txt
@@ -3,9 +3,8 @@
 4100 # Fake SQS/SNS
 8085 # google-pubsub-emulator
 9090 # google-firestore-emulator
-5000 # sync server
+8000 # sync server
 8001 # cirrus (experimenter)
-8000 # auth-server db mysql
 9000 # auth-server key server
 3030 # content-server
 1111 # profile-server


### PR DESCRIPTION
## Because

- We run the syncstorage-rs on 8000 (fixed in https://github.com/mozilla/fxa/pull/17447) instead of 5000 because it's a port used by a system service on MacOS. Our check-ports script wasn't updated to reflect this when that patch landed.

## This pull request

- Updates the ports.txt list based on the `docker-compose.yaml` and `sync-for-fxa/Dockerfile`.

## Issue that this pull request solves

Closes: FXA-9745

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

n/a

## Other information (Optional)

n/a
