### PR TITLE
fix(customs): Don't call customs on the GET /recoveryCodes/exist endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -143,9 +143,7 @@ module.exports = (log, db, config, customs, mailer, glean) => {
       async handler(request) {
         log.begin('checkRecoveryCodesExist', request);
 
-        const { email, uid } = request.auth.credentials;
-
-        await customs.check(request, email, 'checkRecoveryCodesExist');
+        const { uid } = request.auth.credentials;
 
         const { hasBackupCodes, count } =
           await backupCodeManager.getCountForUserId(uid);

--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -42,7 +42,6 @@ const ACCOUNT_STATUS_ACTION = {
   sendUnblockCode: true,
   recoveryKeyExists: true,
   getCredentialsStatus: true,
-  checkRecoveryCodesExist: true,
   recoveryPhoneAvailable: true,
 };
 


### PR DESCRIPTION
## Because

- This endpoint is authenticated with a sessionToken, we don't need to check customs
- This might cause a user to get rate limited unexpectedly

## This pull request

- Remove the customs check

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10880

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
