### PR TITLE
fix(bug): Check and delete any unconfirmed phone numbers before sending another code

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -9,9 +9,9 @@ import {
 import { Inject, Injectable } from '@nestjs/common';
 import {
   getConfirmedPhoneNumber,
+  hasRecoveryCodes,
   registerPhoneNumber,
   removePhoneNumber,
-  hasRecoveryCodes,
 } from './recovery-phone.repository';
 import {
   RecoveryNumberAlreadyExistsError,
@@ -163,6 +163,16 @@ export class RecoveryPhoneManager {
     }
 
     return JSON.parse(data);
+  }
+
+  /**
+   * Returns redis keys for all unconfirmed phone numbers for a user.
+   *
+   * @param uid
+   */
+  async getAllUnconfirmed(uid: string): Promise<string[]> {
+    const redisKey = `${this.redisPrefix}:${uid}:*`;
+    return await this.redisClient.keys(redisKey);
   }
 
   /**

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -71,6 +71,17 @@ export class RecoveryPhoneService {
       }
     }
 
+    // Invalidate and remove any or all previous unconfirmed code entries
+    const unconfirmedKeys = await this.recoveryPhoneManager.getAllUnconfirmed(
+      uid
+    );
+    for (const key of unconfirmedKeys) {
+      const code = key.split(':').pop();
+      if (code) {
+        await this.recoveryPhoneManager.removeCode(uid, code);
+      }
+    }
+
     const code = await this.otpCode.generateCode();
     const msg = await this.smsManager.sendSMS({
       to: phoneNumber,
@@ -168,7 +179,6 @@ export class RecoveryPhoneService {
    * @returns True if successful
    */
   public async removePhoneNumber(uid: string) {
-
     if (!this.config.enabled) {
       throw new RecoveryPhoneNotEnabled();
     }

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -204,6 +204,10 @@ class FxaRedis extends RedisShared {
     return this.redis.zrank(key, member);
   }
 
+  keys(key) {
+    return this.redis.keys(key);
+  }
+
   async zpoprangebyscore(key, min, max) {
     const args = Array.from(arguments);
     const results = await this.redis


### PR DESCRIPTION
## Because

- We should only have one active recovery phone code for a user at a time

## This pull request

- Updates the `setupPhoneNumber` to check for existing unconfirmed phone numbers and deletes them before sending a new code

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11039

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I looked through the spec but didn't see anything defining this. It seems reasonable that we only want one active code at a time.
