### PR TITLE
fix(l10n): Update ftl string with brand term and fix apostrophe

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/en.ftl
@@ -2,7 +2,7 @@
 
 flow-setup-phone-submit-number-heading = Verify your phone number
 # The code is a 6-digit code send by text message/SMS
-flow-setup-phone-verify-number-instruction = You’ll get a text message from Mozilla with a code to verify your number. Don't share this code with anyone.
+flow-setup-phone-verify-number-instruction = You’ll get a text message from { -brand-mozilla } with a code to verify your number. Don’t share this code with anyone.
 
 # The initial rollout of the backup recovery phone is only available to users with US and Canada mobile phone numbers.
 # Voice over Internet Protocol (VoIP), is a technology that uses a broadband Internet connection instead of a regular (or analog) phone line to make calls.

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.tsx
@@ -74,7 +74,7 @@ export const FlowSetupRecoveryPhoneSubmitNumber = ({
       <FtlMsg id="flow-setup-phone-verify-number-instruction">
         <p className="text-base my-4">
           You’ll get a text message from Mozilla with a code to verify your
-          number. Don't share this code with anyone.
+          number. Don’t share this code with anyone.
         </p>
       </FtlMsg>
       <FormPhoneNumber


### PR DESCRIPTION
## Because

- Missing brand term and curly apostrophe

## This pull request

- Fix the ftl string and fallback

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
