### PR TITLE
fix(payments-next): Update sign-in section on Checkout page

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/en.ftl
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/en.ftl
@@ -1,6 +1,7 @@
 ## Page
 checkout-signin-or-create = 1. Sign in or create a { -product-mozilla-account }
-checkout-create-account = Create a { -product-mozilla-account }
+# This string appears as a separation between the two sign-in options, "Enter your email"(signin-form-email-input) "or"(this string) "Continue with Google"(continue-signin-with-google-button) / "Continue with Apple"(continue-signin-with-apple-button)
+checkout-signin-options-or = or
 continue-signin-with-google-button = Continue with { -brand-google }
 continue-signin-with-apple-button = Continue with { -brand-apple }
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -103,14 +103,16 @@ export default async function Checkout({
             newsletterLabel={cms.commonContent.newsletterLabelTextCode}
           />
 
-          <h3 className="font-semibold text-grey-600 text-start">
-            {l10n.getString(
-              'checkout-create-account',
-              'Create a Mozilla account'
-            )}
-          </h3>
+          <div className="text-sm flex items-center justify-center my-6">
+            <div className="flex-1 h-px bg-grey-400 divide-x"></div>
 
-          <div className="flex flex-col gap-4 mt-6 mb-10 desktop:flex-row desktop:items-center desktop:justify-center">
+            <div className="mx-4 text-base text-grey-400 font-extralight">
+              {l10n.getString('checkout-signin-options-or', 'or')}
+            </div>
+            <div className="flex-1 h-px bg-grey-400 divide-x"></div>
+          </div>
+
+          <div className="flex flex-col gap-4 my-10">
             <form
               action={async () => {
                 'use server';

--- a/libs/payments/ui/src/lib/client/components/SignInForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SignInForm/index.tsx
@@ -119,10 +119,7 @@ export const SignInForm = ({
       </Form.Field>
 
       <Form.Submit asChild>
-        <SubmitButton
-          variant={ButtonVariant.Primary}
-          className="mt-6 my-8 w-full"
-        >
+        <SubmitButton variant={ButtonVariant.Primary} className="my-6 w-full">
           <Localized id="signin-form-continue-button">Continue</Localized>
         </SubmitButton>
       </Form.Submit>


### PR DESCRIPTION
## This pull request

- Remove "Create a Mozilla account" from Checkout page

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Mobile
<img width="425" alt="Screenshot 2025-03-25 at 12 51 33 PM" src="https://github.com/user-attachments/assets/fd90e5a5-d0c5-492e-9d37-fc1242c73661" />

Tablet
<img width="762" alt="Screenshot 2025-03-25 at 12 51 49 PM" src="https://github.com/user-attachments/assets/a1283f0a-9416-4632-aa9a-2d932b232e30" />

Desktop
<img width="1020" alt="Screenshot 2025-03-25 at 12 52 02 PM" src="https://github.com/user-attachments/assets/4d98c70a-da03-40c3-91ec-5396348f1816" />

