### PR TITLE
fix(auth): handle apple appstore error

### DIFF
--- a/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/purchase-manager.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { CollectionReference } from '@google-cloud/firestore';
 import {
+  AppStoreError,
   decodeRenewalInfo,
   decodeTransaction,
   NotificationSubtype,
@@ -278,7 +279,10 @@ export class PurchaseManager {
   // https://developer.apple.com/documentation/appstoreserverapi/error_codes
   convertAppStoreAPIErrorToLibraryError(appStoreError: any): Error {
     const libraryError = new Error(appStoreError.message);
-    if (appStoreError.code === 404) {
+    if (
+      appStoreError instanceof AppStoreError &&
+      appStoreError.errorCode === 4040010
+    ) {
       // The account, app or original transaction ID was not found.
       libraryError.name = PurchaseQueryError.NOT_FOUND;
     } else {
@@ -286,6 +290,7 @@ export class PurchaseManager {
       libraryError.name = PurchaseQueryError.OTHER_ERROR;
       this.log.error('convertAppStoreAPIErrorToLibraryError', {
         message: 'Unexpected error when querying the App Store Server API.',
+        err: appStoreError,
       });
     }
     return libraryError;


### PR DESCRIPTION
## Because

- The Apple app-store-server-api SDK in certain circumstances throws an AppStoreError which is not currently being handled.

## This pull request

- Correctly handle Apple AppStoreError when using app-store-server-api.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
