### PR TITLE
feat(sms): Add localized body text to SMS

### DIFF
--- a/libs/accounts/recovery-phone/README.md
+++ b/libs/accounts/recovery-phone/README.md
@@ -8,4 +8,8 @@ Run `nx build recovery-phone` to build the library.
 
 ## Running unit tests
 
-Run `nx test recovery-phone` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test-unit recovery-phone` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running integration tests
+
+Run `nx test-integration recovery-phone` to execute the integration tests via [Jest](https://jestjs.io).

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -130,6 +130,31 @@ describe('RecoveryPhoneService', () => {
     expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
   });
 
+  it('handles message template when provided to setup phone number', async () => {
+    mockOtpManager.generateCode.mockReturnValue(code);
+    const getFormattedMessage = jest.fn().mockResolvedValue('message');
+
+    const result = await service.setupPhoneNumber(
+      uid,
+      phoneNumber,
+      getFormattedMessage
+    );
+
+    expect(result).toBeTruthy();
+    expect(mockOtpManager.generateCode).toBeCalled();
+    expect(mockSmsManager.sendSMS).toBeCalledWith({
+      to: phoneNumber,
+      body: 'message',
+    });
+    expect(mockRecoveryPhoneManager.storeUnconfirmed).toBeCalledWith(
+      uid,
+      code,
+      phoneNumber,
+      true
+    );
+    expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
+  });
+
   it('Will reject a phone number that is not part of launch', async () => {
     const to = '+16005551234';
     await expect(service.setupPhoneNumber(uid, to)).rejects.toEqual(

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -59,9 +59,14 @@ export class RecoveryPhoneService {
    * by sending the phone number provided an OTP code to verify.
    * @param uid The account id
    * @param phoneNumber The phone number to register
+   * @param localizedMessageBody Optional localized message body
    * @returns True if code was sent and stored
    */
-  public async setupPhoneNumber(uid: string, phoneNumber: string) {
+  public async setupPhoneNumber(
+    uid: string,
+    phoneNumber: string,
+    getFormattedMessage?: (code: string) => Promise<string>
+  ) {
     if (!this.config.enabled) {
       throw new RecoveryPhoneNotEnabled();
     }
@@ -88,21 +93,26 @@ export class RecoveryPhoneService {
     }
 
     const code = await this.otpCode.generateCode();
-    const msg = await this.smsManager.sendSMS({
-      to: phoneNumber,
-      body: code,
-    });
 
-    if (!this.isSuccessfulSmsSend(msg)) {
-      return false;
-    }
     await this.recoveryPhoneManager.storeUnconfirmed(
       uid,
       code,
       phoneNumber,
       true
     );
-    return true;
+
+    const formattedSMSbody = getFormattedMessage
+      ? await getFormattedMessage(code)
+      : undefined;
+
+    const smsBody = formattedSMSbody || `${code}`;
+
+    const msg = await this.smsManager.sendSMS({
+      to: phoneNumber,
+      body: smsBody,
+    });
+
+    return this.isSuccessfulSmsSend(msg);
   }
 
   /**
@@ -294,9 +304,13 @@ export class RecoveryPhoneService {
   /**
    * Sends an totp code to a user
    * @param uid Account id
+   * @param getFormattedMessage Optional template function to format the message
    * @returns True if message didn't fail to send.
    */
-  public async sendCode(uid: string) {
+  public async sendCode(
+    uid: string,
+    getFormattedMessage?: (code: string) => Promise<string>
+  ) {
     if (!this.config.enabled) {
       throw new RecoveryPhoneNotEnabled();
     }
@@ -310,9 +324,16 @@ export class RecoveryPhoneService {
       phoneNumber,
       false
     );
+
+    const formattedSMSbody = getFormattedMessage
+      ? await getFormattedMessage(code)
+      : undefined;
+
+    const smsBody = formattedSMSbody || `${code}`;
+
     const msg = await this.smsManager.sendSMS({
       to: phoneNumber,
-      body: `${code}`, // TODO: Other text or translation around code?
+      body: smsBody,
     });
 
     return this.isSuccessfulSmsSend(msg);

--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -59,6 +59,10 @@ export enum EmailType {
   verificationReminderFinal,
   cadReminderFirst,
   cadReminderSecond,
+  postAddRecoveryPhone,
+  postChangeRecoveryPhone,
+  postRemoveRecoveryPhone,
+  postSigninRecoveryPhone,
 }
 
 export enum EmailHeader {

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -103,7 +103,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.disconnectTotp();
     });
 
-    test('can sign-in settings with recovery phone', async ({
+    test('can sign-in to settings with recovery phone', async ({
       target,
       pages: {
         page,

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2196,7 +2196,7 @@ const convictConf = convict({
         format: Array,
       },
       maxMessageLength: {
-        default: 60,
+        default: 160,
         doc: 'Max allows sms message length',
         env: 'RECOVERY_PHONE__SMS__MAX_MESSAGE_LENGTH',
         format: Number,

--- a/packages/fxa-auth-server/lib/l10n/index.ts
+++ b/packages/fxa-auth-server/lib/l10n/index.ts
@@ -7,9 +7,16 @@ import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { determineLocale, parseAcceptLanguage } from '@fxa/shared/l10n';
 import { ILocalizerBindings } from './interfaces/ILocalizerBindings';
 
+/**
+ * Represents a Fluent (FTL) message
+ * @param id - unique identifier for the message
+ * @param message - a fallback message in case the localized string cannot be found
+ * @param vars - optional arguments to be interpolated into the localized string
+ */
 export interface FtlIdMsg {
   id: string;
   message: string;
+  vars?: Record<string, string>;
 }
 
 interface LocalizedStrings {
@@ -118,11 +125,11 @@ class Localizer {
 
     const localizedFtlIdMsgs = await Promise.all(
       ftlIdMsgs.map(async (ftlIdMsg) => {
-        const { id, message } = ftlIdMsg;
+        const { id, message, vars } = ftlIdMsg;
         let localizedMessage;
         try {
-          localizedMessage = (await l10n.formatValue(id, message)) || message;
-        } catch {
+          localizedMessage = (await l10n.formatValue(id, vars)) || message;
+        } catch (e) {
           localizedMessage = message;
         }
         return Promise.resolve({

--- a/packages/fxa-auth-server/lib/l10n/server.ftl
+++ b/packages/fxa-auth-server/lib/l10n/server.ftl
@@ -2,3 +2,15 @@
 
 session-verify-send-push-title-2 = Logging in to your { -product-mozilla-account }?
 session-verify-send-push-body-2 = Click here to confirm it’s you
+
+# Message sent by SMS with limited character length, please test translation with the messaging segment calculator
+# https://twiliodeved.github.io/message-segment-calculator/
+# Messages should be limited to one segment
+# $code  - 6 digit code used to verify phone ownership when registering a recovery phone
+recovery-phone-setup-sms-body = { $code } is your { -brand-mozilla } verification code. Expires in 5 minutes.
+
+# Message sent by SMS with limited character length, please test translation with the messaging segment calculator
+# https://twiliodeved.github.io/message-segment-calculator/
+# Messages should be limited to one segment
+# $code  - 6 digit code used to sign in with a recovery phone as backup for two-step authentication
+recovery-phone-signin-sms-body = { $code } is your { -brand-mozilla } recovery code. Expires in 5 minutes.

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1604,6 +1604,13 @@ module.exports = function (log, config, bounces, statsd) {
   };
 
   Mailer.prototype.postAddRecoveryPhoneEmail = function (message) {
+    const { maskedLastFourPhoneNumber } = message;
+    log.trace('mailer.postAddRecoveryPhoneEmail', {
+      email: message.email,
+      uid: message.uid,
+      maskedLastFourPhoneNumber,
+    });
+
     const templateName = 'postAddRecoveryPhone';
     const links = this._generateSettingLinks(message, templateName);
     const [time, date] = this._constructLocalTimeString(
@@ -1630,7 +1637,7 @@ module.exports = function (log, config, bounces, statsd) {
          * rendering, and adding them to our templateValues for Fluent. Because
          * of this, for now, we'll pass the variable with the bulleted mask
          * instead of handling the bulleted mask in the template itself. */
-        maskedLastFourPhoneNumber: message.maskedLastFourPhoneNumber,
+        maskedLastFourPhoneNumber,
         resetLink: links.resetLink,
         resetLinkAttributes: links.resetLinkAttributes,
         supportLinkAttributes: links.supportLinkAttributes,

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -350,7 +350,7 @@ module.exports = (config) => {
     }
   };
 
-  Client.prototype.recoveryPhoneNumberCreate = async function (phoneNumber) {
+  Client.prototype.recoveryPhoneCreate = async function (phoneNumber) {
     if (this.sessionToken) {
       const resp = await this.api.recoveryPhoneNumberCreate(
         this.sessionToken,
@@ -358,6 +358,7 @@ module.exports = (config) => {
       );
       return resp;
     }
+    return;
   };
 
   Client.prototype.recoveryPhoneAvailable = async function () {
@@ -384,16 +385,6 @@ module.exports = (config) => {
       const resp = await this.api.recoveryPhoneNumberConfirmSetup(
         this.sessionToken,
         code
-      );
-      return resp;
-    }
-  };
-
-  Client.prototype.recoveryPhoneCreate = async function (phoneNumber) {
-    if (this.sessionToken) {
-      const resp = await this.api.recoveryPhoneNumberCreate(
-        this.sessionToken,
-        phoneNumber
       );
       return resp;
     }

--- a/packages/fxa-auth-server/test/local/l10n/index.ts
+++ b/packages/fxa-auth-server/test/local/l10n/index.ts
@@ -144,5 +144,37 @@ describe('Localizer', () => {
         'this-id-definitely-doesnt-exist': 'My fake message',
       });
     });
+
+    it('can handle optional arguments to be interpolated into the localized string', async () => {
+      const code = 'abc123';
+      const result = await localizer.localizeStrings('en', [
+        {
+          id: 'recovery-phone-setup-sms-body',
+          message: `This is a fallback message that includes the code: ${code}`,
+          vars: { code },
+        },
+      ]);
+
+      assert.deepEqual(result, {
+        'recovery-phone-setup-sms-body':
+          'abc123 is your Mozilla verification code. Expires in 5 minutes.',
+      });
+    });
+
+    it('can handle missing localized strings with optional arguments', async () => {
+      const code = 'abc123';
+      const result = await localizer.localizeStrings('en', [
+        {
+          id: 'recovery-phone-setup-sms-body-does-not-exist',
+          message: `This is a fallback message that includes the code: ${code}`,
+          vars: { code },
+        },
+      ]);
+
+      assert.deepEqual(result, {
+        'recovery-phone-setup-sms-body-does-not-exist':
+          'This is a fallback message that includes the code: abc123',
+      });
+    });
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -28,8 +28,8 @@ describe('/recovery_phone', () => {
   const email = 'test@mozilla.com';
   const phoneNumber = '+15550005555';
   const code = '000000';
-  const mockLog = {};
   const mockDb = mocks.mockDB({ uid: uid, email: email });
+  const mockLog = mocks.mockLog();
   let mockMailer;
   const mockCustoms = {
     check: sandbox.fake(),

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -63,7 +63,7 @@ describe(`#integration - recovery phone`, function () {
   // Different magic numbers correspond to different scenarios. e.g. reassigned numbers, sim swapping,
   // etc. See the following documentation for info in the event tests need to consider extra states.
   // https://www.twilio.com/docs/lookup/magic-numbers-for-lookup
