### PR TITLE
task(auth): Setup up customs for recovery phone operations

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -355,6 +355,22 @@ export default class AuthClient {
     );
   }
 
+  private async sessionDelete(
+    path: string,
+    sessionToken: hexstring,
+    payload: object,
+    headers?: Headers
+  ) {
+    return this.hawkRequest(
+      'DELETE',
+      path,
+      sessionToken,
+      tokenType.sessionToken,
+      payload,
+      headers
+    );
+  }
+
   /**
    * Allows us to toggle the key stretch version.
    * @param version
@@ -2242,6 +2258,54 @@ export default class AuthClient {
       {},
       headers
     );
+  }
+
+  async recoveryPhoneCreate(
+    sessionToken: string,
+    phoneNumber: string,
+    headers?: Headers
+  ) {
+    return this.sessionPost(
+      '/recovery-phone/create',
+      sessionToken,
+      { phoneNumber },
+      headers
+    );
+  }
+
+  async recoveryPhoneAvailable(sessionToken: string, headers?: Headers) {
+    return this.sessionPost(
+      '/recovery-phone/available',
+      sessionToken,
+      {},
+      headers
+    );
+  }
+
+  async recoveryPhoneConfirm(
+    sessionToken: string,
+    code: string,
+    headers?: Headers
+  ) {
+    return this.sessionPost(
+      '/recovery-phone/available',
+      sessionToken,
+      { code },
+      headers
+    );
+  }
+
+  async recoveryPhoneSendCode(sessionToken: string, headers?: Headers) {
+    return this.sessionPost(
+      '/recovery-phone/send_code',
+      sessionToken,
+      {},
+      headers
+    );
+  }
+
+  async recoveryPhoneDelete(sessionToken: string, headers?: Headers) {
+    return this.sessionDelete('/recovery-phone', sessionToken, {}, headers);
   }
 
   protected async getPayloadV2({

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -21,9 +21,13 @@ chai.use(chaiAsPromised);
 describe('/recovery-phone', () => {
   const sandbox = sinon.createSandbox();
   const uid = '123435678123435678123435678123435678';
+  const email = 'test@mozilla.com';
   const phoneNumber = '+15550005555';
   const code = '000000';
   const mockLog = {};
+  const mockCustoms = {
+    check: sandbox.fake(),
+  };
   const mockGlean = {
     twoStepAuthPhoneCode: {
       sent: sandbox.fake(),
@@ -44,7 +48,7 @@ describe('/recovery-phone', () => {
 
   before(() => {
     Container.set(RecoveryPhoneService, mockRecoveryPhoneService);
-    routes = recoveryPhoneRoutes(mockLog, mockGlean);
+    routes = recoveryPhoneRoutes(mockCustoms, mockLog, mockGlean);
   });
 
   afterEach(() => {
@@ -64,7 +68,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'POST',
         path: '/recovery-phone/send_code',
-        credentials: { uid },
+        credentials: { uid, email },
       });
 
       assert.isDefined(resp);
@@ -74,6 +78,13 @@ describe('/recovery-phone', () => {
 
       assert.equal(mockGlean.twoStepAuthPhoneCode.sent.callCount, 1);
       assert.equal(mockGlean.twoStepAuthPhoneCode.sendError.callCount, 0);
+
+      assert.equal(mockCustoms.check.callCount, 1);
+      assert.equal(mockCustoms.check.getCall(0).args[1], email);
+      assert.equal(
+        mockCustoms.check.getCall(0).args[2],
+        'recoveryPhoneSendCode'
+      );
     });
 
     it('handles failure to send recovery phone code', async () => {
@@ -82,7 +93,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'POST',
         path: '/recovery-phone/send_code',
-        credentials: { uid },
+        credentials: { uid, email },
       });
 
       assert.isDefined(resp);
@@ -102,7 +113,7 @@ describe('/recovery-phone', () => {
       const promise = makeRequest({
         method: 'POST',
         path: '/recovery-phone/send_code',
-        credentials: { uid },
+        credentials: { uid, email },
       });
 
       await assert.isRejected(promise, 'A backend service request failed.');
@@ -126,7 +137,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'POST',
         path: '/recovery-phone/create',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { phoneNumber },
       });
 
@@ -143,6 +154,10 @@ describe('/recovery-phone', () => {
       );
       assert.equal(mockGlean.twoStepAuthPhoneCode.sent.callCount, 1);
       assert.equal(mockGlean.twoStepAuthPhoneCode.sendError.callCount, 0);
+
+      assert.equal(mockCustoms.check.callCount, 1);
+      assert.equal(mockCustoms.check.getCall(0).args[1], email);
+      assert.equal(mockCustoms.check.getCall(0).args[2], 'recoveryPhoneCreate');
     });
 
     it('indicates failure sending sms', async () => {
@@ -151,7 +166,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'POST',
         path: '/recovery-phone/create',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { phoneNumber: 'invalid' },
       });
 
@@ -169,7 +184,7 @@ describe('/recovery-phone', () => {
       const promise = makeRequest({
         method: 'POST',
         path: '/recovery-phone/create',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { phoneNumber: '+495550005555' },
       });
 
@@ -186,7 +201,7 @@ describe('/recovery-phone', () => {
       const promise = makeRequest({
         method: 'POST',
         path: '/recovery-phone/create',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { phoneNumber },
       });
 
@@ -224,7 +239,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'POST',
         path: '/recovery-phone/confirm',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { code },
       });
 
@@ -247,7 +262,7 @@ describe('/recovery-phone', () => {
       const promise = makeRequest({
         method: 'POST',
         path: '/recovery-phone/confirm',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { code },
       });
 
@@ -262,7 +277,7 @@ describe('/recovery-phone', () => {
       const promise = makeRequest({
         method: 'POST',
         path: '/recovery-phone/confirm',
-        credentials: { uid },
+        credentials: { uid, email },
         payload: { code },
       });
 
@@ -278,7 +293,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'DELETE',
         path: '/recovery-phone',
-        credentials: { uid },
+        credentials: { uid, email },
       });
 
       assert.isDefined(resp);
@@ -297,7 +312,7 @@ describe('/recovery-phone', () => {
       const promise = makeRequest({
         method: 'DELETE',
         path: '/recovery-phone',
-        credentials: { uid },
+        credentials: { uid, email },
       });
 
       await assert.isRejected(promise, 'A backend service request failed.');
@@ -309,7 +324,7 @@ describe('/recovery-phone', () => {
       await makeRequest({
         method: 'DELETE',
         path: '/recovery-phone',
-        credentials: { uid },
+        credentials: { uid, email },
       });
       assert.equal(mockGlean.twoStepAuthPhoneRemove.success.callCount, 0);
     });
@@ -322,7 +337,7 @@ describe('/recovery-phone', () => {
       const resp = await makeRequest({
         method: 'POST',
         path: '/recovery-phone/available',
-        credentials: { uid },
+        credentials: { uid, email },
         geo: {
           location: {
             countryCode: 'US',
@@ -335,6 +350,13 @@ describe('/recovery-phone', () => {
         mockRecoveryPhoneService.available,
         uid,
         'US'
+      );
+
+      assert.equal(mockCustoms.check.callCount, 1);
+      assert.equal(mockCustoms.check.getCall(0).args[1], email);
+      assert.equal(
+        mockCustoms.check.getCall(0).args[2],
+        'recoveryPhoneAvailable'
       );
     });
   });

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -60,4 +60,9 @@ describe(`#integration - recovery phone`, function () {
     // TODO: FXA-10913 Setup test account / twilio emulator
     // TODO: Figure out how to emulate a test code
   });
+
+  it('stops excessive calls', async () => {
+    // TODO: FXA-10913 Setup test account / twilio emulator
+    // TODO: Figure out how to enable and trigger customs for remote tests.
+  });
 });

--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -24,6 +24,7 @@ const CODE_VERIFYING_ACTION = {
   // changes at 60 seconds
   // limits by email
   verifyTotpCode: true,
+  recoveryPhoneConfirm: true,
 };
 
 // Actions that, if allowed, would allow an attacker
@@ -42,6 +43,7 @@ const ACCOUNT_STATUS_ACTION = {
   recoveryKeyExists: true,
   getCredentialsStatus: true,
   checkRecoveryCodesExist: true,
+  recoveryPhoneAvailable: true,
 };
 
 // Actions that send an email, and hence might make
@@ -61,6 +63,8 @@ const EMAIL_SENDING_ACTION = {
 // very annoying to a user if abused.
 const SMS_SENDING_ACTION = {
   connectDeviceSms: true,
+  recoveryPhoneSendCode: true,
+  recoveryPhoneCreate: true,
 };
 
 // Actions that may grant access to an account but


### PR DESCRIPTION
## Because

- We want to prevent excessive requests to certain end points

## This pull request

- Adds customs checks to 
  - `/recovery-phone/available`
  - `/recovery-phone/confirm`
  - `/recovery-phone/create`

## Issue that this pull request solves

Closes: FXA-10361

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I wanted to add some integrations tests but ran into some problems enabling customs in the tests. Hopefully I'll have this addressed in FXA-10913. Also, initially I started patterning this more like [#16948](https://github.com/mozilla/fxa/pull/16948), but realized we already had rules in place for SMS that could be reused. 
