### PR TITLE
fix(cirrus): Do not throw an exception for user request timeouts

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/nimbus/index.ts
+++ b/packages/fxa-content-server/app/scripts/lib/nimbus/index.ts
@@ -17,7 +17,8 @@ export default class Nimbus {
       const resp = await fetch('/nimbus-experiments', {
         method: 'POST',
         body,
-        // A request to cirrus should not be more than 50ms, but we give it a large enough padding.
+        // A request to cirrus should not be more than 50ms,
+        // but this timeout is public-facing so may take longer.
         signal: AbortSignal.timeout(1000),
         headers: {
           'Content-Type': 'application/json',
@@ -31,9 +32,17 @@ export default class Nimbus {
 
       this.experiments = await resp.json();
     } catch (err) {
+      if (err.name === 'TimeoutError') {
+        // We can't do much here if we're reaching timeouts from network issues.
+        return;
+      }
+
       Sentry.withScope(() => {
         Sentry.captureMessage('Experiment fetch error', 'error');
       });
+
+      // Finally, always clear out the experiments;
+      this.experiments = null;
     }
   }
 }


### PR DESCRIPTION
## Because

- We send an exception when a client times out from making a request.

## This pull request

- We ignore this request because it could be due to multiple network failures. 
- Note that this is different from `post-nimbus-experiments.js` where we expect Nimbus to return to us within 50ms.

## Issue that this pull request solves

Closes: FXA-9987

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
