### PR TITLE
fix(build): fix require() of ts path alias in *.js

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -15,7 +15,9 @@ const TOTP_DOCS = require('../../docs/swagger/totp-api').default;
 const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const { Container } = require('typedi');
 const { AccountEventsManager } = require('../account-events');
-const { RecoveryPhoneService } = require('@fxa/accounts/recovery-phone');
+const {
+  RecoveryPhoneService,
+} = require('../../../../libs/accounts/recovery-phone/src');
 
 const RECOVERY_CODE_SANE_MAX_LENGTH = 20;
 


### PR DESCRIPTION
Because:
 - a *.js cannot require() an aliased path intended for *.ts

This commit:
 - updates the path to a relative path
