### PR TITLE
fix(tests): remove update payment method smoke test fixme

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/paymentMode.spec.ts
@@ -15,7 +15,6 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, subscribe, settings, signin },
       credentials,
     }, { project }) => {
-      test.fixme(project.name != 'production', 'FXA-10978');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'


### PR DESCRIPTION
## Because

- Fix me was added to test due to consistent failures

## This pull request

- A configuration change in Stripe caused the setup_intent Stripe API call to fail.
- An update was made in Stripe to disable Card as a valid payment method. Reverting this change resolved the issue.

## Issue that this pull request solves

Closes: #FXA-10978

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/5192b1cb-0735-44a8-bc23-e9fffe6e96b7)

## Other information (Optional)

Any other information that is important to this pull request.
