### PR TITLE
fix(strapi): log cache type to statsd

### DIFF
--- a/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
@@ -94,6 +94,7 @@ describe('productConfigurationManager', () => {
         requestEndTime: 1,
         elapsed: 1,
         cache: false,
+        cacheType: 'method',
         query: eligibilityContentByPlanIdsQuery as any,
         error: undefined,
       });
@@ -106,6 +107,7 @@ describe('productConfigurationManager', () => {
           method: 'query',
           error: 'false',
           cache: 'false',
+          cacheType: 'method',
           operationName: 'EligibilityContentByPlanIds',
         }
       );

--- a/libs/shared/cms/src/lib/product-configuration.manager.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.ts
@@ -60,6 +60,7 @@ export class ProductConfigurationManager {
       method: response.method,
       error: response.error ? 'true' : 'false',
       cache: `${response.cache}`,
+      cacheType: `${response.cacheType}`,
     };
     const operationName = response.query && getOperationName(response.query);
     const tags = operationName

--- a/libs/shared/cms/src/lib/strapi.client.ts
+++ b/libs/shared/cms/src/lib/strapi.client.ts
@@ -41,6 +41,7 @@ export interface StrapiClientEventResponse {
   requestEndTime: number;
   elapsed: number;
   cache: boolean;
+  cacheType: 'method' | 'memory' | 'stale' | 'fallback';
   query?: TypedDocumentNode;
   variables?: string;
   error?: Error;


### PR DESCRIPTION
## Because

- We want to see the cache type for Strapi cache requests in statsd

## This pull request

- Logs cache type to statsd