### PR TITLE
fix(content): Optional chaining breaking string extraction

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
+++ b/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
@@ -28,7 +28,7 @@ module.exports = function (options = {}, statsd) {
         context: req.body.context,
       });
 
-      const previewMode = req.query?.nimbusPreview || false;
+      const previewMode = (req.query && req.query.nimbusPreview) || false;
       const queryParams = new URLSearchParams({
         nimbus_preview: previewMode,
       });


### PR DESCRIPTION
## Because

* gettext doesn't support optional chaining, and using optional chaining in content-server breaks the string extraction

## This pull request

* Replace optional chaining in the one line that was causing string extraction failure

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
