### PR TITLE
fix(next): landing page redirects to internal ip

### DIFF
--- a/apps/payments/next/.env
+++ b/apps/payments/next/.env
@@ -109,6 +109,6 @@ CONTENT_SERVER_CLIENT_CONFIG__URL=http://localhost:3030
 # Other
 CONTENT_SERVER_URL=http://localhost:3030
 SUPPORT_URL=https://support.mozilla.org
-BASE_URL=http://localhost:3035
+PAYMENTS_NEXT_HOSTED_URL=http://localhost:3035
 
 # Nextjs Public Environment Variables

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -63,7 +63,11 @@ export default async function Checkout({
     params.interval,
     'new',
     'checkout',
-    { baseUrl: config.baseUrl, locale: params.locale, searchParams }
+    {
+      baseUrl: config.paymentsNextHostedUrl,
+      locale: params.locale,
+      searchParams,
+    }
   );
 
   return (

--- a/apps/payments/next/app/[locale]/error/auth/signin/page.tsx
+++ b/apps/payments/next/app/[locale]/error/auth/signin/page.tsx
@@ -28,11 +28,17 @@ export default async function Error({
 }) {
   const fallbackErrorPagePath = '/error';
 
+  // TODO: Consider adding this logic to signing callback for the provider
   if (searchParams?.error !== 'OAuthCallbackError') {
     redirect(fallbackErrorPagePath);
   }
   const cookieStore = cookies();
-  const redirectUrl = cookieStore.get('authjs.callback-url');
+  // Not ideal, however this is the most up to date work around I've been
+  // able to find thus far. For more background, see the link below.
+  // https://github.com/nextauthjs/next-auth/issues/4301
+  const redirectUrl =
+    cookieStore.get('__Secure-authjs.callback-url') ||
+    cookieStore.get('authjs.callback-url');
 
   if (redirectUrl?.value) {
     redirect(`${redirectUrl.value}`);

--- a/apps/payments/next/config/index.ts
+++ b/apps/payments/next/config/index.ts
@@ -111,7 +111,7 @@ export class PaymentsNextConfig extends NestAppRootConfig {
   contentServerUrl!: string;
 
   @IsUrl({ require_tld: false })
-  baseUrl!: string;
+  paymentsNextHostedUrl!: string;
 
   /**
    * Nextjs Public Environment Variables

--- a/libs/payments/ui/src/lib/utils/types.ts
+++ b/libs/payments/ui/src/lib/utils/types.ts
@@ -10,9 +10,12 @@ export enum SupportedPages {
   ERROR = 'error',
 }
 
-export type CheckoutParams = {
-  cartId: string;
+export interface BaseParams {
   locale: string;
   interval: string;
   offeringId: string;
-};
+}
+
+export interface CheckoutParams extends BaseParams {
+  cartId: string;
+}

--- a/libs/payments/ui/src/server.ts
+++ b/libs/payments/ui/src/server.ts
@@ -12,3 +12,4 @@ export * from './lib/server/components/SignedIn';
 export * from './lib/server/components/SubscriptionTitle';
 export * from './lib/server/components/TermsAndPrivacy';
 export * from './lib/utils/types';
+export * from './lib/utils/getIpAddress';


### PR DESCRIPTION
## Because

- On hosted environments the landing page redirects to internal localhost domain instead of the external domain.

## This pull request

- Do not use Next.js request.nextUrl to determine the URL domain for redirects.
- Builds the redirect using config.paymentsNextHostedUrl to determine the domain.
- Rename BASE_URL to PAYMENTS_NEXT_HOSTED_URL

## Issue that this pull request solves

Closes: #FXA-10817

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).