### PR TITLE
bug(admin-server): Broken logs

### DIFF
--- a/libs/shared/mozlog/src/index.ts
+++ b/libs/shared/mozlog/src/index.ts
@@ -2,4 +2,5 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export { MozLoggerService } from './lib/mozlog.service';
+export * from './lib/mozlog.service';
+export * from './lib/mozlog.module';

--- a/libs/shared/mozlog/src/lib/mozlog.module.ts
+++ b/libs/shared/mozlog/src/lib/mozlog.module.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Module, Global } from '@nestjs/common';
+
+import { MozLoggerService } from './mozlog.service';
+
+@Global()
+@Module({
+  providers: [MozLoggerService],
+  exports: [MozLoggerService],
+})
+export class MozLoggerModule {}

--- a/libs/shared/mozlog/src/lib/mozlog.service.spec.ts
+++ b/libs/shared/mozlog/src/lib/mozlog.service.spec.ts
@@ -60,7 +60,7 @@ describe('MozLoggerService', () => {
     expect(service).toBeDefined();
     expect(service).toBeInstanceOf(MozLoggerService);
     expect(mockMozLogDefault).toHaveBeenCalledWith(mockConfig);
-    expect(mockMozLogLoggerFactory).toHaveBeenCalledWith('default');
+    expect(mockMozLogLoggerFactory).toHaveBeenCalledWith('MozLoggerService');
   });
 
   it('sets context', () => {
@@ -69,39 +69,61 @@ describe('MozLoggerService', () => {
   });
 
   it('logs info', () => {
-    service.info('info', {});
-    expect(mockMozLog.info).toBeCalledWith('', { message: 'info', '0': {} });
+    service.info('info');
+    expect(mockMozLog.info).toBeCalledWith('info', {});
+  });
+
+  it('logs info with data', () => {
+    service.info('info', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.info).toBeCalledWith('info', { foo: 'bar', baz: 1 });
+  });
+
+  it('logs info for atypical message', () => {
+    service.info({ weird: 'message' }, { foo: 'bar', baz: 1 });
+    expect(mockMozLog.info).toBeCalledWith('', {
+      message: { weird: 'message' },
+      '0': { foo: 'bar', baz: 1 },
+    });
+  });
+
+  it('logs info for atypical number of args', () => {
+    service.info({ weird: 'message' }, { foo: 'bar' }, { baz: 1 });
+    expect(mockMozLog.info).toBeCalledWith('', {
+      message: { weird: 'message' },
+      '0': { foo: 'bar' },
+      '1': { baz: 1 },
+    });
   });
 
   it('logs debug', () => {
-    service.debug('debug', {});
-    expect(mockMozLog.debug).toBeCalledWith('', { message: 'debug', '0': {} });
+    service.debug('debug', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.debug).toBeCalledWith('debug', { foo: 'bar', baz: 1 });
   });
   it('logs error', () => {
-    service.error('error', {});
-    expect(mockMozLog.error).toBeCalledWith('', { message: 'error', '0': {} });
+    service.error('error', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.error).toBeCalledWith('error', { foo: 'bar', baz: 1 });
   });
 
   it('logs warn', () => {
-    service.warn('warn', {});
-    expect(mockMozLog.warn).toBeCalledWith('', { message: 'warn', '0': {} });
+    service.warn('warn', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.warn).toBeCalledWith('warn', { foo: 'bar', baz: 1 });
   });
 
   it('logs verbose', () => {
-    service.verbose('verbose', {});
-    expect(mockMozLog.verbose).toBeCalledWith('', {
-      message: 'verbose',
-      '0': {},
+    service.verbose('verbose', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.verbose).toBeCalledWith('verbose', {
+      foo: 'bar',
+      baz: 1,
     });
   });
 
   it('logs trace', () => {
-    service.trace('trace', {});
-    expect(mockMozLog.trace).toBeCalledWith('', { message: 'trace', '0': {} });
+    service.trace('trace', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.trace).toBeCalledWith('trace', { foo: 'bar', baz: 1 });
   });
 
   it('logs warning', () => {
-    service.warn('warning', {});
-    expect(mockMozLog.warn).toBeCalledWith('', { message: 'warning', '0': {} });
+    service.warn('warning', { foo: 'bar', baz: 1 });
+    expect(mockMozLog.warn).toBeCalledWith('warning', { foo: 'bar', baz: 1 });
   });
 });

--- a/libs/shared/mozlog/src/lib/mozlog.service.ts
+++ b/libs/shared/mozlog/src/lib/mozlog.service.ts
@@ -12,53 +12,107 @@ let logFactory: LoggerFactory;
 @Injectable({ scope: Scope.TRANSIENT })
 export class MozLoggerService implements LoggerService {
   private mozlog: MozLogger;
+  public name: string;
 
   constructor(
     configService: ConfigService,
-    @Inject(INQUIRER) private parentClass: object
+    @Inject(INQUIRER) parentClass: object
   ) {
     if (!logFactory) {
       logFactory = mozlog(configService.get('log'));
     }
-    this.mozlog = logFactory('default');
-    if (this.parentClass?.constructor?.name) {
-      this.setContext(this.parentClass.constructor.name);
+
+    if (parentClass?.constructor?.name) {
+      this.name = parentClass?.constructor?.name;
+    } else {
+      this.name = 'default';
     }
+
+    this.mozlog = logFactory(this.name);
   }
 
   public setContext(name: string): void {
+    this.name = name;
     this.mozlog = logFactory(name);
   }
 
   log(message: any, ...optionalParams: any[]): void {
-    this.mozlog.info('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.info(type, data);
   }
 
   info(message: any, ...optionalParams: any[]): void {
-    this.mozlog.info('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.info(type, data);
   }
 
   error(message: any, ...optionalParams: any[]): void {
-    this.mozlog.error('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.error(type, data);
   }
 
   warn(message: any, ...optionalParams: any[]): void {
-    this.mozlog.warn('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.warn(type, data);
   }
 
   debug(message: any, ...optionalParams: any[]): void {
-    this.mozlog.debug('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.debug(type, data);
   }
 
   verbose(message: any, ...optionalParams: any[]): void {
-    this.mozlog.verbose('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.verbose(type, data);
   }
 
   trace(message: any, ...optionalParams: any[]): void {
-    this.mozlog.trace('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.trace(type, data);
   }
 
   warning(message: any, ...optionalParams: any[]): void {
-    this.mozlog.warn('', { message, ...optionalParams });
+    const { type, data } = supportLegacyFormat(message, optionalParams);
+    this.mozlog.warn(type, data);
   }
+}
+
+/**
+ * Handles legacy logging format which was intended for mozlog. Moz log calls were typically
+ * in the form:
+ *
+ *  > log(type, data);
+ *  > log(type)
+ *
+ * Where type was a discrete log type used for look up, and data was an optional dictionary
+ * of values, a string containing a message, or an Error.
+ *
+ * As long as the logger is invoked in this way, this function ensures the resulting output
+ * is compliant with what mozlog would have produced.
+ *
+ * @param message The message passed to the logger
+ * @param optionalParams The remaining parameters passed to the logger
+ * @returns { type:string, data:any } A mozlog compliant message
+ */
+export function supportLegacyFormat(message: any, optionalParams: any[]) {
+  // This is the way most mozlog calls work, e.g log('some-type', {msg:'okay', foo:'bar'});
+  // We don't want to disrupt the output of these types of calls, since they are can be used
+  // for analytics...
+  if (typeof message === 'string' && optionalParams.length <= 1) {
+    return {
+      type: message,
+      data: optionalParams[0] || {},
+    };
+  }
+
+  // TODO: FXA-9951 - Will prevent this kind of call from occurring by restricting logging types.
+  // Note, this can result in messy or invalid states in bq on jsonPayload.fields. It's
+  // best not rely on this.
+  return {
+    type: '',
+    data: {
+      message,
+      ...optionalParams,
+    },
+  };
 }

--- a/libs/shared/notifier/src/lib/notifier.provider.ts
+++ b/libs/shared/notifier/src/lib/notifier.provider.ts
@@ -2,20 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LoggerService, Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { Provider } from '@nestjs/common';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { SNS } from 'aws-sdk';
 import { StatsD } from 'hot-shots';
 import { NotifierSnsService } from './notifier.sns.provider';
 import { NotifierService } from './notifier.service';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 export const LegacyNotifierServiceProvider: Provider<NotifierService> = {
   provide: NotifierService,
   useFactory: (
     configService: ConfigService,
-    log: LoggerService,
+    log: MozLoggerService,
     sns: SNS,
     statsd: StatsD | undefined
   ) => {
@@ -25,5 +25,5 @@ export const LegacyNotifierServiceProvider: Provider<NotifierService> = {
     }
     return new NotifierService(config, log, sns, statsd);
   },
-  inject: [ConfigService, LOGGER_PROVIDER, NotifierSnsService, StatsDService],
+  inject: [ConfigService, MozLoggerService, NotifierSnsService, StatsDService],
 };

--- a/libs/shared/sentry/project.json
+++ b/libs/shared/sentry/project.json
@@ -15,6 +15,14 @@
         "outputFileName": "main.js",
         "tsConfig": "libs/shared/sentry/tsconfig.lib.json",
         "declaration": true,
+        "external": [
+          "@apollo/gateway",
+          "@apollo/subgraph",
+          "@as-integrations/fastify",
+          "@nestjs/websockets/socket-module",
+          "@nestjs/microservices/microservices-module",
+          "@nestjs/microservices"
+        ],
         "assets": [
           {
             "glob": "libs/shared/sentry/README.md",

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -3,15 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { HealthModule } from 'fxa-shared/nestjs/health/health.module';
-import { LoggerModule } from 'fxa-shared/nestjs/logger/logger.module';
+import { MozLoggerModule, MozLoggerService } from '@fxa/shared/mozlog';
 import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { getVersionInfo } from 'fxa-shared/nestjs/version';
 import { join } from 'path';
 import { APP_FILTER } from '@nestjs/core';
 import { SentryGlobalGraphQLFilter, SentryModule } from '@sentry/nestjs/setup';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
-import { MozLoggerService } from '@fxa/shared/mozlog';
 import {
   LegacyNotifierServiceProvider,
   LegacyNotifierSnsFactory,
@@ -31,6 +29,7 @@ import { EventLoggingModule } from './event-logging/event-logging.module';
 import { GqlModule } from './gql/gql.module';
 import { NewslettersModule } from './newsletters/newsletters.module';
 import { SubscriptionModule } from './subscriptions/subscriptions.module';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
 
 const version = getVersionInfo(__dirname);
 
@@ -71,7 +70,7 @@ const version = getVersionInfo(__dirname);
         extraHealthData: () => db.dbHealthCheck(),
       }),
     }),
-    LoggerModule,
+    MozLoggerModule,
   ],
   controllers: [],
   providers: [
@@ -79,10 +78,6 @@ const version = getVersionInfo(__dirname);
     {
       provide: APP_GUARD,
       useClass: UserGroupGuard,
-    },
-    {
-      provide: LOGGER_PROVIDER,
-      useClass: MozLoggerService,
     },
     LegacyNotifierServiceProvider,
     LegacyNotifierSnsFactory,

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.spec.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.spec.ts
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 import { ExecutionContext, Provider } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+
 import {
   AdminPanelFeature,
   AdminPanelGroup,
   USER_GROUP_HEADER,
 } from 'fxa-shared/guards';
 import { UserGroupGuard } from './user-group-header.guard';
-
-import { createMock } from '@golevelup/ts-jest';
 
 describe('UserGroupGuard for graphql', () => {
   let module: TestingModule;
@@ -50,7 +50,7 @@ describe('UserGroupGuard for graphql', () => {
   beforeEach(async () => {
     logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
     const MockMozLogger: Provider = {
-      provide: LOGGER_PROVIDER,
+      provide: MozLoggerService,
       useValue: logger,
     };
 

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import {
   CanActivate,
@@ -25,10 +24,7 @@ const guard = new AdminPanelGuard(config.get('guard.env') as AdminPanelEnv);
 
 @Injectable()
 export class UserGroupGuard implements CanActivate {
-  constructor(
-    private reflector?: Reflector,
-    @Inject(LOGGER_PROVIDER) private log?: MozLoggerService
-  ) {}
+  constructor(private reflector?: Reflector, private log?: MozLoggerService) {}
 
   canActivate(context: ExecutionContext): boolean {
     // Reflect on the end point to determine if it has been tagged with admin panel feature.

--- a/packages/fxa-admin-server/src/database/database.module.ts
+++ b/packages/fxa-admin-server/src/database/database.module.ts
@@ -2,21 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { Module } from '@nestjs/common';
 import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { DatabaseService } from './database.service';
 
 @Module({
-  providers: [
-    DatabaseService,
-    {
-      provide: LOGGER_PROVIDER,
-      useClass: MozLoggerService,
-    },
-    MetricsFactory,
-  ],
+  providers: [DatabaseService, MozLoggerService, MetricsFactory],
   exports: [DatabaseService],
 })
 export class DatabaseModule {}

--- a/packages/fxa-admin-server/src/database/database.service.spec.ts
+++ b/packages/fxa-admin-server/src/database/database.service.spec.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -11,6 +10,7 @@ import { testDatabaseSetup } from 'fxa-shared/test/db/helpers';
 import { Knex } from 'knex';
 import config, { AppConfig } from '../config';
 import { DatabaseService } from './database.service';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 describe('#integration - DatabaseService', () => {
   let service: DatabaseService;
@@ -54,8 +54,8 @@ describe('#integration - DatabaseService', () => {
       warn: jest.fn(),
       trace: jest.fn(),
     };
-    const MockLogService: Provider = {
-      provide: LOGGER_PROVIDER,
+    const MockMozLoggerService: Provider = {
+      provide: MozLoggerService,
       useValue: logger,
     };
     const MockMetricsFactory: Provider = {
@@ -66,7 +66,7 @@ describe('#integration - DatabaseService', () => {
       providers: [
         DatabaseService,
         MockConfig,
-        MockLogService,
+        MockMozLoggerService,
         MockMetricsFactory,
       ],
     }).compile();

--- a/packages/fxa-admin-server/src/database/database.service.ts
+++ b/packages/fxa-admin-server/src/database/database.service.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Inject, Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -27,7 +26,7 @@ import {
 } from 'fxa-shared/db/models/auth';
 import { MysqlOAuthShared } from 'fxa-shared/db/mysql';
 import { RedisShared } from 'fxa-shared/db/redis';
-import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 import { StatsD } from 'hot-shots';
 import { Knex, knex } from 'knex';
 import { AppConfig } from '../config';
@@ -59,7 +58,7 @@ export class DatabaseService implements OnModuleDestroy {
 
   constructor(
     configService: ConfigService<AppConfig>,
-    @Inject(LOGGER_PROVIDER) logger: MozLoggerService,
+    logger: MozLoggerService,
     @Inject('METRICS') metrics: StatsD
   ) {
     const dbConfig = configService.get('database') as AppConfig['database'];

--- a/packages/fxa-admin-server/src/event-logging/event-logging.module.ts
+++ b/packages/fxa-admin-server/src/event-logging/event-logging.module.ts
@@ -2,19 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { Module } from '@nestjs/common';
 import { EventLoggingService } from './event-logging.service';
 
 @Module({
-  providers: [
-    EventLoggingService,
-    {
-      provide: LOGGER_PROVIDER,
-      useClass: MozLoggerService,
-    },
-  ],
+  providers: [EventLoggingService, MozLoggerService],
   exports: [EventLoggingService],
 })
 export class EventLoggingModule {}

--- a/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
+++ b/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
-import { Inject, Injectable } from '@nestjs/common';
-import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 /** Known event names */
 export enum EventNames {
@@ -27,9 +26,7 @@ export class EventLoggingService {
    * Creates new event logger
    * @param log
    */
-  constructor(
-    @Inject(LOGGER_PROVIDER) private readonly log: MozLoggerService
-  ) {}
+  constructor(private readonly log: MozLoggerService) {}
 
   /**
    * Logs an event occurrence

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 import { NotifierService } from '@fxa/shared/notifier';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -140,7 +140,7 @@ describe('#integration - AccountResolver', () => {
 
     logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
     const MockMozLogger: Provider = {
-      provide: LOGGER_PROVIDER,
+      provide: MozLoggerService,
       useValue: logger,
     };
     const MockConfig: Provider = {

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { NotifierService } from '@fxa/shared/notifier';
 import { Firestore } from '@google-cloud/firestore';
 import { Inject, UseGuards } from '@nestjs/common';
@@ -26,7 +25,7 @@ import { AttachedSession } from 'fxa-shared/connected-services/models/AttachedSe
 import { Account, getAccountCustomerByUid } from 'fxa-shared/db/models/auth';
 import { SecurityEventNames } from 'fxa-shared/db/models/auth/security-event';
 import { AdminPanelFeature } from 'fxa-shared/guards';
-import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 import { ReasonForDeletion } from '../../../../../libs/shared/cloud-tasks/src';
 import { CurrentUser } from '../../auth/auth-header.decorator';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
@@ -110,7 +109,7 @@ export class AccountResolver {
   }
 
   constructor(
-    @Inject(LOGGER_PROVIDER) private log: MozLoggerService,
+    private log: MozLoggerService,
     private db: DatabaseService,
     private subscriptionsService: SubscriptionsService,
     private configService: ConfigService<AppConfig>,

--- a/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.spec.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -17,6 +16,7 @@ import { Knex } from 'knex';
 import { EventLoggingService } from '../../event-logging/event-logging.service';
 
 import { EmailBounceResolver } from './email-bounce.resolver';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 const USER_1 = randomAccount();
 const EMAIL_1 = randomEmail(USER_1);
@@ -46,8 +46,8 @@ describe('#integration - EmailBounceResolver', () => {
 
   beforeEach(async () => {
     logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
-    const MockMozLogger: Provider = {
-      provide: LOGGER_PROVIDER,
+    const MockMozLoggerService: Provider = {
+      provide: MozLoggerService,
       useValue: logger,
     };
     const MockConfig: Provider = {
@@ -64,7 +64,7 @@ describe('#integration - EmailBounceResolver', () => {
       providers: [
         EmailBounceResolver,
         EventLoggingService,
-        MockMozLogger,
+        MockMozLoggerService,
         MockConfig,
         MockMetricsFactory,
         { provide: DatabaseService, useValue: db },

--- a/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.ts
@@ -1,10 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
-import { Inject, UseGuards } from '@nestjs/common';
+import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
-import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 import { AdminPanelFeature } from 'fxa-shared/guards';
 import { CurrentUser } from '../../auth/auth-header.decorator';
@@ -21,7 +20,7 @@ import { EmailBounce as EmailBounceType } from '../../gql/model/email-bounces.mo
 @Resolver((of: any) => EmailBounceType)
 export class EmailBounceResolver {
   constructor(
-    @Inject(LOGGER_PROVIDER) private log: MozLoggerService,
+    private log: MozLoggerService,
     private db: DatabaseService,
     private eventLogging: EventLoggingService
   ) {}

--- a/packages/fxa-admin-server/src/gql/gql.module.ts
+++ b/packages/fxa-admin-server/src/gql/gql.module.ts
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import {
   LegacyNotifierServiceProvider,
   LegacyNotifierSnsFactory,
 } from '@fxa/shared/notifier';
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { BackendModule } from '../backend/backend.module';
 import { DatabaseModule } from '../database/database.module';
 import { EventLoggingModule } from '../event-logging/event-logging.module';
@@ -20,6 +19,7 @@ import { EmailBounceResolver } from './email-bounce/email-bounce.resolver';
 import { RelyingPartyResolver } from './relying-party/relying-party.resolver';
 import { APP_FILTER } from '@nestjs/core';
 import { SentryGlobalGraphQLFilter } from '@sentry/nestjs/setup';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
 
 @Module({
   imports: [
@@ -35,7 +35,11 @@ import { SentryGlobalGraphQLFilter } from '@sentry/nestjs/setup';
     LegacyStatsDProvider,
     LegacyNotifierServiceProvider,
     LegacyNotifierSnsFactory,
+    MozLoggerService,
     {
+      // Note, the 'NotifierService, requires that 'LOGGER_PROVIDER' be injected.
+      //       At the time of writing, it takes any valid LoggerService, and the
+      //       MozLoggerService extends LoggerService, so this will suffice...
       provide: LOGGER_PROVIDER,
       useClass: MozLoggerService,
     },

--- a/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.spec.ts
@@ -1,7 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -38,11 +37,6 @@ describe('#integration - RelyingPartyResolver', () => {
     db.relyingParty = RelyingParty.bindKnex(knex);
     await db.relyingParty.query().insert(MOCK_RP as any);
 
-    let logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
-    const MockMozLogger: Provider = {
-      provide: LOGGER_PROVIDER,
-      useValue: logger,
-    };
     const MockConfig: Provider = {
       provide: ConfigService,
       useValue: {
@@ -52,7 +46,6 @@ describe('#integration - RelyingPartyResolver', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         RelyingPartyResolver,
-        MockMozLogger,
         MockConfig,
         { provide: DatabaseService, useValue: db },
       ],

--- a/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
-import { Inject, UseGuards } from '@nestjs/common';
+import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { uuidTransformer } from '../../database/transformers';
 
 import { AdminPanelFeature } from 'fxa-shared/guards';
@@ -30,10 +28,7 @@ const RELYING_PARTY_COLUMNS = [
 @UseGuards(GqlAuthHeaderGuard)
 @Resolver((of: any) => [RelyingParty])
 export class RelyingPartyResolver {
-  constructor(
-    @Inject(LOGGER_PROVIDER) private log: MozLoggerService,
-    private db: DatabaseService
-  ) {}
+  constructor(private db: DatabaseService) {}
 
   @Features(AdminPanelFeature.RelyingParties)
   @Query((returns) => [RelyingParty])

--- a/packages/fxa-admin-server/src/mocks.ts
+++ b/packages/fxa-admin-server/src/mocks.ts
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Path } from 'convict';
 import { CloudTasksService } from './backend/cloud-tasks.service';
 import { FirestoreService } from './backend/firestore.service';
 import config, { AppConfig } from './config';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 export const mockConfigOverrides: any = {};
 export const MockConfig: Provider = {
@@ -54,7 +54,7 @@ export const logger = {
   trace: jest.fn(),
 };
 export const MockLogService: Provider = {
-  provide: LOGGER_PROVIDER,
+  provide: MozLoggerService,
   useValue: logger,
 };
 

--- a/packages/fxa-admin-server/src/scripts/audit-tokens.spec.ts
+++ b/packages/fxa-admin-server/src/scripts/audit-tokens.spec.ts
@@ -39,6 +39,8 @@ describe('#integration - scripts/audit-tokens', () => {
     fxaProfileDb = bindKnex(config.database.profile, TargetDB.profile);
     fxaOauthDb = bindKnex(config.database.fxa_oauth, TargetDB.oauth);
 
+    await clearDb();
+
     await scaffoldDb(uid, email, createdAt, lastAccessTime);
 
     // Add a dummy profile

--- a/packages/fxa-admin-server/src/subscriptions/appstore.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/appstore.service.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { Firestore } from '@google-cloud/firestore';
 import { Inject, Injectable } from '@nestjs/common';
@@ -17,10 +16,7 @@ import { AppConfig } from '../config';
  */
 @Injectable()
 export class AppStoreHelperService extends AppStoreHelper {
-  constructor(
-    configService: ConfigService,
-    @Inject(LOGGER_PROVIDER) logger: MozLoggerService
-  ) {
+  constructor(configService: ConfigService, logger: MozLoggerService) {
     const config = { subscriptions: configService.get('subscriptions') };
     super(config, logger);
   }
@@ -34,7 +30,7 @@ export class AppStorePurchaseManagerService extends PurchaseManager {
   constructor(
     appStoreHelper: AppStoreHelperService,
     configService: ConfigService<AppConfig>,
-    @Inject(LOGGER_PROVIDER) logger: MozLoggerService,
+    logger: MozLoggerService,
     @Inject(FirestoreService) firestore: Firestore
   ) {
     const config = {
@@ -51,12 +47,6 @@ export class AppStorePurchaseManagerService extends PurchaseManager {
  */
 @Injectable()
 export class AppStoreService {
-  /**
-   * Create new instance
-   * @param configService - application's config
-   * @param logger - application's logger
-   * @param firestore - firestore reference backing data queried from app store api
-   */
   constructor(
     protected readonly purchaseManager: AppStorePurchaseManagerService
   ) {}

--- a/packages/fxa-admin-server/src/subscriptions/playstore.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/playstore.service.ts
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Firestore } from '@google-cloud/firestore';
-import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PurchaseManager } from 'fxa-shared/payments/iap/google-play/purchase-manager';
 import { UserManager } from 'fxa-shared/payments/iap/google-play/user-manager';
 import { Auth, google } from 'googleapis';
 import { FirestoreService } from '../backend/firestore.service';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 /**
  * Extends PurchaseManager to be service like
@@ -19,7 +19,7 @@ export class PlayStorePurchaseManagerService extends PurchaseManager {
   constructor(
     configService: ConfigService,
     @Inject(FirestoreService) firestore: Firestore,
-    @Inject(LOGGER_PROVIDER) logger: LoggerService
+    logger: MozLoggerService
   ) {
     const prefix = `${configService.get('authFirestore.prefix')}iap-`;
     const purchasesDbRef = firestore.collection(`${prefix}play-purchases`);
@@ -52,7 +52,7 @@ export class PlayStorePurchaseManagerService extends PurchaseManager {
 export class PlayStoreUserManagerService extends UserManager {
   constructor(
     configService: ConfigService,
-    @Inject(LOGGER_PROVIDER) logger: LoggerService,
+    logger: MozLoggerService,
     purchaseManager: PlayStorePurchaseManagerService,
     @Inject(FirestoreService) firestore: Firestore
   ) {

--- a/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/stripe.service.ts
@@ -3,15 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { ProductConfigurationManager } from '@fxa/shared/cms';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Firestore } from '@google-cloud/firestore';
-import {
-  Inject,
-  Injectable,
-  LoggerService,
-  OnModuleDestroy,
-  Provider,
-} from '@nestjs/common';
+import { Inject, Injectable, OnModuleDestroy, Provider } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PaymentConfigManager } from 'fxa-shared/payments/configuration/manager';
 import {
@@ -34,6 +27,7 @@ import Stripe from 'stripe';
 import { FirestoreService } from '../backend/firestore.service';
 import { AppConfig } from '../config';
 import { StripeMapperService } from '@fxa/payments/legacy';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 export const StripeFactory: Provider<Stripe> = {
   provide: 'STRIPE',
@@ -73,7 +67,7 @@ export class StripePaymentConfigManagerService
 {
   constructor(
     configService: ConfigService<AppConfig>,
-    @Inject(LOGGER_PROVIDER) logger: LoggerService,
+    logger: MozLoggerService,
     @Inject(FirestoreService) firestore: Firestore
   ) {
     const config = {
@@ -127,7 +121,7 @@ export class StripeService extends StripeHelper {
 
   constructor(
     configService: ConfigService<AppConfig>,
-    @Inject(LOGGER_PROVIDER) logger: LoggerService,
+    logger: MozLoggerService,
     stripeFirestore: StripeFirestoreService,
     paymentConfigManager: StripePaymentConfigManagerService,
     @Inject('STRIPE') stripe: Stripe,

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.module.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.module.ts
@@ -4,7 +4,6 @@
 
 import { Module } from '@nestjs/common';
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import {
   AppStoreHelperService,
@@ -32,6 +31,7 @@ import { SubscriptionsService } from './subscriptions.service';
     AppStoreService,
     FirestoreFactory,
     MetricsFactory,
+    MozLoggerService,
     PlayStorePurchaseManagerService,
     PlayStoreService,
     PlayStoreUserManagerService,
@@ -40,10 +40,6 @@ import { SubscriptionsService } from './subscriptions.service';
     StripePaymentConfigManagerService,
     StripeService,
     SubscriptionsService,
-    {
-      provide: LOGGER_PROVIDER,
-      useClass: MozLoggerService,
-    },
   ],
   exports: [SubscriptionsService],
 })

--- a/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
+++ b/packages/fxa-admin-server/src/subscriptions/subscriptions.service.ts
@@ -2,9 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable, Inject, LoggerService } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { AbbrevPlan } from 'fxa-shared/subscriptions/types';
 import Stripe from 'stripe';
 import { MozSubscription } from '../gql/model/moz-subscription.model';
@@ -16,6 +15,7 @@ import {
   PlayStoreFormatter,
   StripeFormatter,
 } from './subscriptions.formatters';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 /**
  * List of valid of subscription statuses. This should be all known
@@ -60,7 +60,7 @@ export class SubscriptionsService {
    */
   constructor(
     protected readonly configService: ConfigService,
-    @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
+    protected readonly logger: MozLoggerService,
     protected readonly stripeService: StripeService,
     protected readonly appStoreService: AppStoreService,
     protected readonly playStoreService: PlayStoreService

--- a/packages/fxa-shared/guards/AdminPanelGuard.ts
+++ b/packages/fxa-shared/guards/AdminPanelGuard.ts
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Guard, Permissions, Groups, MaxPermissionLevel } from './Guard';
+import {
+  Guard,
+  Permissions,
+  Groups,
+  MaxPermissionLevel,
+  AdminPanelEnv,
+} from './Guard';
 
 /** The header key containing the user group. */
 export const USER_GROUP_HEADER = 'remote-groups';
@@ -45,12 +51,6 @@ export enum AdminPanelGroup {
   SupportAgentProd = 'vpn_fxa_supportagent_prod',
   SupportAgentStage = 'vpn_fxa_supportagent_stage',
   None = '',
-}
-
-/** Enum for known environment names */
-export enum AdminPanelEnv {
-  Prod = 'prod',
-  Stage = 'stage',
 }
 
 const adminPanelGroups: Groups = {

--- a/packages/fxa-shared/guards/Guard.ts
+++ b/packages/fxa-shared/guards/Guard.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AdminPanelEnv } from './AdminPanelGuard';
+/** Enum for known environment names */
+// TODO: Refactor to be called GuardEnv... This isn't really specific to the admin panel...
+export enum AdminPanelEnv {
+  Prod = 'prod',
+  Stage = 'stage',
+}
 
 /* The maximum value that should be allowed for a permission level. */
 export const MaxPermissionLevel = 100;


### PR DESCRIPTION
## Because
- Some analytics were lost
- A previous refactor broke logging

## This pull request

- Restores mzlog.service.ts to its previous glory
- Fixes wonky injection
- Fixes circular ref in admin-panel gaurds that would sometimes cause esbuild error
- Fixes project.json in libs/shared/sentry to avoid esbuild error

## Issue that this pull request solves

Closes: FXA-10920

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


Working Example from Train-294
`28|admin-server  | 2025-02-06T15:30:38: {"Timestamp":1738884638766000000,"Logger":"fxa-user-admin-server","Type":"default.admin-panel-events","Severity":6,"Pid":70121,"EnvVersion":"2.0","Fields":{"event":"account-search","search-type":"email","auto-completed":false}}`

Broken Example from train-305. Note "Fields": { "0": "{...}"}. This won't ingest into our logging tables properly.
`28|admin-server  | 2025-02-06T15:06:20: {"Timestamp":1738883180094000000,"Logger":"fxa-user-admin-server","Type":"EventLoggingService.","Severity":6,"Pid":40424,"EnvVersion":"2.0","Fields":{"0":"{\"event\":\"account-search\",\"search-type\":\"email\",\"auto-completed\":false}","message":"admin-panel-events"}}`

With fix in this PR:
`28|admin-server  | 2025-02-06T16:13:29: {"Timestamp":1738887209919000000,"Logger":"fxa-user-admin-server","Type":"EventLoggingService.admin-panel-events","Severity":6,"Pid":37694,"EnvVersion":"2.0","Fields":{"event":"account-search","search-type":"email","auto-completed":true}}`


## Other information (Optional)

The build error fixes cropped up of all a sudden. Maybe these should be a separate PR? Pulled my hair out trying to figure out why this was happening... I also added a few follows based on this PR to the logging cleanup epic. Basically our logger use is getting more and more inconsistent. We need a full pass to clean this up to remove the partial refactors and ensuing code duplication. This was started in the FXA-10970 branch, ended up bailing on the attempt, because the size of the commit was getting out of hand, hence the FXA-10970.2 branch name.
