### PR TITLE
fix(react): Only show Sync merge warning once

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -738,6 +738,10 @@ describe('signin container', () => {
         });
       });
       it('calls fxaCanLinkAccount when conditions are met', async () => {
+        mockLocationState = {
+          hasLinkedAccount: undefined,
+          email: MOCK_ROUTER_STATE_EMAIL,
+        };
         (firefox.fxaCanLinkAccount as jest.Mock).mockImplementationOnce(
           async () => ({
             ok: true,
@@ -768,6 +772,10 @@ describe('signin container', () => {
       });
 
       it('returns expected error when fxaCanLinkAccount response is ok: false', async () => {
+        mockLocationState = {
+          hasLinkedAccount: undefined,
+          email: MOCK_ROUTER_STATE_EMAIL,
+        };
         (firefox.fxaCanLinkAccount as jest.Mock).mockImplementationOnce(
           async () => ({
             ok: false,

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -160,7 +160,8 @@ const SigninContainer = ({
   // If hasLinkedAccount is defined from location state (React email-first), or query
   // params (Backbone email-first) then we know the user came from email-first
   const originFromEmailFirst = !!(
-    hasLinkedAccountFromLocationState || queryParamModel.hasLinkedAccount
+    hasLinkedAccountFromLocationState !== undefined ||
+    queryParamModel.hasLinkedAccount
   );
 
   const [accountStatus, setAccountStatus] = useState({


### PR DESCRIPTION
Because:
* If users give the OK on email-first, they don't need to see the merge warning on /signin

This commit:
* Fixes a logical error where we were checking if hasLinkedAccountFromLocationState was true, instead of if it's not undefined, to denote the user has come from email-first

fixes FXA-11368