### PR TITLE
task(auth): Remove sms_pumping_risk as default for extraLookupFields

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2232,7 +2232,7 @@ const convictConf = convict({
         format: Number,
       },
       extraLookupFields: {
-        default: ['sms_pumping_risk'],
+        default: [],
         doc: 'Extra data to fetch about phone numbers being registered for sms backup.',
         env: 'RECOVERY_PHONE__SMS__EXTRA_LOOKUP_FIELDS',
         format: Array,


### PR DESCRIPTION
## Because

- Can be configured per deploy environment as needed.
- We don't need it on by default.
- This look up costs money.

## This pull request

- Removes `sms_pumping_risk` as a default extra lookup field.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
