### PR TITLE
feat(next): add payments-next.ftl to merge

### DIFF
--- a/apps/payments/next/Gruntfile.js
+++ b/apps/payments/next/Gruntfile.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = function (grunt) {
+module.exports = function(grunt) {
   const srcPaths = [
     '.license.header',
     'app/**/*.ftl',
@@ -23,6 +23,10 @@ module.exports = function (grunt) {
     },
     concat: {
       ftl: {
+        src: srcPaths,
+        dest: 'public/locales/en/payments-next.ftl',
+      },
+      ftlLegacy: {
         src: srcPaths,
         dest: 'public/locales/en/payments.ftl',
       },
@@ -72,6 +76,6 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-http');
   grunt.loadNpmTasks('grunt-concurrent');
 
-  grunt.registerTask('merge-ftl', ['copy:branding-ftl', 'concat:ftl']);
+  grunt.registerTask('merge-ftl', ['copy:branding-ftl', 'concat:ftl', 'concat:ftlLegacy']);
   grunt.registerTask('watchers', ['concurrent:dev']);
 };


### PR DESCRIPTION
## Because

- l10n repo expects payments-next.ftl file used in payments-next

## This pull request

- Merges strings used by payments-next to payments-next.ftl and temporarily continues to support payments.ftl as well.

## Issue that this pull request solves

Closes: #FXA-7842

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).