### PR TITLE
fix(settings): Clear error messages on submit SigninTokenCode/ConfirmSignupCode

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -119,8 +119,14 @@ const SigninTokenCode = ({
     }
   };
 
+  const clearErrorMessages = () => {
+    setLocalizedErrorBannerMessage('');
+    setCodeErrorMessage('');
+  };
+
   const onSubmit = useCallback(
     async (code: string) => {
+      clearErrorMessages();
       if (!SIX_DIGIT_NUMBER_REGEX.test(code)) {
         setCodeErrorMessage(localizedInvalidCode);
         return;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -114,7 +114,13 @@ const ConfirmSignupCode = ({
     }
   }
 
+  function clearErrorMessages() {
+    setLocalizedErrorBannerHeading('');
+    setCodeErrorMessage('');
+  }
+
   async function verifySession(code: string) {
+    clearErrorMessages();
     logViewEvent(`flow.${viewName}`, 'submit', REACT_ENTRYPOINT);
     GleanMetrics.signupConfirmation.submit();
     try {


### PR DESCRIPTION
## Because

* Error banners were not cleared on submit even if error no longer applied (e.g., throttling) and could result in both an (outdated) error banner and an error tooltip being displayed simultaneously

## This pull request

* clear error messages on submit for both SigninTokenCode and ConfirmSignupCode pages

## Issue that this pull request solves

Closes: #FXA-11059

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To test, turn on customs (set `customsUrl` in `fxa-auth-server/config/dev.json` to `http://localhost:7000`) and submit wrong codes until throttled during sign up. Clear customs with `redis-commander` then resubmit an incorrect code. Banner should be cleared and only error tooltip shown.
