### PR TITLE
fix(totp): Add statsd metrics for totp 'checkDelta'

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -46,6 +46,7 @@ import { uuidTransformer } from 'fxa-shared/db/transformers';
 import { DeleteAccountTasks, ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 import { ProfileClient } from '@fxa/profile/client';
 import { DB } from '../db';
+import { StatsD } from 'hot-shots';
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -82,9 +83,10 @@ export class AccountHandler {
     private subscriptionAccountReminders: any,
     private oauth: any,
     private stripeHelper: StripeHelper,
-    private glean: ReturnType<typeof gleanMetrics>
+    private glean: ReturnType<typeof gleanMetrics>,
+    private statsd: StatsD
   ) {
-    this.otpUtils = require('./utils/otp')(log, config, db);
+    this.otpUtils = require('./utils/otp')(log, config, db, statsd);
     this.skipConfirmationForEmailAddresses = config.signinConfirmation
       .skipForEmailAddresses as string[];
 
@@ -1958,7 +1960,8 @@ export const accountRoutes = (
   oauth: any,
   stripeHelper: StripeHelper,
   pushbox: any,
-  glean: ReturnType<typeof gleanMetrics>
+  glean: ReturnType<typeof gleanMetrics>,
+  statsd: any
 ) => {
   const accountHandler = new AccountHandler(
     log,
@@ -1974,7 +1977,8 @@ export const accountRoutes = (
     subscriptionAccountReminders,
     oauth,
     stripeHelper,
-    glean
+    glean,
+    statsd
   );
   const routes = [
     {

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -89,14 +89,20 @@ module.exports = (
   signupUtils,
   zendeskClient,
   /** @type import('../payments/stripe').StripeHelper */
-  stripeHelper
+  stripeHelper,
+  statsd
 ) => {
   const REMINDER_PATTERN = new RegExp(
     `^(?:${verificationReminders.keys.join('|')})$`
   );
 
   const otpOptions = config.otp;
-  const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
+  const otpUtils = require('../../lib/routes/utils/otp')(
+    log,
+    config,
+    db,
+    statsd
+  );
 
   return [
     {
@@ -1002,7 +1008,12 @@ module.exports = (
         }
 
         const secret = matchedEmail.emailCode;
-        const isValid = otpUtils.verifyOtpCode(code, secret, otpOptions);
+        const isValid = otpUtils.verifyOtpCode(
+          code,
+          secret,
+          otpOptions,
+          'recovery_email.secondary.verify_code'
+        );
 
         if (!isValid) {
           throw error.invalidVerificationCode();

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -36,7 +36,8 @@ module.exports = function (
     db,
     mailer,
     cadReminders,
-    glean
+    glean,
+    statsd
   );
   const clientUtils = require('./utils/clients')(log, config);
   const verificationReminders = require('../verification-reminders')(
@@ -75,7 +76,8 @@ module.exports = function (
     oauthRawDB,
     stripeHelper,
     pushbox,
-    glean
+    glean,
+    statsd
   );
   const oauth = require('./oauth')(
     log,
@@ -115,7 +117,8 @@ module.exports = function (
     cadReminders,
     signupUtils,
     zendeskClient,
-    stripeHelper
+    stripeHelper,
+    statsd
   );
   const password = require('./password')(
     log,
@@ -148,7 +151,8 @@ module.exports = function (
     mailer,
     push,
     customs,
-    glean
+    glean,
+    statsd
   );
   const sign = require('./sign')(
     log,
@@ -174,7 +178,8 @@ module.exports = function (
     config.totp,
     glean,
     profile,
-    config.sentry.env
+    config.sentry.env,
+    statsd
   );
   const recoveryCodes = require('./recovery-codes')(
     log,

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -38,6 +38,7 @@ import {
   ProfileClientError,
   ProfileClientServiceFailureError,
 } from '@fxa/profile/client';
+import { StatsD } from 'hot-shots';
 
 const HEX_STRING = validators.HEX_STRING;
 
@@ -55,7 +56,7 @@ export class LinkedAccountHandler {
     private config: ConfigType,
     private mailer: any,
     private profile: ProfileClient,
-    private statsd: { increment: (value: string) => void },
+    private statsd: StatsD,
     private glean: ReturnType<typeof gleanMetrics>
   ) {
     if (config.googleAuthConfig && config.googleAuthConfig.clientId) {
@@ -63,7 +64,7 @@ export class LinkedAccountHandler {
         config.googleAuthConfig.clientId
       );
     }
-    this.otpUtils = require('./utils/otp')(log, config, db);
+    this.otpUtils = require('./utils/otp')(log, config, db, statsd);
   }
 
   // As generated tokens expire after 6 months (180 days) per Apple documentation,

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -56,7 +56,12 @@ module.exports = function (
   authServerCacheRedis: Redis,
   statsd: StatsD
 ) {
-  const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
+  const otpUtils = require('../../lib/routes/utils/otp')(
+    log,
+    config,
+    db,
+    statsd
+  );
   const otpRedisAdapter = new OtpRedisAdapter(
     authServerCacheRedis,
     config.passwordForgotOtp.ttl

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -26,9 +26,15 @@ module.exports = function (
   mailer,
   push,
   customs,
-  glean
+  glean,
+  statsd
 ) {
-  const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
+  const otpUtils = require('../../lib/routes/utils/otp')(
+    log,
+    config,
+    db,
+    statsd
+  );
 
   const OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS = new Set(
     config.oauth.disableNewConnectionsForClients || []
@@ -373,7 +379,12 @@ module.exports = function (
         const account = await db.account(uid);
         const secret = account.primaryEmail.emailCode;
 
-        const isValidCode = otpUtils.verifyOtpCode(code, secret, otpOptions);
+        const isValidCode = otpUtils.verifyOtpCode(
+          code,
+          secret,
+          otpOptions,
+          'session.verify_code'
+        );
 
         if (!isValidCode) {
           throw error.invalidOrExpiredOtpCode();
@@ -626,7 +637,12 @@ module.exports = function (
         const account = await db.account(uid);
         const secret = account.primaryEmail.emailCode;
 
-        const isValidCode = otpUtils.verifyOtpCode(code, secret, otpOptions);
+        const isValidCode = otpUtils.verifyOtpCode(
+          code,
+          secret,
+          otpOptions,
+          'session.verify_push'
+        );
 
         if (!isValidCode) {
           throw error.invalidOrExpiredOtpCode();

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -20,13 +20,22 @@ const BASE_36 = validators.BASE_36;
 // Currently, only for metrics purposes, not enforced.
 const MAX_ACTIVE_SESSIONS = 200;
 
-module.exports = (log, config, customs, db, mailer, cadReminders, glean) => {
+module.exports = (
+  log,
+  config,
+  customs,
+  db,
+  mailer,
+  cadReminders,
+  glean,
+  statsd
+) => {
   const unblockCodeLifetime =
     (config.signinUnblock && config.signinUnblock.codeLifetime) || 0;
   const unblockCodeLen =
     (config.signinUnblock && config.signinUnblock.codeLength) || 8;
   const otpOptions = config.otp;
-  const otpUtils = otp(log, config, db);
+  const otpUtils = otp(log, config, db, statsd);
 
   const accountEventsManager = Container.has(AccountEventsManager)
     ? Container.get(AccountEventsManager)

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -181,6 +181,7 @@ const makeRoutes = function (options = {}, requireMocks) {
     options.verificationReminders || mocks.mockVerificationReminders();
   cadReminders = options.cadReminders || mocks.mockCadReminders();
   glean = gleanMetrics(config);
+  const statsd = mocks.mockStatsd();
 
   const signupUtils =
     options.signupUtils ||
@@ -203,7 +204,8 @@ const makeRoutes = function (options = {}, requireMocks) {
     cadReminders,
     signupUtils,
     undefined,
-    options.stripeHelper
+    options.stripeHelper,
+    statsd
   );
 };
 
@@ -1148,7 +1150,8 @@ describe('/recovery_email', () => {
     otpUtils = require('../../../lib/routes/utils/otp')(
       {},
       { otp: otpOptions },
-      {}
+      {},
+      { histogram: () => {} }
     );
   });
 

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -63,6 +63,7 @@ function makeRoutes(options = {}) {
   const mailer = options.mailer || mocks.mockMailer();
   const cadReminders = options.cadReminders || mocks.mockCadReminders();
   const glean = options.glean || gleanMock;
+  const statsd = options.statsd || mocks.mockStatsd();
 
   const Password =
     options.Password || require('../../../lib/crypto/password')(log, config);
@@ -79,7 +80,8 @@ function makeRoutes(options = {}) {
       customs,
       db,
       mailer,
-      cadReminders
+      cadReminders,
+      statsd
     );
 
   const verificationReminders =
@@ -108,7 +110,8 @@ function makeRoutes(options = {}) {
     mailer,
     push,
     customs,
-    glean
+    glean,
+    statsd
   );
 }
 
@@ -1127,6 +1130,7 @@ describe('/session/verify_code', () => {
     customs = mocks.mockCustoms();
     customs.check = sinon.spy(() => Promise.resolve(true));
     cadReminders = mocks.mockCadReminders();
+    const statsd = mocks.mockStatsd();
     const config = {};
 
     const routes = makeRoutes({
@@ -1138,6 +1142,7 @@ describe('/session/verify_code', () => {
       customs,
       cadReminders,
       gleanMock,
+      statsd,
     });
     route = getRoute(routes, '/session/verify_code');
 

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -751,7 +751,8 @@ function setup(results, errors, routePath, requestOptions) {
       sharedSecret: secret,
     });
   });
-  routes = makeRoutes({ log, db, customs, mailer, glean, profile });
+  const statsd = mocks.mockStatsd();
+  routes = makeRoutes({ log, db, customs, mailer, glean, profile, statsd });
   route = getRoute(routes, routePath);
   request = mocks.mockRequest(requestOptions);
   request.emitMetricsEvent = sinon.spy(() => Promise.resolve({}));
@@ -768,7 +769,7 @@ function makeRoutes(options = {}) {
     },
   };
   Container.set(AccountEventsManager, accountEventsManager);
-  const { log, db, customs, mailer, glean, profile } = options;
+  const { log, db, customs, mailer, glean, profile, statsd } = options;
   return require('../../../lib/routes/totp')(
     log,
     db,
@@ -776,7 +777,9 @@ function makeRoutes(options = {}) {
     customs,
     config,
     glean,
-    profile
+    profile,
+    undefined,
+    statsd
   );
 }
 

--- a/packages/fxa-auth-server/test/local/routes/utils/signin.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signin.js
@@ -12,7 +12,12 @@ const mocks = require('../../../mocks');
 const Password = require('../../../../lib/crypto/password')({}, {});
 const error = require('../../../../lib/error');
 const butil = require('../../../../lib/crypto/butil');
-const otpUtils = require('../../../../lib/routes/utils/otp')({}, {}, {});
+const otpUtils = require('../../../../lib/routes/utils/otp')(
+  {},
+  {},
+  {},
+  { histogram: () => {} }
+);
 const { AppConfig } = require('../../../../lib/types');
 const { AccountEventsManager } = require('../../../../lib/account-events');
 const glean = mocks.mockGlean();
@@ -60,10 +65,12 @@ describe('checkPassword', () => {
   });
 
   it('should check with correct password', () => {
-    db.checkPassword = sinon.spy((uid) => Promise.resolve({
-      v1: true,
-      v2: false
-    }));
+    db.checkPassword = sinon.spy((uid) =>
+      Promise.resolve({
+        v1: true,
+        v2: false,
+      })
+    );
     const authPW = Buffer.from('aaaaaaaaaaaaaaaa');
     const accountRecord = {
       uid: TEST_UID,

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -212,6 +212,8 @@ const SUBHUB_METHOD_NAMES = [
   'reactivateSubscription',
 ];
 
+const STATSD_METHOD_NAMES = ['increment', 'timing', 'histogram'];
+
 const PROFILE_METHOD_NAMES = ['deleteCache', 'updateDisplayName'];
 
 const MOCK_CMS_CLIENTS = [
@@ -321,6 +323,7 @@ module.exports = {
   mockPushbox,
   mockRequest,
   mockSubHub,
+  mockStatsd: mockObject(STATSD_METHOD_NAMES),
   mockProfile,
   mockVerificationReminders,
   mockCadReminders,


### PR DESCRIPTION
## Because

- We want to see how timing data is distributed with our totp checks

## This pull request

- Adds a histogram statsd metric for each route that uses totp codes

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10932

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This does not fix the issue but will hopefully give us enough insight to make a next step. I bele
