### PR TITLE
task(recovery-phone): Allow some operations when recovery phone config enabled is false

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -535,22 +535,11 @@ describe('RecoveryPhoneService', () => {
       mockRecoveryPhoneConfig.enabled = true;
     });
     it('can disable', () => {
-      expect(service.available(uid, 'US')).rejects.toEqual(
-        new RecoveryPhoneNotEnabled()
-      );
+      expect(service.available(uid, 'US')).resolves.toEqual(false);
       expect(service.confirmSetupCode(uid, '000000')).rejects.toEqual(
         new RecoveryPhoneNotEnabled()
       );
       expect(service.confirmSigninCode(uid, '000000')).rejects.toEqual(
-        new RecoveryPhoneNotEnabled()
-      );
-      expect(service.hasConfirmed(uid)).rejects.toEqual(
-        new RecoveryPhoneNotEnabled()
-      );
-      expect(() => service.stripPhoneNumber('+15550005555')).toThrow(
-        new RecoveryPhoneNotEnabled()
-      );
-      expect(service.removePhoneNumber(uid)).rejects.toEqual(
         new RecoveryPhoneNotEnabled()
       );
       expect(service.sendCode(uid)).rejects.toEqual(

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -40,7 +40,7 @@ export class RecoveryPhoneService {
    */
   public async available(uid: string, region: string): Promise<boolean> {
     if (!this.config.enabled) {
-      throw new RecoveryPhoneNotEnabled();
+      return false;
     }
 
     if (!this.config.allowedRegions?.includes(region)) {
@@ -241,10 +241,6 @@ export class RecoveryPhoneService {
    * @returns True if successful
    */
   public async removePhoneNumber(uid: string) {
-    if (!this.config.enabled) {
-      throw new RecoveryPhoneNotEnabled();
-    }
-
     const hasRecoveryCodes = await this.recoveryPhoneManager.hasRecoveryCodes(
       uid
     );
@@ -279,10 +275,6 @@ export class RecoveryPhoneService {
     phoneNumber?: string;
     nationalFormat?: string;
   }> {
-    if (!this.config.enabled) {
-      throw new RecoveryPhoneNotEnabled();
-    }
-
     try {
       const { phoneNumber, nationalFormat } =
         await this.recoveryPhoneManager.getConfirmedPhoneNumber(uid);
@@ -316,9 +308,6 @@ export class RecoveryPhoneService {
    * @returns The last N number of digits of the phone number
    */
   public stripPhoneNumber(phoneNumber: string, lastN?: number) {
-    if (!this.config.enabled) {
-      throw new RecoveryPhoneNotEnabled();
-    }
     // No stripping needed, session is verified
     if (lastN === undefined) {
       return phoneNumber;


### PR DESCRIPTION
## Because

- We only want to safe guard against calls that might incur costs
- Disabling / enabling of features can be done through UI feature flags

## This pull request

- Removes config.enabled checks in: available, removePhoneNumber, hasConfirmed and stripPhoneNumber

## Issue that this pull request solves

Closes: FXA-11064

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
