### PR TITLE
fix(payments-ui): Show payment method privacy policy

### DIFF
--- a/libs/payments/ui/src/lib/server/components/TermsAndPrivacy/en.ftl
+++ b/libs/payments/ui/src/lib/server/components/TermsAndPrivacy/en.ftl
@@ -7,3 +7,11 @@ next-subplat-mozilla-accounts-legal-heading = { -product-mozilla-accounts(capita
 next-terms = Terms of Service
 next-privacy = Privacy Notice
 next-terms-download = Download Terms
+
+terms-and-privacy-stripe-label = { -brand-mozilla } uses { -brand-name-stripe } for secure payment processing.
+terms-and-privacy-stripe-link = { -brand-name-stripe } privacy policy
+
+terms-and-privacy-paypal-label= { -brand-mozilla } uses { -brand-paypal } for secure payment processing.
+terms-and-privacy-paypal-link = { -brand-paypal } privacy policy
+
+terms-and-privacy-stripe-and-paypal-label = { -brand-mozilla } uses { -brand-name-stripe } and { -brand-paypal } for secure payment processing.

--- a/libs/payments/ui/src/lib/server/components/TermsAndPrivacy/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/TermsAndPrivacy/index.tsx
@@ -5,11 +5,11 @@
 import {
   GenericTermItem,
   GenericTermsListItem,
-  PaymentProvider,
   buildFirefoxAccountsTerms,
   buildPaymentTerms,
   buildProductTerms,
 } from '../../../utils/terms-and-privacy';
+import { PaymentInfo } from '@fxa/payments/cart';
 import { LocalizerRsc } from '@fxa/shared/l10n/server';
 
 type GenericTermsProps = {
@@ -61,7 +61,7 @@ function GenericTerms({
 
 export interface TermsAndPrivacyProps {
   l10n: LocalizerRsc;
-  paymentProvider?: PaymentProvider;
+  paymentInfo?: PaymentInfo;
   productName: string;
   termsOfServiceUrl: string;
   termsOfServiceDownloadUrl: string;
@@ -72,7 +72,7 @@ export interface TermsAndPrivacyProps {
 
 export async function TermsAndPrivacy({
   l10n,
-  paymentProvider,
+  paymentInfo,
   productName,
   termsOfServiceUrl,
   termsOfServiceDownloadUrl,
@@ -81,7 +81,7 @@ export async function TermsAndPrivacy({
   showFXALinks = false,
 }: TermsAndPrivacyProps) {
   const terms: GenericTermItem[] = [
-    ...buildPaymentTerms(paymentProvider),
+    ...buildPaymentTerms(paymentInfo),
     ...buildFirefoxAccountsTerms(showFXALinks, contentServerUrl),
     ...buildProductTerms(
       productName,


### PR DESCRIPTION
## This pull request

-  show Stripe and PayPal privacy policies
    - If the payment method is Stripe, show only Stripe privacy policy
    - If the payment method is PayPal, show only PayPal privacy policy

## Issue that this pull request solves

Closes: FXA-11261

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
<img width="1396" alt="Screenshot 2025-03-10 at 4 17 12 PM" src="https://github.com/user-attachments/assets/a2d0894d-7620-46d6-907e-785df30c7271" />

<img width="1406" alt="Screenshot 2025-03-10 at 4 17 49 PM" src="https://github.com/user-attachments/assets/abedbef1-dc31-42b2-8bb7-54e91eac5daf" />

<img width="1374" alt="Screenshot 2025-03-10 at 5 03 22 PM" src="https://github.com/user-attachments/assets/a02a3d7c-87db-452b-accb-33b184e72b3b" />


