### PR TITLE
fix(sms): Disable playwright tests for recovery phone for stage/prod

### DIFF
--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -18,9 +18,10 @@ import { getCode } from 'fxa-settings/src/lib/totp';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('recovery phone', () => {
-    test.beforeEach(async ({ pages: { configPage } }) => {
+    test.beforeEach(async ({ pages: { configPage } }, { project }) => {
       // Ensure that the feature flag is enabled
       const config = await configPage.getConfig();
+      test.fixme(project.name !== 'local', 'FXA-11159');
       test.skip(config.featureFlags.enableAdding2FABackupPhone !== true);
       test.skip(config.featureFlags.enableUsing2FABackupPhone !== true);
     });


### PR DESCRIPTION
## Because

- The recovery phone tests need access to redis to get the code

## This pull request

- Disables the test until we have a better solution for peeking at codes for tests
- Cleans up some redis error logging in tests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11157

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
