### PR TITLE
feat(email): Add inactiveAccountFinalWarning template, tweak styles

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -9,6 +9,7 @@ $font-sans: sans-serif;
 $blue-500: #0060df;
 $white: #fff;
 $black: #000;
+$grey-50: #f0f0f4;
 $grey-100: #e7e7e7;
 $grey-400: #6d6d6e;
 $grey-500: #4b5563;
@@ -114,6 +115,9 @@ $s-10: 40px;
 .p {
   &-4 {
     padding: $s-4 !important;
+  }
+  &b-2 {
+    padding-bottom: $s-2 !important;
   }
 }
 // Global styles

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
@@ -105,11 +105,11 @@
 }
 
 .info-block {
-  margin: 20px 0 0 0;
-  background-color: global.$grey-100;
+  margin: 28px 0 0 0;
+  background-color: global.$grey-50;
   border-radius: 10px;
 }
 
 .info-block div {
-  padding: 20px 0 0 0;
+  padding: 20px 32px 0;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/accountDeletionInfoBlock/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/accountDeletionInfoBlock/index.mjml
@@ -9,9 +9,9 @@
         If your account is deleted, you’ll still receive emails from Mozilla Corporation and Mozilla Foundation, unless you <a class="link-blue" href="<%- unsubscribeUrl %>" data-l10n-name="unsubscribeLink">ask to unsubscribe</a>.
       </span>
     </mj-text>
-    <%# css-class is not supported for mj-divider and styles must be applied inline %>
-    <mj-divider border-color="#c2c2c2" border-width="2px" padding="10px 0"></mj-divider>
-    <mj-text css-class="text-sub-body">
+    <%# css-class is not supported for mj-divider and styles must be applied inline. Border-color is $grey-100 %>
+    <mj-divider border-color="#E7E7E7" border-width="1px"></mj-divider>
+    <mj-text css-class="text-sub-body pb-2">
       <span data-l10n-id="account-deletion-info-block-support">
         If you have any questions or need assistance, feel free to contact our <a class="link-blue" href="<%- supportUrl %>" data-l10n-name="supportLink">support team</a>.
       </span>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/en.ftl
@@ -1,0 +1,10 @@
+inactiveAccountFinalWarning-subject = Last chance to keep your { -product-mozilla-account }
+inactiveAccountFinalWarning-title = Your { -brand-mozilla } account and data will be deleted
+inactiveAccountFinalWarning-preview = Sign in to keep your account
+inactiveAccountFinalWarning-account-description = Your { -product-mozilla-account } is used to access free privacy and browsing products like { -brand-firefox } sync, { -product-mozilla-monitor }, { -product-firefox-relay }, and { -product-mdn }.
+# $deletionDate - the date when the account will be deleted if the user does not take action to-reactivate their account
+# This date will already be formatted with moment.js into Thursday, Jan 9, 2025 format
+inactiveAccountFinalWarning-impact = On <strong>{ $deletionDate }</strong>, your account and your personal data will be permanently deleted unless you sign in.
+inactiveAccountFirstWarning-action = Sign in to keep your account
+# followed by link to sign in
+inactiveAccountFirstWarning-action-plaintext = Sign in to keep your account:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/includes.json
@@ -1,0 +1,14 @@
+{
+  "subject": {
+    "id": "inactiveAccountFinalWarning-subject",
+    "message": "Donʼt lose your account"
+  },
+  "action": {
+    "id": "inactiveAccountFinalWarning-action",
+    "message": "Sign in to keep your account"
+  },
+  "preview": {
+    "id": "inactiveAccountFinalWarning-preview",
+    "message": "Sign in to keep your account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/index.mjml
@@ -1,0 +1,30 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="inactiveAccountFinalWarning-title">Your Mozilla account and data will be deleted</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="inactiveAccountFinalWarning-account-description">Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN.</span>
+    </mj-text>
+    <mj-text css-class="text-sub-body">
+      <span data-l10n-id="inactiveAccountFinalWarning-impact" data-l10n-args="<%= JSON.stringify({deletionDate}) %>">On <strong>{ $deletionDate }</strong>, your account and your personal data will be permanently deleted unless you sign in.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml', {
+  buttonL10nId: "inactiveAccountFirstWarning-action",
+  buttonText: "Sign in to keep your account"
+}) %>
+
+<%- include('/partials/accountDeletionInfoBlock/index.mjml') %>
+<%- include('/partials/automatedEmailInactiveAccount/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/index.stories.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'FxA Emails/Templates/inactiveAccountFinalWarning',
+} as Meta;
+
+const createStory = storyWithProps(
+  'inactiveAccountFinalWarning',
+  'Final reminder sent to inactive account before account is deleted',
+  {
+    // dates will be passed in to the template already localized and formatted by the email handler
+    deletionDate: 'Thursday, Jan 9, 2025',
+    link: 'http://localhost:3030/signin',
+  }
+);
+
+export const inactiveAccountFinalWarning = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/index.txt
@@ -1,0 +1,12 @@
+inactiveAccountFinalWarning-title = "Your Mozilla account and data will be deleted"
+
+inactiveAccountFinalWarning-account-description = "Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN."
+
+inactiveAccountFinalWarning-impact = "On <%- deletionDate %>, your account and your personal data will be permanently deleted unless you sign in."
+
+inactiveAccountFinalWarning-action-plaintext = "Sign in to keep your account:"
+<%- link %>
+
+<%- include('/partials/accountDeletionInfoBlock/index.txt') %>
+
+<%- include('/partials/automatedEmailInactiveAccount/index.txt') %>


### PR DESCRIPTION
Because:
* We want to send users a third and final email warning about their impending inactive account deletion

This commit:
* Adds the MJML, FTL, plain text, and stories file to complete the template
* Tweaks the grey info box below to better match Figma

closes FXA-10943

---

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e95ddb87-51de-47e1-83f5-690381d6a1ae" />
