### PR TITLE
fix(settings): Refresh recovery phone service availability on delete

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.stories.tsx
@@ -7,7 +7,7 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import PageRecoveryPhoneRemove from '.';
 import { LocationProvider } from '@reach/router';
-import { mockAppContext } from '../../../models/mocks';
+import { mockAppContext, MOCK_ACCOUNT } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 
 export default {
@@ -16,12 +16,20 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+const account = {
+  ...MOCK_ACCOUNT,
+  recoveryPhone: {
+    exists: true,
+    phoneNumber: '123-456-7890',
+    available: true,
+  },
+  removeRecoveryPhone: () => true,
+} as unknown as Account;
+
 export const Default = () => (
   <AppContext.Provider
     value={mockAppContext({
-      account: {
-        removeRecoveryPhone: () => {},
-      } as unknown as Account,
+      account,
     })}
   >
     <LocationProvider>

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@reach/router', () => ({
 }));
 
 const account = {
+  refresh: jest.fn(),
   removeRecoveryPhone: jest.fn().mockResolvedValue({}),
   recoveryPhone: { phoneNumber: MOCK_FULL_PHONE_NUMBER },
 } as unknown as Account;

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
@@ -54,7 +54,10 @@ const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
   const clickRemoveRecoveryPhone = useCallback(async () => {
     try {
       await account.removeRecoveryPhone();
-
+      // get the latest status of recovery phone info and availability
+      // ensure correct data is shown on the settings page
+      // and that service availability is correctly checked against current location
+      await account.refresh('recoveryPhone');
       alertSuccessAndGoHome();
     } catch (e) {
       const localizedError = getLocalizedErrorMessage(ftlMsgResolver, e);

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1392,22 +1392,6 @@ export class Account implements AccountData {
     const result = await this.withLoadingStatus(
       this.authClient.recoveryPhoneDelete(sessionToken()!)
     );
-
-    const cache = this.apolloClient.cache;
-    cache.modify({
-      id: cache.identify({ __typename: 'Account' }),
-      fields: {
-        recoveryPhone() {
-          return {
-            exists: false,
-            phoneNumber: null,
-            nationalFormat: null,
-            available: true,
-          };
-        },
-      },
-    });
-
     return result;
   }
 


### PR DESCRIPTION
## Because

* Recovery phone information and removal option are shown for any user that has enabled the service, even if they are not located in a supported location for setup
* After removing the phone number, service availability should be checked to determine if the user should be able to add another phone number

## This pull request

* refresh recovery phone info after removing phone (this will force a geodb check for service availability)

## Issue that this pull request solves

Closes: #FXA-11165

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
