### PR TITLE
task(recovery-phone): Add check for sms pumping risk

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
@@ -9,7 +9,6 @@ import {
   RecoveryPhoneFactory,
 } from '@fxa/shared/db/mysql/account';
 import { Test } from '@nestjs/testing';
-import { RecoveryPhoneFactory } from '@fxa/shared/db/mysql/account';
 
 describe('RecoveryPhoneManager', () => {
   let recoveryPhoneManager: RecoveryPhoneManager;

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.config.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.config.ts
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsArray, IsBoolean, IsObject } from 'class-validator';
+import { IsArray, IsBoolean, IsNumber, IsObject } from 'class-validator';
 
 export class RecoveryPhoneServiceConfig {
   @IsArray()
   public validNumberPrefixes?: Array<string>;
+
+  @IsNumber()
+  public smsPumpingRiskThreshold?: number;
 }
 
 export class RecoveryPhoneConfig {

--- a/libs/accounts/recovery-phone/src/lib/sms.manager.config.ts
+++ b/libs/accounts/recovery-phone/src/lib/sms.manager.config.ts
@@ -19,4 +19,7 @@ export class SmsManagerConfig {
 
   @IsArray()
   public readonly validNumberPrefixes!: Array<string>;
+
+  @IsArray()
+  public readonly extraLookupFields!: Array<string>;
 }

--- a/libs/accounts/recovery-phone/src/lib/sms.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/sms.manager.ts
@@ -31,7 +31,7 @@ export class SmsManager {
   public async phoneNumberLookup(phoneNumber: string) {
     const result = await this.client.lookups.v2
       .phoneNumbers(phoneNumber)
-      .fetch();
+      .fetch({ fields: this.config.extraLookupFields.join(',') });
     // Calling toJSON converts PhoneNumberInstance into a
     // object that just holds state and can be serialized.
     return result.toJSON();

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -246,6 +246,7 @@ async function run(config) {
     smsManager,
     otpCodeManager,
     config.recoveryPhone,
+    statsd,
     log
   );
   Container.set(RecoveryPhoneService, recoveryPhoneService);

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2213,6 +2213,18 @@ const convictConf = convict({
         env: 'RECOVERY_PHONE__SMS__MAX_RETRIES',
         format: Number,
       },
+      smsPumpingRiskThreshold: {
+        default: 75,
+        doc: 'Max sms pumping risk score allowed. Value is from 0 to 100. e.g. 74-90 is moderate risk. See twilio docs for more info. https://www.twilio.com/docs/lookup/v2-api/sms-pumping-risk',
+        env: 'RECOVERY_PHONE__SMS__SMS_PUMPING_RISK_THRESHOLD',
+        format: Number,
+      },
+      extraLookupFields: {
+        default: ['sms_pumping_risk'],
+        doc: 'Extra data to fetch about phone numbers being registered for sms backup.',
+        env: 'RECOVERY_PHONE__SMS__EXTRA_LOOKUP_FIELDS',
+        format: Array,
+      },
     },
   },
   twilio: {


### PR DESCRIPTION
## Because

- We want to block phone numbers suspected of SMS pumping

## This pull request

- Adds threshold
- Adds configuration to add extra data fields to look up api call
- Adds metrics around sim pumping risk scores and rejections
- Adds statsd to recovery phone service

## Issue that this pull request solves

Closes:FXA-11065

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
