### PR TITLE
feat(payments-next): add location intercept to cart creation

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -8,7 +8,11 @@ import {
   PurchaseDetails,
   SelectTaxLocation,
 } from '@fxa/payments/ui';
-import { fetchCMSData, getCartAction } from '@fxa/payments/ui/actions';
+import {
+  fetchCMSData,
+  getCartAction,
+  updateCartAction,
+} from '@fxa/payments/ui/actions';
 import {
   getApp,
   CheckoutParams,
@@ -86,8 +90,12 @@ export default async function CheckoutLayout({
             }
           />
           <SelectTaxLocation
-            cartId={cart.id}
-            cartVersion={cart.version}
+            saveAction={async (countryCode, postalCode) => {
+              'use server';
+              await updateCartAction(cart.id, cart.version, {
+                taxAddress: { countryCode, postalCode },
+              });
+            }}
             cmsCountries={cms.countries}
             locale={locale.substring(0, 2)}
             productName={purchaseDetails.productName}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -43,6 +43,7 @@ export default async function Checkout({
   searchParams: Record<string, string> | undefined;
 }) {
   const { locale } = params;
+
   const acceptLanguage = headers().get('accept-language');
   const sessionPromise = auth();
   const l10n = getApp().getL10n(acceptLanguage, locale);
@@ -63,6 +64,12 @@ export default async function Checkout({
     cmsDataPromise,
   ]);
 
+  const redirectSearchParams: Record<string, string> = searchParams || {};
+  if (cart.taxAddress) {
+    redirectSearchParams.countryCode = cart.taxAddress.countryCode;
+    redirectSearchParams.postalCode = cart.taxAddress.postalCode;
+  }
+
   const redirectTo = buildRedirectUrl(
     params.offeringId,
     params.interval,
@@ -71,7 +78,7 @@ export default async function Checkout({
     {
       baseUrl: config.paymentsNextHostedUrl,
       locale,
-      searchParams,
+      searchParams: redirectSearchParams,
     }
   );
 
@@ -85,7 +92,6 @@ export default async function Checkout({
               '1. Sign in or create a Mozilla account'
             )}
           </h2>
-
           <SignInForm
             submitAction={async (email?: string) => {
               'use server';

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/en.ftl
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/en.ftl
@@ -1,0 +1,3 @@
+location-required-header = Please select your country and enter your postal code.
+location-required-subheader = We weren’t able to detect your location automatically.
+location-required-disclaimer = We only use this information to calculate taxes and currency.

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  BaseParams,
+  IsolatedSelectTaxLocation,
+  buildRedirectUrl,
+} from '@fxa/payments/ui';
+import { config } from 'apps/payments/next/config';
+import { fetchCMSData } from '@fxa/payments/ui/actions';
+import { getApp, TermsAndPrivacy } from '@fxa/payments/ui/server';
+import { headers } from 'next/headers';
+import { redirect } from 'next/navigation';
+import * as Sentry from '@sentry/nextjs';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Location({
+  params,
+  searchParams,
+}: {
+  params: BaseParams;
+  searchParams: Record<string, string>;
+}) {
+  const acceptLanguage = headers().get('accept-language');
+  const l10n = getApp().getL10n(acceptLanguage, params.locale);
+
+  Sentry.captureMessage('Could not locate user by their ip');
+
+  const cms = await fetchCMSData(
+    params.offeringId,
+    acceptLanguage,
+    params.locale
+  );
+
+  const purchaseDetails =
+    cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
+    cms.defaultPurchase.purchaseDetails;
+
+  return (
+    <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
+      <h2 className="font-semibold text-grey-600 text-lg mt-10">
+        {l10n.getString(
+          'location-required-header',
+          `Please select your country and enter your postal code.`
+        )}
+      </h2>
+      <div className="pt-2">
+        {l10n.getString(
+          'location-required-subheader',
+          `We weren’t able to detect your location automatically.`
+        )}
+      </div>
+      <IsolatedSelectTaxLocation
+        cmsCountries={cms.countries}
+        locale={params.locale.substring(0, 2)}
+        productName={purchaseDetails.productName}
+        unsupportedLocations={config.subscriptionsUnsupportedLocations}
+        saveAction={async (countryCode: string, postalCode: string) => {
+          'use server';
+
+          searchParams['countryCode'] = countryCode;
+          searchParams['postalCode'] = postalCode;
+          const redirectUrl = new URL(
+            buildRedirectUrl(
+              params.offeringId,
+              params.interval,
+              'new',
+              'checkout',
+              {
+                locale: params.locale,
+                baseUrl: config.paymentsNextHostedUrl,
+                searchParams,
+              }
+            )
+          );
+
+          redirect(redirectUrl.href);
+        }}
+      />
+      <div className="pt-5 text-center">
+        {l10n.getString(
+          'location-required-disclaimer',
+          `We only use this information to calculate taxes and currency.`
+        )}
+      </div>
+      <TermsAndPrivacy
+        l10n={l10n}
+        {...purchaseDetails}
+        {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
+        contentServerUrl={config.contentServerUrl}
+        showFXALinks={true}
+      />
+    </div>
+  );
+}

--- a/libs/payments/cart/src/lib/cart.factories.ts
+++ b/libs/payments/cart/src/lib/cart.factories.ts
@@ -45,6 +45,11 @@ export const SetupCartFactory = (override?: Partial<SetupCart>): SetupCart => ({
   interval: faker.helpers.arrayElement(INTERVALS),
   amount: faker.number.int(10000),
   eligibilityStatus: faker.helpers.enumValue(CartEligibilityStatus),
+  taxAddress: {
+    countryCode: faker.location.countryCode(),
+    postalCode: faker.location.zipCode(),
+  },
+  currency: faker.finance.currencyCode(),
   ...override,
 });
 

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -446,6 +446,7 @@ describe('CartService', () => {
   });
 
   describe('setupCart', () => {
+    const taxAddress = TaxAddressFactory();
     const args = {
       interval: SubplatInterval.Monthly,
       offeringConfigId: faker.string.uuid(),
@@ -456,6 +457,8 @@ describe('CartService', () => {
         prefix: '',
         casing: 'lower',
       }),
+      taxAddress,
+      currency: faker.finance.currencyCode(),
       ip: faker.internet.ipv4(),
     };
 
@@ -466,7 +469,6 @@ describe('CartService', () => {
     const mockInvoicePreview = InvoicePreviewFactory();
     const mockResultCart = ResultCartFactory();
     const mockPrice = StripePriceFactory();
-    const taxAddress = TaxAddressFactory();
 
     beforeEach(async () => {
       jest

--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -74,6 +74,8 @@ export type BaseCartDTO = Omit<ResultCart, 'state'> & {
   paymentInfo?: PaymentInfo;
   fromOfferingConfigId?: string;
   fromPrice?: FromPrice;
+  taxAddress: TaxAddress;
+  currency: string;
 };
 
 export type StartCartDTO = BaseCartDTO & {
@@ -110,8 +112,8 @@ export type SetupCart = {
   interval: string;
   offeringConfigId: string;
   experiment?: string;
-  taxAddress?: TaxAddress;
-  currency?: string;
+  taxAddress: TaxAddress;
+  currency: string;
   couponCode?: string;
   stripeCustomerId?: string;
   email?: string;

--- a/libs/payments/ui/src/lib/actions/getTaxAddress.ts
+++ b/libs/payments/ui/src/lib/actions/getTaxAddress.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const getTaxAddressAction = async (ipAddress: string) => {
+  return getApp().getActionsService().getTaxAddress({ ipAddress });
+};

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -10,6 +10,7 @@ export { getCartAction } from './getCart';
 export { getCartOrRedirectAction } from './getCartOrRedirect';
 export { getMetricsFlowAction } from './getMetricsFlow';
 export { getPayPalCheckoutToken } from './getPayPalCheckoutToken';
+export { getTaxAddressAction } from './getTaxAddress';
 export { handleStripeErrorAction } from './handleStripeError';
 export { recordEmitterEventAction } from './recordEmitterEvent';
 export { restartCartAction } from './restartCart';

--- a/libs/payments/ui/src/lib/actions/setupCart.ts
+++ b/libs/payments/ui/src/lib/actions/setupCart.ts
@@ -4,15 +4,15 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
-import type { SubplatInterval } from '@fxa/payments/customer';
+import type { SubplatInterval, TaxAddress } from '@fxa/payments/customer';
 
 export const setupCartAction = async (
   interval: SubplatInterval,
   offeringConfigId: string,
+  taxAddress: TaxAddress,
   experiment?: string,
   promoCode?: string,
-  uid?: string,
-  ip?: string
+  uid?: string
 ) => {
   return getApp().getActionsService().setupCart({
     interval,
@@ -20,6 +20,6 @@ export const setupCartAction = async (
     experiment,
     promoCode,
     uid,
-    ip,
+    taxAddress,
   });
 };

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -49,6 +49,7 @@ import {
   CouponErrorExpired,
   CouponErrorGeneric,
   CouponErrorLimitReached,
+  TaxAddress,
   type SubplatInterval,
 } from '@fxa/payments/customer';
 import { GetPayPalCheckoutTokenResult } from './validators/GetPayPalCheckoutTokenResult';
@@ -59,6 +60,8 @@ import { ValidatePostalCodeActionResult } from './validators/ValidatePostalCodeA
 import { DetermineCurrencyActionResult } from './validators/DetermineCurrencyActionResult';
 import { SetupCartActionResult } from './validators/SetupCartActionResult';
 import { RestartCartActionResult } from './validators/RestartCartActionResult';
+import { GetTaxAddressArgs } from './validators/getTaxAddressArgs';
+import { GetTaxAddressResult } from './validators/getTaxAddressResult';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -144,7 +147,7 @@ export class NextJSActionsService {
     experiment?: string;
     promoCode?: string;
     uid?: string;
-    ip?: string;
+    taxAddress: TaxAddress;
   }) {
     const cart = await this.cartService.setupCart({
       ...args,
@@ -179,6 +182,13 @@ export class NextJSActionsService {
     return {
       token,
     };
+  }
+
+  @SanitizeExceptions()
+  @NextIOValidator(GetTaxAddressArgs, GetTaxAddressResult)
+  async getTaxAddress(args: { ipAddress: string }) {
+    const taxAddress = this.geodbManager.getTaxAddress(args.ipAddress);
+    return { taxAddress };
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/getTaxAddressArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/getTaxAddressArgs.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class GetTaxAddressArgs {
+  @IsString()
+  ipAddress!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/getTaxAddressResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/getTaxAddressResult.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { SubplatInterval } from '@fxa/payments/customer';
-import { Type } from 'class-transformer';
+
 import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 class TaxAddress {
   @IsString()
@@ -13,26 +13,9 @@ class TaxAddress {
   postalCode!: string;
 }
 
-export class SetupCartActionArgs {
-  @IsString()
-  interval!: SubplatInterval;
-
-  @IsString()
-  offeringConfigId!: string;
-
-  @IsString()
+export class GetTaxAddressResult {
   @IsOptional()
-  experiment?: string;
-
-  @IsString()
-  @IsOptional()
-  promoCode?: string;
-
-  @IsString()
-  @IsOptional()
-  uid?: string;
-
   @ValidateNested()
   @Type(() => TaxAddress)
-  TaxAddress!: TaxAddress;
+  taxAddress?: TaxAddress;
 }

--- a/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
+++ b/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-type Page = 'landing' | 'new' | 'start' | 'success' | 'error';
+type Page = 'landing' | 'new' | 'start' | 'success' | 'error' | 'location';
 type PageType = 'checkout' | 'upgrade';
 
 interface Optional {
@@ -22,7 +22,9 @@ export function buildRedirectUrl(
   const baseUrl = optional?.baseUrl ? optional?.baseUrl : '';
 
   const startUrl = baseUrl === '/' ? baseUrl : `${baseUrl}/`;
-  const pageTypeUrl = ['landing', 'new'].includes(page) ? '' : `${pageType}/`;
+  const pageTypeUrl = ['landing', 'new', 'location'].includes(page)
+    ? ''
+    : `${pageType}/`;
   const endUrl = optional?.cartId ? `${optional?.cartId}/${page}` : page;
 
   const searchParamsString = optional?.searchParams


### PR DESCRIPTION
## Because

- Subscription carts need the users tax location to function properly. Currently, if a user can't be found via maxmind, we set their tax address to empty.

## This pull request

- Ensures the tax address and currency code are set on the cart. If the user cannot be located, their cart-creation attempt is intercepted and they are directed to a new page, where they are prompted to input their details

## Issue that this pull request solves

Closes: #FXA-10384

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![Screenshot 2025-03-11 at 3 48 03 PM](https://github.com/user-attachments/assets/147b3981-9102-40eb-9739-114199e946b0)

## Other information (Optional)

Any other information that is important to this pull request.
