### PR TITLE
task(customs): Update rules for consistency

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.manager.ts
@@ -22,7 +22,7 @@ import {
 import { Redis } from 'ioredis';
 import { PhoneNumberInstance } from 'twilio/lib/rest/lookups/v2/phoneNumber';
 
-const RECORD_EXPIRATION_SECONDS = 10 * 60;
+const RECORD_EXPIRATION_SECONDS = 5 * 60;
 
 /**
  *

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -195,7 +195,7 @@ module.exports = function (fs, path, url, convict) {
         },
         passwordResetOtpRateLimitIntervalSeconds: {
           doc: 'Number of seconds to wait until password reset OTP requests are allowed again',
-          default: 1800,
+          default: 15 * 60,
           format: 'nat',
           env: 'PASSWORD_RESET_OTP_EMAIL_RATE_LIMIT_SECONDS',
         },
@@ -431,7 +431,7 @@ module.exports = function (fs, path, url, convict) {
           max: {
             doc: 'max actions during `period` that can occur before rate limit is applied',
             format: 'nat',
-            default: 2,
+            default: 5,
             env: 'TOTP_CODE_RULE_MAX',
           },
           periodMs: {
@@ -443,7 +443,7 @@ module.exports = function (fs, path, url, convict) {
           rateLimitIntervalMs: {
             doc: 'how long rate limit is applied',
             format: 'duration',
-            default: '30 seconds',
+            default: '15 minutes',
             env: 'TOTP_CODE_RULE_LIMIT_INTERVAL_MS',
           },
         },
@@ -458,13 +458,13 @@ module.exports = function (fs, path, url, convict) {
           max: {
             doc: 'max actions during `period` that can occur before rate limit is applied',
             format: 'nat',
-            default: 10,
+            default: 5,
             env: 'RECOVERY_PHONE_TOTP_CODE_RULE_MAX',
           },
           periodMs: {
             doc: 'period needed before rate limit is reset',
             format: 'duration',
-            default: '15 minutes',
+            default: '5 minutes',
             env: 'RECOVERY_PHONE_TOTP_CODE_RULE_PERIOD_MS',
           },
           rateLimitIntervalMs: {


### PR DESCRIPTION
## Because

- We want a consistent user experience.
- We want to give users 5 attempts for codes
- We want to have consistent ban durations

## This pull request

- Changes OTP recovery phone code validity to 5 minute windows
- Changes max attempts to OTP recovery phones to 5
- Changes block durations for otp codes to 15 minutes on recovery phone, 2FA, and password reset otp

## Issue that this pull request solves

Closes: FXA-11272

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There's a chance this could break some tests... Hopefully impact is small. If impact is big we might need to roll back some of these.
