### PR TITLE
feat(tokens): update a session token's last access time more frequently

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1580,6 +1580,12 @@ const convictConf = convict({
       default: 1507081020000,
       env: 'LASTACCESSTIME_EARLIEST_SANE_TIMESTAMP',
     },
+    onOAuthTokenCreation: {
+      doc: 'update lastAccessTime in Redis when the session token is used to create an OAuth token',
+      format: Boolean,
+      default: true,
+      env: 'LASTACCESSTIME_UPDATES_ON_OAUTH_TOKEN_CREATION',
+    },
   },
   signinUnblock: {
     codeLength: {

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -55,6 +55,9 @@ const OAUTH_SERVER_DOCS =
   require('../../../docs/swagger/oauth-server-api').default;
 const DESCRIPTION =
   require('../../../docs/swagger/shared/descriptions').default;
+const updateLastAccessTime = config.get(
+  'lastAccessTimeUpdates.onOAuthTokenCreation'
+);
 
 const MAX_TTL_S = config.get('oauthServer.expiration.accessToken') / 1000;
 
@@ -637,11 +640,11 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
             req,
             grant
           );
+        }
 
-          if (sessionToken) {
-            sessionToken.lastAccessTime = Date.now();
-            await db.touchSessionToken(sessionToken, {}, true);
-          }
+        if (updateLastAccessTime && sessionToken) {
+          sessionToken.lastAccessTime = Date.now();
+          await db.touchSessionToken(sessionToken, {}, true);
         }
 
         // done with 'session_token_id' at this point, do not return it.


### PR DESCRIPTION
Because:
 - we want to keep the last access time of a session token as up to date as possible

This commit:
 - updates a session token's last access time in Redis whenever it is used to create an OAuth token
