### PR TITLE
fix(recovery-phone): Invalidate previous SMS codes

### DIFF
--- a/libs/accounts/recovery-phone/README.md
+++ b/libs/accounts/recovery-phone/README.md
@@ -12,4 +12,6 @@ Run `nx test-unit accounts-recovery-phone` to execute the unit tests via [Jest](
 
 ## Running integration tests
 
+Make sure local infra (ie databases) are spun up by checking status. `yarn pm2 status` should show redis and mysql instances running. If not, run `yarn start infrastructure`.
+
 Run `nx test-integration accounts-recovery-phone` to execute the integration tests via [Jest](https://jestjs.io).

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.spec.ts
@@ -47,7 +47,7 @@ describe('RecoveryPhoneService', () => {
   const mockRecoveryPhoneManager = {
     storeUnconfirmed: jest.fn(),
     getUnconfirmed: jest.fn(),
-    getAllUnconfirmed: jest.fn(),
+    getAllUnconfirmedCodes: jest.fn(),
     registerPhoneNumber: jest.fn(),
     removePhoneNumber: jest.fn(),
     getConfirmedPhoneNumber: jest.fn(),
@@ -99,7 +99,7 @@ describe('RecoveryPhoneService', () => {
       };
     });
     mockRecoveryPhoneManager.hasRecoveryCodes.mockResolvedValue(true);
-    mockRecoveryPhoneManager.getAllUnconfirmed.mockResolvedValue([]);
+    mockRecoveryPhoneManager.getAllUnconfirmedCodes.mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -158,15 +158,15 @@ describe('RecoveryPhoneService', () => {
       phoneNumber,
       true
     );
-    expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
+    expect(mockRecoveryPhoneManager.getAllUnconfirmedCodes).toBeCalledWith(uid);
     expect(result).toBeTruthy();
   });
 
   it('Should send new code to set up a phone number', async () => {
     mockOtpManager.generateCode.mockReturnValue(code);
-    mockRecoveryPhoneManager.getAllUnconfirmed.mockResolvedValue([
-      'this:is:the:code123',
-      'this:is:the:code456',
+    mockRecoveryPhoneManager.getAllUnconfirmedCodes.mockResolvedValue([
+      'code123',
+      'code456',
     ]);
 
     const result = await service.setupPhoneNumber(
@@ -189,7 +189,7 @@ describe('RecoveryPhoneService', () => {
       phoneNumber,
       true
     );
-    expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
+    expect(mockRecoveryPhoneManager.getAllUnconfirmedCodes).toBeCalledWith(uid);
   });
 
   it('handles message template when provided to set up phone number', async () => {
@@ -213,7 +213,7 @@ describe('RecoveryPhoneService', () => {
       phoneNumber,
       true
     );
-    expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
+    expect(mockRecoveryPhoneManager.getAllUnconfirmedCodes).toBeCalledWith(uid);
   });
 
   it('Will reject a phone number that is not part of launch', async () => {
@@ -565,9 +565,9 @@ describe('RecoveryPhoneService', () => {
 
     it('Should send new code for setup phone number', async () => {
       mockOtpManager.generateCode.mockReturnValue(code);
-      mockRecoveryPhoneManager.getAllUnconfirmed.mockResolvedValue([
-        'this:is:the:code123',
-        'this:is:the:code456',
+      mockRecoveryPhoneManager.getAllUnconfirmedCodes.mockResolvedValue([
+        'code123',
+        'code456',
       ]);
 
       mockRecoveryPhoneManager.getConfirmedPhoneNumber.mockResolvedValueOnce({
@@ -602,7 +602,9 @@ describe('RecoveryPhoneService', () => {
         uid,
         'code456'
       );
-      expect(mockRecoveryPhoneManager.getAllUnconfirmed).toBeCalledWith(uid);
+      expect(mockRecoveryPhoneManager.getAllUnconfirmedCodes).toBeCalledWith(
+        uid
+      );
     });
   });
 

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -95,14 +95,10 @@ export class RecoveryPhoneService {
     }
 
     // Invalidate and remove any or all previous unconfirmed code entries
-    const unconfirmedKeys = await this.recoveryPhoneManager.getAllUnconfirmed(
-      uid
-    );
-    for (const key of unconfirmedKeys) {
-      const code = key.split(':').pop();
-      if (code) {
-        await this.recoveryPhoneManager.removeCode(uid, code);
-      }
+    const unconfirmedCodes =
+      await this.recoveryPhoneManager.getAllUnconfirmedCodes(uid);
+    for (const code of unconfirmedCodes) {
+      await this.recoveryPhoneManager.removeCode(uid, code);
     }
 
     // Rejects the phone number if it has been registered for too many accounts
@@ -371,14 +367,10 @@ export class RecoveryPhoneService {
     }
 
     // Invalidate and remove any or all previous unconfirmed code entries
-    const unconfirmedKeys = await this.recoveryPhoneManager.getAllUnconfirmed(
-      uid
-    );
-    for (const key of unconfirmedKeys) {
-      const oldCode = key.split(':').pop();
-      if (oldCode) {
-        await this.recoveryPhoneManager.removeCode(uid, oldCode);
-      }
+    const unconfirmedCodes =
+      await this.recoveryPhoneManager.getAllUnconfirmedCodes(uid);
+    for (const oldCode of unconfirmedCodes) {
+      await this.recoveryPhoneManager.removeCode(uid, oldCode);
     }
 
     // Generate a new otp code, and store it as unconfirmed for later validation

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -9,6 +9,8 @@ require('../lib/monitoring');
 
 const { config } = require('../config');
 
+const Redis = require('ioredis');
+
 const { CapabilityManager } = require('@fxa/payments/capability');
 const { EligibilityManager } = require('@fxa/payments/eligibility');
 const {
@@ -224,7 +226,7 @@ async function run(config) {
   }
 
   const twilio = TwilioFactory.useFactory(config.twilio);
-  const recoveryPhoneRedis = require('../lib/redis')({
+  const recoveryPhoneRedis = new Redis({
     ...config.redis,
     ...config.redis.recoveryPhone,
   });


### PR DESCRIPTION
## Because
- We want to make sure old codes are invalidated (ie cleared) when:
   - Sending code for signin
   - Sending code for setup

## This pull request
- Updates redis code to use SCAN which is more efficient and recommended for production environments.
- Makes this consistent
- Cleans up function so codes are returned and internal key structure isn't exposed
- Cleans up integration tests so they are actually integration. ie They don't rely on redis mocks.
- Updates readme with note that infrastructure should be running.

## Issue that this pull request solves

Closes: FXA-11111

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/250c112d-85a3-416c-a818-1088b44a71ed)

## Other information (Optional)

Any other information that is important to this pull request.
