### PR TITLE
fix(next): move redirect out of try-catch

### DIFF
--- a/libs/payments/legacy/src/lib/utils/getSP2Params.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/getSP2Params.spec.ts
@@ -37,22 +37,6 @@ describe('getSP2Params', () => {
       expect(productId).toBe('prod_productid');
       expect(priceId).toBe('price_priceId');
     });
-
-    it('successfully returns productId and planId if invalid interval is provided', () => {
-      const { productId, priceId } = getSP2Params(
-        sp2mapConfig,
-        reportErrorMock,
-        'vpn',
-        'invalid',
-        'USD'
-      );
-      expect(reportErrorMock).toHaveBeenCalledWith(
-        'Interval is not supported',
-        { interval: 'invalid' }
-      );
-      expect(productId).toBe('prod_productid');
-      expect(priceId).toBe('price_priceId');
-    });
   });
 
   describe('failure', () => {
@@ -70,6 +54,19 @@ describe('getSP2Params', () => {
         expect(reportErrorMock).toHaveBeenCalledWith(
           'Missing or invalid offering',
           { offeringId: 'invalid' }
+        );
+        expect(err).toBeInstanceOf(Error);
+      }
+    });
+
+    it('throws an error if invalid interval is provided', () => {
+      try {
+        getSP2Params(sp2mapConfig, reportErrorMock, 'vpn', 'invalid', 'USD');
+        assert('should have thrown an error');
+      } catch (err) {
+        expect(reportErrorMock).toHaveBeenCalledWith(
+          'Interval is not supported',
+          { interval: 'invalid' }
         );
         expect(err).toBeInstanceOf(Error);
       }

--- a/libs/payments/legacy/src/lib/utils/getSP2Params.ts
+++ b/libs/payments/legacy/src/lib/utils/getSP2Params.ts
@@ -20,6 +20,7 @@ export function getSP2Params(
 ) {
   if (!isValidInterval(interval)) {
     reportError('Interval is not supported', { interval });
+    throw new Error('Interval is not supported');
   }
 
   if (!currency) {


### PR DESCRIPTION
## Because

- Next.js does not allow redirects within a try-catch block.

## This pull request

- Move the redirect to the try-catch, finally block instead.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
