### PR TITLE
bug(settings): Missing login_totp_code_trouble_link metric

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -193,6 +193,7 @@ export const SigninTotpCode = ({
             to={`/signin_recovery_code${location.search}`}
             state={signinState}
             className="text-end"
+            data-glean-id="login_totp_code_trouble_link"
           >
             Trouble entering code?
           </Link>


### PR DESCRIPTION
## Because
- The `login_totp_code_trouble_link` was missing.

## This pull request
- Adds the `login_totp_code_trouble_link` metric via a `data-glean-id` on the link.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
