### PR TITLE
fix(settings): Fix back arrow navigation from step 2 of recovery phone setup

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/en.ftl
@@ -3,3 +3,5 @@
 page-setup-recovery-phone-heading = Add recovery phone
 
 page-setup-recovery-phone-back-button-title = Back to settings
+# Back arrow to return to step 1 of recovery phone setup flow
+page-setup-recovery-phone-step2-back-button-title = Change phone number

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
@@ -36,13 +36,24 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
     'Add recovery phone'
   );
 
-  const localizedBackButtonTitle = ftlMsgResolver.getMsg(
-    'page-setup-recovery-phone-back-button-title',
-    'Back to settings'
-  );
+  const localizedBackButtonTitle =
+    currentStep === 1
+      ? ftlMsgResolver.getMsg(
+          'page-setup-recovery-phone-back-button-title',
+          'Back to settings'
+        )
+      : ftlMsgResolver.getMsg(
+          'page-setup-recovery-phone-step2-back-button-title',
+          'Change phone number'
+        );
 
-  const navigateBackward = () => {
-    navigate(SETTINGS_PATH);
+  const navigateBackward = (e?: React.MouseEvent<HTMLElement>) => {
+    e?.preventDefault();
+    if (currentStep > 1) {
+      setCurrentStep(currentStep - 1);
+    } else {
+      navigate(SETTINGS_PATH);
+    }
   };
 
   const navigateForward = (e?: React.MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
## Because

* Back arrow on step 2 was returning to settings
## This pull request

* Return to step 1
* Add test cases

## Issue that this pull request solves

Closes: #FXA-11178

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
