### PR TITLE
feat(next): add percentage based redirects to landing

### DIFF
--- a/apps/payments/next/.env
+++ b/apps/payments/next/.env
@@ -117,4 +117,10 @@ PAYMENTS_NEXT_HOSTED_URL=http://localhost:3035
 SUBSCRIPTIONS_UNSUPPORTED_LOCATIONS='["CN", "KP", "IR", "SY", "CU", "SD", "BY", "IQ", "OM", "RU", "TR", "TM", "AE"]'
 
 SP2MAP__OFFERINGS={"123donepro":{"USD":{"monthly":"prod_GqM9ToKK62qjkK,plan_GqM9N6qyhvxaVk","halfyearly":"prod_GqM9ToKK62qjkK,price_1LTAC5BVqmGyQTManGVoSBsc","yearly":"prod_GqM9ToKK62qjkK,price_1KbomlBVqmGyQTMaa0Tq7UaW"},"EUR":{"monthly":"prod_GqM9ToKK62qjkK,price_1H8NnnBVqmGyQTMaLwLRKbF3"}},"123doneproplus":{"USD":{"monthly":"prod_GyHm8uwOIjr6k5,price_1NsBeHBVqmGyQTMa0o3zMSH3"}},"123foxkeh":{"USD":{"monthly":"prod_OfV6ko0QPHotas,price_1NsA5qBVqmGyQTMapXvSdxYC"}},"foxkeh":{"USD":{"daily":"prod_GvH2k78kKusAlV,price_1Pe1GiBVqmGyQTMaaPVElv5S","monthly":"prod_GvH2k78kKusAlV,price_1LxakKBVqmGyQTMas2fZaSCG"}},"foxkeh2":{"USD":{"monthly":"prod_OfWo3Xmsn2dOpA,price_1NsBknBVqmGyQTMaXvfEARm2"}},"vpn":{"USD":{"monthly":"prod_JYy0wNbTbA5fDv,price_1Ivq4gBVqmGyQTMaplHcFEGO"}}}
+
+SP2REDIRECT__ENABLED=true
+SP2REDIRECT__SHADOW_MODE=true
+SP2REDIRECT__DEFAULT_REDIRECT_PERCENTAGE=100
+SP2REDIRECT__OFFERINGS={"123donepro":100,"123doneproplus":100,"123foxkeh":100,"foxkeh":100,"foxkeh2":100,"vpn":100}
+
 # Nextjs Public Environment Variables

--- a/apps/payments/next/config/index.ts
+++ b/apps/payments/next/config/index.ts
@@ -18,7 +18,7 @@ import {
   RootConfig as NestAppRootConfig,
   validate,
 } from '@fxa/payments/ui/server';
