### PR TITLE
fix(sms): Update 'backup recovery phone' strings to 'recovery phone'

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/en.ftl
@@ -13,4 +13,4 @@ flow-setup-phone-confirm-code-button = Confirm
 # followed by a button to resend a code
 flow-setup-phone-confirm-code-expired = Code expired?
 flow-setup-phone-confirm-code-resend-code-button = Resend code
-flow-setup-phone-confirm-code-success-message = Backup recovery phone added
+flow-setup-phone-confirm-code-success-message-v2 = Recovery phone added

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
@@ -69,8 +69,8 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
       await verifyRecoveryCode(code);
       alertBar.success(
         ftlMsgResolver.getMsg(
-          'flow-setup-phone-confirm-code-success-message',
-          'Backup recovery phone added'
+          'flow-setup-phone-confirm-code-success-message-v2',
+          'Recovery phone added'
         )
       );
       navigateForward();

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/en.ftl
@@ -4,11 +4,11 @@ flow-setup-phone-submit-number-heading = Verify your phone number
 # The code is a 6-digit code send by text message/SMS
 flow-setup-phone-verify-number-instruction = You’ll get a text message from { -brand-mozilla } with a code to verify your number. Don’t share this code with anyone.
 
-# The initial rollout of the backup recovery phone is only available to users with US and Canada mobile phone numbers.
+# The initial rollout of the recovery phone is only available to users with US and Canada mobile phone numbers.
 # Voice over Internet Protocol (VoIP), is a technology that uses a broadband Internet connection instead of a regular (or analog) phone line to make calls.
 # Phone mask services (for example Relay) provide a temporary virtual number to avoid providing a real phone number.
 # Both VoIP and phone masks can be unreliable for one-time-passcode (OTP) verification
