### PR TITLE
task(auth): Add environment to totp service name

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1652,7 +1652,7 @@ const convictConf = convict({
       env: 'SENTRY_DSN',
     },
     env: {
-      doc: 'Environment name to report to sentry',
+      doc: 'Environment name to report to sentry. This is the most reliable way to determine the active environment.',
       default: 'local',
       format: ['local', 'ci', 'dev', 'stage', 'prod'],
       env: 'SENTRY_ENV',

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -173,7 +173,8 @@ module.exports = function (
     customs,
     config.totp,
     glean,
-    profile
+    profile,
+    config.sentry.env
   );
   const recoveryCodes = require('./recovery-codes')(
     log,

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -19,7 +19,16 @@ const { RecoveryPhoneService } = require('@fxa/accounts/recovery-phone');
 
 const RECOVERY_CODE_SANE_MAX_LENGTH = 20;
 
-module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
+module.exports = (
+  log,
+  db,
+  mailer,
+  customs,
+  config,
+  glean,
+  profileClient,
+  environment
+) => {
   const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
 
   // Currently, QR codes are rendered with the highest possible
@@ -37,6 +46,12 @@ module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
 
   const accountEventsManager = Container.get(AccountEventsManager);
   const recoveryPhoneService = Container.get(RecoveryPhoneService);
+
+  // This helps us distinguish between testing environments and
+  // totp codes per environment.
+  const service = !environment?.startsWith('prod')
+    ? `${config.serviceName} - ${environment}`
+    : `${config.serviceName}`;
 
   return [
     {
@@ -106,7 +121,7 @@ module.exports = (log, db, mailer, customs, config, glean, profileClient) => {
 
         const otpauth = authenticator.keyuri(
           sessionToken.email,
-          config.serviceName,
+          service,
           secret
         );
 


### PR DESCRIPTION
## Because

- We want to be able to distinguish the environment that generated the totp entries

## This pull request

- Append the environment name to the service provided to `authenticator.keyuri`

## Issue that this pull request solves

Closes: FXA-10834

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