-  const phoneNumber = '+12345678900';
+  const phoneNumber = '+14159929960';
   const password = 'password';
 
   before(async function () {
@@ -116,7 +116,7 @@ describe(`#integration - recovery phone`, function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
-    const createResp = await client.recoveryPhoneNumberCreate(phoneNumber);
+    const createResp = await client.recoveryPhoneCreate(phoneNumber);
     const codeSent = await redisUtil.recoveryPhone.getCode(client.uid);
     const confirmResp = await client.recoveryPhoneConfirmSetup(codeSent);
     const checkResp = await client.recoveryPhoneNumber();
@@ -134,7 +134,7 @@ describe(`#integration - recovery phone`, function () {
     }
 
     // Add recovery phone
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
     await client.recoveryPhoneConfirmSetup(
       await redisUtil.recoveryPhone.getCode(client.uid)
     );
@@ -172,7 +172,7 @@ describe(`#integration - recovery phone`, function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
     await client.recoveryPhoneConfirmSetup(
       await redisUtil.recoveryPhone.getCode(client.uid)
     );
@@ -194,7 +194,7 @@ describe(`#integration - recovery phone`, function () {
     let error;
 
     try {
-      await client.recoveryPhoneNumberCreate(phoneNumber);
+      await client.recoveryPhoneCreate(phoneNumber);
     } catch (err) {
       error = err;
     }
@@ -206,8 +206,8 @@ describe(`#integration - recovery phone`, function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
-    await client.recoveryPhoneNumberCreate(phoneNumber);
-    const createResp = await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
+    const createResp = await client.recoveryPhoneCreate(phoneNumber);
 
     assert.equal(createResp.status, 'success');
   });
@@ -217,7 +217,7 @@ describe(`#integration - recovery phone`, function () {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
 
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
 
     let error;
     try {
@@ -233,13 +233,13 @@ describe(`#integration - recovery phone`, function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
     const code = await redisUtil.recoveryPhone.getCode(client.uid);
     await client.recoveryPhoneConfirmSetup(code);
 
     let error;
     try {
-      await client.recoveryPhoneNumberCreate(phoneNumber);
+      await client.recoveryPhoneCreate(phoneNumber);
       const code = await redisUtil.recoveryPhone.getCode(client.uid);
       await client.recoveryPhoneConfirmSetup(code);
     } catch (err) {
@@ -253,7 +253,7 @@ describe(`#integration - recovery phone`, function () {
     if (!isTwilioConfigured) {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
     const code = await redisUtil.recoveryPhone.getCode(client.uid);
     await client.recoveryPhoneConfirmSetup(code);
 
@@ -277,7 +277,7 @@ describe(`#integration - recovery phone - customs checks`, function () {
     customsUrl: config.customsUrl,
   };
   const password = 'password';
-  const phoneNumber = '+12345678900';
+  const phoneNumber = '+14159929960';
 
   before(async function () {
     config.securityHistory.ipProfiling.allowedRecency = 0;
@@ -314,12 +314,12 @@ describe(`#integration - recovery phone - customs checks`, function () {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
 
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
 
     let error;
     try {
       for (let i = 0; i < 9; i++) {
-        await client.recoveryPhoneNumberCreate(phoneNumber);
+        await client.recoveryPhoneCreate(phoneNumber);
       }
     } catch (err) {
       error = err;
@@ -335,7 +335,7 @@ describe(`#integration - recovery phone - customs checks`, function () {
     }
 
     // One code gets sent here
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
 
     // Send 8 more codes, for a total of 9 codes.
     for (let i = 0; i < 9; i++) {
@@ -360,7 +360,7 @@ describe(`#integration - recovery phone - customs checks`, function () {
       this.skip('Invalid twilio accountSid or authToken. Check env / config!');
     }
 
-    await client.recoveryPhoneNumberCreate(phoneNumber);
+    await client.recoveryPhoneCreate(phoneNumber);
     const codeSent = await redisUtil.recoveryPhone.getCode(client.uid, 0);
     await client.recoveryPhoneConfirmSetup(codeSent);
 

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -303,7 +303,7 @@ const conf = convict({
         format: String,
       },
       maxMessageLength: {
-        default: 60,
+        default: 160,
         doc: 'Max allows sms message lenght',
         env: 'RECOVERY_PHONE__SMS__MAX_MESSAGE_LENGTH',
         format: Number,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/en.ftl
@@ -7,7 +7,7 @@ signin-recovery-phone-heading = Enter recovery code
 
 # Text that explains the user should check their phone for a recovery code
 # $maskedPhoneNumber - The users masked phone number
-signin-recovery-phone-instruction = A six-digit code was sent to <span>{ $maskedPhoneNumber }</span> by text message. This code expires after 5 minutes.
+signin-recovery-phone-instruction-v2 = A six-digit code was sent to <span>{ $maskedPhoneNumber }</span> by text message. This code expires after 5 minutes. Donʼt share this code with anyone.
 
 signin-recovery-phone-input-label = Enter 6-digit code
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -124,13 +124,13 @@ const SigninRecoveryPhone = ({
         <h2 className="card-header my-4">Enter recovery code</h2>
       </FtlMsg>
       <FtlMsg
-        id="signin-recovery-phone-instruction"
+        id="signin-recovery-phone-instruction-v2"
         vars={{ maskedPhoneNumber }}
         elems={{ span: spanElement }}
       >
         <p>
           A six-digit code was sent to {spanElement} by text message. This code
-          expires after 5 minutes.
+          expires after 5 minutes. Donʼt share this code with anyone.
         </p>
       </FtlMsg>
       <FormVerifyTotp


### PR DESCRIPTION
## Because

* We want to include a localized message in addition to the code

## This pull request

* Add ftl strings for localized SMS messages
* Pass strings to sms manager for inclusion in sms
* Add missing import in integration test
* Add tags to accounts libs projects for inclusion in CI integration tests
* Add some more logging
* Split email sending for recovery phone actions into separate try catch with error logging that doesn't crash the main SMS actions

## Issue that this pull request solves

Closes: #FXA-11007

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Noticed that the recovery-phone libs tests weren't running on CI and added them + updated instructions in readme to run the tests locally.
