### PR TITLE
fix(settings): Show custom error message on SigninRecoveryPhone code error

### DIFF
--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -366,7 +366,7 @@ test.describe('severity-1 #smoke', () => {
       await signinRecoveryPhone.clickConfirm();
 
       await expect(
-        page.getByText('Invalid or expired confirmation code')
+        page.getByText(/The code is invalid or expired./)
       ).toBeVisible();
 
       const originalCode = await target.smsClient.getCode(
@@ -687,9 +687,7 @@ async function fillOutRecoveryPhoneFromEmailFirst({
   await signinRecoveryPhone.enterCode('123456');
   await signinRecoveryPhone.clickConfirm();
 
-  await expect(
-    page.getByText('Invalid or expired confirmation code')
-  ).toBeVisible();
+  await expect(page.getByText(/The code is invalid or expired./)).toBeVisible();
 
   const originalCode = await target.smsClient.getCode(
     getPhoneNumber(target.name),

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/en.ftl
@@ -7,7 +7,7 @@ signin-recovery-phone-heading = Enter recovery code
 
 # Text that explains the user should check their phone for a recovery code
 # $maskedPhoneNumber - The users masked phone number
-signin-recovery-phone-instruction-v3 = A six-digit code was sent to the phone number ending in <span>{ $lastFourPhoneDigits }</span> by text message. This code expires after 5 minutes. Donʼt share this code with anyone.
+signin-recovery-phone-instruction-v3 = A 6-digit code was sent to the phone number ending in <span>{ $lastFourPhoneDigits }</span> by text message. This code expires after 5 minutes. Donʼt share this code with anyone.
 
 signin-recovery-phone-input-label = Enter 6-digit code
 
@@ -25,3 +25,6 @@ signin-recovery-phone-code-verification-error-heading = There was a problem veri
 
 # Follows the error message (e.g, "There was a problem sending a code")
 signin-recovery-phone-general-error-description = Please try again later.
+
+signin-recovery-phone-invalid-code-error-description = The code is invalid or expired.
+signin-recovery-phone-invalid-code-error-link = Use backup authentication codes instead?


### PR DESCRIPTION
## Because

* We want to show a custom error with a link to use backup authentication codes instead

## This pull request

* Add custom handling for invalid code error

## Issue that this pull request solves

Closes: FXA-11170

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
