### PR TITLE
feat(next): add mapper function for sp3 to sp2 conversion

### DIFF
--- a/apps/payments/next/.env
+++ b/apps/payments/next/.env
@@ -116,4 +116,5 @@ PAYMENTS_NEXT_HOSTED_URL=http://localhost:3035
 
 SUBSCRIPTIONS_UNSUPPORTED_LOCATIONS='["CN", "KP", "IR", "SY", "CU", "SD", "BY", "IQ", "OM", "RU", "TR", "TM", "AE"]'
 
+SP2MAP__OFFERINGS={"123donepro":{"USD":{"monthly":"prod_GqM9ToKK62qjkK,plan_GqM9N6qyhvxaVk","halfyearly":"prod_GqM9ToKK62qjkK,price_1LTAC5BVqmGyQTManGVoSBsc","yearly":"prod_GqM9ToKK62qjkK,price_1KbomlBVqmGyQTMaa0Tq7UaW"},"EUR":{"monthly":"prod_GqM9ToKK62qjkK,price_1H8NnnBVqmGyQTMaLwLRKbF3"}},"123doneproplus":{"USD":{"monthly":"prod_GyHm8uwOIjr6k5,price_1NsBeHBVqmGyQTMa0o3zMSH3"}},"123foxkeh":{"USD":{"monthly":"prod_OfV6ko0QPHotas,price_1NsA5qBVqmGyQTMapXvSdxYC"}},"foxkeh":{"USD":{"daily":"prod_GvH2k78kKusAlV,price_1Pe1GiBVqmGyQTMaaPVElv5S","monthly":"prod_GvH2k78kKusAlV,price_1LxakKBVqmGyQTMas2fZaSCG"}},"foxkeh2":{"USD":{"monthly":"prod_OfWo3Xmsn2dOpA,price_1NsBknBVqmGyQTMaXvfEARm2"}},"vpn":{"USD":{"monthly":"prod_JYy0wNbTbA5fDv,price_1Ivq4gBVqmGyQTMaplHcFEGO"}}}
 # Nextjs Public Environment Variables

--- a/apps/payments/next/config/index.ts
+++ b/apps/payments/next/config/index.ts
@@ -18,6 +18,7 @@ import {
   RootConfig as NestAppRootConfig,
   validate,
 } from '@fxa/payments/ui/server';
