### PR TITLE
feat(sms): Add confirm recovery code page screens

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/container.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import ConfirmRecoveryCode from '.';
+import { ResendStatus } from '../../../lib/types';
+
+const ConfirmRecoveryCodeContainer = (_: RouteComponentProps) => {
+  const [errorMessage, setErrorMessage] = useState('');
+  const [resendErrorMessage, setResendErrorMessage] = useState('');
+  const [resendStatus, setResendStatus] = useState<ResendStatus>(
+    ResendStatus.none
+  );
+
+  const verifyCode = async (otpCode: string) => {};
+  const resendCode = async () => {};
+
+  const clearBanners = () => {
+    setErrorMessage('');
+    setResendErrorMessage('');
+    setResendStatus(ResendStatus.none);
+  };
+
+  // TODO: get from api
+  const maskedPhoneNumber = '••••••1234}';
+
+  return (
+    <ConfirmRecoveryCode
+      {...{
+        clearBanners,
+        maskedPhoneNumber,
+        errorMessage,
+        resendErrorMessage,
+        setErrorMessage,
+        verifyCode,
+        resendCode,
+      }}
+    />
+  );
+};
+
+export default ConfirmRecoveryCodeContainer;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/en.ftl
@@ -1,0 +1,14 @@
+## SigninRecoveryPhoneCodeConfirm page
+
+recovery-phone-code-confirm-flow-heading = Sign in
+
+# A recovery code in context of this page is a one time code sent to the user's phone
+recovery-phone-code-confirm-with-code-heading = Enter recovery code
+
+# Text that explains the user should check their phone for a recovery code
+# $maskedPhoneNumber - The users masked phone number
+recovery-phone-code-confirm-code-instruction = A six-digit code was sent to <span>{ $maskedPhoneNumber }</span> by text message. This code expires after 5 minutes.
+
+recovery-phone-code-confirm-input-group-label = Enter 6-digit code
+
+recovery-phone-code-confirm-otp-submit-button = Confirm

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/index.stories.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import ConfirmRecoveryCode from '.';
+import { Subject } from './mocks';
+
+export default {
+  title: 'Pages/Signin/SigninRecoveryMethod/Phone/ConfirmRecoveryCode',
+  component: ConfirmRecoveryCode,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Basic = () => <Subject />;
+
+export const WithErrorMessage = () => (
+  <ConfirmRecoveryCode
+    errorMessage="An error occurred. Please try again."
+    maskedPhoneNumber="••••••1234"
+    verifyCode={() => Promise.resolve()}
+    resendCode={() => Promise.resolve()}
+    clearBanners={() => {}}
+    setErrorMessage={() => {}}
+  />
+);

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/index.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { screen, act } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import SigninRecoveryPhoneCodeConfirm from './index';
+
+describe('SigninRecoveryPhoneCodeConfirm', () => {
+  const mockVerifyCode = jest.fn(() => Promise.resolve());
+  const mockResendCode = jest.fn(() => Promise.resolve());
+  const mockClearBanners = jest.fn();
+  const mockSetErrorMessage = jest.fn();
+
+  const defaultProps = {
+    clearBanners: mockClearBanners,
+    maskedPhoneNumber: '••••••1234',
+    errorMessage: '',
+    setErrorMessage: mockSetErrorMessage,
+    verifyCode: mockVerifyCode,
+    resendCode: mockResendCode,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders as expected', async () => {
+    renderWithLocalizationProvider(
+      <SigninRecoveryPhoneCodeConfirm {...defaultProps} />
+    );
+
+    expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Sign in' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Enter recovery code' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: 'Enter 6-digit code' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Confirm')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Resend code' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: 'Are you locked out? Opens in new window',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('submits with valid code', async () => {
+    renderWithLocalizationProvider(
+      <SigninRecoveryPhoneCodeConfirm {...defaultProps} />
+    );
+
+    const input = screen.getByRole('textbox');
+    await act(async () => {
+      await userEvent.type(input, '123456');
+      await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    });
+
+    expect(mockVerifyCode).toHaveBeenCalledWith('123456');
+  });
+
+  it('handles resend code', async () => {
+    renderWithLocalizationProvider(
+      <SigninRecoveryPhoneCodeConfirm {...defaultProps} />
+    );
+
+    await act(async () => {
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Resend code' })
+      );
+    });
+
+    expect(mockResendCode).toHaveBeenCalled();
+  });
+
+  it('handles `Are you locked out?` link', async () => {
+    renderWithLocalizationProvider(
+      <SigninRecoveryPhoneCodeConfirm {...defaultProps} />
+    );
+
+    const link = screen.getByRole('link', {
+      name: 'Are you locked out? Opens in new window',
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication'
+    );
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/index.tsx
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import AppLayout from '../../../components/AppLayout';
+import FormVerifyTotp from '../../../components/FormVerifyTotp';
+import { RouteComponentProps } from '@reach/router';
+import { useFtlMsgResolver } from '../../../models';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { BackupRecoveryPhoneCodeImage } from '../../../components/images';
+import Banner from '../../../components/Banner';
+import { HeadingPrimary } from '../../../components/HeadingPrimary';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import ButtonBack from '../../../components/ButtonBack';
+
+export type SigninRecoveryPhoneCodeConfirmProps = {
+  clearBanners?: () => void;
+  maskedPhoneNumber: string;
+  errorMessage: string;
+  setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
+  verifyCode: (code: string) => Promise<void>;
+  resendCode: () => Promise<void>;
+};
+
+const SigninRecoveryPhoneCodeConfirm = ({
+  clearBanners,
+  maskedPhoneNumber,
+  errorMessage,
+  setErrorMessage,
+  verifyCode,
+  resendCode,
+}: SigninRecoveryPhoneCodeConfirmProps & RouteComponentProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const spanElement = <span className="font-bold">{maskedPhoneNumber}</span>;
+
+  return (
+    <AppLayout>
+      <div className="relative flex items-start">
+        <ButtonBack />
+        <FtlMsg id="signin-recovery-method-header">
+          <HeadingPrimary>Sign in</HeadingPrimary>
+        </FtlMsg>
+      </div>
+
+      {errorMessage && (
+        <Banner type="error" content={{ localizedHeading: errorMessage }} />
+      )}
+      <BackupRecoveryPhoneCodeImage />
+      <FtlMsg id="confirm-recovery-code-with-code-heading">
+        <h2 className="card-header my-4">Enter recovery code</h2>
+      </FtlMsg>
+      <FtlMsg
+        id="confirm-recovery-code-with-code-instruction"
+        vars={{ maskedPhoneNumber }}
+        elems={{ span: spanElement }}
+      >
+        <p>
+          A six-digit code was sent to {spanElement} by text message. This code
+          expires after 5 minutes.
+        </p>
+      </FtlMsg>
+      <FormVerifyTotp
+        codeLength={6}
+        codeType="numeric"
+        localizedInputLabel={ftlMsgResolver.getMsg(
+          'confirm-recovery-code-code-input-group-label',
+          'Enter 6-digit code'
+        )}
+        localizedSubmitButtonText={ftlMsgResolver.getMsg(
+          'confirm-recovery-code-otp-submit-button',
+          'Confirm'
+        )}
+        {...{
+          clearBanners,
+          errorMessage,
+          setErrorMessage,
+          verifyCode,
+        }}
+      />
+      <div className="flex justify-between mt-5 text-sm">
+        <FtlMsg id="confirm-recovery-code-otp-resend-code-button">
+          <button
+            className="link-blue mt-4 text-sm"
+            data-glean-id="login_backup_phone_codes_resend"
+            onClick={resendCode}
+          >
+            Resend code
+          </button>
+        </FtlMsg>
+        <FtlMsg id="confirm-recovery-code-otp-different-account-link">
+          <LinkExternal
+            href="https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication"
+            className="link-blue mt-4 text-sm"
+            data-glean-id="login_backup_phone_locked_out_link"
+          >
+            Are you locked out?
+          </LinkExternal>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default SigninRecoveryPhoneCodeConfirm;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/mocks.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import ConfirmRecoveryCode from '.';
+import { MOCK_PHONE_NUMBER } from '../../mocks';
+import { LocationProvider } from '@reach/router';
+import { SigninRecoveryPhoneCodeConfirmProps } from '.';
+
+const mockVerifyCode = (code: string) => Promise.resolve();
+const mockResendCode = () => Promise.resolve();
+
+export const Subject = ({
+  verifyCode = mockVerifyCode,
+  resendCode = mockResendCode,
+}: Partial<SigninRecoveryPhoneCodeConfirmProps>) => {
+  const maskedPhoneNumber = MOCK_PHONE_NUMBER;
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const clearBanners = () => {
+    setErrorMessage('');
+  };
+
+  return (
+    <LocationProvider>
+      <ConfirmRecoveryCode
+        maskedPhoneNumber={maskedPhoneNumber}
+        {...{
+          clearBanners,
+          errorMessage,
+          setErrorMessage,
+          verifyCode,
+          resendCode,
+        }}
+      />
+    </LocationProvider>
+  );
+};

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -74,3 +74,4 @@ export const ALL_PRODUCT_PROMO_SERVICES = [{ name: MozServices.Monitor }];
 export const ALL_PRODUCT_PROMO_SUBSCRIPTIONS = [
   { productName: MozServices.MonitorPlus },
 ];
+export const MOCK_PHONE_NUMBER = '••••••1234';


### PR DESCRIPTION
## Because

- We want a React page to confirm recovery codes for a recovery phone

## This pull request

- Adds the ConfirmRecoveryCode page
- Adds l10n, unit tests
- Does not add functionality

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10367

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="572" alt="Screenshot 2025-01-08 at 3 02 50 PM" src="https://github.com/user-attachments/assets/a7035782-0225-4aab-8b58-01a1975fdf92" />
