### PR TITLE
fix(payments-next): Checkout page - disable PaymentSection if not signed in

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -134,65 +134,74 @@ export default async function Checkout({
         </>
       )}
 
-      {!session?.user?.email ? (
-        <h2
-          className="font-semibold text-grey-600 text-lg mt-10 mb-5"
-          data-testid="header-prefix"
-        >
-          {l10n.getString(
-            'payment-method-header-second-step-next',
-            '2. Choose your payment method2'
-          )}
-        </h2>
-      ) : (
-        <>
-          <div className="hidden tablet:block">
-            <SignedIn email={session.user.email} />
-          </div>
+      <div
+        className={
+          session
+            ? ''
+            : `cursor-not-allowed relative focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus after:absolute after:content-[""] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10`
+        }
+      >
+        {!session?.user?.email ? (
           <h2
             className="font-semibold text-grey-600 text-lg mt-10 mb-5"
             data-testid="header"
           >
             {l10n.getString(
-              'next-payment-method-header',
-              'Choose your payment method'
+              'payment-method-header-second-step-next',
+              '2. Choose your payment method'
             )}
           </h2>
-        </>
-      )}
-      <h3 className="font-semibold text-grey-600 text-start">
-        {l10n.getString(
-          'next-payment-method-first-approve',
-          'First you’ll need to approve your subscription'
+        ) : (
+          <>
+            <div className="hidden tablet:block">
+              <SignedIn email={session.user.email} />
+            </div>
+            <h2
+              className="font-semibold text-grey-600 text-lg mt-10 mb-5"
+              data-testid="header"
+            >
+              {l10n.getString(
+                'next-payment-method-header',
+                'Choose your payment method'
+              )}
+            </h2>
+          </>
         )}
-      </h3>
+        <h3 className="font-semibold text-grey-600 text-start">
+          {l10n.getString(
+            'next-payment-method-first-approve',
+            'First you’ll need to approve your subscription'
+          )}
+        </h3>
 
-      {/*
+        {/*
         If currency could not be determiend, it is most likely due to an invalid
         or undetermined tax address. Future work will add the Tax Location picker
         which should allow a customer to set their tax location, which would then
         provide a valid currency.
       */}
-      {cart.currency &&
-        cart.taxAddress?.countryCode &&
-        cart.taxAddress?.postalCode && (
-          <PaymentSection
-            cmsCommonContent={cms.commonContent}
-            paymentsInfo={{
-              amount: cart.amount,
-              currency: cart.currency.toLowerCase(),
-            }}
-            cart={{
-              ...cart,
-              currency: cart.currency,
-              taxAddress: {
-                countryCode: cart.taxAddress.countryCode,
-                postalCode: cart.taxAddress.postalCode,
-              },
-            }}
-            locale={locale}
-          />
-        )}
+        {cart.currency &&
+          cart.taxAddress?.countryCode &&
+          cart.taxAddress?.postalCode && (
+            <PaymentSection
+              cmsCommonContent={cms.commonContent}
+              paymentsInfo={{
+                amount: cart.amount,
+                currency: cart.currency.toLowerCase(),
+              }}
+              cart={{
+                ...cart,
+                currency: cart.currency,
+                taxAddress: {
+                  countryCode: cart.taxAddress.countryCode,
+                  postalCode: cart.taxAddress.postalCode,
+                },
+              }}
+              locale={locale}
+              sessionExists={session ? true : false}
+            />
+          )}
+      </div>
     </section>
   );
 }

