### PR TITLE
fix(settings): Country selector options hidden on Windows

### DIFF
--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
@@ -129,14 +129,10 @@ const InputPhoneNumber = ({
         )}
         onChange={handleCountryChange}
         value={selectedCountry.id}
-        className={`bg-transparent border border-grey-200 rounded-md py-2 ps-10 w-[60px] me-2 focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus ${selectedCountry.classNameFlag} bg-no-repeat bg-[length:1.5rem_1rem] bg-[40%_50%] text-transparent`}
+        className={`bg-transparent border border-grey-200 rounded-md py-2 ps-10 w-[60px] me-2 focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus ${selectedCountry.classNameFlag} bg-no-repeat bg-[length:1.5rem_1rem] bg-[40%_50%] -indent-9999 z-10`}
       >
         {sortedLocalizedCountries.map((country) => (
-          <option
-            key={country.id}
-            value={country.id}
-            className={`${country.classNameFlag} bg-contain`}
-          >
+          <option key={country.id} value={country.id} className="text-black">
             {country.localizedName} ({country.code})
           </option>
         ))}


### PR DESCRIPTION
## Because

* Select element is handled differently on different platforms
* Country option text was only visible on hover
* Select component was not selectable on narrow viewscreens
* 
## This pull request

* Use text indent instead of text transparent
* Add z-index to ensure selectability

## Issue that this pull request solves

Closes: FXA-11319

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Screenshots from storybook on Windows:

![Screenshot 2025-03-17 142324](https://github.com/user-attachments/assets/5ab57a06-f5de-4980-8fd4-e9a04c96f4e0)

And in high contrast mode:

![Screenshot 2025-03-17 142153](https://github.com/user-attachments/assets/9363922a-c2f6-49f1-9356-ac06db39b478)

## Other information (Optional)