### PR TITLE
fix(payments-next): Remove duplicate ftl ids

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/en.ftl
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/en.ftl
@@ -1,7 +1,0 @@
-next-payment-error-manage-subscription-button = Manage my subscription
-next-iap-upgrade-contact-support = You can still get this product — please contact support so we can help you.
-next-payment-error-retry-button = Try again
-next-basic-error-message = Something went wrong. Please try again later.
-checkout-error-contact-support-button = Contact Support
-checkout-error-not-eligible = You are not eligible to subscribe to this product - please contact support so we can help you.
-checkout-error-contact-support = Please contact support so we can help you.


### PR DESCRIPTION
## This pull request

- removes duplicate ftl ids; these ftl ids are currently in `apps/payments/next/app/[locale]/en.ftl` and are shared between `/checkout` and `/upgrade`

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.