### PR TITLE
feat(next): never show terms for card pm

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -334,6 +334,9 @@ export function CheckoutForm({
                   },
                 },
               },
+              terms: {
+                card: 'never',
+              },
             }}
           />
         )}


### PR DESCRIPTION
## Because

- Should not show terms for card payment method on the payment element

## This pull request

- Configures payment element to never show terms

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/1747c554-4de9-4d2d-b6d2-b376a965b51c)


### After
![image](https://github.com/user-attachments/assets/64afaf53-6659-4139-ad0f-6df85439301a)

