### PR TITLE
polish(auth,gql): Use double underscore notation for twilio confict config

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2203,7 +2203,7 @@ const convictConf = convict({
     authToken: {
       default: '?',
       doc: 'Twilio Auth Token, required to access api',
-      env: 'RECOVERY_PHONE_TWILIO_AUTH_TOKEN',
+      env: 'RECOVERY_PHONE__TWILIO__AUTH_TOKEN',
     },
   },
 });

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -326,7 +326,7 @@ const conf = convict({
     authToken: {
       default: '00000000000000000000000000000000',
       doc: 'Twilio Auth Token, required to access api',
-      env: 'RECOVERY_PHONE_TWILIO_AUTH_TOKEN',
+      env: 'RECOVERY_PHONE__TWILIO__AUTH_TOKEN',
     },
   },
 });


### PR DESCRIPTION
## Because

- The env naming was not consistent

## This pull request

- Uses the double underscore notation, where a double underscore indicates a '.' in a json structure.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I've already updated the CI to support this. We should also communicate this change to team members.
