### PR TITLE
feat(email): Add second warning delete account notice

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/en.ftl
@@ -1,10 +1,11 @@
 inactiveAccountFirstWarning-subject = Donʼt lose your account
 inactiveAccountFirstWarning-title = Do you want to keep your { -brand-mozilla } account and data?
-inactiveAccountFirstWarning-account-description = Your { -product-mozilla-account } is used to access free privacy and browsing products like { -brand-firefox } sync, { -product-mozilla-monitor }, { -product-firefox-relay }, and { -product-mdn }.</span>
+inactiveAccountFirstWarning-account-description-v2 = Your { -product-mozilla-account } is used to access free privacy and browsing products like { -brand-firefox } sync, { -product-mozilla-monitor }, { -product-firefox-relay }, and { -product-mdn }.
 inactiveAccountFirstWarning-inactive-status = We noticed you haven’t signed in for 2 years.
 # $deletionDate - the date when the account will be deleted if the user does not take action to-reactivate their account
 # This date will already be formatted with moment.js into Thursday, Jan 9, 2025 format
 inactiveAccountFirstWarning-impact = Your account and your personal data will be permanently deleted on <strong>{ $deletionDate }</strong> because you haven’t been active.
 inactiveAccountFirstWarning-action = Sign in to keep your account
+inactiveAccountFirstWarning-preview = Sign in to keep your account
 # followed by link to sign in
 inactiveAccountFirstWarning-action-plaintext = Sign in to keep your account:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/includes.json
@@ -6,5 +6,9 @@
   "action": {
     "id": "inactiveAccountFirstWarning-action",
     "message": "Sign in to keep your account"
+  },
+  "preview": {
+    "id": "inactiveAccountFirstWarning-preview",
+    "message": "Sign in to keep your account"
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/en.ftl
@@ -1,0 +1,10 @@
+inactiveAccountSecondWarning-subject = Action required: Account deletion in 7 days
+inactiveAccountSecondWarning-title = Your { -brand-mozilla } account and data will be deleted in 7 days
+inactiveAccountSecondWarning-account-description = Your { -product-mozilla-account } is used to access free privacy and browsing products like { -brand-firefox } sync, { -produt-mozilla-monitor }, { -product-firefox-relay }, and { -product-mdn }.
+
+# $deletionDate - the date when the account will be deleted if the user does not take action to-reactivate their account
+inactiveAccountSecondWarning-impact = Your account and your personal data will be permanently deleted on <strong>{ $deletionDate }</strong> because you haven’t been active.
+inactiveAccountSecondWarning-action = Sign in to keep your account
+inactiveAccountSecondWarning-preview = Sign in to keep your account
+# followed by link to sign in
+inactiveAccountSecondWarning-action = Sign in to keep your account:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/includes.json
@@ -1,0 +1,14 @@
+{
+  "subject": {
+    "id": "inactiveAccountSecondWarning-subject",
+    "message": "Action required: Account deletion in 7 days"
+  },
+  "action": {
+    "id": "inactiveAccountSecondWarning-action",
+    "message": "Sign in to keep your account"
+  },
+  "preview": {
+    "id": "inactiveAccountSecondWarning-preview",
+    "message": "Sign in to keep your account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/index.mjml
@@ -1,0 +1,30 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="inactiveAccountSecondWarning-title">Your Mozilla account and data will be deleted in 7 days</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="inactiveAccountSecondWarning-account-description">Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN.</span>
+    </mj-text>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="inactiveAccountSecondWarning-impact" data-l10n-args="<%= JSON.stringify({deletionDate}) %>">Your account and your personal data will be permanently deleted on <strong>{ $deletionDate }</strong> because you haven’t been active.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml', {
+  buttonL10nId: "inactiveAccountSecondWarning-action",
+  buttonText: "Sign in to keep your account"
+}) %>
+
+<%- include('/partials/accountDeletionInfoBlock/index.mjml') %>
+<%- include('/partials/automatedEmailInactiveAccount/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/index.stories.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'FxA Emails/Templates/inactiveAccountSecondWarning',
+} as Meta;
+
+const createStory = storyWithProps(
+  'inactiveAccountSecondWarning',
+  'Second reminder sent to inactive account before account is deleted',
+  {
+    deletionDate: 'Thursday, Jan 9, 2025',
+    link: 'http://localhost:3030/signin',
+  }
+);
+
+export const inactiveAccountSecondWarning = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/index.txt
@@ -1,0 +1,12 @@
+inactiveAccountSecondWarning-title = "Your Mozilla account and data will be deleted in 7 days"
+
+inactiveAccountSecondWarning-account-description = "Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN."
+
+inactiveAccountSecondWarning-impact = "Your account and your personal data will be permanently deleted on <%- deletionDate %> because you haven’t been active."
+
+inactiveAccountSecondWarning-action-plaintext = "Sign in to keep your account:"
+<%- link %>
+
+<%- include('/partials/accountDeletionInfoBlock/index.txt') %>
+
+<%- include('/partials/automatedEmailInactiveAccount/index.txt') %>


### PR DESCRIPTION
## Because

- We want to send a 2nd notice that Mozilla account will be delete because of inactivity

## This pull request

- Adds the email template

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10637

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="714" alt="Screenshot 2025-01-14 at 10 25 44 AM" src="https://github.com/user-attachments/assets/82004f51-9994-479b-8b81-8f14ed1facd8" />
