### PR TITLE
feat(shared): SanitizeExceptions decorator

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -96,6 +96,18 @@ import { NeedsInputType } from './cart.types';
 import { redirect } from 'next/navigation';
 
 jest.mock('next/navigation');
+jest.mock('@fxa/shared/error', () => ({
+  ...jest.requireActual('@fxa/shared/error'),
+  SanitizeExceptions: jest.fn(({ allowlist = [] } = {}) => {
+    return function (
+      target: any,
+      propertyKey: string,
+      descriptor: PropertyDescriptor
+    ) {
+      return descriptor;
+    };
+  }),
+}));
 
 describe('CartService', () => {
   let accountManager: AccountManager;

--- a/libs/payments/customer/project.json
+++ b/libs/payments/customer/project.json
@@ -50,14 +50,6 @@
         "jestConfig": "libs/payments/customer/jest.config.ts",
         "testPathPattern": ["^(?!.*\\.in\\.spec\\.ts$).*$"]
       }
-    },
-    "test-integration": {
-      "executor": "@nx/jest:jest",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
-      "options": {
-        "jestConfig": "libs/payments/customer/jest.config.ts",
-        "testPathPattern": ["\\.in\\.spec\\.ts$"]
-      }
     }
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -26,6 +26,7 @@ import { FinalizeProcessingCartActionArgs } from './validators/finalizeProcessin
 import { SubmitNeedsInputActionArgs } from './validators/SubmitNeedsInputActionArgs';
 import { GetNeedsInputActionArgs } from './validators/GetNeedsInputActionArgs';
 import { ValidatePostalCodeArgs } from './validators/ValidatePostalCodeArgs';
+import { SanitizeExceptions } from '@fxa/shared/error';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -102,6 +103,7 @@ export class NextJSActionsService {
     await this.cartService.finalizeProcessingCart(args.cartId);
   }
 
+  @SanitizeExceptions()
   async getPayPalCheckoutToken(args: GetPayPalCheckoutTokenArgs) {
     await new Validator().validateOrReject(args);
 
@@ -132,6 +134,7 @@ export class NextJSActionsService {
     );
   }
 
