### PR TITLE
fix(settings): Show email keyboard type for email input

### DIFF
--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -183,6 +183,7 @@ export const Index = ({
           <InputText
             className="mt-8"
             name="email"
+            inputMode="email"
             label="Enter your email"
             inputRef={register()}
             autoFocus


### PR DESCRIPTION
## Because

* Should show the correct keyboard for the input on mobile

## This pull request

* Set 'type' attribute for the index page email input

## Issue that this pull request solves

Closes: FXA-11366

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/ad9072e4-4199-4c9d-a1cc-6b89b0727d5d)

## Other information (Optional)

I had initially included `type="email"` too, but this modified the input validation and error handling. Reverted to only including the inputmode attribute
