### PR TITLE
fix(capability): add stripe and iap subscribed plans to mismatch logs

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -397,6 +397,8 @@ export class CapabilityService {
         return stripeEligibilityResult;
 
       this.log.error(`capability.getPlanEligibility.eligibilityMismatch`, {
+        stripeSubscribedPlans,
+        iapSubscribedPlans,
         eligibilityManagerResult,
         stripeEligibilityResult,
         uid,
@@ -404,6 +406,8 @@ export class CapabilityService {
       });
       Sentry.withScope((scope) => {
         scope.setContext('getPlanEligibility', {
+          stripeSubscribedPlans,
+          iapSubscribedPlans,
           eligibilityManagerResult,
           stripeEligibilityResult,
           uid,

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -526,7 +526,7 @@ describe('CapabilityService', () => {
         SubscriptionEligibilityResult.UPGRADE,
       ]);
       capabilityService.getAllSubscribedAbbrevPlans = sinon.fake.resolves([
-        mockAbbrevPlans[1],
+        [mockAbbrevPlans[1]],
         [],
       ]);
       capabilityService.eligibilityFromEligibilityManager = sinon.fake.resolves(
@@ -543,6 +543,8 @@ describe('CapabilityService', () => {
         sentryScope.setContext,
         'getPlanEligibility',
         {
+          stripeSubscribedPlans: [mockAbbrevPlans[1]],
+          iapSubscribedPlans: [],
           eligibilityManagerResult: [SubscriptionEligibilityResult.CREATE],
           stripeEligibilityResult: [SubscriptionEligibilityResult.UPGRADE],
           uid: UID,


### PR DESCRIPTION
## Because

- We want additional logging for stripe/iap mismatch

## This pull request

- Adds stripe and iap subscribed plans to mismatch logs