+import { SP2MapConfig } from '@fxa/payments/legacy';
 
 class CspConfig {
   @IsUrl()
@@ -97,6 +98,11 @@ export class PaymentsNextConfig extends NestAppRootConfig {
   @ValidateNested()
   @IsDefined()
   sentry!: SentryServerConfig;
+
+  @Type(() => SP2MapConfig)
+  @ValidateNested()
+  @IsDefined()
+  sp2map!: SP2MapConfig;
 
   @IsString()
   authSecret!: string;

--- a/libs/payments/legacy/src/index.ts
+++ b/libs/payments/legacy/src/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/stripe-mapper.service';
+export * from './lib/sp2map.config';
+export * from './lib/utils/getSP2Params';

--- a/libs/payments/legacy/src/lib/factories.ts
+++ b/libs/payments/legacy/src/lib/factories.ts
@@ -2,10 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { SP2MapConfig, Currency, Intervals } from './sp2map.config';
 import { StripeMetadataWithCMS } from './types';
 
 export const StripeMetadataWithCMSFactory = (
   override?: Partial<StripeMetadataWithCMS>
 ): StripeMetadataWithCMS => ({
+  ...override,
+});
+
+export const SP2MapConfigFactory = (
+  override?: Partial<SP2MapConfig>
+): SP2MapConfig => ({
+  offerings: {
+    vpn: CurrencyFactory(),
+  },
+  ...override,
+});
+
+export const CurrencyFactory = (override?: Partial<Currency>): Currency => ({
+  currencies: {
+    USD: IntervalsFactory(),
+  },
+  ...override,
+});
+
+export const IntervalsFactory = (override?: Partial<Intervals>): Intervals => ({
+  monthly: ['prod_productid', 'price_priceId'],
   ...override,
 });

--- a/libs/payments/legacy/src/lib/sp2map.config.ts
+++ b/libs/payments/legacy/src/lib/sp2map.config.ts
@@ -1,0 +1,91 @@
+import { plainToInstance, Transform } from 'class-transformer';
+import {
+  IsString,
+  IsDefined,
+  IsObject,
+  IsOptional,
+  validateSync,
+} from 'class-validator';
+
+export class Intervals {
+  @IsOptional()
+  @IsString({ each: true })
+  @Transform(({ value }) => value.split(','))
+  daily?: string[];
+
+  @IsOptional()
+  @IsString({ each: true })
+  @Transform(({ value }) => value.split(','))
+  monthly?: string[];
+
+  @IsOptional()
+  @IsString({ each: true })
+  @Transform(({ value }) => value.split(','))
+  halfyearly?: string[];
+
+  @IsOptional()
+  @IsString({ each: true })
+  @Transform(({ value }) => value.split(','))
+  yearly?: string[];
+}
+
+export class Currency {
+  @IsDefined()
+  @IsObject()
+  @Transform(({ value }) => {
+    let usdFound = false;
+    const transformedValue = Object.entries(value).reduce((acc, [key, val]) => {
+      if (key === 'USD') {
+        usdFound = true;
+      }
+      const interval = plainToInstance(Intervals, val);
+      try {
+        const validation = validateSync(interval);
+        if (validation.length > 0) {
+          throw new Error(`Validation erorrs: ${JSON.stringify(validation)}`);
+        }
+      } catch (err) {
+        console.log(err);
+        throw new Error(`Validation issue with value: ${JSON.stringify(val)}`);
+      }
+      acc[key] = interval;
+      return acc;
+    }, {} as any);
+
+    if (!usdFound) {
+      console.log(value);
+      throw new Error('USD is required');
+    }
+
+    return transformedValue;
+  })
+  currencies!: Record<string, Intervals | undefined>; // Index signature to allow dynamic keys
+}
+
+export class SP2MapConfig {
+  @IsDefined()
+  @IsObject()
+  @Transform(({ value }) => {
+    const parsedValue = JSON.parse(value);
+    const transformedValue = Object.entries(parsedValue).reduce(
+      (acc, [key, val]) => {
+        const classVal = plainToInstance(Currency, { currencies: val });
+        try {
+          const validation = validateSync(classVal);
+          if (validation.length > 0) {
+            throw new Error(`Validation erorrs: ${JSON.stringify(validation)}`);
+          }
+        } catch (err) {
+          throw new Error(
+            `Validation issue with value: ${JSON.stringify(val)}`
+          );
+        }
+        acc[key] = classVal;
+        return acc;
+      },
+      {} as any
+    );
+    return transformedValue;
+  })
+  offerings!: Record<string, Currency | undefined>; // Index signature to allow dynamic keys
+}

--- a/libs/payments/legacy/src/lib/utils/getSP2Params.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/getSP2Params.spec.ts
@@ -1,0 +1,91 @@
+import assert from 'assert';
+import { SP2MapConfigFactory } from '../factories';
+import { getSP2Params } from './getSP2Params';
+
+describe('getSP2Params', () => {
+  const reportErrorMock = jest.fn();
+  const sp2mapConfig = SP2MapConfigFactory();
+
+  beforeEach(() => {
+    reportErrorMock.mockClear();
+  });
+
+  describe('success', () => {
+    it('successfully returns productId and planId', () => {
+      const { productId, priceId } = getSP2Params(
+        sp2mapConfig,
+        reportErrorMock,
+        'vpn',
+        'monthly',
+        'USD'
+      );
+      expect(reportErrorMock).not.toHaveBeenCalled();
+      expect(productId).toBe('prod_productid');
+      expect(priceId).toBe('price_priceId');
+    });
+  });
+
+  describe('success - with default fallbacks', () => {
+    it('successfully returns productId and planId if no currency is provided', () => {
+      const { productId, priceId } = getSP2Params(
+        sp2mapConfig,
+        reportErrorMock,
+        'vpn',
+        'monthly'
+      );
+      expect(reportErrorMock).toHaveBeenCalledWith('Currency is missing');
+      expect(productId).toBe('prod_productid');
+      expect(priceId).toBe('price_priceId');
+    });
+
+    it('successfully returns productId and planId if invalid interval is provided', () => {
+      const { productId, priceId } = getSP2Params(
+        sp2mapConfig,
+        reportErrorMock,
+        'vpn',
+        'invalid',
+        'USD'
+      );
+      expect(reportErrorMock).toHaveBeenCalledWith(
+        'Interval is not supported',
+        { interval: 'invalid' }
+      );
+      expect(productId).toBe('prod_productid');
+      expect(priceId).toBe('price_priceId');
+    });
+  });
+
+  describe('failure', () => {
+    it('throws an error if offering could not be found in config', () => {
+      try {
+        getSP2Params(
+          sp2mapConfig,
+          reportErrorMock,
+          'invalid',
+          'monthly',
+          'USD'
+        );
+        assert('should have thrown an error');
+      } catch (err) {
+        expect(reportErrorMock).toHaveBeenCalledWith(
+          'Missing or invalid offering',
+          { offeringId: 'invalid' }
+        );
+        expect(err).toBeInstanceOf(Error);
+      }
+    });
+
+    it('throws an error if interval could not be found in config', () => {
+      try {
+        getSP2Params(sp2mapConfig, reportErrorMock, 'vpn', 'daily', 'USD');
+        assert('should have thrown an error');
+      } catch (err) {
+        expect(reportErrorMock).toHaveBeenCalledWith(
+          'Invalid interval for offering',
+          { offeringId: 'vpn', interval: 'daily' }
+        );
+        expect(err).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/libs/payments/legacy/src/lib/utils/getSP2Params.ts
+++ b/libs/payments/legacy/src/lib/utils/getSP2Params.ts
@@ -1,0 +1,50 @@
+import { SP2MapConfig } from '../sp2map.config';
+
+type ValidInterval = 'daily' | 'monthly' | 'halfyearly' | 'yearly';
+
+function isValidInterval(interval: string): interval is ValidInterval {
+  return !(
+    interval !== 'daily' &&
+    interval !== 'monthly' &&
+    interval !== 'halfyearly' &&
+    interval !== 'yearly'
+  );
+}
+
+export function getSP2Params(
+  sp2map: SP2MapConfig,
+  reportError: (...args: any) => void,
+  offeringId: string,
+  interval: string,
+  currency?: string
+) {
+  if (!isValidInterval(interval)) {
+    reportError('Interval is not supported', { interval });
+  }
+
+  if (!currency) {
+    reportError('Currency is missing');
+  }
+
+  const calcInterval = isValidInterval(interval) ? interval : 'monthly';
+  const calcCurrency = currency ? currency : 'USD';
+
+  const offering = sp2map.offerings[offeringId];
+  if (!offering) {
+    reportError('Missing or invalid offering', { offeringId });
+    throw new Error(`Missing or invalid offering: ${offeringId}`);
+  }
+
+  const intervalValues = offering.currencies[calcCurrency]?.[calcInterval];
+  if (intervalValues?.length === 2) {
+    return {
+      productId: intervalValues[0],
+      priceId: intervalValues[1],
+    };
+  } else {
+    reportError('Invalid interval for offering', { offeringId, interval });
+    throw new Error(
+      `Invalid interval for offfering: ${interval}, ${offeringId}`
+    );
+  }
+}

--- a/libs/payments/ui/src/lib/actions/determineCurrency.ts
+++ b/libs/payments/ui/src/lib/actions/determineCurrency.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { plainToClass } from 'class-transformer';
+import { getApp } from '../nestapp/app';
+import { DetermineCurrencyActionArgs } from '../nestapp/validators/DetermineCurrencyActionArgs';
+
+export const determineCurrencyAction = async (ip: string) => {
+  const currency = await getApp().getActionsService().determineCurrency(
+    plainToClass(DetermineCurrencyActionArgs, {
+      ip,
+    })
+  );
+
+  return currency;
+};

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -4,6 +4,7 @@
 
 export { checkoutCartWithPaypal } from './checkoutCartWithPaypal';
 export { checkoutCartWithStripe } from './checkoutCartWithStripe';
+export { determineCurrencyAction } from './determineCurrency';
 export { fetchCMSData } from './fetchCMSData';
 export { getCartAction } from './getCart';
 export { getCartOrRedirectAction } from './getCartOrRedirect';

--- a/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyActionArgs.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class DetermineCurrencyActionArgs {
+  @IsString()
+  ip!: string;
+}


### PR DESCRIPTION
## Because

- The payments-next landing page needs to be able to map SP3 parameters to SP2 product and price IDs.

## This pull request

- Adds new mapper function to map offeringId+interval+currency to productId+priceId.
- Adds config to provide correct values to mapping function

## Issue that this pull request solves

Closes: #FXA-10967

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).