### PR TITLE
task(next): Remove FxA user id from subplat glean

### DIFF
--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -113,7 +113,6 @@ export class PaymentsGleanManager {
     return {
       user_agent: commonMetricsData.userAgent,
       ip_address: commonMetricsData.ipAddress,
-      account_user_id: normalizeGleanFalsyValues(cartMetricsData.uid),
       ...mapRelyingParty(commonMetricsData.searchParams),
       ...mapSession(
         commonMetricsData.searchParams,

--- a/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
+++ b/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
@@ -2,26 +2,6 @@
 # Schema
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
-account:
-  user_id:
-    type: string
-    description: |
-      The firefox/mozilla account id
-    lifetime: application
-    send_in_pings:
-      - events
-    notification_emails:
-      - subplat-team@mozilla.com
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXA-7531
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=tbd
-    expires: never
-    data_sensitivity:
-      - interaction
-    no_lint:
-      - COMMON_PREFIX
-
 relying_party:
   service:
     type: string


### PR DESCRIPTION
## Because

- The uid associated with the firefox account is sensitive user data, and does not need to be collected along with the other metrics that subplat uses.

## This pull request

- Updates the config and glean logic to remove reporting of the fxa uid

## Issue that this pull request solves

Closes: [FXA-10900](https://mozilla-hub.atlassian.net/browse/FXA-10900)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).


[FXA-10900]: https://mozilla-hub.atlassian.net/browse/FXA-10900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