### PR TITLE
fix(strapi): log all mismatches to BQ as errors, remove sentry rate limit

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -532,7 +532,6 @@ describe('CapabilityService', () => {
       capabilityService.eligibilityFromEligibilityManager = sinon.fake.resolves(
         [SubscriptionEligibilityResult.CREATE]
       );
-      capabilityService.logToSentry = sinon.fake.returns(true);
 
       const actual = await capabilityService.getPlanEligibility(
         UID,
@@ -1352,9 +1351,6 @@ describe('CapabilityService', () => {
         `CapabilityService.getClients - Returned Stripe as clients did not match.`,
         'error'
       );
-
-      // Test logToSentry logic. Remove if no longer necessary
-      await capabilityService.getClients();
 
       sinon.assert.calledOnceWithExactly(sentryScope.setContext, 'getClients', {
         cms: mockClientsFromCMS,


### PR DESCRIPTION
## Because

- We no longer want to rate limit our error logging to Sentry since errors are actionable and we don't want to miss them.
- We want to log all error types to BigQuery.

## This pull request

- Disables rate limit for Sentry logging for Strapi mismatches
- Adds logs to BigQuery for all mismatch types
