### PR TITLE
fix(paypal): Fix map accessing for paypal country code

### DIFF
--- a/libs/payments/paypal/src/lib/paypal.client.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.ts
@@ -231,7 +231,6 @@ export class PayPalClient {
     const data = {
       AMT: options.amount,
       CURRENCYCODE: options.currencyCode.toUpperCase(),
-      COUNTRYCODE: options.countryCode.toUpperCase(),
       CUSTOM: options.idempotencyKey,
       INVNUM: options.invoiceNumber,
       ...(options.ipaddress && { IPADDRESS: options.ipaddress }),
@@ -239,6 +238,9 @@ export class PayPalClient {
       PAYMENTACTION: 'Sale',
       PAYMENTTYPE: 'instant',
       REFERENCEID: options.billingAgreementId,
+      ...(options.countryCode && {
+        COUNTRYCODE: options.countryCode.toUpperCase(),
+      }),
       ...(options.taxAmount && {
         TAXAMT: options.taxAmount,
         // PayPal wants all of this when you include taxes 🤷

--- a/libs/payments/paypal/src/lib/paypal.client.types.ts
+++ b/libs/payments/paypal/src/lib/paypal.client.types.ts
@@ -145,7 +145,7 @@ export interface DoReferenceTransactionOptions {
   invoiceNumber: string;
   idempotencyKey: string;
   currencyCode: string;
-  countryCode: string;
+  countryCode?: string;
   taxAmount?: string;
   ipaddress?: string;
 }


### PR DESCRIPTION
Because:

* The paypal country code logic is required by finance, but is a Map not a POJO, and can't be accessed via bracket notation

This commit:

* Fixes this

Closes #FXA-11174

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
