### PR TITLE
feat(emails): Send out emails for SMS actions

### DIFF
--- a/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
+++ b/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
@@ -120,7 +120,7 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toHaveText(
-        'Account backup authentication codes updated'
+        'Backup authentication codes updated'
       );
 
       await settings.signOut();

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -137,9 +137,11 @@ module.exports = function (
     statsd
   );
   const recoveryPhone = require('./recovery-phone').recoveryPhoneRoutes(
-    log,
     customs,
-    glean
+    db,
+    glean,
+    log,
+    mailer
   );
   const securityEvents = require('./security-events')(log, db, config);
   const session = require('./session')(

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -206,11 +206,10 @@ module.exports = (log, db, config, customs, mailer, glean) => {
         const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;
 
         const mailerPromises = [
-          mailer.sendPostConsumeRecoveryCodeEmail(account.emails, account, {
+          mailer.sendPostSigninRecoveryCodeEmail(account.emails, account, {
             acceptLanguage,
             ip,
             location: geo.location,
-            numberRemaining: remaining,
             timeZone: geo.timeZone,
             uaBrowser: ua.browser,
             uaBrowserVersion: ua.browserVersion,

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -381,6 +381,7 @@ module.exports = (
         }
       },
     },
+    // this endpoint is used in the password reset flow only
     {
       method: 'POST',
       path: '/totp/verify/recoveryCode',

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1627,14 +1627,14 @@ module.exports = function (log, config, bounces) {
          * rendering, and adding them to our templateValues for Fluent. Because
          * of this, for now, we'll pass the variable with the bulleted mask
          * instead of handling the bulleted mask in the template itself. */
-        maskedLastFourPhoneNumber: '••••••1234',
+        maskedLastFourPhoneNumber: message.maskedLastFourPhoneNumber,
         resetLink: links.resetLink,
         resetLinkAttributes: links.resetLinkAttributes,
         supportLinkAttributes: links.supportLinkAttributes,
         // TODO, update this with proper #heading once it's written and add to links obj w/
         // UTM parms, tests, & ensure Storybook is updated as well, FXA-10918
         twoFactorSupportLink:
-          'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication',
+          'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
         supportUrl: links.supportUrl,
         time,
       },

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.stories.ts
@@ -18,10 +18,8 @@ const createStory = storyWithProps(
     maskedLastFourPhoneNumber: '••••••1234',
     link: 'http://localhost:3030/settings',
     resetLink: 'http://localhost:3030/reset_password',
-    // TODO, update this link with #section-heading once the SUMO article is updated
-    //  and ensure the mailer also uses the new link (FXA-10918)
     twoFactorSupportLink:
-      'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication',
+      'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
   }
 );
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -60,6 +60,7 @@ const MESSAGE = {
   flowBeginTime: Date.now(),
   flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
   locations: [],
+  maskedLastFourPhoneNumber: '••••••1234',
   numberRemaining: 2,
   primaryEmail: 'c@d.com',
   service: 'sync',
@@ -84,7 +85,7 @@ const MESSAGE = {
   lastFour: '5309',
   mozillaSupportUrl: 'https://support.mozilla.org',
   twoFactorSupportLink:
-    'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication',
+    'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
   nextInvoiceDate: new Date(1587339098816),
   paymentAmountOldInCents: 9999099.9,
   paymentAmountOldCurrency: 'jpy',
@@ -1200,7 +1201,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: 'You created a recovery phone number' },
       { test: 'include', expected: 'You added ••••••1234 as your recovery phone' },
       // TODO, update test with FXA-10918
-      { test: 'include', expected: 'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication' },
+      { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
       { test: 'include', expected: 'You enabled it from:' },
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },
@@ -1215,7 +1216,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: 'You created a recovery phone number' },
       { test: 'include', expected: 'You added ••••••1234 as your recovery phone' },
       // TODO, update test with FXA-10918
-      { test: 'include', expected: 'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication' },
+      { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
       { test: 'include', expected: 'You enabled it from:' },
       { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },
       { test: 'include', expected: `${MESSAGE.date}` },

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -173,6 +173,10 @@ const MAILER_METHOD_NAMES = [
   'sendVerifyLoginEmail',
   'sendVerifyLoginCodeEmail',
   'sendVerifySecondaryCodeEmail',
+  'sendPostAddRecoveryPhoneEmail',
+  'sendPostRemoveRecoveryPhoneEmail',
+  'sendPostSigninRecoveryPhoneEmail',
+  'sendPostSigninRecoveryCodeEmail',
 ];
 
 const METRICS_CONTEXT_METHOD_NAMES = [

--- a/packages/fxa-auth-server/test/remote/recovery_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_code_tests.js
@@ -11,246 +11,243 @@ const Client = require('../client')();
 const otplib = require('otplib');
 const BASE_36 = require('../../lib/routes/validators').BASE_36;
 
-[{version:""},{version:"V2"}].forEach((testOptions) => {
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - remote backup authentication codes`, function () {
+    this.timeout(60000);
 
-describe(`#integration${testOptions.version} - remote backup authentication codes`, function () {
-  this.timeout(60000);
+    let server, client, email, recoveryCodes;
+    const recoveryCodeCount = 9;
+    const password = 'pssssst';
+    const metricsContext = {
+      flowBeginTime: Date.now(),
+      flowId:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    };
 
-  let server, client, email, recoveryCodes;
-  const recoveryCodeCount = 9;
-  const password = 'pssssst';
-  const metricsContext = {
-    flowBeginTime: Date.now(),
-    flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-  };
+    otplib.authenticator.options = {
+      encoding: 'hex',
+      window: 10,
+    };
 
-  otplib.authenticator.options = {
-    encoding: 'hex',
-    window: 10,
-  };
+    before(async () => {
+      config.totp.recoveryCodes.count = recoveryCodeCount;
+      config.totp.recoveryCodes.notifyLowCount = recoveryCodeCount - 2;
+      server = await TestServer.start(config);
+    });
 
-  before(async () => {
-    config.totp.recoveryCodes.count = recoveryCodeCount;
-    config.totp.recoveryCodes.notifyLowCount = recoveryCodeCount - 2;
-    server = await TestServer.start(config);
-  });
+    after(async () => {
+      await TestServer.stop(server);
+    });
 
-  after(async () => {
-    await TestServer.stop(server);
-  });
+    beforeEach(() => {
+      email = server.uniqueEmail();
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      ).then((x) => {
+        client = x;
+        assert.ok(client.authAt, 'authAt was set');
+        return client.createTotpToken({ metricsContext }).then((result) => {
+          otplib.authenticator.options = {
+            secret: result.secret,
+          };
+          recoveryCodes = result.recoveryCodes;
+          assert.equal(
+            result.recoveryCodes.length,
+            recoveryCodeCount,
+            'backup authentication codes returned'
+          );
 
-  beforeEach(() => {
-    email = server.uniqueEmail();
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    ).then((x) => {
-      client = x;
-      assert.ok(client.authAt, 'authAt was set');
-      return client.createTotpToken({ metricsContext }).then((result) => {
-        otplib.authenticator.options = {
-          secret: result.secret,
-        };
-        recoveryCodes = result.recoveryCodes;
-        assert.equal(
-          result.recoveryCodes.length,
-          recoveryCodeCount,
-          'backup authentication codes returned'
-        );
+          // Verify TOTP token so that initial backup authentication codes are generated
+          const code = otplib.authenticator.generate();
+          return client
+            .verifyTotpCode(code, { metricsContext })
+            .then((response) => {
+              assert.equal(response.success, true, 'totp codes match');
 
-        // Verify TOTP token so that initial backup authentication codes are generated
-        const code = otplib.authenticator.generate();
-        return client
-          .verifyTotpCode(code, { metricsContext })
+              return server.mailbox.waitForEmail(email);
+            })
+            .then((emailData) => {
+              assert.equal(
+                emailData.headers['x-template-name'],
+                'postAddTwoStepAuthentication'
+              );
+            });
+        });
+      });
+    });
+
+    it('should create backup authentication codes', () => {
+      assert.ok(recoveryCodes);
+      assert.equal(
+        recoveryCodes.length,
+        recoveryCodeCount,
+        'backup authentication codes returned'
+      );
+      recoveryCodes.forEach((code) => {
+        assert.equal(code.length > 1, true, 'correct length');
+        assert.equal(BASE_36.test(code), true, 'code is hex');
+      });
+    });
+
+    it('should replace backup authentication codes', () => {
+      return client
+        .replaceRecoveryCodes()
+        .then((result) => {
+          assert.ok(
+            result.recoveryCodes.length,
+            recoveryCodeCount,
+            'backup authentication codes returned'
+          );
+          assert.notDeepEqual(
+            result,
+            recoveryCodes,
+            'backup authentication codes should not match'
+          );
+
+          return server.mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(
+            emailData.headers['x-template-name'],
+            'postNewRecoveryCodes'
+          );
+        });
+    });
+
+    describe('backup authentication code verification', () => {
+      beforeEach(() => {
+        // Create a new unverified session to test backup authentication codes
+        return Client.login(config.publicUrl, email, password, testOptions)
           .then((response) => {
-            assert.equal(response.success, true, 'totp codes match');
+            client = response;
+            return client.emailStatus();
+          })
+          .then((res) =>
+            assert.equal(res.sessionVerified, false, 'session not verified')
+          );
+      });
 
+      it('should fail to consume unknown backup authentication code', () => {
+        return client
+          .consumeRecoveryCode('1234abcd', { metricsContext })
+          .then(assert.fail, (err) => {
+            assert.equal(err.code, 400, 'correct error code');
+            assert.equal(err.errno, 156, 'correct error errno');
+          });
+      });
+
+      it('should consume backup authentication code and verify session', () => {
+        return client
+          .consumeRecoveryCode(recoveryCodes[0], { metricsContext })
+          .then((res) => {
+            assert.equal(
+              res.remaining,
+              recoveryCodeCount - 1,
+              'correct remaining codes'
+            );
+            return client.emailStatus();
+          })
+          .then((res) => {
+            assert.equal(res.sessionVerified, true, 'session verified');
             return server.mailbox.waitForEmail(email);
           })
           .then((emailData) => {
             assert.equal(
               emailData.headers['x-template-name'],
-              'postAddTwoStepAuthentication'
+              'postSigninRecoveryCode'
+            );
+          });
+      });
+
+      it('should consume backup authentication code and can remove TOTP token', () => {
+        return client
+          .consumeRecoveryCode(recoveryCodes[0], { metricsContext })
+          .then((res) => {
+            assert.equal(
+              res.remaining,
+              recoveryCodeCount - 1,
+              'correct remaining codes'
+            );
+            return server.mailbox.waitForEmail(email);
+          })
+          .then((emailData) => {
+            assert.equal(
+              emailData.headers['x-template-name'],
+              'postSigninRecoveryCode'
+            );
+            return client.deleteTotpToken();
+          })
+          .then((result) => {
+            assert.ok(result, 'delete totp token successfully');
+            return server.mailbox.waitForEmail(email);
+          })
+          .then((emailData) => {
+            assert.equal(
+              emailData.headers['x-template-name'],
+              'postRemoveTwoStepAuthentication'
             );
           });
       });
     });
-  });
 
-  it('should create backup authentication codes', () => {
-    assert.ok(recoveryCodes);
-    assert.equal(
-      recoveryCodes.length,
-      recoveryCodeCount,
-      'backup authentication codes returned'
-    );
-    recoveryCodes.forEach((code) => {
-      assert.equal(code.length > 1, true, 'correct length');
-      assert.equal(BASE_36.test(code), true, 'code is hex');
-    });
-  });
-
-  it('should replace backup authentication codes', () => {
-    return client
-      .replaceRecoveryCodes()
-      .then((result) => {
-        assert.ok(
-          result.recoveryCodes.length,
-          recoveryCodeCount,
-          'backup authentication codes returned'
-        );
-        assert.notDeepEqual(
-          result,
-          recoveryCodes,
-          'backup authentication codes should not match'
-        );
-
-        return server.mailbox.waitForEmail(email);
-      })
-      .then((emailData) => {
-        assert.equal(
-          emailData.headers['x-template-name'],
-          'postNewRecoveryCodes'
-        );
+    describe('should notify user when backup authentication codes are low', () => {
+      beforeEach(() => {
+        // Create a new unverified session to test backup authentication codes
+        return Client.login(config.publicUrl, email, password, testOptions)
+          .then((response) => {
+            client = response;
+            return client.emailStatus();
+          })
+          .then((res) =>
+            assert.equal(res.sessionVerified, false, 'session not verified')
+          );
       });
-  });
 
-  describe('backup authentication code verification', () => {
-    beforeEach(() => {
-      // Create a new unverified session to test backup authentication codes
-      return Client.login(config.publicUrl, email, password, testOptions)
-        .then((response) => {
-          client = response;
-          return client.emailStatus();
-        })
-        .then((res) =>
-          assert.equal(res.sessionVerified, false, 'session not verified')
-        );
-    });
+      it('should consume backup authentication code and verify session', () => {
+        return client
+          .consumeRecoveryCode(recoveryCodes[0], { metricsContext })
+          .then((res) => {
+            assert.equal(
+              res.remaining,
+              recoveryCodeCount - 1,
+              'correct remaining codes'
+            );
+            return server.mailbox.waitForEmail(email);
+          })
+          .then((emailData) => {
+            assert.equal(
+              emailData.headers['x-template-name'],
+              'postSigninRecoveryCode'
+            );
+            return client.consumeRecoveryCode(recoveryCodes[1], {
+              metricsContext,
+            });
+          })
+          .then((res) => {
+            assert.equal(
+              res.remaining,
+              recoveryCodeCount - 2,
+              'correct remaining codes'
+            );
+            return server.mailbox.waitForEmail(email);
+          })
+          .then((emails) => {
+            // The order in which the emails are sent is not guaranteed, test for both possible templates
+            const email1 = emails[0].headers['x-template-name'];
+            const email2 = emails[1].headers['x-template-name'];
+            if (email1 === 'postSigninRecoveryCode') {
+              assert.equal(email2, 'lowRecoveryCodes');
+            }
 
-    it('should fail to consume unknown backup authentication code', () => {
-      return client
-        .consumeRecoveryCode('1234abcd', { metricsContext })
-        .then(assert.fail, (err) => {
-          assert.equal(err.code, 400, 'correct error code');
-          assert.equal(err.errno, 156, 'correct error errno');
-        });
-    });
-
-    it('should consume backup authentication code and verify session', () => {
-      return client
-        .consumeRecoveryCode(recoveryCodes[0], { metricsContext })
-        .then((res) => {
-          assert.equal(
-            res.remaining,
-            recoveryCodeCount - 1,
-            'correct remaining codes'
-          );
-          return client.emailStatus();
-        })
-        .then((res) => {
-          assert.equal(res.sessionVerified, true, 'session verified');
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postConsumeRecoveryCode'
-          );
-        });
-    });
-
-    it('should consume backup authentication code and can remove TOTP token', () => {
-      return client
-        .consumeRecoveryCode(recoveryCodes[0], { metricsContext })
-        .then((res) => {
-          assert.equal(
-            res.remaining,
-            recoveryCodeCount - 1,
-            'correct remaining codes'
-          );
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postConsumeRecoveryCode'
-          );
-          return client.deleteTotpToken();
-        })
-        .then((result) => {
-          assert.ok(result, 'delete totp token successfully');
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postRemoveTwoStepAuthentication'
-          );
-        });
-    });
-  });
-
-  describe('should notify user when backup authentication codes are low', () => {
-    beforeEach(() => {
-      // Create a new unverified session to test backup authentication codes
-      return Client.login(config.publicUrl, email, password, testOptions)
-        .then((response) => {
-          client = response;
-          return client.emailStatus();
-        })
-        .then((res) =>
-          assert.equal(res.sessionVerified, false, 'session not verified')
-        );
-    });
-
-    it('should consume backup authentication code and verify session', () => {
-      return client
-        .consumeRecoveryCode(recoveryCodes[0], { metricsContext })
-        .then((res) => {
-          assert.equal(
-            res.remaining,
-            recoveryCodeCount - 1,
-            'correct remaining codes'
-          );
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emailData) => {
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postConsumeRecoveryCode'
-          );
-          return client.consumeRecoveryCode(recoveryCodes[1], {
-            metricsContext,
+            if (email1 === 'lowRecoveryCodes') {
+              assert.equal(email2, 'postSigninRecoveryCode');
+            }
           });
-        })
-        .then((res) => {
-          assert.equal(
-            res.remaining,
-            recoveryCodeCount - 2,
-            'correct remaining codes'
-          );
-          return server.mailbox.waitForEmail(email);
-        })
-        .then((emails) => {
-          // The order in which the emails are sent is not guaranteed, test for both possible templates
-          const email1 = emails[0].headers['x-template-name'];
-          const email2 = emails[1].headers['x-template-name'];
-          if (email1 === 'postConsumeRecoveryCode') {
-            assert.equal(email2, 'lowRecoveryCodes');
-          }
-
-          if (email1 === 'lowRecoveryCodes') {
-            assert.equal(email2, 'postConsumeRecoveryCode');
-          }
-        });
+      });
     });
   });
-
-
-});
-
 });

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/en.ftl
@@ -5,6 +5,6 @@ tfa-create-code-error = There was a problem creating your backup authentication 
 tfa-replace-code-success-1 = New codes have been created. Save these one-time use
   backup authentication codes in a safe place — you’ll need them to access your account if you don’t
   have your mobile device.
-tfa-replace-code-success-alert-3 = Account backup authentication codes updated
+tfa-replace-code-success-alert-4 = Backup authentication codes updated
 tfa-replace-code-1-2 = Step 1 of 2
 tfa-replace-code-2-2 = Step 2 of 2

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -44,8 +44,8 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertSuccessAndGoHome = () => {
     alertBar.success(
       ftlMsgResolver.getMsg(
-        'tfa-replace-code-success-alert-3',
-        'Account backup authentication codes updated'
+        'tfa-replace-code-success-alert-4',
+        'Backup authentication codes updated'
       )
     );
     navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
@@ -73,7 +73,7 @@ describe('PageRecoveryPhoneRemove', () => {
       screen.getByRole('link', { name: /Compare recovery methods/ })
     ).toHaveAttribute(
       'href',
-      'https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication'
+      'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication'
     );
     expect(
       screen.getByRole('button', { name: 'Remove phone number' })

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
@@ -18,7 +18,7 @@ import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 const sumoTwoStepLink = (
   <LinkExternal
     className="link-blue"
-    href="https://support.mozilla.org/en-US/kb/secure-firefox-account-two-step-authentication"
+    href="https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication"
   >
     Compare recovery methods
   </LinkExternal>


### PR DESCRIPTION
## Because

* We want to send emails to users to let them know when sms is added, used or removed

## This pull request

* Add email sending to the client methods for adding, removing and using recovery phone to sign in

## Issue that this pull request solves

Closes: #FXA-11027

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Filed a new ticket to review the emails sent when backup authentication codes are used for password reset.
