### PR TITLE
fix(next): allow coupon errors to propogate to client

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -971,6 +971,7 @@ describe('CartService', () => {
           postalCode: faker.location.zipCode(),
           countryCode: faker.location.countryCode(),
         },
+        currency: 'USD',
       });
 
       beforeEach(async () => {
@@ -1004,9 +1005,7 @@ describe('CartService', () => {
       it('throws if coupon is not valid', async () => {
         jest
           .spyOn(promotionCodeManager, 'assertValidPromotionCodeNameForPrice')
-          .mockImplementation(() => {
-            throw new CouponErrorExpired();
-          });
+          .mockRejectedValue(new CouponErrorExpired());
         jest.spyOn(cartManager, 'finishErrorCart').mockResolvedValue();
 
         await expect(
@@ -1020,8 +1019,8 @@ describe('CartService', () => {
           mockPrice,
           mockUpdateCart.currency
         );
-        expect(cartManager.updateFreshCart).not.toHaveBeenCalledWith();
-        expect(cartManager.finishErrorCart).toHaveBeenCalled();
+        expect(cartManager.updateFreshCart).not.toHaveBeenCalled();
+        expect(cartManager.finishErrorCart).not.toHaveBeenCalled();
       });
 
       it('throws if country to currency result is not valid', async () => {

--- a/libs/payments/ui/src/lib/actions/updateCart.ts
+++ b/libs/payments/ui/src/lib/actions/updateCart.ts
@@ -7,11 +7,6 @@
 import { revalidatePath } from 'next/cache';
 
 import { UpdateCart } from '@fxa/payments/cart';
-import {
-  CouponErrorExpired,
-  CouponErrorGeneric,
-  CouponErrorLimitReached,
-} from '@fxa/payments/customer';
 import { getApp } from '../nestapp/app';
 import { CouponErrorMessageType } from '../utils/error-ftl-messages';
 
@@ -29,11 +24,11 @@ export const updateCartAction = async (
       cartDetails,
     });
   } catch (err) {
-    if (err instanceof CouponErrorExpired) {
+    if (err.constructor.name === 'CouponErrorExpired') {
       return CouponErrorMessageType.Expired;
-    } else if (err instanceof CouponErrorGeneric) {
+    } else if (err.constructor === 'CouponErrorGeneric') {
       return CouponErrorMessageType.Generic;
-    } else if (err instanceof CouponErrorLimitReached) {
+    } else if (err.constructor === 'CouponErrorLimitReached') {
       return CouponErrorMessageType.LimitReached;
     } else {
       return CouponErrorMessageType.Invalid;


### PR DESCRIPTION
## Because

- CartService.wrapWithCartCatch is catching Coupon errors in updateCart and finishing the cart with and error instead of allowing the error to propogate to the client so that it is handled appropriately there.

## This pull request

- Overrides the CartService.wrapWithCartCatch method to add an optional options argument which adds an errorAllowList, which will serve as a passthrough for errors added in the errorAllowList.

## Issue that this pull request solves

Closes: #FXA-11256 FXA-11348 FXA-11345

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
