### PR TITLE
fix(emails): update fluent id for inactiveAccountFirstWarning

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/index.mjml
@@ -13,7 +13,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-sub-body">
-      <span data-l10n-id="inactiveAccountFirstWarning-account-description">Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN.</span>
+      <span data-l10n-id="inactiveAccountFirstWarning-account-description-v2">Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN.</span>
     </mj-text>
     <mj-text css-class="text-sub-body">
       <span data-l10n-id="inactiveAccountFirstWarning-inactive-status">We noticed you haven’t signed in for 2 years.</span>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/inactiveAccountFirstWarning/index.txt
@@ -1,6 +1,6 @@
 inactiveAccountFirstWarning-title = "Do you want to keep your Mozilla account and data?"
 
-inactiveAccountFirstWarning-account-description = "Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN."
+inactiveAccountFirstWarning-account-description-v2 = "Your Mozilla account is used to access free privacy and browsing products like Firefox sync, Mozilla Monitor, Firefox Relay, and MDN."
 
 inactiveAccountFirstWarning-inactive-status = "We noticed you haven’t signed in for 2 years."
 


### PR DESCRIPTION
Because:
 - a fluent id and string was updated but the ids where it's used were not