### PR TITLE
feat(emails): Localize email preheaders

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -391,12 +391,15 @@ module.exports = function (log, config, bounces) {
 
   Mailer.prototype.localize = async function (message) {
     message.layout = message.layout || 'fxa';
-    const { html, text, subject } = await this.renderer.renderEmail(message);
+    const { html, text, subject, preview } = await this.renderer.renderEmail(
+      message
+    );
 
     return {
       html,
       language: determineLocale(message.acceptLanguage),
       subject,
+      preview,
       text,
     };
   };
@@ -471,6 +474,7 @@ module.exports = function (log, config, bounces) {
       from: this.sender,
       to,
       subject: localized.subject,
+      preview: localized.preview,
       text: localized.text,
       html: localized.html,
       xMailer: false,
@@ -621,7 +625,6 @@ module.exports = function (log, config, bounces) {
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         time,
-        preHeader: 'Copy/paste this code into your registration form.',
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -7,11 +7,15 @@
     <mj-raw>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     </mj-raw>
+
     <mj-title><%- locals.subject %></mj-title>
+    <% if (locals.preview) { %>
+      <mj-preview><%= locals.preview %></mj-preview>
+    <% } %>
+
     <%- include('/partials/images.mjml') %>
     <%- include('/partials/metadata.mjml') %>
   </mj-head>
-
   <mj-body>
     <mj-include path="<%- locals.cssPath %>/global.css" type="css" css-inline="inline" />
     <mj-include path="<%- locals.cssPath %>/fxa/index.css" type="css" css-inline="inline" />
@@ -21,16 +25,6 @@
     <mj-wrapper css-class="body">
       <mj-section>
         <mj-column>
-          <% if (locals.preHeader) { %>
-            <mj-text css-class="hidden">
-              <%- preHeader %>
-              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
-            </mj-text>
-          <% } %>
           <% if (!locals.sync) { %>
             <mj-image css-class="mozilla-logo"
               width="120px"

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -8,6 +8,7 @@
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     </mj-raw>
     <mj-title><%- locals.subject %></mj-title>
+    <mj-preview><%- locals.preview %></mj-preview>
     <%- include('/partials/images.mjml') %>
     <%- include('/partials/metadata.mjml') %>
   </mj-head>
@@ -19,21 +20,6 @@
     <%- include('/partials/brandMessaging/index.mjml') %>
 
     <mj-wrapper css-class="body">
-      <% if (locals.preHeader) { %>
-        <mj-section>
-          <mj-column>
-            <mj-text css-class="hidden">
-              <%- preHeader %>
-              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
-              ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
-            </mj-text>
-          </mj-column>
-        </mj-section>
-      <% } %>
-
       <mj-section css-class="header-container">
         <mj-column>
           <mj-image css-class="subplat-mozilla-logo"

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en.ftl
@@ -1,6 +1,7 @@
 # Variables:
 #  $code (Number) - e.g. 123456
 verifyShortCode-subject-3 = Confirm your account
+verifyShortCode-preview = Use the included code to confirm your { -product-mozilla-account }.
 verifyShortCode-title-3 = Open the internet with { -brand-mozilla }
 # Information on the browser and device triggering this confirmation email follows below this string.
 verifyShortCode-title-subtext-2 = Confirm your account and get the most out of { -brand-mozilla } everywhere you sign in starting with:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/includes.json
@@ -2,5 +2,9 @@
   "subject": {
     "id": "verifyShortCode-subject-3",
     "message": "Confirm your account"
+  },
+  "preview": {
+    "id": "verifyShortCode-preview",
+    "message": "Use the included code to confirm your Mozilla account."
   }
 }

--- a/packages/fxa-auth-server/lib/senders/renderer/bindings.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/bindings.ts
@@ -58,6 +58,7 @@ export interface RendererContext extends TemplateContext, TemplateValues {
   cssPath: string;
   subject: string;
   action?: string;
+  preview?: string;
 }
 
 export type EjsComponent = {
@@ -83,7 +84,7 @@ export abstract class RendererBindings implements ILocalizerBindings {
 
   /**
    * Renders a mjml template with support for fluent localization.
-   * @param name Name of template
+   * @param template Name of template
    * @param context Contains either values sent through mailer.send or mock values from Storybook
    * @param layout Optional layout, which acts as wrapper for for template
    * @returns Rendered template

--- a/packages/fxa-auth-server/lib/senders/renderer/index.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/index.ts
@@ -23,6 +23,7 @@ const RTL_LOCALES = [
 export interface GlobalTemplateValues {
   subject: FtlIdMsg;
   action?: FtlIdMsg;
+  preview?: FtlIdMsg;
 }
 
 class Renderer extends Localizer {
@@ -79,22 +80,33 @@ class Renderer extends Localizer {
        * `subject` goes inside `mj-title` and `action` goes in a script in `metadata.mjml`
        * 2) We need to return a localized `subject` back to the mailer
        */
-      const { subject, action } = await this.getGlobalTemplateValues(context);
+      const { subject, action, preview } = await this.getGlobalTemplateValues(
+        context
+      );
       const localizeAndRenderSubject = this.localizeAndRender(
         l10n,
         subject,
         context
       );
-      if (action) {
-        const [localizedSubject, localizedAction] = await Promise.all([
-          localizeAndRenderSubject,
-          this.localizeAndRender(l10n, action, context),
-        ]);
 
-        context.subject = localizedSubject;
+      context.subject = await localizeAndRenderSubject;
+
+      if (action) {
+        const localizedAction = await this.localizeAndRender(
+          l10n,
+          action,
+          context
+        );
         context.action = localizedAction;
-      } else {
-        context.subject = await localizeAndRenderSubject;
+      }
+
+      if (preview) {
+        const localizedPreview = await this.localizeAndRender(
+          l10n,
+          preview,
+          context
+        );
+        context.preview = localizedPreview;
       }
     }
 
@@ -123,6 +135,7 @@ class Renderer extends Localizer {
       html: rootElement.outerHTML,
       text: localizedPlaintext,
       subject: context.subject,
+      preview: context.preview || '',
     };
   }
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -561,6 +561,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Verify-Short-Code', { test: 'equal', expected: MESSAGE.code }],
     ])],
     ['html', [
+      { test: 'include', expected: 'Use the included code to confirm your Mozilla account.'},
       { test: 'include', expected: 'Confirm your account' },
       { test: 'include', expected: 'Open the internet with Mozilla' },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome', 'privacy')) },


### PR DESCRIPTION
## Because

* New preheaders will be introduced for the inactive account warning emails
* Email preheaders were not localized
* MJML has a dedicated tag for email previews

## This pull request

* Remove preHeader passed in template values
* Set preview content in email templates instead of handler
* Use MJML mj-preview to set preview text
* Add localization handling for preview text

## Issue that this pull request solves

Closes: #FXA-8558

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Maildev does not show previews, which makes it harder to validate this change locally. I have verified that the preview text is included in the email source and hidden from view (as expected for preview text), but this might need to be validated on stage to ensure it works as expected.
