### PR TITLE
fix(StatsD): Fix StripeClient StatsD key server injection

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -14,9 +14,7 @@ const Redis = require('ioredis');
 const { CapabilityManager } = require('@fxa/payments/capability');
 const { EligibilityManager } = require('@fxa/payments/eligibility');
 const {
-  ProductManager,
   PriceManager,
-  SubscriptionManager,
   PromotionCodeManager,
 } = require('@fxa/payments/customer');
 const { StripeClient } = require('@fxa/payments/stripe');
@@ -149,17 +147,14 @@ async function run(config) {
   /** @type {undefined | import('../lib/payments/stripe').StripeHelper} */
   let stripeHelper = undefined;
   if (config.subscriptions && config.subscriptions.stripeApiKey) {
-    const stripeClient = new StripeClient({
-      apiKey: config.subscriptions.stripeApiKey,
-    });
-    const productManager = new ProductManager(stripeClient);
-    const priceManager = new PriceManager(stripeClient);
-    const subscriptionManager = new SubscriptionManager(stripeClient);
-    const promotionCodeManager = new PromotionCodeManager(
-      stripeClient,
-      productManager,
-      subscriptionManager
+    const stripeClient = new StripeClient(
+      {
+        apiKey: config.subscriptions.stripeApiKey,
+      },
+      statsd
     );
+    const priceManager = new PriceManager(stripeClient);
+    const promotionCodeManager = new PromotionCodeManager(stripeClient);
     Container.set(PromotionCodeManager, promotionCodeManager);
 
     if (


### PR DESCRIPTION
## Because

-The stripe client is being instantiated in the auth server's key_server, and is missing the statsd argument.

## This pull request

- Adds in the statsd arg to allow the statsd decorator to coorrectly read the call timing
- Removes the productManager and subscriptionManagegr args, as they are no longer being used.

## Issue that this pull request solves

Closes: #FXA-11335

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.