### PR TITLE
fix(payments): skip intermittent failing hook test

### DIFF
--- a/packages/fxa-payments-server/src/lib/hooks.test.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.test.tsx
@@ -371,7 +371,8 @@ describe('useInfoBoxMessage', () => {
     expect(messageText).toBe(CouponInfoBoxMessageType.Default);
   });
 
-  it('coupon type is "repeating" plan interval equal to coupon duration', () => {
+  // FXA-11195 - Temporary skip due to intermittent test failure.
+  it.skip('coupon type is "repeating" plan interval equal to coupon duration', () => {
     const { queryByTestId, getByTestId } = renderWithLocalizationProvider(
       <Subject
         coupon={{ ...coupon, type: 'repeating' }}


### PR DESCRIPTION
## Because

- Test related to useInfoBoxMessage is failing intermittently.

## This pull request

- Skips failing test noting ticket number to resolve the intermittent test failures.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).