### PR TITLE
fix(react): Remove 'showReactApp' param on signup 'Change email'

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -231,6 +231,7 @@ const SigninContainer = ({
               // Passing back the 'email' param causes various behaviors in
               // content-server since it marks the email as "coming from a RP".
               queryParams.delete('email');
+              queryParams.delete('showReactApp=true');
               if (isEmailValid(email)) {
                 queryParams.set('prefillEmail', email);
               }
@@ -249,6 +250,7 @@ const SigninContainer = ({
           // Passing back the 'email' param causes various behaviors in
           // content-server since it marks the email as "coming from a RP".
           queryParams.delete('email');
+          queryParams.delete('showReactApp');
           if (email && isEmailValid(email)) {
             queryParams.set('prefillEmail', email);
           }

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -104,6 +104,7 @@ const SignupConfirmCodeContainer = ({
       // content-server since it marks the email as "coming from a RP".
       params.delete('emailStatusChecked');
       params.delete('email');
+      params.delete('showReactApp');
       // passing the 'bouncedEmail' param will display an error tooltip
       // on the email-first signin/signup page and allow to check
       // if the entered email matches the bounced email

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -391,6 +391,7 @@ export const Signup = ({
                 params.delete('emailStatusChecked');
                 params.delete('email');
                 params.delete('login_hint');
+                params.delete('showReactApp');
                 hardNavigate(`/?${params.toString()}`);
               }
             }}


### PR DESCRIPTION
Because:
* We are unintentionally taking users not in the React experiment from Backbone index to React signup back to React index if they click 'Change email' on signup because we do a hard navigate with the showReactApp param that is added by Backbone routing to reach React signup. In this case we want this user to see Backbone email-first as they are not enrolled in the experiment

This commit:
* Removes 'showReactApp' param when hard navigating from signup back to email-first

fixes FXA-11358

---

Noticed this when playing around on stage.