### PR TITLE
bug(auth): Allow startup even if twilio is not configured.

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/twilio.config.ts
+++ b/libs/accounts/recovery-phone/src/lib/twilio.config.ts
@@ -10,12 +10,13 @@ import { IsBoolean, IsString } from 'class-validator';
 export class TwilioConfig {
   /**
    * Determines which credential set to use. Options are
-   * - test - uses the testing account sid and testing auth token
-   * - default - uses the account sid and auth token
-   * - apiKeys - ues the account sid, apiKey and apiSecret
+   * - '' - An unauthenticated twilio client will be created. All calls to twilio will fail.
+   * - 'test' - uses the testing account sid and testing auth token
+   * - 'default' - uses the account sid and auth token
+   * - 'apiKeys' - ues the account sid, apiKey and apiSecret
    */
   @IsString()
-  credentialMode!: 'test' | 'default' | 'apiKeys';
+  credentialMode!: 'test' | 'default' | 'apiKeys' | '';
 
   @IsString()
   testAuthToken?: string;

--- a/libs/accounts/recovery-phone/src/lib/twilio.provider.ts
+++ b/libs/accounts/recovery-phone/src/lib/twilio.provider.ts
@@ -6,6 +6,7 @@ import { ConfigService } from '@nestjs/config';
 import { Provider } from '@nestjs/common';
 import { Twilio } from 'twilio';
 import { TwilioConfig } from './twilio.config';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 export const TwilioConfigProvider = {
   provide: TwilioConfig,
@@ -21,7 +22,7 @@ export const TwilioProvider = Symbol('TwilioProvider');
 //       Should this be moved to shared?
 export const TwilioFactory: Provider<Twilio> = {
   provide: TwilioProvider,
-  useFactory: (config: TwilioConfig) => {
+  useFactory: (config: TwilioConfig, log?: MozLoggerService) => {
     const {
       credentialMode,
       testAccountSid,
@@ -31,6 +32,13 @@ export const TwilioFactory: Provider<Twilio> = {
       apiKey,
       apiSecret,
     } = config;
+
+    if (credentialMode === '') {
+      log?.debug(
+        'Twilio will not be available. Check readme for info about configuring Twilio.'
+      );
+      return new Twilio('AC123', '');
+    }
 
     // Okay for test, dev, and CI when using real phone numbers
     if (credentialMode === 'default' && accountSid && authToken) {

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2240,42 +2240,42 @@ const convictConf = convict({
   },
   twilio: {
     credentialMode: {
-      default: 'default',
-      doc: 'Which credential set to use. Options are test, default, or apiKeys.',
+      default: '',
+      doc: 'Which credential set to use. Options are "", "test", "default", or "apiKeys".',
       env: 'RECOVERY_PHONE__TWILIO__CREDENTIAL_MODE',
       format: String,
     },
     testAccountSid: {
       default: 'AC_REPLACEMEWITHKEY',
-      doc: 'Twilio Testing Account ID. Note must be used for tests leveraging Twilio magic phone numbers.',
+      doc: 'Twilio Testing Account ID. Note must be used for tests leveraging Twilio magic phone numbers. Required when credentialMode is test.',
       env: 'RECOVERY_PHONE__TWILIO__TEST_ACCOUNT_SID',
       format: String,
     },
     testAuthToken: {
       default: '',
-      doc: 'Twilio Testing Account Auth Token. Note must be used for tests leverage Twilio magic phone numbers.',
+      doc: 'Twilio Testing Account Auth Token. Note must be used for tests leverage Twilio magic phone numbers. Required when credentialMode is test.',
       env: 'RECOVERY_PHONE__TWILIO__TEST_AUTH_TOKEN',
       format: String,
     },
     accountSid: {
       default: 'AC_REPLACEMEWITHKEY',
-      doc: 'Twilio Account ID',
+      doc: 'Twilio Account ID.  Required when credentialMode is default or apiKeys.',
       env: 'RECOVERY_PHONE__TWILIO__ACCOUNT_SID',
       format: String,
     },
     authToken: {
       default: '',
-      doc: 'Twilio Auth Token to access api. Note, using apiKey/apiSecret is preferred.',
+      doc: 'Twilio Auth Token to access api. Note, using apiKey/apiSecret is preferred. Required when credentialMode is default.',
       env: 'RECOVERY_PHONE__TWILIO__AUTH_TOKEN',
     },
     apiKey: {
       default: '',
-      doc: 'An api key used to access the twilio rest api. Note, when provided the authToken is no longer needed.',
+      doc: 'An api key used to access the twilio rest api. Required when credentialMode is apiKeys.',
       env: 'RECOVERY_PHONE__TWILIO__API_KEY',
     },
     apiSecret: {
       default: '',
-      doc: 'A secret used in conjunction with the apiKey to access the twilio rest api.',
+      doc: 'A secret used in conjunction with the apiKey to access the twilio rest api. Required when credentialMode is apiKeys.',
       env: 'RECOVERY_PHONE__TWILIO__API_SECRET',
     },
     webhookUrl: {


### PR DESCRIPTION
## Because

- Auth server should still start if twilio isn't configured

## This pull request

- Creates an default empty config state that allows auth server to still start up.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
