### PR TITLE
fix(settings): Hide alert bar on navigation to remove recovery phone

### DIFF
--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -190,6 +190,7 @@ export const UnitRowTwoStepAuth = () => {
             {...(count &&
               count > 0 && {
                 onDeleteClick: () => {
+                  alertBar.hide();
                   navigate(
                     `${SETTINGS_PATH}/recovery_phone/remove`,
                     undefined,


### PR DESCRIPTION
## Because

* Alerts were staying on screen and not dismissed on delete button click

## This pull request

* Explicitly hide the alert

## Issue that this pull request solves

Closes: FXA-11110

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
