### PR TITLE
fix(metrics): emit login.complete at end of multi-step signin

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -263,6 +263,8 @@ module.exports = (log, db, config, customs, mailer, glean) => {
         log.info('account.recoveryCode.verified', { uid });
 
         await request.emitMetricsEvent('recoveryCode.verified', { uid });
+        // this signals the end of the login flow
+        await request.emitMetricsEvent('account.confirmed', { uid });
         glean.login.recoveryCodeSuccess(request, { uid });
 
         accountEventsManager.recordSecurityEvent(db, {

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -241,8 +241,6 @@ class RecoveryPhoneHandler {
       await this.glean.twoStepAuthPhoneCode.sendError(request);
       return { status: RecoveryPhoneStatus.FAILURE };
     } catch (error) {
-      console.log('!!!! setup phone number error', error);
-
       if (error instanceof RecoveryPhoneNotEnabled) {
         throw AppError.featureNotEnabled();
       }
@@ -393,6 +391,8 @@ class RecoveryPhoneHandler {
         }
       } else {
         this.statsd.increment('account.recoveryPhone.phoneSignin.success');
+        // this signals the end of the login flow
+        await request.emitMetricsEvent('account.confirmed', { uid });
 
         this.accountEventsManager.recordSecurityEvent(this.db, {
           name: 'account.recovery_phone_signin_complete',

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -548,6 +548,8 @@ module.exports = (
         if (isValidCode) {
           log.info('totp.verified', { uid });
           await request.emitMetricsEvent('totpToken.verified', { uid });
+          // this signals the end of the login flow
+          await request.emitMetricsEvent('account.confirmed', { uid });
           glean.login.totpSuccess(request, { uid });
 
           accountEventsManager.recordSecurityEvent(db, {

--- a/packages/fxa-auth-server/test/local/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-codes.js
@@ -241,5 +241,16 @@ describe('backup authentication codes', () => {
         { uid: UID }
       );
     });
+
+    it('should emit the flow complete event', async () => {
+      db.consumeRecoveryCode = sandbox.spy((code) => {
+        return Promise.resolve({ remaining: 4 });
+      });
+      await runTest('/session/verify/recoveryCode', requestOptions);
+      sandbox.assert.calledTwice(request.emitMetricsEvent);
+      sandbox.assert.calledWith(request.emitMetricsEvent, 'account.confirmed', {
+        uid: UID,
+      });
+    });
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -72,6 +72,7 @@ describe('/recovery_phone', () => {
     recordSecurityEvent: sandbox.fake(),
   };
   let routes = [];
+  let request;
 
   beforeEach(() => {
     Container.set(RecoveryPhoneService, mockRecoveryPhoneService);
@@ -95,7 +96,9 @@ describe('/recovery_phone', () => {
   async function makeRequest(req) {
     const route = getRoute(routes, req.path, req.method);
     assert.isDefined(route);
-    return await route.handler(mockRequest(req));
+    request = mockRequest(req);
+    request.emitMetricsEvent = sandbox.stub().resolves();
+    return await route.handler(request);
   }
 
   describe('POST /recovery_phone/signin/send_code', () => {
@@ -487,6 +490,11 @@ describe('/recovery_phone', () => {
       assert.calledOnceWithExactly(
         mockStatsd.increment,
         'account.recoveryPhone.phoneSignin.success'
+      );
+      assert.calledOnceWithExactly(
+        request.emitMetricsEvent,
+        'account.confirmed',
+        { uid }
       );
     });
 

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -307,22 +307,15 @@ describe('totp', () => {
         assert.equal('totp-2fa', args[1], 'called with correct method');
 
         // emits correct metrics
-        assert.equal(
-          request.emitMetricsEvent.callCount,
-          1,
-          'called emitMetricsEvent'
-        );
-        args = request.emitMetricsEvent.args[0];
-        assert.equal(
-          args[0],
+        sinon.assert.calledTwice(request.emitMetricsEvent);
+        sinon.assert.calledWith(
+          request.emitMetricsEvent,
           'totpToken.verified',
-          'called emitMetricsEvent with correct event'
+          { uid: 'uid' }
         );
-        assert.equal(
-          args[1]['uid'],
-          'uid',
-          'called emitMetricsEvent with correct event'
-        );
+        sinon.assert.calledWith(request.emitMetricsEvent, 'account.confirmed', {
+          uid: 'uid',
+        });
 
         // correct emails sent
         assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
@@ -386,27 +379,20 @@ describe('totp', () => {
           1,
           'call verify session'
         );
-        let args = db.verifyTokensWithMethod.args[0];
+        const args = db.verifyTokensWithMethod.args[0];
         assert.equal(sessionId, args[0], 'called with correct session id');
         assert.equal('totp-2fa', args[1], 'called with correct method');
 
         // emits correct metrics
-        assert.equal(
-          request.emitMetricsEvent.callCount,
-          1,
-          'called emitMetricsEvent'
-        );
-        args = request.emitMetricsEvent.args[0];
-        assert.equal(
-          args[0],
+        sinon.assert.calledTwice(request.emitMetricsEvent);
+        sinon.assert.calledWith(
+          request.emitMetricsEvent,
           'totpToken.verified',
-          'called emitMetricsEvent with correct event'
+          { uid: 'uid' }
         );
-        assert.equal(
-          args[1]['uid'],
-          'uid',
-          'called emitMetricsEvent with correct event'
-        );
+        sinon.assert.calledWith(request.emitMetricsEvent, 'account.confirmed', {
+          uid: 'uid',
+        });
 
         // correct emails sent
         assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
@@ -466,27 +452,20 @@ describe('totp', () => {
           1,
           'call verify session'
         );
-        let args = db.verifyTokensWithMethod.args[0];
+        const args = db.verifyTokensWithMethod.args[0];
         assert.equal(sessionId, args[0], 'called with correct session id');
         assert.equal('totp-2fa', args[1], 'called with correct method');
 
         // emits correct metrics
-        assert.equal(
-          request.emitMetricsEvent.callCount,
-          1,
-          'called emitMetricsEvent'
-        );
-        args = request.emitMetricsEvent.args[0];
-        assert.equal(
-          args[0],
+        sinon.assert.calledTwice(request.emitMetricsEvent);
+        sinon.assert.calledWith(
+          request.emitMetricsEvent,
           'totpToken.verified',
-          'called emitMetricsEvent with correct event'
+          { uid: 'uid' }
         );
-        assert.equal(
-          args[1]['uid'],
-          'uid',
-          'called emitMetricsEvent with correct event'
-        );
+        sinon.assert.calledWith(request.emitMetricsEvent, 'account.confirmed', {
+          uid: 'uid',
+        });
 
         // correct emails sent
         assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);


### PR DESCRIPTION
Because:
 - the backend login.complete Glean event was not emitted when a user signed in successfully with TOTP 2FA, TOTP backup code, or SMS recovery code

This commit:
 - emits the end of flow signal so that the login.complete Glean event is emitted
