### PR TITLE
chore(circleci): remove playwright-functional-tests-chromium from the nightly build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1357,12 +1357,6 @@ workflows:
           parallelism: 8
           requires:
             - Build (nightly)
-      - playwright-functional-tests-chromium:
-          name: Chromium Functional Tests - Playwright (nightly)
-          resource_class: xlarge
-          parallelism: 8
-          requires:
-            - Build (nightly)
       - playwright-functional-test-report:
           name: Merge Playwright Reports (nightly)
           requires:
@@ -1382,7 +1376,6 @@ workflows:
             - Integration Test - Libraries (nightly)
             - Firefox Functional Tests - Playwright (nightly)
             - Check all required jobs are complete (nightly)
-            - Chromium Functional Tests - Playwright (nightly)
       - build-and-deploy-storybooks:
           name: Deploy Storybooks (nightly)
           requires:


### PR DESCRIPTION
## Because

- Chromium tests have been failing in Nightly, and there is limited capacity to address the failures.

## This pull request

- Removes the tests from nightly to be re-evaluated in 2025

## Issue that this pull request solves

Relates To: #FXA-10806

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
