### PR TITLE
fix(next): spVersion should override other logic

### DIFF
--- a/libs/payments/legacy/src/index.ts
+++ b/libs/payments/legacy/src/index.ts
@@ -2,4 +2,4 @@ export * from './lib/stripe-mapper.service';
 export * from './lib/sp2map.config';
 export * from './lib/utils/buildSp2RedirectUrl';
 export * from './lib/utils/getSP2Params';
-export * from './lib/utils/redirectToSp2';
+export * from './lib/utils/determineRedirectToSp2';

--- a/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.spec.ts
@@ -37,4 +37,17 @@ describe('buildSp2RedirectUrl', () => {
       'http://content-server.com/subscriptions/products/prod_123?plan=price_123&flow_id=one&flow_begin_time=123'
     );
   });
+
+  it('should send no query params', () => {
+    const defaultSearchParams = new URLSearchParams();
+    const result = buildSp2RedirectUrl(
+      defaultProductId,
+      defaultPriceId,
+      defaultContentServerUrl,
+      defaultSearchParams
+    );
+    expect(result).toBe(
+      'http://content-server.com/subscriptions/products/prod_123?plan=price_123'
+    );
+  });
 });

--- a/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.ts
+++ b/libs/payments/legacy/src/lib/utils/buildSp2RedirectUrl.ts
@@ -14,5 +14,11 @@ export function buildSp2RedirectUrl(
 
   const remainingQueryParams = searchParams.toString();
 
-  return `${contentServerUrl}/subscriptions/products/${productId}?plan=${priceId}&${remainingQueryParams}`;
+  const baseUrl = `${contentServerUrl}/subscriptions/products/${productId}?plan=${priceId}`;
+
+  if (remainingQueryParams) {
+    return `${baseUrl}&${remainingQueryParams}`;
+  } else {
+    return baseUrl;
+  }
 }

--- a/libs/payments/legacy/src/lib/utils/determineRedirectToSp2.spec.ts
+++ b/libs/payments/legacy/src/lib/utils/determineRedirectToSp2.spec.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { redirectToSp2 } from './redirectToSp2';
+import { determineRedirectToSp2 } from './determineRedirectToSp2';
 import { RedirectParamsFactory, SP2RedirectConfigFactory } from '../factories';
 import { RedirectParams } from '../sp2map.config';
 
-describe('redirectToSp2', () => {
+describe('determineRedirectToSp2', () => {
   const defaultOfferingId = 'vpn';
   const mockReportError = jest.fn();
 
@@ -24,7 +24,7 @@ describe('redirectToSp2', () => {
     });
     const defaultRandomPercentage = 100;
     it('uses percentage from config', () => {
-      const result = redirectToSp2(
+      const result = determineRedirectToSp2(
         defaultConfig,
         defaultOfferingId,
         defaultRandomPercentage,
@@ -35,7 +35,7 @@ describe('redirectToSp2', () => {
     });
 
     it('uses config default percentage if config not found', () => {
-      const result = redirectToSp2(
+      const result = determineRedirectToSp2(
         defaultConfig,
         'invalidOfferingId',
         defaultRandomPercentage,
@@ -58,7 +58,7 @@ describe('redirectToSp2', () => {
     const defaultRandomPercentage = 1;
 
     it('uses percentage from config', () => {
-      const result = redirectToSp2(
+      const result = determineRedirectToSp2(
         defaultConfig,
         defaultOfferingId,
         defaultRandomPercentage,
@@ -69,7 +69,7 @@ describe('redirectToSp2', () => {
     });
 
     it('uses config default percentage if config not found', () => {
-      const result = redirectToSp2(
+      const result = determineRedirectToSp2(
         defaultConfig,
         'invalidOfferingId',
         defaultRandomPercentage,
@@ -90,7 +90,7 @@ describe('redirectToSp2', () => {
         offerings: defaultOfferings,
       });
 
-      const result = redirectToSp2(
+      const result = determineRedirectToSp2(
         mockConfig,
         defaultOfferingId,
         200,
@@ -109,13 +109,60 @@ describe('redirectToSp2', () => {
         defaultRedirectPercentage: 0,
       });
 
-      const result = redirectToSp2(
+      const result = determineRedirectToSp2(
         mockConfig,
         defaultOfferingId,
         0,
         mockReportError
       );
       expect(result).toBe(false);
+    });
+  });
+
+  describe('versionOverride', () => {
+    const defaultOfferings = {} as Record<string, RedirectParams>;
+    defaultOfferings[defaultOfferingId] = RedirectParamsFactory({
+      sp2RedirectPercentage: 100,
+    });
+    const defaultConfig = SP2RedirectConfigFactory({
+      offerings: defaultOfferings,
+    });
+    const defaultRandomPercentage = 100;
+
+    it('should return true', () => {
+      const result = determineRedirectToSp2(
+        defaultConfig,
+        defaultOfferingId,
+        defaultRandomPercentage,
+        mockReportError,
+        '2'
+      );
+      expect(result).toBe(true);
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it('should return false', () => {
+      const result = determineRedirectToSp2(
+        defaultConfig,
+        defaultOfferingId,
+        defaultRandomPercentage,
+        mockReportError,
+        '3'
+      );
+      expect(result).toBe(false);
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it('ignores invalid values', () => {
+      const result = determineRedirectToSp2(
+        defaultConfig,
+        defaultOfferingId,
+        defaultRandomPercentage,
+        mockReportError,
+        'random'
+      );
+      expect(result).toBe(true);
+      expect(mockReportError).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/payments/legacy/src/lib/utils/determineRedirectToSp2.ts
+++ b/libs/payments/legacy/src/lib/utils/determineRedirectToSp2.ts
@@ -4,12 +4,20 @@
 
 import { SP2RedirectConfig } from '../sp2map.config';
 
-export function redirectToSp2(
+export function determineRedirectToSp2(
   config: SP2RedirectConfig,
   offeringId: string,
   randomPercentage: number,
-  reportError: (...args: any) => void
+  reportError: (...args: any) => void,
+  versionOverride?: string | null
 ) {
+  // If version override is provided, short circuit return
+  if (versionOverride === '2') {
+    return true;
+  } else if (versionOverride === '3') {
+    return false;
+  }
+
   const configPercentage = config.offerings[offeringId]?.sp2RedirectPercentage;
   const sp2RedirectPercentage =
     configPercentage ?? config.defaultRedirectPercentage;


### PR DESCRIPTION
## Because

- If spVersion is provided in query params, it should always be override any other logic.

## This pull request

- Updates determineRedirectToSp2 function to include override param.
- If spVersion is provided, pass it into determineRedirectToSp2

## Issue that this pull request solves

Closes: FXA-11431

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
