### PR TITLE
fix(l10n): Fix mismatched or missing l10n

### DIFF
--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -148,6 +148,7 @@ test.describe('severity-1 #smoke', () => {
       });
 
       await page.waitForURL(/settings/);
+      await expect(settings.settingsHeading).toBeVisible();
 
       // Remove totp so account can be deleted
       await settings.disconnectTotp();

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/en.ftl
@@ -8,3 +8,5 @@ tfa-replace-code-success-1 = New codes have been created. Save these one-time us
 tfa-replace-code-success-alert-4 = Backup authentication codes updated
 tfa-replace-code-1-2 = Step 1 of 2
 tfa-replace-code-2-2 = Step 2 of 2
+
+tfa-enter-code-to-confirm-v2 = Please enter one of your new backup authentication codes to confirm that you have saved them. Your old backup authentication codes will be disabled once this step is completed.

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/en.ftl
@@ -1,3 +1,5 @@
 ## PageSetupRecoveryPhone
 
 page-setup-recovery-phone-heading = Add recovery phone
+
+page-setup-recovery-phone-back-button-title = Back to settings

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
@@ -28,7 +28,7 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
     navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });
 
   const localizedPageTitle = ftlMsgResolver.getMsg(
-    'page-setup-recovery-phone-title',
+    'page-setup-recovery-phone-heading',
     'Add recovery phone'
   );
 

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/en.ftl
@@ -37,8 +37,9 @@ tfa-input-enter-totp-v2 =
 tfa-save-these-codes-1 = Save these one-time use backup authentication codes in a safe place for when
   you don’t have your mobile device.
 
-tfa-enter-code-to-confirm-v2 = Please enter one of your new backup authentication codes to
-  confirm that you have saved them. Your old backup authentication codes will be disabled once this step is completed.
+# codes here refers to backup authentication codes
+tfa-enter-code-to-confirm-setup = Confirm you saved your codes by entering one. Without these codes, you might not be able to sign in if you don’t have your authenticator app.
+
 tfa-enter-recovery-code-1 =
  .label = Enter a backup authentication code
 

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -407,11 +407,11 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
       )}
       {totpVerified && recoveryCodesAcknowledged && (
         <form onSubmit={recoveryCodeForm.handleSubmit(onRecoveryCodeSubmit)}>
-          <Localized id="tfa-enter-code-to-confirm-1">
+          <Localized id="tfa-enter-code-to-confirm-setup">
             <p className="mt-4 mb-4">
-              Please enter one of your backup authentication codes now to
-              confirm you've saved it. You’ll need a code to login if you don’t
-              have access to your mobile device.
+              Confirm you saved your codes by entering one. Without these codes,
+              you might not be able to sign in if you don’t have your
+              authenticator app.
             </p>
           </Localized>
           <div className="mt-4 mb-6" data-testid="recovery-code-input">

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/en.ftl
@@ -7,6 +7,8 @@ signin-recovery-code-heading = Sign in
 signin-recovery-code-sub-heading = Enter backup authentication code
 # codes here refers to backup authentication codes
 signin-recovery-code-instruction-v3 = Enter one of the one-time-use codes you saved when you set up two-step authentication.
+# code here refers to backup authentication code
+signin-recovery-code-input-label-v2 = Enter 10-character code
 # Form button to confirm if the backup authentication code entered by the user is valid
 signin-recovery-code-confirm-button = Confirm
 # Link to go to the page to use recovery phone instead


### PR DESCRIPTION
## Because

* Some string localization was incorrectly matched and not displayed in product

## This pull request

* Fix ftl ids
* Update one string for backup authentication codes to match updated design since no l10n was available for old string

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
