### PR TITLE
feat(glean): Add glean metrics for React email-first page

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -83,7 +83,7 @@ jest.mock('../../lib/glean', () => ({
     getEnabled: jest.fn(),
     useGlean: jest.fn().mockReturnValue({ enabled: true }),
     accountPref: { view: jest.fn(), promoMonitorView: jest.fn() },
-    emailFirst: { view: jest.fn() },
+    emailFirst: { view: jest.fn(), engage: jest.fn() },
     pageLoad: jest.fn(),
   },
 }));

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -8,6 +8,8 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 import { Subject } from './mocks';
 
 const mockViewWithNoPasswordSet = jest.fn();
+const mockStartGoogleAuthFromIndex = jest.fn();
+const mockStartAppleAuthFromIndex = jest.fn();
 const mockStartGoogleAuthFromLogin = jest.fn();
 const mockStartAppleAuthFromLogin = jest.fn();
 const mockStartGoogleAuthFromReg = jest.fn();
@@ -20,6 +22,14 @@ jest.mock('../../lib/glean', () => {
     default: {
       isDone: () => {
         mockGleanIsDone();
+      },
+      emailFirst: {
+        googleOauthStart: () => {
+          mockStartGoogleAuthFromIndex();
+        },
+        appleOauthStart: () => {
+          mockStartAppleAuthFromIndex();
+        },
       },
       thirdPartyAuth: {
         viewWithNoPasswordSet: () => {
@@ -159,6 +169,33 @@ describe('ThirdPartyAuthComponent', () => {
         onContinueWithGoogle,
       });
       expect(mockViewWithNoPasswordSet).toBeCalled();
+    });
+
+    it('emits glean metrics startGoogleAuthFromIndex', async () => {
+      renderWith({
+        enabled: true,
+        showSeparator: false,
+        onContinueWithApple,
+        onContinueWithGoogle,
+        viewName: 'index',
+      });
+      const button = await screen.findByText('Continue with Google');
+      button.click();
+      expect(mockStartGoogleAuthFromIndex).toBeCalled();
+      expect(mockGleanIsDone).toBeCalled();
+    });
+
+    it('emits glean metrics startAppleAuthFromIndex', async () => {
+      renderWith({
+        enabled: true,
+        showSeparator: false,
+        onContinueWithApple,
+        onContinueWithGoogle,
+        viewName: 'index',
+      });
+      const button = await screen.findByText('Continue with Apple');
+      button.click();
+      expect(mockStartAppleAuthFromIndex).toBeCalled();
     });
 
     it('emits glean metrics startGoogleAuthFromLogin', async () => {

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -147,6 +147,12 @@ const ThirdPartySignInForm = ({
     logViewEventOnce(`flow.${party}`, 'oauth-start');
 
     switch (`${party}-${viewName}`) {
+      case 'google-index':
+        GleanMetrics.emailFirst.googleOauthStart();
+        break;
+      case 'apple-index':
+        GleanMetrics.emailFirst.appleOauthStart();
+        break;
       case 'google-signin':
         GleanMetrics.thirdPartyAuth.startGoogleAuthFromLogin();
         break;

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -346,6 +346,47 @@ describe('lib/glean', () => {
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(setEventNameStub, 'email_first_view');
       });
+
+      it('submits a ping with the email_first_engage event name', async () => {
+        GleanMetrics.emailFirst.engage();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'email_first_engage');
+      });
+
+      it('submits a ping with the email_first_submit_success event name', async () => {
+        GleanMetrics.emailFirst.submitSuccess();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'email_first_submit_success');
+      });
+
+      it('submits a ping with the email_first_submit_fail event name', async () => {
+        GleanMetrics.emailFirst.submitFail();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(setEventNameStub, 'email_first_submit_fail');
+      });
+
+      it('submits a ping with the email_first_google_oauth_start event name', async () => {
+        GleanMetrics.emailFirst.googleOauthStart();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'email_first_google_oauth_start'
+        );
+      });
+
+      it('submits a ping with the email_first_apple_oauth_start event name', async () => {
+        GleanMetrics.emailFirst.appleOauthStart();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'email_first_apple_oauth_start'
+        );
+      });
     });
 
     describe('registration', () => {

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -209,6 +209,21 @@ const recordEventMetric = (
     case 'email_first_view':
       email.firstView.record();
       break;
+    case 'email_first_engage':
+      email.firstEngage.record();
+      break;
+    case 'email_first_submit_success':
+      email.firstSubmitSuccess.record();
+      break;
+    case 'email_first_submit_fail':
+      email.firstSubmitFail.record();
+      break;
+    case 'email_first_google_oauth_start':
+      email.firstGoogleOauthStart.record();
+      break;
+    case 'email_first_apple_oauth_start':
+      email.firstAppleOauthStart.record();
+      break;
     case 'reg_cwts_engage':
       reg.cwtsEngage.record();
       break;

--- a/packages/fxa-settings/src/pages/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.test.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import {
   createMockIndexOAuthIntegration,
   createMockIndexOAuthNativeIntegration,
@@ -12,6 +13,7 @@ import {
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { POCKET_CLIENTIDS } from '../../models/integrations/client-matching';
 import { MozServices } from '../../lib/types';
+import GleanMetrics from '../../lib/glean';
 
 const syncText =
   'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.';
@@ -37,6 +39,10 @@ function thirdPartyAuthNotRendered() {
 }
 
 describe('Index page', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders as expected with web integration', () => {
     renderWithLocalizationProvider(<Subject />);
 
@@ -56,6 +62,7 @@ describe('Index page', () => {
       })
     ).toHaveAttribute('href', '/legal/terms');
   });
+
   it('renders as expected when sync', () => {
     renderWithLocalizationProvider(
       <Subject
@@ -129,5 +136,46 @@ describe('Index page', () => {
 
     expect(tosLinks[0]).toHaveAttribute('href', 'https://getpocket.com/tos/');
     expect(tosLinks[1]).toHaveAttribute('href', '/legal/terms');
+  });
+
+  describe('glean metrics', () => {
+    it('emits emailFirst.view on initial render', () => {
+      const viewSpy = jest.spyOn(GleanMetrics.emailFirst, 'view');
+
+      renderWithLocalizationProvider(<Subject />);
+
+      expect(viewSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits emailFirst.engage on first input change only once', async () => {
+      const user = userEvent.setup();
+      const engageSpy = jest.spyOn(GleanMetrics.emailFirst, 'engage');
+
+      renderWithLocalizationProvider(<Subject />);
+
+      const input = screen.getByRole('textbox');
+
+      // First change should trigger the engage metric.
+      user.type(input, 't');
+      await waitFor(() => {
+        expect(input).toHaveValue('t');
+      });
+      expect(engageSpy).toHaveBeenCalledTimes(1);
+
+      // Subsequent changes should not trigger the metric again.
+      user.type(input, 'est@example.com');
+      await waitFor(() => {
+        expect(input).toHaveValue('test@example.com');
+      });
+      expect(engageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('has glean data attribute on the submit button', () => {
+      renderWithLocalizationProvider(<Subject />);
+
+      expect(
+        screen.getByRole('button', { name: 'Sign up or sign in' })
+      ).toHaveAttribute('data-glean-id', 'email_first_submit');
+    });
   });
 });

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { IndexFormData, IndexProps } from './interfaces';
 import AppLayout from '../../components/AppLayout';
@@ -56,6 +56,8 @@ export const Index = ({
         )
       : undefined
   );
+
+  const emailEngageEventEmitted = useRef(false);
 
   useEffect(() => {
     // Note we might not need this later due to automatic page load events,
@@ -127,6 +129,22 @@ export const Index = ({
     }
   };
 
+  const handleInputChange = () => {
+    if (!emailEngageEventEmitted.current) {
+      GleanMetrics.emailFirst.engage();
+      emailEngageEventEmitted.current = true;
+    }
+
+    if (errorBannerMessage || successBannerMessage) {
+      // TODO improve this, needs height or some animation, FXA-9143
+      setErrorBannerMessage('');
+      setSuccessBannerMessage('');
+    }
+    if (tooltipErrorText) {
+      setTooltipErrorText('');
+    }
+  };
+
   return (
     <AppLayout>
       {isSync ? (
@@ -188,20 +206,15 @@ export const Index = ({
             inputRef={register()}
             autoFocus
             errorText={tooltipErrorText}
-            onChange={() => {
-              if (errorBannerMessage || successBannerMessage) {
-                // TODO improve this, needs height or some animation, FXA-9143
-                setErrorBannerMessage('');
-                setSuccessBannerMessage('');
-              }
-              if (tooltipErrorText) {
-                setTooltipErrorText('');
-              }
-            }}
+            onChange={handleInputChange}
           />
         </FtlMsg>
         <div className="flex mt-5">
-          <button className="cta-primary cta-xl" type="submit">
+          <button
+            className="cta-primary cta-xl"
+            type="submit"
+            data-glean-id="email_first_submit"
+          >
             <FtlMsg id="index-cta">Sign up or sign in</FtlMsg>
           </button>
         </div>

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -572,7 +572,64 @@ email:
       - interaction
     no_lint:
       - COMMON_PREFIX
-
+  first_engage:
+    type: event
+    description: |
+      User types in the email field of the email first page.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-11312
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+  first_submit_success:
+    type: event
+    description: |
+      User clicked on the button to submit an email on the email first page
+      and is navigated onwards to sign in or sign up.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-11312
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: additional information - 'login' or 'registration'
+        type: string
+  first_submit_fail:
+    type: event
+    description: |
+      The user clicked on the button to submit their email on the email-first page
+      but email submission failed, likely due to a failed email domain check.
+      The user is not navigated onwards to sign in or sign up.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-11312
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
 login:
   email_confirmation_submit:
     type: event

--- a/packages/fxa-shared/metrics/glean/web/email.ts
+++ b/packages/fxa-shared/metrics/glean/web/email.ts
@@ -23,6 +23,22 @@ export const firstAppleOauthStart = new EventMetricType(
 );
 
 /**
+ * User types in the email field of the email first page.
+ *
+ * Generated from `email.first_engage`.
+ */
+export const firstEngage = new EventMetricType(
+  {
+    category: 'email',
+    name: 'first_engage',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * User clicks on the Google third party link from email first page.
  *
  * Generated from `email.first_google_oauth_start`.
@@ -36,6 +52,43 @@ export const firstGoogleOauthStart = new EventMetricType(
     disabled: false,
   },
   []
+);
+
+/**
+ * The user clicked on the button to submit their email on the email-first page
+ * but email submission failed, likely due to a failed email domain check.
+ * The user is not navigated onwards to sign in or sign up.
+ *
+ * Generated from `email.first_submit_fail`.
+ */
+export const firstSubmitFail = new EventMetricType(
+  {
+    category: 'email',
+    name: 'first_submit_fail',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
+ * User clicked on the button to submit an email on the email first page
+ * and is navigated onwards to sign in or sign up.
+ *
+ * Generated from `email.first_submit_success`.
+ */
+export const firstSubmitSuccess = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'email',
+    name: 'first_submit_success',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
 );
 
 /**

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -7,6 +7,7 @@ import {
   twoStepAuthEnterCodeSuccessView,
   twoStepAuthPhoneVerifyView,
 } from './accountPref';
+import { firstGoogleOauthStart } from './email';
 import { backupChoiceSubmit } from './login';
 
 export type GleanMetricsConfig = {
@@ -51,6 +52,11 @@ export type GleanPingMetrics = {
 export const eventsMap = {
   emailFirst: {
     view: 'email_first_view',
+    googleOauthStart: 'email_first_google_oauth_start',
+    appleOauthStart: 'email_first_apple_oauth_start',
+    engage: 'email_first_engage',
+    submitSuccess: 'email_first_submit_success',
+    submitFail: 'email_first_submit_fail',
   },
 
   registration: {


### PR DESCRIPTION
## Because

* We want to track metrics for the react email-first conversion

## This pull request

* Adds custom glean events and automated click event for react email-first page
* Add tests for these events

## Issue that this pull request solves

Closes: FXA-11312

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
