### PR TITLE
task(auth): Remove recoveryPhoneAvailable customs check

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -227,8 +227,6 @@ class RecoveryPhoneHandler {
       throw AppError.invalidToken();
     }
 
-    await this.customs.check(request, email, 'recoveryPhoneAvailable');
-
     // Maxmind countryCode is two-letter ISO country code (ex `US` for the United States)
     // This is the same format as the `region` field in the recovery phone config
     const location = request.app.geo?.location;

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -408,13 +408,6 @@ describe('/recovery_phone', () => {
         uid,
         'US'
       );
-
-      assert.equal(mockCustoms.check.callCount, 1);
-      assert.equal(mockCustoms.check.getCall(0).args[1], email);
-      assert.equal(
-        mockCustoms.check.getCall(0).args[2],
-        'recoveryPhoneAvailable'
-      );
     });
   });
 

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -307,6 +307,26 @@ describe(`#integration - recovery phone - customs checks`, function () {
     await redisUtil.customs.clearAll();
   });
 
+  it('prevents excessive calls to /recovery_phone/create', async function () {
+    if (!isTwilioConfigured) {
+      this.skip('Invalid twilio accountSid or authToken. Check env / config!');
+    }
+
+    await client.recoveryPhoneNumberCreate(phoneNumber);
+
+    let error;
+    try {
+      for (let i = 0; i < 9; i++) {
+        await client.recoveryPhoneNumberCreate(phoneNumber);
+      }
+    } catch (err) {
+      error = err;
+    }
+
+    assert.isDefined(error);
+    assert.equal(error.message, 'Client has sent too many requests');
+  });
+
   it('prevents excessive calls to /recovery_phone/confirm', async function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
@@ -344,29 +364,9 @@ describe(`#integration - recovery phone - customs checks`, function () {
 
     let error;
     try {
-      for (let i = 0; i < 20; i++) {
+      for (let i = 0; i < 9; i++) {
         await client.recoveryPhoneSendCode();
       }
-    } catch (err) {
-      error = err;
-    }
-
-    assert.isDefined(error);
-    assert.equal(error.message, 'Client has sent too many requests');
-  });
-
-  it('prevents excessive calls to /recovery_phone/available', async function () {
-    if (!isTwilioConfigured) {
-      this.skip('Invalid twilio accountSid or authToken. Check env / config!');
-    }
-
-    for (let i = 0; i < 10; i++) {
-      await client.recoveryPhoneAvailable();
-    }
-
-    let error;
-    try {
-      await client.recoveryPhoneAvailable();
     } catch (err) {
       error = err;
     }

--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -75,9 +75,7 @@ const RESET_PASSWORD_OTP_VERIFICATION_ACTION = {
 };
 
 // Actions that result in calls to the twilio api
-const TWILIO_ACTIONS = {
-  recoveryPhoneAvailable: true,
-};
+const TWILIO_ACTIONS = {};
 
 module.exports = {
   isPasswordCheckingAction: function (action) {

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -130,16 +130,18 @@ module.exports = function (fs, path, url, convict) {
       smsRateLimit: {
         limitIntervalSeconds: {
           doc: 'Duration of automatic throttling for sms',
-          default: 30 * 60,
+          default: 24 * 60 * 60, // One day
           format: 'nat',
           env: 'SMS_RATE_LIMIT_INTERVAL_SECONDS',
         },
         maxSms: {
           doc: 'Number of sms sent within rateLimitIntervalSeconds before throttling',
-          default: 3,
+          default: 6,
           format: 'nat',
           env: 'MAX_SMS',
         },
+
+        // Not currently used... But might leaving around for future calls.
         maxTwilioRequests: {
           doc: 'Number of twilio requests sent within rateLimitIntervalSeconds before throttling',
           default: 10,

--- a/packages/fxa-customs-server/test/remote/too_many_sms.js
+++ b/packages/fxa-customs-server/test/remote/too_many_sms.js
@@ -365,62 +365,6 @@ test('/check `connectDeviceSms` by email', function (t) {
   );
 });
 
-test('/check `recoveryPhoneAvailable` by email', function (t) {
-  const action = 'recoveryPhoneAvailable';
-  return (
-    client
-      .postAsync('/check', {
-        ip: TEST_IP,
-        email: 'test1@example.com',
-        action,
-      })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns a 200');
-        t.equal(obj.block, false, 'not rate limited');
-        return client.postAsync('/check', {
-          ip: TEST_IP,
-          email: 'test1@example.com',
-          action,
-        });
-      })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns a 200');
-        t.equal(obj.block, false, 'not rate limited');
-        return client.postAsync('/check', {
-          ip: TEST_IP,
-          email: 'test1@example.com',
-          action,
-        });
-      })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns a 200');
-        t.equal(obj.block, true, 'rate limited');
-        t.equal(obj.retryAfter, 1, 'rate limit retry amount');
-
-        // Delay ~1s for rate limit to go away
-        return Promise.delay(1010);
-      })
-
-      // Reissue requests to verify that throttling is disabled
-      .then(function () {
-        return client.postAsync('/check', {
-          ip: TEST_IP,
-          email: 'test1@example.com',
-          action,
-        });
-      })
-      .spread(function (req, res, obj) {
-        t.equal(res.statusCode, 200, 'returns a 200');
-        t.equal(obj.block, false, 'not rate limited');
-        t.end();
-      })
-      .catch(function (err) {
-        t.fail(err);
-        t.end();
-      })
-  );
-});
-
 test('clear everything', function (t) {
   mcHelper.clearEverything(function (err) {
     t.notOk(err, 'no errors were returned');


### PR DESCRIPTION
## Because
- We were reviewing customs rules and deemed this recoveryPhoneAvailable check wasn't necessary.
- We also decided to change the default custom rate limits here.

## This pull request

- Removes the recoveryPhoneAvailable check.
- Removes the action from customs.
- Leaving isTwilioAction, however. We might need it later.
- Changes default config to 9 sms per 24 hour period
- Fixes remote test to be inline with updated customs rate limits

## Issue that this pull request solves

Closes: FXA-11006, FXA-11005

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We are leaving `isTwilioAction` and the `TWILIO_ACTION` group set in customs. Pretty sure we will need it at some point soon, but with different actions.
