### PR TITLE
bug(customs): Fix broken customs integration tests

### DIFF
--- a/packages/fxa-customs-server/test/remote/user_defined_rules.js
+++ b/packages/fxa-customs-server/test/remote/user_defined_rules.js
@@ -24,8 +24,11 @@ function randomUid() {
 }
 
 const config = require('../../lib/config').getProperties();
+
+config.userDefinedRateLimitRules.totpCodeRules.limits.max = 2;
 config.userDefinedRateLimitRules.totpCodeRules.limits.periodMs = 1000;
 config.userDefinedRateLimitRules.totpCodeRules.limits.rateLimitIntervalMs = 1000;
+
 config.userDefinedRateLimitRules.tokenCodeRules.limits.max = 2;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.periodMs = 1000;
 config.userDefinedRateLimitRules.tokenCodeRules.limits.rateLimitIntervalMs = 1000;


### PR DESCRIPTION
## Because

- We updated the totpCodeRules.limit.max default value, but failed to update the corresponding test.

## This pull request

- Sets the max for totpCodeRules.limits to 2 since that's what test expects.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
