### PR TITLE
fix(recovery-phone): Don't strip nationalFormat number after successful setup

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -303,7 +303,9 @@ class RecoveryPhoneHandler {
 
         try {
           const { phoneNumber, nationalFormat } =
-            await this.recoveryPhoneService.hasConfirmed(uid, 4);
+            // User has successfully set up a recovery phone. Give back the
+            // full nationalFormat (don't strip it).
+            await this.recoveryPhoneService.hasConfirmed(uid);
           await this.mailer.sendPostAddRecoveryPhoneEmail(
             account.emails,
             account,

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -342,6 +342,9 @@ describe('/recovery_phone', () => {
 
       assert.isDefined(resp);
       assert.equal(resp.status, 'success');
+      // Gives back the full national format as the user just successfully
+      // confirmed the code
+      assert.equal(resp.nationalFormat, nationalFormat);
       assert.equal(mockRecoveryPhoneService.confirmSetupCode.callCount, 1);
       assert.equal(
         mockRecoveryPhoneService.confirmSetupCode.getCall(0).args[0],


### PR DESCRIPTION
Because:
* We are stripping the nationalFormat from Twilio to only return 4 digits, even though the response in question is for a successful recovery phone set up

This commit:
* Returns the full nationalFormat in this case, as the user is logged in and confirmed their code

fixes FXA-11162
fixes FXA-11166