### PR TITLE
feat(metrics): Add missing metrics for recovery phone

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -141,7 +141,8 @@ module.exports = function (
     db,
     glean,
     log,
-    mailer
+    mailer,
+    statsd
   );
   const securityEvents = require('./security-events')(log, db, config);
   const session = require('./session')(

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -38,6 +38,10 @@ describe('/recovery_phone', () => {
     check: sandbox.fake(),
     checkAuthenticated: sandbox.fake(),
   };
+  const mockStatsd = {
+    increment: sandbox.fake(),
+    histogram: sandbox.fake(),
+  };
   const mockGlean = {
     twoStepAuthPhoneCode: {
       sent: sandbox.fake(),
@@ -75,7 +79,8 @@ describe('/recovery_phone', () => {
       mockDb,
       mockGlean,
       mockLog,
-      mockMailer
+      mockMailer,
+      mockStatsd
     );
   });
 
@@ -123,6 +128,10 @@ describe('/recovery_phone', () => {
           ipAddr: '63.245.221.32',
           tokenId: undefined,
         }
+      );
+      assert.calledOnceWithExactly(
+        mockStatsd.increment,
+        'account.recoveryPhone.signinSendCode.success'
       );
     });
 
@@ -210,6 +219,10 @@ describe('/recovery_phone', () => {
       assert.equal(
         mockCustoms.checkAuthenticated.getCall(0).args[2],
         'recoveryPhoneCreate'
+      );
+      assert.calledOnceWithExactly(
+        mockStatsd.increment,
+        'account.recoveryPhone.setupPhoneNumber.success'
       );
     });
 
@@ -363,6 +376,11 @@ describe('/recovery_phone', () => {
           tokenId: undefined,
         }
       );
+
+      assert.calledOnceWithExactly(
+        mockStatsd.increment,
+        'account.recoveryPhone.phoneAdded.success'
+      );
     });
 
     it('indicates a failure confirming code', async () => {
@@ -439,6 +457,10 @@ describe('/recovery_phone', () => {
           tokenId: undefined,
         }
       );
+      assert.calledOnceWithExactly(
+        mockStatsd.increment,
+        'account.recoveryPhone.phoneSignin.success'
+      );
     });
 
     it('fails confirms a code during signin', async () => {
@@ -495,6 +517,10 @@ describe('/recovery_phone', () => {
           ipAddr: '63.245.221.32',
           tokenId: undefined,
         }
+      );
+      assert.calledOnceWithExactly(
+        mockStatsd.increment,
+        'account.recoveryPhone.phoneRemoved.success'
       );
     });
 


### PR DESCRIPTION
## Because

- We wanted additional statsd metrics for sms

## This pull request

- Adds statsd metrics
  - **Graph for Lookup Phone Number error**
  - **Graph for Lookup Phone Number success**
    - Potential sim swap
    - Potential sim pumping risk
  - **Graph for Recovery Phone Added**
  - **Graph for Recovery Phone Setup Confirmed**
  - **Graph for Recovery Phone SignIn Confirmed**
  - **Graph for Recovery Phone Removed**
- Updates our routes to also replace `this.log.info` with statsd

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11128
Closes: https://mozilla-hub.atlassian.net/browse/FXA-11067

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Dashboards have been started here https://yardstick.mozilla.org/d/eed2dadjju48wc/fxa-sms?orgId=1&from=now-6h&to=now&timezone=browser
