### PR TITLE
fix(next): call l10n-prime script before bundle

### DIFF
--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -48,7 +48,8 @@
       "command": "pm2 delete apps/payments/next/pm2.config.js"
     },
     "l10n-merge": {
-      "command": "yarn grunt --gruntfile='apps/payments/next/Gruntfile.js' merge-ftl"
+      "command": "yarn grunt --gruntfile='apps/payments/next/Gruntfile.js' merge-ftl",
+      "dependsOn": ["l10n-prime"]
     },
     "l10n-prime": {
       "command": "./_scripts/l10n/prime.sh apps/payments/next"


### PR DESCRIPTION
## Because

- Translated localization files are not loaded into public folder of payments-next.

## This pull request

- Calls l10n-prime script to load translated ftl files into public folder before calling l10n-bundle script.

## Issue that this pull request solves

Closes: #FXA-11330

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
