### PR TITLE
feat(paypal): Send country code with paypal transactions

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -688,7 +688,9 @@ describe('CheckoutService', () => {
       );
       const mockPaypalCustomer = ResultPaypalCustomerFactory();
       const mockInvoice = StripeResponseFactory(
-        StripeInvoiceFactory({ status: 'paid' })
+        StripeInvoiceFactory({
+          status: 'paid',
+        })
       );
       const mockPrice = StripePriceFactory();
       const mockPrePayStepsResult = PrePayStepsResultFactory({
@@ -852,7 +854,9 @@ describe('CheckoutService', () => {
         );
         const mockPaypalCustomer = ResultPaypalCustomerFactory();
         const mockInvoice = StripeResponseFactory(
-          StripeInvoiceFactory({ status: 'uncollectible' })
+          StripeInvoiceFactory({
+            status: 'uncollectible',
+          })
         );
         const mockPrice = StripePriceFactory();
         const mockPrePayStepsResult = PrePayStepsResultFactory({

--- a/libs/payments/currency/src/index.ts
+++ b/libs/payments/currency/src/index.ts
@@ -5,3 +5,4 @@
 export * from './lib/currency.constants';
 export * from './lib/currency.error';
 export * from './lib/currency.manager';
+export * from './lib/currency.config';

--- a/libs/payments/currency/src/lib/currency.manager.ts
+++ b/libs/payments/currency/src/lib/currency.manager.ts
@@ -72,4 +72,14 @@ export class CurrencyManager {
 
     return undefined;
   }
+
+  getDefaultCountryForCurrency(currency: string) {
+    if (
+      currency in Object.getOwnPropertyNames(this.config.currenciesToCountries)
+    ) {
+      return this.config.currenciesToCountries[currency][0];
+    } else {
+      return undefined;
+    }
+  }
 }

--- a/libs/payments/paypal/src/lib/factories.ts
+++ b/libs/payments/paypal/src/lib/factories.ts
@@ -180,6 +180,7 @@ export const ChargeOptionsFactory = (
   amountInCents: faker.number.int({ max: 100000000 }),
   billingAgreementId: faker.string.uuid(),
   currencyCode: faker.finance.currencyCode(),
+  countryCode: faker.finance.currencyCode(),
   idempotencyKey: faker.string.uuid(),
   invoiceNumber: faker.string.uuid(),
   taxAmountInCents: faker.number.int({ max: 100000000 }),

--- a/libs/payments/paypal/src/lib/paypal.client.spec.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.spec.ts
@@ -148,6 +148,7 @@ describe('PayPalClient', () => {
       const options = {
         amount: faker.finance.amount(),
         currencyCode: faker.finance.currencyCode(),
+        countryCode: faker.location.countryCode(),
         idempotencyKey: faker.string.sample(),
         ipaddress: faker.internet.ipv4(),
         billingAgreementId: faker.string.sample(),
@@ -161,6 +162,7 @@ describe('PayPalClient', () => {
         PAYMENTTYPE: 'instant',
         AMT: options.amount,
         CURRENCYCODE: options.currencyCode,
+        COUNTRYCODE: options.countryCode,
         CUSTOM: options.idempotencyKey,
         INVNUM: options.invoiceNumber,
         IPADDRESS: options.ipaddress,
@@ -184,6 +186,7 @@ describe('PayPalClient', () => {
       const options = {
         amount: faker.finance.amount(),
         currencyCode: faker.finance.currencyCode(),
+        countryCode: faker.location.countryCode(),
         idempotencyKey: faker.string.sample(),
         ipaddress: faker.internet.ipv4(),
         billingAgreementId: faker.string.sample(),
@@ -198,6 +201,7 @@ describe('PayPalClient', () => {
         PAYMENTTYPE: 'instant',
         AMT: options.amount,
         CURRENCYCODE: options.currencyCode,
+        COUNTRYCODE: options.countryCode,
         CUSTOM: options.idempotencyKey,
         INVNUM: options.invoiceNumber,
         IPADDRESS: options.ipaddress,

--- a/libs/payments/paypal/src/lib/paypal.client.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.ts
@@ -231,6 +231,7 @@ export class PayPalClient {
     const data = {
       AMT: options.amount,
       CURRENCYCODE: options.currencyCode.toUpperCase(),
+      COUNTRYCODE: options.countryCode.toUpperCase(),
       CUSTOM: options.idempotencyKey,
       INVNUM: options.invoiceNumber,
       ...(options.ipaddress && { IPADDRESS: options.ipaddress }),
@@ -342,6 +343,7 @@ export class PayPalClient {
       ),
       billingAgreementId: options.billingAgreementId,
       currencyCode: options.currencyCode,
+      countryCode: options.countryCode,
       idempotencyKey: options.idempotencyKey,
       invoiceNumber: options.invoiceNumber,
       ...(options.ipaddress && { ipaddress: options.ipaddress }),

--- a/libs/payments/paypal/src/lib/paypal.client.types.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.types.ts
@@ -145,6 +145,7 @@ export interface DoReferenceTransactionOptions {
   invoiceNumber: string;
   idempotencyKey: string;
   currencyCode: string;
+  countryCode: string;
   taxAmount?: string;
   ipaddress?: string;
 }

--- a/libs/payments/paypal/src/lib/paypal.types.ts
+++ b/libs/payments/paypal/src/lib/paypal.types.ts
@@ -23,6 +23,7 @@ export interface ChargeOptions {
   amountInCents: number;
   billingAgreementId: string;
   currencyCode: string;
+  countryCode: string;
   idempotencyKey: string;
   invoiceNumber: string;
   ipaddress?: string;

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -5,6 +5,7 @@
 export * from './lib/accountCustomer/accountCustomer.error';
 export * from './lib/accountCustomer/accountCustomer.factories';
 export * from './lib/accountCustomer/accountCustomer.manager';
+export { StripeAddressFactory } from './lib/factories/address.factory';
 export {
   StripeApiListFactory,
   StripeResponseFactory,

--- a/libs/payments/stripe/src/lib/factories/address.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/address.factory.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { StripeAddress } from '../stripe.client.types';
+
+export const StripeAddressFactory = (override?: Partial<StripeAddress>) => ({
+  city: '',
+  line1: '',
+  line2: '',
+  state: '',
+  postal_code: faker.location.zipCode(),
+  country: faker.location.countryCode(),
+  ...override,
+});

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -348,6 +348,7 @@ export type StripePaymentMethod = NegotiateExpanded<
   'customer'
 >;
 
+export type StripeAddress = Stripe.Address;
 export type StripeApiList<T> = Stripe.ApiList<T>;
 export type StripeApiListPromise<T> = Stripe.ApiListPromise<T>;
 export type StripeResponse<T> = Stripe.Response<T>;

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -7,6 +7,7 @@
       "@fxa/payments/stripe": ["libs/payments/stripe/src/index"],
       "@fxa/payments/paypal": ["libs/payments/paypal/src/index"],
       "@fxa/payments/customer": ["libs/payments/customer/src/index"],
+      "@fxa/payments/currency": ["libs/payments/currency/src/index"],
       "@fxa/shared/cms": ["libs/shared/cms/src/index"],
       "@fxa/shared/cloud-tasks": ["libs/shared/cloud-tasks/src/index"],
       "@fxa/shared/db/firestore": ["libs/shared/db/firestore/src/index"],

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -52,6 +52,7 @@ describe('PayPalHelper', () => {
     total: 1234,
     currency: 'usd',
     period_end: 1587426018,
+    customer_shipping: { address: { country: 'US' } },
     lines: {
       data: [
         {
@@ -229,6 +230,7 @@ describe('PayPalHelper', () => {
       amountInCents: 1099,
       billingAgreementId: 'B-12345',
       currencyCode: 'usd',
+      countryCode: 'US',
       invoiceNumber: 'in_asdf',
       idempotencyKey: ' in_asdf-0',
     };
@@ -247,6 +249,7 @@ describe('PayPalHelper', () => {
         invoiceNumber: validOptions.invoiceNumber,
         idempotencyKey: validOptions.idempotencyKey,
         currencyCode: validOptions.currencyCode,
+        countryCode: validOptions.countryCode,
       };
       assert.ok(
         paypalHelper.client.doReferenceTransaction.calledOnceWith(
@@ -292,6 +295,7 @@ describe('PayPalHelper', () => {
         invoiceNumber: options.invoiceNumber,
         idempotencyKey: options.idempotencyKey,
         currencyCode: options.currencyCode,
+        countryCode: options.countryCode,
         taxAmount:
           paypalHelper.currencyHelper.getPayPalAmountStringFromAmountInCents(
             options.taxAmountInCents
@@ -982,6 +986,7 @@ describe('PayPalHelper', () => {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
         currencyCode: validInvoice.currency,
+        countryCode: validInvoice.customer_shipping.address.country,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -1019,6 +1024,7 @@ describe('PayPalHelper', () => {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
         currencyCode: validInvoice.currency,
+        countryCode: validInvoice.customer_shipping.address.country,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -1055,6 +1061,7 @@ describe('PayPalHelper', () => {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
         currencyCode: validInvoice.currency,
+        countryCode: validInvoice.customer_shipping.address.country,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -1104,6 +1111,7 @@ describe('PayPalHelper', () => {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
         currencyCode: validInvoice.currency,
+        countryCode: validInvoice.customer_shipping.address.country,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -1147,6 +1155,7 @@ describe('PayPalHelper', () => {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
         currencyCode: validInvoice.currency,
+        countryCode: validInvoice.customer_shipping.address.country,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -1201,6 +1210,7 @@ describe('PayPalHelper', () => {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
         currencyCode: validInvoice.currency,
+        countryCode: validInvoice.customer_shipping.address.country,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,


### PR DESCRIPTION
## Because

- Accounting needs a queriable country code on paypal transactions

## This pull request

- uses the ip-located country when available (or the currency default country when not), and sends that to paypal's `COUNTYCODE` NVP field.

## Issue that this pull request solves
Closes #FXA-10948

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
