### PR TITLE
fix(payments): Coupons - Handle error when currency for coupon and cart do not match

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -533,6 +533,9 @@ describe('CartService', () => {
         CartInvalidPromoCodeError
       );
 
+      expect(
+        promotionCodeManager.assertValidPromotionCodeNameForPrice
+      ).toHaveBeenCalledWith(args.promoCode, mockPrice, mockResolvedCurrency);
       expect(cartManager.createCart).not.toHaveBeenCalled();
     });
 
@@ -683,6 +686,13 @@ describe('CartService', () => {
         cartService.restartCart(mockOldCart.id)
       ).rejects.toThrowError(CartInvalidPromoCodeError);
 
+      expect(
+        promotionCodeManager.assertValidPromotionCodeNameForPrice
+      ).toHaveBeenCalledWith(
+        mockOldCart.couponCode,
+        mockPrice,
+        mockOldCart.currency
+      );
       expect(cartManager.createCart).not.toHaveBeenCalled();
       expect(cartManager.finishErrorCart).toHaveBeenCalled();
     });
@@ -998,6 +1008,13 @@ describe('CartService', () => {
           cartService.updateCart(mockCart.id, mockCart.version, mockUpdateCart)
         ).rejects.toBeInstanceOf(CouponErrorExpired);
 
+        expect(
+          promotionCodeManager.assertValidPromotionCodeNameForPrice
+        ).toHaveBeenCalledWith(
+          mockUpdateCart.couponCode,
+          mockPrice,
+          mockUpdateCart.currency
+        );
         expect(cartManager.updateFreshCart).not.toHaveBeenCalledWith();
         expect(cartManager.finishErrorCart).toHaveBeenCalled();
       });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -262,7 +262,8 @@ export class CartService {
       try {
         await this.promotionCodeManager.assertValidPromotionCodeNameForPrice(
           args.promoCode,
-          price
+          price,
+          currency
         );
       } catch (e) {
         throw new CartInvalidPromoCodeError(args.promoCode);
@@ -318,7 +319,8 @@ export class CartService {
 
           await this.promotionCodeManager.assertValidPromotionCodeNameForPrice(
             oldCart.couponCode,
-            price
+            price,
+            oldCart.currency || DEFAULT_CURRENCY
           );
         } catch (e) {
           throw new CartInvalidPromoCodeError(oldCart.couponCode);
@@ -491,7 +493,8 @@ export class CartService {
 
         await this.promotionCodeManager.assertValidPromotionCodeNameForPrice(
           cartDetails.couponCode,
-          price
+          price,
+          cartDetails.currency || DEFAULT_CURRENCY
         );
       }
 

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -304,7 +304,11 @@ describe('CheckoutService', () => {
       it('fetches promotion code by name', async () => {
         expect(
           promotionCodeManager.assertValidPromotionCodeNameForPrice
-        ).toHaveBeenCalledWith(mockCart.couponCode, mockPrice);
+        ).toHaveBeenCalledWith(
+          mockCart.couponCode,
+          mockPrice,
+          mockCart.currency
+        );
       });
     });
 

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -188,7 +188,8 @@ export class CheckoutService {
       try {
         await this.promotionCodeManager.assertValidPromotionCodeNameForPrice(
           cart.couponCode,
-          price
+          price,
+          cart.currency
         );
 
         promotionCode = await this.promotionCodeManager.retrieveByName(

--- a/libs/payments/customer/src/lib/promotionCode.manager.ts
+++ b/libs/payments/customer/src/lib/promotionCode.manager.ts
@@ -9,7 +9,10 @@ import {
   StripePrice,
   StripePromotionCode,
 } from '@fxa/payments/stripe';
-import { PromotionCodeCouldNotBeAttachedError } from './error';
+import {
+  CouponErrorInvalid,
+  PromotionCodeCouldNotBeAttachedError,
+} from './error';
 import { assertPromotionCodeApplicableToPrice } from './util/assertPromotionCodeApplicableToPrice';
 import { assertPromotionCodeActive } from './util/assertPromotionCodeActive';
 import { getPriceFromSubscription } from './util/getPriceFromSubscription';
@@ -33,11 +36,15 @@ export class PromotionCodeManager {
 
   async assertValidPromotionCodeNameForPrice(
     promoCodeName: string,
-    price: StripePrice
+    price: StripePrice,
+    cartCurrency: string
   ) {
     const promoCode = await this.retrieveByName(promoCodeName);
     if (!promoCode)
       throw new PromotionCodeCouldNotBeAttachedError('PromoCode not found');
+
+    if (promoCode.coupon.currency !== cartCurrency)
+      throw new CouponErrorInvalid();
 
     await this.assertValidPromotionCodeForPrice(promoCode, price);
   }

--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
@@ -241,7 +241,10 @@ const Expanded = ({
         </Form.Message>
         {serverErrors.productNotAvailable && (
           <Form.Message>
-            <Localized id="select-tax-location-product-not-available">
+            <Localized
+              id="select-tax-location-product-not-available"
+              vars={{ productName }}
+            >
               <p className="mt-1 text-alert-red" role="alert">
                 {productName} is not available in this location.
               </p>


### PR DESCRIPTION
## Because

- it currently crashes if currency for coupon and cart do not match

## This pull request

- handles the error when currency for coupon and cart do not match
- customer will see an `The code you entered is invalid.` error message

## Issue that this pull request solves

Closes: FXA-10915

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots 
<img width="1071" alt="Screenshot 2025-02-11 at 9 53 56 AM" src="https://github.com/user-attachments/assets/9dc6da25-bdb1-4792-8a13-8b537817ea16" />