### PR TITLE
fix(auth): handle apple iap transaction 404 error

### DIFF
--- a/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
@@ -229,10 +229,26 @@ export class PurchaseManager {
           this.log.info('queryCurrentSubscriptionPurchases.cache.update', {
             originalTransactionId: purchase.originalTransactionId,
           });
-          purchase = await this.querySubscriptionPurchase(
-            purchase.bundleId,
-            purchase.originalTransactionId
-          );
+          try {
+            purchase = await this.querySubscriptionPurchase(
+              purchase.bundleId,
+              purchase.originalTransactionId
+            );
+          } catch (error) {
+            if (error.name === PurchaseQueryError.NOT_FOUND) {
+              // An expired Apple subscription could not be found. No action is necessary.
+              this.log.info(
+                'queryCurrentSubscriptionPurchases.TransactionIdNotFound',
+                {
+                  bundle: purchase.bundleId,
+                  originalTransactionId: purchase.originalTransactionId,
+                  userId,
+                }
+              );
+            } else {
+              throw error;
+            }
+          }
         }
 
         // Add the updated purchase to list to returned to clients


### PR DESCRIPTION
## Because

- For expired Apple IAP subscriptions, Apple is still queried to check if any change has occured to the subscription since the same transaction ID will be reused for a new subscription.

## This pull request

- If an Apple subscription is already expired, ignore TransactionIdNotFoundError errors received from Apple and log an info message.

## Issue that this pull request solves

Closes: #FXA-6720

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The code being changed in this PR is used in a few scenarios, some of which are listed below.
1. When a customers subscriptions are fetched
1. When handling a webhook message from Apple

This PR aims to address a specific issue related to the scenario when a customers subscriptions are fetched.

A record of a customers Apple IAP subscriptions are stored in a Firestore table. These records contain a bunch of information, including the originalTransactionId and subscription status, which are important to note for this specific issue.

When subscriptions are fetched for a customer, when checking for Apple IAP subscriptions, the Firestore table is queried for active and inactive subscriptions. For inactive subscriptions, Apple is queried as well, to check if the status of the subscription tied to the originalTransactionId has changed to active, which can occur when the subscription restarted. i.e. The same Transaction Id is used again.

However, in cases where Apple no longer has a record of this transaction, Apple throws a 404 - TransactionIdNotFoundError error, which is currently not being handled.

This PR is a band-aid fix to handle the error and log an info message, and continue with regular processing.