### PR TITLE
fix(next): add name to server errors used in client

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -72,7 +72,7 @@ export default async function New({
       })
     );
   } catch (error) {
-    if (error.constructor.name === 'CartInvalidPromoCodeError') {
+    if (error.name === 'CartInvalidPromoCodeError') {
       const { id: cartId, eligibilityStatus } = await setupCartAction(
         interval as SubplatInterval,
         offeringId,

--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -11,9 +11,14 @@ import {
 import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
 
 export class CartError extends BaseError {
-  constructor(message: string, info: Record<string, any>, cause?: Error) {
+  constructor(
+    message: string,
+    info: Record<string, any>,
+    cause?: Error,
+    name?: string
+  ) {
     super(message, {
-      name: 'CartError',
+      name: name || 'CartError',
       cause,
       info,
     });
@@ -127,10 +132,15 @@ export class CartUidNotFoundError extends CartError {
 
 export class CartInvalidPromoCodeError extends CartError {
   constructor(promoCode: string, cartId?: string) {
-    super('Cart specified promo code does not exist', {
-      cartId,
-      promoCode,
-    });
+    super(
+      'Cart specified promo code does not exist',
+      {
+        cartId,
+        promoCode,
+      },
+      undefined,
+      'CartInvalidPromoCodeError'
+    );
   }
 }
 

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -41,7 +41,6 @@ import {
   CartState,
 } from '@fxa/shared/db/mysql/account';
 import { SanitizeExceptions } from '@fxa/shared/error';
-import { GeoDBManager } from '@fxa/shared/geodb';
 
 import {
   CartError,
@@ -89,7 +88,6 @@ export class CartService {
     private customerSessionManager: CustomerSessionManager,
     private promotionCodeManager: PromotionCodeManager,
     private eligibilityService: EligibilityService,
-    private geodbManager: GeoDBManager,
     private invoiceManager: InvoiceManager,
     private productConfigurationManager: ProductConfigurationManager,
     private subscriptionManager: SubscriptionManager,

--- a/libs/payments/customer/src/lib/error.ts
+++ b/libs/payments/customer/src/lib/error.ts
@@ -40,9 +40,10 @@ export class PromotionCodeCouldNotBeAttachedError extends PaymentsCustomerError 
       customerId?: string;
       subscriptionId?: string;
       promotionId?: string;
-    }
+    },
+    name?: string
   ) {
-    super(message, { cause });
+    super(message, { cause, name });
     this.customerId = data?.customerId;
     this.subscriptionId = data?.subscriptionId;
     this.promotionId = data?.promotionId;
@@ -51,25 +52,45 @@ export class PromotionCodeCouldNotBeAttachedError extends PaymentsCustomerError 
 
 export class CouponErrorExpired extends PromotionCodeCouldNotBeAttachedError {
   constructor() {
-    super('The code you entered has expired.');
+    super(
+      'The code you entered has expired.',
+      undefined,
+      undefined,
+      'CouponErrorExpired'
+    );
   }
 }
 
 export class CouponErrorGeneric extends PromotionCodeCouldNotBeAttachedError {
   constructor() {
-    super('An error occurred processing the code. Please try again.');
+    super(
+      'An error occurred processing the code. Please try again.',
+      undefined,
+      undefined,
+      'CouponErrorGeneric'
+    );
   }
 }
 
 export class CouponErrorInvalid extends PromotionCodeCouldNotBeAttachedError {
   constructor() {
-    super('The code you entered is invalid.');
+    super(
+      'The code you entered is invalid.',
+      undefined,
+      undefined,
+      'CouponErrorInvalid'
+    );
   }
 }
 
 export class CouponErrorLimitReached extends PromotionCodeCouldNotBeAttachedError {
   constructor() {
-    super('The code you entered has reached its limit.');
+    super(
+      'The code you entered has reached its limit.',
+      undefined,
+      undefined,
+      'CouponErrorLimitReached'
+    );
   }
 }
 

--- a/libs/payments/ui/src/lib/actions/updateCart.ts
+++ b/libs/payments/ui/src/lib/actions/updateCart.ts
@@ -24,11 +24,11 @@ export const updateCartAction = async (
       cartDetails,
     });
   } catch (err) {
-    if (err.constructor.name === 'CouponErrorExpired') {
+    if (err.name === 'CouponErrorExpired') {
       return CouponErrorMessageType.Expired;
-    } else if (err.constructor === 'CouponErrorGeneric') {
+    } else if (err.name === 'CouponErrorGeneric') {
       return CouponErrorMessageType.Generic;
-    } else if (err.constructor === 'CouponErrorLimitReached') {
+    } else if (err.name === 'CouponErrorLimitReached') {
       return CouponErrorMessageType.LimitReached;
     } else {
       return CouponErrorMessageType.Invalid;


### PR DESCRIPTION
## Because

- Nextjs build minification changes the name of classes, making it not feasible for comparison logic on the client.

## This pull request

- Set the error name property to match the name of the error class and then use that in client side comparisons.

## Issue that this pull request solves

Closes: #FXA-11348

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Discussed in a bit more detail in [this SO post](https://stackoverflow.com/questions/77336592/how-to-throw-and-handle-custom-errors-from-server-to-client-side-in-next-js). Note, I'm not sure it's 100% applicable anymore.
