### PR TITLE
fix(l10n): Update incorrect FTL IDs for inactive second/final emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFinalWarning/en.ftl
@@ -5,6 +5,6 @@ inactiveAccountFinalWarning-account-description = Your { -product-mozilla-accoun
 # $deletionDate - the date when the account will be deleted if the user does not take action to-reactivate their account
 # This date will already be formatted with moment.js into Thursday, Jan 9, 2025 format
 inactiveAccountFinalWarning-impact = On <strong>{ $deletionDate }</strong>, your account and your personal data will be permanently deleted unless you sign in.
-inactiveAccountFirstWarning-action = Sign in to keep your account
+inactiveAccountFinalWarning-action = Sign in to keep your account
 # followed by link to sign in
-inactiveAccountFirstWarning-action-plaintext = Sign in to keep your account:
+inactiveAccountFinalWarning-action-plaintext = Sign in to keep your account:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountSecondWarning/en.ftl
@@ -7,4 +7,4 @@ inactiveAccountSecondWarning-impact = Your account and your personal data will b
 inactiveAccountSecondWarning-action = Sign in to keep your account
 inactiveAccountSecondWarning-preview = Sign in to keep your account
 # followed by link to sign in
-inactiveAccountSecondWarning-action = Sign in to keep your account:
+inactiveAccountSecondWarning-action-plaintext = Sign in to keep your account:


### PR DESCRIPTION
Because:
* These were updated in the MJML/txt files but not in the en.ftl files

This commit:
* Corrects the l10n IDs