### PR TITLE
fix(settings): Don't localize user's display name

### DIFF
--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/en.ftl
@@ -1,10 +1,9 @@
 # DropDownAvatarMenu component
 
 drop-down-menu-title-2 = { -product-mozilla-account } menu
-# This string is used to show the current user's name or email in the settings page menu.
-# Variables:
-#   $user (String) - the user's name (or email address, if they haven't added their name to their account)
-drop-down-menu-signed-in-as = <signin>Signed in as</signin><user>{ $user }</user>
+# This is displayed in the Settings menu after user's click on their profile icon.
+# Following this string on a new line will be their display name (user's name or email)
+drop-down-menu-signed-in-as-v2 = Signed in as
 drop-down-menu-sign-out = Sign out
 
 drop-down-menu-sign-out-error-2 = Sorry, there was a problem signing you out

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.tsx
@@ -11,6 +11,7 @@ import { ReactComponent as SignOut } from './sign-out.svg';
 import { logViewEvent, settingsViewName } from '../../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
 import firefox from '../../../lib/channels/firefox';
+import { FtlMsg } from 'fxa-react/lib/utils';
 
 export const DropDownAvatarMenu = () => {
   const { displayName, primaryEmail, avatar, uid } = useAccount();
@@ -79,29 +80,17 @@ export const DropDownAvatarMenu = () => {
                 <div className="ltr:mr-3 rtl:ml-3 flex-none">
                   <Avatar className="w-10" {...{ avatar }} />
                 </div>
-                <Localized
-                  id="drop-down-menu-signed-in-as"
-                  vars={{ user: displayName || primaryEmail.email }}
-                  elems={{
-                    user: (
-                      <span
-                        className="font-bold block truncate"
-                        data-testid="drop-down-name-or-email"
-                      ></span>
-                    ),
-                    signin: <span className="text-grey-400 text-xs"></span>,
-                  }}
-                >
-                  <p className="leading-5 max-w-full truncate">
+                <p className="leading-5 max-w-full truncate">
+                  <FtlMsg id="drop-down-menu-signed-in-as-2">
                     <span className="text-grey-400 text-xs">Signed in as</span>
-                    <span
-                      className="font-bold block truncate"
-                      data-testid="drop-down-name-or-email"
-                    >
-                      {displayName || primaryEmail.email}
-                    </span>
-                  </p>
-                </Localized>
+                  </FtlMsg>
+                  <span
+                    className="font-bold block truncate"
+                    data-testid="drop-down-name-or-email"
+                  >
+                    {displayName || primaryEmail.email}
+                  </span>
+                </p>
               </div>
               <div className="w-full">
                 <div className="bg-gradient-to-r from-blue-500 via-pink-700 to-yellow-500 h-px" />


### PR DESCRIPTION
Because:
* Fluent strips at least some characters, and user's display names are allowed to have special characters

This commit:
* Removes the user's display name from the localization string

fixes FXA-10890