### PR TITLE
feat(sms): Revoke old recovery phone codes when sending new code

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.in.spec.ts
@@ -9,7 +9,6 @@ import {
   RecoveryPhoneFactory,
 } from '@fxa/shared/db/mysql/account';
 import { Test } from '@nestjs/testing';
-import { RecoveryPhoneFactory } from '@fxa/shared/db/mysql/account';
 
 describe('RecoveryPhoneManager', () => {
   let recoveryPhoneManager: RecoveryPhoneManager;

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -104,7 +104,7 @@ describe('RecoveryPhoneService', () => {
     expect(result).toBeTruthy();
   });
 
-  it('Should send new code for setup phone number ', async () => {
+  it('Should send new code for setup phone number', async () => {
     mockOtpManager.generateCode.mockReturnValue(code);
     mockRecoveryPhoneManager.getAllUnconfirmed.mockResolvedValue([
       'this:is:the:code123',
@@ -383,6 +383,48 @@ describe('RecoveryPhoneService', () => {
       const error = new RecoveryNumberNotExistsError(uid);
       mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockRejectedValue(error);
       expect(service.sendCode(uid)).rejects.toThrow(error);
+    });
+
+    it('Should send new code for setup phone number', async () => {
+      mockOtpManager.generateCode.mockReturnValue(code);
+      mockRecoveryPhoneManager.getAllUnconfirmed.mockResolvedValue([
+        'this:is:the:code123',
+        'this:is:the:code456',
+      ]);
+
+      mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockResolvedValueOnce({
+        phoneNumber,
+      });
+      mockOtpManager.generateCode.mockResolvedValueOnce(code);
+      mockSmsManager.sendSMS.mockResolvedValue({ status: 'success' });
+
+      const result = await service.sendCode(uid);
+
+      expect(result).toBeTruthy();
+      expect(mockRecoveryPhoneManager.getConfirmedPhoneNumber).toBeCalledWith(
+        uid
+      );
+      expect(mockRecoveryPhoneManager.storeUnconfirmed).toBeCalledWith(
+        uid,
+        code,
+        phoneNumber,
+        false
+      );
+      expect(mockOtpManager.generateCode).toBeCalled();
+      expect(mockSmsManager.sendSMS).toBeCalledWith({
+        to: phoneNumber,
+        body: code,
+      });
+
+      expect(mockRecoveryPhoneManager.removeCode).toBeCalledWith(
+        uid,
+        'code123'
+      );
+      expect(mockRecoveryPhoneManager.removeCode).toBeCalledWith(
+        uid,
+        'code456'
+      );
+      expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
     });
   });
 


### PR DESCRIPTION
## Because

- We want to be consistent with how we revoke codes

## This pull request

- Revokes the older unconfirmed codes

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11130

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
