### PR TITLE
fix(settings): Remove divider in country selector

### DIFF
--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.test.tsx
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { act, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { extendedCountryOptions, Subject } from './mocks';
-import userEvent from '@testing-library/user-event';
 
 describe('InputPhoneNumber', () => {
   it('renders as expected with default countries', () => {
@@ -20,17 +19,18 @@ describe('InputPhoneNumber', () => {
     const options = screen.getAllByRole('option');
     expect(options.length).toBe(2);
 
-    // The first option should be United States, and it should be selected by default
-    expect(options[0]).toHaveTextContent('United States (+1)');
-    expect((options[0] as HTMLOptionElement).selected).toBe(true);
+    // expect list to be sorted alphabetically
+    expect(options[0]).toHaveTextContent('Canada (+1)');
+    expect(options[1]).toHaveTextContent('United States (+1)');
+    // US is currently the default
+    expect((options[1] as HTMLOptionElement).selected).toBe(true);
 
     expect(
       screen.getByRole('textbox', { name: /Enter phone number/i })
     ).toBeInTheDocument();
   });
 
-  it('renders a select option for every country, and the country with ID=1 is always the first option', async () => {
-    const user = userEvent.setup();
+  it('renders a select option for every country, and the country with ID=1 is selected by default', async () => {
     renderWithLocalizationProvider(
       <Subject countries={extendedCountryOptions} />
     );
@@ -38,28 +38,20 @@ describe('InputPhoneNumber', () => {
     expect(options.length).toBe(extendedCountryOptions.length);
 
     // There should be an option for each country listed
-    options.forEach((option, index) => {
-      const { name, code } = extendedCountryOptions[index];
-      const expectedText = `${name} (${code})`;
-      expect(option).toHaveTextContent(expectedText);
+    expect(extendedCountryOptions.length).toEqual(options.length);
+    extendedCountryOptions.forEach((countryOption) => {
+      expect(
+        options.some((option) =>
+          option.textContent?.includes(countryOption.name)
+        )
+      ).toBe(true);
     });
 
-    // The first option should correspond to the country with ID=1
+    // The default country (country with ID=1) should be selected by default
     const defaultCountry = extendedCountryOptions.find(
       (country) => country.id === 1
     );
-    expect(options[0]).toHaveTextContent(
-      `${defaultCountry?.name} (${defaultCountry?.code})`
-    );
     const selectElement = options[0].closest('select') as HTMLSelectElement;
-    expect(selectElement).not.toBeNull();
-
-    // We must use 'act' because we need to get all options after selection has finished
-    await act(async () => {
-      // Select "Murica" (id=100)
-      await user.selectOptions(selectElement, ['100']);
-    });
-    const updatedOptions = screen.getAllByRole('option');
-    expect(updatedOptions[0]).toHaveTextContent('United States (+1)');
+    expect(selectElement).toHaveValue(defaultCountry?.id.toString());
   });
 });


### PR DESCRIPTION
## Because

* Divider is picked up as an option on Android
* HR nested in select component is not currently supported on Android
* Countries should be sorted alphabetically

## This pull request

* Remove HR in select component
* Sort country list alphabetically based on localized name
* Select USA by default for now

## Issue that this pull request solves

Closes: #FXA-11210

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![image](https://github.com/user-attachments/assets/9b005af4-16ec-4999-be2e-31791623ea08)

After:
![image](https://github.com/user-attachments/assets/4481970f-3336-4813-8d06-2a2b4cd7fed2)

## Other information (Optional)

Any other information that is important to this pull request.
