### PR TITLE
fix(bug): Ensure `unlink` route is called with correct assurance level

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -562,6 +562,24 @@ describe('/linked_account', function () {
       assert.isTrue(mockDB.deleteLinkedAccount.calledOnceWith(UID));
       assert.isTrue(result.success);
     });
+
+    it('fails to unlink with incorrect assurance level', async () => {
+      mockRequest.auth.credentials.authenticatorAssuranceLevel = 1;
+      mockDB.totpToken = sinon.spy(() =>
+        Promise.resolve({
+          verified: true,
+          enabled: true,
+        })
+      );
+
+      try {
+        await runTest(route, mockRequest);
+        assert.fail('should have failed');
+      } catch(err) {
+        assert.isTrue(mockDB.deleteLinkedAccount.notCalled);
+        assert.equal(err.errno, 138, 'unconfirmed session');
+      }
+    });
   });
 
   describe('/linked_account/webhook/google_event_receiver', () => {


### PR DESCRIPTION
## Because

- The linked account `unlink` route didn't respect assurance levels

## This pull request

- Have it check before unlinking

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10904

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
