### PR TITLE
feat(payments): Do not allow duplicate subscriptions to the same offering and interval

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/en.ftl
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/en.ftl
@@ -2,3 +2,6 @@ next-payment-error-manage-subscription-button = Manage my subscription
 next-iap-upgrade-contact-support = You can still get this product — please contact support so we can help you.
 next-payment-error-retry-button = Try again
 next-basic-error-message = Something went wrong. Please try again later.
+checkout-error-contact-support-button = Contact Support
+checkout-error-not-eligible = You are not eligible to subscribe to this product - please contact support so we can help you.
+checkout-error-contact-support = Please contact support so we can help you.

--- a/apps/payments/next/config/index.ts
+++ b/apps/payments/next/config/index.ts
@@ -133,6 +133,9 @@ export class PaymentsNextConfig extends NestAppRootConfig {
   @IsString()
   subscriptionsUnsupportedLocations!: string;
 
+  @IsUrl({ require_tld: false })
+  supportUrl!: string;
+
   /**
    * Nextjs Public Environment Variables
    */

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -27,7 +27,11 @@ import {
 } from '@fxa/payments/stripe';
 import { ProductConfigurationManager } from '@fxa/shared/cms';
 import { CurrencyManager } from '@fxa/payments/currency';
-import { CartErrorReasonId, CartState } from '@fxa/shared/db/mysql/account';
+import {
+  CartEligibilityStatus,
+  CartErrorReasonId,
+  CartState,
+} from '@fxa/shared/db/mysql/account';
 import { GeoDBManager } from '@fxa/shared/geodb';
 
 import { CartManager } from './cart.manager';
@@ -217,6 +221,20 @@ export class CartService {
       eligibilityStatus: cartEligibilityStatus,
       couponCode: args.promoCode,
     });
+
+    if (cartEligibilityStatus === CartEligibilityStatus.INVALID) {
+      await this.finalizeCartWithError(
+        cart.id,
+        CartErrorReasonId.CartEligibilityStatusInvalid
+      );
+    }
+
+    if (cartEligibilityStatus === CartEligibilityStatus.DOWNGRADE) {
+      await this.finalizeCartWithError(
+        cart.id,
+        CartErrorReasonId.CartEligibilityStatusDowngrade
+      );
+    }
 
     return cart;
   }

