### PR TITLE
task(recovery-phone): Add lookup data to registered numbers

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -20,6 +20,7 @@ describe('RecoveryPhoneService', () => {
 
   const mockSmsManager = {
     sendSMS: jest.fn(),
+    phoneNumberLookup: jest.fn(),
   };
   const mockRecoveryPhoneManager = {
     storeUnconfirmed: jest.fn(),
@@ -184,6 +185,9 @@ describe('RecoveryPhoneService', () => {
         phoneNumber,
       });
       mockRecoveryPhoneManager.registerPhoneNumber.mockResolvedValue({});
+      mockSmsManager.phoneNumberLookup.mockResolvedValueOnce({
+        phoneNumber: '+15005550000',
+      });
 
       const result = await service.confirmCode(uid, code);
 
@@ -191,7 +195,8 @@ describe('RecoveryPhoneService', () => {
       expect(mockRecoveryPhoneManager.getUnconfirmed).toBeCalledWith(uid, code);
       expect(mockRecoveryPhoneManager.registerPhoneNumber).toBeCalledWith(
         uid,
-        phoneNumber
+        phoneNumber,
+        { phoneNumber: '+15005550000' }
       );
     });
 

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -101,9 +101,13 @@ export class RecoveryPhoneService {
 
     // If this was for a setup operation. Register the phone number to the uid.
     if (data.isSetup === true) {
+      const lookupData = await this.smsManager.phoneNumberLookup(
+        data.phoneNumber
+      );
       await this.recoveryPhoneManager.registerPhoneNumber(
         uid,
-        data.phoneNumber
+        data.phoneNumber,
+        lookupData
       );
     }
 

--- a/libs/accounts/recovery-phone/src/lib/sms.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/sms.manager.ts
@@ -20,6 +20,15 @@ export class SmsManager {
     private readonly config: SmsManagerConfig
   ) {}
 
+  public async phoneNumberLookup(phoneNumber: string) {
+    const result = await this.client.lookups.v2
+      .phoneNumbers(phoneNumber)
+      .fetch();
+    // Calling toJSON converts PhoneNumberInstance into a
+    // object that just holds state and can be serialized.
+    return result.toJSON();
+  }
+
   public async sendSMS({ to, body }: { to: string; body: string }) {
     if (body.length > this.config.maxMessageLength) {
       throw new Error(


### PR DESCRIPTION
## Because

- Lookup data has extra info that could be helpful down the road. e.g Info about sim swapping.

## This pull request

- Calls the Twilio API to get lookup data
- Stores data in DB

## Issue that this pull request solves

Closes: FXA-10727

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