-import { SP2MapConfig } from '@fxa/payments/legacy';
+import { SP2MapConfig, SP2RedirectConfig } from '@fxa/payments/legacy';
 
 class CspConfig {
   @IsUrl()
@@ -103,6 +103,11 @@ export class PaymentsNextConfig extends NestAppRootConfig {
   @ValidateNested()
   @IsDefined()
   sp2map!: SP2MapConfig;
+
+  @Type(() => SP2RedirectConfig)
+  @ValidateNested()
+  @IsDefined()
+  sp2redirect!: SP2RedirectConfig;
 
   @IsString()
   authSecret!: string;

--- a/libs/payments/legacy/src/index.ts
+++ b/libs/payments/legacy/src/index.ts
@@ -1,3 +1,5 @@
 export * from './lib/stripe-mapper.service';
 export * from './lib/sp2map.config';
+export * from './lib/utils/buildSp2RedirectUrl';
 export * from './lib/utils/getSP2Params';
+export * from './lib/utils/redirectToSp2';

--- a/libs/payments/legacy/src/lib/factories.ts
+++ b/libs/payments/legacy/src/lib/factories.ts
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { SP2MapConfig, Currency, Intervals } from './sp2map.config';
+import { faker } from '@faker-js/faker';
+import {
+  SP2MapConfig,
+  Currency,
+  Intervals,
+  SP2RedirectConfig,
+  RedirectParams,
+} from './sp2map.config';
 import { StripeMetadataWithCMS } from './types';
 
 export const StripeMetadataWithCMSFactory = (
@@ -29,5 +36,24 @@ export const CurrencyFactory = (override?: Partial<Currency>): Currency => ({
 
 export const IntervalsFactory = (override?: Partial<Intervals>): Intervals => ({
   monthly: ['prod_productid', 'price_priceId'],
+  ...override,
+});
+
+export const RedirectParamsFactory = (
+  override?: Partial<RedirectParams>
+): RedirectParams => ({
+  sp2RedirectPercentage: faker.number.int({ min: 0, max: 100 }),
+  ...override,
+});
+
+export const SP2RedirectConfigFactory = (
+  override?: Partial<SP2RedirectConfig>
+): SP2RedirectConfig => ({
+  enabled: true,
+  shadowMode: false,
+  defaultRedirectPercentage: 100,
+  offerings: {
+    vpn: RedirectParamsFactory(),
+  },
   ...override,
 });

--- a/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.spec.ts
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { buildSp2RedirectUrl } from './buildSp2RedirectUrl';
+
+describe('buildSp2RedirectUrl', () => {
+  const defaultProductId = 'prod_123';
+  const defaultPriceId = 'price_123';
+  const defaultContentServerUrl = 'http://content-server.com';
+  const defaultSearchParams = new URLSearchParams(
+    'flow_id=one&flow_begin_time=123'
+  );
+
+  it('should return the correct URL', () => {
+    const result = buildSp2RedirectUrl(
+      defaultProductId,
+      defaultPriceId,
+      defaultContentServerUrl,
+      defaultSearchParams
+    );
+    expect(result).toBe(
+      'http://content-server.com/subscriptions/products/prod_123?plan=price_123&flow_id=one&flow_begin_time=123'
+    );
+  });
+
+  it('should remove SP2 redirect logic specific query params', () => {
+    defaultSearchParams.append('currency', 'USD');
+    defaultSearchParams.append('spVersion', '2');
+    const result = buildSp2RedirectUrl(
+      defaultProductId,
+      defaultPriceId,
+      defaultContentServerUrl,
+      defaultSearchParams
+    );
+    expect(result).toBe(
+      'http://content-server.com/subscriptions/products/prod_123?plan=price_123&flow_id=one&flow_begin_time=123'
+    );
+  });
+});

--- a/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.ts
+++ b/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function buildSp2RedirectUrl(
+  productId: string,
+  priceId: string,
+  contentServerUrl: string,
+  searchParams: URLSearchParams
+) {
+  // Remove SP2 redirect logic specific query params
+  searchParams.delete('currency');
+  searchParams.delete('spVersion');
+
+  const remainingQueryParams = searchParams.toString();
+
+  return `${contentServerUrl}/subscriptions/products/${productId}?plan=${priceId}&${remainingQueryParams}`;
+}

--- a/libs/payments/legacy/src/lib/utils/redirectToSp2.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/redirectToSp2.spec.ts
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { redirectToSp2 } from './redirectToSp2';
+import { RedirectParamsFactory, SP2RedirectConfigFactory } from '../factories';
+import { RedirectParams } from '../sp2map.config';
+
+describe('redirectToSp2', () => {
+  const defaultOfferingId = 'vpn';
+  const mockReportError = jest.fn();
+
+  beforeEach(() => {
+    mockReportError.mockClear();
+  });
+
+  describe('should return true', () => {
+    const defaultOfferings = {} as Record<string, RedirectParams>;
+    defaultOfferings[defaultOfferingId] = RedirectParamsFactory({
+      sp2RedirectPercentage: 100,
+    });
+    const defaultConfig = SP2RedirectConfigFactory({
+      offerings: defaultOfferings,
+    });
+    const defaultRandomPercentage = 100;
+    it('uses percentage from config', () => {
+      const result = redirectToSp2(
+        defaultConfig,
+        defaultOfferingId,
+        defaultRandomPercentage,
+        mockReportError
+      );
+      expect(result).toBe(true);
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it('uses config default percentage if config not found', () => {
+      const result = redirectToSp2(
+        defaultConfig,
+        'invalidOfferingId',
+        defaultRandomPercentage,
+        mockReportError
+      );
+      expect(result).toBe(true);
+      expect(mockReportError).toHaveBeenCalled();
+    });
+  });
+
+  describe('should return false', () => {
+    const defaultOfferings = {} as Record<string, RedirectParams>;
+    defaultOfferings[defaultOfferingId] = RedirectParamsFactory({
+      sp2RedirectPercentage: 0,
+    });
+    const defaultConfig = SP2RedirectConfigFactory({
+      offerings: defaultOfferings,
+      defaultRedirectPercentage: 0,
+    });
+    const defaultRandomPercentage = 1;
+
+    it('uses percentage from config', () => {
+      const result = redirectToSp2(
+        defaultConfig,
+        defaultOfferingId,
+        defaultRandomPercentage,
+        mockReportError
+      );
+      expect(result).toBe(false);
+      expect(mockReportError).toHaveBeenCalled();
+    });
+
+    it('uses config default percentage if config not found', () => {
+      const result = redirectToSp2(
+        defaultConfig,
+        'invalidOfferingId',
+        defaultRandomPercentage,
+        mockReportError
+      );
+      expect(result).toBe(false);
+      expect(mockReportError).toHaveBeenCalled();
+    });
+  });
+
+  describe('randomPercentage stays in bound', () => {
+    it('returns true even if randomPercentage is more than 100', () => {
+      const defaultOfferings = {} as Record<string, RedirectParams>;
+      defaultOfferings[defaultOfferingId] = RedirectParamsFactory({
+        sp2RedirectPercentage: 100,
+      });
+      const mockConfig = SP2RedirectConfigFactory({
+        offerings: defaultOfferings,
+      });
+
+      const result = redirectToSp2(
+        mockConfig,
+        defaultOfferingId,
+        200,
+        mockReportError
+      );
+      expect(result).toBe(true);
+    });
+
+    it('returns false even if randomPercentage is less than 1', () => {
+      const defaultOfferings = {} as Record<string, RedirectParams>;
+      defaultOfferings[defaultOfferingId] = RedirectParamsFactory({
+        sp2RedirectPercentage: 0,
+      });
+      const mockConfig = SP2RedirectConfigFactory({
+        offerings: defaultOfferings,
+        defaultRedirectPercentage: 0,
+      });
+
+      const result = redirectToSp2(
+        mockConfig,
+        defaultOfferingId,
+        0,
+        mockReportError
+      );
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/libs/payments/legacy/src/lib/utils/redirectToSp2.ts
+++ b/libs/payments/legacy/src/lib/utils/redirectToSp2.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { SP2RedirectConfig } from '../sp2map.config';
+
+export function redirectToSp2(
+  config: SP2RedirectConfig,
+  offeringId: string,
+  randomPercentage: number,
+  reportError: (...args: any) => void
+) {
+  const configPercentage = config.offerings[offeringId]?.sp2RedirectPercentage;
+  const sp2RedirectPercentage =
+    configPercentage ?? config.defaultRedirectPercentage;
+
+  // Each offering should have a value indicating which percentage
+  // of traffic should redirect to SP2. If config is not found, then
+  // report the error.
+  if (!configPercentage) {
+    reportError('No SP2 redirect percentage found for offering', {
+      offeringId,
+    });
+  }
+
+  let validPercentage;
+  if (randomPercentage < 1) {
+    console.log('Random percentage is too low');
+    validPercentage = 1;
+  } else if (randomPercentage > 100) {
+    console.log('Random percentage is too high');
+    validPercentage = 100;
+  } else {
+    validPercentage = randomPercentage;
+  }
+
+  // sp2RedirectPercentage indicates the percentage of traffic that
+  // should be redirected to SP2.
+  // validPercentage is a random number between 1 and 100
+  if (validPercentage <= sp2RedirectPercentage) {
+    return true;
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
## Because

- Landing page needs to redirect to either `payments-server` or `payments-next` depending on configuration per offering.

## This pull request

- Adds SP2 redirect config to `payments-next`.
- Adds a function to determine whether SP3 landing page should redirect to SP2 based on per offeringId percentage configuration.

## Issue that this pull request solves

Closes: #FXA-10968

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).