### PR TITLE
feat(react): Reactify email-first/Index page

### DIFF
--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -104,7 +104,9 @@ export class SigninPage extends BaseLayout {
 
   get syncSignInHeading() {
     return this.page.getByRole('heading', {
-      name: /^Continue to your Mozilla account/,
+      // Fluent inserts directional markers around "Mozilla account" so
+      // just look for partial match
+      name: /^Continue to your/,
     });
   }
 

--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -11,7 +11,9 @@ export class SignupPage extends BaseLayout {
 
   get emailFormHeading() {
     return this.page.getByRole('heading', {
-      name: /^Enter your email|^Continue to your Mozilla account/,
+      // Fluent inserts directional markers around "Mozilla account" so
+      // just look for partial match
+      name: /^Enter your email|^Continue to your/,
     });
   }
 

--- a/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
@@ -97,6 +97,6 @@ async function removeAccount(
   await settings.deleteAccountButton.click();
   await deleteAccount.deleteAccount(password);
 
-  await expect(page).toHaveURL(`${target.baseUrl}?delete_account_success=true`);
+  await expect(page).toHaveURL(`${target.baseUrl}`);
   await expect(page.getByText('Account deleted successfully')).toBeVisible();
 }

--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -25,10 +25,13 @@ test.describe('severity-2 #smoke', () => {
     }) => {
       const { email } = testAccountTracker.generateAccountDetails();
 
-      await relier.goto(`login_hint=${email}`);
+      await relier.goto(
+        `login_hint=${email}&forceExperiment=generalizedReactApp&forceExperimentGroup=react`
+      );
       await relier.clickEmailFirst();
 
       await page.waitForURL(`${target.contentServerUrl}/oauth/signup**`);
+
       await expect(signup.signupFormHeading).toBeVisible();
       // email provided as login hint is displayed on the signup page
       await expect(page.getByText(email)).toBeVisible();

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -115,7 +115,9 @@ Cocktail.mixin(Router, ReactExperimentMixin);
 
 Router = Router.extend({
   routes: {
-    '(/)': createViewHandler(IndexView),
+    '(/)': function () {
+      this.createReactOrBackboneViewHandler('/', IndexView);
+    },
     'account_recovery_confirm_key(/)': function () {
       this.createReactOrBackboneViewHandler(
         'account_recovery_confirm_key',
@@ -692,18 +694,24 @@ Router = Router.extend({
   },
 
   createReactViewHandler(routeName, additionalParams) {
-    const { deviceId, flowBeginTime, flowId } =
-      this.metrics.getFlowEventMetadata();
+    if (routeName === '/') {
+      const queryParams = new URLSearchParams(this.window.location.search);
+      queryParams.set('showReactApp', 'true');
+      this.navigateAway(`/?${queryParams.toString()}`);
+    } else {
+      const { deviceId, flowBeginTime, flowId } =
+        this.metrics.getFlowEventMetadata();
 
-    const link = `/${routeName}${Url.objToSearchString({
-      showReactApp: true,
-      deviceId,
-      flowBeginTime,
-      flowId,
-      ...additionalParams,
-    })}`;
+      const link = `/${routeName}${Url.objToSearchString({
+        showReactApp: true,
+        deviceId,
+        flowBeginTime,
+        flowId,
+        ...additionalParams,
+      })}`;
 
-    this.navigateAway(link);
+      this.navigateAway(link);
+    }
   },
 
   createReactOrBackboneViewHandler(

--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -191,8 +191,6 @@ function makeApp() {
   const routeHelpers = routing(app, routeLogger);
 
   function addNonSettingsRoutes(middleware) {
-    addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n);
-
     /* This creates `app.whatever('/path' ...` handlers for every content-server route and
      * excludes routes in `react-app.js` if corresponding feature flags are on. We manually add
      * these excluded routes for content-server to serve in checks above if the feature flag is
@@ -200,6 +198,11 @@ function makeApp() {
      * must come after React-related route modifications so that `next('route')` skips to these
      * route implementations. */
     routes.forEach(routeHelpers.addRoute);
+
+    // Adding React routes should come _after_ adding Backbone routes above because the Index
+    // page ('/'), which will get added to Backbone routing too in this function if conditions
+    // are not met for React, must come _after_ at least some of the frontend Backbone routing.
+    addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n, config);
 
     // must come after route handling but before wildcard routes
     app.use(

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -62,7 +62,7 @@
     "resetPasswordRoutes": true,
     "signUpRoutes": true,
     "signInRoutes": true,
-    "emailFirstRoutes": false,
+    "emailFirstRoutes": true,
     "postVerifyThirdPartyAuthRoutes": true
   },
   "featureFlags": {

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -90,6 +90,7 @@ const settingsConfig = {
   showReactApp: {
     signUpRoutes: config.get('showReactApp.signUpRoutes'),
     signInRoutes: config.get('showReactApp.signInRoutes'),
+    emailFirstRoutes: config.get('showReactApp.emailFirstRoutes'),
   },
   rolloutRates: {
     keyStretchV2: config.get('rolloutRates.keyStretchV2'),

--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -12,7 +12,8 @@ module.exports = function (config, i18n, statsd, glean) {
   const redirectVersionedToUnversioned = require('./routes/redirect-versioned-to-unversioned');
   const reactRouteGroups = getServerReactRouteGroups(
     config.get('showReactApp'),
-    i18n
+    i18n,
+    config
   );
 
   const routes = [
@@ -25,7 +26,7 @@ module.exports = function (config, i18n, statsd, glean) {
     require('./routes/get-oauth-success').default(reactRouteGroups),
     require('./routes/get-terms-privacy').default(reactRouteGroups, i18n),
     require('./routes/get-update-firefox')(config),
-    require('./routes/get-index')(config),
+    require('./routes/get-index').default(reactRouteGroups, config),
     require('./routes/get-ver.json'),
     require('./routes/get-client.json')(i18n),
     require('./routes/get-config')(i18n),

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -4,190 +4,24 @@
 
 'use strict';
 
-const flowMetrics = require('../flow-metrics');
-const logger = require('../logging/log')('routes.index');
+const {
+  getIndexRouteDefinition,
+} = require('./react-app/route-definition-index');
 
-module.exports = function (config) {
-  let featureFlags;
-  const featureFlagConfig = config.get('featureFlags');
-  if (featureFlagConfig.enabled) {
-    featureFlags = require('fxa-shared').featureFlags(
-      featureFlagConfig,
-      logger
+/**
+ * Remove index route ('/') from list if React feature flag is set to true
+ * and route is included in the emailFirstRoutes route group.
+ */
+/** @type {import("./react-app/types").GetBackboneRouteDefinition} */
+function getIndex(reactRouteGroups, config) {
+  const isOnReact =
+    reactRouteGroups.emailFirstRoutes.featureFlagOn &&
+    reactRouteGroups.emailFirstRoutes.routes.find(
+      (route) => route.name === '/'
     );
-  } else {
-    featureFlags = { get: () => ({}) };
-  }
+  return isOnReact ? null : getIndexRouteDefinition(config);
+}
 
-  const AUTH_SERVER_URL = config.get('fxaccount_url');
-  const CLIENT_ID = config.get('oauth_client_id');
-  const COPPA_ENABLED = config.get('coppa.enabled');
-  const ENV = config.get('env');
-  const FLOW_ID_KEY = config.get('flow_id_key');
-  const MARKETING_EMAIL_ENABLED = config.get('marketing_email.enabled');
-  const MARKETING_EMAIL_PREFERENCES_URL = config.get(
-    'marketing_email.preferences_url'
-  );
-  const MX_RECORD_VALIDATION = config.get('mxRecordValidation');
-  const MAX_EVENT_OFFSET = config.get('client_metrics.max_event_offset');
-  const REDIRECT_CHECK_ALLOW_LIST = config.get('redirect_check.allow_list');
-  const SENTRY_CLIENT_DSN = config.get('sentry.dsn');
-  const SENTRY_CLIENT_ENV = config.get('sentry.env');
-  const SENTRY_SAMPLE_RATE = config.get('sentry.sampleRate');
-  const SENTRY_TRACES_SAMPLE_RATE = config.get('sentry.tracesSampleRate');
-  const SENTRY_CLIENT_NAME = config.get('sentry.clientName');
-  const OAUTH_SERVER_URL = config.get('oauth_url');
-  const PAIRING_CHANNEL_URI = config.get('pairing.server_base_uri');
-  const PAIRING_CLIENTS = config.get('pairing.clients');
-  const PROFILE_SERVER_URL = config.get('profile_url');
-  const STATIC_RESOURCE_URL = config.get('static_resource_url');
-  const SCOPED_KEYS_ENABLED = config.get('scopedKeys.enabled');
-  const SCOPED_KEYS_VALIDATION = config.get('scopedKeys.validation');
-  const SUBSCRIPTIONS = config.get('subscriptions');
-  const GOOGLE_AUTH_CONFIG = config.get('googleAuthConfig');
-  const APPLE_AUTH_CONFIG = config.get('appleAuthConfig');
-  const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
-  const SHOW_REACT_APP = config.get('showReactApp');
-  const BRAND_MESSAGING_MODE = config.get('brandMessagingMode');
-  const FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS = config.get(
-    'featureFlags.sendFxAStatusOnSettings'
-  );
-  const FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN = config.get(
-    'featureFlags.recoveryCodeSetupOnSyncSignIn'
-  );
-  const FEATURE_FLAGS_ENABLE_ADDING_2FA_BACKUP_PHONE = config.get(
-    'featureFlags.enableAdding2FABackupPhone'
-  );
-  const FEATURE_FLAGS_ENABLE_USING_2FA_BACKUP_PHONE = config.get(
-    'featureFlags.enableUsing2FABackupPhone'
-  );
-  const GLEAN_ENABLED = config.get('glean.enabled');
-  const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
-  const GLEAN_UPLOAD_ENABLED = config.get('glean.uploadEnabled');
-  const GLEAN_APP_CHANNEL = config.get('glean.appChannel');
-  const GLEAN_SERVER_ENDPOINT = config.get('glean.serverEndpoint');
-  const GLEAN_LOG_PINGS = config.get('glean.logPings');
-  const GLEAN_DEBUG_VIEW_TAG = config.get('glean.debugViewTag');
-
-  // Rather than relay all rollout rates, hand pick the ones that are applicable
-  const ROLLOUT_RATES = config.get('rolloutRates');
-
-  // Note that this list is only enforced for clients that use login_hint/email
-  // with prompt=none. id_token_hint clients are not subject to this check.
-  const PROMPT_NONE_ENABLED_CLIENT_IDS = new Set(
-    config.get('oauth.prompt_none.enabled_client_ids')
-  );
-
-  // add version from package.json to config
-  const RELEASE = require('../../../package.json').version;
-  const WEBPACK_PUBLIC_PATH = `${STATIC_RESOURCE_URL}/${config.get(
-    'jsResourcePath'
-  )}/`;
-
-  const configForFrontEnd = {
-    authServerUrl: AUTH_SERVER_URL,
-    maxEventOffset: MAX_EVENT_OFFSET,
-    env: ENV,
-    isCoppaEnabled: COPPA_ENABLED,
-    isPromptNoneEnabled: PROMPT_NONE_ENABLED,
-    googleAuthConfig: GOOGLE_AUTH_CONFIG,
-    appleAuthConfig: APPLE_AUTH_CONFIG,
-    marketingEmailEnabled: MARKETING_EMAIL_ENABLED,
-    marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,
-    mxRecordValidation: MX_RECORD_VALIDATION,
-    oAuthClientId: CLIENT_ID,
-    oAuthUrl: OAUTH_SERVER_URL,
-    pairingChannelServerUri: PAIRING_CHANNEL_URI,
-    pairingClients: PAIRING_CLIENTS,
-    profileUrl: PROFILE_SERVER_URL,
-    release: RELEASE,
-    redirectAllowlist: REDIRECT_CHECK_ALLOW_LIST,
-    rolloutRates: ROLLOUT_RATES,
-    scopedKeysEnabled: SCOPED_KEYS_ENABLED,
-    scopedKeysValidation: SCOPED_KEYS_VALIDATION,
-    sentry: {
-      dsn: SENTRY_CLIENT_DSN,
-      env: SENTRY_CLIENT_ENV,
-      sampleRate: SENTRY_SAMPLE_RATE,
-      clientName: SENTRY_CLIENT_NAME,
-      tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
-    },
-    staticResourceUrl: STATIC_RESOURCE_URL,
-    subscriptions: SUBSCRIPTIONS,
-    webpackPublicPath: WEBPACK_PUBLIC_PATH,
-    showReactApp: SHOW_REACT_APP,
-    brandMessagingMode: BRAND_MESSAGING_MODE,
-    featureFlags: {
-      sendFxAStatusOnSettings: FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS,
-      recoveryCodeSetupOnSyncSignIn:
-        FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
-      enableAdding2FABackupPhone: FEATURE_FLAGS_ENABLE_ADDING_2FA_BACKUP_PHONE,
-      enableUsing2FABackupPhone: FEATURE_FLAGS_ENABLE_USING_2FA_BACKUP_PHONE,
-    },
-    glean: {
-      // feature toggle
-      enabled: GLEAN_ENABLED,
-      // Glean SDK config
-      applicationId: GLEAN_APPLICATION_ID,
-      uploadEnabled: GLEAN_UPLOAD_ENABLED,
-      appDisplayVersion: RELEASE,
-      channel: GLEAN_APP_CHANNEL,
-      serverEndpoint: GLEAN_SERVER_ENDPOINT,
-      logPings: GLEAN_LOG_PINGS,
-      debugViewTag: GLEAN_DEBUG_VIEW_TAG,
-    },
-  };
-
-  const NO_LONGER_SUPPORTED_CONTEXTS = new Set([
-    'fx_desktop_v1',
-    'fx_desktop_v2',
-    'fx_firstrun_v2',
-    'iframe',
-  ]);
-
-  return {
-    method: 'get',
-    path: '/',
-    process: async function (req, res) {
-      const flowEventData = flowMetrics.create(FLOW_ID_KEY);
-
-      if (NO_LONGER_SUPPORTED_CONTEXTS.has(req.query.context)) {
-        return res.redirect(`/update_firefox?${req.originalUrl.split('?')[1]}`);
-      }
-
-      let flags;
-      try {
-        flags = await featureFlags.get();
-      } catch (err) {
-        logger.error('featureFlags.error', err);
-        flags = {};
-      }
-
-      const isPromptNoneEnabledForClient =
-        req.query.client_id &&
-        PROMPT_NONE_ENABLED_CLIENT_IDS.has(req.query.client_id);
-
-      res.render('index', {
-        // Note that bundlePath is added to templates as a build step
-        bundlePath: '/bundle',
-        config: encodeURIComponent(
-          JSON.stringify({
-            ...configForFrontEnd,
-            isPromptNoneEnabled: PROMPT_NONE_ENABLED,
-            isPromptNoneEnabledForClient,
-          })
-        ),
-        featureFlags: encodeURIComponent(JSON.stringify(flags)),
-        flowBeginTime: flowEventData.flowBeginTime,
-        flowId: flowEventData.flowId,
-        // Note that staticResourceUrl is added to templates as a build step
-        staticResourceUrl: STATIC_RESOURCE_URL,
-      });
-
-      if (req.headers.dnt === '1') {
-        logger.info('request.headers.dnt');
-      }
-    },
-    terminate: featureFlags.terminate,
-  };
+module.exports = {
+  default: getIndex,
 };

--- a/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
@@ -3,16 +3,23 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { getServerReactRouteGroups } = require('./route-groups-server');
-const config = require('../../configuration');
 
 /** Add all routes from all route objects for fxa-settings or fxa-content-server to serve.
  * @type {import("./types").AddRoutes}
  */
-function addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n) {
-  /** Check if the feature flag passed in is `true` and the request contains `?showReactApp=true`.
-   * If true, use the middleware passed ('createSettingsProxy' in dev, else 'modifySettingsStatic')
-   * for that route, allowing `fxa-settings` to serve the page. If false, skip the middleware and
-   * use the default routing middleware from `fxa-shared/express/routing.ts`.
+function addAllReactRoutesConditionally(
+  app,
+  routeHelpers,
+  middleware,
+  i18n,
+  config
+) {
+  /** Check if the feature flag passed in is `true`, and either the request contains
+   * `?showReactApp=true` or `fullProdRollout` is set to `true`. If true, use the
+   * middleware passed ('createSettingsProxy' in dev, else 'modifySettingsStatic') for
+   * that route, allowing `fxa-settings` to serve the page. If false, skip the middleware
+   * and use the default routing middleware from `fxa-shared/express/routing.ts` to
+   * serve the Backbone app.
    * @param {import("./types").ReactRouteGroup}
    */
   function addReactRoutesConditionally({
@@ -25,11 +32,21 @@ function addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n) {
         // possible TODO - `definition.method`s will either be 'get' or 'post'. Not sure if we need
         // this for any 'post' requests but shouldn't hurt anything; 'get' alone may suffice.
         app[definition.method](definition.path, (req, res, next) => {
-          if (req.query.showReactApp === 'true' || fullProdRollout === true) {
+          if (req.query.showReactApp === 'true' || fullProdRollout) {
+            // req.path === '/' seems to match some content-server routes like `/authorization`.
+            // To be sure we are only pointing to React for '/' with '?showReactApp=true' and not
+            // other routes when only '/' is set in react-app/index.js, explicitly check for
+            // `originalUrl` as well.
+            if (definition.path === '/') {
+              if (req.originalUrl.split('?')[0] === '/') {
+                return middleware(req, res, next);
+              } else {
+                return next('route');
+              }
+            }
             return middleware(req, res, next);
-          } else {
-            next('route');
           }
+          next('route');
         });
         // Manually add route for content-server to serve; occurs when above next('route'); is called
         routeHelpers.addRoute(definition);
@@ -39,7 +56,8 @@ function addAllReactRoutesConditionally(app, routeHelpers, middleware, i18n) {
 
   const reactRouteGroups = getServerReactRouteGroups(
     config.get('showReactApp'),
-    i18n
+    i18n,
+    config
   );
   for (const routeGroup in reactRouteGroups) {
     addReactRoutesConditionally(reactRouteGroups[routeGroup]);

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -25,7 +25,7 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
   return {
     emailFirstRoutes: {
       featureFlagOn: showReactApp.emailFirstRoutes,
-      routes: reactRoute.getRoutes([]),
+      routes: reactRoute.getRoutes(['/']),
       fullProdRollout: false,
     },
     simpleRoutes: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/react-route-client.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/react-route-client.js
@@ -17,7 +17,8 @@ const reactRouteClient = {
   getRoute(name) {
     if (
       typeof name === 'string' &&
-      (FRONTEND_ROUTES.includes(name) ||
+      (name === '/' ||
+        FRONTEND_ROUTES.includes(name) ||
         PAIRING_ROUTES.includes(name) ||
         OAUTH_SUCCESS_ROUTES.includes(name))
     ) {

--- a/packages/fxa-content-server/server/lib/routes/react-app/react-route-server.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/react-route-server.js
@@ -14,6 +14,7 @@ const {
   getOAuthSuccessRouteDefinition,
   getTermsPrivacyRouteDefinition,
 } = require('./route-definitions');
+const { getIndexRouteDefinition } = require('./route-definition-index');
 
 /**
  * Returns a route object with the `name` of the route and the route `definition`.
@@ -21,13 +22,17 @@ const {
 class ReactRouteServer {
   /** @param {any} i18n
    * */
-  constructor(i18n) {
+  constructor(i18n, config) {
     this.i18n = i18n;
+    this.config = config;
   }
 
   /** @param {String|RegExp} name */
   getRoute(name) {
     if (typeof name === 'string') {
+      if (name === '/') {
+        return this.getIndex(name);
+      }
       if (FRONTEND_ROUTES.includes(name)) {
         return this.getFrontEnd(name);
       }
@@ -70,6 +75,11 @@ class ReactRouteServer {
   /** @private */
   getFrontEnd(name) {
     return this.getRouteObject(name, getFrontEndRouteDefinition([name]));
+  }
+
+  /** @private */
+  getIndex(name) {
+    return this.getRouteObject(name, getIndexRouteDefinition(this.config));
   }
 
   /** @private */

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -1,0 +1,195 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const flowMetrics = require('../../flow-metrics');
+const logger = require('../../logging/log')('routes.index');
+
+function getIndexRouteDefinition(config) {
+  let featureFlags;
+  const featureFlagConfig = config.get('featureFlags');
+  if (featureFlagConfig.enabled) {
+    featureFlags = require('fxa-shared').featureFlags(
+      featureFlagConfig,
+      logger
+    );
+  } else {
+    featureFlags = { get: () => ({}) };
+  }
+
+  const AUTH_SERVER_URL = config.get('fxaccount_url');
+  const CLIENT_ID = config.get('oauth_client_id');
+  const COPPA_ENABLED = config.get('coppa.enabled');
+  const ENV = config.get('env');
+  const FLOW_ID_KEY = config.get('flow_id_key');
+  const MARKETING_EMAIL_ENABLED = config.get('marketing_email.enabled');
+  const MARKETING_EMAIL_PREFERENCES_URL = config.get(
+    'marketing_email.preferences_url'
+  );
+  const MX_RECORD_VALIDATION = config.get('mxRecordValidation');
+  const MAX_EVENT_OFFSET = config.get('client_metrics.max_event_offset');
+  const REDIRECT_CHECK_ALLOW_LIST = config.get('redirect_check.allow_list');
+  const SENTRY_CLIENT_DSN = config.get('sentry.dsn');
+  const SENTRY_CLIENT_ENV = config.get('sentry.env');
+  const SENTRY_SAMPLE_RATE = config.get('sentry.sampleRate');
+  const SENTRY_TRACES_SAMPLE_RATE = config.get('sentry.tracesSampleRate');
+  const SENTRY_CLIENT_NAME = config.get('sentry.clientName');
+  const OAUTH_SERVER_URL = config.get('oauth_url');
+  const PAIRING_CHANNEL_URI = config.get('pairing.server_base_uri');
+  const PAIRING_CLIENTS = config.get('pairing.clients');
+  const PROFILE_SERVER_URL = config.get('profile_url');
+  const STATIC_RESOURCE_URL = config.get('static_resource_url');
+  const SCOPED_KEYS_ENABLED = config.get('scopedKeys.enabled');
+  const SCOPED_KEYS_VALIDATION = config.get('scopedKeys.validation');
+  const SUBSCRIPTIONS = config.get('subscriptions');
+  const GOOGLE_AUTH_CONFIG = config.get('googleAuthConfig');
+  const APPLE_AUTH_CONFIG = config.get('appleAuthConfig');
+  const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
+  const SHOW_REACT_APP = config.get('showReactApp');
+  const BRAND_MESSAGING_MODE = config.get('brandMessagingMode');
+  const FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS = config.get(
+    'featureFlags.sendFxAStatusOnSettings'
+  );
+  const FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN = config.get(
+    'featureFlags.recoveryCodeSetupOnSyncSignIn'
+  );
+  const FEATURE_FLAGS_ENABLE_ADDING_2FA_BACKUP_PHONE = config.get(
+    'featureFlags.enableAdding2FABackupPhone'
+  );
+  const FEATURE_FLAGS_ENABLE_USING_2FA_BACKUP_PHONE = config.get(
+    'featureFlags.enableUsing2FABackupPhone'
+  );
+  const GLEAN_ENABLED = config.get('glean.enabled');
+  const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
+  const GLEAN_UPLOAD_ENABLED = config.get('glean.uploadEnabled');
+  const GLEAN_APP_CHANNEL = config.get('glean.appChannel');
+  const GLEAN_SERVER_ENDPOINT = config.get('glean.serverEndpoint');
+  const GLEAN_LOG_PINGS = config.get('glean.logPings');
+  const GLEAN_DEBUG_VIEW_TAG = config.get('glean.debugViewTag');
+
+  // Rather than relay all rollout rates, hand pick the ones that are applicable
+  const ROLLOUT_RATES = config.get('rolloutRates');
+
+  // Note that this list is only enforced for clients that use login_hint/email
+  // with prompt=none. id_token_hint clients are not subject to this check.
+  const PROMPT_NONE_ENABLED_CLIENT_IDS = new Set(
+    config.get('oauth.prompt_none.enabled_client_ids')
+  );
+
+  // add version from package.json to config
+  const RELEASE = require('../../../../package.json').version;
+  const WEBPACK_PUBLIC_PATH = `${STATIC_RESOURCE_URL}/${config.get(
+    'jsResourcePath'
+  )}/`;
+
+  const configForFrontEnd = {
+    authServerUrl: AUTH_SERVER_URL,
+    maxEventOffset: MAX_EVENT_OFFSET,
+    env: ENV,
+    isCoppaEnabled: COPPA_ENABLED,
+    isPromptNoneEnabled: PROMPT_NONE_ENABLED,
+    googleAuthConfig: GOOGLE_AUTH_CONFIG,
+    appleAuthConfig: APPLE_AUTH_CONFIG,
+    marketingEmailEnabled: MARKETING_EMAIL_ENABLED,
+    marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,
+    mxRecordValidation: MX_RECORD_VALIDATION,
+    oAuthClientId: CLIENT_ID,
+    oAuthUrl: OAUTH_SERVER_URL,
+    pairingChannelServerUri: PAIRING_CHANNEL_URI,
+    pairingClients: PAIRING_CLIENTS,
+    profileUrl: PROFILE_SERVER_URL,
+    release: RELEASE,
+    redirectAllowlist: REDIRECT_CHECK_ALLOW_LIST,
+    rolloutRates: ROLLOUT_RATES,
+    scopedKeysEnabled: SCOPED_KEYS_ENABLED,
+    scopedKeysValidation: SCOPED_KEYS_VALIDATION,
+    sentry: {
+      dsn: SENTRY_CLIENT_DSN,
+      env: SENTRY_CLIENT_ENV,
+      sampleRate: SENTRY_SAMPLE_RATE,
+      clientName: SENTRY_CLIENT_NAME,
+      tracesSampleRate: SENTRY_TRACES_SAMPLE_RATE,
+    },
+    staticResourceUrl: STATIC_RESOURCE_URL,
+    subscriptions: SUBSCRIPTIONS,
+    webpackPublicPath: WEBPACK_PUBLIC_PATH,
+    showReactApp: SHOW_REACT_APP,
+    brandMessagingMode: BRAND_MESSAGING_MODE,
+    featureFlags: {
+      sendFxAStatusOnSettings: FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS,
+      recoveryCodeSetupOnSyncSignIn:
+        FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
+      enableAdding2FABackupPhone: FEATURE_FLAGS_ENABLE_ADDING_2FA_BACKUP_PHONE,
+      enableUsing2FABackupPhone: FEATURE_FLAGS_ENABLE_USING_2FA_BACKUP_PHONE,
+    },
+    glean: {
+      // feature toggle
+      enabled: GLEAN_ENABLED,
+      // Glean SDK config
+      applicationId: GLEAN_APPLICATION_ID,
+      uploadEnabled: GLEAN_UPLOAD_ENABLED,
+      appDisplayVersion: RELEASE,
+      channel: GLEAN_APP_CHANNEL,
+      serverEndpoint: GLEAN_SERVER_ENDPOINT,
+      logPings: GLEAN_LOG_PINGS,
+      debugViewTag: GLEAN_DEBUG_VIEW_TAG,
+    },
+  };
+
+  const NO_LONGER_SUPPORTED_CONTEXTS = new Set([
+    'fx_desktop_v1',
+    'fx_desktop_v2',
+    'fx_firstrun_v2',
+    'iframe',
+  ]);
+
+  return {
+    method: 'get',
+    path: '/',
+    process: async function (req, res) {
+      const flowEventData = flowMetrics.create(FLOW_ID_KEY);
+
+      if (NO_LONGER_SUPPORTED_CONTEXTS.has(req.query.context)) {
+        return res.redirect(`/update_firefox?${req.originalUrl.split('?')[1]}`);
+      }
+
+      let flags;
+      try {
+        flags = await featureFlags.get();
+      } catch (err) {
+        logger.error('featureFlags.error', err);
+        flags = {};
+      }
+
+      const isPromptNoneEnabledForClient =
+        req.query.client_id &&
+        PROMPT_NONE_ENABLED_CLIENT_IDS.has(req.query.client_id);
+
+      res.render('index', {
+        // Note that bundlePath is added to templates as a build step
+        bundlePath: '/bundle',
+        config: encodeURIComponent(
+          JSON.stringify({
+            ...configForFrontEnd,
+            isPromptNoneEnabled: PROMPT_NONE_ENABLED,
+            isPromptNoneEnabledForClient,
+          })
+        ),
+        featureFlags: encodeURIComponent(JSON.stringify(flags)),
+        flowBeginTime: flowEventData.flowBeginTime,
+        flowId: flowEventData.flowId,
+        // Note that staticResourceUrl is added to templates as a build step
+        staticResourceUrl: STATIC_RESOURCE_URL,
+      });
+
+      if (req.headers.dnt === '1') {
+        logger.info('request.headers.dnt');
+      }
+    },
+    terminate: featureFlags.terminate,
+  };
+}
+
+module.exports = { getIndexRouteDefinition };

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definitions.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definitions.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// Note that the route definition for the Index page is more complex
+
 /** @type {import("./types").GetRouteDefinition} */
 function getFrontEndRouteDefinition(routes) {
   const path = routes.join('|'); // prepare for use in a RegExp

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-groups-server.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-groups-server.js
@@ -10,8 +10,8 @@ const { ReactRouteServer } = require('./react-route-server');
 
  *  @type {import("./types").GetReactRouteGroups}
  */
-const getServerReactRouteGroups = (showReactApp, i18n) => {
-  const reactRoute = new ReactRouteServer(i18n);
+const getServerReactRouteGroups = (showReactApp, i18n, config) => {
+  const reactRoute = new ReactRouteServer(i18n, config);
   return getReactRouteGroups(showReactApp, reactRoute);
 };
 

--- a/packages/fxa-content-server/tests/server/routes/get-index.js
+++ b/packages/fxa-content-server/tests/server/routes/get-index.js
@@ -4,7 +4,7 @@
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
 const sinon = require('sinon');
-const route = require('../../../server/lib/routes/get-index');
+const route = require('../../../server/lib/routes/react-app/route-definition-index');
 const config = require('../../../server/lib/configuration');
 
 var instance, request, response;

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -83,6 +83,7 @@ jest.mock('../../lib/glean', () => ({
     getEnabled: jest.fn(),
     useGlean: jest.fn().mockReturnValue({ enabled: true }),
     accountPref: { view: jest.fn(), promoMonitorView: jest.fn() },
+    emailFirst: { view: jest.fn() },
     pageLoad: jest.fn(),
   },
 }));
@@ -163,7 +164,10 @@ describe('metrics', () => {
     });
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: jest.fn(),
+      isDesktopRelay: jest.fn(),
       getServiceName: jest.fn(),
+      getClientId: jest.fn(),
+      data: {},
     });
     const flowInit = jest.spyOn(Metrics, 'init');
     const userPreferencesInit = jest.spyOn(Metrics, 'initUserPreferences');
@@ -197,7 +201,10 @@ describe('glean', () => {
     });
     const mockIntegration = {
       isSync: jest.fn(),
+      isDesktopRelay: jest.fn(),
       getServiceName: jest.fn(),
+      getClientId: jest.fn(),
+      data: {},
     };
     (useIntegration as jest.Mock).mockReturnValue(mockIntegration);
     (useLocalSignedInQueryState as jest.Mock).mockReturnValueOnce({
@@ -267,6 +274,7 @@ describe('loading spinner states', () => {
     });
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: jest.fn().mockReturnValueOnce(true),
+      isDesktopRelay: jest.fn().mockReturnValueOnce(false),
       data: {
         context: {},
       },
@@ -315,6 +323,7 @@ describe('SettingsRoutes', () => {
     });
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => false,
+      isDesktopRelay: jest.fn().mockReturnValueOnce(false),
       getServiceName: jest.fn(),
     });
     (useLocalSignedInQueryState as jest.Mock).mockReturnValue({
@@ -374,6 +383,7 @@ describe('SettingsRoutes', () => {
   it('redirects to sign out of sync warning', async () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
+      isDesktopRelay: () => false,
       data: {
         context: {},
       },
@@ -417,6 +427,7 @@ describe('SettingsRoutes', () => {
   it('restores sync user when session is valid', async () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
+      isDesktopRelay: () => false,
       data: {
         context: {},
       },

--- a/packages/fxa-settings/src/components/Settings/AlertBar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/AlertBar/index.test.tsx
@@ -8,6 +8,7 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import AlertBar from '.';
 
 jest.mock('@apollo/client', () => ({
+  ...jest.requireActual('@apollo/client'),
   useReactiveVar: (x: Function) => x(),
 }));
 

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -21,6 +21,7 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import GleanMetrics from '../../../lib/glean';
 import { useFtlMsgResolver } from '../../../models/hooks';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 type FormData = {
   password: string;
@@ -107,6 +108,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
   const goHome = useCallback(() => window.history.back(), []);
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const account = useAccount();
 
@@ -143,7 +145,15 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
           'flow.settings.account-delete',
           'confirm-password.success'
         );
-        hardNavigate('/', { delete_account_success: true }, true);
+        if (shouldUseReactEmailFirst) {
+          navigate('/', {
+            state: {
+              deleteAccountSuccess: true,
+            },
+          });
+        } else {
+          hardNavigate('/', { delete_account_success: true }, true);
+        }
       } catch (e) {
         const localizedError = getLocalizedErrorMessage(ftlMsgResolver, e);
         if (e.errno === AuthUiErrors.INCORRECT_PASSWORD.errno) {
@@ -155,7 +165,15 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
         }
       }
     },
-    [account, setErrorText, setValue, alertBar, ftlMsgResolver]
+    [
+      account,
+      setErrorText,
+      setValue,
+      alertBar,
+      ftlMsgResolver,
+      navigate,
+      shouldUseReactEmailFirst,
+    ]
   );
 
   const handleConfirmChange =

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -414,7 +414,7 @@ const ERRORS = {
   },
   DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN: {
     errno: 1020,
-    message: 'Enter a valid email address. firefox.com does not offer email.',
+    message: 'Mistyped email? firefox.com isn’t a valid email service',
   },
   CHANNEL_TIMEOUT: {
     errno: 1021,
@@ -629,11 +629,12 @@ const ERRORS = {
       errno: 1063,
       message: 'Could not get Subscription Platform Terms of Service'
     },
-    INVALID_EMAIL_DOMAIN: {
-        errno: 1064,
-        message: 'Mistyped email? %(domain)s does not offer email.'
-    },
-     */
+    */
+  INVALID_EMAIL_DOMAIN: {
+    errno: 1064,
+    message: 'Mistyped email? %(domain)s isn’t a valid email service',
+    interpolate: true,
+  },
   IMAGE_TOO_LARGE: {
     errno: 1065,
     message: 'The image file size is too large to be uploaded.',
@@ -641,6 +642,10 @@ const ERRORS = {
   EMAIL_MASK_NEW_ACCOUNT: {
     errno: 1066,
     message: 'Email masks can’t be used to create an account.',
+  },
+  MX_LOOKUP_WARNING: {
+    errno: 1067,
+    message: 'Mistyped email?',
   },
 };
 

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -37,8 +37,14 @@ auth-error-1003 = Local storage or cookies are still disabled
 auth-error-1008 = Your new password must be different
 auth-error-1010 = Valid password required
 auth-error-1011 = Valid email required
+auth-error-1018 = Your confirmation email was just returned. Mistyped email?
+auth-error-1020 = Mistyped email? firefox.com isn’t a valid email service
 auth-error-1031 = You must enter your age to sign up
 auth-error-1032 = You must enter a valid age to sign up
 auth-error-1054 = Invalid two-step authentication code
 auth-error-1056 = Invalid backup authentication code
 auth-error-1062 = Invalid redirect
+# Shown when a user tries to sign up with an email address with a domain that doesn't receive emails
+auth-error-1064 = Mistyped email? { $domain } isn’t a valid email service
+auth-error-1066 = Email masks can’t be used to create an account.
+auth-error-1067 = Mistyped email?

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -6,6 +6,7 @@ import config from './config';
 import { StoredAccountData } from './storage-utils';
 import { v4 as uuid } from 'uuid';
 import * as Sentry from '@sentry/browser';
+import { Constants } from './constants';
 
 const storage = Storage.factory('localStorage');
 
@@ -239,3 +240,18 @@ export const cache = new InMemoryCache({
     },
   },
 });
+
+/*
+ * Check that the React enrolled flag in local storage is set to `true`.
+ * Note that if users don't hit the Backbone JS bundle, this is not going
+ * to get set.
+ */
+export function isInReactExperiment() {
+  const storageReactExp = storage.get(Constants.STORAGE_REACT_EXPERIMENT);
+  try {
+    const parsedData = JSON.parse(storageReactExp);
+    return parsedData && parsedData.enrolled === true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -347,8 +347,13 @@ export class Firefox extends EventTarget {
     });
   }
 
+  /*
+   * Sends an fxa_status and returns the signed in user if available.
+   */
   async requestSignedInUser(
-    context: string
+    context: string,
+    isPairing: boolean,
+    service: string
   ): Promise<undefined | SignedInUser> {
     let timeout: number;
     return Promise.race<undefined | SignedInUser>([
@@ -370,7 +375,8 @@ export class Firefox extends EventTarget {
         requestAnimationFrame(() => {
           this.send(FirefoxCommand.FxAStatus, {
             context,
-            isPairing: false,
+            isPairing,
+            service,
           });
         });
       }),

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -82,6 +82,7 @@ export interface Config {
   showReactApp: {
     signUpRoutes: boolean;
     signInRoutes: boolean;
+    emailFirstRoutes: boolean;
   };
   rolloutRates?: {
     keyStretchV2?: number;

--- a/packages/fxa-settings/src/lib/constants.ts
+++ b/packages/fxa-settings/src/lib/constants.ts
@@ -195,4 +195,6 @@ export const Constants = {
 
   DISABLE_PROMO_ACCOUNT_RECOVERY_KEY_DO_IT_LATER:
     '__fxa_storage.disable_promo.account-recovery-do-it-later',
+
+  STORAGE_REACT_EXPERIMENT: 'experiment.generalizedReactApp',
 };

--- a/packages/fxa-settings/src/lib/email-domain-validator-resolve-domain.ts
+++ b/packages/fxa-settings/src/lib/email-domain-validator-resolve-domain.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This function was moved to a separate file for easier mocking.
+
+const EMAIL_VALIDATION_ENDPOINT = '/validate-email-domain';
+
+export async function resolveDomain(domain: string) {
+  const response = await fetch(
+    `${EMAIL_VALIDATION_ENDPOINT}?domain=${domain}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to check domain ${domain}: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/packages/fxa-settings/src/lib/email-domain-validator.test.ts
+++ b/packages/fxa-settings/src/lib/email-domain-validator.test.ts
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { checkEmailDomain } from './email-domain-validator';
+import { AuthUiErrors } from './auth-errors/auth-errors';
+import topEmailDomains from 'fxa-shared/email/topEmailDomains';
+import { resolveDomain } from './email-domain-validator-resolve-domain';
+
+jest.mock('./email-domain-validator-resolve-domain', () => ({
+  resolveDomain: jest.fn(),
+}));
+
+describe('checkEmailDomain', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('should throw EMAIL_REQUIRED if no domain is present', async () => {
+    await expect(checkEmailDomain('invalidEmail')).rejects.toBe(
+      AuthUiErrors.EMAIL_REQUIRED
+    );
+  });
+
+  it('should skip validation for known top domains', async () => {
+    jest.spyOn(topEmailDomains, 'has').mockReturnValue(true);
+    await expect(checkEmailDomain('user@popular.com')).resolves.toBeUndefined();
+  });
+
+  it('should allow submission on a successful MX record lookup', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'MX' });
+    await expect(
+      checkEmailDomain('user@valid-mx.com')
+    ).resolves.toBeUndefined();
+    expect(resolveDomain).toHaveBeenCalledWith('valid-mx.com');
+  });
+
+  it('should throw MX_LOOKUP_WARNING on a successful A record lookup', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'A' });
+    await expect(checkEmailDomain('user@only-a.com')).rejects.toBe(
+      AuthUiErrors.MX_LOOKUP_WARNING
+    );
+  });
+
+  it('should throw INVALID_EMAIL_DOMAIN on a result of none', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'none' });
+    await expect(checkEmailDomain('user@no-records.com')).rejects.toBe(
+      AuthUiErrors.INVALID_EMAIL_DOMAIN
+    );
+  });
+
+  it('should resolve when the domain is marked as skip', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'skip' });
+    await expect(checkEmailDomain('user@skip.com')).resolves.toBeUndefined();
+  });
+
+  it('should allow submission on resolveDomain failure', async () => {
+    (resolveDomain as jest.Mock).mockRejectedValueOnce(
+      new Error('Network Error')
+    );
+    await expect(
+      checkEmailDomain('user@server-down.com')
+    ).resolves.toBeUndefined();
+  });
+
+  it('should reject immediately if the domain has previously failed', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'none' });
+    await expect(checkEmailDomain('user@failed.com')).rejects.toBe(
+      AuthUiErrors.INVALID_EMAIL_DOMAIN
+    );
+    await expect(checkEmailDomain('user@failed.com')).rejects.toBe(
+      AuthUiErrors.INVALID_EMAIL_DOMAIN
+    );
+  });
+
+  it('should resolve if the domain was previously resolved with an A record', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'A' });
+    await expect(checkEmailDomain('user@prev-a.com')).rejects.toBe(
+      AuthUiErrors.MX_LOOKUP_WARNING
+    );
+    await expect(checkEmailDomain('user@prev-a.com')).resolves.toBeUndefined();
+    expect(resolveDomain).toHaveBeenCalledTimes(1);
+  });
+  it('should resolve if the domain was previously resolved with an MX record', async () => {
+    (resolveDomain as jest.Mock).mockResolvedValueOnce({ result: 'MX' });
+    await expect(checkEmailDomain('user@prev-a.com')).resolves.toBeUndefined();
+    await expect(checkEmailDomain('user@cool.com')).resolves.toBeUndefined();
+    expect(resolveDomain).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/lib/email-domain-validator.ts
+++ b/packages/fxa-settings/src/lib/email-domain-validator.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AuthUiErrors } from './auth-errors/auth-errors';
+import topEmailDomains from 'fxa-shared/email/topEmailDomains';
+import { resolveDomain } from './email-domain-validator-resolve-domain';
+
+let previousDomain: string | undefined;
+let previousDomainResult: string | undefined;
+
+/**
+ * This validates an email address's domain through DNS lookups.
+ *
+ * The validation is performed after the existing account email check during
+ * the form submission process. At this point, the email address has gone
+ * through: 1) regex validation, 2) an email mask check, and 3) existing
+ * email address check.
+ *
+ * Prior to sending the email domain to the server side, it is checked against
+ * a list of known top domains. If the domain is found in the list, then the
+ * process is skipped.
+ *
+ * There are three possible validation results: 'MX', 'A', and 'none'.
+ *  - 'MX': MX record exists, proceed
+ *  - 'A': no MX, but A record exists, display tooltip but allow submission
+ *  - 'none: neither MX or A records found, block submission
+ *
+ * If the validation request itself fails, we allow the submission to
+ * continue.
+ */
+export const checkEmailDomain = async (email: string) => {
+  const [, domain] = email.split('@');
+  // This should have already been checked, but it's an extra sanity check
+  if (!domain) {
+    throw AuthUiErrors.EMAIL_REQUIRED;
+  }
+
+  if (topEmailDomains.has(domain)) {
+    // Glean / FXA-11292: email-domain-validation.skipped
+    return;
+  }
+
+  // User could repeatedly submit the form
+  if (previousDomain === domain) {
+    // if the previous result is 'A' or 'MX', allow it
+    if (previousDomainResult === 'A' || previousDomainResult === 'MX') {
+      // Glean / FXA-11292: for A - email-domain-validation.ignored
+      return;
+    }
+    throw AuthUiErrors.INVALID_EMAIL_DOMAIN;
+  }
+
+  // Glean / FXA-11292: email-domain-validation.triggered
+
+  let resp;
+  try {
+    resp = await resolveDomain(domain);
+    if (!resp) {
+      // Don't error and allow submission in case of server failure
+      return;
+    }
+  } catch (error) {
+    // Don't error and allow submission in case of server failure
+    return;
+  }
+
+  const { result } = resp;
+  previousDomain = domain;
+  previousDomainResult = result;
+
+  switch (result) {
+    case 'MX':
+      // Glean / FXA-11292: emailDomainValidation.success, email-domain-validation.success
+      return;
+    case 'A':
+      // Glean / FXA-11292: email-domain-validation.warn
+      throw AuthUiErrors.MX_LOOKUP_WARNING;
+    case 'skip':
+      return;
+    default:
+      // Glean / FXA-11292: email-domain-validation.block
+      throw AuthUiErrors.INVALID_EMAIL_DOMAIN;
+  }
+};

--- a/packages/fxa-settings/src/lib/error-utils.ts
+++ b/packages/fxa-settings/src/lib/error-utils.ts
@@ -173,3 +173,10 @@ export const getErrorFtlId = (err: { errno?: number; message?: string }) => {
   Sentry.captureMessage(logMessage);
   return '';
 };
+
+const NAMED_VARIABLE = /%\(([a-zA-Z]+)\)s/g;
+export function interpolate(string: string, context: Record<string, string>) {
+  return string.replace(NAMED_VARIABLE, (match, name) => {
+    return name in context ? context[name] : match;
+  });
+}

--- a/packages/fxa-settings/src/lib/hooks.tsx
+++ b/packages/fxa-settings/src/lib/hooks.tsx
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useEffect, useRef } from 'react';
+import { useConfig } from '../models';
+import { isInReactExperiment } from './cache';
 
 // Focus on the element that triggered some action after the first
 // argument changes from `false` to `true` unless a `triggerException`
@@ -54,4 +56,14 @@ export function useChangeFocusEffect() {
   }, []);
 
   return elToFocus;
+}
+
+/*
+ * Temporary helper to check that emailFirstRoutes feature flag is on
+ * and (if not 100% rolled out) that the user is in the React experiment.
+ */
+export function useCheckReactEmailFirst() {
+  const config = useConfig();
+  // TODO with FXA-11221 (100% prod rollout), remove isInReactExperiment() check
+  return config.showReactApp.emailFirstRoutes === true && isInReactExperiment();
 }

--- a/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
+++ b/packages/fxa-settings/src/lib/oauth/oauth-errors.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { interpolate } from '../error-utils';
+
 export type AuthError = {
   errno: number;
   message: string;
@@ -201,13 +203,6 @@ export class OAuthError extends Error {
     this.name = 'OAuthError';
     this.errno = err?.errno || OAUTH_ERRORS.UNEXPECTED_ERROR.errno;
   }
-}
-
-const NAMED_VARIABLE = /%\(([a-zA-Z]+)\)s/g;
-function interpolate(string: string, context: Record<string, string>) {
-  return string.replace(NAMED_VARIABLE, (match, name) => {
-    return name in context ? context[name] : match;
-  });
 }
 
 export function normalizeXHRError(response: Response) {

--- a/packages/fxa-settings/src/models/integrations/utils.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.ts
@@ -10,3 +10,13 @@ export function isFirefoxService(service?: string) {
     service === OAuthNativeServices.Relay
   );
 }
+
+const NO_LONGER_SUPPORTED_CONTEXTS = new Set([
+  'fx_desktop_v1',
+  'fx_desktop_v2',
+  'fx_firstrun_v2',
+  'iframe',
+]);
+export function isUnsupportedContext(context?: string): boolean {
+  return !!context && NO_LONGER_SUPPORTED_CONTEXTS.has(context);
+}

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -10,7 +10,7 @@ import {
   AppContextValue,
   defaultAppContext,
   SettingsContextValue,
-} from '.';
+} from './contexts/AppContext';
 
 import {
   createHistory,

--- a/packages/fxa-settings/src/models/pages/index/index.ts
+++ b/packages/fxa-settings/src/models/pages/index/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './query-params';

--- a/packages/fxa-settings/src/models/pages/index/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/index/query-params.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsEmail, IsOptional } from 'class-validator';
+import { bind, ModelDataProvider } from '../../../lib/model-data';
+
+export class IndexQueryParams extends ModelDataProvider {
+  @IsEmail()
+  @IsOptional()
+  @bind()
+  email: string = '';
+}

--- a/packages/fxa-settings/src/models/pages/signup/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signup/query-params.ts
@@ -7,12 +7,15 @@ import { bind, ModelDataProvider } from '../../../lib/model-data';
 
 export class SignupQueryParams extends ModelDataProvider {
   // 'email' will be optional once the index page is converted to React
-  // and we pass it with router-state instead of a param, and `emailStatusChecked`
-  // can be removed
+  // and we pass it with router-state instead of a param
   @IsEmail()
+  @IsOptional()
   @bind()
   email: string = '';
 
+  // When we get rid of Backbone email-first or React email-first has been
+  // rolled out for a while (to ensure we won't turn the feature off), this
+  // `emailStatusChecked` can be removed
   @IsOptional()
   @IsBoolean()
   @bind()

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
+import Index from '.';
+import { IndexContainerProps, LocationState } from './interfaces';
+import { useCallback, useEffect } from 'react';
+import { useAuthClient } from '../../models';
+import firefox from '../../lib/channels/firefox';
+import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { getHandledError } from '../../lib/error-utils';
+import { currentAccount } from '../../lib/cache';
+import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
+import { IndexQueryParams } from '../../models/pages/index';
+import { isUnsupportedContext } from '../../models/integrations/utils';
+import { hardNavigate } from 'fxa-react/lib/utils';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { checkEmailDomain } from '../../lib/email-domain-validator';
+import { isEmailMask, isEmailValid } from 'fxa-shared/email/helpers';
+
+// TODO: remove this function, it's only here to make TS happy until
+// we work on FXA-9757. errnos are always defined
+function getErrorWithDefinedErrNo(error: AuthUiError) {
+  return {
+    ...error,
+    errno: error.errno!,
+  };
+}
+
+export const IndexContainer = ({
+  integration,
+  serviceName,
+}: IndexContainerProps & RouteComponentProps) => {
+  // TODO, more strict validation for bad oauth params, FXA-11297
+  const authClient = useAuthClient();
+  const navigate = useNavigate();
+  const location = useLocation() as ReturnType<typeof useLocation> & {
+    state?: LocationState;
+  };
+  const { queryParamModel, validationError } =
+    useValidatedQueryParams(IndexQueryParams);
+
+  const { prefillEmail, deleteAccountSuccess, hasBounced } =
+    location.state || {};
+
+  const isWebChannelIntegration =
+    integration.isSync() || integration.isDesktopRelay();
+
+  // Query param should take precedence
+  const email = queryParamModel.email || currentAccount()?.email;
+  const shouldRedirectToSignin = email && !prefillEmail;
+
+  useEffect(() => {
+    if (shouldRedirectToSignin) {
+      navigate('/signin', {
+        state: {
+          email,
+        },
+      });
+    }
+  });
+
+  const signUpOrSignInHandler = useCallback(
+    async (email: string) => {
+      try {
+        if (!isEmailValid(email)) {
+          return {
+            error: getErrorWithDefinedErrNo(AuthUiErrors.EMAIL_REQUIRED),
+          };
+        }
+        const { exists, hasLinkedAccount, hasPassword } =
+          await authClient.accountStatusByEmail(email, {
+            thirdPartyAuthStatus: true,
+          });
+
+        if (!exists) {
+          if (isEmailMask(email)) {
+            return {
+              error: getErrorWithDefinedErrNo(
+                AuthUiErrors.EMAIL_MASK_NEW_ACCOUNT
+              ),
+            };
+            // "@firefox" or "@firefox.com" email addresses are not valid
+            // at this time, therefore block the attempt.
+            // the added 'i' disallows uppercase letters
+          } else if (new RegExp('@firefox(\\.com)?$', 'i').test(email)) {
+            return {
+              error: getErrorWithDefinedErrNo(
+                AuthUiErrors.DIFFERENT_EMAIL_REQUIRED_FIREFOX_DOMAIN
+              ),
+            };
+          }
+          // DNS lookup for MX record
+          await checkEmailDomain(email);
+        }
+
+        if (isWebChannelIntegration) {
+          const { ok } = await firefox.fxaCanLinkAccount({ email });
+          if (!ok) {
+            return {
+              error: getErrorWithDefinedErrNo(AuthUiErrors.USER_CANCELED_LOGIN),
+            };
+          }
+        }
+        if (!exists) {
+          navigate('/signup', {
+            state: {
+              email,
+              emailStatusChecked: true,
+            },
+          });
+        } else {
+          navigate('/signin', {
+            state: {
+              email,
+              hasLinkedAccount,
+              hasPassword,
+            },
+          });
+        }
+        return { error: null };
+      } catch (error) {
+        return getHandledError(error);
+      }
+    },
+    [authClient, navigate, isWebChannelIntegration]
+  );
+
+  if (validationError) {
+    // TODO: handle param validation errors in FXA-11297
+    // currently this is only a validation error for query param 'email', so do nothing?
+  }
+
+  if (isUnsupportedContext(integration.data.context)) {
+    hardNavigate('/update_firefox', {}, true);
+    return <LoadingSpinner fullScreen />;
+  }
+
+  if (shouldRedirectToSignin) {
+    return <LoadingSpinner fullScreen />;
+  }
+
+  return (
+    <Index
+      {...{
+        integration,
+        serviceName,
+        signUpOrSignInHandler,
+        prefillEmail,
+        deleteAccountSuccess,
+        hasBounced,
+      }}
+    />
+  );
+};

--- a/packages/fxa-settings/src/pages/Index/en.ftl
+++ b/packages/fxa-settings/src/pages/Index/en.ftl
@@ -3,6 +3,8 @@
 index-header = Enter your email
 index-sync-header = Continue to your { -product-mozilla-account }
 index-sync-subheader = Sync your passwords, tabs, and bookmarks everywhere you use { -brand-firefox }.
+index-relay-header = Create an email mask
+index-relay-subheader = Please provide the email address where you’d like to forward emails from your masked email.
 # $serviceName - the service (e.g., Pontoon) that the user is signing into with a Mozilla account
 index-subheader-with-servicename = Continue to { $serviceName }
 index-subheader-with-logo = Continue to <span>{ $serviceLogo }</span>
@@ -11,3 +13,7 @@ index-cta = Sign up or sign in
 index-account-info = A { -product-mozilla-account } also unlocks access to more privacy-protecting products from { -brand-mozilla }.
 index-email-input =
   .label = Enter your email
+# When users delete their Mozilla account inside account Settings, they are redirected to this page with a success message
+index-account-delete-success = Account deleted successfully
+# Displayed when users try to sign up for an account and their confirmation code email bounces
+index-email-bounced = Your confirmation email was just returned. Mistyped email?

--- a/packages/fxa-settings/src/pages/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.stories.tsx
@@ -9,7 +9,7 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { IndexProps } from './interfaces';
 import {
   createMockIndexOAuthIntegration,
-  createMockIndexSyncIntegration,
+  createMockIndexOAuthNativeIntegration,
   Subject,
 } from './mocks';
 import {
@@ -17,6 +17,7 @@ import {
   POCKET_CLIENTIDS,
 } from '../../models/integrations/client-matching';
 import { MozServices } from '../../lib/types';
+import { MOCK_EMAIL } from '../mocks';
 
 export default {
   title: 'Pages/Index',
@@ -33,8 +34,28 @@ const storyWithProps = ({
 
 export const Default = storyWithProps();
 
+export const WithBouncedEmail = storyWithProps({
+  hasBounced: true,
+  prefillEmail: MOCK_EMAIL,
+});
+
+export const WithServiceRelayIntegration = storyWithProps({
+  integration: createMockIndexOAuthNativeIntegration({
+    isDesktopRelay: true,
+    isSync: false,
+  }),
+});
+
+export const WithPrefilledEmail = storyWithProps({
+  prefillEmail: MOCK_EMAIL,
+});
+
+export const WithDeleteAccountSuccess = storyWithProps({
+  deleteAccountSuccess: true,
+});
+
 export const Sync = storyWithProps({
-  integration: createMockIndexSyncIntegration(),
+  integration: createMockIndexOAuthNativeIntegration(),
   serviceName: MozServices.FirefoxSync,
 });
 

--- a/packages/fxa-settings/src/pages/Index/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Index/interfaces.ts
@@ -2,15 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { HandledError } from '../../lib/error-utils';
 import { MozServices } from '../../lib/types';
 import { Integration } from '../../models';
 
 export type IndexIntegration = Pick<
   Integration,
-  'type' | 'isSync' | 'getClientId' | 'isDesktopRelay'
+  'type' | 'isSync' | 'getClientId' | 'isDesktopRelay' | 'data'
 >;
 
-export interface IndexProps {
+export interface IndexContainerProps {
   integration: IndexIntegration;
   serviceName: MozServices;
+}
+
+export interface LocationState {
+  prefillEmail?: string;
+  deleteAccountSuccess?: boolean;
+  hasBounced?: boolean;
+}
+
+export interface IndexProps extends LocationState {
+  integration: IndexIntegration;
+  serviceName: MozServices;
+  signUpOrSignInHandler: (
+    email: string
+  ) => Promise<{ error: HandledError | null }>;
+}
+
+export interface IndexFormData {
+  email: string;
 }

--- a/packages/fxa-settings/src/pages/Index/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Index/mocks.tsx
@@ -9,6 +9,7 @@ import { IntegrationType } from '../../models';
 import { IndexIntegration } from './interfaces';
 import Index from '.';
 import { MOCK_CLIENT_ID } from '../mocks';
+import { Constants } from '../../lib/constants';
 
 export function createMockIndexOAuthIntegration({
   clientId = MOCK_CLIENT_ID,
@@ -18,14 +19,26 @@ export function createMockIndexOAuthIntegration({
     isSync: () => false,
     getClientId: () => clientId,
     isDesktopRelay: () => false,
+    data: {
+      context: '',
+    },
   };
 }
-export function createMockIndexSyncIntegration(): IndexIntegration {
+export function createMockIndexOAuthNativeIntegration({
+  isSync = true,
+  isDesktopRelay = false,
+}: {
+  isSync?: boolean;
+  isDesktopRelay?: boolean;
+} = {}): IndexIntegration {
   return {
     type: IntegrationType.OAuthNative,
-    isSync: () => true,
+    isSync: () => isSync,
     getClientId: () => MOCK_CLIENT_ID,
-    isDesktopRelay: () => false,
+    isDesktopRelay: () => isDesktopRelay,
+    data: {
+      context: Constants.OAUTH_WEBCHANNEL_CONTEXT,
+    },
   };
 }
 
@@ -35,20 +48,33 @@ export function createMockIndexWebIntegration(): IndexIntegration {
     isSync: () => false,
     getClientId: () => undefined,
     isDesktopRelay: () => false,
+    data: {
+      context: '',
+    },
   };
 }
 
 export const Subject = ({
   integration = createMockIndexWebIntegration(),
   serviceName = MozServices.Default,
+  prefillEmail,
+  deleteAccountSuccess,
+  hasBounced,
 }: {
   integration?: IndexIntegration;
   serviceName?: MozServices;
+  prefillEmail?: string;
+  deleteAccountSuccess?: boolean;
+  hasBounced?: boolean;
 }) => {
   return (
     <LocationProvider>
       <Index
+        signUpOrSignInHandler={async () => ({ error: null })}
         {...{
+          prefillEmail,
+          deleteAccountSuccess,
+          hasBounced,
           integration,
           serviceName,
         }}

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.tsx
@@ -12,6 +12,8 @@ import FormVerifyCode, {
   FormAttributes,
 } from '../../../components/FormVerifyCode';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 
 export type ConfirmTotpResetPasswordProps = {
   verifyCode: (code: string) => Promise<void>;
@@ -28,6 +30,8 @@ const ConfirmTotpResetPassword = ({
 }: ConfirmTotpResetPasswordProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const [showRecoveryCode, setShowRecoveryCode] = useState<boolean>(false);
+  const navigate = useNavigate();
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const totpFormAttributes: FormAttributes = {
     inputFtlId: 'confirm-totp-reset-password-input-label-v2',
@@ -140,8 +144,12 @@ const ConfirmTotpResetPassword = ({
               className="link-blue text-sm"
               data-glean-id="reset_password_confirm_totp_use_different_account_button"
               onClick={() => {
-                // Navigate to email first page and keep search params
-                hardNavigate('/', {}, true);
+                if (shouldUseReactEmailFirst) {
+                  navigate('/');
+                } else {
+                  // Navigate to email first page and keep search params
+                  hardNavigate('/', {}, true);
+                }
               }}
             >
               <FtlMsg id="confirm-totp-reset-password-use-different-account">

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -8,11 +8,13 @@ import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ReactComponent as EmailBounced } from './graphic_email_bounced.svg';
 import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 
 import AppLayout from '../../../components/AppLayout';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import CardHeader from '../../../components/CardHeader';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 export type SigninBouncedProps = {
   email?: string;
@@ -32,6 +34,8 @@ const SigninBounced = ({
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMessageResolver = useFtlMsgResolver();
   const backText = ftlMessageResolver.getMsg('back', 'Back');
+  const navigate = useNavigate();
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const handleNavigationBack = (event: any) => {
     logViewEvent(viewName, 'link.back', REACT_ENTRYPOINT);
@@ -44,15 +48,19 @@ const SigninBounced = ({
 
   useEffect(() => {
     if (!email) {
-      hardNavigate('/', {}, true);
+      if (shouldUseReactEmailFirst) {
+        navigate('/');
+      } else {
+        hardNavigate('/', {}, true);
+      }
     }
-  }, [email]);
+  }, [email, navigate, shouldUseReactEmailFirst]);
 
   const createAccountHandler = () => {
     logViewEvent(viewName, 'link.create-account', REACT_ENTRYPOINT);
     localStorage.removeItem('__fxa_storage.accounts');
     sessionStorage.clear();
-    hardNavigate('/signup', {}, true);
+    navigate('/signup');
   };
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -21,6 +21,7 @@ import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useEffect, useState } from 'react';
 import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 export type SigninPushCodeContainerProps = {
   integration: Integration;
@@ -33,6 +34,7 @@ export const SigninPushCodeContainer = ({
 }: SigninPushCodeContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const navigate = useNavigate();
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
     integration
@@ -73,7 +75,11 @@ export const SigninPushCodeContainer = ({
   }
 
   if (!signinState) {
-    hardNavigate('/', {}, true);
+    if (shouldUseReactEmailFirst) {
+      navigate('/');
+    } else {
+      hardNavigate('/', {}, true);
+    }
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -35,6 +35,7 @@ import {
   PASSWORD_CHANGE_FINISH_MUTATION,
   PASSWORD_CHANGE_START_MUTATION,
 } from '../gql';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 // The email with token code (verifyLoginCodeEmail) is sent on `/signin`
 // submission if conditions are met.
@@ -48,6 +49,7 @@ const SigninTokenCodeContainer = ({
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state?: SigninLocationState;
   };
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const signinState = getSigninState(location.state);
   const sensitiveDataClient = useSensitiveDataClient();
@@ -94,7 +96,11 @@ const SigninTokenCodeContainer = ({
   }, [authClient, signinState]);
 
   if (!signinState || !signinState.sessionToken) {
-    hardNavigate('/', {}, true);
+    if (shouldUseReactEmailFirst) {
+      navigate('/');
+    } else {
+      hardNavigate('/', {}, true);
+    }
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -43,6 +43,8 @@ import {
 } from '../gql';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
@@ -69,6 +71,8 @@ export const SigninTotpCodeContainer = ({
 
   const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
   const { service } = queryParamModel;
+  const navigate = useNavigate();
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
@@ -160,7 +164,11 @@ export const SigninTotpCodeContainer = ({
     (signinState.verificationMethod &&
       signinState.verificationMethod !== VerificationMethods.TOTP_2FA)
   ) {
-    hardNavigate('/', {}, true);
+    if (shouldUseReactEmailFirst) {
+      navigate('/');
+    } else {
+      hardNavigate('/', {}, true);
+    }
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -52,6 +52,8 @@ import { SignInOptions } from 'fxa-auth-client/browser';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { isFirefoxService } from '../../../models/integrations/utils';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
+import { useCheckReactEmailFirst } from '../../../lib/hooks';
+import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 
 export const SigninUnblockContainer = ({
   integration,
@@ -62,6 +64,8 @@ export const SigninUnblockContainer = ({
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
+  const navigate = useNavigate();
+  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: SigninUnblockLocationState;
@@ -217,7 +221,11 @@ export const SigninUnblockContainer = ({
   }
 
   if (!email || !password) {
-    hardNavigate('/', {}, true);
+    if (shouldUseReactEmailFirst) {
+      navigate('/');
+    } else {
+      hardNavigate('/', {}, true);
+    }
     return <LoadingSpinner fullScreen />;
   }
   return (

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -135,6 +135,12 @@ function applyDefaultMocks() {
   mockSentryModule();
 }
 
+let mockUseCheckReactEmailFirst = jest.fn().mockReturnValue(true);
+jest.mock('../../lib/hooks', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../lib/hooks'),
+  useCheckReactEmailFirst: () => mockUseCheckReactEmailFirst(),
+}));
 jest.mock('../../models', () => {
   return {
     ...jest.requireActual('../../models'),
@@ -761,7 +767,7 @@ describe('signin container', () => {
         });
       });
 
-      it('returns expected error when fxaCanLinkAccount response is !ok', async () => {
+      it('returns expected error when fxaCanLinkAccount response is ok: false', async () => {
         (firefox.fxaCanLinkAccount as jest.Mock).mockImplementationOnce(
           async () => ({
             ok: false,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -178,7 +178,7 @@ const ConfirmSignupCode = ({
 
         // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
-          hardNavigate('oauth/signin', {}, true);
+          navigate('oauth/signin');
           return;
         } else {
           const { redirect, code, state, error } = await finishOAuthFlowHandler(

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -245,25 +245,6 @@ describe('sign-up-container', () => {
     });
   });
 
-  describe('loading-states', () => {
-    beforeEach(() => {
-      // TIP - In this case, we want to override the previous behavior. We can do this
-      // easily in a before each or even within a test block.
-      (useAuthClient as jest.Mock).mockImplementation(() => {
-        let client = new AuthClient('localhost:9000', { keyStretchVersion: 1 });
-        client.accountStatusByEmail = jest
-          .fn()
-          .mockReturnValue(new Promise(() => {}));
-        return client;
-      });
-    });
-
-    it('shows loading until account status query resolves', async () => {
-      await render('loading spinner mock');
-      expect(screen.queryByText('signup mock')).toBeNull();
-    });
-  });
-
   describe('error-states', () => {
     it('handles invalid email', async () => {
       // In this case want to mimic a bad email value

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -12,26 +12,22 @@ import {
   createMockSignupOAuthWebIntegration,
   createMockSignupSyncDesktopV3Integration,
   mockBeginSignupHandler,
-  signupQueryParams,
 } from './mocks';
 import { SignupIntegration } from './interfaces';
-import { SignupQueryParams } from '../../models/pages/signup';
-import { mockAppContext, mockUrlQueryData } from '../../models/mocks';
+import { mockAppContext } from '../../models/mocks';
 import {
   MONITOR_CLIENTIDS,
   POCKET_CLIENTIDS,
 } from '../../models/integrations/client-matching';
 import { AppContext } from '../../models';
 import { useMockSyncEngines } from '../../lib/hooks/useSyncEngines/mocks';
+import { MOCK_EMAIL } from '../mocks';
 
 export default {
   title: 'Pages/Signup',
   component: Signup,
   decorators: [withLocalization],
 } as Meta;
-
-const urlQueryData = mockUrlQueryData(signupQueryParams);
-const queryParamModel = new SignupQueryParams(urlQueryData);
 
 const StoryWithProps = ({
   integration = createMockSignupOAuthWebIntegration(),
@@ -46,10 +42,10 @@ const StoryWithProps = ({
         <Signup
           {...{
             integration,
-            queryParamModel,
             beginSignupHandler: mockBeginSignupHandler,
             useSyncEnginesResult,
           }}
+          email={MOCK_EMAIL}
         />
       </LocationProvider>
     </AppContext.Provider>

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -18,7 +18,6 @@ import { REACT_ENTRYPOINT } from '../../constants';
 import {
   BEGIN_SIGNUP_HANDLER_FAIL_RESPONSE,
   BEGIN_SIGNUP_HANDLER_RESPONSE,
-  MOCK_SEARCH_PARAMS,
   Subject,
   createMockSignupOAuthWebIntegration,
   createMockSignupOAuthNativeIntegration,
@@ -50,18 +49,10 @@ jest.mock('../../lib/metrics', () => ({
   }),
 }));
 
-const mockLocation = () => {
-  return {
-    pathname: `/signup`,
-    search: '?' + new URLSearchParams(MOCK_SEARCH_PARAMS),
-  };
-};
-
 const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   useNavigate: () => mockNavigate,
-  useLocation: () => mockLocation(),
 }));
 
 jest.mock('../../lib/glean', () => ({
@@ -409,9 +400,7 @@ describe('Signup page', () => {
         });
         expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
         expect(GleanMetrics.registration.success).not.toHaveBeenCalled();
-        expect(mockNavigate).toHaveBeenCalledWith(
-          `/cannot_create_account?email=${encodeURIComponent(MOCK_EMAIL)}`
-        );
+        expect(mockNavigate).toHaveBeenCalledWith('/cannot_create_account');
         expect(mockBeginSignupHandler).not.toBeCalled();
       });
 
@@ -469,9 +458,7 @@ describe('Signup page', () => {
       ['a@relay.firefox.com', 'b@mozmail.com', 'c@sub.mozmail.com'].forEach(
         (mask) => {
           it(`fails for mask ${mask}`, async () => {
-            renderWithLocalizationProvider(
-              <Subject queryParams={{ email: mask }} />
-            );
+            renderWithLocalizationProvider(<Subject email={mask} />);
             await fillOutForm();
             submit();
 
@@ -520,23 +507,20 @@ describe('Signup page', () => {
         });
 
         // expect navigation to have been called with newsletter slugs
-        expect(mockNavigate).toHaveBeenCalledWith(
-          `/confirm_signup_code${mockLocation().search}`,
-          {
-            state: {
-              origin: 'signup',
-              // we expect three newsletter options, but 4 slugs should be passed
-              // because the first newsletter checkbox subscribes the user to 2 newsletters
-              selectedNewsletterSlugs: [
-                'mozilla-and-you',
-                'mozilla-accounts',
-                'mozilla-foundation',
-                'test-pilot',
-              ],
-            },
-            replace: true,
-          }
-        );
+        expect(mockNavigate).toHaveBeenCalledWith(`/confirm_signup_code`, {
+          state: {
+            origin: 'signup',
+            // we expect three newsletter options, but 4 slugs should be passed
+            // because the first newsletter checkbox subscribes the user to 2 newsletters
+            selectedNewsletterSlugs: [
+              'mozilla-and-you',
+              'mozilla-accounts',
+              'mozilla-foundation',
+              'test-pilot',
+            ],
+          },
+          replace: true,
+        });
       });
     });
 
@@ -578,16 +562,13 @@ describe('Signup page', () => {
         expect(fxaLoginSpy).not.toBeCalled();
         expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
 
-        expect(mockNavigate).toHaveBeenCalledWith(
-          `/confirm_signup_code${mockLocation().search}`,
-          {
-            state: {
-              origin: 'signup',
-              selectedNewsletterSlugs: [],
-            },
-            replace: true,
-          }
-        );
+        expect(mockNavigate).toHaveBeenCalledWith(`/confirm_signup_code`, {
+          state: {
+            origin: 'signup',
+            selectedNewsletterSlugs: [],
+          },
+          replace: true,
+        });
       });
 
       describe('Sync integrations', () => {
@@ -919,10 +900,7 @@ describe('Signup page', () => {
       renderWithLocalizationProvider(
         <Subject
           {...{
-            queryParams: {
-              email: 'foo@bar.com',
-              emailStatusChecked: 'true',
-            },
+            email: 'foo@bar.com',
           }}
         />
       );
@@ -957,10 +935,7 @@ describe('Signup page', () => {
       renderWithLocalizationProvider(
         <Subject
           {...{
-            queryParams: {
-              email: 'foo@bar.com',
-              emailStatusChecked: 'true',
-            },
+            email: 'foo@bar.com',
           }}
         />
       );

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -5,7 +5,6 @@
 import { HandledError } from '../../lib/error-utils';
 import useSyncEngines from '../../lib/hooks/useSyncEngines';
 import { BaseIntegration, OAuthIntegration } from '../../models';
-import { SignupQueryParams } from '../../models/pages/signup';
 import { MetricsContext } from '@fxa/shared/glean';
 
 export interface BeginSignupResponse {
@@ -41,7 +40,7 @@ export interface BeginSignupResult {
 
 export interface SignupProps {
   integration: SignupIntegration;
-  queryParamModel: SignupQueryParams;
+  email: string;
   beginSignupHandler: BeginSignupHandler;
   useSyncEnginesResult: ReturnType<typeof useSyncEngines>;
 }

--- a/packages/fxa-settings/src/pages/Signup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/mocks.tsx
@@ -6,8 +6,6 @@ import { LocationProvider } from '@reach/router';
 import Signup from '.';
 import { MozServices } from '../../lib/types';
 import { IntegrationType } from '../../models';
-import { mockUrlQueryData } from '../../models/mocks';
-import { SignupQueryParams } from '../../models/pages/signup';
 import {
   MOCK_REDIRECT_URI,
   MOCK_UID,
@@ -25,10 +23,6 @@ import {
   SignupOAuthIntegration,
 } from './interfaces';
 import { useMockSyncEngines } from '../../lib/hooks/useSyncEngines/mocks';
-
-export const MOCK_SEARCH_PARAMS = {
-  email: MOCK_EMAIL,
-};
 
 export function createMockSignupWebIntegration(): SignupBaseIntegration {
   return {
@@ -129,25 +123,23 @@ export const signupQueryParamsWithContent = {
 };
 
 export const Subject = ({
-  queryParams = signupQueryParams,
   integration = createMockSignupWebIntegration(),
   beginSignupHandler = mockBeginSignupHandler,
+  email = MOCK_EMAIL,
 }: {
-  queryParams?: Record<string, string>;
+  email?: string;
   integration?: SignupIntegration;
   beginSignupHandler?: BeginSignupHandler;
 }) => {
-  const urlQueryData = mockUrlQueryData(queryParams);
-  const queryParamModel = new SignupQueryParams(urlQueryData);
   const useMockSyncEnginesResult = useMockSyncEngines();
   return (
     <LocationProvider>
       <Signup
         {...{
           integration,
-          queryParamModel,
           beginSignupHandler,
           useSyncEnginesResult: useMockSyncEnginesResult,
+          email,
         }}
       />
     </LocationProvider>


### PR DESCRIPTION
Because:
* We are converting our Backbone pages to React

This commit:
* Adjusts content-server routing to make email-first servable by Express to React
* Adds functionality from Backbone email-first to React email-first
* Makes React email-first backwards compatible with Backbone until we feel confident in the full prod rollout, e.g. navigate vs hardNavigates
* Adjusts stories/tests

fixes FXA-8636, fixes FXA-8072

---

TODO:
* ~Non-React routes are not being served by Express properly, except for the Backbone index/email-first screen, e.g. going to `/pair` in this branch currently 404s. This is preventing me from testing RP redirect~ This is fixed.
* ~Look at/do some stuff in the Backbone Express handler for React (e.g. MX stuff/redirects etc.)~
* ~Might need to look at `InputText` and `prefillEmail` again since I've got it as a placeholder but we want it to also be text in the input. Setting `value` makes it uneditable (still needs doing, see further down)~
* ~Finish unit tests~

Things with follow up issues:
* DNS email address lookup metrics ([filed issue](https://mozilla-hub.atlassian.net/browse/FXA-11292))
* Probably a ticket to look at stricter oauth param validation or to at least log it in a ticket, since Backbone is more strict ([filed issue](https://mozilla-hub.atlassian.net/browse/FXA-11297))
* Any needed functional test updates, but I think I may update our full prod rollout ticket to a 3-pointer to do these ([ticket here](https://mozilla-hub.atlassian.net/browse/FXA-11221))

Here's some things that could be worth doing maybe as a follow up:
* Index container tests, and maybe more test coverage in general, this has just gotten to be a gnarly PR. Also not sure if I am missing any metrics from email-first, need to look

### Preferred way to test
* Refresh back and forth between email-first and `/clear` until email-first enrolls you and takes you to `/?showReactApp=true` (which is what will happen for users).
 
You can also use `?forceExperiment=generalizedReactApp&forceExperimentGroup=react` in a pinch but the new `isInReactExperiment()` in fxa-settings doesn't seem to always work with that. (This seems to add the value to local storage, so not sure off the top of my head why.)

Additionally you can go to `/?showReactApp=true` directly but similarly the `isInReactExperiment()` check won't work so navigating around back to `/` will load Backbone. 

### Things to test
* location state updates instead of query params for Backbone, for example on reset password, clicking "Remember password? Signin" should prefill the email and not do a hard navigate
* Backbone _and_ React works
* Sync signin/signup
* RP signin, though we have a separate `/oauth/` ticket for this. If you're using 123done and you click "Email-first", you can change the route from `/oauth/` to `/` to test
* Third party auth (note this currently appears to work, but I need to do more testing) 
* Metrics coming from React email-first and into flows work as expected
* DNS lookup behaving as expected
