### PR TITLE
test(functional-tests): skip flaky v1 signup to v2 keystretching recoveryKey tests

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -69,6 +69,12 @@ test.describe('severity-2 #smoke', () => {
       },
       testAccountTracker,
     }) => {
+      test.skip(
+        signupVersion.version === 1,
+        "Skipping v1 signup tests as v1 signup isn't supported. \
+        These tests will be removed as part of https://mozilla-hub.atlassian.net/browse/FXA-11426"
+      );
+
       const accountDetails = {
         email: testAccountTracker.generateEmail(),
         password: testAccountTracker.generatePassword(),


### PR DESCRIPTION
## Because

- these tests, using v1 sign up in the recoveryKey flows, are flaky, 
- and users cannot sign up with v1, 
- and the v1 support is going away soon

## This pull request

- Skips any tests here that try to sign up with `v1` then perform another action in the `recoveryKey.spec` flows

## Issue that this pull request solves

Closes: (FXA-11160)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
