### PR TITLE
fix(settings): Fix Settings pages scrolling down on render

### DIFF
--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.tsx
@@ -98,7 +98,6 @@ const FormVerifyTotp = ({
         inputMode={codeType === 'numeric' ? 'numeric' : 'text'}
         label={localizedInputLabel}
         onChange={handleChange}
-        autoFocus
         maxLength={codeLength}
         className="text-start"
         anchorPosition="start"

--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
@@ -154,7 +154,6 @@ const InputPhoneNumber = ({
         name="phoneNumber"
         type="tel"
         label={localizedLabel}
-        autoFocus
         required
         className="text-start w-full"
         autoComplete="off"

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
@@ -142,7 +142,6 @@ export const RecoveryKeySetupHint = ({
             name="hint"
             label="Enter a hint (optional)"
             prefixDataTestId="hint"
-            autoFocus
             inputRef={register()}
             onChange={() => {
               setHintError(undefined);

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -276,7 +276,6 @@ const RecoveryCodeCheck = ({
             name="recoveryCode"
             label="Enter a backup authentication code"
             prefixDataTestId="recovery-code"
-            autoFocus
             onChange={() => {
               setRecoveryCodeError('');
               recoveryCodeForm.trigger('recoveryCode');

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -326,7 +326,6 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 label="Enter authentication code"
                 prefixDataTestId="totp"
                 maxLength={6}
-                autoFocus
                 onChange={() => {
                   setInvalidCodeError('');
                   totpForm.trigger('totp');
@@ -444,7 +443,6 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                 name="recoveryCode"
                 label="Enter a backup authentication code"
                 prefixDataTestId="recovery-code"
-                autoFocus
                 onChange={() => {
                   setRecoveryCodeError('');
                   recoveryCodeForm.trigger('recoveryCode');

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -166,7 +166,7 @@ export const UnitRowTwoStepAuth = () => {
         <BackupCodesSubRow
           numCodesAvailable={count}
           onCtaClick={() => {
-            navigate(replaceCodesRoute);
+            navigate(replaceCodesRoute, undefined, false);
           }}
           key={1}
         />
@@ -180,13 +180,21 @@ export const UnitRowTwoStepAuth = () => {
         subRows.push(
           <BackupPhoneSubRow
             onCtaClick={() => {
-              navigate(`${SETTINGS_PATH}/recovery_phone/setup`);
+              navigate(
+                `${SETTINGS_PATH}/recovery_phone/setup`,
+                undefined,
+                false
+              );
             }}
             // only include the delete option if the user has recovery codes available
             {...(count &&
               count > 0 && {
                 onDeleteClick: () => {
-                  navigate(`${SETTINGS_PATH}/recovery_phone/remove`);
+                  navigate(
+                    `${SETTINGS_PATH}/recovery_phone/remove`,
+                    undefined,
+                    false
+                  );
                 },
               })}
             phoneNumber={

--- a/packages/fxa-settings/src/lib/hooks/useNavigateWithQuery/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useNavigateWithQuery/index.tsx
@@ -7,7 +7,11 @@ import { useNavigate, NavigateOptions } from '@reach/router';
 export function useNavigateWithQuery() {
   const navigate = useNavigate();
 
-  return (to: string, options?: NavigateOptions<{}>) => {
+  return (
+    to: string,
+    options?: NavigateOptions<{}>,
+    includeHash: boolean = true
+  ) => {
     const location = window.location;
     let path = to;
 
@@ -17,7 +21,7 @@ export function useNavigateWithQuery() {
       path = `${to}${location.search}`;
     }
 
-    if (location.hash) {
+    if (includeHash && location.hash) {
       path = `${path}${location.hash}`;
     }
 


### PR DESCRIPTION
## Because

* The top part of some pages (replace backup authentication codes, add recovery phone, remove recovery phone) was not visible on first load
* AlertBar from adding recovery phone stayed on screen after navigation to remove recovery phone

## This pull request

* Only optionally include existing hash from router location when navigating
* Remove autofocus on components where it was causing page to scroll away from top on smaller viewscreens

## Issue that this pull request solves

Closes: FXA-11239, FXA-11110

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
