### PR TITLE
fix(settings): Show user-friendly message if recovery phone service is disabled

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -64,6 +64,7 @@ const SigninRecoveryChoice = ({
     if (
       error === AuthUiErrors.BACKEND_SERVICE_FAILURE ||
       error === AuthUiErrors.SMS_SEND_RATE_LIMIT_EXCEEDED ||
+      error === AuthUiErrors.FEATURE_NOT_ENABLED ||
       error === AuthUiErrors.UNEXPECTED_ERROR
     ) {
       setErrorBannerMessage(generalSendCodeErrorHeading);

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -5,7 +5,11 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { AppContext, isWebIntegration, useFtlMsgResolver } from '../../../models';
+import {
+  AppContext,
+  isWebIntegration,
+  useFtlMsgResolver,
+} from '../../../models';
 import { BackupCodesImage } from '../../../components/images';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import FormVerifyCode, {
@@ -179,6 +183,7 @@ const SigninRecoveryCode = ({
     }
     if (
       handledError.errno === AuthUiErrors.BACKEND_SERVICE_FAILURE.errno ||
+      handledError.errno === AuthUiErrors.FEATURE_NOT_ENABLED.errno ||
       handledError.errno === AuthUiErrors.SMS_SEND_RATE_LIMIT_EXCEEDED.errno ||
       handledError.errno === AuthUiErrors.UNEXPECTED_ERROR.errno
     ) {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -90,6 +90,7 @@ const SigninRecoveryPhone = ({
     if (error) {
       if (
         error.errno === AuthUiErrors.BACKEND_SERVICE_FAILURE.errno ||
+        error.errno === AuthUiErrors.FEATURE_NOT_ENABLED.errno ||
         error.errno === AuthUiErrors.SMS_SEND_RATE_LIMIT_EXCEEDED.errno ||
         error.errno === AuthUiErrors.UNEXPECTED_ERROR.errno
       ) {


### PR DESCRIPTION
## Because

* We want to show a more informative error message

## This pull request

* Add FEATURE_NOT_AVAILABLE case to the error handler

## Issue that this pull request solves

Closes: FXA-11305

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
