### PR TITLE
chore(settings): load account from local storage

### DIFF
--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -55,11 +55,8 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/oauth\/signin/);
 
-      // By default, we should see the email we signed up for Sync with
-      await expect(page.getByText(syncCredentials.email)).toBeVisible();
-
-      // with backbone, sign in is cached, but with react password is required
-      // we won't check for that here, we mostly wanted to verify that the correct email is suggested
+      // By default, we should see the most recent signed in email
+      await expect(page.getByText(email)).toBeVisible();
     });
   });
 

--- a/packages/functional-tests/tests/settings/multitab.spec.ts
+++ b/packages/functional-tests/tests/settings/multitab.spec.ts
@@ -64,7 +64,7 @@ test.describe('severity-1 #smoke', () => {
 
     // Signout of 2nd tab
     await settings.signOut();
-    await expect(signin.passwordFormHeading).toBeVisible();
+    await expect(page.getByText(credentials.email)).toBeVisible();
 
     // Switch focus back to 1st tab. Page should NOT logout,
     // since this account is unaffected


### PR DESCRIPTION
Because:
 - Settings should use an account that on local storage when no email argument is given on sign in

This commit:
 - updates Settings signin to use an account from local storage when no email is given

