### PR TITLE
feat(settings): Add nimbus experiments to AppContext

### DIFF
--- a/packages/fxa-settings/src/lib/nimbus/index.ts
+++ b/packages/fxa-settings/src/lib/nimbus/index.ts
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/browser';
+
+/**
+ * A collection of attributes about the client that will be used for
+ * targetting an experiment.
+ */
+export type NimbusContextT = {
+  language: string | null;
+  region: string | null;
+};
+
+/**
+ * Initializes Nimbus in the React app. This should be done before the first render
+ * so that experiments can be applied during first initialization.
+ *
+ * @param clientId A unique identifier that is typically stable.
+ * @param context See {@link NimbusContextT}.
+ * @returns the experiment and enrollment information for that `clientId`.
+ */
+export async function initializeNimbus(
+  clientId: string,
+  context: NimbusContextT
+) {
+  const MAX_TIMEOUT_MS = 1000;
+  const body = JSON.stringify({
+    client_id: clientId,
+    context,
+  });
+
+  let experiments;
+
+  try {
+    const resp = await fetch('/nimbus-experiments', {
+      method: 'POST',
+      body,
+      // A request to cirrus should not be more than 50ms,
+      // but we give it a large enough padding.
+      signal: AbortSignal.timeout(MAX_TIMEOUT_MS),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (resp.status !== 200) {
+      return;
+    }
+
+    experiments = await resp.json();
+  } catch (err) {
+    Sentry.withScope(() => {
+      let errorMsg = 'Experiment fetch error';
+      if (err.name === 'TimeoutError') {
+        errorMsg = `Timeout: It took more than ${MAX_TIMEOUT_MS} milliseconds to get the result - this is render blocking!`;
+      }
+      Sentry.captureMessage(errorMsg, 'error');
+    });
+  }
+
+  return experiments;
+}

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -104,6 +104,15 @@ export function useIntegration() {
   }, [clientInfoState, productInfoState]);
 }
 
+export function useExperiments() {
+  const { experiments } = useContext(AppContext);
+  const { Features, Enrollments } = experiments;
+  if (!Features || !Enrollments) {
+    return {};
+  }
+  return { features: Features, enrollments: Enrollments };
+}
+
 export function useSession() {
   const { session } = useContext(AppContext);
   if (!session) {

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -172,6 +172,7 @@ export function mockAppContext(context?: AppContextValue) {
       session: mockSession(),
       config: getDefault(),
       sensitiveDataClient: mockSensitiveDataClient(),
+      uniqueUserId: '4a9512ac-3110-43df-aa8a-958A3d210b9c3',
     },
     context
   ) as AppContextValue;


### PR DESCRIPTION


## Because

- We want to fetch experiments that can target a user on the first render/launch.

## This pull request

- Adds uniqueUserId generation which would happen in Backbone into React as a prerequiste.
- Adds a new call to experiments in the AppContext.

## Issue that this pull request solves

Closes: FXA-9783

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

- In development, `useMemo` is called twice because of StrictMode. This will not happen in a production build.
- Tests will be followed up in FXA-9784, but I'd happily take some links and pointers to equivalent features that I could base mine on top of.