### PR TITLE
fix(functional-tests): Update sms client to check for target

### DIFF
--- a/packages/functional-tests/lib/sms.ts
+++ b/packages/functional-tests/lib/sms.ts
@@ -22,8 +22,8 @@ export class SmsClient {
   private redisClientConnected = false;
   private hasLoggedRedisConnectionError = false;
 
-  constructor() {
-    if (accountSid && authToken && testPhoneNumber) {
+  constructor(private readonly name: string) {
+    if (name !== 'local' && accountSid && authToken && testPhoneNumber) {
       this.twilioClient = new TwilioSDK.Twilio(accountSid, authToken);
     } else {
       this.redisClient = new Redis();

--- a/packages/functional-tests/lib/targets/base.ts
+++ b/packages/functional-tests/lib/targets/base.ts
@@ -24,21 +24,35 @@ interface SubConfig {
 export abstract class BaseTarget {
   readonly authClient: AuthClient;
   readonly emailClient: EmailClient;
-  readonly smsClient: SmsClient;
+  protected smsClient!: SmsClient; // Deferred initialization
   abstract readonly contentServerUrl: string;
   abstract readonly paymentsServerUrl: string;
   abstract readonly relierUrl: string;
   abstract readonly relierClientID: string;
-  abstract readonly name: TargetName;
+  readonly name: TargetName;
   abstract readonly subscriptionConfig: SubConfig;
 
-  constructor(readonly authServerUrl: string, emailUrl?: string) {
+  constructor(
+    readonly authServerUrl: string,
+    name: TargetName,
+    emailUrl?: string
+  ) {
+    this.name = name;
     const keyStretchVersion = parseInt(
       process.env.AUTH_CLIENT_KEY_STRETCH_VERSION || '1'
     );
     this.authClient = this.createAuthClient(keyStretchVersion);
     this.emailClient = new EmailClient(emailUrl);
-    this.smsClient = new SmsClient();
+
+    this.initializeSmsClient();
+  }
+
+  protected initializeSmsClient() {
+    this.smsClient = new SmsClient(this.name);
+  }
+
+  getSmsClient(): SmsClient {
+    return this.smsClient;
   }
 
   get baseUrl() {

--- a/packages/functional-tests/lib/targets/local.ts
+++ b/packages/functional-tests/lib/targets/local.ts
@@ -13,7 +13,6 @@ const SUB_PLAN = 'plan_GqM9N6qyhvxaVk';
 
 export class LocalTarget extends BaseTarget {
   static readonly target = 'local';
-  readonly name: TargetName = LocalTarget.target;
   readonly contentServerUrl = 'http://localhost:3030';
   readonly paymentsServerUrl = 'http://localhost:3031';
   readonly relierUrl = 'http://localhost:8080';
@@ -25,7 +24,7 @@ export class LocalTarget extends BaseTarget {
   };
 
   constructor() {
-    super('http://localhost:9000', 'http://localhost:9001');
+    super('http://localhost:9000', LocalTarget.target, 'http://localhost:9001');
   }
 
   async createAccount(

--- a/packages/functional-tests/lib/targets/production.ts
+++ b/packages/functional-tests/lib/targets/production.ts
@@ -16,7 +16,6 @@ const RELIER_CLIENT_ID = '3c32bf6654542211';
 
 export class ProductionTarget extends RemoteTarget {
   static readonly target = 'production';
-  readonly name: TargetName = ProductionTarget.target;
 
   readonly contentServerUrl = `https://${ACCOUNTS_DOMAIN}`;
   readonly paymentsServerUrl = `https://${PAYMENTS_DOMAIN}`;
@@ -29,6 +28,6 @@ export class ProductionTarget extends RemoteTarget {
   };
 
   constructor() {
-    super(`https://${ACCOUNTS_API_DOMAIN}`);
+    super(`https://${ACCOUNTS_API_DOMAIN}`, ProductionTarget.target);
   }
 }

--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -21,7 +21,6 @@ const SUB_PLAN = 'plan_FfiupsKXZ3mMZ6';
 
 export class StageTarget extends RemoteTarget {
   static readonly target = 'stage';
-  readonly name: TargetName = StageTarget.target;
   readonly contentServerUrl = `https://${ACCOUNTS_DOMAIN}`;
   readonly paymentsServerUrl = `https://${PAYMENTS_DOMAIN}`;
   readonly relierUrl = `https://${RELIER_DOMAIN}`;
@@ -33,6 +32,6 @@ export class StageTarget extends RemoteTarget {
   };
 
   constructor() {
-    super(`https://${ACCOUNTS_API_DOMAIN}`);
+    super(`https://${ACCOUNTS_API_DOMAIN}`, StageTarget.target);
   }
 }

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -46,12 +46,12 @@ test.describe('severity-1 #smoke', () => {
       // Therefore, we fallback to peeking at Redis to get confirmation codes.
       if (target.name === 'local') {
         expect(
-          target.smsClient.isTwilioEnabled(),
+          target.getSmsClient().isTwilioEnabled(),
           'Local env found, use redis and Twilio test creds'
         ).toBeFalsy();
       } else {
         expect(
-          target.smsClient.isTwilioEnabled(),
+          target.getSmsClient().isTwilioEnabled(),
           'Stage/Prod env, use Twilio API'
         ).toBeTruthy();
       }
@@ -104,10 +104,9 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      const code = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const code = await target
+        .getSmsClient()
+        .getCode(getPhoneNumber(target.name), credentials.uid);
 
       // Invalid code
       await recoveryPhone.enterCode('123456');
@@ -118,10 +117,9 @@ test.describe('severity-1 #smoke', () => {
 
       // Sends a new code
       await recoveryPhone.clickResendCode();
-      const nextCode = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const nextCode = await target
+        .getSmsClient()
+        .getCode(getPhoneNumber(target.name), credentials.uid);
 
       expect(code).not.toEqual(nextCode);
 
@@ -369,19 +367,17 @@ test.describe('severity-1 #smoke', () => {
         page.getByText(/The code is invalid or expired./)
       ).toBeVisible();
 
-      const originalCode = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const originalCode = await target
+        .getSmsClient()
+        .getCode(getPhoneNumber(target.name), credentials.uid);
 
       // Sends a new code
       await signinRecoveryPhone.clickResendCode();
       await expect(page.getByText('Code sent')).toBeVisible();
 
-      const nextCode = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const nextCode = await target
+        .getSmsClient()
+        .getCode(getPhoneNumber(target.name), credentials.uid);
 
       expect(originalCode).not.toEqual(nextCode);
 
@@ -638,10 +634,9 @@ async function setupRecoveryPhone({
 
   await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-  const code = await target.smsClient.getCode(
-    getPhoneNumber(target.name),
-    credentials.uid
-  );
+  const code = await target
+    .getSmsClient()
+    .getCode(getPhoneNumber(target.name), credentials.uid);
 
   await recoveryPhone.enterCode(code);
   await recoveryPhone.clickConfirm();
@@ -689,19 +684,17 @@ async function fillOutRecoveryPhoneFromEmailFirst({
 
   await expect(page.getByText(/The code is invalid or expired./)).toBeVisible();
 
-  const originalCode = await target.smsClient.getCode(
-    getPhoneNumber(target.name),
-    credentials.uid
-  );
+  const originalCode = await target
+    .getSmsClient()
+    .getCode(getPhoneNumber(target.name), credentials.uid);
 
   // Sends a new code
   await signinRecoveryPhone.clickResendCode();
   await expect(page.getByText('Code sent')).toBeVisible();
 
-  const nextCode = await target.smsClient.getCode(
-    getPhoneNumber(target.name),
-    credentials.uid
-  );
+  const nextCode = await target
+    .getSmsClient()
+    .getCode(getPhoneNumber(target.name), credentials.uid);
 
   expect(originalCode).not.toEqual(nextCode);
 


### PR DESCRIPTION
## Because

* We only want to set up the twilio client in CI if the target is stage or prod otherwise use redis

## This pull request

* Check for target name

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
