### PR TITLE
fix(auth): update bounce config defaults

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -522,9 +522,10 @@ const convictConf = convict({
         doc: 'Tiers of max allowed complaints per amount of milliseconds',
         format: Object,
         default: {
-          // # of bounces allowed : time since last bounce
-          0: 3 * FIVE_MINUTES,
-          1: ONE_DAY,
+          // 0 are allowed in the past day.
+          // 1 is allowed in the past year.
+          0: ONE_DAY,
+          1: 365 * ONE_DAY,
         },
         env: 'BOUNCES_COMPLAINT',
       },


### PR DESCRIPTION
A partial revert of 82b67a4e348090bb3dc3b52d0290d7206f8daf03.

- I looked at the defaults in the now removed [`fxa-email-service`](https://github.com/mozilla/fxa/tree/b033d5f6a96b072bac8bb9b591c811161012df18/packages/fxa-email-service) package to see if there was an equivalent in the `fxa/k8s/fxa/values-prod.yaml` but couldn't find any.
- This patch hasn't been tested.


## Because

- We want to revert the `BOUNCES_COMPLAINT` default

## This pull request

- Does that.

## Issue that this pull request solves

Closes: FXA-10962

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
