### PR TITLE
fix(payments-next): Create subscription with valid coupon

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -17,21 +17,16 @@ import {
   SubscriptionTitle,
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
+import { CartState } from '@fxa/shared/db/mysql/account';
 import { auth } from 'apps/payments/next/auth';
 import { config } from 'apps/payments/next/config';
-
-// TODO - Replace these placeholders as part of FXA-8227
-export const metadata = {
-  title: 'Mozilla accounts',
-  description: 'Mozilla accounts',
-};
 
 export interface CheckoutSearchParams {
   experiment?: string;
   promotion_code?: string;
 }
 
-export default async function RootLayout({
+export default async function CheckoutLayout({
   children,
   params,
 }: {
@@ -104,7 +99,7 @@ export default async function RootLayout({
             cartId={cart.id}
             cartVersion={cart.version}
             promoCode={cart.couponCode}
-            readOnly={false}
+            readOnly={cart.state === CartState.START ? false : true}
           />
         </section>
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -2,19 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { Metadata } from 'next';
 import { headers } from 'next/headers';
+import Image from 'next/image';
 
 import { formatPlanPricing, getCardIcon } from '@fxa/payments/ui';
-
-import { SupportedPages, getApp } from '@fxa/payments/ui/server';
 import {
   fetchCMSData,
   getCartOrRedirectAction,
   recordEmitterEventAction,
 } from '@fxa/payments/ui/actions';
-import { CheckoutParams } from '@fxa/payments/ui/server';
-import Image from 'next/image';
-import type { Metadata } from 'next';
+import {
+  getApp,
+  CheckoutParams,
+  SupportedPages,
+} from '@fxa/payments/ui/server';
 
 export const dynamic = 'force-dynamic';
 

--- a/apps/payments/next/app/layout.tsx
+++ b/apps/payments/next/app/layout.tsx
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import './styles/global.css';
+import type { Metadata } from 'next';
 
-// TODO - Replace these placeholders as part of FXA-8227
-export const metadata = {
-  title: 'Mozilla accounts',
-  description: 'Mozilla accounts',
+export const metadata: Metadata = {
+  title: 'Mozilla',
+  description: 'Subscription management',
 };
 
 export default function RootLayout({

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -36,7 +36,7 @@ import {
   PriceManager,
   ProductManager,
   PromotionCodeManager,
-  STRIPE_CUSTOMER_METADATA,
+  STRIPE_SUBSCRIPTION_METADATA,
   SubscriptionManager,
   TaxAddressFactory,
 } from '@fxa/payments/customer';
@@ -447,7 +447,7 @@ describe('CheckoutService', () => {
       const mockUpdatedSubscription = StripeResponseFactory(
         StripeSubscriptionFactory({
           metadata: {
-            [STRIPE_CUSTOMER_METADATA.SubscriptionPromotionCode]:
+            [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
               mockCart.couponCode as string,
           },
         })
@@ -476,7 +476,7 @@ describe('CheckoutService', () => {
         {
           metadata: {
             ...mockSubscription.metadata,
-            [STRIPE_CUSTOMER_METADATA.SubscriptionPromotionCode]:
+            [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
               mockCart.couponCode,
           },
         }

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -227,12 +227,12 @@ export class CheckoutService {
     await this.customerChanged(uid);
 
     if (cart.couponCode) {
-      const subscriptionMetadata = {
-        ...subscription.metadata,
-        [STRIPE_CUSTOMER_METADATA.SubscriptionPromotionCode]: cart.couponCode,
-      };
       await this.subscriptionManager.update(subscription.id, {
-        metadata: subscriptionMetadata,
+        metadata: {
+          ...subscription.metadata,
+          [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
+            cart.couponCode,
+        },
       });
     }
     await this.cartManager.finishCart(cart.id, version, {});

--- a/libs/payments/customer/src/lib/promotionCode.manager.spec.ts
+++ b/libs/payments/customer/src/lib/promotionCode.manager.spec.ts
@@ -193,8 +193,8 @@ describe('PromotionCodeManager', () => {
       const mockCartCurrency = mockPrice.currency;
 
       jest
-        .spyOn(stripeClient, 'promotionCodesList')
-        .mockResolvedValue(StripeResponseFactory(StripeApiListFactory([])));
+        .spyOn(promotionCodeManager, 'retrieveByName')
+        .mockResolvedValue(undefined);
 
       await expect(() =>
         promotionCodeManager.assertValidPromotionCodeNameForPrice(
@@ -226,6 +226,62 @@ describe('PromotionCodeManager', () => {
           mockCartCurrency
         )
       ).rejects.toBeInstanceOf(PromotionCodeCouldNotBeAttachedError);
+    });
+
+    it('resolves when cart and coupon currencies match', async () => {
+      const mockPrice = StripePriceFactory({
+        currency: 'cad',
+      });
+      const mockPromotionCode = StripePromotionCodeFactory({
+        coupon: StripeCouponFactory({
+          currency: 'cad',
+        }),
+      });
+      const mockCartCurrency = 'CAD';
+
+      jest
+        .spyOn(promotionCodeManager, 'retrieveByName')
+        .mockResolvedValue(mockPromotionCode);
+
+      jest
+        .spyOn(promotionCodeManager, 'assertValidPromotionCodeForPrice')
+        .mockResolvedValue();
+
+      await expect(
+        promotionCodeManager.assertValidPromotionCodeNameForPrice(
+          mockPromotionCode.code,
+          mockPrice,
+          mockCartCurrency
+        )
+      ).resolves.toEqual(undefined);
+    });
+
+    it('resolves when coupon currency is null', async () => {
+      const mockPrice = StripePriceFactory({
+        currency: 'cad',
+      });
+      const mockPromotionCode = StripePromotionCodeFactory({
+        coupon: StripeCouponFactory({
+          currency: null,
+        }),
+      });
+      const mockCartCurrency = 'CAD';
+
+      jest
+        .spyOn(promotionCodeManager, 'retrieveByName')
+        .mockResolvedValue(mockPromotionCode);
+
+      jest
+        .spyOn(promotionCodeManager, 'assertValidPromotionCodeForPrice')
+        .mockResolvedValue();
+
+      await expect(
+        promotionCodeManager.assertValidPromotionCodeNameForPrice(
+          mockPromotionCode.code,
+          mockPrice,
+          mockCartCurrency
+        )
+      ).resolves.toEqual(undefined);
     });
 
     it('throws an error if currencies do no match', async () => {

--- a/libs/payments/customer/src/lib/promotionCode.manager.ts
+++ b/libs/payments/customer/src/lib/promotionCode.manager.ts
@@ -43,7 +43,11 @@ export class PromotionCodeManager {
     if (!promoCode)
       throw new PromotionCodeCouldNotBeAttachedError('PromoCode not found');
 
-    if (promoCode.coupon.currency !== cartCurrency)
+    // promotion code currency may be null, in which case it is applicable to all currencies
+    if (
+      promoCode.coupon.currency &&
+      promoCode.coupon.currency.toLowerCase() !== cartCurrency.toLowerCase()
+    )
       throw new CouponErrorInvalid();
 
     await this.assertValidPromotionCodeForPrice(promoCode, price);

--- a/libs/payments/customer/src/lib/subscription.manager.spec.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.spec.ts
@@ -15,7 +15,7 @@ import {
   StripeSubscriptionFactory,
   MockStripeConfigProvider,
 } from '@fxa/payments/stripe';
-import { STRIPE_CUSTOMER_METADATA } from './types';
+import { STRIPE_SUBSCRIPTION_METADATA } from './types';
 import { SubscriptionManager } from './subscription.manager';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 
@@ -179,7 +179,8 @@ describe('SubscriptionManager', () => {
     it('updates metadata', async () => {
       const mockParams = {
         metadata: {
-          [STRIPE_CUSTOMER_METADATA.SubscriptionPromotionCode]: 'test-coupon',
+          [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
+            'test-coupon',
         },
       };
       const mockSubscription = StripeSubscriptionFactory(mockParams);
@@ -204,7 +205,9 @@ describe('SubscriptionManager', () => {
     it('throws if metadata key does not match', async () => {
       const mockParams = {
         metadata: {
-          [STRIPE_CUSTOMER_METADATA.SubscriptionPromotionCode]: 'test-coupon',
+          amount: '1200',
+          [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
+            'test-coupon',
           promotionCode: 'test-coupon',
         },
       };

--- a/libs/payments/customer/src/lib/subscription.manager.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.ts
@@ -11,7 +11,7 @@ import {
   StripeSubscription,
 } from '@fxa/payments/stripe';
 import { ACTIVE_SUBSCRIPTION_STATUSES } from '@fxa/payments/stripe';
-import { STRIPE_CUSTOMER_METADATA } from './types';
+import { STRIPE_SUBSCRIPTION_METADATA } from './types';
 import { InvalidPaymentIntentError, PaymentIntentNotFoundError } from './error';
 
 @Injectable()
@@ -44,15 +44,14 @@ export class SubscriptionManager {
       const newMetadata = params.metadata;
       Object.keys(newMetadata).forEach((key) => {
         if (
-          !Object.values(STRIPE_CUSTOMER_METADATA).includes(
-            key as STRIPE_CUSTOMER_METADATA
+          !Object.values(STRIPE_SUBSCRIPTION_METADATA).includes(
+            key as STRIPE_SUBSCRIPTION_METADATA
           )
         ) {
           throw new Error(`Invalid metadata key: ${key}`);
         }
       });
     }
-
     return this.stripeClient.subscriptionsUpdate(subscriptionId, params);
   }
 

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -32,7 +32,6 @@ export interface TaxAmount {
 
 export enum STRIPE_CUSTOMER_METADATA {
   PaypalAgreement = 'paypalAgreementId',
-  SubscriptionPromotionCode = 'appliedPromotionCode',
 }
 
 export enum STRIPE_PRICE_METADATA {
@@ -48,6 +47,7 @@ export enum STRIPE_PRODUCT_METADATA {
 export enum STRIPE_SUBSCRIPTION_METADATA {
   Currency = 'currency',
   Amount = 'amount',
+  SubscriptionPromotionCode = 'appliedPromotionCode',
 }
 
 export enum STRIPE_INVOICE_METADATA {

--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
@@ -5,13 +5,13 @@
 'use client';
 
 import { Localized } from '@fluent/react';
+import { useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
 import { useFormState } from 'react-dom';
 import { ButtonVariant } from '../BaseButton';
 import { SubmitButton } from '../SubmitButton';
 import { updateCartAction } from '../../../actions/updateCart';
 import { getFallbackTextByFluentId } from '../../../utils/error-ftl-messages';
-import { useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
 
 interface WithCouponProps {
   cartId: string;
@@ -30,7 +30,7 @@ const WithCoupon = ({
   }
 
   return (
-    <>
+    <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8">
       <h2 className="m-0 mb-4 font-semibold text-grey-600">
         <Localized id="next-coupon-promo-code-applied">
           Promo Code Applied
@@ -54,7 +54,7 @@ const WithCoupon = ({
           </span>
         )}
       </form>
-    </>
+    </div>
   );
 };
 
@@ -88,7 +88,7 @@ const WithoutCoupon = ({
   const [error, formAction] = useFormState(applyCoupon, null);
 
   return (
-    <>
+    <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8">
       <h2 className="m-0 mb-4 font-semibold text-grey-600">
         <Localized id="next-coupon-promo-code">Promo Code</Localized>
       </h2>
@@ -124,7 +124,7 @@ const WithoutCoupon = ({
           </div>
         )}
       </form>
-    </>
+    </div>
   );
 };
 
@@ -142,22 +142,18 @@ export function CouponForm({
   readOnly,
 }: CouponFormProps) {
   const hasCouponCode = !!promoCode;
-  return (
-    <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8">
-      {hasCouponCode ? (
-        <WithCoupon
-          cartId={cartId}
-          cartVersion={cartVersion}
-          couponCode={promoCode}
-          readOnly={readOnly}
-        />
-      ) : (
-        <WithoutCoupon
-          cartId={cartId}
-          cartVersion={cartVersion}
-          readOnly={readOnly}
-        />
-      )}
-    </div>
+  return hasCouponCode ? (
+    <WithCoupon
+      cartId={cartId}
+      cartVersion={cartVersion}
+      couponCode={promoCode}
+      readOnly={readOnly}
+    />
+  ) : readOnly ? null : (
+    <WithoutCoupon
+      cartId={cartId}
+      cartVersion={cartVersion}
+      readOnly={readOnly}
+    />
   );
 }


### PR DESCRIPTION
## Because

- we were unable to apply valid coupons to subscriptions

## This pull request

- fixes ability to apply valid coupons to subscriptions
- updates subscriptionManager.update to check metadata key before updating subscription
- revises layout
  - CouponForm should not be shown on pages other than /start if a valid coupon was not applied to the subscription
  - CouponForm should not be interactive on pages other than /start if valid coupon was applied

## Issue that this pull request solves

Closes: FXA-11251

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