-flow-setup-phone-submit-number-info-message = Backup recovery phone is only available in the United States and Canada. VoIP numbers and phone masks are not recommended.
+flow-setup-phone-submit-number-info-message-v2 = Recovery phone is only available in the United States and Canada. VoIP numbers and phone masks are not recommended.
 
 flow-setup-phone-submit-number-legal = By providing your number, you agree to us storing it so we can text you for account verification only. Message and data rates may apply.
 # cliking on the button sends a code by text message to the phone number typed in by the user

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.tsx
@@ -80,8 +80,8 @@ export const FlowSetupRecoveryPhoneSubmitNumber = ({
       <FormPhoneNumber
         infoBannerContent={{
           localizedDescription: ftlMsgResolver.getMsg(
-            'flow-setup-phone-submit-number-info-message',
-            'Backup recovery phone is only available in the United States and Canada. VoIP numbers and phone masks are not recommended.'
+            'flow-setup-phone-submit-number-info-message-v2',
+            'Recovery phone is only available in the United States and Canada. VoIP numbers and phone masks are not recommended.'
           ),
         }}
         localizedCTAText={ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
@@ -15,21 +15,21 @@ tfa-row-backup-codes-add-cta = Add
 # 'This' refers to 'backup authentication codes', used as a recovery method for two-step authentication
 tfa-row-backup-codes-description-2 = This is the safest recovery method if you canʼt use your mobile device or authenticator app.
 
-# Backup recovery phone is a recovery method for two-step authentication
+# Recovery phone is a recovery method for two-step authentication
 # A recovery code can be sent to the user's phone
-tfa-row-backup-phone-title = Backup recovery phone
-# Shown with an alert icon to indicate that no backup recovery phone is configured
+tfa-row-backup-phone-title-v2 = Recovery phone
+# Shown with an alert icon to indicate that no recovery phone is configured
 tfa-row-backup-phone-not-available = No recovery phone number available
-# button to change the configured backup recovery phone
+# button to change the configured recovery phone
 tfa-row-backup-phone-change-cta = Change
-# button to add/configure a backup recovery phone
+# button to add/configure a recovery phone
 tfa-row-backup-phone-add-cta = Add
-# Button to remove a backup recovery phone from the user's account
+# Button to remove a recovery phone from the user's account
 tfa-row-backup-phone-delete-button = Remove
 # Shown in tooltip on delete button or delete icon
-tfa-row-backup-phone-delete-title = Remove backup recovery phone
-tfa-row-backup-phone-delete-restriction = If you want to remove your backup recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.
-# "this" refers to backup recovery phone
+tfa-row-backup-phone-delete-title-v2 = Remove recovery phone
+tfa-row-backup-phone-delete-restriction-v2 = If you want to remove your recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.
+# "this" refers to recovery phone
 tfa-row-backup-phone-description = This is the easier recovery method if you canʼt use your authenticator app.
 # A SIM swap attack is a type of identity theft where an attacker tricks or bribes a mobile carrier
 # into transferring a victim's phone number to their own SIM card, enabling access to accounts secured

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -111,7 +111,7 @@ describe('BackupPhoneSubRow', () => {
     renderWithLocalizationProvider(
       <BackupPhoneSubRow onCtaClick={jest.fn()} />
     );
-    expect(screen.getByText('Backup recovery phone')).toBeInTheDocument();
+    expect(screen.getByText('Recovery phone')).toBeInTheDocument();
     expect(
       screen.getByText('No recovery phone number available')
     ).toBeInTheDocument();
@@ -126,12 +126,12 @@ describe('BackupPhoneSubRow', () => {
 
   it('renders correctly when phone number is available and delete is not an option', () => {
     renderWithLocalizationProvider(<BackupPhoneSubRow {...defaultProps} />);
-    expect(screen.getByText('Backup recovery phone')).toBeInTheDocument();
+    expect(screen.getByText('Recovery phone')).toBeInTheDocument();
     expect(screen.getByText('••• ••• 1234')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
     expect(
       screen.getByText(
-        'If you want to remove your backup recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.'
+        'If you want to remove your recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.'
       )
     ).toBeInTheDocument();
     expect(screen.getByText(/Learn about SIM swap risk/)).toBeInTheDocument();
@@ -141,7 +141,7 @@ describe('BackupPhoneSubRow', () => {
     renderWithLocalizationProvider(
       <BackupPhoneSubRow {...defaultProps} onDeleteClick={jest.fn()} />
     );
-    expect(screen.getByText('Backup recovery phone')).toBeInTheDocument();
+    expect(screen.getByText('Recovery phone')).toBeInTheDocument();
     expect(screen.getByText('••• ••• 1234')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
     const deleteButtons = screen.getAllByTitle(/Remove/);

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -250,8 +250,8 @@ export const BackupPhoneSubRow = ({
     : 'account_pref_two_step_auth_phone_add_submit';
 
   const localizedDeleteIconTitle = ftlMsgResolver.getMsg(
-    'tfa-row-backup-phone-delete-title',
-    'Remove backup recovery phone'
+    'tfa-row-backup-phone-delete-title-v2',
+    'Remove recovery phone'
   );
 
   const linkExternalProps = {
@@ -275,14 +275,14 @@ export const BackupPhoneSubRow = ({
             // info message should only be shown when a phone number is set and the user can't delete it
             // (i.e. when the user has no other recovery method)
             localizedInfoMessage: ftlMsgResolver.getMsg(
-              'tfa-row-backup-phone-delete-restriction',
-              'If you want to remove your backup recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.'
+              'tfa-row-backup-phone-delete-restriction-v2',
+              'If you want to remove your recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.'
             ),
           }
         : null)}
       {...((!hasPhoneNumber || (hasPhoneNumber && onDeleteClick)) && {
         // description should not be shown when the user can't delete the phone number (only one message displayed at a time)
-        // description should only be shown when both backup authentication codes and backup recovery phone
+        // description should only be shown when both backup authentication codes and recovery phone
         // are available recovery methods (description is intended to allow for comparison of the two methods)
         localizedDescription: ftlMsgResolver.getMsg(
           'tfa-row-backup-phone-description',
@@ -300,8 +300,8 @@ export const BackupPhoneSubRow = ({
         linkExternalProps,
       }}
       localizedRowTitle={ftlMsgResolver.getMsg(
-        'tfa-row-backup-phone-title',
-        'Backup recovery phone'
+        'tfa-row-backup-phone-title-v2',
+        'Recovery phone'
       )}
     />
   );

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -23,7 +23,7 @@ const route = `${SETTINGS_PATH}/two_step_authentication`;
 const replaceCodesRoute = `${route}/replace_codes`;
 
 // These props are temporary for storybook purposes
-// until backup recovery phone feature is enabled.
+// until recovery phone feature is enabled.
 type UnitRowTwoStepAuthProps = {
   backupPhoneSubRowProps?: BackupPhoneSubRowProps;
 };


### PR DESCRIPTION
Because:
* We decided removing 'backup' is clearer for users

This commit:
* Updates references in our codebase from 'backup recovery phone' to 'recovery phone', adds new FTL strings

closes FXA-10949