### PR TITLE
task(auth): Check recovery-phone enabled config for all endpoints

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.errors.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.errors.ts
@@ -58,3 +58,9 @@ export class SmsSendRateLimitExceededError extends RecoveryPhoneError {
     );
   }
 }
+
+export class RecoveryPhoneNotEnabled extends RecoveryPhoneError {
+  constructor(cause?: Error) {
+    super('Recovery phone not enabled.', {}, cause);
+  }
+}

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -11,6 +11,7 @@ import { RecoveryPhoneManager } from './recovery-phone.manager';
 import {
   RecoveryNumberNotExistsError,
   RecoveryNumberNotSupportedError,
+  RecoveryPhoneNotEnabled,
 } from './recovery-phone.errors';
 
 describe('RecoveryPhoneService', () => {
@@ -335,12 +336,6 @@ describe('RecoveryPhoneService', () => {
       mockRecoveryPhoneConfig.allowedRegions = ['US'];
     });
 
-    it('should return false if config is not enabled', async () => {
-      mockRecoveryPhoneConfig.enabled = false;
-      const result = await service.available(uid, region);
-      expect(result).toBe(false);
-    });
-
     it('should return false if region is not in allowedRegions', async () => {
       mockRecoveryPhoneConfig.allowedRegions = ['USA'];
       const result = await service.available(uid, region);
@@ -365,6 +360,41 @@ describe('RecoveryPhoneService', () => {
       mockRecoveryPhoneManager.hasRecoveryCodes.mockResolvedValueOnce(false);
       const result = await service.available(uid, region);
       expect(result).toBe(false);
+    });
+  });
+
+  describe('can disabled service', () => {
+    beforeAll(() => {
+      mockRecoveryPhoneConfig.enabled = false;
+    });
+    afterAll(() => {
+      mockRecoveryPhoneConfig.enabled = true;
+    });
+    it('can disable', () => {
+      expect(service.available(uid, 'US')).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(service.confirmSetupCode(uid, '000000')).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(service.confirmSigninCode(uid, '000000')).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(service.hasConfirmed(uid)).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(() => service.maskPhoneNumber('+15550005555')).toThrow(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(service.removePhoneNumber(uid)).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(service.sendCode(uid)).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
+      expect(service.setupPhoneNumber(uid, '+15550005555')).rejects.toEqual(
+        new RecoveryPhoneNotEnabled()
+      );
     });
   });
 

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -67,6 +67,7 @@ describe(`#integration - recovery phone`, function () {
   const password = 'password';
 
   before(async function () {
+    config.recoveryPhone.enabled = true;
     config.securityHistory.ipProfiling.allowedRecency = 0;
     config.signinConfirmation.skipForNewAccounts.enabled = false;
     server = await TestServer.start(config);


### PR DESCRIPTION
## Because

- We want this config to gate all recovery-phone endpoints

## This pull request

- Adds checks to see if config indicates recovery-phone is enabled.

## Issue that this pull request solves

Closes: FXA-11020

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
