### PR TITLE
feat(Settings): add /authorization to fxa-settings

### DIFF
--- a/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
@@ -1,0 +1,243 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Page, expect, test } from '../../lib/fixtures/standard';
+import { BaseTarget, Credentials } from '../../lib/targets/base';
+import { TestAccountTracker } from '../../lib/testAccountTracker';
+import { SettingsPage } from '../../pages/settings';
+import { SigninPage } from '../../pages/signin';
+
+test.describe('severity-1 #smoke', () => {
+  test.beforeEach(async ({}, { project }) => {
+    test.skip(
+      project.name === 'production',
+      'test plan not yet available in prod'
+    );
+  });
+
+  test.describe('oauth prompt none', () => {
+    test('fails if no user logged in', async ({
+      page,
+      target,
+      pages: { relier },
+      testAccountTracker,
+    }) => {
+      const { email } = testAccountTracker.generateAccountDetails();
+
+      const query = new URLSearchParams({
+        login_hint: email,
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify error message
+      await page.waitForURL(/authorization/);
+      await expect(page.getByText('User is not signed in')).toBeVisible();
+    });
+
+    test('fails RP that is not allowed', async ({
+      page,
+      target,
+      pages: { relier },
+      testAccountTracker,
+    }, { project }) => {
+      test.skip(
+        project.name !== 'local',
+        'we dont have an untrusted oauth for stage and prod'
+      );
+      const { email } = testAccountTracker.generateAccountDetails();
+
+      const query = new URLSearchParams({
+        login_hint: email,
+        return_on_error: 'false',
+      });
+      await page.goto(`http://localhost:10139` + `/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify error message
+      await expect(
+        page.getByText('prompt=none is not enabled for this client')
+      ).toBeVisible();
+    });
+
+    test('fails if requesting keys', async ({
+      page,
+      target,
+      pages: { relier },
+      testAccountTracker,
+    }) => {
+      const { email } = testAccountTracker.generateAccountDetails();
+      const query = new URLSearchParams({
+        client_id: '7f368c6886429f19', // eslint-disable-line camelcase
+        forceUA:
+          'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36',
+        // eslint-disable-next-line camelcase
+        keys_jwk:
+          'eyJrdHkiOiJFQyIsImtpZCI6Im9DNGFudFBBSFZRX1pmQ09RRUYycTRaQlZYblVNZ2xISGpVRzdtSjZHOEEiLCJjcnYiOi' +
+          'JQLTI1NiIsIngiOiJDeUpUSjVwbUNZb2lQQnVWOTk1UjNvNTFLZVBMaEg1Y3JaQlkwbXNxTDk0IiwieSI6IkJCWDhfcFVZeHpTaldsdX' +
+          'U5MFdPTVZwamIzTlpVRDAyN0xwcC04RW9vckEifQ',
+        login_hint: email, // eslint-disable-line camelcase
+        redirect_uri:
+          'https://mozilla.github.io/notes/fxa/android-redirect.html', // eslint-disable-line camelcase
+        scope: 'profile https://identity.mozilla.com/apps/notes',
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify error message
+      await expect(
+        page.getByText('prompt=none cannot be used when requesting keys')
+      ).toBeVisible();
+    });
+
+    test('fails if session is no longer valid', async ({
+      page,
+      target,
+      pages: { relier, settings, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      //Verify logged in on Settings page
+      await expect(settings.settingsHeading).toBeVisible();
+      await target.authClient.accountDestroy(
+        credentials.email,
+        credentials.password,
+        {},
+        credentials.sessionToken
+      );
+      const query = new URLSearchParams({
+        login_hint: credentials.email,
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      // Verify error message
+      await page.waitForURL(/authorization/);
+      await expect(page.getByText('User is not signed in')).toBeVisible();
+    });
+
+    test('fails if account is not verified', async ({
+      target,
+      pages: { page, confirmSignupCode, relier, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp({
+        lang: 'en',
+        preVerified: 'false',
+      });
+
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      //Verify sign up code header
+      await expect(page).toHaveURL(/confirm_signup_code/);
+
+      const query = new URLSearchParams({
+        login_hint: credentials.email,
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify error message
+      await expect(page.getByText('Unverified user or session')).toBeVisible();
+    });
+  });
+
+  test.describe('oauth prompt none with emails', () => {
+    test('succeeds if login_hint same as logged in user', async ({
+      page,
+      target,
+      pages: { relier, settings, signin },
+      testAccountTracker,
+    }) => {
+      const { email } = await signInAccount(
+        target,
+        page,
+        settings,
+        signin,
+        testAccountTracker
+      );
+
+      const query = new URLSearchParams({
+        login_hint: email,
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify logged in to relier
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('succeeds if no login_hint is provided', async ({
+      page,
+      target,
+      pages: { relier, settings, signin },
+      testAccountTracker,
+    }) => {
+      await signInAccount(target, page, settings, signin, testAccountTracker);
+
+      const query = new URLSearchParams({
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify logged in to relier
+      expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    test('fails if login_hint is different to logged in user', async ({
+      page,
+      target,
+      pages: { relier, settings, signin },
+      testAccountTracker,
+    }) => {
+      const loginHintAccount = testAccountTracker.generateAccountDetails();
+      await signInAccount(target, page, settings, signin, testAccountTracker);
+
+      const query = new URLSearchParams({
+        login_hint: loginHintAccount.email,
+        return_on_error: 'false',
+      });
+      await page.goto(`${target.relierUrl}/?${query.toString()}`);
+      await relier.signInPromptNone();
+
+      //Verify error message
+      await expect(
+        page.getByText('A different user is signed in')
+      ).toBeVisible();
+    });
+  });
+});
+
+async function signInAccount(
+  target: BaseTarget,
+  page: Page,
+  settings: SettingsPage,
+  signin: SigninPage,
+  testAccountTracker: TestAccountTracker
+): Promise<Credentials> {
+  const credentials = await testAccountTracker.signUp();
+  await page.goto(
+    `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
+  );
+  await signin.fillOutEmailFirstForm(credentials.email);
+  await signin.fillOutPasswordForm(credentials.password);
+  await page.waitForURL(/settings/);
+  //Verify logged in on Settings page
+  await expect(settings.settingsHeading).toBeVisible();
+
+  return credentials;
+}

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -130,7 +130,9 @@ Router = Router.extend({
         CompleteResetPasswordView
       );
     },
-    'authorization(/)': createViewHandler(RedirectAuthView),
+    'authorization(/)': function () {
+      this.createReactOrBackboneViewHandler('authorization', RedirectAuthView);
+    },
     'cannot_create_account(/)': function () {
       this.createReactViewHandler('cannot_create_account');
     },

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -25,7 +25,9 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
   return {
     emailFirstRoutes: {
       featureFlagOn: showReactApp.emailFirstRoutes,
-      routes: reactRoute.getRoutes(['/']),
+      // the order of the routes in teh array is important.  do not put '/'
+      // first.
+      routes: reactRoute.getRoutes(['authorization', '/']),
       fullProdRollout: false,
     },
     simpleRoutes: {

--- a/packages/fxa-react/components/AppErrorBoundary/index.tsx
+++ b/packages/fxa-react/components/AppErrorBoundary/index.tsx
@@ -38,11 +38,7 @@ class AppErrorBoundary extends React.Component<
 
   render() {
     const { error } = this.state;
-    return error ? (
-      <AppErrorDialog {...{ error }} />
-    ) : (
-      (this.props as any).children
-    );
+    return error ? <AppErrorDialog /> : (this.props as any).children;
   }
 }
 

--- a/packages/fxa-react/components/AppErrorDialog/index.stories.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.stories.tsx
@@ -8,6 +8,6 @@ storiesOf('Components/AppErrorDialog', module).add('basic', () => (
     baseDir="./locales"
     userLocales={navigator.languages}
   >
-    <AppErrorDialog error={new Error('Uh oh!')} />
+    <AppErrorDialog />
   </AppLocalizationProvider>
 ));

--- a/packages/fxa-react/components/AppErrorDialog/index.test.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.test.tsx
@@ -9,7 +9,7 @@ import { renderWithLocalizationProvider } from '../../lib/test-utils/localizatio
 describe('AppErrorDialog', () => {
   it('renders a general error dialog', () => {
     const { queryByTestId } = renderWithLocalizationProvider(
-      <AppErrorDialog error={new Error('bad')} />
+      <AppErrorDialog />
     );
 
     expect(queryByTestId('error-loading-app')).toBeInTheDocument();

--- a/packages/fxa-react/components/AppErrorDialog/index.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { Localized } from '@fluent/react';
 
-const AppErrorDialog = ({ error }: { error: Error }) => {
+const AppErrorDialog = () => {
   return (
     <div className="bg-grey-20 flex items-center flex-col justify-center h-screen">
       <div className="text-center max-w-lg">

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -88,6 +88,7 @@ import SetPasswordContainer from '../../pages/PostVerify/SetPassword/container';
 import SigninRecoveryChoiceContainer from '../../pages/Signin/SigninRecoveryChoice/container';
 import SigninRecoveryPhoneContainer from '../../pages/Signin/SigninRecoveryPhone/container';
 import { IndexContainer } from '../../pages/Index/container';
+import AuthorizationContainer from '../../pages/Authorization/container';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -378,6 +379,7 @@ const AuthAndAccountSetupRoutes = ({
       />
 
       {/* Signin */}
+      <AuthorizationContainer path="/authorization/*" {...{ integration }} />
       <ReportSigninContainer path="/report_signin/*" />
       <SigninContainer
         path="/oauth/force_auth/*"

--- a/packages/fxa-settings/src/components/OAuthDataError/index.tsx
+++ b/packages/fxa-settings/src/components/OAuthDataError/index.tsx
@@ -24,7 +24,10 @@ const OAuthDataError = ({ error }: { error: AuthError }) => {
       <Banner
         type="error"
         content={{
-          localizedHeading: getLocalizedErrorMessage(ftlMsgResolver, error),
+          // TODO FXA-9502
+          localizedHeading: error.version
+            ? getLocalizedErrorMessage(ftlMsgResolver, error)
+            : error.message,
         }}
       />
     </AppLayout>

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -130,7 +130,7 @@ export const Settings = ({
   if (error) {
     Sentry.captureException(error, { tags: { source: 'settings' } });
     GleanMetrics.error.view({ event: { reason: error.message } });
-    return <AppErrorDialog data-testid="error-dialog" {...{ error }} />;
+    return <AppErrorDialog data-testid="error-dialog" />;
   }
 
   const canAddRecoveryPhone =

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -133,6 +133,46 @@ export interface ProfileInfo {
   emails: Email[];
 }
 
+// Account attributes that can be persisted
+const PERSISTENT = {
+  accountResetToken: undefined,
+  alertText: undefined,
+  displayName: undefined,
+  email: undefined,
+  grantedPermissions: undefined,
+  hadProfileImageSetBefore: undefined,
+  lastLogin: undefined,
+  // password field intentionally omitted to avoid unintentional leaks
+  permissions: undefined,
+  profileImageId: undefined,
+  profileImageUrl: undefined,
+  profileImageUrlDefault: undefined,
+  providerUid: undefined,
+  recoveryKeyId: undefined,
+  sessionToken: undefined,
+  uid: undefined,
+  metricsEnabled: undefined,
+  verified: undefined,
+};
+const DEFAULTS = {
+  ...PERSISTENT,
+  accessToken: undefined,
+  declinedSyncEngines: undefined,
+  hasBounced: undefined,
+  hasLinkedAccount: undefined,
+  hasPassword: undefined,
+  keyFetchToken: undefined,
+  newsletters: undefined,
+  offeredSyncEngines: undefined,
+  // password field intentionally omitted to avoid unintentional leaks
+  providerUid: undefined,
+  unwrapBKey: undefined,
+  verificationMethod: undefined,
+  verificationReason: undefined,
+  totpVerified: undefined,
+  atLeast18AtReg: undefined,
+};
+
 export const GET_PROFILE_INFO = gql`
   query GetProfileInfo {
     account {
@@ -307,6 +347,12 @@ export function getNextAvatar(
 
   return { id: existingId, url: existingUrl, isDefault: false };
 }
+
+// I'm fairly certain that we do not need this as Settings does not create a
+// "default" account model with a set of undefined properties.  But there is an
+// interface that calls for an isDefault impl so here it is.
+export const isDefault = (account: Record<string, any>) =>
+  !Object.keys(DEFAULTS).some((x) => account[x] !== undefined);
 
 export class Account implements AccountData {
   private readonly authClient: AuthClient;

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -26,7 +26,7 @@ export interface AppContextValue {
   sensitiveDataClient?: SensitiveDataClient; // used for sensitive data that needs to be encrypted between components
   config?: Config;
   account?: Account;
-  session?: Session; // used exclusively for test mocking
+  session?: Session;
   uniqueUserId?: string; // used for experiments
   experiments?: any; // TODO: add types for experiments
 }

--- a/packages/fxa-settings/src/models/integrations/base-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/base-integration.ts
@@ -67,7 +67,7 @@ export interface RelierAccount {
     clientId: string,
     gracePeriod: number
   ): Promise<{ sub: string }>;
-  isDefault(): unknown;
+  isDefault(): boolean;
 }
 
 // TODO: probably move this to another file

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -1,0 +1,156 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import {
+  Integration,
+  isDefault,
+  isOAuthWebIntegration,
+  OAuthWebIntegration,
+  RelierAccount,
+  useAuthClient,
+  useSession,
+} from '../../models';
+import { cache } from '../../lib/cache';
+import { useCallback, useEffect, useState } from 'react';
+import { currentAccount } from '../../lib/cache';
+import { useFinishOAuthFlowHandler } from '../../lib/oauth/hooks';
+import OAuthDataError from '../../components/OAuthDataError';
+import { cachedSignIn, handleNavigation } from '../Signin/utils';
+import { AuthError, OAuthError } from '../../lib/oauth/oauth-errors';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { hardNavigate } from 'fxa-react/lib/utils';
+
+const convertToRelierAccount = (
+  account: ReturnType<typeof currentAccount>,
+  authClient: ReturnType<typeof useAuthClient>
+) => {
+  const relierAccount: RelierAccount = {
+    uid: account?.uid!,
+    email: account?.email!,
+    sessionToken: account?.sessionToken!,
+    verifyIdToken: authClient.verifyIdToken,
+    isDefault: () => isDefault(account || {}),
+  };
+  return relierAccount;
+};
+
+/**
+ * Unlike the other containers, this one does not attempt to render anything.
+ * It handles a 'prompt=none' authorization or hand off to the signin routes.
+ */
+const AuthorizationContainer = ({
+  integration,
+}: {
+  integration: Integration;
+} & RouteComponentProps) => {
+  const [oauthError, setOauthError] = useState<AuthError | OAuthError | null>(
+    null
+  );
+  const navigate = useNavigate();
+  const authClient = useAuthClient();
+  const location = useLocation() as ReturnType<typeof useLocation>;
+  const session = useSession();
+  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
+    authClient,
+    integration
+  );
+  if (oAuthDataError) {
+    setOauthError(oAuthDataError);
+  }
+
+  const promptNoneHandler = useCallback(async () => {
+    const account = currentAccount();
+    const relierAccount = convertToRelierAccount(account, authClient);
+
+    try {
+      await (integration as OAuthWebIntegration).validatePromptNoneRequest(
+        relierAccount
+      );
+
+      const { data, error } = await cachedSignIn(
+        account?.sessionToken!,
+        authClient,
+        cache,
+        session
+      );
+
+      if (error === AuthUiErrors.SESSION_EXPIRED) {
+        throw new OAuthError('PROMPT_NONE_NOT_SIGNED_IN');
+      }
+
+      if (error) {
+        throw error;
+      }
+
+      if (!data?.verified) {
+        throw new OAuthError('PROMPT_NONE_UNVERIFIED');
+      }
+
+      if (data) {
+        const navigationOptions = {
+          email: account?.email!,
+          signinData: {
+            verified: data.verified,
+            verificationMethod: data.verificationMethod,
+            verificationReason: data.verificationReason,
+            uid: data.uid,
+            sessionToken: account?.sessionToken!,
+          },
+          integration,
+          redirectTo: integration.data.redirectTo,
+          finishOAuthFlowHandler,
+          queryParams: location.search,
+        };
+
+        const { error: navError } = await handleNavigation(navigationOptions);
+
+        if (navError) {
+          throw navError;
+        }
+      }
+    } catch (err) {
+      setOauthError(err);
+    }
+  }, [
+    authClient,
+    finishOAuthFlowHandler,
+    integration,
+    location.search,
+    session,
+  ]);
+
+  useEffect(() => {
+    if (isOAuthWebIntegration(integration) && integration.wantsPromptNone()) {
+      promptNoneHandler();
+      return;
+    }
+
+    const urlSearchParams = new URLSearchParams(location.search);
+    urlSearchParams.delete('showReactApp');
+
+    if (integration.data.action) {
+      if (integration.data.action === 'email') {
+        // this really should be navigating to /oauth/ but FXA-6516 hasn't been completed at the time of writing.
+        // @TODO FXA-6516
+        hardNavigate(`/oauth?${urlSearchParams.toString()}`);
+      } else {
+        hardNavigate(
+          `/${integration.data.action}?${urlSearchParams.toString()}`
+        );
+      }
+      return;
+    }
+
+    hardNavigate(`/oauth?${urlSearchParams.toString()}`);
+  }, [integration, location.search, navigate, promptNoneHandler]);
+
+  if (oauthError) {
+    return <OAuthDataError error={oauthError} />;
+  }
+
+  return <></>;
+};
+
+export default AuthorizationContainer;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -276,7 +276,7 @@ describe('confirm-signup-container', () => {
                   };
                 }
               ),
-            oAuthDataError: { message: 'BOOM', errno: 1 },
+            oAuthDataError: { message: 'BOOM', errno: 1, version: 1 },
           };
         });
       render();


### PR DESCRIPTION
Because:
 - we need our React UI to handle the /authorization route

This commit:
 - adds the /authorization route to fxa-settings
 - moves the cached sign-in logic out of the sign-in container
 - fixes bugs in the prompt=none validation
 - fixes/updates code or comments (not necessarily related to /authorization) for clarity or consistency

