### PR TITLE
feat(cirrus): Add nimbus preview support to React and Backbone

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -107,6 +107,7 @@ const settingsConfig = {
       'featureFlags.enableUsing2FABackupPhone'
     ),
   },
+  nimbusPreview: config.get('nimbusPreview'),
 };
 
 // Inject Settings content into the index HTML

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -376,6 +376,12 @@ const conf = (module.exports = convict({
       format: String,
     },
   },
+  nimbusPreview: {
+    default: false,
+    doc: 'Enables preview mode for nimbus experiments for development and testing.',
+    format: Boolean,
+    env: 'NIMBUS_PREVIEW',
+  },
   glean: {
     enabled: {
       default: false,

--- a/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
+++ b/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
@@ -28,9 +28,16 @@ module.exports = function (options = {}, statsd) {
         context: req.body.context,
       });
 
+      const previewMode = req.query?.nimbusPreview || false;
+      const queryParams = new URLSearchParams({
+        nimbus_preview: previewMode,
+      });
+
       try {
         const resp = await fetch(
-          `${config.getProperties().nimbus.host}/v2/features/`,
+          `${
+            config.getProperties().nimbus.host
+          }/v2/features/?${queryParams.toString()}`,
           {
             method: 'POST',
             body,

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -61,6 +61,7 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_ENABLE_USING_2FA_BACKUP_PHONE = config.get(
     'featureFlags.enableUsing2FABackupPhone'
   );
+  const NIMBUS_PREVIEW = config.get('nimbusPreview');
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
   const GLEAN_UPLOAD_ENABLED = config.get('glean.uploadEnabled');
@@ -124,6 +125,7 @@ function getIndexRouteDefinition(config) {
       enableAdding2FABackupPhone: FEATURE_FLAGS_ENABLE_ADDING_2FA_BACKUP_PHONE,
       enableUsing2FABackupPhone: FEATURE_FLAGS_ENABLE_USING_2FA_BACKUP_PHONE,
     },
+    nimbusPreview: NIMBUS_PREVIEW,
     glean: {
       // feature toggle
       enabled: GLEAN_ENABLED,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -93,6 +93,7 @@ export interface Config {
     enableAdding2FABackupPhone?: boolean;
     enableUsing2FABackupPhone?: boolean;
   };
+  nimbusPreview: boolean;
 }
 
 export function getDefault() {
@@ -172,6 +173,7 @@ export function getDefault() {
       enableAdding2FABackupPhone: false,
       enableUsing2FABackupPhone: false,
     },
+    nimbusPreview: false,
   } as Config;
 }
 

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -54,7 +54,10 @@ function fetchNimbusExperiments(uniqueUserId: string): Promise<any> {
     region = region.toLowerCase();
   }
 
-  return initializeNimbus(uniqueUserId, { language, region } as NimbusContextT);
+  return initializeNimbus(uniqueUserId, config.nimbusPreview, {
+    language,
+    region,
+  } as NimbusContextT);
 }
 
 export function initializeAppContext() {


### PR DESCRIPTION
## Because

- For an A/A experiment we need to also be able to use preview mode.

## This pull request

- This follows the pattern used by `GLEAN_ENABLED` so that `NIMBUS_PREVIEW` can be used the same way for local development and deployments.

## Issue that this pull request solves

Fixes FXA-11372

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1115" alt="Screenshot 2025-03-24 at 1 53 12 PM" src="https://github.com/user-attachments/assets/33bafdce-0b6d-4112-bf26-bfd023111bde" />

## Other information (Optional)

- Adding the query param `nimbusPreview=[true|false]` to the requests should also have the equivalent params request to the `/nimbus-experiments` endpoint.
- For reference, see the demo-app in experimenter: https://github.com/mozilla/experimenter/tree/main/demo-app
