### PR TITLE
feat(next): support existing payment methods

### DIFF
--- a/apps/payments/next/tailwind.config.ts
+++ b/apps/payments/next/tailwind.config.ts
@@ -20,6 +20,8 @@ export default <Partial<Config>>{
       boxShadow: {
         inputError:
           '0 1px 2px rgba(0, 0, 0, 0.3), 0 3px 6px rgba(0, 0, 0, 0.02), 0 0 0 1px #df1b41',
+        stripeBox:
+          'rgba(0, 0, 0, 0.03) 0px 1px 1px 0px, rgba(0, 0, 0, 0.02) 0px 3px 6px 0px',
       },
       colors: {
         'alert-red': '#D70022',

--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -51,6 +51,7 @@ export interface PaymentInfo {
   type: PaymentProvidersType;
   last4?: string;
   brand?: string;
+  customerSessionClientSecret?: string;
 }
 
 export type ResultCart = Readonly<Omit<Cart, 'id' | 'uid'>> & {

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -28,6 +28,7 @@ import {
 } from '@fxa/payments/paypal';
 import {
   CustomerManager,
+  CustomerSessionManager,
   InvoiceManager,
   InvoicePreviewFactory,
   PaymentIntentManager,
@@ -126,6 +127,7 @@ describe('CheckoutService', () => {
         CartService,
         CheckoutService,
         CustomerManager,
+        CustomerSessionManager,
         CurrencyManager,
         EligibilityManager,
         EligibilityService,
@@ -579,7 +581,7 @@ describe('CheckoutService', () => {
       it('calls calls paymentIntentManager.confirm', async () => {
         expect(paymentIntentManager.confirm).toHaveBeenCalledWith(
           mockInvoice.payment_intent,
-          { confirmation_token: mockConfirmationToken.id }
+          { confirmation_token: mockConfirmationToken.id, off_session: false }
         );
       });
 

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -119,7 +119,7 @@ export class CheckoutService {
       customer = await this.customerManager.retrieve(stripeCustomerId);
     }
 
-    if (uid && stripeCustomerId) {
+    if (uid && !cart.stripeCustomerId) {
       await this.accountCustomerManager.createAccountCustomer({
         uid,
         stripeCustomerId,
@@ -297,6 +297,7 @@ export class CheckoutService {
       invoice.payment_intent,
       {
         confirmation_token: confirmationTokenId,
+        off_session: false,
       }
     );
 

--- a/libs/payments/customer/src/index.ts
+++ b/libs/payments/customer/src/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * from './lib/customer.manager';
+export * from './lib/customerSession.manager';
 export * from './lib/invoice.manager';
 export * from './lib/invoice.factories';
 export * from './lib/paymentIntent.manager';

--- a/libs/payments/customer/src/lib/customerSession.manager.spec.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.spec.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Test } from '@nestjs/testing';
+
+import { CustomerSessionManager } from './customerSession.manager';
+import {
+  StripeClient,
+  MockStripeConfigProvider,
+  StripeResponseFactory,
+  StripeCustomerSessionFactory,
+} from '@fxa/payments/stripe';
+
+describe('CustomerSessionManager', () => {
+  let customerSessionManager: CustomerSessionManager;
+  let stripeClient: StripeClient;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        MockStripeConfigProvider,
+        CustomerSessionManager,
+        StripeClient,
+      ],
+    }).compile();
+
+    customerSessionManager = moduleRef.get(CustomerSessionManager);
+    stripeClient = moduleRef.get(StripeClient);
+  });
+
+  describe('create', () => {
+    it('should create a customer session', async () => {
+      const customerId = 'customerId';
+      const mockCustomerSession = StripeCustomerSessionFactory();
+      const mockResponse = StripeResponseFactory(mockCustomerSession);
+
+      jest
+        .spyOn(stripeClient, 'customersSessionsCreate')
+        .mockResolvedValue(mockResponse);
+
+      const result = await customerSessionManager.create(customerId);
+
+      expect(stripeClient.customersSessionsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ customer: customerId })
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/libs/payments/customer/src/lib/customerSession.manager.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StripeClient } from '@fxa/payments/stripe';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CustomerSessionManager {
+  constructor(private stripeClient: StripeClient) {}
+
+  async create(customerId: string) {
+    return this.stripeClient.customersSessionsCreate({
+      customer: customerId,
+      components: {
+        payment_element: {
+          enabled: true,
+          features: {
+            payment_method_redisplay: 'enabled',
+            payment_method_save: 'disabled',
+            payment_method_remove: 'disabled',
+            payment_method_allow_redisplay_filters: ['always', 'unspecified'],
+          },
+        },
+      },
+    });
+  }
+}

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -13,6 +13,7 @@ export { StripeCardFactory } from './lib/factories/card.factory';
 export { StripeConfirmationTokenFactory } from './lib/factories/confirmation-token.factory';
 export { StripeCouponFactory } from './lib/factories/coupon.factory';
 export { StripeCustomerFactory } from './lib/factories/customer.factory';
+export { StripeCustomerSessionFactory } from './lib/factories/customer-session.factory';
 export { StripeDiscountFactory } from './lib/factories/discount.factory';
 export { StripeInvoiceLineItemFactory } from './lib/factories/invoice-line-item.factory';
 export { StripeInvoiceFactory } from './lib/factories/invoice.factory';

--- a/libs/payments/stripe/src/lib/factories/customer-session.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/customer-session.factory.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { StripeCustomerSession } from '../stripe.client.types';
+
+export const StripeCustomerSessionFactory = (
+  override?: Partial<StripeCustomerSession>
+): StripeCustomerSession => ({
+  object: 'customer_session',
+  client_secret: faker.string.alphanumeric(24),
+  customer: faker.string.alphanumeric(24),
+  expires_at: faker.number.int(),
+  created: faker.number.int(),
+  livemode: false,
+  ...override,
+});

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -8,6 +8,7 @@ import { Stripe } from 'stripe';
 import {
   StripeApiList,
   StripeCustomer,
+  StripeCustomerSession,
   StripeDeletedCustomer,
   StripeInvoice,
   StripePaymentIntent,
@@ -78,6 +79,11 @@ export class StripeClient {
     });
 
     return result as StripeResponse<StripeCustomer>;
+  }
+
+  async customersSessionsCreate(params: Stripe.CustomerSessionCreateParams) {
+    const result = await this.stripe.customerSessions.create(params);
+    return result as StripeResponse<StripeCustomerSession>;
   }
 
   async subscriptionsList(params?: Stripe.SubscriptionListParams) {

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -82,6 +82,12 @@ export type StripeCustomer = NegotiateExpanded<
   | 'test_clock'
 >;
 
+export type StripeCustomerSession = NegotiateExpanded<
+  never,
+  Stripe.CustomerSession,
+  'customer'
+>;
+
 export type StripeCustomerInvoiceSettings = NegotiateExpanded<
   never,
   Stripe.Customer.InvoiceSettings,

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
@@ -7,7 +7,6 @@
 import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
 import { CheckoutCartWithPaypalActionArgs } from '../nestapp/validators/CheckoutCartWithPaypalActionArgs';
-import { redirect } from 'next/navigation';
 
 export const checkoutCartWithPaypal = async (
   cartId: string,
@@ -23,6 +22,4 @@ export const checkoutCartWithPaypal = async (
       token,
     })
   );
-
-  redirect('processing');
 };

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/en.ftl
@@ -3,6 +3,8 @@
 next-new-user-submit = Subscribe Now
 next-payment-validate-name-error = Please enter your full name
 
+next-pay-with-heading-paypal = Pay with { -brand-paypal }
+
 # Label for the Full Name input
 payment-name-label = Name as it appears on your card
 payment-name-placeholder = Full Name

--- a/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
@@ -4,6 +4,7 @@
 
 'use client';
 
+import Stripe from 'stripe';
 import { CheckoutForm } from '../CheckoutForm';
 import { StripeWrapper } from '../StripeWrapper';
 
@@ -28,6 +29,16 @@ interface PaymentFormProps {
       countryCode: string;
       postalCode: string;
     };
+    paymentInfo?: {
+      type:
+        | Stripe.PaymentMethod.Type
+        | 'google_iap'
+        | 'apple_iap'
+        | 'external_paypal';
+      last4?: string;
+      brand?: string;
+      customerSessionClientSecret?: string;
+    };
   };
   locale: string;
 }
@@ -42,6 +53,7 @@ export function PaymentSection({
     <StripeWrapper
       amount={paymentsInfo.amount}
       currency={paymentsInfo.currency}
+      paymentInfo={cart.paymentInfo}
     >
       <CheckoutForm
         cmsCommonContent={cmsCommonContent}

--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 'use client';
 
+import Stripe from 'stripe';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe, StripeElementsOptions } from '@stripe/stripe-js';
 import { useContext, useState } from 'react';
@@ -11,12 +12,23 @@ import { ConfigContext } from '../providers/ConfigProvider';
 interface StripeWrapperProps {
   amount: number;
   currency: string;
+  paymentInfo?: {
+    type:
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
+    last4?: string;
+    brand?: string;
+    customerSessionClientSecret?: string;
+  };
   children: React.ReactNode;
 }
 
 export function StripeWrapper({
   amount,
   currency,
+  paymentInfo,
   children,
 }: StripeWrapperProps) {
   const config = useContext(ConfigContext);
@@ -28,6 +40,7 @@ export function StripeWrapper({
     currency,
     paymentMethodCreation: 'manual',
     externalPaymentMethodTypes: ['external_paypal'],
+    customerSessionClientSecret: paymentInfo?.customerSessionClientSecret,
     appearance: {
       variables: {
         fontFamily:
@@ -56,6 +69,13 @@ export function StripeWrapper({
       },
     },
   };
+
+  if (
+    paymentInfo?.type !== 'external_paypal' &&
+    paymentInfo?.customerSessionClientSecret
+  ) {
+    delete options.externalPaymentMethodTypes;
+  }
 
   return (
     <Elements stripe={stripePromise} options={options}>

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -30,6 +30,7 @@ import {
   ProductManager,
   PromotionCodeManager,
   SubscriptionManager,
+  CustomerSessionManager,
 } from '@fxa/payments/customer';
 import { PaymentsGleanManager } from '@fxa/payments/metrics';
 import { PaymentsGleanFactory } from '@fxa/payments/metrics/provider';
@@ -81,6 +82,7 @@ import { PaymentsEmitterService } from '../emitter/emitter.service';
     ContentServerManager,
     ContentServerClient,
     CustomerManager,
+    CustomerSessionManager,
     CurrencyManager,
     CheckoutService,
     EligibilityManager,


### PR DESCRIPTION
## Because

- Adds support for customers with existing payment methods.

## This pull request

- Create Customer Sessions and add it to the Payment Element to support reuse of existing payment method. This only supports non-external payment methods, i.e. PayPal.
- Support existing PayPal payment method.
- If existing Payment Element payment method exists, do not allow PayPal as a payment method.
- If existing PayPal payment method exists, do not allow adding of new Payment Element payment method.

## Issue that this pull request solves

Closes: #FXA-7591

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/6d0d8779-29f2-4be7-b235-65d34cec574b)

![image](https://github.com/user-attachments/assets/aefc05b0-d208-4b8d-ba8a-cd312a345ba4)

## Other information (Optional)

Any other information that is important to this pull request.
