### PR TITLE
feat(next): disable payment method without account

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -4,6 +4,7 @@
 
 import { headers } from 'next/headers';
 import Image from 'next/image';
+import clsx from 'clsx';
 import {
   BaseButton,
   buildRedirectUrl,
@@ -135,7 +136,11 @@ export default async function Checkout({
 
       {!session?.user?.email ? (
         <h2
-          className="font-semibold text-grey-600 text-lg mt-10 mb-5"
+          className={clsx(
+            'font-semibold text-grey-600 text-lg mt-10 mb-5',
+            !session?.user?.email &&
+              'cursor-not-allowed relative focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus after:absolute after:content-[""] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10 select-none'
+          )}
           data-testid="header-prefix"
         >
           {l10n.getString(
@@ -159,7 +164,13 @@ export default async function Checkout({
           </h2>
         </>
       )}
-      <h3 className="font-semibold text-grey-600 text-start">
+      <h3
+        className={clsx(
+          'font-semibold text-grey-600 text-start',
+          !session?.user?.email &&
+            'cursor-not-allowed relative focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus after:absolute after:content-[""] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10 select-none'
+        )}
+      >
         {l10n.getString(
           'next-payment-method-first-approve',
           'First you’ll need to approve your subscription'

--- a/libs/payments/ui/src/lib/client/components/CheckoutCheckbox/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutCheckbox/index.tsx
@@ -6,10 +6,12 @@
 import { Localized } from '@fluent/react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { useEffect, useState } from 'react';
+import clsx from 'clsx';
 import { LinkExternal } from '@fxa/shared/react';
 
 interface CheckoutCheckboxProps {
   isRequired: boolean;
+  disabled: boolean;
   termsOfService: string;
   privacyNotice: string;
   notifyCheckboxChange: (isChecked: boolean) => void;
@@ -17,6 +19,7 @@ interface CheckoutCheckboxProps {
 
 export function CheckoutCheckbox({
   isRequired,
+  disabled,
   termsOfService,
   privacyNotice,
   notifyCheckboxChange,
@@ -33,98 +36,115 @@ export function CheckoutCheckbox({
   useEffect(() => setIsClient(true), []);
 
   const changeHandler = () => {
+    if (disabled) {
+      return;
+    }
     const newValue = !isChecked;
     setIsChecked(newValue);
     notifyCheckboxChange(newValue);
   };
 
   return (
-    <Tooltip.Provider>
-      <Tooltip.Root open={isRequired && !isChecked}>
-        <label className="flex gap-5 items-center my-6">
-          <Tooltip.Trigger asChild>
-            <input
-              type="checkbox"
-              name="confirm"
-              className="grow-0 shrink-0 basis-4 scale-150 cursor-pointer"
-              checked={isChecked}
-              onChange={changeHandler}
-              required
-              aria-describedby="checkboxError"
-              aria-required
-            />
-          </Tooltip.Trigger>
-          {isClient && (
-            <Localized
-              id="next-payment-confirm-with-legal-links-static-3"
-              elems={{
-                termsOfServiceLink: (
+    <div className={clsx(disabled && 'cursor-not-allowed')}>
+      <Tooltip.Provider>
+        <Tooltip.Root open={isRequired && !isChecked && !disabled}>
+          <label
+            className={clsx(
+              'flex gap-5 items-center my-6',
+              disabled &&
+                'pointer-events-none cursor-not-allowed relative focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus after:absolute after:content-[""] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10 select-none'
+            )}
+          >
+            <Tooltip.Trigger asChild>
+              <input
+                type="checkbox"
+                name="confirm"
+                className="ml-1 grow-0 shrink-0 basis-4 scale-150 cursor-pointer"
+                checked={isChecked}
+                onChange={changeHandler}
+                required
+                aria-describedby="checkboxError"
+                aria-required
+                aria-disabled={disabled}
+                tabIndex={disabled ? -1 : 0}
+              />
+            </Tooltip.Trigger>
+            {isClient && (
+              <Localized
+                id="next-payment-confirm-with-legal-links-static-3"
+                elems={{
+                  termsOfServiceLink: (
+                    <LinkExternal
+                      href={termsOfService}
+                      className="text-blue-500 underline"
+                      data-testid="link-external-terms-of-service"
+                      tabIndex={disabled ? -1 : 0}
+                    >
+                      Terms of Service
+                    </LinkExternal>
+                  ),
+                  privacyNoticeLink: (
+                    <LinkExternal
+                      href={privacyNotice}
+                      className="text-blue-500 underline"
+                      data-testid="link-external-privacy-notice"
+                      tabIndex={disabled ? -1 : 0}
+                    >
+                      Privacy Notice
+                    </LinkExternal>
+                  ),
+                }}
+              >
+                <span className="font-normal text-sm leading-5 block">
+                  I authorize Mozilla to charge my payment method for the amount
+                  shown, according to{' '}
                   <LinkExternal
                     href={termsOfService}
                     className="text-blue-500 underline"
                     data-testid="link-external-terms-of-service"
+                    tabIndex={disabled ? -1 : 0}
                   >
                     Terms of Service
-                  </LinkExternal>
-                ),
-                privacyNoticeLink: (
+                  </LinkExternal>{' '}
+                  and{' '}
                   <LinkExternal
                     href={privacyNotice}
                     className="text-blue-500 underline"
                     data-testid="link-external-privacy-notice"
+                    tabIndex={disabled ? -1 : 0}
                   >
                     Privacy Notice
                   </LinkExternal>
-                ),
-              }}
-            >
-              <span className="font-normal text-sm leading-5 block">
-                I authorize Mozilla to charge my payment method for the amount
-                shown, according to{' '}
-                <LinkExternal
-                  href={termsOfService}
-                  className="text-blue-500 underline"
-                  data-testid="link-external-terms-of-service"
-                >
-                  Terms of Service
-                </LinkExternal>{' '}
-                and{' '}
-                <LinkExternal
-                  href={privacyNotice}
-                  className="text-blue-500 underline"
-                  data-testid="link-external-privacy-notice"
-                >
-                  Privacy Notice
-                </LinkExternal>
-                , until I cancel my subscription.
-              </span>
-            </Localized>
-          )}
-          <Tooltip.Portal>
-            <Tooltip.Content
-              id="checkboxError"
-              className="animate-slide-down z-20"
-              side="bottom"
-              sideOffset={20}
-              align="start"
-              alignOffset={50}
-              arrowPadding={20}
-              role="alert"
-            >
-              <Localized id="next-payment-confirm-checkbox-error">
-                <div className="text-white text-sm bg-alert-red py-1.5 px-4">
-                  You need to complete this before moving forward
-                </div>
+                  , until I cancel my subscription.
+                </span>
               </Localized>
-              <Tooltip.Arrow
-                className="fill-alert-red"
-                height={11}
-                width={22}
-              />
-            </Tooltip.Content>
-          </Tooltip.Portal>
-        </label>
-      </Tooltip.Root>
-    </Tooltip.Provider>
+            )}
+            <Tooltip.Portal>
+              <Tooltip.Content
+                id="checkboxError"
+                className="animate-slide-down z-20"
+                side="bottom"
+                sideOffset={20}
+                align="start"
+                alignOffset={50}
+                arrowPadding={20}
+                role="alert"
+              >
+                <Localized id="next-payment-confirm-checkbox-error">
+                  <div className="text-white text-sm bg-alert-red py-1.5 px-4">
+                    You need to complete this before moving forward
+                  </div>
+                </Localized>
+                <Tooltip.Arrow
+                  className="fill-alert-red"
+                  height={11}
+                  width={22}
+                />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </label>
+        </Tooltip.Root>
+      </Tooltip.Provider>
+    </div>
   );
 }

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -184,6 +184,7 @@ export function CheckoutForm({
     >
       <CheckoutCheckbox
         isRequired={showConsentError}
+        disabled={!cart.uid}
         termsOfService={cmsCommonContent.termsOfServiceUrl}
         privacyNotice={cmsCommonContent.privacyNoticeUrl}
         notifyCheckboxChange={(consentCheckbox) => {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "bn.js": "^5.2.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "clsx": "^2.1.1",
     "diffparser": "^2.0.1",
     "dotenv": "^16.4.5",
     "graphql": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33112,6 +33112,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
+  languageName: node
+  linkType: hard
+
 "cluster-key-slot@npm:^1.1.0":
   version: 1.1.0
   resolution: "cluster-key-slot@npm:1.1.0"
@@ -42300,6 +42307,7 @@ fsevents@~2.1.1:
     bn.js: ^5.2.1
     class-transformer: ^0.5.1
     class-validator: ^0.14.1
+    clsx: ^2.1.1
     diffparser: ^2.0.1
     dotenv: ^16.4.5
     esbuild: ^0.17.15


### PR DESCRIPTION
## Because

- Customers should not be able to enter payment information until they have created or signed into their FxA account

## This pull request

- Adds disabled state to CheckoutCheckbox component
- Adds disabled state to section 2 headers
- Disable CheckoutCheckbox and section 2 headers if current cart does not have an FxA account

## Issue that this pull request solves

Closes: #FXA-10748

Co-authored-by: Lisa Chan <lchan@mozilla.com>

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
