### PR TITLE
fix(ci): set jest maxWorkers to 1

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -1,3 +1,6 @@
 const nxPreset = require('@nx/jest/preset').default;
 
-module.exports = { ...nxPreset };
+module.exports = {
+  ...nxPreset,
+  maxWorkers: 1,
+};


### PR DESCRIPTION
We are seeing jest processes being killed  when running jest tests in CI.  It started happening after the increased the nx parallelism level to 2.