### PR TITLE
fix(payments-next): Ensure button and redirects work on error page

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -51,7 +51,7 @@ const getErrorReason = (
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
-        buttonUrl: `/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `${config.contentServerUrl}/subscriptions`,
         message:
           'You can still get this product — please contact support so we can help you.',
         messageFtl: 'next-iap-upgrade-contact-support',
@@ -60,7 +60,7 @@ const getErrorReason = (
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
         message: 'Something went wrong. Please try again later.',
         messageFtl: 'next-basic-error-message',
       };


### PR DESCRIPTION
## This pull request

- [x] Updates link for `Try Again` button
- [x] Updates link for `Manage my subscriptions` button

## Issue that this pull request solves

Closes: FXA-11096

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.