### PR TITLE
feat(docker): Push to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1097,24 +1097,6 @@ workflows:
               only: /.*/
           requires:
             - Build
-      - deploy-fxa-image:
-          name: Deploy Fxa Image
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-          requires:
-            - Lint
-            - Compile
-            - Unit Test
-            - Integration Test - Frontends
-            - Integration Test - Servers
-            - Integration Test - Servers - Auth
-            - Integration Test - Servers - Auth V2
-            - Integration Test - Libraries
-            - Functional Tests - Playwright
-            - Create FxA Image
 
   nightly:
     # This work flow runs a full build, test suite, and deployment of docker images nightly

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,12 +87,27 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE}}
+            ${{ vars.DOCKERHUB_REPOSITORY }}
+          tags: |
+            type=raw,${{ env.GIT_TAG }}
+
       - id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
           token_format: 'access_token'
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID}}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - id: dockerhub-auth
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - uses: docker/login-action@v3
         with:
@@ -105,7 +120,8 @@ jobs:
         with:
           context: .
           file: _dev/docker/mono/Dockerfile
-          tags: ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE}}:${{ env.GIT_TAG }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Because

- We are using GitHub Actions and Google Artifact Registry to build and push production container images

## This pull request

- Pushes the container image to Docker Hub from GitHub Actions

## Issue that this pull request solves

Closes: FXA-10933

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
