### PR TITLE
fix(payments-next): Prevent stripe webhook race condition from cancelling subscription

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -98,6 +98,7 @@ import { CurrencyManager } from '@fxa/payments/currency';
 import { MockCurrencyConfigProvider } from 'libs/payments/currency/src/lib/currency.config';
 import { NeedsInputType } from './cart.types';
 import { redirect } from 'next/navigation';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 jest.mock('next/navigation');
 jest.mock('@fxa/shared/error', () => ({
@@ -134,6 +135,9 @@ describe('CartService', () => {
   const mockLogger = {
     error: jest.fn(),
     debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    setContext: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -180,6 +184,20 @@ describe('CartService', () => {
         {
           provide: LOGGER_PROVIDER,
           useValue: mockLogger,
+        },
+        {
+          provide: MozLoggerService,
+          useValue: {
+            error: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            warning: jest.fn(),
+            log: jest.fn(),
+            verbose: jest.fn(),
+            trace: jest.fn(),
+            setContext: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -234,6 +252,7 @@ describe('CartService', () => {
         state: CartState.PROCESSING,
         stripeSubscriptionId: mockSubscription.id,
         stripeCustomerId: mockCustomer.id,
+        eligibilityStatus: CartEligibilityStatus.CREATE,
       });
 
       jest

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -2,10 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import assert from 'assert';
 import assertNotNull from 'assert';
+import { StatsD } from 'hot-shots';
 
 import {
   CustomerManager,
@@ -44,6 +45,8 @@ import {
   CartState,
 } from '@fxa/shared/db/mysql/account';
 import { SanitizeExceptions } from '@fxa/shared/error';
+import { MozLoggerService } from '@fxa/shared/mozlog';
+import { StatsDService } from '@fxa/shared/metrics/statsd';
 
 import {
   CartError,
@@ -92,11 +95,15 @@ export class CartService {
     private promotionCodeManager: PromotionCodeManager,
     private eligibilityService: EligibilityService,
     private invoiceManager: InvoiceManager,
+    private log: MozLoggerService,
     private productConfigurationManager: ProductConfigurationManager,
     private subscriptionManager: SubscriptionManager,
     private paymentMethodManager: PaymentMethodManager,
-    private paymentIntentManager: PaymentIntentManager
-  ) {}
+    private paymentIntentManager: PaymentIntentManager,
+    @Inject(StatsDService) private statsd: StatsD
+  ) {
+    this.log.setContext(CartService.name);
+  }
 
   /**
    * Should be used to wrap any method that mutates an existing cart.
@@ -203,11 +210,23 @@ export class CartService {
             });
           }
 
-          await this.subscriptionManager.cancel(cart.stripeSubscriptionId, {
-            cancellation_details: {
-              comment: 'Automatic Cancellation: Cart checkout failed.',
-            },
-          });
+          if (cart.eligibilityStatus === CartEligibilityStatus.CREATE) {
+            await this.subscriptionManager.cancel(cart.stripeSubscriptionId, {
+              cancellation_details: {
+                comment: 'Automatic Cancellation: Cart checkout failed.',
+              },
+            });
+          } else {
+            this.statsd.increment(
+              'checkout_failure_subscription_not_cancelled'
+            );
+
+            this.log.info('checkout failed, subscription not canceled', {
+              eligibility_status: cart.eligibilityStatus,
+              offering_id: cart.offeringConfigId,
+              interval: cart.interval,
+            });
+          }
         }
       } catch (e) {
         // All errors thrown during the cleanup process should go to Sentry

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -99,6 +99,7 @@ import {
   MockGeoDBNestFactory,
 } from '@fxa/shared/geodb';
 import { MockCurrencyConfigProvider } from 'libs/payments/currency/src/lib/currency.config';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 describe('CheckoutService', () => {
   let accountCustomerManager: AccountCustomerManager;
@@ -168,6 +169,20 @@ describe('CheckoutService', () => {
         {
           provide: LOGGER_PROVIDER,
           useValue: mockLogger,
+        },
+        {
+          provide: MozLoggerService,
+          useValue: {
+            error: jest.fn(),
+            debug: jest.fn(),
+            info: jest.fn(),
+            warn: jest.fn(),
+            warning: jest.fn(),
+            log: jest.fn(),
+            verbose: jest.fn(),
+            trace: jest.fn(),
+            setContext: jest.fn(),
+          },
         },
       ],
     }).compile();


### PR DESCRIPTION
## Because

- A stripe webhooks race condition occurs in SP3 for upgrades, which can cause the cart to be thrown into an error state.
- A cart in the error state cancels the subscription.
- The race condition causes some upgrades that use PayPal to cancel the original subscription, despite payment 

## This pull request

- Prevents stripe webhook from erroring when it attempts to finalize an invoice that was finalized elsewhere.
- Adjusts the logic in the cart service to only cancel the subscription for erroring carts that are creating a new subscription.

## Issue that this pull request solves

Closes: #FXA-11414

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.