### PR TITLE
fix(next): display correct list amount

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -255,6 +255,7 @@ describe('CartService', () => {
 
     it('throws an error when couponCode is invalid', async () => {
       const mockAccount = AccountFactory();
+      const mockResolvedCurrency = faker.finance.currencyCode();
 
       jest
         .spyOn(promotionCodeManager, 'assertValidPromotionCodeNameForPrice')
@@ -263,6 +264,9 @@ describe('CartService', () => {
       jest
         .spyOn(accountManager, 'getAccounts')
         .mockResolvedValue([mockAccount]);
+      jest
+        .spyOn(currencyManager, 'getCurrencyForCountry')
+        .mockReturnValue(mockResolvedCurrency);
 
       await expect(() => cartService.setupCart(args)).rejects.toThrowError(
         CartInvalidPromoCodeError
@@ -709,6 +713,7 @@ describe('CartService', () => {
       );
       expect(invoiceManager.previewUpcoming).toHaveBeenCalledWith({
         priceId: mockPrice.id,
+        currency: mockCart.currency,
         customer: mockCustomer,
         taxAddress: mockCart.taxAddress,
       });
@@ -772,6 +777,7 @@ describe('CartService', () => {
       );
       expect(invoiceManager.previewUpcoming).toHaveBeenCalledWith({
         priceId: mockPrice.id,
+        currency: mockCart.currency,
         customer: mockCustomer,
         taxAddress: mockCart.taxAddress,
       });
@@ -810,6 +816,7 @@ describe('CartService', () => {
       expect(customerManager.retrieve).not.toHaveBeenCalled();
       expect(invoiceManager.previewUpcoming).toHaveBeenCalledWith({
         priceId: mockPrice.id,
+        currency: mockCart.currency,
         customer: undefined,
         taxAddress: mockCart.taxAddress,
       });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -162,6 +162,7 @@ export class CheckoutService {
 
     const upcomingInvoice = await this.invoiceManager.previewUpcoming({
       priceId: price.id,
+      currency: cart.currency,
       customer: customer,
       taxAddress: taxAddress,
     });

--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -47,11 +47,13 @@ export class InvoiceManager {
 
   async previewUpcoming({
     priceId,
+    currency,
     customer,
     taxAddress,
     couponCode,
   }: {
     priceId: string;
+    currency: string;
     customer?: StripeCustomer;
     taxAddress?: TaxAddress;
     couponCode?: string;
@@ -81,6 +83,7 @@ export class InvoiceManager {
         : undefined;
 
     const requestObject: Stripe.InvoiceRetrieveUpcomingParams = {
+      currency,
       customer: customer?.id,
       automatic_tax: {
         enabled: automaticTax,

--- a/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
+++ b/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
@@ -25,7 +25,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     const result = stripeInvoiceToInvoicePreviewDTO(mockUpcomingInvoice);
     expect(result).toEqual({
       currency: mockUpcomingInvoice.currency,
-      listAmount: mockUpcomingInvoice.amount_due,
+      listAmount: mockUpcomingInvoice.subtotal,
       totalAmount: mockUpcomingInvoice.total,
       taxAmounts: [
         {
@@ -57,7 +57,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     const result = stripeInvoiceToInvoicePreviewDTO(mockUpcomingInvoice);
     expect(result).toEqual({
       currency: mockUpcomingInvoice.currency,
-      listAmount: mockUpcomingInvoice.amount_due,
+      listAmount: mockUpcomingInvoice.subtotal,
       totalAmount: mockUpcomingInvoice.total,
       taxAmounts: [
         {
@@ -89,7 +89,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
     const result = stripeInvoiceToInvoicePreviewDTO(mockUpcomingInvoice);
     expect(result).toEqual({
       currency: mockUpcomingInvoice.currency,
-      listAmount: mockUpcomingInvoice.amount_due,
+      listAmount: mockUpcomingInvoice.subtotal,
       totalAmount: mockUpcomingInvoice.total,
       taxAmounts: [
         {

--- a/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
+++ b/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
@@ -26,7 +26,7 @@ export function stripeInvoiceToInvoicePreviewDTO(
 
   return {
     currency: invoice.currency,
-    listAmount: invoice.amount_due,
+    listAmount: invoice.subtotal,
     totalAmount: invoice.total,
     taxAmounts,
     discountAmount,

--- a/libs/payments/ui/src/lib/server/components/PriceInterval/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/PriceInterval/index.tsx
@@ -18,8 +18,8 @@ export async function PriceInterval(props: PriceIntervalProps) {
   return l10n.getString(
     `plan-price-interval-${interval}`,
     {
-      amount: l10n.getLocalizedCurrency(totalAmount || listAmount, currency),
+      amount: l10n.getLocalizedCurrency(totalAmount ?? listAmount, currency),
     },
-    formatPlanPricing(totalAmount || listAmount, currency, interval)
+    formatPlanPricing(totalAmount ?? listAmount, currency, interval)
   );
 }


### PR DESCRIPTION
## Because

- List amount should not include exclusive tax.

## This pull request

- Changes list amount to invoice.subtotal in DTO, to support inclusive and exclusive tax amounts.
- Adds currency to invoice preview
- Explicitly set a default currency to USD as a temporary solution.

## Issue that this pull request solves

Closes: #FXA-10899

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

### Exclusive Tax
![image](https://github.com/user-attachments/assets/bda6af65-bd07-4b70-bf7e-ecf48f2a8871)

![image](https://github.com/user-attachments/assets/e65953e7-a486-4dfd-9d34-fca335ed939b)

![image](https://github.com/user-attachments/assets/27e5d3b3-94b2-4172-8c51-dc8dcaaae19e)

### Inclusive Tax
![image](https://github.com/user-attachments/assets/5e786e9c-e6d9-4ab0-aef6-e28638671856)

![image](https://github.com/user-attachments/assets/612e2f35-e140-44a9-8f3d-e15c1fe8597b)

