### PR TITLE
feat(next): redirect to 404 page for invalid path

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -62,7 +62,7 @@ export default async function CheckoutLayout({
           <SignedIn email={session.user.email} />
         </div>
       )}
-      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mt-4 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
+      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
         <SubscriptionTitle cartState={cart.state} l10n={l10n} />
 
         <section

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { auth } from 'apps/payments/next/auth';
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { setupCartAction } from '@fxa/payments/ui/actions';
 import { CartEligibilityStatus } from '@fxa/shared/db/mysql/account';
 import { BaseParams, buildRedirectUrl } from '@fxa/payments/ui';
@@ -95,6 +95,11 @@ export default async function New({
           searchParams,
         })
       );
+    } else if (
+      error.name === 'RetrieveStripePriceInvalidOfferingError' ||
+      error.name === 'RetrieveStripePriceNotFoundError'
+    ) {
+      notFound();
     } else {
       throw error;
     }

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/page-not-found/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/page-not-found/page.tsx
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { notFound } from 'next/navigation';
+
+/**
+ * This page only exists for Route Handlers, i.e. `/landing`, to redirect
+ * to in cases where a not found error should be shown to the client.
+ *
+ * This page should not be confused with the Next.js not-found.tsx file
+ */
+export default async function NotFoundPage() {
+  notFound();
+}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
@@ -33,7 +33,7 @@ export default async function UpgradeSuccessLayout({
     cms.defaultPurchase.purchaseDetails;
   return (
     <MetricsWrapper cart={cart}>
-      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mt-4 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
+      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
         <SubscriptionTitle
           cartState={cart.state}
           cartEligibilityStatus={CartEligibilityStatus.UPGRADE}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -44,7 +44,7 @@ export default async function UpgradeLayout({
 
   return (
     <MetricsWrapper cart={cart}>
-      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mt-4 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
+      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
         <SubscriptionTitle
           cartState={cart.state}
           cartEligibilityStatus={CartEligibilityStatus.UPGRADE}

--- a/apps/payments/next/app/[locale]/not-found.tsx
+++ b/apps/payments/next/app/[locale]/not-found.tsx
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import Image from 'next/image';
+import errorIcon from '@fxa/shared/assets/images/error.svg';
+import { Localized } from '@fluent/react';
+import { BaseButton, ButtonVariant } from '@fxa/payments/ui';
+import { useRouter } from 'next/navigation';
+
+export default function NotFoundPage() {
+  const router = useRouter();
+
+  return (
+    <section
+      className="flex flex-col items-center text-center max-w-lg mx-auto mt-6 p-16 tablet:my-10 gap-16 bg-white shadow tablet:rounded-xl border border-transparent"
+      aria-label="Payment error"
+    >
+      <Localized id="page-not-found-title">
+        <h1 className="text-xl font-bold">Page not found</h1>
+      </Localized>
+      <Image src={errorIcon} alt="" />
+      <p className="flex flex-col gap-6 items-center text-grey-400 max-w-md text-sm">
+        <Localized id="page-not-found-description">
+          The page you requested was not found. We’ve been notified and will fix
+          any links that may be broken.
+        </Localized>
+        <BaseButton
+          variant={ButtonVariant.Primary}
+          className="text-base"
+          onClick={() => router.back()}
+        >
+          Go Back
+        </BaseButton>
+      </p>
+    </section>
+  );
+}

--- a/apps/payments/next/app/en.ftl
+++ b/apps/payments/next/app/en.ftl
@@ -1,0 +1,4 @@
+# Page - Not Found
+page-not-found-title = Page not found
+page-not-found-description = The page you requested was not found. We’ve been notified and will fix any links that may be broken.
+page-not-found-back-button = Go Back

--- a/apps/payments/next/app/layout.tsx
+++ b/apps/payments/next/app/layout.tsx
@@ -18,7 +18,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <main className="mt-16 min-h-[calc(100vh_-_4rem)]">{children}</main>
+        <main className="mt-16 tablet:mt-20 min-h-[calc(100vh_-_4rem)]">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/apps/payments/next/app/not-found.tsx
+++ b/apps/payments/next/app/not-found.tsx
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getApp } from '@fxa/payments/ui/server';
+import { headers } from 'next/headers';
+import Image from 'next/image';
+import errorIcon from '@fxa/shared/assets/images/error.svg';
+import { captureMessage } from '@sentry/nextjs';
+
+export default function NotFoundPage() {
+  const acceptLanguage = headers().get('accept-language');
+  const l10n = getApp().getL10n(acceptLanguage);
+
+  captureMessage('Page not found', 'warning');
+
+  return (
+    <section
+      className="flex flex-col items-center text-center max-w-lg mx-auto mt-6 p-16 tablet:my-10 gap-16 bg-white shadow tablet:rounded-xl border border-transparent"
+      aria-label="Payment error"
+    >
+      <h1 className="text-xl font-bold">
+        {l10n.getString('page-not-found-title', 'Page not found')}
+      </h1>
+      <Image src={errorIcon} alt="" />
+      <p className="text-grey-400 max-w-md text-sm">
+        {l10n.getString(
+          'page-not-found-description',
+          'The page you requested was not found. We’ve been notified and will fix any links that may be broken.'
+        )}
+      </p>
+    </section>
+  );
+}

--- a/apps/payments/next/middleware.ts
+++ b/apps/payments/next/middleware.ts
@@ -88,7 +88,7 @@ export const config = {
      */
     {
       source:
-        '/((?!api|error|_next/static|_next/image|favicon.ico|__heartbeat__|__lbheartbeat__|__version__).*)',
+        '/((?!api|error|_next/static|_next/image|favicon.ico|__heartbeat__|__lbheartbeat__|__version__|monitoring).*)',
       missing: [
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' },

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -32,7 +32,10 @@ import {
   StripeCustomer,
   StripeSubscription,
 } from '@fxa/payments/stripe';
-import { ProductConfigurationManager } from '@fxa/shared/cms';
+import {
+  ProductConfigError,
+  ProductConfigurationManager,
+} from '@fxa/shared/cms';
 import { CurrencyManager } from '@fxa/payments/currency';
 import { AccountManager } from '@fxa/shared/account/account';
 import {
@@ -223,7 +226,9 @@ export class CartService {
    * Initialize a brand new cart
    * **Note**: This method is currently a placeholder. The arguments will likely change, and the internal implementation is far from complete.
    */
-  @SanitizeExceptions({ allowlist: [CartInvalidPromoCodeError] })
+  @SanitizeExceptions({
+    allowlist: [CartInvalidPromoCodeError, ProductConfigError],
+  })
   async setupCart(args: {
     interval: SubplatInterval;
     offeringConfigId: string;

--- a/libs/payments/customer/src/lib/util/doesPriceMatchSubplatInterval.ts
+++ b/libs/payments/customer/src/lib/util/doesPriceMatchSubplatInterval.ts
@@ -13,7 +13,7 @@ export const doesPriceMatchSubplatInterval = (
   const stripeInterval = subplatIntervalToInterval[subplatInterval];
 
   return (
-    price.recurring?.interval === stripeInterval.interval &&
-    price.recurring?.interval_count === stripeInterval.intervalCount
+    price.recurring?.interval === stripeInterval?.interval &&
+    price.recurring?.interval_count === stripeInterval?.intervalCount
   );
 };

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -19,6 +19,7 @@ import {
   EligibilityContentByOfferingResultUtil,
   EligibilityContentOfferingResultFactory,
   MockStrapiClientConfigProvider,
+  OfferingNotFoundError,
   ProductConfigurationManager,
   StrapiClient,
 } from '@fxa/shared/cms';
@@ -97,7 +98,7 @@ describe('EligibilityService', () => {
           'prod_test1',
           mockCustomer.id
         )
-      ).rejects.toThrowError('getOffering - No offering exists');
+      ).rejects.toThrowError(OfferingNotFoundError);
     });
 
     it('returns eligibility status successfully', async () => {

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -14,7 +14,10 @@ import {
 import { ContentServerManager } from '@fxa/payments/content-server';
 import { CurrencyManager } from '@fxa/payments/currency';
 import { CheckoutTokenManager } from '@fxa/payments/paypal';
-import { ProductConfigurationManager } from '@fxa/shared/cms';
+import {
+  ProductConfigError,
+  ProductConfigurationManager,
+} from '@fxa/shared/cms';
 import {
   CartState,
   type CartErrorReasonId,
@@ -62,6 +65,7 @@ import { SetupCartActionResult } from './validators/SetupCartActionResult';
 import { RestartCartActionResult } from './validators/RestartCartActionResult';
 import { GetTaxAddressArgs } from './validators/getTaxAddressArgs';
 import { GetTaxAddressResult } from './validators/getTaxAddressResult';
+import { CartInvalidPromoCodeError } from 'libs/payments/cart/src/lib/cart.error';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -139,7 +143,9 @@ export class NextJSActionsService {
     return cart;
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({
+    allowlist: [CartInvalidPromoCodeError, ProductConfigError],
+  })
   @NextIOValidator(SetupCartActionArgs, SetupCartActionResult)
   async setupCart(args: {
     interval: SubplatInterval;
@@ -223,7 +229,7 @@ export class NextJSActionsService {
     );
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({ allowlist: [ProductConfigError] })
   @NextIOValidator(FetchCMSDataActionArgs, FetchCMSDataActionResult)
   async fetchCMSData(args: {
     offeringId: string;

--- a/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
+++ b/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
@@ -2,7 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-type Page = 'landing' | 'new' | 'start' | 'success' | 'error' | 'location';
+type Page =
+  | 'landing'
+  | 'new'
+  | 'start'
+  | 'success'
+  | 'error'
+  | 'location'
+  | 'page-not-found';
 type PageType = 'checkout' | 'upgrade';
 
 interface Optional {
@@ -22,7 +29,9 @@ export function buildRedirectUrl(
   const baseUrl = optional?.baseUrl ? optional?.baseUrl : '';
 
   const startUrl = baseUrl === '/' ? baseUrl : `${baseUrl}/`;
-  const pageTypeUrl = ['landing', 'new', 'location'].includes(page)
+  const pageTypeUrl = ['landing', 'new', 'location', 'page-not-found'].includes(
+    page
+  )
     ? ''
     : `${pageType}/`;
   const endUrl = optional?.cartId ? `${optional?.cartId}/${page}` : page;

--- a/libs/shared/cms/src/lib/cms.error.ts
+++ b/libs/shared/cms/src/lib/cms.error.ts
@@ -18,3 +18,50 @@ export class ProductConfigError extends BaseError {
     super(...args);
   }
 }
+
+export class QueriesUtilError extends BaseError {
+  constructor(...args: ConstructorParameters<typeof BaseError>) {
+    super(...args);
+  }
+}
+
+export class FetchCmsInvalidOfferingError extends ProductConfigError {
+  constructor(error: Error, offeringId: string) {
+    super('Invalid offering id', {
+      name: 'FetchCmsInvalidOfferingError',
+      cause: error,
+      info: { offeringId },
+    });
+  }
+}
+
+export class RetrieveStripePriceNotFoundError extends ProductConfigError {
+  constructor(offeringId: string, interval: string) {
+    super('Price not found', {
+      name: 'RetrieveStripePriceNotFoundError',
+      info: { offeringId, interval },
+    });
+  }
+}
+
+export class RetrieveStripePriceInvalidOfferingError extends ProductConfigError {
+  constructor(error: Error, offeringId: string) {
+    super('Invalid offering id', {
+      name: 'RetrieveStripePriceInvalidOfferingError',
+      cause: error,
+      info: { offeringId },
+    });
+  }
+}
+
+export class OfferingNotFoundError extends QueriesUtilError {
+  constructor() {
+    super('Offering not found');
+  }
+}
+
+export class OfferingMultipleError extends QueriesUtilError {
+  constructor() {
+    super('More than one offering found');
+  }
+}

--- a/libs/shared/cms/src/lib/queries/eligibility-content-by-offering/util.spec.ts
+++ b/libs/shared/cms/src/lib/queries/eligibility-content-by-offering/util.spec.ts
@@ -8,6 +8,7 @@ import {
   EligibilityContentByOfferingResultUtil,
   EligibilityContentOfferingResultFactory,
 } from '.';
+import { OfferingMultipleError, OfferingNotFoundError } from '../../cms.error';
 
 describe('EligibilityByOfferingResultUtil', () => {
   it('should create a util from response', () => {
@@ -27,9 +28,7 @@ describe('EligibilityByOfferingResultUtil', () => {
     const util = new EligibilityContentByOfferingResultUtil(
       result as EligibilityContentByOfferingResult
     );
-    expect(() => util.getOffering()).toThrowError(
-      'getOffering - No offering exists'
-    );
+    expect(() => util.getOffering()).toThrowError(OfferingNotFoundError);
   });
 
   it('throws error if more than offering is returned', () => {
@@ -43,8 +42,6 @@ describe('EligibilityByOfferingResultUtil', () => {
     const util = new EligibilityContentByOfferingResultUtil(
       result as EligibilityContentByOfferingResult
     );
-    expect(() => util.getOffering()).toThrowError(
-      'getOffering - More than one offering'
-    );
+    expect(() => util.getOffering()).toThrowError(OfferingMultipleError);
   });
 });

--- a/libs/shared/cms/src/lib/queries/eligibility-content-by-offering/util.ts
+++ b/libs/shared/cms/src/lib/queries/eligibility-content-by-offering/util.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { OfferingMultipleError, OfferingNotFoundError } from '../../cms.error';
 import {
   EligibilityContentByOfferingResult,
   EligibilityContentOfferingResult,
@@ -12,9 +13,8 @@ export class EligibilityContentByOfferingResultUtil {
 
   getOffering(): EligibilityContentOfferingResult {
     const offering = this.offerings.at(0);
-    if (!offering) throw Error('getOffering - No offering exists');
-    if (this.offerings.length > 1)
-      throw Error('getOffering - More than one offering');
+    if (!offering) throw new OfferingNotFoundError();
+    if (this.offerings.length > 1) throw new OfferingMultipleError();
     return offering;
   }
 

--- a/libs/shared/cms/src/lib/queries/page-content-for-offering/util.ts
+++ b/libs/shared/cms/src/lib/queries/page-content-for-offering/util.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { OfferingMultipleError, OfferingNotFoundError } from '../../cms.error';
 import {
   PageContentForOfferingResult,
   PageContentOfferingTransformed,
@@ -18,9 +19,12 @@ export class PageContentForOfferingResultUtil {
 
   getOffering(): PageContentOfferingTransformed {
     const offering = this.offerings.at(0);
-    if (!offering) throw Error('getOffering - No offering exists');
-    if (this.offerings.length > 1)
-      throw Error('getOffering - More than one offering');
+    if (!offering) {
+      throw new OfferingNotFoundError();
+    }
+    if (this.offerings.length > 1) {
+      throw new OfferingMultipleError();
+    }
 
     return {
       ...offering,


### PR DESCRIPTION
## Because

- Invalid paths currently display a generic error message to the user and log a generic error message in Sentry.

## This pull request

- Add {locale}/not-found.tsx for localized not found page.
- Add {root}/not-found.tsx as fallback page.
- Update thrown server errors for invalid path params, so that they can be handled on the client, and use Next.js notFound function.
- Adds new page-not-found/page.tsx for to handle invalid path params errors thrown in a route handler, that need to show a page not found error to the client. This is mainly applicable to the /landing page

## Issue that this pull request solves

Closes: #FXA-11271

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/7d12412b-7f46-4515-b12e-a8935e0d9ebc)

## Other information (Optional)

Any other information that is important to this pull request.
