### PR TITLE
task(recovery-phone): Add support for message status updates

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/twilio.config.ts
+++ b/libs/accounts/recovery-phone/src/lib/twilio.config.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsString } from 'class-validator';
+import { IsBoolean, IsString } from 'class-validator';
 
 /**
  * Configuration for twilio client. See twilio SDK docs for more details.
@@ -12,4 +12,8 @@ export class TwilioConfig {
   accountSid!: string;
   @IsString()
   authToken!: string;
+  @IsString()
+  webhookUrl!: string;
+  @IsBoolean()
+  validateWebhookCalls!: boolean;
 }

--- a/libs/accounts/recovery-phone/src/lib/twilio.provider.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/twilio.provider.spec.ts
@@ -15,6 +15,8 @@ describe('TwilioFactory', () => {
   const MockTwilioConfig = {
     accountSid: 'AC',
     authToken: '',
+    webhookUrl: 'https://accounts.firefox.com/v1/recovery_phone/message_status',
+    validateWebhookCalls: true,
   } satisfies TwilioConfig;
 
   const MockTwilioConfigProvider = {

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2239,6 +2239,16 @@ const convictConf = convict({
       doc: 'Twilio Auth Token, required to access api',
       env: 'RECOVERY_PHONE__TWILIO__AUTH_TOKEN',
     },
+    webhookUrl: {
+      default: 'http://localhost:9000/v1/recovery_phone/message_status',
+      doc: 'Webhook url registered with twilio for message status updates',
+      env: 'RECOVERY_PHONE__TWILIO__WEBHOOK_URL',
+    },
+    validateWebhookCalls: {
+      default: true,
+      doc: 'Controls if twilio signature is validated during webhook calls from twilio',
+      env: 'RECOVERY_PHONE__TWILIO__VALIDATE_WEBHOOK_CALLS',
+    },
   },
 });
 

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/twilio-signature.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/twilio-signature.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Container } from 'typedi';
+import { Request, ResponseToolkit } from '@hapi/hapi';
+import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
+import AppError from '../../error';
+
+export const strategy = function () {
+  // Resolve the recovery phone service from typedi. This service
+  // is a wrapper around the calls to the twilio sdk needed to
+  // authenticate incoming requests.
+  const recoveryPhoneService = Container.get(RecoveryPhoneService);
+  if (!recoveryPhoneService) {
+    throw new Error('RecoveryPhoneService not registered with typedi');
+  }
+
+  return () => ({
+    authenticate: async function (req: Request, h: ResponseToolkit) {
+      const signature = req.headers['X-Twilio-Signature'];
+      if (!signature) {
+        throw AppError.unauthorized('X-Twilio-Signature header missing');
+      }
+
+      if (typeof req.payload !== 'object') {
+        throw AppError.unauthorized('Invalid payload');
+      }
+
+      const valid = recoveryPhoneService.validateTwilioSignature(
+        req.headers['X-Twilio-Signature'],
+        req.payload
+      );
+
+      // Signature invalid. Deny request
+      if (!valid) {
+        throw AppError.unauthorized('X-Twilio-Signature header invalid');
+      }
+      return { signature };
+    },
+  });
+};

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -430,7 +430,6 @@ module.exports = function (
       },
       handler: async function (request) {
         log.begin('Session.resend_code', request);
-        console.log('!!! resend code');
         const sessionToken = request.auth.credentials;
 
         request.emitMetricsEvent('session.resend_code');
@@ -481,14 +480,12 @@ module.exports = function (
         if (account.primaryEmail.isVerified) {
           // Unverified emails mean that the user is attempting to resend the code from signup page,
           // therefore they get sent a different email template with the code.
-          console.log('!!! sendVerifyLoginCodeEmail', account.email);
           await mailer.sendVerifyLoginCodeEmail(
             account.emails,
             account,
             options
           );
         } else {
-          console.log('!!! sendVerifyShortCodeEmail');
           await mailer.sendVerifyShortCodeEmail([], account, options);
         }
 

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -13,6 +13,7 @@ const userAgent = require('fxa-shared/lib/user-agent').parseToScalars;
 const schemeRefreshToken = require('./routes/auth-schemes/refresh-token');
 const authOauth = require('./routes/auth-schemes/auth-oauth');
 const sharedSecretAuth = require('./routes/auth-schemes/shared-secret');
+const twilioSignatureAuth = require('./routes/auth-schemes/twilio-signature');
 const pubsubAuth = require('./routes/auth-schemes/pubsub');
 const googleOIDC = require('./routes/auth-schemes/google-oidc');
 const { HEX_STRING } = require('./routes/validators');
@@ -475,6 +476,10 @@ async function create(log, error, config, routes, db, statsd, glean) {
     googleOIDC.strategy(config.cloudScheduler.oidc)
   );
   server.auth.strategy('cloudSchedulerOIDC', 'cloudSchedulerOIDC');
+
+  // Authorizes incoming webhook calls from Twilio
+  server.auth.scheme('twilioSignature', twilioSignatureAuth.strategy());
+  server.auth.strategy('twilioSignature', 'twilioSignature');
 
   // register all plugins and Swagger configuration
   await server.register([

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/twilio-signature.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/twilio-signature.js
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { Container } = require('typedi');
+const { assert } = require('chai');
+const AppError = require('../../../../lib/error');
+const {
+  strategy,
+} = require('../../../../lib/routes/auth-schemes/twilio-signature');
+const { RecoveryPhoneService } = require('@fxa/accounts/recovery-phone');
+const sinon = require('sinon');
+
+describe('lib/routes/auth-schemes/twilio-signature', () => {
+  let mockRecoveryPhoneService;
+  let tempRecoveryPhoneService;
+
+  function getTwilioAuth() {
+    return strategy()();
+  }
+
+  before(() => {
+    tempRecoveryPhoneService = Container.get(RecoveryPhoneService);
+    mockRecoveryPhoneService = {
+      // There is already test coverage that signature validation works
+      // in the recovery-phone library, so using a simplified mock here.
+      validateTwilioSignature: sinon.fake((signature) => {
+        return signature === 'VALID_SIGNATURE';
+      }),
+    };
+    Container.set(RecoveryPhoneService, mockRecoveryPhoneService);
+  });
+
+  after(() => {
+    Container.set(RecoveryPhoneService, tempRecoveryPhoneService);
+  });
+
+  it('should return valid signature', async () => {
+    const request = {
+      headers: { 'X-Twilio-Signature': 'VALID_SIGNATURE' },
+      payload: { foo: 'bar' },
+    };
+    const result = await getTwilioAuth().authenticate(request, { foo: 'bar' });
+    assert.equal(result.signature, 'VALID_SIGNATURE');
+  });
+
+  it('throw on missing header', async () => {
+    const request = {
+      headers: {},
+      payload: { foo: 'bar' },
+    };
+    try {
+      await getTwilioAuth().authenticate(request, {});
+      assert.fail('Missing X-Twilio-Signature header should have thrown');
+    } catch (err) {
+      assert.deepEqual(
+        err,
+        AppError.unauthorized('X-Twilio-Signature header missing')
+      );
+    }
+  });
+
+  it('should throw on missing payload', async () => {
+    const request = {
+      headers: { 'X-Twilio-Signature': 'VALID_SIGNATURE' },
+    };
+    try {
+      await getTwilioAuth().authenticate(request, {});
+      assert.fail('Missing payload should have thrown');
+    } catch (err) {
+      assert.deepEqual(err, AppError.unauthorized('Invalid payload'));
+    }
+  });
+
+  it('should throw on invalid signature', async () => {
+    const request = {
+      headers: { 'X-Twilio-Signature': 'INVALID_SIGNATURE' },
+      payload: { foo: 'bar' },
+    };
+    try {
+      await getTwilioAuth().authenticate(request);
+      assert.fail('Invalid X-Twilio-Signature header should have thrown');
+    } catch (err) {
+      assert.deepEqual(
+        err,
+        AppError.unauthorized('X-Twilio-Signature header invalid')
+      );
+    }
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -60,6 +60,7 @@ describe('/recovery_phone', () => {
     removePhoneNumber: sandbox.fake(),
     stripPhoneNumber: sandbox.fake(),
     hasConfirmed: sandbox.fake(),
+    onMessageStatusUpdate: sandbox.fake(),
   };
   const mockAccountManager = {
     verifySession: sandbox.fake(),
@@ -628,6 +629,37 @@ describe('/recovery_phone', () => {
         uid
       );
       assert.equal(mockRecoveryPhoneService.hasConfirmed.getCall(0).args[1], 4);
+    });
+  });
+
+  describe('POST /recovery_phone/message_status', async () => {
+    it('handles a message status update from twilio', async () => {
+      mockRecoveryPhoneService.onMessageStatusUpdate =
+        sinon.fake.resolves(undefined);
+
+      const payload = {
+        AccountSid: 'AC123',
+        MessageSid: 'M123',
+        From: '+1234567890',
+        MessageStatus: 'delivered',
+        RawDlrDoneDate: 'TWILIO_DATE_FORMAT',
+      };
+
+      const resp = await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/message_status',
+        headers: {
+          'X-Twilio-Signature': 'VALID_SIGNATURE',
+        },
+        payload,
+      });
+
+      assert.isDefined(resp);
+      assert.equal(mockRecoveryPhoneService.onMessageStatusUpdate.callCount, 1);
+      assert.equal(
+        mockRecoveryPhoneService.onMessageStatusUpdate.getCall(0).args[0],
+        payload
+      );
     });
   });
 });


### PR DESCRIPTION
## Because
- We want to monitor sms delivery status

## This pull request
- Adds endpoint for twilio webhook
- Logs info about delivery status
- Records metrics about delivery status

## Issue that this pull request solves

Closes: FXA-11133

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We can fully test this once we get it on stage. 
