### PR TITLE
feat(sms): Create 'adding' and 'using' backup phone feature flags

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -67,6 +67,8 @@
   },
   "featureFlags": {
     "sendFxAStatusOnSettings": true,
-    "recoveryCodeSetupOnSyncSignIn": true
+    "recoveryCodeSetupOnSyncSignIn": true,
+    "enableAdding2FABackupPhone": true,
+    "enableUsing2FABackupPhone": true
   }
 }

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -105,6 +105,12 @@ const settingsConfig = {
     recoveryCodeSetupOnSyncSignIn: config.get(
       'featureFlags.recoveryCodeSetupOnSyncSignIn'
     ),
+    enableAdding2FABackupPhone: config.get(
+      'featureFlags.enableAdding2FABackupPhone'
+    ),
+    enableUsing2FABackupPhone: config.get(
+      'featureFlags.enableUsing2FABackupPhone'
+    ),
   },
 };
 

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -232,6 +232,18 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN',
     },
+    enableAdding2FABackupPhone: {
+      default: false,
+      doc: 'Enables adding a new backup phone number for 2FA',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_ADDING_2FA_BACKUP_PHONE',
+    },
+    enableUsing2FABackupPhone: {
+      default: false,
+      doc: 'Enables using and managing an already confirmed backup phone number for 2FA',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_USING_2FA_BACKUP_PHONE',
+    },
   },
   showReactApp: {
     emailFirstRoutes: {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -89,6 +89,8 @@ export interface Config {
   featureFlags?: {
     keyStretchV2?: boolean;
     recoveryCodeSetupOnSyncSignIn?: boolean;
+    enableAdding2FABackupPhone?: boolean;
+    enableUsing2FABackupPhone?: boolean;
   };
 }
 
@@ -166,6 +168,8 @@ export function getDefault() {
     },
     featureFlags: {
       recoveryCodeSetupOnSyncSignIn: false,
+      enableAdding2FABackupPhone: false,
+      enableUsing2FABackupPhone: false,
     },
   } as Config;
 }


### PR DESCRIPTION
Because:
* We want SMS to be behind a feature flag

This commit:
* Creates two feature flags to support disabling users from adding a new phone while preventing locking them out if they already have a backup phone added

closes FXA-10250

--

SRE side PR: https://github.com/mozilla-it/webservices-infra/pull/3750