### PR TITLE
fix(settings): Retrieve last stored account from email-first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ executors:
       # Recovery phone feature flags
       FEATURE_FLAGS_ADDING_2FA_BACKUP_PHONE: true
       FEATURE_FLAGS_USING_2FA_BACKUP_PHONE: true
+      ROLLOUT_GENERALIZED_REACT_APP: 1
       GEODB_LOCATION_OVERRIDE: '{"location": {"countryCode": "US", "postalCode": "85001"}}'
       RECOVERY_PHONE__ENABLED: true
       CUSTOMS_SERVER_URL: none

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -10,7 +10,7 @@ import { useAuthClient } from '../../models';
 import firefox from '../../lib/channels/firefox';
 import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { getHandledError } from '../../lib/error-utils';
-import { currentAccount } from '../../lib/cache';
+import { currentAccount, lastStoredAccount } from '../../lib/cache';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
 import { IndexQueryParams } from '../../models/pages/index';
 import { isUnsupportedContext } from '../../models/integrations/utils';
@@ -53,7 +53,8 @@ export const IndexContainer = ({
   const suggestedEmail =
     queryParamModel.email ||
     integration.data.loginHint ||
-    currentAccount()?.email;
+    currentAccount()?.email ||
+    lastStoredAccount()?.email;
 
   const hasEmailSuggestion = suggestedEmail && !prefillEmail;
 


### PR DESCRIPTION
## Because

* We want to suggest the last stored account from local storage if there is no account marked as current

## This pull request

* Add lastStoredAccount to the suggested account check in react email first

## Issue that this pull request solves

Closes: FXA-11429

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Example use case (on local):

- `yarn firefox`
- Sign in to Sync with Account1
- Go directly to localhost:3030
- See cached sign in for Account1, click "Use different account"
- Sign in with Account2
- Go directly to localhost:3030
- See cached sign in for Account2
- Sign in, sign out from Account2
- See cached sign in for Account1 (sync account) --- this is what was previously not working, there would not have been as suggested account and would have stayed on email first