### PR TITLE
fix(bug): Fix phone number input, dont show country name

### DIFF
--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
@@ -119,7 +119,7 @@ const InputPhoneNumber = ({
         )}
         onChange={handleCountryChange}
         value={selectedCountry.id}
-        className={`bg-transparent border border-grey-200 rounded-md py-2 ps-10 w-[60px] me-2 focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus ${selectedCountry.classNameFlag} bg-no-repeat bg-[length:1.5rem_1rem] bg-[40%_50%]`}
+        className={`bg-transparent border border-grey-200 rounded-md py-2 ps-10 w-[60px] me-2 focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus ${selectedCountry.classNameFlag} bg-no-repeat bg-[length:1.5rem_1rem] bg-[40%_50%] text-transparent`}
       >
         {/* Default country is always first */}
         <option


### PR DESCRIPTION
## Because

- The style is off in Safari

## This pull request

- Fixes the styling in Safari to not show country

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11189

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
![Screenshot 2025-02-24 at 1 06 14 PM](https://github.com/user-attachments/assets/8655556b-9694-47f0-a0e6-8599b7795cf2)

After:
![Screenshot 2025-02-24 at 1 05 40 PM](https://github.com/user-attachments/assets/ada46fd1-c775-4530-b532-738a9eb8de9c)


## Other information (Optional)

I didn't test this on mobile but Safari had the same issue on OSX. Since both are webkit it should work.
