### PR TITLE
feat(payments-iap): Create Apple IAP Service

### DIFF
--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
@@ -124,7 +124,7 @@ export class AppleIapPurchaseManager {
    * triggerNotificationType is only necessary if the purchase query action is triggered
    * by an App Store Server notification.
    */
-  private async getFromAppStoreAPI(
+  async getFromAppStoreAPI(
     bundleId: string,
     originalTransactionId: string,
     triggerNotificationType?: NotificationType,

--- a/libs/payments/iap/src/lib/apple/apple-iap.error.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.error.ts
@@ -10,6 +10,18 @@ export class AppleIapError extends BaseError {
   }
 }
 
+export class AppleIapInvalidOriginalTransactionIdError extends AppleIapError {
+  constructor(...args: ConstructorParameters<typeof AppleIapError>) {
+    super(...args);
+  }
+}
+
+export class AppleIapConflictError extends AppleIapError {
+  constructor(...args: ConstructorParameters<typeof AppleIapError>) {
+    super(...args);
+  }
+}
+
 export class AppleIapUnknownError extends AppleIapError {
   constructor(...args: ConstructorParameters<typeof AppleIapError>) {
     super(...args);

--- a/libs/payments/iap/src/lib/apple/apple-iap.service.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.service.spec.ts
@@ -1,0 +1,220 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import {
+  DecodedNotificationPayload,
+  NotificationSubtype,
+  NotificationType,
+} from 'app-store-server-api';
+
+import { FirestoreService } from '@fxa/shared/db/firestore';
+import { AppleIapClient } from './apple-iap.client';
+import { MockAppleIapClientConfigProvider } from './apple-iap.client.config';
+import {
+  AppleIapConflictError,
+  AppleIapInvalidOriginalTransactionIdError,
+} from './apple-iap.error';
+import { AppleIapPurchaseManager } from './apple-iap-purchase.manager';
+import { AppleIapService } from './apple-iap.service';
+import { NOTIFICATION_TYPES_FOR_NON_SUBSCRIPTION_PURCHASES } from './constants';
+import { AppStoreSubscriptionPurchase } from './subscription-purchase';
+
+jest.mock('app-store-server-api', () => {
+  const actual = jest.requireActual('app-store-server-api');
+  return {
+    Environment: actual.Environment,
+    NotificationSubtype: actual.NotificationSubtype,
+    NotificationType: actual.NotificationType,
+    AppStoreServerAPI: jest.fn().mockImplementation(() => ({})),
+  };
+});
+
+describe('AppleIapService', () => {
+  let appleIapPurchaseManager: AppleIapPurchaseManager;
+  let appleIapService: AppleIapService;
+
+  const mockLogger = {
+    error: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MockAppleIapClientConfigProvider,
+        AppleIapClient,
+        AppleIapPurchaseManager,
+        AppleIapService,
+        {
+          provide: FirestoreService,
+          useValue: {
+            collection: jest.fn().mockReturnValue({}),
+          },
+        },
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    appleIapPurchaseManager = module.get(AppleIapPurchaseManager);
+    appleIapService = module.get(AppleIapService);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('registerToUserAccount', () => {
+    it('registers a purchase to a user', async () => {
+      const mockBundleId = faker.string.sample();
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockUserId = faker.string.uuid();
+      const mockPurchase = { userId: mockUserId };
+      jest
+        .spyOn(appleIapService, 'getSubscriptionPurchase')
+        .mockResolvedValue(mockPurchase as AppStoreSubscriptionPurchase);
+      jest
+        .spyOn(appleIapPurchaseManager, 'forceRegisterToUser')
+        .mockResolvedValue();
+
+      const result = await appleIapService.registerToUserAccount(
+        mockBundleId,
+        mockOriginalTransactionId,
+        mockUserId
+      );
+      expect(result).toEqual(mockPurchase);
+    });
+
+    it('throws an error when attempting to query purchase - invalid original transaction id', async () => {
+      const mockBundleId = faker.string.sample();
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockUserId = faker.string.uuid();
+
+      jest
+        .spyOn(appleIapService, 'getSubscriptionPurchase')
+        .mockResolvedValue(undefined);
+
+      await expect(() =>
+        appleIapService.registerToUserAccount(
+          mockBundleId,
+          mockOriginalTransactionId,
+          mockUserId
+        )
+      ).rejects.toThrowError(AppleIapInvalidOriginalTransactionIdError);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'registerToUserAccount.PurchaseUpdateError.InvalidOriginalTransactionId',
+        {
+          err: expect.any(AppleIapInvalidOriginalTransactionIdError),
+          originalTransactionId: mockOriginalTransactionId,
+        }
+      );
+    });
+
+    it('throws an error when purchase record is already registered to another user', async () => {
+      const mockBundleId = faker.string.sample();
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockUserId = faker.string.uuid();
+      const mockPurchase = { userId: faker.string.uuid() };
+      jest
+        .spyOn(appleIapService, 'getSubscriptionPurchase')
+        .mockResolvedValue(mockPurchase as AppStoreSubscriptionPurchase);
+
+      await expect(() =>
+        appleIapService.registerToUserAccount(
+          mockBundleId,
+          mockOriginalTransactionId,
+          mockUserId
+        )
+      ).rejects.toThrowError(AppleIapConflictError);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'registerToUserAccount.PurchaseUpdateError.Conflict',
+        {
+          err: expect.any(AppleIapConflictError),
+          originalTransactionId: mockOriginalTransactionId,
+        }
+      );
+    });
+  });
+
+  describe('processNotification', () => {
+    it('returns null for not application notifications', async () => {
+      const mockBundleId = faker.string.sample();
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockNotification = {
+        notificationType: NOTIFICATION_TYPES_FOR_NON_SUBSCRIPTION_PURCHASES[0],
+      } as DecodedNotificationPayload;
+      const mockPurchase = { userId: faker.string.uuid() };
+
+      jest
+        .spyOn(appleIapPurchaseManager, 'getFromAppStoreAPI')
+        .mockResolvedValue(mockPurchase as AppStoreSubscriptionPurchase);
+      const result = await appleIapService.processNotification(
+        mockBundleId,
+        mockOriginalTransactionId,
+        mockNotification
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null for new subscriptions', async () => {
+      const mockBundleId = faker.string.sample();
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockNotification = {
+        notificationType: NotificationType.Subscribed,
+        subtype: NotificationSubtype.InitialBuy,
+      } as DecodedNotificationPayload;
+      const mockPurchase = { userId: faker.string.uuid() };
+
+      jest
+        .spyOn(appleIapPurchaseManager, 'getFromAppStoreAPI')
+        .mockResolvedValue(mockPurchase as AppStoreSubscriptionPurchase);
+      const result = await appleIapService.processNotification(
+        mockBundleId,
+        mockOriginalTransactionId,
+        mockNotification
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns a subscription for other valid subscription notifications', async () => {
+      const mockBundleId = faker.string.sample();
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockNotification = {
+        notificationType: NotificationType.DidRenew,
+      } as DecodedNotificationPayload;
+      const mockPurchase = { userId: faker.string.uuid() };
+
+      jest
+        .spyOn(appleIapPurchaseManager, 'getFromAppStoreAPI')
+        .mockResolvedValue(mockPurchase as AppStoreSubscriptionPurchase);
+      const result = await appleIapService.processNotification(
+        mockBundleId,
+        mockOriginalTransactionId,
+        mockNotification
+      );
+      expect(result).toEqual(mockPurchase);
+    });
+  });
+
+  describe('getSubscriptionPurchase', () => {
+    it('returns subscription purchase', async () => {
+      const mockOriginalTransactionId = faker.string.uuid();
+      const mockPurchase = { userId: faker.string.uuid() };
+      jest
+        .spyOn(appleIapPurchaseManager, 'getStaleCached')
+        .mockResolvedValue(mockPurchase as AppStoreSubscriptionPurchase);
+
+      const result = await appleIapService.getSubscriptionPurchase(
+        mockOriginalTransactionId
+      );
+      expect(result).toEqual(mockPurchase);
+    });
+  });
+});

--- a/libs/payments/iap/src/lib/apple/apple-iap.service.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.service.ts
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  DecodedNotificationPayload,
+  NotificationSubtype,
+  NotificationType,
+} from 'app-store-server-api';
+import { AppleIapPurchaseManager } from './apple-iap-purchase.manager';
+import {
+  AppleIapConflictError,
+  AppleIapInvalidOriginalTransactionIdError,
+} from './apple-iap.error';
+import { NOTIFICATION_TYPES_FOR_NON_SUBSCRIPTION_PURCHASES } from './constants';
+import { AppStoreSubscriptionPurchase } from './subscription-purchase';
+
+@Injectable()
+export class AppleIapService {
+  constructor(
+    private appleIapPurchaseManager: AppleIapPurchaseManager,
+    private log: Logger
+  ) {}
+
+  /**
+   * Register a purchase (autorenewing subscription) to a user.
+   * It's intended to be exposed to the iOS app to verify purchases made in the app.
+   */
+  async registerToUserAccount(
+    bundleId: string,
+    originalTransactionId: string,
+    userId: string
+  ) {
+    // STEP 1. Check if the purchase record is already in Firestore
+    let purchase = await this.getSubscriptionPurchase(originalTransactionId);
+    if (!purchase) {
+      // STEP 1b. Query App Store Server API to verify the purchase
+      try {
+        purchase = await this.appleIapPurchaseManager.getFromAppStoreAPI(
+          bundleId,
+          originalTransactionId
+        );
+      } catch (err) {
+        // Error when attempt to query purchase. Return not found error to caller.
+        const libraryError = new AppleIapInvalidOriginalTransactionIdError(
+          'Invalid original transaction id',
+          { cause: err }
+        );
+        this.log.error(
+          'registerToUserAccount.PurchaseUpdateError.InvalidOriginalTransactionId',
+          {
+            err: libraryError,
+            originalTransactionId,
+          }
+        );
+        throw libraryError;
+      }
+    }
+    // Unlike Google Play subscriptions, We don't need to check if the purchase is
+    // registerable (i.e. not terminal), since the original transaction ID is
+    // the primary key in Firestore, and it can be "revived at any time if the customer
+    // returns to any SKU in that subscription group".
+    // See https://developer.apple.com/forums/thread/704167.
+
+    // STEP 2. Check if the purchase has been registered to a user. If it is, then return conflict error to our caller.
+    if (purchase.userId === userId) {
+      // Purchase record already registered to the target user. We'll do nothing.
+      return purchase;
+    } else if (purchase.userId) {
+      // this.log.info('Purchase already registered', { purchase });
+      // Purchase record already registered to different user. Return 'conflict' to caller
+      const libraryError = new AppleIapConflictError(
+        'Purchase has been registered to another user'
+      );
+      this.log.error('registerToUserAccount.PurchaseUpdateError.Conflict', {
+        err: libraryError,
+        originalTransactionId,
+      });
+      throw libraryError;
+    }
+
+    // STEP 3: Register purchase to the user
+    await this.appleIapPurchaseManager.forceRegisterToUser(
+      originalTransactionId,
+      userId
+    );
+
+    return purchase;
+  }
+
+  /**
+   * Update Firestore with the latest subscription status information from
+   * the App Store Server.
+   *
+   * See https://developer.apple.com/documentation/appstoreservernotifications/notificationtype
+   * and https://developer.apple.com/documentation/appstoreservernotifications/subtype
+   */
+  async processNotification(
+    bundleId: string,
+    originalTransactionId: string,
+    notification: DecodedNotificationPayload
+  ): Promise<AppStoreSubscriptionPurchase | null> {
+    // Type-guard to ensure the notification is for a subscription
+    if (
+      NOTIFICATION_TYPES_FOR_NON_SUBSCRIPTION_PURCHASES.includes(
+        notification.notificationType
+      )
+    ) {
+      return null;
+    }
+
+    // We can safely ignore Subscribed - InitialBuy notifications, because
+    // with a new subscription, our iOS app will send the same original
+    // transaction ID to the server for verification.
+    if (
+      notification.notificationType === NotificationType.Subscribed &&
+      notification?.subtype === NotificationSubtype.InitialBuy
+    ) {
+      return null;
+    }
+
+    // For other types of notifications, we query the App Store Server API
+    // to update our purchase record cache in Firestore
+    return this.appleIapPurchaseManager.getFromAppStoreAPI(
+      bundleId,
+      originalTransactionId,
+      notification.notificationType,
+      notification?.subtype
+    );
+  }
+
+  async getSubscriptionPurchase(originalTransactionId: string) {
+    return this.appleIapPurchaseManager.getStaleCached(originalTransactionId);
+  }
+}

--- a/libs/payments/iap/src/lib/apple/constants.ts
+++ b/libs/payments/iap/src/lib/apple/constants.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { NotificationType } from 'app-store-server-api';
+
+export const NOTIFICATION_TYPES_FOR_NON_SUBSCRIPTION_PURCHASES = [
+  NotificationType.ConsumptionRequest,
+];


### PR DESCRIPTION
## This pull request

- [x] Create AppleIapService, and add the following methods:
  - [x] registerToUserAccount
  - [x] processNotification
  - [x] getSubscriptionPurchase
- [x] Copy existing and add new unit tests

## Issue that this pull request solves

Closes: FXA-10730

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.