### PR TITLE
feat(payments-next): actions response validation and dto updates

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/route.ts
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/route.ts
@@ -10,6 +10,7 @@ import { CartEligibilityStatus } from '@fxa/shared/db/mysql/account';
 import { BaseParams, buildRedirectUrl } from '@fxa/payments/ui';
 import { getIpAddress } from '@fxa/payments/ui/server';
 import { config } from 'apps/payments/next/config';
+import type { SubplatInterval } from '@fxa/payments/customer';
 
 export const dynamic = 'force-dynamic';
 
@@ -32,7 +33,7 @@ export async function GET(
   let redirectToUrl: URL;
   try {
     const { id: cartId, eligibilityStatus } = await setupCartAction(
-      interval,
+      interval as SubplatInterval,
       offeringId,
       undefined,
       coupon,
@@ -56,7 +57,7 @@ export async function GET(
   } catch (error) {
     if (error.constructor.name === 'CartInvalidPromoCodeError') {
       const { id: cartId, eligibilityStatus } = await setupCartAction(
-        interval,
+        interval as SubplatInterval,
         offeringId,
         undefined,
         undefined,

--- a/libs/payments/cart/src/index.ts
+++ b/libs/payments/cart/src/index.ts
@@ -6,5 +6,6 @@ export * from './lib/cart.factories';
 export * from './lib/cart.manager';
 export * from './lib/cart.service';
 export * from './lib/cart.utils';
+export { CartInvalidStateForActionError } from './lib/cart.error';
 export * from './lib/checkout.service';
 export * from './lib/checkout.error';

--- a/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
+++ b/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.ts
@@ -12,7 +12,7 @@ export function stripeInvoiceToInvoicePreviewDTO(
   invoice: StripeUpcomingInvoice | StripeInvoice
 ): InvoicePreview {
   const taxAmounts = invoice.total_tax_amounts.map((amount) => ({
-    title: amount.tax_rate.display_name,
+    title: amount.tax_rate.display_name || '',
     inclusive: amount.inclusive,
     amount: amount.amount,
   }));

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ResultCart } from '@fxa/payments/cart';
+import Stripe from 'stripe';
 
 export const CheckoutTypes = ['with-accounts', 'without-accounts'] as const;
 export type CheckoutTypesType = (typeof CheckoutTypes)[number];
@@ -13,7 +14,7 @@ export const PaymentProvidersTypePartial = [
   'external_paypal',
 ] as const;
 export type PaymentProvidersType =
-  | 'card'
+  | Stripe.PaymentMethod.Type
   | 'google_iap'
   | 'apple_iap'
   | 'external_paypal';

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
@@ -4,9 +4,7 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { CheckoutCartWithPaypalActionArgs } from '../nestapp/validators/CheckoutCartWithPaypalActionArgs';
 
 export const checkoutCartWithPaypal = async (
   cartId: string,
@@ -14,12 +12,10 @@ export const checkoutCartWithPaypal = async (
   customerData: { locale: string; displayName: string },
   token?: string
 ) => {
-  await getApp().getActionsService().checkoutCartWithPaypal(
-    plainToClass(CheckoutCartWithPaypalActionArgs, {
-      cartId,
-      version,
-      customerData,
-      token,
-    })
-  );
+  await getApp().getActionsService().checkoutCartWithPaypal({
+    cartId,
+    version,
+    customerData,
+    token,
+  });
 };

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
@@ -4,25 +4,21 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import {
-  CheckoutCartWithStripeActionArgs,
-  CheckoutCartWithStripeActionCustomerData,
-} from '../nestapp/validators/CheckoutCartWithStripeActionArgs';
 
 export const checkoutCartWithStripe = async (
   cartId: string,
   version: number,
   confirmationTokenId: string,
-  customerData: CheckoutCartWithStripeActionCustomerData
+  customerData: {
+    locale: string;
+    displayName: string;
+  }
 ) => {
-  getApp().getActionsService().checkoutCartWithStripe(
-    plainToClass(CheckoutCartWithStripeActionArgs, {
-      cartId,
-      version,
-      customerData,
-      confirmationTokenId,
-    })
-  );
+  getApp().getActionsService().checkoutCartWithStripe({
+    cartId,
+    version,
+    customerData,
+    confirmationTokenId,
+  });
 };

--- a/libs/payments/ui/src/lib/actions/determineCurrency.ts
+++ b/libs/payments/ui/src/lib/actions/determineCurrency.ts
@@ -4,16 +4,12 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { DetermineCurrencyActionArgs } from '../nestapp/validators/DetermineCurrencyActionArgs';
 
 export const determineCurrencyAction = async (ip: string) => {
-  const currency = await getApp().getActionsService().determineCurrency(
-    plainToClass(DetermineCurrencyActionArgs, {
-      ip,
-    })
-  );
+  const { currency } = await getApp().getActionsService().determineCurrency({
+    ip,
+  });
 
   return currency;
 };

--- a/libs/payments/ui/src/lib/actions/fetchCMSData.ts
+++ b/libs/payments/ui/src/lib/actions/fetchCMSData.ts
@@ -4,20 +4,16 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { FetchCMSDataArgs } from '../nestapp/validators/FetchCMSDataArgs';
 
 export const fetchCMSData = (
   offeringId: string,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
-  return getApp().getActionsService().fetchCMSData(
-    plainToClass(FetchCMSDataArgs, {
-      offeringId,
-      acceptLanguage,
-      selectedLanguage,
-    })
-  );
+  return getApp().getActionsService().fetchCMSData({
+    offeringId,
+    acceptLanguage,
+    selectedLanguage,
+  });
 };

--- a/libs/payments/ui/src/lib/actions/finalizeCartWithError.ts
+++ b/libs/payments/ui/src/lib/actions/finalizeCartWithError.ts
@@ -4,19 +4,15 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { FinalizeCartWithErrorArgs } from '../nestapp/validators/FinalizeCartWithErrorArgs';
 import { CartErrorReasonId } from '@fxa/shared/db/mysql/account/kysely-types';
 
 export const finalizeCartWithError = async (
   cartId: string,
   errorReasonId: CartErrorReasonId
 ) => {
-  return await getApp().getActionsService().finalizeCartWithError(
-    plainToClass(FinalizeCartWithErrorArgs, {
-      cartId,
-      errorReasonId,
-    })
-  );
+  return await getApp().getActionsService().finalizeCartWithError({
+    cartId,
+    errorReasonId,
+  });
 };

--- a/libs/payments/ui/src/lib/actions/finalizeProcessingCart.ts
+++ b/libs/payments/ui/src/lib/actions/finalizeProcessingCart.ts
@@ -4,16 +4,12 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { GetCartActionArgs } from '../nestapp/validators/GetCartActionArgs';
 
 export const finalizeProcessingCartAction = async (cartId: string) => {
-  const cart = await getApp().getActionsService().finalizeProcessingCart(
-    plainToClass(GetCartActionArgs, {
-      cartId,
-    })
-  );
+  const cart = await getApp().getActionsService().finalizeProcessingCart({
+    cartId,
+  });
 
   return cart;
 };

--- a/libs/payments/ui/src/lib/actions/getCart.ts
+++ b/libs/payments/ui/src/lib/actions/getCart.ts
@@ -4,16 +4,12 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { GetCartActionArgs } from '../nestapp/validators/GetCartActionArgs';
 
 export const getCartAction = async (cartId: string) => {
-  const cart = await getApp().getActionsService().getCart(
-    plainToClass(GetCartActionArgs, {
-      cartId,
-    })
-  );
+  const cart = await getApp().getActionsService().getCart({
+    cartId,
+  });
 
   return cart;
 };

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -4,10 +4,8 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { redirect } from 'next/navigation';
 import { getApp } from '../nestapp/app';
-import { GetCartActionArgs } from '../nestapp/validators/GetCartActionArgs';
 import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
 import {
@@ -17,8 +15,8 @@ import {
   FailCartDTO,
   SuccessCartDTO,
   CartDTO,
+  CartInvalidStateForActionError,
 } from '@fxa/payments/cart';
-import { CartInvalidStateForActionError } from 'libs/payments/cart/src/lib/cart.error';
 import { VError } from 'verror';
 
 /**
@@ -63,11 +61,9 @@ async function getCartOrRedirectAction(
   switch (page) {
     case SupportedPages.SUCCESS: {
       try {
-        cart = await getApp().getActionsService().getSuccessCart(
-          plainToClass(GetCartActionArgs, {
-            cartId,
-          })
-        );
+        cart = await getApp().getActionsService().getSuccessCart({
+          cartId,
+        });
       } catch (error) {
         if (error instanceof CartInvalidStateForActionError) {
           redirect(getRedirect(VError.info(error).state) + params);
@@ -81,11 +77,9 @@ async function getCartOrRedirectAction(
     case SupportedPages.PROCESSING:
     case SupportedPages.NEEDS_INPUT:
     case SupportedPages.ERROR: {
-      cart = await getApp().getActionsService().getCart(
-        plainToClass(GetCartActionArgs, {
-          cartId,
-        })
-      );
+      cart = await getApp().getActionsService().getCart({
+        cartId,
+      });
       break;
     }
   }

--- a/libs/payments/ui/src/lib/actions/getNeedsInput.ts
+++ b/libs/payments/ui/src/lib/actions/getNeedsInput.ts
@@ -5,13 +5,9 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
-import { plainToClass } from 'class-transformer';
-import { GetNeedsInputActionArgs } from '../nestapp/validators/GetNeedsInputActionArgs';
 
 export const getNeedsInputAction = async (cartId: string) => {
-  const inputNeeded = getApp()
-    .getActionsService()
-    .getNeedsInput(plainToClass(GetNeedsInputActionArgs, { cartId }));
+  const inputNeeded = getApp().getActionsService().getNeedsInput({ cartId });
 
   return inputNeeded;
 };

--- a/libs/payments/ui/src/lib/actions/getPayPalCheckoutToken.ts
+++ b/libs/payments/ui/src/lib/actions/getPayPalCheckoutToken.ts
@@ -4,18 +4,14 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { GetPayPalCheckoutTokenArgs } from '../nestapp/validators/GetPayPalCheckoutTokenArgs';
 
-export const getPayPalCheckoutToken = async (currencyCode?: string | null) => {
+export const getPayPalCheckoutToken = async (currencyCode: string) => {
   const actionsService = getApp().getActionsService();
 
-  const token = await actionsService.getPayPalCheckoutToken(
-    plainToClass(GetPayPalCheckoutTokenArgs, {
-      currencyCode,
-    })
-  );
+  const { token } = await actionsService.getPayPalCheckoutToken({
+    currencyCode,
+  });
 
   return token;
 };

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
@@ -4,8 +4,6 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
-import { plainToClass } from 'class-transformer';
-import { RecordEmitterEventArgs } from '../nestapp/validators/RecordEmitterEvent';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
 import { PaymentProvidersType } from '@fxa/payments/cart';
 import { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
@@ -38,17 +36,16 @@ async function recordEmitterEventAction(
 ) {
   const requestArgs = {
     ...getAdditionalRequestArgs(),
-    params,
+    // TODO: This type mismatch appears to be an actual bug -- FXA-11214
+    params: params as Record<string, string>,
     searchParams,
   };
 
-  return getApp().getActionsService().recordEmitterEvent(
-    plainToClass(RecordEmitterEventArgs, {
-      eventName,
-      requestArgs,
-      paymentProvider,
-    })
-  );
+  return getApp().getActionsService().recordEmitterEvent({
+    eventName,
+    requestArgs,
+    paymentProvider,
+  });
 }
 
 export { recordEmitterEventAction };

--- a/libs/payments/ui/src/lib/actions/restartCart.ts
+++ b/libs/payments/ui/src/lib/actions/restartCart.ts
@@ -4,18 +4,14 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { RestartCartActionArgs } from '../nestapp/validators/RestartCartActionArgs';
 
 export const restartCartAction = async (cartId: string) => {
   const actionsService = getApp().getActionsService();
 
-  const cart = await actionsService.restartCart(
-    plainToClass(RestartCartActionArgs, {
-      cartId,
-    })
-  );
+  const cart = await actionsService.restartCart({
+    cartId,
+  });
 
   return cart;
 };

--- a/libs/payments/ui/src/lib/actions/setupCart.ts
+++ b/libs/payments/ui/src/lib/actions/setupCart.ts
@@ -4,25 +4,22 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
-import { plainToClass } from 'class-transformer';
-import { SetupCartActionArgs } from '../nestapp/validators/SetupCartActionArgs';
+import type { SubplatInterval } from '@fxa/payments/customer';
 
 export const setupCartAction = async (
-  interval: string,
+  interval: SubplatInterval,
   offeringConfigId: string,
   experiment?: string,
   promoCode?: string,
   uid?: string,
   ip?: string
 ) => {
-  return getApp().getActionsService().setupCart(
-    plainToClass(SetupCartActionArgs, {
-      interval,
-      offeringConfigId,
-      experiment,
-      promoCode,
-      uid,
-      ip,
-    })
-  );
+  return getApp().getActionsService().setupCart({
+    interval,
+    offeringConfigId,
+    experiment,
+    promoCode,
+    uid,
+    ip,
+  });
 };

--- a/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
@@ -5,16 +5,12 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
-import { plainToClass } from 'class-transformer';
-import { SubmitNeedsInputActionArgs } from '../nestapp/validators/SubmitNeedsInputActionArgs';
 import { redirect } from 'next/navigation';
 import { CheckoutFailedError } from '@fxa/payments/cart';
 
 export const submitNeedsInputAndRedirectAction = async (cartId: string) => {
   try {
-    await getApp()
-      .getActionsService()
-      .submitNeedsInput(plainToClass(SubmitNeedsInputActionArgs, { cartId }));
+    await getApp().getActionsService().submitNeedsInput({ cartId });
     redirect('success');
   } catch (error) {
     console.error('Error submitting needs input', error);

--- a/libs/payments/ui/src/lib/actions/updateCart.ts
+++ b/libs/payments/ui/src/lib/actions/updateCart.ts
@@ -4,7 +4,6 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { revalidatePath } from 'next/cache';
 
 import { UpdateCart } from '@fxa/payments/cart';
@@ -14,7 +13,6 @@ import {
   CouponErrorLimitReached,
 } from '@fxa/payments/customer';
 import { getApp } from '../nestapp/app';
-import { UpdateCartActionArgs } from '../nestapp/validators/UpdateCartActionArgs';
 import { CouponErrorMessageType } from '../utils/error-ftl-messages';
 
 export const updateCartAction = async (
@@ -25,13 +23,11 @@ export const updateCartAction = async (
   const actionsService = getApp().getActionsService();
 
   try {
-    await actionsService.updateCart(
-      plainToClass(UpdateCartActionArgs, {
-        cartId,
-        version,
-        cartDetails,
-      })
-    );
+    await actionsService.updateCart({
+      cartId,
+      version,
+      cartDetails,
+    });
   } catch (err) {
     if (err instanceof CouponErrorExpired) {
       return CouponErrorMessageType.Expired;

--- a/libs/payments/ui/src/lib/actions/validatePostalCode.ts
+++ b/libs/payments/ui/src/lib/actions/validatePostalCode.ts
@@ -4,15 +4,11 @@
 
 'use server';
 
-import { plainToClass } from 'class-transformer';
 import { getApp } from '../nestapp/app';
-import { ValidatePostalCodeArgs } from '../nestapp/validators/ValidatePostalCodeArgs';
 
 export const validatePostalCode = (postalCode: string, countryCode: string) => {
-  return getApp().getActionsService().validatePostalCode(
-    plainToClass(ValidatePostalCodeArgs, {
-      postalCode,
-      countryCode,
-    })
-  );
+  return getApp().getActionsService().validatePostalCode({
+    postalCode,
+    countryCode,
+  });
 };

--- a/libs/payments/ui/src/lib/nestapp/NextIOValidator.ts
+++ b/libs/payments/ui/src/lib/nestapp/NextIOValidator.ts
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { plainToInstance } from 'class-transformer';
+import { Validator } from 'class-validator';
+
+/**
+ * Will capture timing for this method and send them to StatsD. Requires the target class to have statsd exposed as a public property.
+ * Timings will appear as ClassName_methodName in StatsD.
+ */
+export function NextIOValidator<
+  I extends { new (...args: any[]): any } | undefined,
+  O extends { new (...args: any[]): any } | undefined,
+  Args extends object | void,
+  Result extends object | void,
+  Target extends object
+>(inputClass: I, outputClass: O) {
+  type Func = (args: Args) => Promise<Result>;
+
+  return function (
+    _target: Target,
+    key: string,
+    descriptor: TypedPropertyDescriptor<Func>
+  ) {
+    const originalDef = descriptor.value as NonNullable<Func>;
+
+    descriptor.value = async function (input: Args): Promise<Result> {
+      if (inputClass) {
+        const val = plainToInstance<NonNullable<I>, Args>(inputClass, input);
+        await new Validator().validateOrReject(val);
+      } else if (input) {
+        throw new Error(
+          'Input class must be provided if the method is passed a value.'
+        );
+      }
+
+      const originalReturnValue = await originalDef.apply(this, [input]);
+
+      if (outputClass) {
+        const output = plainToInstance<NonNullable<O>, Result>(
+          outputClass,
+          originalReturnValue
+        );
+        await new Validator().validateOrReject(output);
+      } else if (originalReturnValue) {
+        throw new Error(
+          'Output class must be provided if the method returns a value.'
+        );
+      }
+
+      return originalReturnValue;
+    };
+    return descriptor;
+  };
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyActionResult.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsOptional, IsString } from 'class-validator';
+
+export class DetermineCurrencyActionResult {
+  @IsString()
+  @IsOptional()
+  currency?: string | null;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/FetchCMSDataActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/FetchCMSDataActionArgs.ts
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsOptional, IsString } from 'class-validator';
+
+export class FetchCMSDataActionArgs {
+  @IsString()
+  offeringId!: string;
+
+  @IsString()
+  @IsOptional()
+  acceptLanguage?: string | null;
+
+  @IsString()
+  @IsOptional()
+  selectedLanguage?: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/FetchCMSDataActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/FetchCMSDataActionResult.ts
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString, IsArray, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class PageContentCommonContentResult {
+  @IsString()
+  privacyNoticeUrl!: string;
+
+  @IsString()
+  privacyNoticeDownloadUrl!: string;
+
+  @IsString()
+  termsOfServiceUrl!: string;
+
+  @IsString()
+  termsOfServiceDownloadUrl!: string;
+
+  @IsOptional()
+  @IsString()
+  cancellationUrl!: string | null;
+
+  @IsOptional()
+  @IsString()
+  emailIcon!: string | null;
+
+  @IsString()
+  successActionButtonUrl!: string;
+
+  @IsString()
+  successActionButtonLabel!: string;
+
+  @IsOptional()
+  @IsString()
+  newsletterLabelTextCode!: string | null;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  newsletterSlug!: string[] | null;
+}
+
+class PageContentPurchaseDetailsTransformed {
+  @IsArray()
+  @IsString({ each: true })
+  details!: string[];
+
+  @IsString()
+  productName!: string;
+
+  @IsOptional()
+  @IsString()
+  subtitle!: string | null;
+
+  @IsString()
+  webIcon!: string;
+}
+
+class PageContentOfferingDefaultPurchaseTransformed {
+  @ValidateNested()
+  @Type(() => PageContentPurchaseDetailsTransformed)
+  purchaseDetails!: PageContentPurchaseDetailsTransformed & {
+    localizations: PageContentPurchaseDetailsTransformed[];
+  };
+}
+
+class PageContentOfferingTransformed {
+  @IsString()
+  apiIdentifier!: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  countries!: string[];
+
+  @IsString()
+  stripeProductId!: string;
+
+  @ValidateNested()
+  @Type(() => PageContentOfferingDefaultPurchaseTransformed)
+  defaultPurchase!: PageContentOfferingDefaultPurchaseTransformed;
+
+  @ValidateNested()
+  @Type(() => PageContentCommonContentResult)
+  commonContent!: PageContentCommonContentResult & {
+    localizations: PageContentCommonContentResult[];
+  };
+}
+
+export class FetchCMSDataActionResult {
+  @ValidateNested({ each: true })
+  @Type(() => PageContentOfferingTransformed)
+  offerings!: PageContentOfferingTransformed[];
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetCartActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetCartActionResult.ts
@@ -1,0 +1,191 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { PaymentProvidersType } from '@fxa/payments/cart';
+import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+class TaxAmount {
+  @IsString()
+  title!: string;
+
+  @IsBoolean()
+  inclusive!: number;
+
+  @IsNumber()
+  amount!: number;
+}
+
+class Invoice {
+  @IsString()
+  currency!: string;
+
+  @IsNumber()
+  listAmount!: number;
+
+  @IsNumber()
+  totalAmount!: number;
+
+  @ValidateNested({ each: true })
+  @Type(() => TaxAmount)
+  taxAmounts!: TaxAmount[];
+
+  @IsOptional()
+  @IsNumber()
+  discountAmount?: number | null;
+
+  @IsNumber()
+  subtotal!: number;
+
+  @IsOptional()
+  @IsNumber()
+  discountEnd?: number | null;
+
+  @IsOptional()
+  @IsString()
+  discountType?: string;
+
+  @IsOptional()
+  @IsString()
+  number?: string | null;
+}
+
+class PaymentInfo {
+  @IsString()
+  @IsIn([
+    'card',
+    'google_iap',
+    'apple_iap',
+    'external_paypal',
+  ] satisfies PaymentProvidersType[])
+  type!: PaymentProvidersType;
+
+  @IsOptional()
+  @IsString()
+  last4?: string;
+
+  @IsOptional()
+  @IsString()
+  brand?: string;
+
+  @IsOptional()
+  @IsString()
+  customerSessionClientSecret?: string;
+}
+
+class FromPriceInfo {
+  @IsString()
+  currency!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsNumber()
+  listAmount!: number;
+}
+
+class TaxAddress {
+  @IsString()
+  countryCode!: string;
+
+  @IsString()
+  postalCode!: string;
+}
+
+export class GetCartActionResult {
+  @IsString()
+  id!: string;
+
+  @IsOptional()
+  @IsString()
+  uid?: string;
+
+  @IsEnum(CartState)
+  state!: CartState;
+
+  @IsString()
+  offeringConfigId!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsOptional()
+  @IsString()
+  experiment?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TaxAddress)
+  taxAddress?: TaxAddress;
+
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @IsNumber()
+  createdAt!: number;
+
+  @IsNumber()
+  updatedAt!: number;
+
+  @IsOptional()
+  @IsString()
+  couponCode?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeCustomerId?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeSubscriptionId?: string;
+
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @IsNumber()
+  amount!: number;
+
+  @IsNumber()
+  version!: number;
+
+  @IsEnum(CartEligibilityStatus)
+  eligibilityStatus!: CartEligibilityStatus;
+
+  @IsBoolean()
+  metricsOptedOut!: boolean;
+
+  @ValidateNested()
+  @Type(() => Invoice)
+  upcomingInvoicePreview!: Invoice;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => Invoice)
+  latestInvoicePreview?: Invoice;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PaymentInfo)
+  paymentInfo?: PaymentInfo;
+
+  @IsOptional()
+  @IsString()
+  fromOfferingConfigId?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => FromPriceInfo)
+  fromPrice?: FromPriceInfo;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetMetricsFlowActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetMetricsFlowActionResult.ts
@@ -2,17 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsOptional, IsString } from 'class-validator';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
-export class FetchCMSDataArgs {
+export class GetMetricsFlowActionResult {
   @IsString()
-  offeringId!: string;
+  flowId!: string;
 
   @IsString()
+  @IsNumber()
+  flowBeginTime!: string | number;
+
   @IsOptional()
-  acceptLanguage?: string | null;
-
   @IsString()
-  @IsOptional()
-  selectedLanguage?: string;
+  deviceId?: string;
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/GetNeedsInputActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetNeedsInputActionResult.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Equals } from 'class-validator';
+import { GetCartActionResult } from './GetCartActionResult';
+import { CartState } from '@fxa/shared/db/mysql/account';
+
+export class getNeedsInputActionResult extends GetCartActionResult {
+  @Equals(CartState.NEEDS_INPUT)
+  state!: CartState.NEEDS_INPUT;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetPayPalCheckoutTokenResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetPayPalCheckoutTokenResult.ts
@@ -4,10 +4,7 @@
 
 import { IsString } from 'class-validator';
 
-export class ValidatePostalCodeArgs {
+export class GetPayPalCheckoutTokenResult {
   @IsString()
-  postalCode!: string;
-
-  @IsString()
-  countryCode!: string;
+  token!: string;
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/GetSuccessCartActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetSuccessCartActionResult.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Equals } from 'class-validator';
+import { GetCartActionResult } from './GetCartActionResult';
+import { CartState } from '@fxa/shared/db/mysql/account';
+
+export class GetSuccessCartActionResult extends GetCartActionResult {
+  @Equals(CartState.SUCCESS)
+  state!: CartState.SUCCESS;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/RestartCartActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RestartCartActionResult.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+class TaxAddress {
+  @IsString()
+  countryCode!: string;
+
+  @IsString()
+  postalCode!: string;
+}
+
+export class RestartCartActionResult {
+  @IsString()
+  id!: string;
+
+  @IsOptional()
+  @IsString()
+  uid?: string;
+
+  @IsEnum(CartState)
+  state!: CartState;
+
+  @IsString()
+  offeringConfigId!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsOptional()
+  @IsString()
+  experiment?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TaxAddress)
+  taxAddress?: TaxAddress;
+
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @IsNumber()
+  createdAt!: number;
+
+  @IsNumber()
+  updatedAt!: number;
+
+  @IsOptional()
+  @IsString()
+  couponCode?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeCustomerId?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeSubscriptionId?: string;
+
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @IsNumber()
+  amount!: number;
+
+  @IsNumber()
+  version!: number;
+
+  @IsEnum(CartEligibilityStatus)
+  eligibilityStatus!: CartEligibilityStatus;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/SetupCartActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/SetupCartActionResult.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+class TaxAddress {
+  @IsString()
+  countryCode!: string;
+
+  @IsString()
+  postalCode!: string;
+}
+
+export class SetupCartActionResult {
+  @IsString()
+  id!: string;
+
+  @IsOptional()
+  @IsString()
+  uid?: string;
+
+  @IsEnum(CartState)
+  state!: CartState;
+
+  @IsString()
+  offeringConfigId!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsOptional()
+  @IsString()
+  experiment?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TaxAddress)
+  taxAddress?: TaxAddress;
+
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @IsNumber()
+  createdAt!: number;
+
+  @IsNumber()
+  updatedAt!: number;
+
+  @IsOptional()
+  @IsString()
+  couponCode?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeCustomerId?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeSubscriptionId?: string;
+
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @IsNumber()
+  amount!: number;
+
+  @IsNumber()
+  version!: number;
+
+  @IsEnum(CartEligibilityStatus)
+  eligibilityStatus!: CartEligibilityStatus;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/ValidatePostalCodeActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/ValidatePostalCodeActionArgs.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class ValidatePostalCodeActionArgs {
+  @IsString()
+  postalCode!: string;
+
+  @IsString()
+  countryCode!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/ValidatePostalCodeActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/ValidatePostalCodeActionResult.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsBoolean } from 'class-validator';
+
+export class ValidatePostalCodeActionResult {
+  @IsBoolean()
+  isValid!: string;
+}

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.spec.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.spec.ts
@@ -81,7 +81,7 @@ describe('SanitizeExceptions Decorator', () => {
     it('should pass acceptable errors through', () => {
       expect(() => service.throwAcceptableError()).toThrow(AcceptableError);
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error caught by SanitizeExceptions decorator',
+        'Error caught by SanitizeExceptions decorator in MockService.throwAcceptableError',
         expect.any(AcceptableError)
       );
     });
@@ -92,7 +92,7 @@ describe('SanitizeExceptions Decorator', () => {
       );
       expect(() => service.throwSensitiveError()).not.toThrow(SensitiveError);
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error caught by SanitizeExceptions decorator',
+        'Error caught by SanitizeExceptions decorator in MockService.throwSensitiveError',
         expect.any(SensitiveError)
       );
     });
@@ -104,7 +104,7 @@ describe('SanitizeExceptions Decorator', () => {
         AcceptableError
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error caught by SanitizeExceptions decorator',
+        'Error caught by SanitizeExceptions decorator in MockService.throwAcceptableErrorAsync',
         expect.any(AcceptableError)
       );
     });
@@ -117,7 +117,7 @@ describe('SanitizeExceptions Decorator', () => {
         SensitiveError
       );
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'Error caught by SanitizeExceptions decorator',
+        'Error caught by SanitizeExceptions decorator in MockService.throwSensitiveErrorAsync',
         expect.any(SensitiveError)
       );
     });


### PR DESCRIPTION
## Because

- We want response validation
- We want a better way of doing IO validation for actions without the hassle of conversion to class-validator format each time

## This pull request

- Adds a decorator that does the above

## Issue that this pull request solves

Closes FXA-10708