+  @SanitizeExceptions()
   async fetchCMSData(args: FetchCMSDataArgs) {
     await new Validator().validateOrReject(args);
 
@@ -143,6 +146,7 @@ export class NextJSActionsService {
     return offering;
   }
 
+  @SanitizeExceptions()
   async recordEmitterEvent(args: RecordEmitterEventArgs) {
     await new Validator().validateOrReject(args);
 
@@ -183,10 +187,12 @@ export class NextJSActionsService {
     return await this.cartService.submitNeedsInput(args.cartId);
   }
 
+  @SanitizeExceptions()
   async getMetricsFlow() {
     return this.contentServerManager.getMetricsFlow();
   }
 
+  @SanitizeExceptions()
   async validatePostalCode(args: ValidatePostalCodeArgs) {
     await new Validator().validateOrReject(args);
 

--- a/libs/shared/error/src/index.ts
+++ b/libs/shared/error/src/index.ts
@@ -2,3 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 export { BaseError, BaseMultiError, TypeError } from './lib/error';
+export { SanitizeExceptions } from './lib/sanitizeExceptionsDecorator';

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.spec.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.spec.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { SanitizeExceptions } from './sanitizeExceptionsDecorator';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
+
+// Mock Sentry
+jest.mock('@sentry/nextjs', () => ({
+  withScope: jest.fn((callback) => callback({ setExtra: jest.fn() })),
+  captureException: jest.fn(),
+}));
+
+class SensitiveError extends Error {
+  public subtype: string;
+  constructor(message: string) {
+    super(message);
+    this.subtype = 'SensitiveError';
+  }
+}
+
+class AcceptableError extends Error {
+  public subtype: string;
+  constructor(message: string) {
+    super(message);
+    this.subtype = 'AcceptableError';
+  }
+}
+
+class MockService {
+  @SanitizeExceptions({ allowlist: [AcceptableError] })
+  throwSensitiveError() {
+    throw new SensitiveError('Sensitive error');
+  }
+
+  @SanitizeExceptions({ allowlist: [AcceptableError] })
+  async throwSensitiveErrorAsync() {
+    throw new SensitiveError('Sensitive error');
+  }
+
+  @SanitizeExceptions({ allowlist: [AcceptableError] })
+  throwAcceptableError() {
+    throw new AcceptableError('Acceptable error');
+  }
+
+  @SanitizeExceptions({ allowlist: [AcceptableError] })
+  async throwAcceptableErrorAsync() {
+    throw new AcceptableError('Acceptable error');
+  }
+}
+
+describe('SanitizeExceptions Decorator', () => {
+  let service: MockService;
+  let mockLogger: { error: jest.Mock; info: jest.Mock };
+
+  beforeEach(async () => {
+    mockLogger = {
+      error: jest.fn(),
+      info: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MockService,
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    service = module.get<MockService>(MockService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('synchronous methods', () => {
+    it('should pass acceptable errors through', () => {
+      expect(() => service.throwAcceptableError()).toThrow(AcceptableError);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Error caught by SanitizeExceptions decorator',
+        expect.any(AcceptableError)
+      );
+    });
+
+    it('should sanitize sensitive errors', () => {
+      expect(() => service.throwSensitiveError()).toThrow(
+        'Something went wrong'
+      );
+      expect(() => service.throwSensitiveError()).not.toThrow(SensitiveError);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Error caught by SanitizeExceptions decorator',
+        expect.any(SensitiveError)
+      );
+    });
+  });
+
+  describe('asynchronous methods', () => {
+    it('should pass acceptable errors through', async () => {
+      await expect(service.throwAcceptableErrorAsync()).rejects.toThrow(
+        AcceptableError
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Error caught by SanitizeExceptions decorator',
+        expect.any(AcceptableError)
+      );
+    });
+
+    it('should sanitize sensitive errors', async () => {
+      await expect(service.throwSensitiveErrorAsync()).rejects.toThrow(
+        'Something went wrong'
+      );
+      await expect(service.throwSensitiveErrorAsync()).rejects.not.toThrow(
+        SensitiveError
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Error caught by SanitizeExceptions decorator',
+        expect.any(SensitiveError)
+      );
+    });
+  });
+});

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/nextjs';
+import { Inject } from '@nestjs/common';
+import { ILogger } from '@fxa/shared/log';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
+
+type Constructor<T> = new (...args: any[]) => T;
+
+/**
+ * A method decorator that provides error handling with Sentry reporting and error sanitization.
+ * The logger is injected via NestJS DI.
+ * @param allowlist An optional list of error classes that should be passed to the client unaltered
+ * @returns PropertyDecorator
+ */
+export function SanitizeExceptions(
+  { allowlist }: { allowlist: Constructor<Error>[] } = { allowlist: [] }
+) {
+  const injectLogger = Inject(LOGGER_PROVIDER);
+
+  return function (
+    target: any,
+    propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    injectLogger(target, 'logger');
+
+    const originalMethod = descriptor.value;
+    const isAsync = originalMethod.constructor.name === 'AsyncFunction';
+
+    descriptor.value = isAsync
+      ? async function (this: any, ...args: any[]) {
+          try {
+            const result = await originalMethod.apply(this, args);
+            return result;
+          } catch (error) {
+            throw handleException(error as Error, allowlist, this.logger);
+          }
+        }
+      : function (this: any, ...args: any[]) {
+          try {
+            return originalMethod.apply(this, args);
+          } catch (error) {
+            throw handleException(error as Error, allowlist, this.logger);
+          }
+        };
+
+    return descriptor;
+  };
+}
+
+function handleException(
+  error: Error,
+  allowlist: Constructor<Error>[],
+  logger: ILogger
+): Error {
+  logger.error('Error caught by SanitizeExceptions decorator', error);
+
+  const isAllowedError =
+    error instanceof Error &&
+    allowlist.some((ErrorClass) => {
+      const isInstance = error instanceof ErrorClass;
+      return isInstance;
+    });
+
+  if (!isAllowedError) {
+    return new Error('Something went wrong');
+  } else {
+    Sentry.withScope((scope) => {
+      scope.setExtra('sanitizedBeforeSend', !isAllowedError);
+      Sentry.captureException(error);
+    });
+    return error;
+  }
+}


### PR DESCRIPTION
## Because

- In instances where the client can call methods "directly" (such as via NextJS Server Actions), we need to ensure that the only data that gets passed through to the user is what is intended. Error propagation is a common way for unexpected data to leak to the user.

## This pull request

- Adds a SanitizeExceptions decorator to libs/shared/error that wraps a class, and captures any errors thrown by its methods. Unless specified, errors are replaced with a generic error message. Original error data is sent to Sentry, along with a data tag to indicate whether it was sanitized or passed through.

## Issue that this pull request solves

Closes: [FXA-10626](https://mozilla-hub.atlassian.net/browse/FXA-10626)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

[FXA-10626]: https://mozilla-hub.atlassian.net/browse/FXA-10626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