### PR TITLE
chore(dev-launcher) - Change the default context to oauth_webchannel_v1

### DIFF
--- a/packages/fxa-dev-launcher/README.md
+++ b/packages/fxa-dev-launcher/README.md
@@ -11,7 +11,7 @@ Available options:
 - `FIREFOX_DEBUGGER=true` - open the [Browser Toolbox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox) on start (NOTE: `false` by default for speed).
 - `FXA_DESKTOP_CONTEXT` - context value for the fxa-content-server: `context=[value]` (NOTE: `fx_desktop_v3` is default).
 
-Tip: run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 yarn firefox` (from the repo root) to test the OAuth Desktop flow. Run `FXA_DESKTOP_CONTEXT=oauth_webchannel_v1 FIREFOX_BIN=/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox yarn firefox` to test the OAuth Desktop flow (for MacOS) on Nightly.
+Tip: run `FXA_DESKTOP_CONTEXT=fx_desktop_v3 yarn firefox` (from the repo root) to test the old Desktop flow (supported until ESR 140). Run `FXA_DESKTOP_CONTEXT=fx_desktop_v3 FIREFOX_BIN=/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox yarn firefox` to test the Desktop flow (for MacOS) on Nightly.
 
 ### Basic Usage Example in OS X
 

--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -47,7 +47,7 @@ const CONFIGS = {
 };
 
 const env = process.env.FXA_ENV || 'local';
-const FXA_DESKTOP_CONTEXT = process.env.FXA_DESKTOP_CONTEXT || 'fx_desktop_v3';
+const FXA_DESKTOP_CONTEXT = process.env.FXA_DESKTOP_CONTEXT || 'oauth_webchannel_v1';
 const e10sDisabled = process.env.DISABLE_E10S === 'true';
 let fxaEnv = CONFIGS[env];
 
@@ -115,11 +115,11 @@ const fxaProfile = {
   // allow webchannel url, strips slash from content-server origin.
   'webchannel.allowObject.urlWhitelist': fxaEnv.content.slice(0, -1),
   'browser.tabs.firefox-view': true,
+  // TODO in FXA-11026, see if we still need the other prefs since we only need
+  // to use the autoconfig to get everything else set. See: bug 1942925.
   'identity.fxaccounts.autoconfig.uri': fxaEnv.content,
   // disable password auto-fill; we typically don't need to test this daily.
   'signon.rememberSignons': false,
-  // TODO in FXA-9872, make oauth_webchannel_v1 the default context and
-  // change these values for fx_desktop_v3. (Also, update the README note)
   ...(process.env.FXA_DESKTOP_CONTEXT === 'oauth_webchannel_v1' && {
     'identity.fxaccounts.oauth.enabled': true,
     'identity.fxaccounts.contextParam': 'oauth_webchannel_v1',


### PR DESCRIPTION
## Because

- This is the default flow that we use in desktop today, but we can't remove the old flow until ESR is updated to v140+.

## This pull request

- Changes the default context to use the Firefox browser default OAuth flow.

## Issue that this pull request solves

Closes: Fixes FXA-9872

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

n/a

## Other information (Optional)

> **From [this comment in JIRA](https://mozilla-hub.atlassian.net/browse/FXA-9872?focusedCommentId=917774):**
> Following up on  https://github.com/mozilla/fxa/pull/17274, we might want to take this opportunity to clean up the profile for dev-launcher. A lot of the custom configuration might not be needed anymore with the addition of the autoConfig setting.

We still need to support the older flow until the next ESR version ([v140](https://whattrainisitnow.com/release/?version=140)), so I don't recommend removing or cleaning up the previous one until the June release.
