### PR TITLE
task(auth): Improve recovery phone endpoint names

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -2266,7 +2266,7 @@ export default class AuthClient {
     headers?: Headers
   ) {
     return this.sessionPost(
-      '/recovery-phone/create',
+      '/recovery_phone/create',
       sessionToken,
       { phoneNumber },
       headers
@@ -2275,7 +2275,7 @@ export default class AuthClient {
 
   async recoveryPhoneAvailable(sessionToken: string, headers?: Headers) {
     return this.sessionPost(
-      '/recovery-phone/available',
+      '/recovery_phone/available',
       sessionToken,
       {},
       headers
@@ -2288,7 +2288,7 @@ export default class AuthClient {
     headers?: Headers
   ) {
     return this.sessionPost(
-      '/recovery-phone/available',
+      '/recovery_phone/available',
       sessionToken,
       { code },
       headers
@@ -2297,7 +2297,7 @@ export default class AuthClient {
 
   async recoveryPhoneSendCode(sessionToken: string, headers?: Headers) {
     return this.sessionPost(
-      '/recovery-phone/send_code',
+      '/recovery_phone/signin/send_code',
       sessionToken,
       {},
       headers
@@ -2305,7 +2305,7 @@ export default class AuthClient {
   }
 
   async recoveryPhoneDelete(sessionToken: string, headers?: Headers) {
-    return this.sessionDelete('/recovery-phone', sessionToken, {}, headers);
+    return this.sessionDelete('/recovery_phone', sessionToken, {}, headers);
   }
 
   protected async getPayloadV2({

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -275,7 +275,7 @@ export const recoveryPhoneRoutes = (
     // TODO: See blocked tasks for FXA-10354
     {
       method: 'POST',
-      path: '/recovery-phone/create',
+      path: '/recovery_phone/create',
       options: {
         auth: {
           strategies: ['sessionToken'],
@@ -292,7 +292,7 @@ export const recoveryPhoneRoutes = (
     },
     {
       method: 'POST',
-      path: '/recovery-phone/available',
+      path: '/recovery_phone/available',
       options: {
         auth: {
           strategies: ['sessionToken'],
@@ -304,7 +304,7 @@ export const recoveryPhoneRoutes = (
     },
     {
       method: 'POST',
-      path: '/recovery-phone/confirm',
+      path: '/recovery_phone/confirm',
       options: {
         auth: {
           strategies: ['sessionToken'],
@@ -321,7 +321,7 @@ export const recoveryPhoneRoutes = (
     },
     {
       method: 'POST',
-      path: '/recovery-phone/send_code',
+      path: '/recovery_phone/signin/send_code',
       options: {
         auth: {
           strategies: ['sessionToken'],
@@ -333,7 +333,7 @@ export const recoveryPhoneRoutes = (
     },
     {
       method: 'POST',
-      path: '/recovery-phone/signin/confirm',
+      path: '/recovery_phone/signin/confirm',
       options: {
         auth: {
           strategies: ['sessionToken'],
@@ -345,7 +345,7 @@ export const recoveryPhoneRoutes = (
     },
     {
       method: 'DELETE',
-      path: '/recovery-phone',
+      path: '/recovery_phone',
       options: {
         auth: {
           strategies: ['sessionToken'],
@@ -357,7 +357,7 @@ export const recoveryPhoneRoutes = (
     },
     {
       method: 'GET',
-      path: '/recovery-phone',
+      path: '/recovery_phone',
       options: {
         auth: {
           strategy: 'sessionToken',

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -15,9 +15,7 @@ const TOTP_DOCS = require('../../docs/swagger/totp-api').default;
 const DESCRIPTION = require('../../docs/swagger/shared/descriptions').default;
 const { Container } = require('typedi');
 const { AccountEventsManager } = require('../account-events');
-const {
-  RecoveryPhoneService,
-} = require('../../../../libs/accounts/recovery-phone/src');
+const { RecoveryPhoneService } = require('@fxa/accounts/recovery-phone');
 
 const RECOVERY_CODE_SANE_MAX_LENGTH = 20;
 

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -951,7 +951,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'POST',
-      `${this.baseURL}/recovery-phone/create`,
+      `${this.baseURL}/recovery_phone/create`,
       token,
       {
         phoneNumber,
@@ -965,7 +965,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'POST',
-      `${this.baseURL}/recovery-phone/available`,
+      `${this.baseURL}/recovery_phone/available`,
       token,
       {}
     );
@@ -978,7 +978,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'POST',
-      `${this.baseURL}/recovery-phone/confirm`,
+      `${this.baseURL}/recovery_phone/confirm`,
       token,
       {
         code,
@@ -993,7 +993,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'POST',
-      `${this.baseURL}/recovery-phone/signin/confirm`,
+      `${this.baseURL}/recovery_phone/signin/confirm`,
       token,
       {
         code,
@@ -1007,7 +1007,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'POST',
-      `${this.baseURL}/recovery-phone/send_code`,
+      `${this.baseURL}/recovery_phone/signin/send_code`,
       token,
       {}
     );
@@ -1019,7 +1019,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'DELETE',
-      `${this.baseURL}/recovery-phone`,
+      `${this.baseURL}/recovery_phone`,
       token,
       {}
     );
@@ -1029,7 +1029,7 @@ module.exports = (config) => {
     const token = await tokens.SessionToken.fromHex(sessionTokenHex);
     return await this.doRequest(
       'GET',
-      `${this.baseURL}/recovery-phone`,
+      `${this.baseURL}/recovery_phone`,
       token,
       {}
     );

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -19,7 +19,7 @@ const { mockRequest } = require('../../mocks');
 const { Container } = require('typedi');
 chai.use(chaiAsPromised);
 
-describe('/recovery-phone', () => {
+describe('/recovery_phone', () => {
   const sandbox = sinon.createSandbox();
   const uid = '123435678123435678123435678123435678';
   const email = 'test@mozilla.com';
@@ -67,13 +67,13 @@ describe('/recovery-phone', () => {
     return await route.handler(mockRequest(req));
   }
 
-  describe('POST /recovery-phone/send_code', () => {
+  describe('POST /recovery_phone/signin/send_code', () => {
     it('sends recovery phone code', async () => {
       mockRecoveryPhoneService.sendCode = sinon.fake.returns(true);
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/send_code',
+        path: '/recovery_phone/signin/send_code',
         credentials: { uid, email },
       });
 
@@ -98,7 +98,7 @@ describe('/recovery-phone', () => {
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/send_code',
+        path: '/recovery_phone/signin/send_code',
         credentials: { uid, email },
       });
 
@@ -118,7 +118,7 @@ describe('/recovery-phone', () => {
 
       const promise = makeRequest({
         method: 'POST',
-        path: '/recovery-phone/send_code',
+        path: '/recovery_phone/signin/send_code',
         credentials: { uid, email },
       });
 
@@ -131,18 +131,22 @@ describe('/recovery-phone', () => {
     });
 
     it('requires session authorization', () => {
-      const route = getRoute(routes, '/recovery-phone/send_code', 'POST');
+      const route = getRoute(
+        routes,
+        '/recovery_phone/signin/send_code',
+        'POST'
+      );
       assert.include(route.options.auth.strategies, 'sessionToken');
     });
   });
 
-  describe('POST /recovery-phone/create', () => {
+  describe('POST /recovery_phone/create', () => {
     it('creates recovery phone number', async () => {
       mockRecoveryPhoneService.setupPhoneNumber = sinon.fake.returns(true);
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/create',
+        path: '/recovery_phone/create',
         credentials: { uid, email },
         payload: { phoneNumber },
       });
@@ -171,7 +175,7 @@ describe('/recovery-phone', () => {
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/create',
+        path: '/recovery_phone/create',
         credentials: { uid, email },
         payload: { phoneNumber: 'invalid' },
       });
@@ -189,7 +193,7 @@ describe('/recovery-phone', () => {
 
       const promise = makeRequest({
         method: 'POST',
-        path: '/recovery-phone/create',
+        path: '/recovery_phone/create',
         credentials: { uid, email },
         payload: { phoneNumber: '+495550005555' },
       });
@@ -206,7 +210,7 @@ describe('/recovery-phone', () => {
 
       const promise = makeRequest({
         method: 'POST',
-        path: '/recovery-phone/create',
+        path: '/recovery_phone/create',
         credentials: { uid, email },
         payload: { phoneNumber },
       });
@@ -217,7 +221,7 @@ describe('/recovery-phone', () => {
     });
 
     it('validates incoming phone number', () => {
-      const route = getRoute(routes, '/recovery-phone/create', 'POST');
+      const route = getRoute(routes, '/recovery_phone/create', 'POST');
       const joiSchema = route.options.validate.payload;
 
       const validNumber = joiSchema.validate({ phoneNumber: '+15550005555' });
@@ -233,18 +237,18 @@ describe('/recovery-phone', () => {
     });
 
     it('requires session authorization', () => {
-      const route = getRoute(routes, '/recovery-phone/create', 'POST');
+      const route = getRoute(routes, '/recovery_phone/create', 'POST');
       assert.include(route.options.auth.strategies, 'sessionToken');
     });
   });
 
-  describe('POST /recovery-phone/confirm', async () => {
+  describe('POST /recovery_phone/confirm', async () => {
     it('confirms a code', async () => {
       mockRecoveryPhoneService.confirmSetupCode = sinon.fake.returns(true);
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/confirm',
+        path: '/recovery_phone/confirm',
         credentials: { uid, email },
         payload: { code },
       });
@@ -267,7 +271,7 @@ describe('/recovery-phone', () => {
       mockRecoveryPhoneService.confirmSetupCode = sinon.fake.returns(false);
       const promise = makeRequest({
         method: 'POST',
-        path: '/recovery-phone/confirm',
+        path: '/recovery_phone/confirm',
         credentials: { uid, email },
         payload: { code },
       });
@@ -282,7 +286,7 @@ describe('/recovery-phone', () => {
       );
       const promise = makeRequest({
         method: 'POST',
-        path: '/recovery-phone/confirm',
+        path: '/recovery_phone/confirm',
         credentials: { uid, email },
         payload: { code },
       });
@@ -292,13 +296,13 @@ describe('/recovery-phone', () => {
     });
   });
 
-  describe('POST /recovery-phone/signin/confirm', async () => {
+  describe('POST /recovery_phone/signin/confirm', async () => {
     it('confirms a code during signin', async () => {
       mockRecoveryPhoneService.confirmSigninCode = sinon.fake.returns(true);
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/signin/confirm',
+        path: '/recovery_phone/signin/confirm',
         credentials: { uid, email },
         payload: { code },
       });
@@ -319,13 +323,13 @@ describe('/recovery-phone', () => {
     });
   });
 
-  describe('DELETE /recovery-phone', async () => {
+  describe('DELETE /recovery_phone', async () => {
     it('removes a recovery phone', async () => {
       mockRecoveryPhoneService.removePhoneNumber = sinon.fake.returns(true);
 
       const resp = await makeRequest({
         method: 'DELETE',
-        path: '/recovery-phone',
+        path: '/recovery_phone',
         credentials: { uid, email },
       });
 
@@ -344,7 +348,7 @@ describe('/recovery-phone', () => {
       );
       const promise = makeRequest({
         method: 'DELETE',
-        path: '/recovery-phone',
+        path: '/recovery_phone',
         credentials: { uid, email },
       });
 
@@ -356,20 +360,20 @@ describe('/recovery-phone', () => {
       mockRecoveryPhoneService.removePhoneNumber = sinon.fake.returns(false);
       await makeRequest({
         method: 'DELETE',
-        path: '/recovery-phone',
+        path: '/recovery_phone',
         credentials: { uid, email },
       });
       assert.equal(mockGlean.twoStepAuthPhoneRemove.success.callCount, 0);
     });
   });
 
-  describe('POST /recovery-phone/available', async () => {
+  describe('POST /recovery_phone/available', async () => {
     it('should return true if user can setup phone number', async () => {
       mockRecoveryPhoneService.available = sinon.fake.returns(true);
 
       const resp = await makeRequest({
         method: 'POST',
-        path: '/recovery-phone/available',
+        path: '/recovery_phone/available',
         credentials: { uid, email },
         geo: {
           location: {
@@ -394,7 +398,7 @@ describe('/recovery-phone', () => {
     });
   });
 
-  describe('GET /recovery-phone', async () => {
+  describe('GET /recovery_phone', async () => {
     it('gets a recovery phone', async () => {
       mockRecoveryPhoneService.hasConfirmed = sinon.fake.returns({
         exists: true,
@@ -403,7 +407,7 @@ describe('/recovery-phone', () => {
 
       const resp = await makeRequest({
         method: 'GET',
-        path: '/recovery-phone',
+        path: '/recovery_phone',
         credentials: { uid, emailVerified: true },
       });
 
@@ -421,7 +425,7 @@ describe('/recovery-phone', () => {
       );
       const promise = makeRequest({
         method: 'GET',
-        path: '/recovery-phone',
+        path: '/recovery_phone',
         credentials: { uid, emailVerified: true },
       });
 
@@ -436,7 +440,7 @@ describe('/recovery-phone', () => {
       });
       const resp = await makeRequest({
         method: 'GET',
-        path: '/recovery-phone',
+        path: '/recovery_phone',
         credentials: { uid, mustVerify: true },
       });
       assert.isDefined(resp);

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -307,7 +307,7 @@ describe(`#integration - recovery phone - customs checks`, function () {
     await redisUtil.customs.clearAll();
   });
 
-  it('prevents excessive calls to /recovery-phone/confirm', async function () {
+  it('prevents excessive calls to /recovery_phone/confirm', async function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
@@ -333,7 +333,7 @@ describe(`#integration - recovery phone - customs checks`, function () {
     assert.equal(error.message, 'Client has sent too many requests');
   });
 
-  it('prevents excessive calls to /recovery-phone/send-code', async function () {
+  it('prevents excessive calls to /recovery_phone/signin/send_code', async function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
@@ -355,7 +355,7 @@ describe(`#integration - recovery phone - customs checks`, function () {
     assert.equal(error.message, 'Client has sent too many requests');
   });
 
-  it('prevents excessive calls to /recovery-phone/available', async function () {
+  it('prevents excessive calls to /recovery_phone/available', async function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -19,7 +19,7 @@ import { AuthClientService } from '../backend/auth-client.service';
 import { ProfileClientService } from '../backend/profile-client.service';
 import { AccountResolver } from './account.resolver';
 import { NotifierService, NotifierSnsService } from '@fxa/shared/notifier';
-import { RecoveryPhoneService } from '../../../../libs/accounts/recovery-phone/src';
+import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
 
 let USER_1: any;
 let SESSION_1: any;


### PR DESCRIPTION
## Because

- We noticed that endpoint names could be a bit better

## This pull request

- Changes endpoints names. `/recovery-code/*` is now `/recovery_code/*`
- Endpoints solely for sign in operations now have `signin` in the path name.

## Issue that this pull request solves

Closes: FXA-10946

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
