### PR TITLE
task(recovery-phone): Handle error retrieveving Twilio lookup

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
@@ -8,6 +8,7 @@ import {
   testAccountDatabaseSetup,
 } from '@fxa/shared/db/mysql/account';
 import { Test } from '@nestjs/testing';
+import { RecoveryPhoneFactory } from '@fxa/shared/db/mysql/account';
 
 describe('RecoveryPhoneManager', () => {
   let recoveryPhoneManager: RecoveryPhoneManager;

--- a/libs/shared/db/mysql/account/src/index.ts
+++ b/libs/shared/db/mysql/account/src/index.ts
@@ -9,6 +9,7 @@ export {
   AccountFactory,
   AccountCustomerFactory,
   PaypalCustomerFactory,
+  RecoveryPhoneFactory,
 } from './lib/factories';
 export { setupAccountDatabase, AccountDbProvider } from './lib/setup';
 export { testAccountDatabaseSetup } from './lib/tests';

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -245,7 +245,8 @@ async function run(config) {
     recoveryPhoneManager,
     smsManager,
     otpCodeManager,
-    config.recoveryPhone
+    config.recoveryPhone,
+    log
   );
   Container.set(RecoveryPhoneService, recoveryPhoneService);
 


### PR DESCRIPTION
Because:


This Commit:


## Because

- We want to let the user know if the number is invalid.
- If the number look fails we probably can't send either.

## This pull request
- Fails fast if the number look fails
- Throws the `PhoneNumberNotSupported` error
- Logs the error, so we can keep tabs on it.
- Injects logger into recovery-phone-service. This might be helpful in general.
- Fixes import in recovery-phone-manager.in.spec.

## Issue that this pull request solves

Closes: FXA-11055

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
