### PR TITLE
fix(l10n): Ensure a11y text is displayed on Complete Reset PW page for service=relay

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -363,6 +363,7 @@ const CompleteResetPasswordContainer = ({
         recoveryKeyExists,
         estimatedSyncDeviceCount,
       }}
+      isDesktopServiceRelay={integration.isDesktopRelay()}
       integrationIsSync={integration.isSync()}
       locationState={location.state as CompleteResetPasswordLocationState}
     />

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/interfaces.ts
@@ -44,7 +44,7 @@ export interface CompleteResetPasswordProps {
   estimatedSyncDeviceCount?: number;
   recoveryKeyExists?: boolean;
   integrationIsSync: boolean;
-  isDesktopServiceRelay?: boolean;
+  isDesktopServiceRelay: boolean;
 }
 
 export type AccountResetData = {


### PR DESCRIPTION
Because:
* This text is not being rendered as it should be on this page

This commit:
* Passes the missed prop into CompleteResetPassword from the container component, updates the optional type

fixes FXA-11016