### PR TITLE
feat(metrics): Add metrics when the bounce check blocks an email

### DIFF
--- a/packages/fxa-auth-server/lib/bounces.js
+++ b/packages/fxa-auth-server/lib/bounces.js
@@ -71,6 +71,7 @@ module.exports = (config, db) => {
         tally.count++;
       }
     });
+    return tallies;
   }
 
   function disabled() {

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -28,7 +28,7 @@ const UTM_PREFIX = 'fx-';
 const X_SES_CONFIGURATION_SET = 'X-SES-CONFIGURATION-SET';
 const X_SES_MESSAGE_TAGS = 'X-SES-MESSAGE-TAGS';
 
-module.exports = function (log, config, bounces) {
+module.exports = function (log, config, bounces, statsd) {
   const oauthClientInfo = require('./oauth_client_info')(log, config);
   const verificationReminders = require('../verification-reminders')(
     log,
@@ -461,6 +461,9 @@ module.exports = function (log, config, bounces) {
     try {
       await bounces.check(to, template);
     } catch (err) {
+      const tags = { template, error: err.errno };
+      statsd.increment('email.bounce.limit', tags);
+
       log.error('email.bounce.limit', {
         err: err.message,
         errno: err.errno,

--- a/packages/fxa-auth-server/lib/senders/index.js
+++ b/packages/fxa-auth-server/lib/senders/index.js
@@ -14,7 +14,7 @@ module.exports = async (
   sender // This is only used in tests
 ) => {
   const defaultLanguage = config.i18n.defaultLanguage;
-  const Mailer = createMailer(log, config, bounces);
+  const Mailer = createMailer(log, config, bounces, statsd);
 
   async function createSenders() {
     return {


### PR DESCRIPTION
## Because

- We want to increment a statsd metric when we are blocked from sending an email.

## This pull request

- Adds a statsd metric when we throw a bouce check exception.
- This change also includes a change to bounces.js that isn't used in the metrics along with tests because it was part of a footgun that I ran into while working on this patch.

## Issue that this pull request solves

Closes: FXA-10964

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
