### PR TITLE
chore(cirrus): Move preview fallback logic to caller

### DIFF
--- a/packages/fxa-settings/src/lib/nimbus/index.ts
+++ b/packages/fxa-settings/src/lib/nimbus/index.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as Sentry from '@sentry/browser';
-import { searchParams } from '../utilities';
 
 /**
  * A collection of attributes about the client that will be used for
@@ -40,15 +39,12 @@ export async function initializeNimbus(
     client_id: clientId,
     context,
   });
-  const nimbusPreview = previewEnabled
-    ? previewEnabled
-    : searchParams(window.location.search).nimbusPreview;
 
   let experiments;
 
   try {
     const resp = await fetch(
-      `/nimbus-experiments?nimbusPreview=${nimbusPreview}`,
+      `/nimbus-experiments?nimbusPreview=${previewEnabled}`,
       {
         method: 'POST',
         body,

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -17,6 +17,7 @@ import { SensitiveDataClient } from '../../lib/sensitive-data-client';
 import { initializeNimbus, NimbusContextT } from '../../lib/nimbus';
 import { parseAcceptLanguage } from '../../../../../libs/shared/l10n/src';
 import { getUniqueUserId } from '../../lib/cache';
+import { searchParams } from '../../lib/utilities';
 
 // TODO, move some values from AppContext to SettingsContext after
 // using container components, FXA-8107
@@ -54,7 +55,11 @@ function fetchNimbusExperiments(uniqueUserId: string): Promise<any> {
     region = region.toLowerCase();
   }
 
-  return initializeNimbus(uniqueUserId, config.nimbusPreview, {
+  const nimbusPreview = config.nimbusPreview
+    ? config.nimbusPreview
+    : searchParams(window.location.search).nimbusPreview === 'true';
+
+  return initializeNimbus(uniqueUserId, nimbusPreview, {
     language,
     region,
   } as NimbusContextT);


### PR DESCRIPTION
## Because

- A [follow-up review comment](https://github.com/mozilla/fxa/pull/18598#discussion_r2014092326) made a good suggestion to lift this logic to the caller.

## This pull request

- Does just that.

## Issue that this pull request solves

Closes: FXA-11372

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
