### PR TITLE
bug(auth): Fix connection pooling issues observed in integration tests

### DIFF
--- a/libs/shared/db/mysql/account/src/lib/setup.ts
+++ b/libs/shared/db/mysql/account/src/lib/setup.ts
@@ -10,8 +10,29 @@ export type AccountDatabase = Kysely<DB>;
 export const AccountDbProvider = Symbol('AccountDbProvider');
 
 export async function setupAccountDatabase(opts: MySQLConfig) {
-  const dialect = await createDialect(opts);
-  return new Kysely<DB>({
+  const { dialect, pool } = await createDialect(opts);
+  const db = new Kysely<DB>({
     dialect,
   });
+
+  /**
+   * Important! We've observed that connection pools aren't being destroyed.
+   * In theory Kysely should do this when the instance is destroyed, but it
+   * appears not work in practice. The following hijack works around the
+   * issue and manually closes the connection pool we created.
+   *
+   * This was most noticeable when running auth-server remote tests, where
+   * we'd hit random timeouts acquiring connections because previous connections
+   * pools were never closed.
+   *
+   * When running our services in production, this isn't really a noticeable
+   * because we aren't creating lots of new account database instances.
+   */
+  const _dbDestroy = db.destroy;
+  db.destroy = async function () {
+    await _dbDestroy.call(db);
+    pool.end(() => {});
+  };
+
+  return db;
 }

--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -46,7 +46,7 @@ So run:
 - `yarn start infrastructure`
 - `nx start fxa-customs-server`
 
-Now unit tests can be executed:
+Now integration tests can be executed:
 
 - `nx test-integration fxa-auth-server`
   _Note this matches how auth server unit tests jobs in CI._
@@ -57,15 +57,15 @@ _From packages/fxa-auth-server:_
 
 - `yarn test -- test/local/account_routes.js`
 - `yarn test -- test/local/account* test/local/password_*`
-- `yarn test -- test/remote`
 - `NODE_ENV=dev npx mocha -r esbuild-register test/*/** -g "SQSReceiver"`
 
 Notes / Tips:
 
-- For quick enviroment config, consider running tests with a .env file and the dotenv command. For example: `dotenv -- yarn workspace fxa-auth-server:test-integration remote`
+- For quick environment config, consider running tests with a .env file and the dotenv command. For example: `dotenv -- yarn workspace fxa-auth-server:test-integration remote`
 - you can use `LOG_LEVEL`, such as `LOG_LEVEL=debug` to specify the test logging level.
 - recovery-phone tests require twilio testing credentials!
 - recovery-phone-customs tests require that customs server is running. So run `nx start fxa-customs-server` prior to executing tests.
+- The test/remote folder contains mostly integration tests that were not designed to be run in parallel. As a result the `yarn test -- remote/test` command may result in errors. For these tests run `yarn test-integration remote` instead.
 
 _Other Stuff_
 This package uses [Mocha](https://mochajs.org/) to test its code. By default `npm test` will run a series of NPM test scripts and then lint the code:

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -395,6 +395,16 @@ async function run(config) {
           message: 'Database connection did not shutdown cleanly. ' + e.message,
         });
       }
+
+      try {
+        await accountDatabase.destroy();
+      } catch (e) {
+        log.warn('shutdown', {
+          message:
+            'Account database connection did not shutdown cleanly. ' +
+            e.message,
+        });
+      }
     },
   };
 }

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -110,6 +110,7 @@ describe(`#integration - recovery phone`, function () {
 
   after(async () => {
     await TestServer.stop(server);
+    await db.destroy();
   });
 
   it('sets up a recovery phone', async function () {


### PR DESCRIPTION
## Because
- Integration tests were failing in a flaky manner because db connections couldn't be created.
- Connection pool was getting exhausted.
- Connection pool was not getting terminated

## This pull request
- Exposes the connection pool
- Makes sure it's terminated when destroy is called on the Kysely db instance.
- Adds a couple missing places where destroy wasn't called during a tear down.

## Issue that this pull request solves

Closes: ?

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Prior to fix:
![image](https://github.com/user-attachments/assets/08668857-d1d9-4dae-919a-0aefed665eb6)

Also mysql workbench would show **lots** of open connections from fxa:
![image](https://github.com/user-attachments/assets/adf71bfa-f0cb-4973-87ee-3a1d9ba6c9e0)

## Other information (Optional)

It's possible this fix addresses issues already filed in the backlog. I'll go snoop around, but if the reviewer knows any off hand please comment.

Running locally with `yarn workspace fxa-auth-server test-integration remote` would consistently fail for prior to this fix. Basically tests would fail & timeout in during test stetup (i.e. in before/beforeEach) because a connection pool couldn't be resolved. By opening mysql workbench and looking at the client connections, it was easy to see that fxa was creating tons of connections that weren't actually getting closed. 

This problem is specific to Kysely db instances. If I can reproduce in a simple git gist, I will be filing a ticket with them, and hopefully in the future we can remove this work around.


