### PR TITLE
temp skip of recovery phone tests

### DIFF
--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -27,6 +27,10 @@ function getPhoneNumber(env: string) {
 }
 
 test.describe('severity-1 #smoke', () => {
+  test.fixme(
+    true,
+    'FXA-11191 will resolve issue with switching between twilio and redis clients'
+  );
   test.describe('recovery phone', () => {
     // Run these tests sequentially when using the Twilio API because they rely on the same test phone number.
     // When using the Twilio API, we cannot determine the order in which the messages were received.


### PR DESCRIPTION
## Because

- CI runs are failing for PRs unrelated to recovery phone

## This pull request

- adds a temporary fixme on the recovery phone functional tests - fix is already up in draft PR

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
