### PR TITLE
feat(settings): Create PageRecoveryPhoneRemove, add l10n/tests/stories

### DIFF
--- a/packages/fxa-settings/src/components/Banner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.stories.tsx
@@ -161,6 +161,29 @@ export const TypeInfo = () => (
   </AppLayout>
 );
 
+export const TypeInfoFancyWithCustomContent = () => (
+  <AppLayout>
+    <Banner
+      type="info"
+      isFancy
+      customContent={
+        <div>
+          <p>This version has custom JSX/HTML...</p>
+          <p className="mt-4">
+            ... meaning we're not limited to just one header/paragraph! We can
+            put images etc. in here.
+          </p>
+          <p className="mt-4">
+            Cupcake ipsum: Cake tootsie roll jelly-o wafer icing wafer fruitcake
+            jelly. Chocolate bar danish cake apple pie jelly liquorice. Candy
+            canes carrot cake sweet jujubes fruitcake biscuit cotton candy pie.
+          </p>
+        </div>
+      }
+    />
+  </AppLayout>
+);
+
 export const TypeInfoFancy = () => (
   <AppLayout>
     <Banner

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -21,6 +21,7 @@ import { Link } from '@reach/router';
 export const Banner = ({
   type,
   content,
+  customContent,
   animation,
   dismissButton,
   link,
@@ -65,11 +66,11 @@ export const Banner = ({
         <WarningIcon className="shrink-0" mode="attention" ariaHidden />
       )}
 
-      <div className="flex flex-col grow ">
-        {content.localizedHeading && (
+      <div className="flex flex-col grow">
+        {content?.localizedHeading && (
           <p className="font-bold">{content.localizedHeading}</p>
         )}
-        {content.localizedDescription && <p>{content.localizedDescription}</p>}
+        {content?.localizedDescription && <p>{content.localizedDescription}</p>}
         {/* Link is optional and can be either an external or internal link */}
         {/* Link color here was tweaked for accessibility - this colour passes AAA for all banner background colors */}
         {link && link.url && (
@@ -94,6 +95,8 @@ export const Banner = ({
             </Link>
           </span>
         )}
+
+        {customContent && <>{customContent}</>}
       </div>
       {dismissButton && (
         <button

--- a/packages/fxa-settings/src/components/Banner/interfaces.ts
+++ b/packages/fxa-settings/src/components/Banner/interfaces.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ReactNode } from 'react';
 import { NotificationType } from '../../models';
 
 /**
@@ -9,14 +10,16 @@ import { NotificationType } from '../../models';
  *
  * @typedef {Object} BannerProps
  * @property {'error' | 'info' | 'success' | 'warning'} type - The type of the banner, which determines its styling and icon.
- * @property {BannerContentProps} content - The content to be displayed inside the banner.
+ * @property {BannerContentProps} content - Content to be displayed inside the banner, accepts a header and description string.
+ * @property {ReactNode} customContent - Pass in an entire custom component to be displayed inside the banner.
  * @property {Animation} [animation] - Optional animation settings for the banner.
  * @property {DismissButtonProps} [dismissButton] - Optional properties for a dismiss button.
  * @property {BannerLinkProps} [link] - Optional properties for a link within the banner.
  */
 export type BannerProps = {
   type: NotificationType;
-  content: BannerContentProps;
+  content?: BannerContentProps;
+  customContent?: ReactNode;
   animation?: Animation;
   dismissButton?: DismissButtonProps;
   link?: BannerLinkProps;

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/en.ftl
@@ -1,0 +1,12 @@
+## PageRecoveryPhoneRemove
+## Users reach this page from account settings when they want to remove a backup phone number.
+
+recovery-phone-remove-header = Remove recovery phone number
+# Variables:
+#   $formattedFullPhoneNumber (String) - the user's full phone number
+settings-recovery-phone-remove-info = This will remove <strong>{ $formattedFullPhoneNumber }</strong> as your recovery phone.
+settings-recovery-phone-remove-recommend = We recommend you keep this method because it’s easier than saving backup authentication codes.
+# "Saved backup authentication codes" refers to previously saved backup authentication codes
+settings-recovery-phone-remove-recovery-methods = If you delete it, make sure you still have your saved backup authentication codes. <linkExternal>Compare recovery methods</linkExternal>
+settings-recovery-phone-remove-button = Remove phone number
+settings-recovery-phone-remove-cancel = Cancel

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.stories.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import PageRecoveryPhoneRemove from '.';
+import { LocationProvider } from '@reach/router';
+import { mockAppContext } from '../../../models/mocks';
+import { Account, AppContext } from '../../../models';
+
+export default {
+  title: 'Pages/Settings/RecoveryPhoneRemove',
+  component: PageRecoveryPhoneRemove,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Default = () => (
+  <AppContext.Provider
+    value={mockAppContext({
+      account: {
+        removeRecoveryPhone: () => {},
+      } as unknown as Account,
+    })}
+  >
+    <LocationProvider>
+      <PageRecoveryPhoneRemove />
+    </LocationProvider>
+  </AppContext.Provider>
+);

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import PageRecoveryPhoneRemove from '.';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Account, AppContext } from '../../../models';
+import {
+  mockAppContext,
+  mockSettingsContext,
+  renderWithRouter,
+} from '../../../models/mocks';
+import { SettingsContext } from '../../../models/contexts/SettingsContext';
+
+const account = {
+  removeRecoveryPhone: jest.fn().mockResolvedValue({}),
+} as unknown as Account;
+
+describe('PageRecoveryPhoneRemove', () => {
+  it('renders as expected', () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <SettingsContext.Provider value={mockSettingsContext()}>
+          <PageRecoveryPhoneRemove />
+        </SettingsContext.Provider>
+      </AppContext.Provider>
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Remove recovery phone number' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'We recommend you keep this method because it’s easier than saving backup authentication codes.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'If you delete it, make sure you still have your saved authentication codes.'
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: /Compare recovery methods/ })
+    ).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication'
+    );
+  });
+
+  it('submits', async () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <SettingsContext.Provider value={mockSettingsContext()}>
+          <PageRecoveryPhoneRemove />
+        </SettingsContext.Provider>
+      </AppContext.Provider>
+    );
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(
+        screen.getByRole('button', { name: 'Remove phone number' })
+      );
+    });
+
+    expect(account.removeRecoveryPhone).toBeCalled();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Link, RouteComponentProps, useNavigate } from '@reach/router';
+import VerifiedSessionGuard from '../VerifiedSessionGuard';
+import { SETTINGS_PATH } from '../../../constants';
+import CardHeader from '../../CardHeader';
+import AppLayout from '../../AppLayout';
+import Banner from '../../Banner';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { useAccount } from '../../../models';
+
+// TODO, update this link with #section-heading once the SUMO article is updated (FXA-10918)
+const sumoTwoStepLink = (
+  <LinkExternal
+    className="link-blue"
+    href="https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication"
+  >
+    Compare recovery methods
+  </LinkExternal>
+);
+
+const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
+  const navigate = useNavigate();
+  const account = useAccount();
+  // TODO, actually get this number back and format it
+  const formattedFullPhoneNumber = '+1 (555) 555-5555';
+
+  const goHome = () => navigate(SETTINGS_PATH + '#security', { replace: true });
+
+  return (
+    <AppLayout>
+      <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
+      <CardHeader
+        headingText="Remove recovery phone number"
+        headingTextFtlId="recovery-phone-remove-header"
+      />
+      <FtlMsg
+        id="settings-recovery-phone-remove-info"
+        vars={{ formattedFullPhoneNumber }}
+        elems={{ strong: <strong></strong> }}
+      >
+        <p>
+          This will remove <strong>{formattedFullPhoneNumber}</strong> as your
+          recovery phone.
+        </p>
+      </FtlMsg>
+
+      <Banner
+        type="info"
+        isFancy
+        customContent={
+          <div>
+            <FtlMsg id="settings-recovery-phone-remove-recommend">
+              <p>
+                We recommend you keep this method because it’s easier than
+                saving backup authentication codes.
+              </p>
+            </FtlMsg>
+
+            <FtlMsg
+              id="settings-recovery-phone-remove-recovery-methods"
+              elems={{
+                linkExternal: sumoTwoStepLink,
+              }}
+            >
+              <p className="mt-4">
+                If you delete it, make sure you still have your saved
+                authentication codes. {sumoTwoStepLink}
+              </p>
+            </FtlMsg>
+          </div>
+        }
+      />
+
+      <FtlMsg id="settings-recovery-phone-remove-button">
+        <button
+          className="cta-caution cta-xl w-full mt-10"
+          data-glean-id="two_step_auth_phone_remove_confirm_submit"
+          onClick={async () => {
+            // TODO, implement functionality
+            await account.removeRecoveryPhone();
+          }}
+        >
+          Remove phone number
+        </button>
+      </FtlMsg>
+
+      <div className="text-center mt-4">
+        <FtlMsg id="settings-recovery-phone-remove-cancel">
+          <Link className="link-blue text-sm" to={SETTINGS_PATH}>
+            Cancel
+          </Link>
+        </FtlMsg>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default PageRecoveryPhoneRemove;

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1363,4 +1363,6 @@ export class Account implements AccountData {
     });
     return data;
   }
+
+  async removeRecoveryPhone() {}
 }


### PR DESCRIPTION
Because:
* We're buildling out our SMS components

This commit:
* Creates PageRecoveryPhoneRemove for use in settings
* Adds l10n, basic unit tests, and updates stories

closes FXA-10247

---

<img width="580" alt="image" src="https://github.com/user-attachments/assets/64bbb564-8509-41c6-851a-cab5d9ce4218" />

This does not _precisely_ match Figma because the "info" icon in Figma is closer to the top, but we don't have a banner like that right now from what I can tell? I can update it across the board for Banner types if desired. Similarly, I used our existing `cta-caution` red button for consistency, which is slightly lighter than what I see in Figma.