### PR TITLE
Rename duplicate ftl string in 2FA recovery flow

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/en.ftl
@@ -10,5 +10,5 @@ signin-recovery-method-code-v2 = Backup authentication codes
 # Variable: $numberOfCodes (String) - The number of authentication codes the user has left, e.g. 4
 signin-recovery-method-code-info = { $numberOfCodes } codes remaining
 # Shown when a backend service fails and a code cannot be sent to the user's recovery phone.
-signin-recovery-phone-send-code-error-heading = There was a problem sending a code to your recovery phone
-signin-recovery-phone-send-code-error-description = Please try again later or use your backup authentication codes.
+signin-recovery-method-send-code-error-heading = There was a problem sending a code to your recovery phone
+signin-recovery-method-send-code-error-description = Please try again later or use your backup authentication codes.

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -47,12 +47,12 @@ const SigninRecoveryChoice = ({
   const navigateWithQuery = useNavigateWithQuery();
 
   const generalSendCodeErrorHeading = ftlMsgResolver.getMsg(
-    'signin-recovery-phone-send-code-error-heading',
+    'signin-recovery-method-send-code-error-heading',
     'There was a problem sending a code to your recovery phone'
   );
 
   const generalSendCodeErrorDescription = ftlMsgResolver.getMsg(
-    'signin-recovery-phone-send-code-error-description',
+    'signin-recovery-method-send-code-error-description',
     'Please try again later or use your backup authentication codes.'
   );
 


### PR DESCRIPTION
## Because

- string id was duplicated with different messages

## This pull request

- rename strings to align with component where they are used

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
