### PR TITLE
fix(inactives): Don't hard navigate when redirectTo is 'settings'

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -249,7 +249,9 @@ const getNonOAuthNavigationTarget = async (
       ),
     };
   }
-  if (redirectTo) {
+  // We don't want a hard navigate to `/settings` as it
+  // clears out the initially created integration.
+  if (redirectTo && redirectTo !== '/settings') {
     return { to: redirectTo, shouldHardNavigate: true };
   }
   return { to: '/settings' };


### PR DESCRIPTION
Because:
* This is causing the integration to get recreated in Settings, and we're not currently passing params into Settings, meaning the integration query param data is undefined and the active banner is not shown

This commit:
* Checks that the 'redirectTo' condition in our signin utils does not equal '/settings', to avoid the hard navigate

fixes FXA-11092