--- a/libs/payments/cart/src/lib/cart.utils.ts
+++ b/libs/payments/cart/src/lib/cart.utils.ts
@@ -34,7 +34,7 @@ export const cartEligibilityDetailsMap: Record<
   [EligibilityStatus.DOWNGRADE]: {
     eligibilityStatus: CartEligibilityStatus.DOWNGRADE,
     state: CartState.FAIL,
-    errorReasonId: CartErrorReasonId.BASIC_ERROR,
+    errorReasonId: CartErrorReasonId.CartEligibilityStatusDowngrade,
   },
   [EligibilityStatus.BLOCKED_IAP]: {
     eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
@@ -44,7 +44,7 @@ export const cartEligibilityDetailsMap: Record<
   [EligibilityStatus.INVALID]: {
     eligibilityStatus: CartEligibilityStatus.INVALID,
     state: CartState.FAIL,
-    errorReasonId: CartErrorReasonId.Unknown,
+    errorReasonId: CartErrorReasonId.CartEligibilityStatusInvalid,
   },
 };
 

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -33,20 +33,34 @@ export class EligibilityManager {
    * @returns Array of overlapping priceIds/offeringProductIds and their comparison
    *          to the target price.
    */
-  async getOfferingOverlap(
-    priceIds: string[],
-    targetPriceId: string
-  ): Promise<OfferingOverlapResult[]> {
+  async getOfferingOverlap({
+    priceIds,
+    targetPriceId,
+    providedTargetOffering,
+  }: {
+    priceIds: string[];
+    targetPriceId?: string;
+    providedTargetOffering?: EligibilityContentOfferingResult;
+  }): Promise<OfferingOverlapResult[]> {
     if (!priceIds.length) return [];
+    if (!targetPriceId && !providedTargetOffering) return [];
+
+    const ids = targetPriceId ? [...priceIds, targetPriceId] : [...priceIds];
 
     const detailsResult =
       await this.productConfigurationManager.getPurchaseDetailsForEligibility(
-        Array.from(new Set([...priceIds, targetPriceId]))
+        Array.from(new Set(ids))
       );
 
     const result: OfferingOverlapResult[] = [];
 
-    const targetOffering = detailsResult.offeringForPlanId(targetPriceId);
+    let targetOffering;
+    if (providedTargetOffering) {
+      targetOffering = providedTargetOffering;
+    }
+    if (targetPriceId) {
+      targetOffering = detailsResult.offeringForPlanId(targetPriceId);
+    }
     if (!targetOffering) return [];
 
     for (const priceId of priceIds) {

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -140,10 +140,10 @@ describe('EligibilityService', () => {
       expect(subscriptionManager.listForCustomer).toHaveBeenCalledWith(
         mockCustomer.id
       );
-      expect(eligibilityManager.getOfferingOverlap).toHaveBeenCalledWith(
-        [],
-        mockOffering.apiIdentifier
-      );
+      expect(eligibilityManager.getOfferingOverlap).toHaveBeenCalledWith({
+        priceIds: [],
+        providedTargetOffering: mockOffering,
+      });
       expect(eligibilityManager.compareOverlap).toHaveBeenCalledWith(
         mockOverlapResult,
         mockOffering,

--- a/libs/payments/eligibility/src/lib/eligibility.service.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.ts
@@ -45,10 +45,10 @@ export class EligibilityService {
 
     const priceIds = subscribedPrices.map((price) => price.id);
 
-    const overlaps = await this.eligibilityManager.getOfferingOverlap(
+    const overlaps = await this.eligibilityManager.getOfferingOverlap({
       priceIds,
-      offeringConfigId
-    );
+      providedTargetOffering: targetOffering,
+    });
 
     const eligibility = await this.eligibilityManager.compareOverlap(
       overlaps,

--- a/libs/payments/ui/src/index.ts
+++ b/libs/payments/ui/src/index.ts
@@ -20,6 +20,7 @@ export * from './lib/client/components/LoadingSpinner';
 export * from './lib/client/components/MetricsWrapper';
 export * from './lib/client/components/StripeWrapper';
 export * from './lib/client/providers/Providers';
+export * from './lib/constants';
 export * from './lib/utils/helpers';
 export * from './lib/utils/types';
 export * from './lib/utils/get-cart';

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -34,6 +34,8 @@ export enum CartErrorReasonId {
   BASIC_ERROR = 'basic-error-message',
   IAP_UPGRADE_CONTACT_SUPPORT = 'iap_upgrade_contact_support',
   SUCCESS_CART_MISSING_REQUIRED = 'success_cart_missing_required',
+  CartEligibilityStatusDowngrade = 'cart_eligibility_status_downgrade',
+  CartEligibilityStatusInvalid = 'cart_eligibility_status_invalid',
   Unknown = 'unknown',
 }
 

--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -441,15 +441,15 @@ export class CapabilityService {
         subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
       };
     const stripePlanIds = stripeSubscribedPlans.map((p) => p.plan_id);
-    const stripeOverlaps = await this.eligibilityManager.getOfferingOverlap(
-      stripePlanIds,
-      targetPlan.plan_id
-    );
+    const stripeOverlaps = await this.eligibilityManager.getOfferingOverlap({
+      priceIds: stripePlanIds,
+      targetPriceId: targetPlan.plan_id,
+    });
     const iapPlanIds = iapSubscribedPlans.map((p) => p.plan_id);
-    const iapOverlaps = await this.eligibilityManager.getOfferingOverlap(
-      iapPlanIds,
-      targetPlan.plan_id
-    );
+    const iapOverlaps = await this.eligibilityManager.getOfferingOverlap({
+      priceIds: iapPlanIds,
+      targetPriceId: targetPlan.plan_id,
+    });
     const overlaps = [...stripeOverlaps, ...iapOverlaps];
 
     // No overlap, we can create a new subscription

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -645,6 +645,10 @@ describe('CapabilityService', () => {
             SubscriptionEligibilityResult.BLOCKED_IAP,
           eligibleSourcePlan: mockPlanTier1ShortInterval,
         });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1ShortInterval.plan_id],
+          targetPriceId: mockPlanTier1LongInterval.plan_id,
+        });
       });
 
       it('returns create for targetPlan with offering user is not subscribed to', async () => {
@@ -657,6 +661,10 @@ describe('CapabilityService', () => {
           );
         assert.deepEqual(actual, {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.CREATE,
+        });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [],
+          targetPriceId: mockPlanTier1ShortInterval.plan_id,
         });
       });
 
@@ -681,6 +689,10 @@ describe('CapabilityService', () => {
         assert.deepEqual(actual, {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
           eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1ShortInterval.plan_id],
+          targetPriceId: mockPlanTier2LongInterval.plan_id,
         });
       });
 
@@ -707,6 +719,10 @@ describe('CapabilityService', () => {
             SubscriptionEligibilityResult.DOWNGRADE,
           eligibleSourcePlan: undefined,
         });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier2LongInterval.plan_id],
+          targetPriceId: mockPlanTier1ShortInterval.plan_id,
+        });
       });
 
       it('returns upgrade for targetPlan with offering user is subscribed to a higher interval of', async () => {
@@ -730,6 +746,10 @@ describe('CapabilityService', () => {
         assert.deepEqual(actual, {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
           eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1ShortInterval.plan_id],
+          targetPriceId: mockPlanTier1LongInterval.plan_id,
         });
       });
 
@@ -755,6 +775,10 @@ describe('CapabilityService', () => {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
           eligibleSourcePlan: mockPlanTier1ShortInterval,
         });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1ShortInterval.plan_id],
