### PR TITLE
chore(cirrus): Add statsd metric to nimbus experiments

### DIFF
--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -41,7 +41,7 @@ module.exports = function (config, i18n, statsd, glean) {
     require('./routes/post-third-party-auth-redirect')(config),
     require('./routes/get-500')(config),
     require('./routes/validate-email-domain')(config),
-    require('./routes/post-nimbus-experiments')(config),
+    require('./routes/post-nimbus-experiments')(config, statsd),
   ].filter((routeDefinition) => routeDefinition); // get rid of null values
 
   if (config.get('csp.enabled')) {

--- a/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
+++ b/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
@@ -14,7 +14,8 @@ const BODY_SCHEMA = {
   context: joi.object().required(),
 };
 
-module.exports = function (options = {}) {
+module.exports = function (options = {}, statsd) {
+  const requestReceivedTime = Date.now();
   return {
     method: 'post',
     path: '/nimbus-experiments',
@@ -52,6 +53,12 @@ module.exports = function (options = {}) {
           }
           Sentry.captureMessage(errorMsg, 'error');
         });
+      } finally {
+        const requestCompletedTime = Date.now();
+        const responseTime = requestCompletedTime - requestReceivedTime;
+        if (statsd) {
+          statsd.increment('cirrus.response-time', { responseTime });
+        }
       }
     },
   };


### PR DESCRIPTION
We can do this here to covert Backbone and React because both of them use content-server to access nimbus experiments. We should also keep it this way in the future too. It is also recommended by [the nimbus demo app](https://github.com/mozilla/experimenter/tree/main/demo-app) to proxy the request.

## Because

- We want to mark how long it takes requests from the Cirrus container to the content server to complete for Grafana.
- We want to rule out that timeouts are caused by the sidecar container.

## This pull request

- Adds a statsd metric for the fetch request.

## Issue that this pull request solves

Fixes FXA-11260

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

How do I write unit tests for this? 
