### PR TITLE
feat(keys): Update key stretching to optionally use session token on password change

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -20,7 +20,10 @@ test.describe('severity-2 #smoke', () => {
     password: string
   ) {
     const client = target.createAuthClient(version);
-    const response = await client.signIn(email, password, { keys: true });
+    const response = await client.signIn(email, password, {
+      keys: true,
+      skipPasswordUpgrade: true,
+    });
     expect(response.keyFetchToken).toBeDefined();
     expect(response.unwrapBKey).toBeDefined();
 

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -20,7 +20,10 @@ test.describe('severity-2 #smoke', () => {
     password: string
   ) {
     const client = target.createAuthClient(version);
-    const response = await client.signIn(email, password, { keys: true });
+    const response = await client.signIn(email, password, {
+      keys: true,
+      skipPasswordUpgrade: true,
+    });
     expect(response.keyFetchToken).toBeDefined();
     expect(response.unwrapBKey).toBeDefined();
 

--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -120,6 +120,7 @@ test.describe('auth-client-tests', () => {
     const { email, password } = testAccountTracker.generateAccountDetails();
 
     await signUp(client, email, password);
+
     const signInResult = await client.signIn(email, password, { keys: true });
     expect(signInResult.keyFetchToken).toBeDefined();
     expect(signInResult.unwrapBKey).toBeDefined();
@@ -129,6 +130,7 @@ test.describe('auth-client-tests', () => {
       signInResult.keyFetchToken as string,
       signInResult.unwrapBKey as string
     );
+
     expect(keys1).toBeDefined();
     expect(keys1.kA).toBeDefined();
     expect(keys1.kB).toBeDefined();
@@ -143,13 +145,26 @@ test.describe('auth-client-tests', () => {
     expect(statusBefore.clientSalt).toBeUndefined();
     expect(statusBefore.currentVersion).toBe('v1');
 
-    // The sign in should automatically reset the password
+    // The sign in should automatically upgrade the password, but return V1 creds
     const signInResult2 = await client2.signIn(email, password, {
       keys: true,
     });
     expect(signInResult2).toBeDefined();
     expect(signInResult2.keyFetchToken).toBeDefined();
     expect(signInResult2.unwrapBKey).toBeDefined();
+    expect(signInResult2.unwrapBKey).toEqual(signInResult.unwrapBKey);
+
+    // Grab keys, so we can compare kA and kB
+    const keys2 = await client.accountKeys(
+      signInResult2.keyFetchToken as string,
+      signInResult2.unwrapBKey as string
+    );
+
+    expect(keys2).toBeDefined();
+    expect(keys2.kA).toBeDefined();
+    expect(keys2.kB).toBeDefined();
+    expect(keys2.kA).toEqual(keys1.kA);
+    expect(keys2.kB).toEqual(keys1.kB);
 
     // Check the status after the signin
     const statusAfter = await client2.getCredentialStatusV2(email);
@@ -159,7 +174,12 @@ test.describe('auth-client-tests', () => {
     expect(statusAfter.clientSalt).toMatch('quickStretchV2:');
     expect(statusAfter.currentVersion).toBe('v2');
 
-    // Check unwrapKB. It should match our V2 credential unwrapBKey.
+    // Do another signin to get V2 credentials
+    const signInResult3 = await client2.signIn(email, password, {
+      keys: true,
+    });
+
+    // Check unwrapKB. It should match our V1 credential unwrapBKey.
     const status = await client.getCredentialStatusV2(email);
     expect(status.clientSalt).toBeDefined();
     expect(status.clientSalt).toBeDefined();
@@ -168,22 +188,23 @@ test.describe('auth-client-tests', () => {
       password,
       clientSalt: status.clientSalt as string,
     });
-    expect(credentialsV2.unwrapBKey).toEqual(signInResult2.unwrapBKey);
+    expect(credentialsV2.unwrapBKey).toEqual(signInResult3.unwrapBKey);
 
     const credentialsV1 = await getCredentials(email, password);
-    expect(credentialsV1.unwrapBKey).not.toEqual(signInResult2.unwrapBKey);
-    expect(signInResult2.keyFetchToken).toBeDefined();
-    expect(signInResult2.unwrapBKey).toBeDefined();
+    expect(credentialsV1.unwrapBKey).not.toEqual(signInResult3.unwrapBKey);
+    expect(signInResult3.keyFetchToken).toBeDefined();
+    expect(signInResult3.unwrapBKey).toBeDefined();
 
     // Check that keys didn't drift
-    const keys2 = await client2.accountKeys(
-      signInResult2.keyFetchToken as string,
-      signInResult2.unwrapBKey as string
+    const keys3 = await client2.accountKeys(
+      signInResult3.keyFetchToken as string,
+      signInResult3.unwrapBKey as string
     );
-    expect(keys2).toBeDefined();
-    expect(keys2.kA).toBeDefined();
-    expect(keys2.kB).toBeDefined();
-    expect(keys2.kA).toEqual(keys1.kA);
-    expect(keys2.kB).toEqual(keys1.kB);
+
+    expect(keys3).toBeDefined();
+    expect(keys3.kA).toBeDefined();
+    expect(keys3.kB).toBeDefined();
+    expect(keys3.kA).toEqual(keys1.kA);
+    expect(keys3.kB).toEqual(keys1.kB);
   });
 });

--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -18,6 +18,10 @@ const usersLastSms = {};
 async function printMatchingKeys(startUp = false) {
   const redisKeyPattern = 'recovery-phone:sms-attempt:*:*';
   try {
+    if (redis.status !== 'ready') {
+      throw new Error('Redis connection is not ready');
+    }
+
     const keys = await redis.keys(redisKeyPattern);
 
     if (keys.length > 0) {
@@ -40,7 +44,7 @@ async function printMatchingKeys(startUp = false) {
       }
     }
   } catch (error) {
-    console.error('Failed to retrieve keys:', error);
+    // Ignore errors
   } finally {
     // 1s delay seems reasonable
     setTimeout(printMatchingKeys, 1000);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -51,6 +51,7 @@ const DB_METHOD_NAMES = [
   'createEmail',
   'createKeyFetchToken',
   'createPassword',
+  'createPasswordChangeToken',
   'createPasswordForgotToken',
   'createRecoveryCodes',
   'createRecoveryKey',
@@ -497,6 +498,11 @@ function mockDB(data, errors) {
         data: crypto.randomBytes(32).toString('hex'),
         id: data.keyFetchTokenId,
         uid: data.uid,
+      });
+    }),
+    createPasswordChangeToken: sinon.spy(() => {
+      return Promise.resolve({
+        data: crypto.randomBytes(32).toString('hex'),
       });
     }),
     createPasswordForgotToken: sinon.spy(() => {

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -736,9 +736,8 @@ FxaClientWrapper.prototype = {
     ) => {
       var email = trim(originalEmail);
       return client
-        .passwordChange(email, oldPassword, newPassword, {
+        .passwordChange(email, oldPassword, newPassword, sessionToken, {
           keys: wantsKeys(relier, sessionTokenContext),
-          sessionToken: sessionToken,
         })
         .then((accountData = {}) => {
           return getUpdatedSessionData(email, relier, accountData, {

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1347,9 +1347,9 @@ function trim(str) {
                 trim(email),
                 password,
                 'new_password',
+                'sessionToken',
                 {
                   keys: true,
-                  sessionToken: 'sessionToken',
                 }
               )
             );
@@ -1402,9 +1402,9 @@ function trim(str) {
                 trimmedEmail,
                 password,
                 'new_password',
+                'sessionToken',
                 {
                   keys: true,
-                  sessionToken: 'sessionToken',
                 }
               )
             );

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -907,6 +907,7 @@ describe('#integration - AccountResolver', () => {
           .mockResolvedValue(mockRespPayload);
 
         const result = await resolver.passwordChangeStart(headers, {
+          sessionToken: 'sessionToken',
           email: 'foo@moz.com',
           oldAuthPW: '3456789abcdef12',
         });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -942,6 +942,7 @@ export class AccountResolver {
     return this.authAPI.passwordChangeStartWithAuthPW(
       input.email,
       input.oldAuthPW,
+      input.sessionToken,
       {},
       headers
     );

--- a/packages/fxa-graphql-api/src/gql/dto/input/password-change-start.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/password-change-start.ts
@@ -10,4 +10,7 @@ export class PasswordChangeStartInput {
 
   @Field()
   oldAuthPW!: string;
+
+  @Field()
+  sessionToken!: string;
 }

--- a/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
+++ b/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
@@ -116,7 +116,7 @@ export class GqlKeyStretchUpgrade {
     v2Credentials: V2Credentials,
     sessionToken: string
   ): Promise<boolean> {
-    let result1 = await this.startUpgrade(email, v1Credentials);
+    let result1 = await this.startUpgrade(email, v1Credentials, sessionToken);
 
     if (result1?.keyFetchToken && result1?.passwordChangeToken) {
       const result2 = await this.getWrappedKeys(result1.keyFetchToken);
@@ -158,13 +158,18 @@ export class GqlKeyStretchUpgrade {
     return undefined;
   }
 
-  private async startUpgrade(email: string, v1Credentials: V1Credentials) {
+  private async startUpgrade(
+    email: string,
+    v1Credentials: V1Credentials,
+    sessionToken: string
+  ) {
     try {
       const response = await this.gqlPasswordChangeStart({
         variables: {
           input: {
             email: email,
             oldAuthPW: v1Credentials.authPW,
+            sessionToken,
           },
         },
       });

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -544,9 +544,9 @@ export class Account implements AccountData {
         this.primaryEmail.email,
         oldPassword,
         newPassword,
+        sessionToken()!,
         {
           keys: true,
-          sessionToken: sessionToken()!,
         }
       )
     );

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -263,6 +263,7 @@ export function mockGqlPasswordChangeStartMutation() {
         input: {
           email: MOCK_EMAIL,
           oldAuthPW: MOCK_AUTH_PW,
+          sessionToken: MOCK_SESSION_TOKEN,
         },
       },
     },


### PR DESCRIPTION
## Because

- Users and playwright tests might be running into the rate limit in stage and production
- We use the customs.check request (much stricter rate limit) in password change
  - This is used in key stretching upgrades, createing recovery key, so could in theory get trigger a lot

## This pull request

- Updates the `/password/change/start` route to optionally use a session token and call `customs.checkAuthenticated`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11060

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

@dschom I ended up making the session token optional in the backend, but updated all the front end bits to use session token. This seems like a reasonable approach since it won't require the FxA Python client to ugrade yet. I will file some tickets with what I found while working on this.
