### PR TITLE
task(recovery-phone): Also block on twilio country country

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,10 +326,13 @@ commands:
           # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
           command: |
             if [[ "<< parameters.project >>" == "production" ]]; then
+              FUNCTIONAL_TESTS__USE_TWILIO_CLIENT="true"
               GREP="--grep=\"severity-1\""
             elif [[ "<< parameters.project >>" == "stage" ]]; then
+              FUNCTIONAL_TESTS__USE_TWILIO_CLIENT="true"
               GREP="--grep=\"severity-(1|2)\""
             else
+              FUNCTIONAL_TESTS__USE_TWILIO_CLIENT="false"
               GREP=""
             fi
             echo "targeting project << parameters.project >> $GREP"

--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.config.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.config.ts
@@ -5,23 +5,47 @@
 import { IsArray, IsBoolean, IsNumber, IsObject } from 'class-validator';
 
 export class RecoveryPhoneServiceConfig {
+  /**
+   * A set of valid phone number prefix that sms can be sent to. e.g. +1
+   */
   @IsArray()
   public validNumberPrefixes?: Array<string>;
 
+  /**
+   * A set of valid country codes that SMS can be sent to.
+   */
+  @IsArray()
+  public validCountryCodes!: Array<string>;
+
+  /**
+   * The max sms pumping risk score accepted.
+   */
   @IsNumber()
   public smsPumpingRiskThreshold?: number;
 }
 
 export class RecoveryPhoneConfig {
+  /**
+   * Whether or not the recovery phone feature is supported.
+   */
   @IsBoolean()
   public enabled?: boolean;
 
+  /**
+   * These are a set of allowed regions based on IP that are accepted for recovery phone setup.
+   */
   @IsArray()
   public allowedRegions?: Array<string>;
 
+  /**
+   * Total number of registrations a single number can have
+   */
   @IsNumber()
   public maxRegistrationsPerNumber?: number;
 
+  /**
+   * SMS specific config
+   */
   @IsObject()
   public sms?: RecoveryPhoneServiceConfig;
 }

--- a/libs/accounts/recovery-phone/src/lib/sms.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/sms.manager.ts
@@ -44,12 +44,14 @@ export class SmsManager {
     private readonly config: SmsManagerConfig
   ) {}
 
-  public async phoneNumberLookup(phoneNumber: string) {
+  public async phoneNumberLookup(phoneNumber: string, extraFields?: string) {
     try {
       this.metrics.increment('sms.phoneNumberLookup.start');
       const result = await this.client.lookups.v2
         .phoneNumbers(phoneNumber)
-        .fetch({ fields: this.config.extraLookupFields.join(',') });
+        .fetch({
+          fields: extraFields || this.config.extraLookupFields.join(','),
+        });
 
       this.metrics.increment('sms.phoneNumberLookup.success');
 

--- a/packages/functional-tests/lib/sms.ts
+++ b/packages/functional-tests/lib/sms.ts
@@ -9,7 +9,7 @@ import type { Redis as RedisType } from 'ioredis';
 function wait() {
   return new Promise((r) => setTimeout(r, 500));
 }
-
+const useTwilioClient = process.env.FUNCTIONAL_TESTS__USE_TWILIO_CLIENT;
 const accountSid = process.env.RECOVERY_PHONE__TWILIO__ACCOUNT_SID;
 const authToken = process.env.RECOVERY_PHONE__TWILIO__AUTH_TOKEN;
 const testPhoneNumber = process.env.RECOVERY_PHONE__TWILIO__TEST_NUMBER;
@@ -23,7 +23,12 @@ export class SmsClient {
   private hasLoggedRedisConnectionError = false;
 
   constructor() {
-    if (accountSid && authToken && testPhoneNumber) {
+    if (
+      useTwilioClient === 'true' &&
+      accountSid &&
+      authToken &&
+      testPhoneNumber
+    ) {
       this.twilioClient = new TwilioSDK.Twilio(accountSid, authToken);
     } else {
       this.redisClient = new Redis();

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -247,6 +247,7 @@ async function run(config) {
     smsManager,
     otpCodeManager,
     config.recoveryPhone,
+    config.twilio,
     statsd,
     log
   );

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2209,8 +2209,14 @@ const convictConf = convict({
       },
       validNumberPrefixes: {
         default: ['+1'], // USA and Canada
-        doc: 'Allowed phone number prefixes. Controls the locales that a message can be sent to.',
+        doc: 'Allowed phone number prefixes. Controls the numbers that a message can be sent to.',
         env: 'RECOVERY_PHONE__SMS__VALID_NUMBER_PREFIXES',
+        format: Array,
+      },
+      validCountryCodes: {
+        default: ['US', 'CA'], // USA and Canada
+        doc: 'Allowed phone number prefixes. Controls the countries that a message can be sent to.',
+        env: 'RECOVERY_PHONE__SMS__VALID_COUNTRY_CODES',
         format: Array,
       },
       maxRetries: {

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -54,6 +54,9 @@ const isTwilioConfigured =
   config.twilio.authToken?.length >= 24;
 
 describe(`#integration - recovery phone`, function () {
+  // TODO: Something flakes sometimes... figure out where the slowdown is.
+  this.timeout(10000);
+
   let server;
   let client;
   let email;


### PR DESCRIPTION
## Because

- It's not enough to block by IP
- Not all +1 numbers reside in our initial target regions of US and Canada

## This pull request

- Adds config for validCountryCodes.
- Adds call to get lookup data on phone number during setup.
- If look up data cannot be retrieved, phone number is deemed invalid.
- If look up data indicates country code isn't a target country, phone number is deemed invalid.
- Updates auth server config to include validCountryCodes
- Modifies phoneNumberLook up so that extra fields can be passed in conditionally.
- Updates tests to reflect how phone number prefixes and country code actually interact with configs.
- Adds some comments to config classes.

## Issue that this pull request solves

Closes: FXA-11257

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