--- a/libs/payments/ui/src/lib/client/components/CheckoutCheckbox/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutCheckbox/index.tsx
@@ -13,6 +13,7 @@ interface CheckoutCheckboxProps {
   termsOfService: string;
   privacyNotice: string;
   notifyCheckboxChange: (isChecked: boolean) => void;
+  sessionExists: boolean;
 }
 
 export function CheckoutCheckbox({
@@ -20,6 +21,7 @@ export function CheckoutCheckbox({
   termsOfService,
   privacyNotice,
   notifyCheckboxChange,
+  sessionExists,
 }: CheckoutCheckboxProps) {
   // Fluent React Overlays cause hydration issues due to SSR.
   // Using isClient along with the useEffect ensures its only run Client Side
@@ -41,7 +43,7 @@ export function CheckoutCheckbox({
   return (
     <Tooltip.Provider>
       <Tooltip.Root open={isRequired && !isChecked}>
-        <label className="flex gap-5 items-center my-6">
+        <label className="flex gap-5 items-center mx-1 my-6">
           <Tooltip.Trigger asChild>
             <input
               type="checkbox"
@@ -49,6 +51,7 @@ export function CheckoutCheckbox({
               className="grow-0 shrink-0 basis-4 scale-150 cursor-pointer"
               checked={isChecked}
               onChange={changeHandler}
+              tabIndex={sessionExists ? 0 : -1}
               required
               aria-describedby="checkboxError"
               aria-required
@@ -63,6 +66,7 @@ export function CheckoutCheckbox({
                     href={termsOfService}
                     className="text-blue-500 underline"
                     data-testid="link-external-terms-of-service"
+                    tabIndex={sessionExists ? 0 : -1}
                   >
                     Terms of Service
                   </LinkExternal>
@@ -72,6 +76,7 @@ export function CheckoutCheckbox({
                     href={privacyNotice}
                     className="text-blue-500 underline"
                     data-testid="link-external-privacy-notice"
+                    tabIndex={sessionExists ? 0 : -1}
                   >
                     Privacy Notice
                   </LinkExternal>

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -49,12 +49,14 @@ interface CheckoutFormProps {
     };
   };
   locale: string;
+  sessionExists: boolean;
 }
 
 export function CheckoutForm({
   cmsCommonContent,
   cart,
   locale,
+  sessionExists,
 }: CheckoutFormProps) {
   const { l10n } = useLocalization();
   const elements = useElements();
@@ -193,6 +195,7 @@ export function CheckoutForm({
           setFormEnabled(consentCheckbox);
           setShowConsentError(true);
         }}
+        sessionExists={sessionExists}
       />
       <div
         className={
@@ -314,6 +317,7 @@ export function CheckoutForm({
                 className="mt-10 w-full"
                 type="submit"
                 variant={ButtonVariant.Primary}
+                tabIndex={sessionExists ? 0 : -1}
                 aria-disabled={
                   !stripeFieldsComplete || !nonStripeFieldsComplete || loading
                 }

--- a/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
@@ -30,6 +30,7 @@ interface PaymentFormProps {
     };
   };
   locale: string;
+  sessionExists: boolean;
 }
 
 export function PaymentSection({
@@ -37,6 +38,7 @@ export function PaymentSection({
   paymentsInfo,
   cart,
   locale,
+  sessionExists,
 }: PaymentFormProps) {
   return (
     <StripeWrapper
@@ -47,6 +49,7 @@ export function PaymentSection({
         cmsCommonContent={cmsCommonContent}
         cart={cart}
         locale={locale}
+        sessionExists={sessionExists}
       />
     </StripeWrapper>
   );


### PR DESCRIPTION
## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
### Mobile
<img width="335" alt="Screenshot 2024-12-17 at 4 55 26 PM" src="https://github.com/user-attachments/assets/58bdf080-89d7-446e-803a-0d30aaad4903" />

### Tablet
<img width="603" alt="Screenshot 2024-12-17 at 4 58 14 PM" src="https://github.com/user-attachments/assets/fd0cb2c8-4ad0-41e9-95e3-aa0c7f7b40d9" />

### Desktop
<img width="806" alt="Screenshot 2024-12-17 at 4 59 19 PM" src="https://github.com/user-attachments/assets/bc1eaed2-ea6b-48c6-9f26-44c7cfd70625" />
