### PR TITLE
feat(libs): Update libs for subscription upgrades

### DIFF
--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TaxAddress } from '@fxa/payments/customer';
+import { StripePrice } from '@fxa/payments/stripe';
 import {
   Cart,
   CartEligibilityStatus,
@@ -64,6 +65,8 @@ export type BaseCartDTO = Omit<ResultCart, 'state'> & {
   upcomingInvoicePreview: Invoice;
   latestInvoicePreview?: Invoice;
   paymentInfo?: PaymentInfo;
+  fromOfferingConfigId?: string;
+  fromPrice?: StripePrice;
 };
 
 export type StartCartDTO = BaseCartDTO & {

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -240,9 +240,9 @@ describe('CheckoutService', () => {
         .spyOn(accountCustomerManager, 'createAccountCustomer')
         .mockResolvedValue(mockAccountCustomer);
       jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
-      jest
-        .spyOn(eligibilityService, 'checkEligibility')
-        .mockResolvedValue(EligibilityStatus.CREATE);
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      });
       jest
         .spyOn(productConfigurationManager, 'retrieveStripePrice')
         .mockResolvedValue(mockPrice);

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -143,7 +143,8 @@ export class CheckoutService {
       stripeCustomerId
     );
 
-    const cartEligibilityStatus = handleEligibilityStatusMap[eligibility];
+    const cartEligibilityStatus =
+      handleEligibilityStatusMap[eligibility.subscriptionEligibilityResult];
 
     if (cartEligibilityStatus !== cart.eligibilityStatus) {
       throw new CartEligibilityMismatchError(

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -13,6 +13,7 @@ export type InvoicePreview = {
   discountType?: string;
   number: string | null; // customer-facing invoice identifier
   paypalTransactionId?: string;
+  oneTimeCharge?: number;
 };
 
 export interface TaxAmount {

--- a/libs/payments/eligibility/src/lib/eligibility.service.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.ts
@@ -25,7 +25,9 @@ export class EligibilityService {
     stripeCustomerId?: string | null | undefined
   ) {
     if (!stripeCustomerId) {
-      return EligibilityStatus.CREATE;
+      return {
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      };
     }
 
     const targetOfferingResult =

--- a/libs/payments/eligibility/src/lib/eligibility.types.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.types.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { StripePrice } from '@fxa/payments/stripe';
+
 export enum EligibilityStatus {
   CREATE = 'create',
   UPGRADE = 'upgrade',
@@ -27,9 +29,24 @@ export enum IntervalComparison {
 export type OfferingOverlapResult = {
   comparison: OfferingComparison;
   priceId: string;
+  fromOfferingId: string;
 };
 
 export type Interval = {
   unit: 'day' | 'week' | 'month' | 'year';
   count: number;
 };
+
+export type SubscriptionEligibilityResult =
+  | {
+      subscriptionEligibilityResult:
+        | EligibilityStatus.CREATE
+        | EligibilityStatus.INVALID;
+    }
+  | {
+      subscriptionEligibilityResult:
+        | EligibilityStatus.UPGRADE
+        | EligibilityStatus.DOWNGRADE;
+      fromOfferingConfigId: string;
+      fromPrice: StripePrice;
+    };

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -8,8 +8,12 @@ import { Validator } from 'class-validator';
 import { GoogleManager } from '@fxa/google';
 import { CartService, SuccessCartDTO } from '@fxa/payments/cart';
 import { ContentServerManager } from '@fxa/payments/content-server';
+import { CurrencyManager } from '@fxa/payments/currency';
 import { CheckoutTokenManager } from '@fxa/payments/paypal';
 import { ProductConfigurationManager } from '@fxa/shared/cms';
+import { CartState } from '@fxa/shared/db/mysql/account';
+import { SanitizeExceptions } from '@fxa/shared/error';
+import { GeoDBManager } from '@fxa/shared/geodb';
 
 import { CheckoutCartWithPaypalActionArgs } from './validators/CheckoutCartWithPaypalActionArgs';
 import { CheckoutCartWithStripeActionArgs } from './validators/CheckoutCartWithStripeActionArgs';
@@ -26,11 +30,7 @@ import { FinalizeProcessingCartActionArgs } from './validators/finalizeProcessin
 import { SubmitNeedsInputActionArgs } from './validators/SubmitNeedsInputActionArgs';
 import { GetNeedsInputActionArgs } from './validators/GetNeedsInputActionArgs';
 import { ValidatePostalCodeArgs } from './validators/ValidatePostalCodeArgs';
-import { SanitizeExceptions } from '@fxa/shared/error';
-import { GeoDBManager } from '@fxa/shared/geodb';
-import { CurrencyManager } from '@fxa/payments/currency';
 import { DetermineCurrencyActionArgs } from './validators/DetermineCurrencyActionArgs';
-import { CartState } from '@fxa/shared/db/mysql/account';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.


### PR DESCRIPTION
## This pull request

-  [x] Updates checkEligibility, when eligibility status is upgrade, to also return the price and the offering config id that the customer is upgrading from
- [x] Updates InvoiceManager to add previewUpcomingForUpgrade which should also return oneTimeCharge
- [x] Updates CartService.getCart to utilize previewUpcomingForUpgrade

## Issue that this pull request solves

Closes: FXA-11023

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.