### PR TITLE
task(auth): Add ability to mask recovery phone number

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -133,6 +133,19 @@ describe('RecoveryPhoneService', () => {
       ).toHaveBeenCalledWith(uid);
     });
 
+    it('can return masked phone number', async () => {
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockReturnValueOnce({
+        phoneNumber,
+      });
+
+      const result = await service.hasConfirmed(uid, 4);
+
+      expect(result.phoneNumber).toEqual('+•••••••1234');
+      expect(
+        mockRecoveryPhoneManager.getConfirmedPhoneNumber
+      ).toHaveBeenCalledWith(uid);
+    });
+
     it('can determine confirmed phone number does not exist', async () => {
       const mockError = new RecoveryNumberNotExistsError(uid);
       mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockRejectedValueOnce(
@@ -352,6 +365,17 @@ describe('RecoveryPhoneService', () => {
       mockRecoveryPhoneManager.hasRecoveryCodes.mockResolvedValueOnce(false);
       const result = await service.available(uid, region);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('mask phone number', () => {
+    it('can mask number', () => {
+      const phoneNumber = '+123456789';
+      expect(service.maskPhoneNumber(phoneNumber, -1)).toEqual('+•••••••••');
+      expect(service.maskPhoneNumber(phoneNumber, 0)).toEqual('+•••••••••');
+      expect(service.maskPhoneNumber(phoneNumber, 4)).toEqual('+•••••6789');
+      expect(service.maskPhoneNumber(phoneNumber, 9)).toEqual('+123456789');
+      expect(service.maskPhoneNumber(phoneNumber, 12)).toEqual('+123456789');
     });
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -419,7 +419,7 @@ describe('/recovery_phone', () => {
       );
     });
 
-    it('indicates service', async () => {
+    it('indicates  error', async () => {
       mockRecoveryPhoneService.hasConfirmed = sinon.fake.returns(
         Promise.reject(new Error('BOOM'))
       );
@@ -433,7 +433,7 @@ describe('/recovery_phone', () => {
       assert.equal(mockGlean.twoStepAuthPhoneRemove.success.callCount, 0);
     });
 
-    it('returns empty response for unverified session', async () => {
+    it('returns masked phone number for unverified session', async () => {
       mockRecoveryPhoneService.hasConfirmed = sinon.fake.returns({
         exists: true,
         phoneNumber,
@@ -444,8 +444,36 @@ describe('/recovery_phone', () => {
         credentials: { uid, mustVerify: true },
       });
       assert.isDefined(resp);
-      assert.isEmpty(resp);
-      assert.equal(mockRecoveryPhoneService.hasConfirmed.callCount, 0);
+      assert.isDefined(resp.exists);
+      assert.isDefined(resp.phoneNumber);
+      assert.equal(mockRecoveryPhoneService.hasConfirmed.callCount, 1);
+      assert.equal(
+        mockRecoveryPhoneService.hasConfirmed.getCall(0).args[0],
+        uid
+      );
+      assert.equal(mockRecoveryPhoneService.hasConfirmed.getCall(0).args[1], 4);
+    });
+
+    it('returns masked phone number format requested', async () => {
+      mockRecoveryPhoneService.hasConfirmed = sinon.fake.returns({
+        exists: true,
+        phoneNumber,
+      });
+      const resp = await makeRequest({
+        method: 'GET',
+        path: '/recovery_phone',
+        credentials: { uid, mustVerify: true },
+        payload: { phoneNumberMask: 2 },
+      });
+      assert.isDefined(resp);
+      assert.isDefined(resp.exists);
+      assert.isDefined(resp.phoneNumber);
+      assert.equal(mockRecoveryPhoneService.hasConfirmed.callCount, 1);
+      assert.equal(
+        mockRecoveryPhoneService.hasConfirmed.getCall(0).args[0],
+        uid
+      );
+      assert.equal(mockRecoveryPhoneService.hasConfirmed.getCall(0).args[1], 2);
     });
   });
 });


### PR DESCRIPTION
## Because

- By generating the mask server side we offer better data privacy for unverified sessions.

## This pull request

- Masks the phone number when session is not verified.

## Issue that this pull request solves

Closes: FXA-10947

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
