### PR TITLE
feat(settings): Show banner when unverified accounts signin

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSettings/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/en.ftl
@@ -1,2 +1,4 @@
 # Link to delete account on main Settings page
 delete-account-link = Delete account
+# Success message displayed in alert bar after the user has successfully confirmed their account is not inactive.
+inactive-update-status-success-alert = Signed in successfully. Your { -product-mozilla-account } and data will stay active.

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -35,12 +35,12 @@ import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
 import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
 import { hardNavigate } from 'fxa-react/lib/utils';
-import { SettingsIntegration } from './interfaces';
 import { currentAccount } from '../../lib/cache';
 import { hasAccount, setCurrentAccount } from '../../lib/storage-utils';
 import GleanMetrics from '../../lib/glean';
 import Head from 'fxa-react/components/Head';
 import PageRecoveryPhoneRemove from './PageRecoveryPhoneRemove';
+import { SettingsIntegration } from './interfaces';
 
 export const Settings = ({
   integration,
@@ -149,7 +149,7 @@ export const Settings = ({
       <Head />
       <Router basepath={SETTINGS_PATH}>
         <ScrollToTop default>
-          <PageSettings path="/" />
+          <PageSettings path="/" {...{ integration }} />
           <PageDisplayName path="/display_name" />
           <PageAvatar path="/avatar" />
           {hasPassword ? (

--- a/packages/fxa-settings/src/components/Settings/interfaces.ts
+++ b/packages/fxa-settings/src/components/Settings/interfaces.ts
@@ -4,4 +4,4 @@
 
 import { Integration } from '../../models';
 
-export type SettingsIntegration = Pick<Integration, 'type' | 'isSync'>;
+export type SettingsIntegration = Pick<Integration, 'type' | 'data'>;

--- a/packages/fxa-settings/src/components/Settings/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/mocks.tsx
@@ -15,7 +15,7 @@ export function createMockSettingsIntegration({
 } = {}): SettingsIntegration {
   return {
     type,
-    isSync: () => isSync,
+    data: {},
   };
 }
 

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -518,6 +518,9 @@ const recordEventMetric = (
     case 'account_banner_create_recovery_key_view':
       accountBanner.createRecoveryKeyView.record();
       break;
+    case 'account_banner_reactivation_success_view':
+      accountBanner.reactivationSuccessView.record();
+      break;
     case 'error_view':
       error.view.record({
         reason: gleanPingMetrics?.event?.['reason'] || '',

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2460,6 +2460,24 @@ account_banner:
     expires: never
     data_sensitivity:
       - interaction
+  reactivation_success_view:
+    type: event
+    description: |
+      User sees the reactivation banner after receiving the inactive
+      account email and clicking the provided link inside it.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10983
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 
 delete_account:
   settings_submit:

--- a/packages/fxa-shared/metrics/glean/web/accountBanner.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountBanner.ts
@@ -21,3 +21,20 @@ export const createRecoveryKeyView = new EventMetricType(
   },
   []
 );
+
+/**
+ * User sees the reactivation banner after receiving the inactive
+ * account email and clicking the provided link inside it.
+ *
+ * Generated from `account_banner.reactivation_success_view`.
+ */
+export const reactivationSuccessView = new EventMetricType(
+  {
+    category: 'account_banner',
+    name: 'reactivation_success_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -195,6 +195,7 @@ export const eventsMap = {
 
   accountBanner: {
     createRecoveryKeyView: 'account_banner_create_recovery_key_view',
+    reactivationSuccessView: 'account_banner_reactivation_success_view',
   },
 
   deleteAccount: {


### PR DESCRIPTION
## Because

- We want to show a banner when a user signs in after clicking an inactive account reminder email.

## This pull request

- Shows a banner when we receive particular UTM params from clicking links in the inactive account emails.
- Adds metric `account_banner_reactivation_success_view` as custom metric.

## Issue that this pull request solves

Fixes FXA-10983

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="700" alt="Screenshot 2025-01-28 at 10 58 34 AM" src="https://github.com/user-attachments/assets/2871f12d-1014-4e96-b0fa-8819c6727bac" />

## Other information (Optional)

- Separated the metrics to different commit instead it's preferable to have it linked to another issue or PR.
- For testing, add the UTM params when signing in. e.g. `http://localhost:3030/signin?email=tester%40gmail.com&utm_medium=email&utm_campaign=fx-account-inactive-reminder-third&utm_content=fx-account-deletion`
