### PR TITLE
chore: Do not use hash symbol in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## Issue that this pull request solves
 
-Closes: # (issue number)
+Closes: (issue number)
 
 ## Checklist
 


### PR DESCRIPTION
## Because

- We use Jira now and `#FXA-xxxx` confuses the jira integration bot. It was useful when PR issues needed to have the hash symbol for linking.

## This pull request

- Removes the `#` in the template.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