+          targetPriceId: mockPlanTier2ShortInterval.plan_id,
+        });
       });
 
       it('returns upgrade for targetPlan with same offering and longer interval', async () => {
@@ -778,6 +802,10 @@ describe('CapabilityService', () => {
         assert.deepEqual(actual, {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
           eligibleSourcePlan: mockPlanTier1ShortInterval,
+        });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1ShortInterval.plan_id],
+          targetPriceId: mockPlanTier1LongInterval.plan_id,
         });
       });
 
@@ -806,6 +834,10 @@ describe('CapabilityService', () => {
             SubscriptionEligibilityResult.DOWNGRADE,
           eligibleSourcePlan: mockPlanTier1LongInterval,
         });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1LongInterval.plan_id],
+          targetPriceId: mockPlanTier2ShortInterval.plan_id,
+        });
       });
 
       it('returns invalid for targetPlan with same offering user is subscribed to', async () => {
@@ -829,6 +861,10 @@ describe('CapabilityService', () => {
         assert.deepEqual(actual, {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
         });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier1ShortInterval.plan_id],
+          targetPriceId: mockPlanTier1ShortInterval.plan_id,
+        });
       });
 
       it('returns invalid for targetPlan with same offering user is subscribed to but different currency', async () => {
@@ -851,6 +887,10 @@ describe('CapabilityService', () => {
           );
         assert.deepEqual(actual, {
           subscriptionEligibilityResult: SubscriptionEligibilityResult.INVALID,
+        });
+        sinon.assert.calledWith(mockEligibilityManager.getOfferingOverlap, {
+          priceIds: [mockPlanTier2LongInterval.plan_id],
+          targetPriceId: mockPlanTier2LongIntervalDiffCurr.plan_id,
         });
       });
     });


### PR DESCRIPTION
## This pull request

- [x] fixes checkEligibility to return correct status
- [x] prevents customer from creating duplicate subscriptions to the same offering and interval

## Issue that this pull request solves

Closes: FXA-10994

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots
### Invalid eligibility status
<img width="1028" alt="Screenshot 2025-02-06 at 10 31 53 AM" src="https://github.com/user-attachments/assets/0a79e837-6687-4abe-a043-5bf6f7af54b7" />

### Downgrade eligibility status
<img width="1114" alt="Screenshot 2025-02-07 at 3 41 00 PM" src="https://github.com/user-attachments/assets/fbe7235c-ebd5-41cc-a661-690448a6ff61" />


#### Example of Error page without Button
<img width="1025" alt="Screenshot 2025-02-06 at 10 32 07 AM" src="https://github.com/user-attachments/assets/9c0d37a0-271e-4ac2-9342-4296562c682f" />
