### PR TITLE
feat(recovery-phone): Display phone number in desired format (masking + Twilio's nationalFormat)

### DIFF
--- a/libs/accounts/recovery-phone/README.md
+++ b/libs/accounts/recovery-phone/README.md
@@ -8,8 +8,8 @@ Run `nx build recovery-phone` to build the library.
 
 ## Running unit tests
 
-Run `nx test-unit recovery-phone` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test-unit accounts-recovery-phone` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## Running integration tests
 
-Run `nx test-integration recovery-phone` to execute the integration tests via [Jest](https://jestjs.io).
+Run `nx test-integration accounts-recovery-phone` to execute the integration tests via [Jest](https://jestjs.io).

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -82,9 +82,11 @@ export class RecoveryPhoneManager {
    *
    * @param uid
    */
-  async getConfirmedPhoneNumber(
-    uid: string
-  ): Promise<{ uid: Buffer; phoneNumber: string }> {
+  async getConfirmedPhoneNumber(uid: string): Promise<{
+    uid: Buffer;
+    phoneNumber: string;
+    nationalFormat?: string;
+  }> {
     const uidBuffer = Buffer.from(uid, 'hex');
     const result = await getConfirmedPhoneNumber(this.db, uidBuffer);
     if (!result) {

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.repository.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.repository.ts
@@ -7,12 +7,27 @@ import { RecoveryPhone } from './recovery-phone.types';
 export async function getConfirmedPhoneNumber(
   db: AccountDatabase,
   uid: Buffer
-): Promise<{ uid: Buffer; phoneNumber: string } | undefined> {
-  return db
+): Promise<
+  { uid: Buffer; phoneNumber: string; nationalFormat?: string } | undefined
+> {
+  const row = await db
     .selectFrom('recoveryPhones')
     .where('uid', '=', uid)
-    .select(['uid', 'phoneNumber'])
+    .select(['uid', 'phoneNumber', 'lookupData'])
     .executeTakeFirst();
+
+  if (!row) {
+    return undefined;
+  }
+  const { uid: userId, phoneNumber, lookupData } = row;
+  const nationalFormat = (lookupData as { nationalFormat?: string })
+    ?.nationalFormat;
+
+  return {
+    uid: userId,
+    phoneNumber,
+    nationalFormat,
+  };
 }
 
 export async function registerPhoneNumber(

--- a/libs/accounts/recovery-phone/src/lib/sms.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/sms.manager.ts
@@ -72,6 +72,7 @@ export class SmsManager {
     const from = this.rotateFromNumber();
 
     try {
+      // Validate the `to` phone number and send the SMS
       const msg = await this.client.messages.create({
         to,
         from,

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -2171,7 +2171,7 @@ export default class AuthClient {
     sessionToken: string,
     phoneNumber: string,
     headers?: Headers
-  ) {
+  ): Promise<{ nationalFormat?: string; success: boolean }> {
     return this.sessionPost(
       '/recovery_phone/create',
       sessionToken,
@@ -2205,7 +2205,7 @@ export default class AuthClient {
     sessionToken: string,
     code: string,
     headers?: Headers
-  ) {
+  ): Promise<{ nationalFormat?: string }> {
     return this.sessionPost(
       '/recovery_phone/confirm',
       sessionToken,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/en.ftl
@@ -3,7 +3,7 @@ postAddRecoveryPhone-preview = Account protected by two-step authentication
 postAddRecoveryPhone-title = You created a recovery phone number
 # Variables:
 #  $maskedLastFourPhoneNumber (String) - A bullet point mask with the last four digits of the user's phone number, e.g. ••••••1234
-postAddRecoveryPhone-description = You added { $maskedLastFourPhoneNumber } as your recovery phone
+postAddRecoveryPhone-description-v2 = You added { $maskedLastFourPhoneNumber } as your recovery phone number
 # Links out to a support article about two factor authentication
 postAddRecoveryPhone-how-protect = How this protects your account
 postAddRecoveryPhone-how-protect-plaintext = How this protects your account:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.mjml
@@ -9,7 +9,7 @@
     </mj-text>
 
     <mj-text css-class="text-body-no-margin">
-      <span dir="ltr" data-l10n-id="postAddRecoveryPhone-description" data-l10n-args="<%= JSON.stringify({ maskedLastFourPhoneNumber }) %>">You added <%- maskedLastFourPhoneNumber %> as your recovery phone</span>
+      <span dir="ltr" data-l10n-id="postAddRecoveryPhone-description-v2" data-l10n-args="<%= JSON.stringify({ maskedLastFourPhoneNumber }) %>">You added <%- maskedLastFourPhoneNumber %> as your recovery phone number</span>
     </mj-text>
     <mj-text css-class="text-body">
       <a class="link-blue" href="<%- twoFactorSupportLink %>">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.txt
@@ -1,6 +1,6 @@
 postAddRecoveryPhone-title = "You created a recovery phone number"
 
-postAddRecoveryPhone-description = "You added <%- maskedLastFourPhoneNumber %> as your recovery phone"
+postAddRecoveryPhone-description-v2 = "You added <%- maskedLastFourPhoneNumber %> as your recovery phone number"
 
 postAddRecoveryPhone-how-protect-plaintext = "How this protects your account:"
 <%- twoFactorSupportLink %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1201,7 +1201,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: 'You created a recovery phone number' },
-      { test: 'include', expected: 'You added ••••••1234 as your recovery phone' },
+      { test: 'include', expected: 'You added ••••••1234 as your recovery phone number' },
       // TODO, update test with FXA-10918
       { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
       { test: 'include', expected: 'You enabled it from:' },
@@ -1216,7 +1216,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
     ['text', [
       { test: 'include', expected: 'You created a recovery phone number' },
-      { test: 'include', expected: 'You added ••••••1234 as your recovery phone' },
+      { test: 'include', expected: 'You added ••••••1234 as your recovery phone number' },
       // TODO, update test with FXA-10918
       { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
       { test: 'include', expected: 'You enabled it from:' },

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -877,8 +877,11 @@ export class AccountResolver {
       this.shouldIncludeRecoveryPhoneAvailability(info);
 
     try {
-      const recoveryPhone = await this.recoveryPhoneService.hasConfirmed(
-        account.uid
+      // This endpoint will strip the phone number if the user's session
+      // is not verified
+      const recoveryPhone = await this.authAPI.recoveryPhoneGet(
+        sessionToken,
+        headers
       );
 
       if (includeAvailability) {
@@ -899,6 +902,7 @@ export class AccountResolver {
         exists: false,
         ...(includeAvailability ? { available: false } : {}),
         phoneNumber: null,
+        nationalFormat: null,
       };
     }
   }

--- a/packages/fxa-graphql-api/src/gql/model/recoveryPhone.ts
+++ b/packages/fxa-graphql-api/src/gql/model/recoveryPhone.ts
@@ -21,6 +21,13 @@ export class RecoveryPhone {
   @Field({
     nullable: true,
     description:
+      "The recovery phone number in Twilio's national_format format.",
+  })
+  public nationalFormat!: string;
+
+  @Field({
+    nullable: true,
+    description:
       'Returns true if the user is eligible to set up a recovery phone.',
   })
   public available!: boolean;

--- a/packages/fxa-settings/src/components/App/gql.ts
+++ b/packages/fxa-settings/src/components/App/gql.ts
@@ -116,6 +116,7 @@ export const GET_RECOVERY_PHONE = gql`
         available
         exists
         phoneNumber
+        nationalFormat
       }
     }
   }

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
@@ -9,7 +9,7 @@ import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import FlowSetupRecoveryPhoneConfirmCode from '.';
-import { MOCK_FULL_PHONE_NUMBER } from '../../../pages/mocks';
+import { MOCK_NATIONAL_FORMAT_PHONE_NUMBER } from '../../../pages/mocks';
 
 export default {
   title: 'Components/Settings/FlowSetupRecoveryPhoneConfirmCode',
@@ -44,13 +44,13 @@ const verifyRecoveryCodeFailure = async (code: string) => {
   return Promise.reject(AuthUiErrors.UNEXPECTED_ERROR);
 };
 
-const formattedPhoneNumber = MOCK_FULL_PHONE_NUMBER;
+const nationalFormatPhoneNumber = MOCK_NATIONAL_FORMAT_PHONE_NUMBER;
 
 export const Success = () => (
   <SettingsLayout>
     <FlowSetupRecoveryPhoneConfirmCode
       {...{
-        formattedPhoneNumber,
+        nationalFormatPhoneNumber,
         localizedBackButtonTitle,
         localizedPageTitle,
         navigateBackward,
@@ -66,7 +66,7 @@ export const Error = () => (
   <SettingsLayout>
     <FlowSetupRecoveryPhoneConfirmCode
       {...{
-        formattedPhoneNumber,
+        nationalFormatPhoneNumber,
         localizedBackButtonTitle,
         localizedPageTitle,
         navigateBackward,

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
@@ -30,7 +30,7 @@ const defaultProps = {
   localizedPageTitle: 'Add phone number',
   navigateBackward: mockNavigateBackward,
   navigateForward: mockNavigateForward,
-  formattedPhoneNumber: '+1 (555) 555-5555',
+  nationalFormatPhoneNumber: '(555) 555-8888',
   sendCode: mockSendCode,
   verifyRecoveryCode: mockVerifyRecoveryCode,
 };
@@ -49,7 +49,7 @@ describe('FlowSetupRecoveryPhoneConfirmCode', () => {
     expect(
       screen.getByText(/A six-digit code was sent to/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/\+1 \(555\) 555-5555/)).toBeInTheDocument();
+    expect(screen.getByText(/\(555\) 555-8888/)).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Resend code/i })
     ).toBeInTheDocument();

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
@@ -16,7 +16,7 @@ import GleanMetrics from '../../../lib/glean';
 
 export type FlowSetupRecoveryPhoneConfirmCodeProps = {
   currentStep?: number;
-  formattedPhoneNumber: string;
+  nationalFormatPhoneNumber: string;
   localizedBackButtonTitle: string;
   localizedPageTitle: string;
   navigateBackward: () => void;
@@ -28,7 +28,7 @@ export type FlowSetupRecoveryPhoneConfirmCodeProps = {
 
 export const FlowSetupRecoveryPhoneConfirmCode = ({
   currentStep = 2,
-  formattedPhoneNumber,
+  nationalFormatPhoneNumber,
   localizedBackButtonTitle,
   localizedPageTitle,
   navigateBackward,
@@ -124,12 +124,12 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
       <FtlMsg
         id="flow-setup-phone-confirm-code-instruction"
         elems={{ span: <span dir="ltr" className="font-bold"></span> }}
-        vars={{ phoneNumber: formattedPhoneNumber }}
+        vars={{ phoneNumber: nationalFormatPhoneNumber }}
       >
         <p className="text-base mt-4">
           A six-digit code was sent to{' '}
           <span dir="ltr" className="font-bold">
-            {formattedPhoneNumber}
+            {nationalFormatPhoneNumber}
           </span>{' '}
           by text message. This code expires after 5 minutes.
         </p>

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
@@ -31,8 +31,9 @@ const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  // TODO, we may want national_format back from Twilio
-  const formattedFullPhoneNumber = account.recoveryPhone.phoneNumber!;
+  const { phoneNumber, nationalFormat } = account.recoveryPhone;
+  // Use phoneNumber as a fallback in case nationalFormat is not available
+  const formattedFullPhoneNumber = nationalFormat || phoneNumber;
 
   const goHome = () => navigate(SETTINGS_PATH + '#security', { replace: true });
 
@@ -60,6 +61,12 @@ const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
       alertBar.error(localizedError);
     }
   }, [account, alertSuccessAndGoHome, alertBar, ftlMsgResolver]);
+
+  // Should never happen, but just in case, and makes TS happy.
+  if (!formattedFullPhoneNumber) {
+    goHome();
+    return <></>;
+  }
 
   return (
     <FlowContainer hideBackButton={true}>

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
@@ -7,18 +7,24 @@ import { screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
 import { Subject } from './mocks';
 import userEvent, { UserEvent } from '@testing-library/user-event';
+import {
+  MOCK_FULL_PHONE_NUMBER,
+  MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
+} from '../../../pages/mocks';
 
 jest.mock('../../../models/AlertBarInfo');
 
-const phoneNumber = '1231231234';
-const phoneNumberWithCountryCode = '+11231231234';
+const phoneNumberWithoutCountryCode = MOCK_FULL_PHONE_NUMBER.slice(2);
 const otpCode = '123456';
+const mockSuccessResponse = {
+  nationalFormat: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
+};
 
 const completeStepOne = async (user: UserEvent) => {
   await waitFor(() =>
     user.type(
       screen.getByRole('textbox', { name: /Enter phone number/i }),
-      phoneNumber
+      phoneNumberWithoutCountryCode
     )
   );
   user.click(screen.getByRole('button', { name: /Send code/i }));
@@ -36,13 +42,15 @@ describe('PageRecoveryPhoneSetup', () => {
 
   it('add recovery phone with successful submission renders step 2', async () => {
     const user = userEvent.setup();
-    const addRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    const addRecoveryPhone = jest
+      .fn()
+      .mockResolvedValueOnce(mockSuccessResponse);
     renderWithRouter(<Subject account={{ addRecoveryPhone }} />);
 
     await completeStepOne(user);
     await waitFor(() => expect(addRecoveryPhone).toHaveBeenCalledTimes(1));
     await waitFor(() =>
-      expect(addRecoveryPhone).toHaveBeenCalledWith(phoneNumberWithCountryCode)
+      expect(addRecoveryPhone).toHaveBeenCalledWith(MOCK_FULL_PHONE_NUMBER)
     );
     expect(
       screen.queryByText(/You’ll get a text message from Mozilla/i)
@@ -52,11 +60,13 @@ describe('PageRecoveryPhoneSetup', () => {
 
   it('at step 2, allows code resend', async () => {
     const user = userEvent.setup();
-    const confirmRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    const confirmRecoveryPhone = jest
+      .fn()
+      .mockResolvedValueOnce(mockSuccessResponse);
     const addRecoveryPhone = jest
       .fn()
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(undefined);
+      .mockResolvedValueOnce(mockSuccessResponse)
+      .mockResolvedValueOnce(mockSuccessResponse);
     renderWithRouter(
       <Subject account={{ confirmRecoveryPhone, addRecoveryPhone }} />
     );
@@ -75,20 +85,18 @@ describe('PageRecoveryPhoneSetup', () => {
     );
 
     await waitFor(() => expect(addRecoveryPhone).toHaveBeenCalledTimes(2));
-    expect(addRecoveryPhone).toHaveBeenNthCalledWith(
-      1,
-      phoneNumberWithCountryCode
-    );
-    expect(addRecoveryPhone).toHaveBeenNthCalledWith(
-      2,
-      phoneNumberWithCountryCode
-    );
+    expect(addRecoveryPhone).toHaveBeenNthCalledWith(1, MOCK_FULL_PHONE_NUMBER);
+    expect(addRecoveryPhone).toHaveBeenNthCalledWith(2, MOCK_FULL_PHONE_NUMBER);
   });
 
   it('at step 2, allows code confirm', async () => {
     const user = userEvent.setup();
-    const confirmRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
-    const addRecoveryPhone = jest.fn().mockResolvedValueOnce(undefined);
+    const confirmRecoveryPhone = jest
+      .fn()
+      .mockResolvedValueOnce(mockSuccessResponse);
+    const addRecoveryPhone = jest
+      .fn()
+      .mockResolvedValueOnce(mockSuccessResponse);
     renderWithRouter(
       <Subject account={{ confirmRecoveryPhone, addRecoveryPhone }} />
     );
@@ -107,7 +115,7 @@ describe('PageRecoveryPhoneSetup', () => {
     await waitFor(() => expect(confirmRecoveryPhone).toHaveBeenCalledTimes(1));
     expect(confirmRecoveryPhone).toHaveBeenCalledWith(
       otpCode,
-      phoneNumberWithCountryCode
+      MOCK_FULL_PHONE_NUMBER
     );
   });
 });

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -7,8 +7,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import SubRow, { BackupCodesSubRow, BackupPhoneSubRow } from './index';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import {
-  MOCK_FULL_PHONE_NUMBER,
-  MOCK_MASKED_PHONE_NUMBER,
+  MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER,
+  MOCK_MASKED_PHONE_NUMBER_WITH_COPY,
 } from '../../../pages/mocks';
 
 describe('SubRow', () => {
@@ -118,7 +118,7 @@ describe('BackupCodesSubRow', () => {
 describe('BackupPhoneSubRow', () => {
   const defaultProps = {
     onCtaClick: jest.fn(),
-    phoneNumber: MOCK_FULL_PHONE_NUMBER,
+    phoneNumber: MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER,
   };
 
   it('renders correctly when phone number unavailable', () => {
@@ -141,7 +141,9 @@ describe('BackupPhoneSubRow', () => {
   it('renders correctly when phone number is available and delete is not an option', () => {
     renderWithLocalizationProvider(<BackupPhoneSubRow {...defaultProps} />);
     expect(screen.getByText('Recovery phone')).toBeInTheDocument();
-    expect(screen.getByText(MOCK_MASKED_PHONE_NUMBER)).toBeInTheDocument();
+    expect(
+      screen.getByText(MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER)
+    ).toBeInTheDocument();
     // Temporary until we work on the change flow for SMS phase 2, FXA-10995
     expect(
       screen.queryByRole('button', { name: 'Change' })
@@ -156,15 +158,17 @@ describe('BackupPhoneSubRow', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders correctly when user does not have a verified session (phone number is already masked)', () => {
+  it('renders correctly when user does not have a verified session', () => {
     renderWithLocalizationProvider(
       <BackupPhoneSubRow
         {...defaultProps}
-        phoneNumber={MOCK_MASKED_PHONE_NUMBER}
+        phoneNumber={MOCK_MASKED_PHONE_NUMBER_WITH_COPY}
       />
     );
     expect(screen.getByText('Recovery phone')).toBeInTheDocument();
-    expect(screen.getByText(MOCK_MASKED_PHONE_NUMBER)).toBeInTheDocument();
+    expect(
+      screen.getByText(MOCK_MASKED_PHONE_NUMBER_WITH_COPY)
+    ).toBeInTheDocument();
   });
 
   it('renders correctly when phone number is available and delete is an option', () => {
@@ -172,7 +176,9 @@ describe('BackupPhoneSubRow', () => {
       <BackupPhoneSubRow {...defaultProps} onDeleteClick={jest.fn()} />
     );
     expect(screen.getByText('Recovery phone')).toBeInTheDocument();
-    expect(screen.getByText(MOCK_MASKED_PHONE_NUMBER)).toBeInTheDocument();
+    expect(
+      screen.getByText(MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER)
+    ).toBeInTheDocument();
     // Temporary until we work on the change flow for SMS phase 2, FXA-10995
     expect(
       screen.queryByRole('button', { name: 'Change' })

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -238,15 +238,8 @@ export const BackupPhoneSubRow = ({
     <BackupRecoverySmsDisabledIcon className="-ms-1 -my-2 scale-50" />
   );
   const message = hasPhoneNumber ? (
-    // If the user's session is not verified, an already masked phone number is returned.
-    // If it is verified, the full phone number is returned but here we want a client-side mask.
-    // We may want to get `national_format` back from Twilio.
     // Phone numbers should always be displayed left-to-right, *including* in rtl languages
-    <p dir="ltr">
-      {phoneNumber.includes('•')
-        ? phoneNumber
-        : `••••••${phoneNumber.slice(-4)}`}
-    </p>
+    <p dir="ltr">{phoneNumber}</p>
   ) : (
     <FtlMsg id="tfa-row-backup-phone-not-available">
       <p>No recovery phone number available</p>

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.stories.tsx
@@ -8,7 +8,7 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';
 import UnitRowTwoStepAuth from '.';
 import { createSubject } from './mocks';
-import { MOCK_FULL_PHONE_NUMBER } from '../../../pages/mocks';
+import { MOCK_NATIONAL_FORMAT_PHONE_NUMBER } from '../../../pages/mocks';
 
 export default {
   title: 'Components/Settings/UnitRowTwoStepAuth',
@@ -59,7 +59,7 @@ export const TwoFAEnabledWithBackupPhoneNoBackupCodes = () =>
   createSubject({
     recoveryPhone: {
       exists: true,
-      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      phoneNumber: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
       available: true,
     },
     backupCodes: { hasBackupCodes: false, count: 0 },
@@ -69,7 +69,16 @@ export const TwoFAEnabledWithBackupCodesAndBackupPhone = () =>
   createSubject({
     recoveryPhone: {
       exists: true,
-      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      phoneNumber: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
+      available: true,
+    },
+  });
+
+export const TwoFAEnabledWithBackupCodesAndBackupPhoneUnverifiedSession = () =>
+  createSubject({
+    recoveryPhone: {
+      exists: true,
+      phoneNumber: '7890',
       available: true,
     },
   });
@@ -87,7 +96,7 @@ export const TwoFAEnabledWithBackupPhoneAndUnsupportedCurrentRegion = () =>
   createSubject({
     recoveryPhone: {
       exists: true,
-      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      phoneNumber: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
       available: false,
     },
     backupCodes: { hasBackupCodes: true, count: 1 },

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.test.tsx
@@ -8,7 +8,8 @@ import { renderWithRouter } from '../../../models/mocks';
 import { createSubject } from './mocks';
 import {
   MOCK_FULL_PHONE_NUMBER,
-  MOCK_MASKED_PHONE_NUMBER,
+  MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER,
+  MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
 } from '../../../pages/mocks';
 import GleanMetrics from '../../../lib/glean';
 
@@ -126,7 +127,12 @@ describe('UnitRowTwoStepAuth', () => {
     renderWithRouter(
       createSubject({
         backupCodes: { hasBackupCodes: false, count: 0 },
-        recoveryPhone: { exists: false, phoneNumber: null, available: false },
+        recoveryPhone: {
+          exists: false,
+          phoneNumber: null,
+          nationalFormat: null,
+          available: false,
+        },
       })
     );
 
@@ -147,6 +153,7 @@ describe('UnitRowTwoStepAuth', () => {
         recoveryPhone: {
           exists: true,
           phoneNumber: MOCK_FULL_PHONE_NUMBER,
+          nationalFormat: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
           available: true,
         },
         backupCodes: { hasBackupCodes: false, count: 0 },
@@ -158,7 +165,7 @@ describe('UnitRowTwoStepAuth', () => {
     ).toContain('Enabled');
     expect(
       screen.getByTestId('backup-recovery-phone-sub-row').textContent
-    ).toContain(MOCK_MASKED_PHONE_NUMBER);
+    ).toContain(MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER);
     expect(
       screen.queryByTestId('backup-authentication-codes-sub-row')
     ).toBeInTheDocument();
@@ -170,6 +177,7 @@ describe('UnitRowTwoStepAuth', () => {
         recoveryPhone: {
           exists: true,
           phoneNumber: MOCK_FULL_PHONE_NUMBER,
+          nationalFormat: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
           available: true,
         },
         backupCodes: { hasBackupCodes: true, count: 3 },
@@ -181,7 +189,7 @@ describe('UnitRowTwoStepAuth', () => {
     ).toContain('Enabled');
     expect(
       screen.getByTestId('backup-recovery-phone-sub-row').textContent
-    ).toContain(MOCK_MASKED_PHONE_NUMBER);
+    ).toContain(MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER);
     expect(
       screen.getByTestId('backup-authentication-codes-sub-row').textContent
     ).toContain('3');
@@ -195,6 +203,7 @@ describe('UnitRowTwoStepAuth', () => {
         recoveryPhone: {
           exists: true,
           phoneNumber: MOCK_FULL_PHONE_NUMBER,
+          nationalFormat: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
           available: false,
         },
         backupCodes: { hasBackupCodes: true, count: 1 },
@@ -206,7 +215,7 @@ describe('UnitRowTwoStepAuth', () => {
     ).toContain('Enabled');
     expect(
       screen.getByTestId('backup-recovery-phone-sub-row').textContent
-    ).toContain(MOCK_MASKED_PHONE_NUMBER);
+    ).toContain(MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER);
     expect(
       screen.getByTestId('backup-authentication-codes-sub-row').textContent
     ).toContain('1');

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -20,6 +20,7 @@ import GleanMetrics from '../../../lib/glean';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { BackupCodesSubRow, BackupPhoneSubRow } from '../SubRow';
 import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { formatPhoneNumber } from '../../../lib/recovery-phone-utils';
 
 const route = `${SETTINGS_PATH}/two_step_authentication`;
 const replaceCodesRoute = `${route}/replace_codes`;
@@ -175,6 +176,7 @@ export const UnitRowTwoStepAuth = () => {
           recoveryPhone.available === true) ||
         recoveryPhone.exists === true
       ) {
+        const { nationalFormat, phoneNumber } = recoveryPhone;
         subRows.push(
           <BackupPhoneSubRow
             onCtaClick={() => {
@@ -187,7 +189,16 @@ export const UnitRowTwoStepAuth = () => {
                   navigate(`${SETTINGS_PATH}/recovery_phone/remove`);
                 },
               })}
-            phoneNumber={recoveryPhone.phoneNumber || ''}
+            phoneNumber={
+              (phoneNumber
+                ? formatPhoneNumber({
+                    nationalFormat,
+                    phoneNumber,
+                    ftlMsgResolver,
+                  })
+                : {}
+              ).maskedPhoneNumber
+            }
             key={2}
           />
         );

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/mocks.tsx
@@ -17,7 +17,12 @@ export const createSubject = (
     hasPassword: true,
     backupCodes: { hasBackupCodes: true, count: 3 },
     totp: { exists: true, verified: true },
-    recoveryPhone: { exists: false, phoneNumber: null, available: false },
+    recoveryPhone: {
+      exists: false,
+      phoneNumber: null,
+      nationalFormat: null,
+      available: false,
+    },
     ...accountOverrides,
   } as unknown as Account;
   const config = {

--- a/packages/fxa-settings/src/lib/en.ftl
+++ b/packages/fxa-settings/src/lib/en.ftl
@@ -1,0 +1,5 @@
+# Displayed when we want to reference a user's previously set up recovery phone
+# number, but they are not completely signed in yet. We'll only show the last 4 digits.
+# Variables:
+#  $lastFourPhoneNumber (Number) - The last 4 digits of the user's recovery phone number
+recovery-phone-number-ending-digits = Number ending in { $lastFourPhoneNumber }

--- a/packages/fxa-settings/src/lib/recovery-phone-utils.test.tsx
+++ b/packages/fxa-settings/src/lib/recovery-phone-utils.test.tsx
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  MOCK_FULL_PHONE_NUMBER,
+  MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
+} from '../pages/mocks';
+import { FtlMsgResolver } from 'fxa-react/lib/utils';
+import { formatPhoneNumber } from './recovery-phone-utils';
+
+describe('formatPhoneNumber', () => {
+  let mockFtlMsgResolver: FtlMsgResolver;
+
+  beforeEach(() => {
+    mockFtlMsgResolver = {
+      getMsg: jest.fn((_, defaultMsg) => defaultMsg),
+    } as unknown as FtlMsgResolver;
+  });
+
+  it('masks NANP national format phone number correctly', () => {
+    const result = formatPhoneNumber({
+      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      nationalFormat: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
+      ftlMsgResolver: mockFtlMsgResolver,
+    });
+    expect(result.maskedPhoneNumber).toBe('(•••) •••-1234');
+    expect(result.lastFourPhoneDigits).toBe('1234');
+  });
+
+  it('masks non-NANP national format phone number correctly', () => {
+    const result = formatPhoneNumber({
+      phoneNumber: '+33987654321',
+      nationalFormat: '+33 9 87 65 43 21',
+      ftlMsgResolver: mockFtlMsgResolver,
+    });
+    expect(result.maskedPhoneNumber).toBe('+•• • •• •• 43 21');
+    expect(result.lastFourPhoneDigits).toBe('4321');
+  });
+
+  it('masks fallback phone number when nationalFormat is null', () => {
+    const result = formatPhoneNumber({
+      phoneNumber: MOCK_FULL_PHONE_NUMBER,
+      nationalFormat: null,
+      ftlMsgResolver: mockFtlMsgResolver,
+    });
+    expect(result.maskedPhoneNumber).toBe('+•••••••1234');
+    expect(result.lastFourPhoneDigits).toBe('1234');
+  });
+
+  it('returns localized message when only last four digits are provided (unverified session)', () => {
+    const result = formatPhoneNumber({
+      phoneNumber: '4567',
+      nationalFormat: '4567',
+      ftlMsgResolver: mockFtlMsgResolver,
+    });
+    expect(mockFtlMsgResolver.getMsg).toHaveBeenCalledWith(
+      'recovery-phone-number-ending-digits',
+      'Number ending in 4567',
+      { lastFourPhoneNumber: '4567' }
+    );
+    expect(result.maskedPhoneNumber).toBe('Number ending in 4567');
+    expect(result.lastFourPhoneDigits).toBe('4567');
+  });
+});

--- a/packages/fxa-settings/src/lib/recovery-phone-utils.tsx
+++ b/packages/fxa-settings/src/lib/recovery-phone-utils.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { FtlMsgResolver } from 'fxa-react/lib/utils';
+
+const NUMBER_OF_DIGITS_TO_SHOW = 4;
+/**
+ * When the user has a verified session, we get back the full national format
+ * phone number from Twilio, if available. We still want to "mask" it in some
+ * cases to only show the last 4 digits while keeping the formatting from Twilio.
+ * */
+function maskNationalFormatPhoneNumber(numberToMask: string) {
+  const digits = numberToMask.replace(/\D/g, '');
+  const digitsToMask = digits.length - NUMBER_OF_DIGITS_TO_SHOW;
+
+  let maskedDigitsCount = 0;
+  // Replace digits with '•' or keep them based on their position
+  const maskedPhoneNumber = numberToMask.replace(/\d/g, (digit) => {
+    if (maskedDigitsCount < digitsToMask) {
+      maskedDigitsCount++;
+      return '•';
+    } else {
+      return digit;
+    }
+  });
+  return maskedPhoneNumber;
+}
+
+/**
+ * This function ensures the phone number is masked correctly.
+ * If passed the last 4 digits of the phone number, it will return a localized
+ * string. If passed a nationalFormat or full phone number, it will mask all
+ * numbers except the last 4 digits.
+ * @param phoneNumber - A full number, or last 4 digits
+ * @param nationalFormat - A nationalFormat phone number, or last 4 digits
+ * @returns maskedPhoneNumber - will be localized copy if the user does not
+ * have a verified session, e.g. "Number ending in 7890", or the national
+ * format with only the last 4 shown, e.g. (•••) •••-7890
+ * @returns lastFourPhoneDigits - the last 4 digits of the phone number
+ * */
+export function formatPhoneNumber({
+  phoneNumber,
+  nationalFormat,
+  ftlMsgResolver,
+}: {
+  phoneNumber: string;
+  nationalFormat: null | string;
+  ftlMsgResolver: FtlMsgResolver;
+}) {
+  // Prefer nationalFormat, but use phoneNumber as a fallback in case
+  // nationalFormat is not available
+  const numberToMask = nationalFormat || phoneNumber;
+  // This may already only be 4 digits, but this guarantees it
+  const lastFourPhoneDigits = phoneNumber.slice(-NUMBER_OF_DIGITS_TO_SHOW);
+
+  const maskedPhoneNumber =
+    numberToMask.length === NUMBER_OF_DIGITS_TO_SHOW
+      ? // This means the user does not have a verified session
+        ftlMsgResolver.getMsg(
+          'recovery-phone-number-ending-digits',
+          `Number ending in ${numberToMask}`,
+          { lastFourPhoneNumber: numberToMask }
+        )
+      : maskNationalFormatPhoneNumber(numberToMask);
+
+  return { maskedPhoneNumber, lastFourPhoneDigits };
+}

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -118,6 +118,7 @@ export interface AccountData {
   recoveryPhone: {
     exists: boolean;
     phoneNumber: string | null;
+    nationalFormat: string | null;
     available: boolean;
   };
   subscriptions: Subscription[];
@@ -206,6 +207,7 @@ export const GET_ACCOUNT = gql`
       recoveryPhone {
         exists
         phoneNumber
+        nationalFormat
         available
       }
       subscriptions {
@@ -1399,6 +1401,7 @@ export class Account implements AccountData {
           return {
             exists: false,
             phoneNumber: null,
+            nationalFormat: null,
             available: true,
           };
         },
@@ -1409,13 +1412,14 @@ export class Account implements AccountData {
   }
 
   async addRecoveryPhone(phoneNumber: string) {
-    await this.withLoadingStatus(
+    const result = await this.withLoadingStatus(
       this.authClient.recoveryPhoneCreate(sessionToken()!, phoneNumber)
     );
+    return result;
   }
 
   async confirmRecoveryPhone(code: string, phoneNumber: string) {
-    await this.withLoadingStatus(
+    const { nationalFormat } = await this.withLoadingStatus(
       this.authClient.recoveryPhoneConfirmSetup(sessionToken()!, code)
     );
     const cache = this.apolloClient.cache;
@@ -1426,6 +1430,7 @@ export class Account implements AccountData {
           return {
             exists: true,
             phoneNumber,
+            nationalFormat,
             available: true,
           };
         },

--- a/packages/fxa-settings/src/models/contexts/SettingsContext.ts
+++ b/packages/fxa-settings/src/models/contexts/SettingsContext.ts
@@ -65,6 +65,7 @@ export const INITIAL_SETTINGS_QUERY = gql`
       recoveryPhone {
         exists
         phoneNumber
+        nationalFormat
         available
       }
       subscriptions {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.test.tsx
@@ -11,7 +11,7 @@ import { waitFor } from '@testing-library/react';
 import { LocationProvider } from '@reach/router';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import {
-  MOCK_MASKED_PHONE_NUMBER,
+  MOCK_MASKED_PHONE_NUMBER_WITH_COPY,
   MOCK_STORED_ACCOUNT,
   mockLoadingSpinnerModule,
 } from '../../mocks';
@@ -37,7 +37,7 @@ function mockModelsModule({
   }),
   mockRecoveryPhoneGet = jest.fn().mockResolvedValue({
     exists: true,
-    phoneNumber: MOCK_MASKED_PHONE_NUMBER,
+    phoneNumber: MOCK_MASKED_PHONE_NUMBER_WITH_COPY,
   }),
   mockRecoveryPhoneSigninSendCode = jest.fn().mockResolvedValue(true),
 }) {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.stories.tsx
@@ -9,6 +9,7 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { MOCK_SIGNIN_LOCATION_STATE } from './mocks';
 import { LocationProvider } from '@reach/router';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { MOCK_MASKED_PHONE_NUMBER_WITH_COPY } from '../mocks';
 
 export default {
   title: 'Pages/Signin/SigninRecoveryChoice',
@@ -20,6 +21,7 @@ export const Default = () => (
   <LocationProvider>
     <SigninRecoveryChoice
       handlePhoneChoice={() => Promise.resolve()}
+      maskedPhoneNumber={MOCK_MASKED_PHONE_NUMBER_WITH_COPY}
       lastFourPhoneDigits="1234"
       numBackupCodes={4}
       signinState={MOCK_SIGNIN_LOCATION_STATE}
@@ -33,6 +35,7 @@ export const WithSMSSendRateLimitExceeded = () => (
       handlePhoneChoice={() =>
         Promise.resolve(AuthUiErrors.SMS_SEND_RATE_LIMIT_EXCEEDED)
       }
+      maskedPhoneNumber={MOCK_MASKED_PHONE_NUMBER_WITH_COPY}
       lastFourPhoneDigits="1234"
       numBackupCodes={4}
       signinState={MOCK_SIGNIN_LOCATION_STATE}
@@ -44,6 +47,7 @@ export const WithUnexpectedError = () => (
   <LocationProvider>
     <SigninRecoveryChoice
       handlePhoneChoice={() => Promise.resolve(AuthUiErrors.UNEXPECTED_ERROR)}
+      maskedPhoneNumber={MOCK_MASKED_PHONE_NUMBER_WITH_COPY}
       lastFourPhoneDigits="1234"
       numBackupCodes={4}
       signinState={MOCK_SIGNIN_LOCATION_STATE}
@@ -57,6 +61,7 @@ export const WithBackendServiceFailure = () => (
       handlePhoneChoice={() =>
         Promise.resolve(AuthUiErrors.BACKEND_SERVICE_FAILURE)
       }
+      maskedPhoneNumber={MOCK_MASKED_PHONE_NUMBER_WITH_COPY}
       lastFourPhoneDigits="1234"
       numBackupCodes={4}
       signinState={MOCK_SIGNIN_LOCATION_STATE}
@@ -68,6 +73,7 @@ export const WithThrottlingError = () => (
   <LocationProvider>
     <SigninRecoveryChoice
       handlePhoneChoice={() => Promise.resolve(AuthUiErrors.THROTTLED)}
+      maskedPhoneNumber={MOCK_MASKED_PHONE_NUMBER_WITH_COPY}
       lastFourPhoneDigits="1234"
       numBackupCodes={4}
       signinState={MOCK_SIGNIN_LOCATION_STATE}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
@@ -13,10 +13,12 @@ import SigninRecoveryChoice from '.';
 import { MOCK_SIGNIN_LOCATION_STATE } from './mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../../lib/glean';
+import { MOCK_MASKED_PHONE_NUMBER_WITH_COPY } from '../mocks';
 
 function renderSigninRecoveryChoice(overrides = {}) {
   const defaultProps = {
     handlePhoneChoice: jest.fn(),
+    maskedPhoneNumber: MOCK_MASKED_PHONE_NUMBER_WITH_COPY,
     lastFourPhoneDigits: '1234',
     numBackupCodes: 4,
     signinState: MOCK_SIGNIN_LOCATION_STATE,
@@ -80,7 +82,7 @@ describe('SigninRecoveryChoice', () => {
       screen.getByText('Let’s make sure it’s you using your recovery methods.')
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/Recovery phone/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/••••••1234/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Number ending in 1234/)).toBeInTheDocument();
     expect(
       screen.getByLabelText(/Backup authentication codes/i)
     ).toBeInTheDocument();

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -29,6 +29,7 @@ import GleanMetrics from '../../../lib/glean';
 
 export type SigninRecoveryChoiceProps = {
   handlePhoneChoice: () => Promise<AuthUiError | void>;
+  maskedPhoneNumber: string;
   lastFourPhoneDigits: string;
   numBackupCodes: number;
   signinState: SigninLocationState;
@@ -36,6 +37,7 @@ export type SigninRecoveryChoiceProps = {
 
 const SigninRecoveryChoice = ({
   handlePhoneChoice,
+  maskedPhoneNumber,
   lastFourPhoneDigits,
   numBackupCodes,
   signinState,
@@ -103,7 +105,7 @@ const SigninRecoveryChoice = ({
         'Recovery phone'
       ),
       // This doesn't need localization
-      localizedChoiceInfo: `••••••${lastFourPhoneDigits}`,
+      localizedChoiceInfo: maskedPhoneNumber,
     },
     {
       id: 'recovery-choice-code',

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/en.ftl
@@ -7,7 +7,7 @@ signin-recovery-phone-heading = Enter recovery code
 
 # Text that explains the user should check their phone for a recovery code
 # $maskedPhoneNumber - The users masked phone number
-signin-recovery-phone-instruction-v2 = A six-digit code was sent to <span>{ $maskedPhoneNumber }</span> by text message. This code expires after 5 minutes. Donʼt share this code with anyone.
+signin-recovery-phone-instruction-v3 = A six-digit code was sent to the phone number ending in <span>{ $lastFourPhoneDigits }</span> by text message. This code expires after 5 minutes. Donʼt share this code with anyone.
 
 signin-recovery-phone-input-label = Enter 6-digit code
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -28,9 +28,7 @@ const SigninRecoveryPhone = ({
     React.useState(false);
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const maskedPhoneNumber = `••••••${lastFourPhoneDigits}`;
-
-  const spanElement = <span className="font-bold">{maskedPhoneNumber}</span>;
+  const spanElement = <span className="font-bold">{lastFourPhoneDigits}</span>;
 
   const clearBanners = () => {
     setErrorMessage('');
@@ -124,13 +122,14 @@ const SigninRecoveryPhone = ({
         <h2 className="card-header my-4">Enter recovery code</h2>
       </FtlMsg>
       <FtlMsg
-        id="signin-recovery-phone-instruction-v2"
-        vars={{ maskedPhoneNumber }}
+        id="signin-recovery-phone-instruction-v3"
+        vars={{ lastFourPhoneDigits }}
         elems={{ span: spanElement }}
       >
         <p>
-          A six-digit code was sent to {spanElement} by text message. This code
-          expires after 5 minutes. Donʼt share this code with anyone.
+          A six-digit code was sent to the phone number ending in {spanElement}{' '}
+          by text message. This code expires after 5 minutes. Donʼt share this
+          code with anyone.
         </p>
       </FtlMsg>
       <FormVerifyTotp

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -74,5 +74,7 @@ export const ALL_PRODUCT_PROMO_SERVICES = [{ name: MozServices.Monitor }];
 export const ALL_PRODUCT_PROMO_SUBSCRIPTIONS = [
   { productName: MozServices.MonitorPlus },
 ];
-export const MOCK_MASKED_PHONE_NUMBER = '••••••1234';
 export const MOCK_FULL_PHONE_NUMBER = '+15555551234';
+export const MOCK_NATIONAL_FORMAT_PHONE_NUMBER = '(555) 555-1234';
+export const MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER = '(•••) •••-1234';
+export const MOCK_MASKED_PHONE_NUMBER_WITH_COPY = 'Number ending in 1234';


### PR DESCRIPTION
Because:
* We want to show the national format provided by Twilio to better display phone numbers for users, but want to hide the formatting when a user's session is not verified

This commit:
* Adds a Twilio lookup call at recovery phone number add for nationalFormat, reads nationalFormat from DB when querying recovery phone data
* Updates our server response to return the last 4 digits of a phone number instead of the mask, displays accordingly on the client including new copy
* Updates account resolver recovery phone auth-server call to ensure only the last 4 digits are returned if a user's session is not verified
* postAddRecoveryPhone email copy tweak

closes FXA-11044

<img width="400" alt="image" src="https://github.com/user-attachments/assets/1451772f-6de2-4afa-a358-18d3d07ff848" /> 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8552fb37-85c3-49f1-8877-1607e2a2167f" />


<img width="600" alt="image" src="https://github.com/user-attachments/assets/db9111f5-dd0f-46cc-a97e-468e3c2d3b2d" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/beadd1b9-9457-4a28-b5cb-78825e33621d" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/628c4b78-de75-41ab-9f1e-41e8ef3f582d" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0838085b-2739-4baa-92a7-2f10f673d9cd" />