### PR TITLE
fix(next): reuse subscription item fetch logic

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -1022,9 +1022,6 @@ describe('CheckoutService', () => {
           .spyOn(subscriptionManager, 'retrieveForCustomerAndPrice')
           .mockResolvedValue(subscription);
         jest
-          .spyOn(subscriptionManager, 'retrieveSubscriptionItem')
-          .mockReturnValue(subscription.items.data[0]);
-        jest
           .spyOn(subscriptionManager, 'update')
           .mockResolvedValue(StripeResponseFactory(subscription));
       });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -18,6 +18,7 @@ import {
   InvoiceManager,
   PaymentIntentManager,
   PromotionCodeManager,
+  retrieveSubscriptionItem,
   STRIPE_CUSTOMER_METADATA,
   STRIPE_SUBSCRIPTION_METADATA,
   SubplatInterval,
@@ -488,7 +489,7 @@ export class CheckoutService {
     }
 
     const upgradeSubscriptionItem =
-      this.subscriptionManager.retrieveSubscriptionItem(upgradeSubscription);
+      retrieveSubscriptionItem(upgradeSubscription);
 
     return this.subscriptionManager.update(upgradeSubscription.id, {
       cancel_at_period_end: false,

--- a/libs/payments/customer/src/index.ts
+++ b/libs/payments/customer/src/index.ts
@@ -18,3 +18,4 @@ export * from './lib/error';
 export * from './lib/util/stripeInvoiceToFirstInvoicePreviewDTO';
 export * from './lib/util/getSubplatInterval';
 export * from './lib/util/determinePaymentMethodType';
+export * from './lib/util/retrieveSubscriptionItem';

--- a/libs/payments/customer/src/lib/error.ts
+++ b/libs/payments/customer/src/lib/error.ts
@@ -5,10 +5,8 @@
 import { BaseError } from '@fxa/shared/error';
 
 export class PaymentsCustomerError extends BaseError {
-  constructor(message: string, cause?: Error) {
-    super(message, {
-      cause,
-    });
+  constructor(...args: ConstructorParameters<typeof BaseError>) {
+    super(...args);
   }
 }
 
@@ -44,7 +42,7 @@ export class PromotionCodeCouldNotBeAttachedError extends PaymentsCustomerError 
       promotionId?: string;
     }
   ) {
-    super(message, cause);
+    super(message, { cause });
     this.customerId = data?.customerId;
     this.subscriptionId = data?.subscriptionId;
     this.promotionId = data?.promotionId;
@@ -99,6 +97,16 @@ export class InvalidInvoiceError extends PaymentsCustomerError {
   }
 }
 
+export class UpgradeCustomerMissingCurrencyInvoiceError extends PaymentsCustomerError {
+  constructor(customerId: string) {
+    super('Customer performing upgrade is missing currency', {
+      info: {
+        customerId,
+      },
+    });
+  }
+}
+
 export class StripePayPalAgreementNotFoundError extends PaymentsCustomerError {
   constructor(customerId: string) {
     super(`PayPal agreement not found for Stripe customer ${customerId}`);
@@ -111,13 +119,7 @@ export class PayPalPaymentFailedError extends PaymentsCustomerError {
   }
 }
 
-export class PaymentsSubscriptionError extends BaseError {
-  constructor(...args: ConstructorParameters<typeof BaseError>) {
-    super(...args);
-  }
-}
-
-export class SubscriptionItemMultipleItemsError extends PaymentsSubscriptionError {
+export class SubscriptionItemMultipleItemsError extends PaymentsCustomerError {
   constructor(subscriptionId: string) {
     super('Multiple subscription items not supported', {
       info: { subscriptionId },
@@ -125,7 +127,7 @@ export class SubscriptionItemMultipleItemsError extends PaymentsSubscriptionErro
   }
 }
 
-export class SubscriptionItemMissingItemError extends PaymentsSubscriptionError {
+export class SubscriptionItemMissingItemError extends PaymentsCustomerError {
   constructor(subscriptionId: string) {
     super('Subscription item missing', { info: { subscriptionId } });
   }

--- a/libs/payments/customer/src/lib/subscription.manager.spec.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.spec.ts
@@ -14,15 +14,10 @@ import {
   StripePaymentIntentFactory,
   StripeSubscriptionFactory,
   MockStripeConfigProvider,
-  StripeSubscriptionItemFactory,
 } from '@fxa/payments/stripe';
 import { STRIPE_SUBSCRIPTION_METADATA } from './types';
 import { SubscriptionManager } from './subscription.manager';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
-import {
-  SubscriptionItemMissingItemError,
-  SubscriptionItemMultipleItemsError,
-} from './error';
 
 describe('SubscriptionManager', () => {
   let subscriptionManager: SubscriptionManager;
@@ -261,46 +256,6 @@ describe('SubscriptionManager', () => {
           mockPriceId
         )
       ).rejects.toThrow();
-    });
-  });
-
-  describe('retrieveSubscriptionItem', () => {
-    const mockSubscription = StripeSubscriptionFactory();
-    it('successfully returns the subsriptions item', () => {
-      const result =
-        subscriptionManager.retrieveSubscriptionItem(mockSubscription);
-      expect(result.id).toEqual(mockSubscription.items.data[0].id);
-    });
-
-    it('throws an error if there are multiple subscription items', async () => {
-      const mockSubscription = StripeSubscriptionFactory({
-        items: {
-          object: 'list',
-          data: [
-            StripeSubscriptionItemFactory(),
-            StripeSubscriptionItemFactory(),
-          ],
-          has_more: false,
-          url: '/v1/subscription_items?subscription=sub_24',
-        },
-      });
-      expect(() =>
-        subscriptionManager.retrieveSubscriptionItem(mockSubscription)
-      ).toThrowError(SubscriptionItemMultipleItemsError);
-    });
-
-    it('throws an error if no subscription item is found', () => {
-      const mockSubscription = StripeSubscriptionFactory({
-        items: {
-          object: 'list',
-          data: [],
-          has_more: false,
-          url: '/v1/subscription_items?subscription=sub_24',
-        },
-      });
-      expect(() =>
-        subscriptionManager.retrieveSubscriptionItem(mockSubscription)
-      ).toThrowError(SubscriptionItemMissingItemError);
     });
   });
 

--- a/libs/payments/customer/src/lib/subscription.manager.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.ts
@@ -9,20 +9,14 @@ import {
   StripeClient,
   StripePaymentIntent,
   StripeSubscription,
-  StripeSubscriptionItem,
 } from '@fxa/payments/stripe';
 import { ACTIVE_SUBSCRIPTION_STATUSES } from '@fxa/payments/stripe';
 import { STRIPE_SUBSCRIPTION_METADATA } from './types';
-import {
-  InvalidPaymentIntentError,
-  PaymentIntentNotFoundError,
-  SubscriptionItemMissingItemError,
-  SubscriptionItemMultipleItemsError,
-} from './error';
+import { InvalidPaymentIntentError, PaymentIntentNotFoundError } from './error';
 
 @Injectable()
 export class SubscriptionManager {
-  constructor(private stripeClient: StripeClient) { }
+  constructor(private stripeClient: StripeClient) {}
 
   async cancel(
     subscriptionId: string,
@@ -90,21 +84,6 @@ export class SubscriptionManager {
     return subscriptions.find((sub) =>
       sub.items.data.find((subItem) => subItem.price.id === priceId)
     );
-  }
-
-  retrieveSubscriptionItem(
-    subscription: StripeSubscription
-  ): StripeSubscriptionItem {
-    if (subscription.items.data.length > 1) {
-      throw new SubscriptionItemMultipleItemsError(subscription.id);
-    }
-
-    const firstSubscriptionItem = subscription.items.data.at(0);
-    if (!firstSubscriptionItem) {
-      throw new SubscriptionItemMissingItemError(subscription.id);
-    }
-
-    return firstSubscriptionItem;
   }
 
   getPaymentProvider(subscription: StripeSubscription): 'paypal' | 'stripe' {

--- a/libs/payments/customer/src/lib/util/retrieveSubscriptionItem.spec.ts
+++ b/libs/payments/customer/src/lib/util/retrieveSubscriptionItem.spec.ts
@@ -1,0 +1,48 @@
+import {
+  StripeSubscriptionFactory,
+  StripeSubscriptionItemFactory,
+} from '@fxa/payments/stripe';
+import { retrieveSubscriptionItem } from './retrieveSubscriptionItem';
+import {
+  SubscriptionItemMissingItemError,
+  SubscriptionItemMultipleItemsError,
+} from '../error';
+
+describe('retrieveSubscriptionItem', () => {
+  const mockSubscription = StripeSubscriptionFactory();
+  it('successfully returns the subsriptions item', () => {
+    const result = retrieveSubscriptionItem(mockSubscription);
+    expect(result.id).toEqual(mockSubscription.items.data[0].id);
+  });
+
+  it('throws an error if there are multiple subscription items', async () => {
+    const mockSubscription = StripeSubscriptionFactory({
+      items: {
+        object: 'list',
+        data: [
+          StripeSubscriptionItemFactory(),
+          StripeSubscriptionItemFactory(),
+        ],
+        has_more: false,
+        url: '/v1/subscription_items?subscription=sub_24',
+      },
+    });
+    expect(() => retrieveSubscriptionItem(mockSubscription)).toThrowError(
+      SubscriptionItemMultipleItemsError
+    );
+  });
+
+  it('throws an error if no subscription item is found', () => {
+    const mockSubscription = StripeSubscriptionFactory({
+      items: {
+        object: 'list',
+        data: [],
+        has_more: false,
+        url: '/v1/subscription_items?subscription=sub_24',
+      },
+    });
+    expect(() => retrieveSubscriptionItem(mockSubscription)).toThrowError(
+      SubscriptionItemMissingItemError
+    );
+  });
+});

--- a/libs/payments/customer/src/lib/util/retrieveSubscriptionItem.ts
+++ b/libs/payments/customer/src/lib/util/retrieveSubscriptionItem.ts
@@ -1,0 +1,23 @@
+import {
+  StripeSubscription,
+  StripeSubscriptionItem,
+} from '@fxa/payments/stripe';
+import {
+  SubscriptionItemMissingItemError,
+  SubscriptionItemMultipleItemsError,
+} from '../error';
+
+export function retrieveSubscriptionItem(
+  subscription: StripeSubscription
+): StripeSubscriptionItem {
+  if (subscription.items.data.length > 1) {
+    throw new SubscriptionItemMultipleItemsError(subscription.id);
+  }
+
+  const firstSubscriptionItem = subscription.items.data.at(0);
+  if (!firstSubscriptionItem) {
+    throw new SubscriptionItemMissingItemError(subscription.id);
+  }
+
+  return firstSubscriptionItem;
+}

--- a/libs/payments/eligibility/src/lib/eligibility.factories.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.factories.ts
@@ -11,13 +11,21 @@ export const SubscriptionEligibilityResultCreateFactory =
   });
 
 export const SubscriptionEligibilityResultUpgradeFactory = (): {
-  subscriptionEligibilityResult:
-    | EligibilityStatus.UPGRADE
-    | EligibilityStatus.DOWNGRADE;
+  subscriptionEligibilityResult: EligibilityStatus.UPGRADE;
   fromOfferingConfigId: string;
   fromPrice: StripePrice;
 } => ({
   subscriptionEligibilityResult: EligibilityStatus.UPGRADE,
+  fromOfferingConfigId: faker.helpers.arrayElement(['vpn']),
+  fromPrice: StripePriceFactory(),
+});
+
+export const SubscriptionEligibilityResultDowngradeFactory = (): {
+  subscriptionEligibilityResult: EligibilityStatus.DOWNGRADE;
+  fromOfferingConfigId: string;
+  fromPrice: StripePrice;
+} => ({
+  subscriptionEligibilityResult: EligibilityStatus.DOWNGRADE,
   fromOfferingConfigId: faker.helpers.arrayElement(['vpn']),
   fromPrice: StripePriceFactory(),
 });


### PR DESCRIPTION
## Because

- Reuse function to retrieve subscription item from subscription.

## This pull request

- Move retrieveSubscriptionItem into util function and reuse in invoice.manager.
- Extract logic to fetch upcoming upgrade invoice into previewUpcomingUpgrade method.
- Rewrite previewUpcomingForUpgrade to more accurately reflect its purpose.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
