### PR TITLE
feat(sms): Set up flow to add recovery phone from Settings

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -80,7 +80,6 @@ export class RecoveryPhoneService {
     if (!this.isSuccessfulSmsSend(msg)) {
       return false;
     }
-
     await this.recoveryPhoneManager.storeUnconfirmed(
       uid,
       code,
@@ -168,7 +167,6 @@ export class RecoveryPhoneService {
    * @returns True if successful
    */
   public async removePhoneNumber(uid: string) {
-
     if (!this.config.enabled) {
       throw new RecoveryPhoneNotEnabled();
     }

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2182,7 +2182,7 @@ const convictConf = convict({
       },
       maxMessageLength: {
         default: 60,
-        doc: 'Max allows sms message lenght',
+        doc: 'Max allows sms message length',
         env: 'RECOVERY_PHONE__SMS__MAX_MESSAGE_LENGTH',
         format: Number,
       },

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -212,7 +212,6 @@ class RecoveryPhoneHandler {
     try {
       success = await this.recoveryPhoneService.removePhoneNumber(uid);
     } catch (error) {
-
       if (error instanceof RecoveryPhoneNotEnabled) {
         throw AppError.featureNotEnabled();
       }
@@ -229,7 +228,7 @@ class RecoveryPhoneHandler {
         'RecoveryPhoneService',
         'destroy',
         { uid },
-        error,
+        error
       );
     }
 
@@ -274,16 +273,6 @@ class RecoveryPhoneHandler {
         available,
       };
     } catch (error) {
-      if (error instanceof RecoveryPhoneNotEnabled) {
-        // In this case we won't throw an AppError. Unlike other endpoints,
-        // this drives whether or not the feature shows up in the UI, so
-        // if the recovery phone services isn't enabled, we can simply
-        // return available false.
-        return {
-          available: false,
-        };
-      }
-
       throw AppError.backendServiceFailure(
         'RecoveryPhoneService',
         'destroy',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -91,6 +91,7 @@ import { EmailBounceStatusPayload } from './dto/payload/email-bounce';
 import { NotifierService } from '@fxa/shared/notifier';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
+import { RecoveryPhone } from './model/recoveryPhone';
 
 function snakeToCamel(str: string) {
   return str.replace(/(_\w)/g, (m: string) => m[1].toUpperCase());
@@ -146,6 +147,22 @@ export class AccountResolver {
       info.returnType
     );
     return simplified.fields.hasOwnProperty('securityEvents');
+  }
+
+  private shouldIncludeRecoveryPhoneAvailability(
+    info: GraphQLResolveInfo
+  ): boolean {
+    // Introspect the query to determine if we should check recovery phone availability
+    const parsed: ResolveTree = parseResolveInfo(info) as ResolveTree;
+    const simplified = simplifyParsedResolveInfoFragmentWithType(
+      parsed,
+      info.returnType
+    ) as {
+      fields: {
+        available?: boolean;
+      };
+    };
+    return !!simplified.fields.hasOwnProperty('available');
   }
 
   @Mutation((returns) => CreateTotpPayload, {
@@ -849,9 +866,41 @@ export class AccountResolver {
     return [];
   }
 
-  @ResolveField()
-  public async recoveryPhone(@Parent() account: Account) {
-    return this.recoveryPhoneService.hasConfirmed(account.uid);
+  @ResolveField(() => RecoveryPhone)
+  public async recoveryPhone(
+    @GqlSessionToken() sessionToken: string,
+    @GqlXHeaders() headers: Headers,
+    @Parent() account: Account,
+    @Info() info: GraphQLResolveInfo
+  ) {
+    const includeAvailability =
+      this.shouldIncludeRecoveryPhoneAvailability(info);
+
+    try {
+      const recoveryPhone = await this.recoveryPhoneService.hasConfirmed(
+        account.uid
+      );
+
+      if (includeAvailability) {
+        // This queries the auth-server endpoint instead of directly due to
+        // this endpoint needing maxmind
+        const { available } = await this.authAPI.recoveryPhoneAvailable(
+          sessionToken,
+          headers
+        );
+        return { ...recoveryPhone, available };
+      }
+
+      return recoveryPhone;
+    } catch (_) {
+      // The service either failed, or we have the backend config for this off.
+      // Return some reasonable defaults.
+      return {
+        exists: false,
+        ...(includeAvailability ? { available: false } : {}),
+        phoneNumber: null,
+      };
+    }
   }
 
   @ResolveField()

--- a/packages/fxa-graphql-api/src/gql/model/recoveryPhone.ts
+++ b/packages/fxa-graphql-api/src/gql/model/recoveryPhone.ts
@@ -13,7 +13,15 @@ export class RecoveryPhone {
 
   @Field({
     nullable: true,
-    description: 'The registered recovery phone number',
+    description:
+      'The registered recovery phone number. If the user does not have a verified session, this field will return the last 4 digits of the phone number with a mask on the rest.',
   })
   public phoneNumber!: string;
+
+  @Field({
+    nullable: true,
+    description:
+      'Returns true if the user is eligible to set up a recovery phone.',
+  })
+  public available!: boolean;
 }

--- a/packages/fxa-settings/src/components/App/gql.ts
+++ b/packages/fxa-settings/src/components/App/gql.ts
@@ -108,3 +108,15 @@ export const GET_BACKUP_CODES_STATUS = gql`
     }
   }
 `;
+
+export const GET_RECOVERY_PHONE = gql`
+  query GetRecoveryPhone {
+    account {
+      recoveryPhone {
+        available
+        exists
+        phoneNumber
+      }
+    }
+  }
+`;

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/en.ftl
@@ -13,4 +13,5 @@ flow-setup-phone-confirm-code-button = Confirm
 # followed by a button to resend a code
 flow-setup-phone-confirm-code-expired = Code expired?
 flow-setup-phone-confirm-code-resend-code-button = Resend code
+flow-setup-phone-confirm-code-resend-code-success = Code sent
 flow-setup-phone-confirm-code-success-message-v2 = Recovery phone added

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
@@ -9,6 +9,7 @@ import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import FlowSetupRecoveryPhoneConfirmCode from '.';
+import { MOCK_FULL_PHONE_NUMBER } from '../../../pages/mocks';
 
 export default {
   title: 'Components/Settings/FlowSetupRecoveryPhoneConfirmCode',
@@ -43,7 +44,7 @@ const verifyRecoveryCodeFailure = async (code: string) => {
   return Promise.reject(AuthUiErrors.UNEXPECTED_ERROR);
 };
 
-const formattedPhoneNumber = '+1 123-456-3019';
+const formattedPhoneNumber = MOCK_FULL_PHONE_NUMBER;
 
 export const Success = () => (
   <SettingsLayout>

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
@@ -87,7 +87,7 @@ describe('FlowSetupRecoveryPhoneConfirmCode', () => {
 
     await waitFor(() => {
       expect(mockSendCode).toHaveBeenCalledTimes(1);
-      expect(screen.getByText(/Resend code/i)).toBeInTheDocument();
+      expect(screen.getByText(/Code sent/i)).toBeInTheDocument();
     });
   });
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import FlowContainer from '../FlowContainer';
 import ProgressBar from '../ProgressBar';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import Banner, { ResendCodeSuccessBanner } from '../../Banner';
+import Banner from '../../Banner';
 import FormVerifyTotp from '../../FormVerifyTotp';
 import { BackupRecoveryPhoneCodeImage } from '../../images';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
@@ -95,7 +95,15 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
     >
       <ProgressBar {...{ currentStep, numberOfSteps }} />
       {resendStatus === ResendStatus.sent && !localizedErrorBannerMessage && (
-        <ResendCodeSuccessBanner />
+        <Banner
+          type="success"
+          content={{
+            localizedHeading: ftlMsgResolver.getMsg(
+              'flow-setup-phone-confirm-code-resend-code-success',
+              'Code sent'
+            ),
+          }}
+        />
       )}
       {localizedErrorBannerMessage && (
         <Banner

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../models/mocks';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import { useAlertBar } from '../../../models';
+import { MOCK_FULL_PHONE_NUMBER } from '../../../pages/mocks';
 
 jest.mock('../../../models', () => ({
   ...jest.requireActual('../../../models'),
@@ -31,6 +32,7 @@ jest.mock('@reach/router', () => ({
 
 const account = {
   removeRecoveryPhone: jest.fn().mockResolvedValue({}),
+  recoveryPhone: { phoneNumber: MOCK_FULL_PHONE_NUMBER },
 } as unknown as Account;
 
 describe('PageRecoveryPhoneRemove', () => {

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
@@ -30,8 +30,8 @@ const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  // TODO, actually get this number back and format it
-  const formattedFullPhoneNumber = '+1 ••• ••••';
+  // TODO, we may want national_format back from Twilio
+  const formattedFullPhoneNumber = account.recoveryPhone.phoneNumber!;
 
   const goHome = () => navigate(SETTINGS_PATH + '#security', { replace: true });
 

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.stories.tsx
@@ -8,6 +8,9 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { Meta } from '@storybook/react';
 import SettingsLayout from '../SettingsLayout';
 import { LocationProvider } from '@reach/router';
+import { Account, AppContext } from '../../../models';
+import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
+import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 
 export default {
   title: 'Pages/Settings/RecoveryPhoneSetup',
@@ -15,18 +18,60 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Step1 = () => (
+export const WithSuccessAddAndConfirm = () => (
   <LocationProvider>
     <SettingsLayout>
-      <PageRecoveryPhoneSetup testStep={1} />
+      <AppContext.Provider
+        value={mockAppContext({
+          account: {
+            ...MOCK_ACCOUNT,
+            addRecoveryPhone: () => {},
+            confirmRecoveryPhone: () => {},
+          } as unknown as Account,
+        })}
+      >
+        <PageRecoveryPhoneSetup />
+      </AppContext.Provider>
     </SettingsLayout>
   </LocationProvider>
 );
 
-export const Step2 = () => (
+export const WithErrorOnAdd = () => (
   <LocationProvider>
     <SettingsLayout>
-      <PageRecoveryPhoneSetup testStep={2} testPhoneNumber="+1 123-456-7890" />
+      <AppContext.Provider
+        value={mockAppContext({
+          account: {
+            ...MOCK_ACCOUNT,
+            addRecoveryPhone: () => {
+              throw AuthUiErrors.BACKEND_SERVICE_FAILURE;
+            },
+            confirmRecoveryPhone: () => {},
+          } as unknown as Account,
+        })}
+      >
+        <PageRecoveryPhoneSetup />
+      </AppContext.Provider>
+    </SettingsLayout>
+  </LocationProvider>
+);
+
+export const WithErrorOnConfirm = () => (
+  <LocationProvider>
+    <SettingsLayout>
+      <AppContext.Provider
+        value={mockAppContext({
+          account: {
+            ...MOCK_ACCOUNT,
+            addRecoveryPhone: () => {},
+            confirmRecoveryPhone: () => {
+              throw AuthUiErrors.INVALID_OTP_CODE;
+            },
+          } as unknown as Account,
+        })}
+      >
+        <PageRecoveryPhoneSetup />
+      </AppContext.Provider>
     </SettingsLayout>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '../../../models/mocks';
+import { Subject } from './mocks';
+import userEvent, { UserEvent } from '@testing-library/user-event';
+
+jest.mock('../../../models/AlertBarInfo');
+
+const phoneNumber = '1231231234';
+const phoneNumberWithCountryCode = '+11231231234';
+const otpCode = '123456';
+
+const completeStepOne = async (user: UserEvent) => {
+  await waitFor(() =>
+    user.type(
+      screen.getByRole('textbox', { name: /Enter phone number/i }),
+      phoneNumber
+    )
+  );
+  user.click(screen.getByRole('button', { name: /Send code/i }));
+};
+
+// Note, most unit tests are in component tests rendered for each step of the flow
+describe('PageRecoveryPhoneSetup', () => {
+  it('renders step 1 by default', () => {
+    renderWithRouter(<Subject />);
+    // renders step 1 component
+    expect(
+      screen.getByText(/You’ll get a text message from Mozilla/i)
+    ).toBeInTheDocument();
+  });
+
+  it('add recovery phone with successful submission renders step 2', async () => {
+    const user = userEvent.setup();
+    const addRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    renderWithRouter(<Subject account={{ addRecoveryPhone }} />);
+
+    await completeStepOne(user);
+    await waitFor(() => expect(addRecoveryPhone).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(addRecoveryPhone).toHaveBeenCalledWith(phoneNumberWithCountryCode)
+    );
+    expect(
+      screen.queryByText(/You’ll get a text message from Mozilla/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/A six-digit code was sent/i)).toBeInTheDocument();
+  });
+
+  it('at step 2, allows code resend', async () => {
+    const user = userEvent.setup();
+    const confirmRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    const addRecoveryPhone = jest
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined);
+    renderWithRouter(
+      <Subject account={{ confirmRecoveryPhone, addRecoveryPhone }} />
+    );
+
+    await completeStepOne(user);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/A six-digit code was sent/i)
+      ).toBeInTheDocument();
+    });
+
+    user.click(
+      screen.getByRole('button', {
+        name: /Resend code/i,
+      })
+    );
+
+    await waitFor(() => expect(addRecoveryPhone).toHaveBeenCalledTimes(2));
+    expect(addRecoveryPhone).toHaveBeenNthCalledWith(
+      1,
+      phoneNumberWithCountryCode
+    );
+    expect(addRecoveryPhone).toHaveBeenNthCalledWith(
+      2,
+      phoneNumberWithCountryCode
+    );
+  });
+
+  it('at step 2, allows code confirm', async () => {
+    const user = userEvent.setup();
+    const confirmRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    const addRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    renderWithRouter(
+      <Subject account={{ confirmRecoveryPhone, addRecoveryPhone }} />
+    );
+
+    await completeStepOne(user);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/A six-digit code was sent/i)
+      ).toBeInTheDocument();
+    });
+    await waitFor(async () => {
+      await user.type(screen.getByLabelText(/Enter 6-digit code/i), otpCode);
+      user.click(screen.getByRole('button', { name: /Confirm/i }));
+    });
+
+    await waitFor(() => expect(confirmRecoveryPhone).toHaveBeenCalledTimes(1));
+    expect(confirmRecoveryPhone).toHaveBeenCalledWith(
+      otpCode,
+      phoneNumberWithCountryCode
+    );
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/mocks.tsx
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
+import { Account, AppContext } from '../../../models';
+import PageRecoveryPhoneSetup from '.';
+import { LocationProvider } from '@reach/router';
+
+export const Subject = ({ account: accountOverrides = {} }) => {
+  const account = {
+    ...MOCK_ACCOUNT,
+    ...accountOverrides,
+  } as Account;
+  return (
+    <LocationProvider>
+      <AppContext.Provider value={{ ...mockAppContext({ account }) }}>
+        <PageRecoveryPhoneSetup />
+      </AppContext.Provider>
+    </LocationProvider>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.test.tsx
@@ -48,6 +48,7 @@ describe('Security', () => {
       emails: [],
       displayName: 'Jody',
       passwordCreated: 0,
+      recoveryPhone: { exists: true },
       recoveryKey: { exists: true },
       totp: { exists: true, verified: true },
       backupCodes: { hasBackupCodes: true, count: 3 },

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
@@ -8,6 +8,7 @@ import SubRow, { BackupCodesSubRow, BackupPhoneSubRow } from './index';
 import { action } from '@storybook/addon-actions';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { CodeIcon } from '../../Icons';
+import { MOCK_FULL_PHONE_NUMBER } from '../../../pages/mocks';
 
 export default {
   title: 'Components/Settings/SubRow',
@@ -80,14 +81,14 @@ export const BackupPhoneUnavailableWithDescription: StoryFn = () => (
 export const BackupPhoneAvailable: StoryFn = () => (
   <BackupPhoneSubRow
     onCtaClick={action('Change recovery phone')}
-    phoneNumber="555-555-1234"
+    phoneNumber={MOCK_FULL_PHONE_NUMBER}
   />
 );
 
 export const BackupPhoneAvailableWithDescription: StoryFn = () => (
   <BackupPhoneSubRow
     onCtaClick={action('Change recovery phone')}
-    phoneNumber="555-555-1234"
+    phoneNumber={MOCK_FULL_PHONE_NUMBER}
     showDescription
   />
 );
@@ -96,7 +97,7 @@ export const BackupPhoneAvailableWithDelete: StoryFn = () => (
   <BackupPhoneSubRow
     onCtaClick={action('Change recovery phone')}
     onDeleteClick={action('Delete recovery phone')}
-    phoneNumber="555-555-1234"
+    phoneNumber={MOCK_FULL_PHONE_NUMBER}
   />
 );
 
@@ -104,7 +105,7 @@ export const BackupPhoneAvailableWithDeleteAndDescription: StoryFn = () => (
   <BackupPhoneSubRow
     onCtaClick={action('Change recovery phone')}
     onDeleteClick={action('Delete recovery phone')}
-    phoneNumber="555-555-1234"
+    phoneNumber={MOCK_FULL_PHONE_NUMBER}
     showDescription
   />
 );
@@ -112,6 +113,6 @@ export const BackupPhoneAvailableWithDeleteAndDescription: StoryFn = () => (
 export const BackupPhoneAvailableNoDelete: StoryFn = () => (
   <BackupPhoneSubRow
     onCtaClick={action('Change recovery phone')}
-    phoneNumber="555-555-1234"
+    phoneNumber={MOCK_FULL_PHONE_NUMBER}
   />
 );

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -6,6 +6,10 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SubRow, { BackupCodesSubRow, BackupPhoneSubRow } from './index';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import {
+  MOCK_FULL_PHONE_NUMBER,
+  MOCK_MASKED_PHONE_NUMBER,
+} from '../../../pages/mocks';
 
 describe('SubRow', () => {
   const defaultProps = {
@@ -104,7 +108,7 @@ describe('BackupCodesSubRow', () => {
 describe('BackupPhoneSubRow', () => {
   const defaultProps = {
     onCtaClick: jest.fn(),
-    phoneNumber: '555-555-1234',
+    phoneNumber: MOCK_FULL_PHONE_NUMBER,
   };
 
   it('renders correctly when phone number unavailable', () => {
@@ -127,14 +131,30 @@ describe('BackupPhoneSubRow', () => {
   it('renders correctly when phone number is available and delete is not an option', () => {
     renderWithLocalizationProvider(<BackupPhoneSubRow {...defaultProps} />);
     expect(screen.getByText('Recovery phone')).toBeInTheDocument();
-    expect(screen.getByText('••• ••• 1234')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
+    expect(screen.getByText(MOCK_MASKED_PHONE_NUMBER)).toBeInTheDocument();
+    // Temporary until we work on the change flow for SMS phase 2, FXA-10995
+    expect(
+      screen.queryByRole('button', { name: 'Change' })
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(
         'If you want to remove your recovery phone, add backup authentication codes or disable two-step authentication first to avoid getting locked out of your account.'
       )
     ).toBeInTheDocument();
-    expect(screen.getByText(/Learn about SIM swap risk/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Learn about SIM swap risk/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders correctly when user does not have a verified session (phone number is already masked)', () => {
+    renderWithLocalizationProvider(
+      <BackupPhoneSubRow
+        {...defaultProps}
+        phoneNumber={MOCK_MASKED_PHONE_NUMBER}
+      />
+    );
+    expect(screen.getByText('Recovery phone')).toBeInTheDocument();
+    expect(screen.getByText(MOCK_MASKED_PHONE_NUMBER)).toBeInTheDocument();
   });
 
   it('renders correctly when phone number is available and delete is an option', () => {
@@ -142,8 +162,11 @@ describe('BackupPhoneSubRow', () => {
       <BackupPhoneSubRow {...defaultProps} onDeleteClick={jest.fn()} />
     );
     expect(screen.getByText('Recovery phone')).toBeInTheDocument();
-    expect(screen.getByText('••• ••• 1234')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Change' })).toBeInTheDocument();
+    expect(screen.getByText(MOCK_MASKED_PHONE_NUMBER)).toBeInTheDocument();
+    // Temporary until we work on the change flow for SMS phase 2, FXA-10995
+    expect(
+      screen.queryByRole('button', { name: 'Change' })
+    ).not.toBeInTheDocument();
     const deleteButtons = screen.getAllByTitle(/Remove/);
     expect(deleteButtons).toHaveLength(2);
     expect(
@@ -151,10 +174,13 @@ describe('BackupPhoneSubRow', () => {
         'This is the easier recovery method if you canʼt use your authenticator app.'
       )
     ).toBeInTheDocument();
-    expect(screen.getByText(/Learn about SIM swap risk/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Learn about SIM swap risk/)
+    ).not.toBeInTheDocument();
   });
 
-  it('calls onCtaClick when CTA button is clicked', () => {
+  // Temporary skip we work on the change flow for SMS phase 2, FXA-10995
+  it.skip('calls onCtaClick when CTA button is clicked', () => {
     renderWithLocalizationProvider(<BackupPhoneSubRow {...defaultProps} />);
     fireEvent.click(screen.getByRole('button', { name: 'Change' }));
     expect(defaultProps.onCtaClick).toHaveBeenCalled();

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
@@ -7,9 +7,8 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';
 import UnitRowTwoStepAuth from '.';
-import { Account, AppContext } from 'fxa-settings/src/models';
-import { mockAppContext } from 'fxa-settings/src/models/mocks';
-import { action } from '@storybook/addon-actions';
+import { createSubject } from './mocks';
+import { MOCK_FULL_PHONE_NUMBER } from '../../../pages/mocks';
 
 export default {
   title: 'Components/Settings/UnitRowTwoStepAuth',
@@ -27,133 +26,69 @@ export default {
   ],
 } as Meta;
 
-export const TFAEnabledWithCodesRemaining = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: true, verified: true },
-        backupCodes: { hasBackupCodes: true, count: 3 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth />
-  </AppContext.Provider>
-);
+export const TFAEnabledWithBackupCodesRemainingAndRecoveryPhoneUnavailable =
+  () =>
+    createSubject({
+      recoveryPhone: { exists: false, phoneNumber: null, available: false },
+    });
 
-export const TFAEnabledNoCodesRemaining = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: true, verified: true },
-        backupCodes: { hasBackupCodes: false, count: 0 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth />
-  </AppContext.Provider>
-);
+export const TFAEnabledNoCodesRemaining = () =>
+  createSubject({
+    backupCodes: { hasBackupCodes: false, count: 0 },
+  });
 
-export const TFADisabled = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: false, verified: false },
-        backupCodes: { count: 0 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth />
-  </AppContext.Provider>
-);
+export const TFADisabled = () =>
+  createSubject({
+    totp: { exists: false, verified: false },
+    backupCodes: { count: 0 },
+  });
 
-export const DisabledNoPassword = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: false,
-        totp: { enabled: false },
-        backupCodes: { count: 0 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth />
-  </AppContext.Provider>
-);
+export const DisabledNoPassword = () =>
+  createSubject({
+    hasPassword: false,
+    totp: { enabled: false },
+    backupCodes: { count: 0 },
+  });
 
-export const TwoFAEnabledWithBackupCodesNoBackupPhone = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: true, verified: true },
-        backupCodes: { hasBackupCodes: true, count: 3 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth
-      backupPhoneSubRowProps={{ onCtaClick: () => action('Add clicked') }}
-    />
-  </AppContext.Provider>
-);
+export const TwoFAEnabledWithBackupCodesNoBackupPhone = () =>
+  createSubject({
+    recoveryPhone: { exists: false, phoneNumber: null, available: true },
+  });
 
-export const TwoFAEnabledWithBackupPhoneNoBackupCodes = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: true, verified: true },
-        backupCodes: { hasBackupCodes: false, count: 0 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth
-      backupPhoneSubRowProps={{
-        phoneNumber: '555-555-1234',
-        onCtaClick: () => action('Change clicked'),
-      }}
-    />
-  </AppContext.Provider>
-);
+export const TwoFAEnabledWithBackupPhoneNoBackupCodes = () =>
+  createSubject({
+    recoveryPhone: {
+      exists: true,
+      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      available: true,
+    },
+    backupCodes: { hasBackupCodes: false, count: 0 },
+  });
 
-export const TwoFAEnabledWithBackupCodesAndBackupPhone = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: true, verified: true },
-        backupCodes: { hasBackupCodes: true, count: 3 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth
-      backupPhoneSubRowProps={{
-        phoneNumber: '555-555-1234',
-        onCtaClick: () => action('Change clicked'),
-        onDeleteClick: () => action('Delete clicked'),
-        showDescription: true,
-      }}
-    />
-  </AppContext.Provider>
-);
+export const TwoFAEnabledWithBackupCodesAndBackupPhone = () =>
+  createSubject({
+    recoveryPhone: {
+      exists: true,
+      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      available: true,
+    },
+  });
 
 // if backup codes run out and user does not replace them
-export const TwoFAEnabledNoBackupCodesNoBackupPhone = () => (
-  <AppContext.Provider
-    value={mockAppContext({
-      account: {
-        hasPassword: true,
-        totp: { exists: true, verified: true },
-        backupCodes: { hasBackupCodes: false, count: 0 },
-      } as unknown as Account,
-    })}
-  >
-    <UnitRowTwoStepAuth
-      backupPhoneSubRowProps={{
-        onCtaClick: () => action('Add clicked'),
-      }}
-    />
-  </AppContext.Provider>
-);
+// Recovery phone not shown since `available` is based on region and recovery codes
+export const TwoFAEnabledNoBackupCodesNoBackupPhone = () =>
+  createSubject({
+    backupCodes: { hasBackupCodes: false, count: 0 },
+    recoveryPhone: { exists: false, phoneNumber: null, available: false },
+  });
+
+// User is currently in an unsupported region, but already has a previously added backup phone
+export const TwoFAEnabledWithBackupPhoneAndUnsupportedCurrentRegion = () =>
+  createSubject({
+    recoveryPhone: {
+      exists: true,
+      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      available: false,
+    },
+    backupCodes: { hasBackupCodes: true, count: 1 },
+  });

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.test.tsx
@@ -4,30 +4,19 @@
 
 import React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { UnitRowTwoStepAuth } from '.';
+import { renderWithRouter } from '../../../models/mocks';
+import { createSubject } from './mocks';
 import {
-  renderWithRouter,
-  mockAppContext,
-  mockSettingsContext,
-} from '../../../models/mocks';
-import { Account, AppContext } from '../../../models';
-import { SettingsContext } from '../../../models/contexts/SettingsContext';
+  MOCK_FULL_PHONE_NUMBER,
+  MOCK_MASKED_PHONE_NUMBER,
+} from '../../../pages/mocks';
 
 jest.mock('../../../models/AlertBarInfo');
-const account = {
-  hasPassword: true,
-  backupCodes: { hasBackupCodes: true, count: 3 },
-  totp: { exists: true, verified: true },
-  disableTwoStepAuth: jest.fn().mockResolvedValue(true),
-} as unknown as Account;
 
 describe('UnitRowTwoStepAuth', () => {
-  it('renders when Two-step authentication is enabled', async () => {
-    renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
-        <UnitRowTwoStepAuth />
-      </AppContext.Provider>
-    );
+  it('renders when two-step authentication is enabled', async () => {
+    renderWithRouter(createSubject());
+
     expect(
       screen.getByTestId('two-step-unit-row-header').textContent
     ).toContain('Two-step authentication');
@@ -37,17 +26,14 @@ describe('UnitRowTwoStepAuth', () => {
     expect(screen.getByRole('button', { name: 'Disable' })).toBeVisible();
   });
 
-  it('renders as expected when Two-step authentication is not enabled', () => {
-    const account = {
-      hasPassword: true,
-      totp: { exists: false, verified: false },
-      backupCodes: { hasBackupCodes: false, count: 0 },
-    } as unknown as Account;
+  it('renders when two-step authentication is not enabled', () => {
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
-        <UnitRowTwoStepAuth />
-      </AppContext.Provider>
+      createSubject({
+        totp: { exists: false, verified: false },
+        backupCodes: { hasBackupCodes: false, count: 0 },
+      })
     );
+
     expect(
       screen.getByTestId('two-step-unit-row-header').textContent
     ).toContain('Two-step authentication');
@@ -59,44 +45,13 @@ describe('UnitRowTwoStepAuth', () => {
     );
   });
 
-  it('renders view as not enabled after disabling TOTP', async () => {
-    const context = mockAppContext({ account });
-    const settingsContext = mockSettingsContext();
-    renderWithRouter(
-      <AppContext.Provider value={context}>
-        <SettingsContext.Provider value={settingsContext}>
-          <UnitRowTwoStepAuth />
-        </SettingsContext.Provider>
-      </AppContext.Provider>
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Disable' }));
-
-    await waitFor(() =>
-      expect(
-        screen.queryByTestId('disable-totp-modal-header')
-      ).toBeInTheDocument()
-    );
-
-    // using test id here because the modal cta has the same name as the row button
-    fireEvent.click(screen.getByTestId('modal-confirm'));
-
-    await waitFor(() =>
-      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1)
-    );
-  });
-
   it('renders disabled state when account has no password', async () => {
-    const account = {
-      hasPassword: false,
-      totp: { exists: false, verified: false },
-      backupCodes: { hasBackupCodes: false, count: 0 },
-    } as unknown as Account;
-
     renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ account })}>
-        <UnitRowTwoStepAuth />
-      </AppContext.Provider>
+      createSubject({
+        hasPassword: false,
+        totp: { exists: false, verified: false },
+        backupCodes: { hasBackupCodes: false, count: 0 },
+      })
     );
 
     const mainButton = await screen.findByText('Add');
@@ -111,5 +66,121 @@ describe('UnitRowTwoStepAuth', () => {
     expect(
       screen.queryByTestId('backup-authentication-codes-sub-row')
     ).not.toBeInTheDocument();
+  });
+
+  it('renders view as not enabled after disabling TOTP', async () => {
+    const disableTwoStepAuthMock = jest.fn().mockResolvedValue(true);
+
+    renderWithRouter(
+      createSubject({
+        disableTwoStepAuth: disableTwoStepAuthMock,
+      })
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disable' }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('disable-totp-modal-header')
+      ).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByTestId('modal-confirm'));
+
+    await waitFor(() =>
+      expect(disableTwoStepAuthMock).toHaveBeenCalledTimes(1)
+    );
+  });
+
+  it('renders with no backup codes and no recovery phone', () => {
+    renderWithRouter(
+      createSubject({
+        backupCodes: { hasBackupCodes: false, count: 0 },
+        recoveryPhone: { exists: false, phoneNumber: null, available: false },
+      })
+    );
+
+    expect(
+      screen.getByTestId('two-step-unit-row-header-value').textContent
+    ).toContain('Enabled');
+    expect(
+      screen.queryByTestId('backup-authentication-codes-sub-row')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('backup-recovery-phone-sub-row')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders with backup phone but no backup codes', () => {
+    renderWithRouter(
+      createSubject({
+        recoveryPhone: {
+          exists: true,
+          phoneNumber: MOCK_FULL_PHONE_NUMBER,
+          available: true,
+        },
+        backupCodes: { hasBackupCodes: false, count: 0 },
+      })
+    );
+
+    expect(
+      screen.getByTestId('two-step-unit-row-header-value').textContent
+    ).toContain('Enabled');
+    expect(
+      screen.getByTestId('backup-recovery-phone-sub-row').textContent
+    ).toContain(MOCK_MASKED_PHONE_NUMBER);
+    expect(
+      screen.queryByTestId('backup-authentication-codes-sub-row')
+    ).toBeInTheDocument();
+  });
+
+  it('renders with backup codes and backup phone', () => {
+    renderWithRouter(
+      createSubject({
+        recoveryPhone: {
+          exists: true,
+          phoneNumber: MOCK_FULL_PHONE_NUMBER,
+          available: true,
+        },
+        backupCodes: { hasBackupCodes: true, count: 3 },
+      })
+    );
+
+    expect(
+      screen.getByTestId('two-step-unit-row-header-value').textContent
+    ).toContain('Enabled');
+    expect(
+      screen.getByTestId('backup-recovery-phone-sub-row').textContent
+    ).toContain(MOCK_MASKED_PHONE_NUMBER);
+    expect(
+      screen.getByTestId('backup-authentication-codes-sub-row').textContent
+    ).toContain('3');
+    // There are two because they are conditionally rendered based on the container size
+    expect(screen.getAllByTitle(/Remove/)).toHaveLength(2);
+  });
+
+  it('renders with backup phone added but currently unsupported recovery phone region', () => {
+    renderWithRouter(
+      createSubject({
+        recoveryPhone: {
+          exists: true,
+          phoneNumber: MOCK_FULL_PHONE_NUMBER,
+          available: false,
+        },
+        backupCodes: { hasBackupCodes: true, count: 1 },
+      })
+    );
+
+    expect(
+      screen.getByTestId('two-step-unit-row-header-value').textContent
+    ).toContain('Enabled');
+    expect(
+      screen.getByTestId('backup-recovery-phone-sub-row').textContent
+    ).toContain(MOCK_MASKED_PHONE_NUMBER);
+    expect(
+      screen.getByTestId('backup-authentication-codes-sub-row').textContent
+    ).toContain('1');
+    // There are two because they are conditionally rendered based on the container size
+    expect(screen.getAllByTitle(/Remove/)).toHaveLength(2);
   });
 });

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -8,36 +8,31 @@ import { useBooleanState } from 'fxa-react/lib/hooks';
 import Modal from '../Modal';
 import UnitRow, { UnitRowProps } from '../UnitRow';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
-import { useAccount, useAlertBar, useFtlMsgResolver } from '../../../models';
+import {
+  useAccount,
+  useAlertBar,
+  useConfig,
+  useFtlMsgResolver,
+} from '../../../models';
 import { SETTINGS_PATH } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import {
-  BackupCodesSubRow,
-  BackupPhoneSubRow,
-  BackupPhoneSubRowProps,
-} from '../SubRow';
+import { BackupCodesSubRow, BackupPhoneSubRow } from '../SubRow';
 import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 
 const route = `${SETTINGS_PATH}/two_step_authentication`;
 const replaceCodesRoute = `${route}/replace_codes`;
 
-// These props are temporary for storybook purposes
-// until recovery phone feature is enabled.
-type UnitRowTwoStepAuthProps = {
-  backupPhoneSubRowProps?: BackupPhoneSubRowProps;
-};
-
-export const UnitRowTwoStepAuth = ({
-  backupPhoneSubRowProps,
-}: UnitRowTwoStepAuthProps) => {
+export const UnitRowTwoStepAuth = () => {
   const alertBar = useAlertBar();
   const account = useAccount();
   const navigate = useNavigate();
   const {
     backupCodes: { count },
     totp: { exists, verified },
+    recoveryPhone,
   } = account;
+  const config = useConfig();
   const [disable2FAModalRevealed, revealDisable2FAModal, hideDisable2FAModal] =
     useBooleanState();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -155,17 +150,27 @@ export const UnitRowTwoStepAuth = ({
           onCtaClick={() => {
             navigate(replaceCodesRoute);
           }}
+          key={1}
         />
       );
-    }
-    if (backupPhoneSubRowProps?.onCtaClick) {
-      subRows.push(
-        <BackupPhoneSubRow
-          onCtaClick={backupPhoneSubRowProps.onCtaClick}
-          onDeleteClick={backupPhoneSubRowProps.onDeleteClick}
-          phoneNumber={backupPhoneSubRowProps.phoneNumber}
-        />
-      );
+      if (
+        (config.featureFlags?.enableAdding2FABackupPhone === true &&
+          recoveryPhone.available === true) ||
+        recoveryPhone.exists === true
+      ) {
+        subRows.push(
+          <BackupPhoneSubRow
+            onCtaClick={() => {
+              navigate(`${SETTINGS_PATH}/recovery_phone/setup`);
+            }}
+            onDeleteClick={() => {
+              navigate(`${SETTINGS_PATH}/recovery_phone/remove`);
+            }}
+            phoneNumber={recoveryPhone.phoneNumber || ''}
+            key={2}
+          />
+        );
+      }
     }
 
     return subRows;

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/mocks.tsx
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { mockAppContext, mockSettingsContext } from '../../../models/mocks';
+import { Account, AppContext } from '../../../models';
+import UnitRowTwoStepAuth from '.';
+import { SettingsContext } from '../../../models/contexts/SettingsContext';
+import { getDefault } from '../../../lib/config';
+
+export const createSubject = (
+  accountOverrides = {},
+  settingsOverrides = {}
+) => {
+  const account = {
+    hasPassword: true,
+    backupCodes: { hasBackupCodes: true, count: 3 },
+    totp: { exists: true, verified: true },
+    recoveryPhone: { exists: false, phoneNumber: null, available: false },
+    ...accountOverrides,
+  } as unknown as Account;
+  const config = {
+    ...getDefault(),
+    featureFlags: {
+      enableAdding2FABackupPhone: true,
+    },
+  };
+  const appContext = mockAppContext({ account, config });
+  const settingsContext = mockSettingsContext(settingsOverrides);
+
+  return (
+    <AppContext.Provider value={appContext}>
+      <SettingsContext.Provider value={settingsContext}>
+        <UnitRowTwoStepAuth />
+      </SettingsContext.Provider>
+    </AppContext.Provider>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -27,6 +27,7 @@ import PageSecondaryEmailVerify from './PageSecondaryEmailVerify';
 import { PageDisplayName } from './PageDisplayName';
 import PageTwoStepAuthentication from './PageTwoStepAuthentication';
 import { Page2faReplaceRecoveryCodes } from './Page2faReplaceRecoveryCodes';
+import { PageRecoveryPhoneSetup } from './PageRecoveryPhoneSetup';
 import { PageDeleteAccount } from './PageDeleteAccount';
 import { ScrollToTop } from './ScrollToTop';
 import { SETTINGS_PATH } from '../../constants';
@@ -167,6 +168,10 @@ export const Settings = ({
               />
               <PageTwoStepAuthentication path="/two_step_authentication" />
               <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+              {config.featureFlags?.enableAdding2FABackupPhone === true &&
+                account.recoveryPhone.available === true && (
+                  <PageRecoveryPhoneSetup path="/recovery_phone/setup" />
+                )}
             </>
           ) : (
             <>

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -100,6 +100,11 @@ export function defaultAppContext(context?: AppContextValue) {
     },
     linkedAccounts: [],
     securityEvents: [],
+    recoveryPhone: {
+      exists: false,
+      phoneNumber: null,
+      available: false,
+    },
   };
   const session = {
     verified: true,

--- a/packages/fxa-settings/src/models/contexts/SettingsContext.ts
+++ b/packages/fxa-settings/src/models/contexts/SettingsContext.ts
@@ -62,6 +62,11 @@ export const INITIAL_SETTINGS_QUERY = gql`
         hasBackupCodes
         count
       }
+      recoveryPhone {
+        exists
+        phoneNumber
+        available
+      }
       subscriptions {
         created
         productName

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhoneCodeConfirm/mocks.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import ConfirmRecoveryCode from '.';
-import { MOCK_PHONE_NUMBER } from '../../mocks';
+import { MOCK_MASKED_PHONE_NUMBER } from '../../mocks';
 import { LocationProvider } from '@reach/router';
 import { SigninRecoveryPhoneCodeConfirmProps } from '.';
 
@@ -15,7 +15,6 @@ export const Subject = ({
   verifyCode = mockVerifyCode,
   resendCode = mockResendCode,
 }: Partial<SigninRecoveryPhoneCodeConfirmProps>) => {
-  const maskedPhoneNumber = MOCK_PHONE_NUMBER;
   const [errorMessage, setErrorMessage] = useState('');
 
   const clearBanners = () => {
@@ -25,7 +24,7 @@ export const Subject = ({
   return (
     <LocationProvider>
       <ConfirmRecoveryCode
-        maskedPhoneNumber={maskedPhoneNumber}
+        maskedPhoneNumber={MOCK_MASKED_PHONE_NUMBER}
         {...{
           clearBanners,
           errorMessage,

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -74,4 +74,5 @@ export const ALL_PRODUCT_PROMO_SERVICES = [{ name: MozServices.Monitor }];
 export const ALL_PRODUCT_PROMO_SUBSCRIPTIONS = [
   { productName: MozServices.MonitorPlus },
 ];
-export const MOCK_PHONE_NUMBER = '••••••1234';
+export const MOCK_MASKED_PHONE_NUMBER = '••••••1234';
+export const MOCK_FULL_PHONE_NUMBER = '+15555551234';


### PR DESCRIPTION
Because:
* We want users to be able to add a recovery phone

This commit:
* Enables the "add" page if the feature flag is on and availability from GQL is true
* Returns 'availability' with other recovery phone info in the GQL resolver
* Displays recovery phone info in recovery phone row,
* Hides 'change' and 'delete' buttons if user doesn't have a recovery phone set up, displays SIM swap link only if user doesn't have a recovery phone

closes [FXA-10370](https://mozilla-hub.atlassian.net/browse/FXA-10370)

---

You will need these env vars set:
```
RECOVERY_PHONE__TWILIO__ACCOUNT_SID=updateMe
RECOVERY_PHONE__TWILIO__AUTH_TOKEN=updateMe
GEODB_LOCATION_OVERRIDE={ "location": { "countryCode": "US", "postalCode": "85001"} }
```

The magic number `4159929960` works for this flow.

[FXA-10370]: https://mozilla-hub.atlassian.net/browse/FXA-10370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