### PR TITLE
fix(payments-next): fix locale-less redirects

### DIFF
--- a/apps/payments/next/middleware.ts
+++ b/apps/payments/next/middleware.ts
@@ -12,10 +12,7 @@ export function middleware(request: NextRequest) {
   );
   if (result.redirect) {
     return NextResponse.redirect(
-      new URL(
-        `${result.pathname}${request.nextUrl.search}`,
-        request.nextUrl.hostname
-      )
+      new URL(`${result.pathname}${request.nextUrl.search}`, request.url)
     );
   }
 


### PR DESCRIPTION
Because:

* nextRequest.hostname was defaulting to localhost, rather than the correct base url

This commit:

* nextRequest.url has the correct hostname. Using it fixes the redirect host issue

Closes #N/A
