### PR TITLE
bug(auth): fix broken @fxa imports

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -10,11 +10,11 @@
   },
   "scripts": {
     "prebuild": "nx l10n-prime && nx install-ejs",
-    "build": "nx build-l10n && nx build-ts && nx build-css && nx build-finalize",
+    "build": "nx build-l10n && nx build-css && nx build-ts && nx build-copy-assets",
     "build-l10n": "nx l10n-merge && nx l10n-merge-test",
+    "build-copy-assets": "./scripts/copy-assets.sh",
     "build-css": "nx emails-scss",
     "build-ts": "tsc --build && tsc-alias",
-    "build-finalize": "cp -R config public lib scripts dist/packages/fxa-auth-server",
     "build-storybook": "NODE_OPTIONS=--openssl-legacy-provider STORYBOOK_BUILD=true storybook build && yarn build-storybook-copy-locales && yarn build-storybook-copy-templates",
     "build-storybook-copy-locales": "mkdir -p ./storybook-static/public/locales && cp -R ./public/locales ./storybook-static/public",
     "build-storybook-copy-templates": "mkdir -p ./storybook-static/lib/senders/emails/templates && cp -R ./lib/senders/emails ./storybook-static/lib/senders",

--- a/packages/fxa-auth-server/scripts/copy-assets.sh
+++ b/packages/fxa-auth-server/scripts/copy-assets.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+#Make sure all directories exist
+find config lib scripts bin public -type d | \
+xargs -L1 bash -c 'mkdir -p dist/packages/fxa-auth-server/$0'
+
+# Copy all non-code files into the dist. Basically everything except javascript, typescript and shell scripts.
+find config lib scripts bin public -type f | \
+grep --invert -E "\.js$|\.ts$|\.sh" | \
+xargs -L1 bash -c 'cp $0 dist/packages/fxa-auth-server/$0'

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -14,9 +14,11 @@
     "noImplicitAny": false
   },
   "include": [
-    "bin/*", // Include bin so that it's included in `build-ts`, specifically for "tsc-alias".
-    "lib/**/*.ts",
-    "lib/**/*.js",
-    "scripts/**/*.ts"
+    // Note, we want to include javascript and type script files. This ensures
+    // ts aliases (ie imports for @fxa/...) work.
+    "bin/*",
+    "config/*",
+    "lib/**/*",
+    "scripts/**/*"
   ]
 }


### PR DESCRIPTION
## Because
- Build finalize was clobbering js output produces by `build-ts` which effectively undid any `tsc-aliases` applied by typescript compilation


## This pull request
- Creates a script for copying assets and not code
- Removes the `build-finalize` script that was clobbering assets


## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This was an attempt to fix a deploy issue in train-304. Note that previous fix is [here](https://github.com/mozilla/fxa/pull/18365), which would have worked if not for this problem... 

To validate / see why this fix works do the following:

- Check out main
- run `cd packages/fxa-auth-server`
- run `yarn build`
- run `cat dist/packages/fxa-auth-server/lib/routes/totp.js | grep @fxa`

Prior to this change the last file would have picked up a couple lines.
