### PR TITLE
feat(scripts): use BigQuery in inactive account deletion script

### DIFF
--- a/packages/fxa-auth-server/scripts/clean-up-partial-account-customer.ts
+++ b/packages/fxa-auth-server/scripts/clean-up-partial-account-customer.ts
@@ -20,7 +20,7 @@ import { createStripeHelper, StripeHelper } from '../lib/payments/stripe';
 import initRedis from '../lib/redis';
 import Token from '../lib/tokens';
 import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
-import { parseDryRun } from './lib/args';
+import { parseBooleanArg } from './lib/args';
 import {
   DeleteAccountTasksFactory,
   ReasonForDeletion,
@@ -65,7 +65,7 @@ const init = async () => {
     );
 
   program.parse(process.argv);
-  const isDryRun = parseDryRun(program.dryRun);
+  const isDryRun = parseBooleanArg(program.dryRun);
   const limit = program.limit ? parseInt(program.limit) : Infinity;
   const reason = ReasonForDeletion.Cleanup;
 

--- a/packages/fxa-auth-server/scripts/cleanup-partial-firestore-customers.ts
+++ b/packages/fxa-auth-server/scripts/cleanup-partial-firestore-customers.ts
@@ -4,7 +4,7 @@
 import program from 'commander';
 
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
-import { parseDryRun } from './lib/args';
+import { parseBooleanArg } from './lib/args';
 import { FieldPath, Firestore } from '@google-cloud/firestore';
 import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
 import Container from 'typedi';
@@ -152,7 +152,7 @@ export async function init() {
 
   const options = program.opts();
   const batchSize = parseInt(options.batchSize);
-  const isDryRun = parseDryRun(options.dryRun);
+  const isDryRun = parseBooleanArg(options.dryRun);
 
   // TBD, do we still need this? fxaDb is no longer referenced...
   await setupProcessingTaskObjects('cleanup-delete-partial-firestore');

--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/get-inactive-account-uids.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/get-inactive-account-uids.ts
@@ -20,7 +20,7 @@ import { StatsD } from 'hot-shots';
 import { Container } from 'typedi';
 import PQueue from 'p-queue-compat';
 
-import { parseDryRun } from '../lib/args';
+import { parseBooleanArg } from '../lib/args';
 import { AppConfig, AuthFirestore, AuthLogger } from '../../lib/types';
 import appConfig from '../../config';
 import initLog from '../../lib/log';
@@ -117,7 +117,7 @@ const init = async () => {
 
   program.parse(process.argv);
 
-  const isDryRun = parseDryRun(program.dryRun);
+  const isDryRun = parseBooleanArg(program.dryRun);
   const startDate = setDateToUTC(program.startDate);
   const endDate = setDateToUTC(program.endDate);
   const startDateTimestamp = startDate.valueOf();

--- a/packages/fxa-auth-server/scripts/delete-unverified-accounts.ts
+++ b/packages/fxa-auth-server/scripts/delete-unverified-accounts.ts
@@ -17,7 +17,7 @@ import { createStripeHelper, StripeHelper } from '../lib/payments/stripe';
 import initRedis from '../lib/redis';
 import Token from '../lib/tokens';
 import { AppConfig, AuthFirestore, AuthLogger } from '../lib/types';
-import { parseDryRun } from './lib/args';
+import { parseBooleanArg } from './lib/args';
 import {
   DeleteAccountTasksFactory,
   ReasonForDeletion,
@@ -119,7 +119,7 @@ const init = async () => {
     );
 
   program.parse(process.argv);
-  const isDryRun = parseDryRun(program.dryRun);
+  const isDryRun = parseBooleanArg(program.dryRun);
   const limit = program.limit ? parseInt(program.limit) : Infinity;
   const hasUid = program.uid.length > 0;
   const hasEmail = program.email.length > 0;

--- a/packages/fxa-auth-server/scripts/lib/args.ts
+++ b/packages/fxa-auth-server/scripts/lib/args.ts
@@ -2,6 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const parseDryRun = (dryRun: boolean | string) => {
-  return `${dryRun}`.toLowerCase() !== 'false';
+export const parseBooleanArg = (val: boolean | string) => {
+  const allowedValues = ['false', 'true'];
+  const normalizedVal = `${val}`.toLowerCase();
+
+  if (!allowedValues.includes(normalizedVal)) {
+    throw new Error(`Invalid boolean argument value: ${val}`);
+  }
+
+  return Boolean(allowedValues.indexOf(normalizedVal));
+};
+
+// helper to collect repeatable Commander args into a single array
+export const collect = () => (val: string, xs: string[]) => {
+  xs.push(val);
+  return xs;
 };

--- a/packages/fxa-auth-server/scripts/refund-unverified-accounts.ts
+++ b/packages/fxa-auth-server/scripts/refund-unverified-accounts.ts
@@ -9,7 +9,7 @@ import Container from 'typedi';
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
 import { AppConfig } from '../lib/types';
 import { promises as fs } from 'fs';
-import { parseDryRun } from './lib/args';
+import { parseBooleanArg } from './lib/args';
 
 const pckg = require('../package.json');
 
@@ -418,7 +418,7 @@ async function init() {
     'refund-unverified-accounts'
   );
 
-  const isDryRun = parseDryRun(program.dryRun);
+  const isDryRun = parseBooleanArg(program.dryRun);
   const startDate = parseStartDate(program.startDate);
   const endDate = parseEndDate(program.endDate);
   const skipFile = program.skipFile || '';

--- a/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents.ts
+++ b/packages/fxa-auth-server/scripts/stripe-products-and-plans-to-firestore-documents.ts
@@ -7,7 +7,7 @@ import Container from 'typedi';
 
 import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
 import { AppConfig } from '../lib/types';
-import { parseDryRun } from './lib/args';
+import { parseBooleanArg } from './lib/args';
 import {
   OutputTarget,
   StripeProductsAndPlansConverter,
@@ -60,7 +60,7 @@ async function init() {
     'stripe-products-and-plans-to-firestore-documents'
   );
 
-  const isDryRun = parseDryRun(program.dryRun);
+  const isDryRun = parseBooleanArg(program.dryRun);
   const target = parseTarget(program.target);
   const targetDir = parseTargetPath(program.targetDir);
   const productId = program.productId;


### PR DESCRIPTION
Because:
 - we want to allow RPs to exclude accounts from deletion by providing a list of uids in BigQuery

This commit:
 - uses BigQuery in multiple steps
   - unions the exclusion lists into a single session-scoped temp table
   - saves the MySQL results into a table
   - excludes the RP provided uids by joining the MySQL results
   - (optionally) saves the inactive account uids into a table
 - adds a parameter to make enqueuing emails optional
 - adds a parameter to schedule the emails
 - updates some Commander argument parsing functions
