### PR TITLE
fix(errors): Display correct error for reset PW submit fail

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -338,7 +338,7 @@ const CompleteResetPasswordContainer = ({
     } catch (err) {
       const localizedBannerMessage = getLocalizedErrorMessage(
         ftlMsgResolver,
-        err.error
+        err
       );
       setErrorMessage(localizedBannerMessage);
     }


### PR DESCRIPTION
Because:
* These errors were all coming up as 'Unexpected error'

This commit:
* Passes in the full error object instead of error.error to getLocalizedErrorMessage

fixes FXA-10936

---

This ticket ended up being more of a spike than anything - the person was getting rate limited (more details will be added in ticket). We should be displaying the correct error here though because we were showing "Unexpected error" for all errors and it looked like this is the fix.

There's no container tests here yet unfortunately but I tested this by manually testing and `throw`ing an error object here.