### PR TITLE
chore(test): remove chromium functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,32 +342,6 @@ commands:
             RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
             UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
 
-  run-playwright-tests-chromium:
-    parameters:
-      project:
-        type: string
-    steps:
-      - run:
-          name: Running Playwright tests
-          # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
-          command: |
-            npx nx build fxa-auth-client
-            cd packages/functional-tests/tests
-            TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
-            cd ..
-            echo $TEST_FILES | circleci tests run \
-              --command="xargs yarn playwright test --project=<< parameters.project >> $GREP" \
-              --verbose \
-              --split-by=timings \
-              --timings-type=classname
-          environment:
-            NODE_OPTIONS: --dns-result-order=ipv4first
-            ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
-            PAYMENTS_DOMAIN: << pipeline.parameters.payments-domain >>
-            ACCOUNTS_API_DOMAIN: << pipeline.parameters.accounts-api-domain >>
-            RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
-            UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
-
   store-artifacts:
     steps:
       - run:
@@ -727,31 +701,6 @@ jobs:
           environment:
             NODE_ENV: test
       - run-playwright-tests:
-          project: local
-      - store-artifacts
-
-  playwright-functional-tests-chromium:
-    parameters:
-      parallelism:
-        type: integer
-        default: 8  # this should correspond with the resource-class defined in the executor
-    executor: functional-test-executor
-    parallelism: << parameters.parallelism >>
-    steps:
-      - git-checkout
-      - restore-workspace
-      - run:
-          name: Add localhost
-          command: |
-            sudo tee -a /etc/hosts \<<<'127.0.0.1 localhost'
-            sudo cat /etc/hosts
-      - wait-for-infrastructure
-      - run:
-          name: Start services for playwright tests
-          command: ./packages/functional-tests/scripts/start-services.sh
-          environment:
-            NODE_ENV: test
-      - run-playwright-tests-chromium:
           project: local
       - store-artifacts
 

--- a/packages/functional-tests/package.json
+++ b/packages/functional-tests/package.json
@@ -7,7 +7,6 @@
     "compile": "tsc --noEmit",
     "test": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local",
     "test-local": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local",
-    "test-local-chromium": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=local-chromium",
     "test-stage": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=stage",
     "test-production": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --project=production",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -79,21 +79,6 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
           },
         } as Project)
     ),
-    ...TargetNames.map(
-      (name) =>
-        ({
-          name: `${name}-chromium`,
-          use: {
-            browserName: 'chromium',
-            targetName: name,
-            launchOptions: {
-              headless: !DEBUG,
-              slowMo: SLOWMO,
-            },
-            trace: 'retain-on-failure',
-          },
-        } as Project)
-    ),
   ],
   reporter: CI
     ? [

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -13,10 +13,6 @@ test.describe('recovery key promo', () => {
         config.featureFlags.recoveryCodeSetupOnSyncSignIn !== true,
         'inline recovery key setup is not enabled'
       );
-      test.skip(
-        project.name === 'local-chromium',
-        'Sync tests can not run on Chrome'
-      );
     });
 
     test('not shown after signup', async ({

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -51,8 +51,8 @@ test.describe('severity-2 #smoke', () => {
       credentials,
     }, { project }) => {
       test.skip(
-        project.name === 'production' || project.name === 'local-chromium',
-        'no real payment method available in prod or local-chromium'
+        project.name === 'production',
+        'no real payment method available in prod'
       );
       await relier.goto();
       await relier.clickSubscribe();


### PR DESCRIPTION
## Because

* The chromium functional tests do not cover a known critical risk or a significant usership sector
* The ETE and FxA teams do not have capacity to finish their implementation or keep them in good health
* The chromium functional tests give false positives, for example tests using Sync pass

## This pull request

* removes the chromium tests from the project

## Issue that this pull request solves

Closes: #FXA-10806

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
