### PR TITLE
fix(payments-ui): Updates SubmitButton and UpgradePurchaseDetails components

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
@@ -9,7 +9,7 @@ import * as Form from '@radix-ui/react-form';
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { useFormState } from 'react-dom';
-import { BaseButton, ButtonVariant } from '../BaseButton';
+import { ButtonVariant } from '../BaseButton';
 import { SubmitButton } from '../SubmitButton';
 import { updateCartAction } from '../../../actions/updateCart';
 import { getFallbackTextByFluentId } from '../../../utils/error-ftl-messages';
@@ -46,12 +46,12 @@ const WithCoupon = ({
           <span className="break-all">{couponCode}</span>
           {readOnly ? null : (
             <Form.Submit asChild>
-              <BaseButton
+              <SubmitButton
                 variant={ButtonVariant.Secondary}
                 data-testid="coupon-remove-button"
               >
                 <Localized id="next-coupon-remove">Remove</Localized>
-              </BaseButton>
+              </SubmitButton>
             </Form.Submit>
           )}
         </div>
@@ -120,7 +120,11 @@ const WithoutCoupon = ({
             </Localized>
           </Form.Control>
           <Form.Submit asChild>
-            <SubmitButton data-testid="coupon-button" disabled={readOnly}>
+            <SubmitButton
+              variant={ButtonVariant.Primary}
+              data-testid="coupon-button"
+              disabled={readOnly}
+            >
               <Localized id="next-coupon-submit">Apply</Localized>
             </SubmitButton>
           </Form.Submit>

--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
@@ -8,9 +8,8 @@ import { Localized } from '@fluent/react';
 import * as Form from '@radix-ui/react-form';
 import countries from 'i18n-iso-countries';
 import { useEffect, useState } from 'react';
-import { BaseButton, ButtonVariant } from '@fxa/payments/ui';
+import { ButtonVariant, SubmitButton } from '@fxa/payments/ui';
 import { validatePostalCode } from '@fxa/payments/ui/actions';
-import { SubmitButton } from '../SubmitButton';
 import { useSearchParams } from 'next/navigation';
 
 interface CollapsedProps {
@@ -34,14 +33,14 @@ const Collapsed = ({
         </span>
         <span>
           <Form.Submit asChild>
-            <BaseButton
+            <SubmitButton
               variant={ButtonVariant.Secondary}
               data-testid="tax-location-edit-button"
             >
               <Localized id="select-tax-location-edit-button">
                 <p>Edit</p>
               </Localized>
-            </BaseButton>
+            </SubmitButton>
           </Form.Submit>
         </span>
       </div>
@@ -322,7 +321,11 @@ const Expanded = ({
       )}
 
       <Form.Submit asChild>
-        <SubmitButton className="w-full" data-testid="tax-location-save-button">
+        <SubmitButton
+          variant={ButtonVariant.Primary}
+          className="w-full"
+          data-testid="tax-location-save-button"
+        >
           <Localized id="select-tax-location-save-button">
             <p>Save</p>
           </Localized>

--- a/libs/payments/ui/src/lib/client/components/SignInForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SignInForm/index.tsx
@@ -7,7 +7,7 @@
 import { Localized } from '@fluent/react';
 import * as Form from '@radix-ui/react-form';
 import Image from 'next/image';
-import { SubmitButton } from '@fxa/payments/ui';
+import { ButtonVariant, SubmitButton } from '@fxa/payments/ui';
 import shieldIcon from './images/shield.svg';
 
 const DEFAULT_NEWSLETTER_STRING_ID =
@@ -119,7 +119,10 @@ export const SignInForm = ({
       </Form.Field>
 
       <Form.Submit asChild>
-        <SubmitButton className="mt-6 my-8 w-full">
+        <SubmitButton
+          variant={ButtonVariant.Primary}
+          className="mt-6 my-8 w-full"
+        >
           <Localized id="signin-form-continue-button">Continue</Localized>
         </SubmitButton>
       </Form.Submit>

--- a/libs/payments/ui/src/lib/client/components/SubmitButton/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SubmitButton/index.tsx
@@ -11,19 +11,21 @@ import { BaseButton, ButtonVariant } from '../BaseButton';
 
 interface SubmitButtonProps {
   children: React.ReactNode;
+  variant: ButtonVariant;
 }
 
 export function SubmitButton({
   children,
   disabled,
   className,
+  variant,
   ...otherProps
 }: SubmitButtonProps & React.HTMLProps<HTMLButtonElement>) {
   const { pending } = useFormStatus();
 
   return (
     <BaseButton
-      variant={ButtonVariant.Primary}
+      variant={variant}
       {...otherProps}
       disabled={pending || disabled}
       type="submit"

--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
@@ -210,7 +210,7 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
         </li>
       </ul>
 
-      {oneTimeCharge && (
+      {!!oneTimeCharge && (
         <>
           <div className="border-b border-grey-200"></div>
           <div className="flex items-center justify-between gap-2 leading-5 text-base text-grey-600 mt-6 pb-6 font-semibold">


### PR DESCRIPTION
## This pull request

- [x] updates `<SubmitButton />` so that different button variants show the loading spinner animation
  - [x] The "Remove" button in `<CouponForm />` displays the loading spinner animation when removing the coupon code
- [x]  Prevents showing 0 instead of nothing when there is no one-time charge in `<UpgradePurchaseDetails />`

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.