### PR TITLE
feat(iap): add google iap service

### DIFF
--- a/libs/payments/iap/src/lib/google/factories.ts
+++ b/libs/payments/iap/src/lib/google/factories.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import {
+  DeveloperNotification,
+  NotificationType,
+  SubscriptionNotification,
+} from './types';
+
+export const SubscriptionNotificationFactory = (
+  override?: Partial<SubscriptionNotification>
+): SubscriptionNotification => ({
+  version: `${faker.number.float({ min: 1.0, max: 5.0 })}`,
+  notificationType: faker.helpers.enumValue(NotificationType),
+  purchaseToken: faker.string.uuid(),
+  subscriptionId: `sub_${faker.string.alphanumeric({ length: 24 })}`,
+  ...override,
+});
+
+export const DeveloperNotificationFactory = (
+  override?: Partial<DeveloperNotification>
+): DeveloperNotification => ({
+  version: `${faker.number.float({ min: 1.0, max: 5.0 })}`,
+  packageName: faker.internet.domainName(),
+  eventTimeMillis: faker.date.recent().getTime(),
+  ...override,
+});

--- a/libs/payments/iap/src/lib/google/google-iap-purchase.manager.ts
+++ b/libs/payments/iap/src/lib/google/google-iap-purchase.manager.ts
@@ -73,12 +73,15 @@ export class GoogleIapPurchaseManager {
         );
       }
 
+      if (purchase.isAccountHold() || purchase.isPaused()) {
+        this.log.log('getForUser.accountHoldOrPaused', {
+          purchaseToken: purchase.purchaseToken,
+          userId: purchase.userId,
+        });
+      }
+
       // Add the updated purchase to list to returned to clients
-      if (
-        purchase.isEntitlementActive() ||
-        purchase.isAccountHold() ||
-        purchase.isPaused()
-      ) {
+      if (purchase.isEntitlementActive()) {
         purchaseList.push(purchase);
       }
     }

--- a/libs/payments/iap/src/lib/google/google-iap.error.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.error.ts
@@ -27,3 +27,15 @@ export class GoogleIapUnknownError extends GoogleIapError {
     super(...args);
   }
 }
+
+export class GoogleIapInvalidPurchaseTokenError extends GoogleIapError {
+  constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
+    super(...args);
+  }
+}
+
+export class GoogleIapConflictError extends GoogleIapError {
+  constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
+    super(...args);
+  }
+}

--- a/libs/payments/iap/src/lib/google/google-iap.service.spec.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.service.spec.ts
@@ -1,0 +1,245 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Test } from '@nestjs/testing';
+import { GoogleIapPurchaseManager } from './google-iap-purchase.manager';
+import { GoogleIapService } from './google-iap.service';
+import { MockGoogleIapClientConfigProvider } from './google-iap.client.config';
+import { GoogleIapClient } from './google-iap.client';
+import { FirestoreService } from '@fxa/shared/db/firestore';
+import { Logger } from '@nestjs/common';
+import { faker } from '@faker-js/faker';
+import { FirestoreGoogleIapPurchaseRecordFactory } from '../factories';
+import { PlayStoreSubscriptionPurchase } from './subscription-purchase';
+import { NotificationType } from './types';
+import {
+  DeveloperNotificationFactory,
+  SubscriptionNotificationFactory,
+} from './factories';
+import assert from 'assert';
+import {
+  GoogleIapConflictError,
+  GoogleIapInvalidPurchaseTokenError,
+} from './google-iap.error';
+
+describe('GoogleIapService', () => {
+  let service: GoogleIapService;
+  let manager: GoogleIapPurchaseManager;
+  let logger: Logger;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MockGoogleIapClientConfigProvider,
+        GoogleIapService,
+        GoogleIapPurchaseManager,
+        GoogleIapClient,
+        {
+          provide: FirestoreService,
+          useValue: {
+            collection: jest.fn().mockReturnValue({}),
+          },
+        },
+        {
+          provide: Logger,
+          useValue: {
+            log: jest.fn(),
+            debug: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    manager = module.get(GoogleIapPurchaseManager);
+    service = module.get(GoogleIapService);
+    logger = module.get(Logger);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getActiveSubscriptions', () => {
+    const purchaseToken = faker.string.uuid();
+    const firestoreRecord = FirestoreGoogleIapPurchaseRecordFactory({
+      purchaseToken,
+    });
+    const activeSubscription =
+      PlayStoreSubscriptionPurchase.fromFirestoreObject(firestoreRecord);
+    activeSubscription.isEntitlementActive = jest.fn().mockReturnValue(true);
+
+    it('returns active Google Play subscription purchases', async () => {
+      jest.spyOn(manager, 'getForUser').mockResolvedValue([activeSubscription]);
+
+      const result = await service.getActiveSubscriptions('testUserId');
+
+      expect(result).toEqual([activeSubscription]);
+    });
+
+    // TODO - Part of FXA-7839
+    //it('returns [] if PlayBilling is undefined', async () => {});
+  });
+
+  describe('processNotification', () => {
+    const mockNotification = DeveloperNotificationFactory();
+    const purchaseToken = faker.string.uuid();
+    const firestoreRecord = FirestoreGoogleIapPurchaseRecordFactory({
+      purchaseToken,
+    });
+    const subscription =
+      PlayStoreSubscriptionPurchase.fromFirestoreObject(firestoreRecord);
+
+    beforeEach(() => {
+      jest
+        .spyOn(manager, 'getFromPlayStoreApi')
+        .mockResolvedValue(subscription);
+    });
+
+    it('returns null without a notification', async () => {
+      const result = await service.processNotification(
+        'testPackage',
+        mockNotification
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null with a SUBSCRIPTION_PURCHASED type', async () => {
+      const mockNotification = DeveloperNotificationFactory({
+        subscriptionNotification: SubscriptionNotificationFactory({
+          notificationType: NotificationType.SUBSCRIPTION_PURCHASED,
+        }),
+      });
+      const result = await service.processNotification(
+        'testPackage',
+        mockNotification
+      );
+      expect(result).toBeNull();
+      expect(manager.getFromPlayStoreApi).not.toHaveBeenCalled();
+    });
+
+    it('returns a subscription for other valid subscription notifications', async () => {
+      const mockNotification = DeveloperNotificationFactory({
+        subscriptionNotification: SubscriptionNotificationFactory({
+          notificationType: NotificationType.SUBSCRIPTION_RENEWED,
+        }),
+      });
+      const result = await service.processNotification(
+        'testPackage',
+        mockNotification
+      );
+      expect(result).toEqual(subscription);
+      expect(manager.getFromPlayStoreApi).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('registerToUserAccount', () => {
+    const purchaseToken = faker.string.uuid();
+    const mockUserId = faker.string.uuid();
+    const firestoreRecord = FirestoreGoogleIapPurchaseRecordFactory({
+      purchaseToken,
+      userId: undefined,
+    });
+    const firestoreRecordWithUserId = FirestoreGoogleIapPurchaseRecordFactory({
+      purchaseToken,
+      userId: mockUserId,
+    });
+    const subscription =
+      PlayStoreSubscriptionPurchase.fromFirestoreObject(firestoreRecord);
+    const subscriptionWithUserId =
+      PlayStoreSubscriptionPurchase.fromFirestoreObject(
+        firestoreRecordWithUserId
+      );
+
+    beforeEach(() => {
+      subscription.isRegisterable = jest.fn().mockReturnValue(true);
+      jest.spyOn(manager, 'getStaleCached').mockResolvedValue(undefined);
+      jest
+        .spyOn(manager, 'getFromPlayStoreApi')
+        .mockResolvedValue(subscription);
+      jest.spyOn(manager, 'forceRegisterToUser').mockResolvedValue();
+    });
+
+    it('registers successfully for non-cached token', async () => {
+      const result = await service.registerToUserAccount(
+        'testPackage',
+        'testSku',
+        'testToken',
+        mockUserId
+      );
+      expect(result).toEqual(subscription);
+      expect(manager.getFromPlayStoreApi).toHaveBeenCalledTimes(1);
+      expect(manager.forceRegisterToUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips doing anything for cached token', async () => {
+      jest
+        .spyOn(manager, 'getStaleCached')
+        .mockResolvedValue(subscriptionWithUserId);
+      const result = await service.registerToUserAccount(
+        'testPackage',
+        'testSku',
+        'testToken',
+        mockUserId
+      );
+      expect(result).toEqual(subscriptionWithUserId);
+      expect(manager.getFromPlayStoreApi).not.toHaveBeenCalled();
+      expect(manager.forceRegisterToUser).not.toHaveBeenCalled();
+    });
+
+    it('throws conflict error for existing token registered to other user', async () => {
+      jest
+        .spyOn(manager, 'getStaleCached')
+        .mockResolvedValue(subscriptionWithUserId);
+      try {
+        await service.registerToUserAccount(
+          'testPackage',
+          'testSku',
+          'testToken',
+          `different-${mockUserId}`
+        );
+        assert.fail('Expected error');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GoogleIapConflictError);
+        expect(logger.log).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('throws invalid token error on non-registerable purchase', async () => {
+      subscription.isRegisterable = jest.fn().mockReturnValue(false);
+      jest.spyOn(manager, 'getStaleCached').mockResolvedValue(subscription);
+      try {
+        await service.registerToUserAccount(
+          'testPackage',
+          'testSku',
+          'testToken',
+          'testUserId'
+        );
+        assert.fail('Expected error');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GoogleIapInvalidPurchaseTokenError);
+        expect(subscription.isRegisterable).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('throws invalid token error if purchase cant be queried', async () => {
+      jest
+        .spyOn(manager, 'getFromPlayStoreApi')
+        .mockRejectedValue(new Error('Oops'));
+      try {
+        await service.registerToUserAccount(
+          'testPackage',
+          'testSku',
+          'testToken',
+          'testUserId'
+        );
+        assert.fail('Expected error');
+      } catch (err) {
+        expect(err).toBeInstanceOf(GoogleIapInvalidPurchaseTokenError);
+        expect(err.message).toBe('Oops');
+      }
+    });
+  });
+});

--- a/libs/payments/iap/src/lib/google/google-iap.service.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.service.ts
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  AppendedPlayStoreSubscriptionPurchase,
+  DeveloperNotification,
+  NotificationType,
+} from './types';
+import { GoogleIapPurchaseManager } from './google-iap-purchase.manager';
+import { PlayStoreSubscriptionPurchase } from './subscription-purchase';
+import {
+  GoogleIapConflictError,
+  GoogleIapInvalidPurchaseTokenError,
+} from './google-iap.error';
+
+@Injectable()
+export class GoogleIapService {
+  constructor(
+    private purchaseManager: GoogleIapPurchaseManager,
+    private log: Logger
+  ) {}
+
+  async getActiveSubscriptions(
+    uid: string
+  ): Promise<AppendedPlayStoreSubscriptionPurchase[]> {
+    const purchases = await this.purchaseManager.getForUser(uid);
+
+    // Below to be completed as part of FXA-7839
+    //return this.stripeHelper.addPriceInfoToIapPurchases(
+    //  purchases,
+    //  MozillaSubscriptionTypes.IAP_GOOGLE
+    //);
+    return purchases as AppendedPlayStoreSubscriptionPurchase[];
+  }
+
+  async processNotification(
+    packageName: string,
+    notification: DeveloperNotification
+  ): Promise<PlayStoreSubscriptionPurchase | null> {
+    // Type-guard for a real-time developer notification.
+    const subscriptionNotification = notification.subscriptionNotification;
+    if (!subscriptionNotification) {
+      return null;
+    }
+    if (
+      subscriptionNotification.notificationType !==
+      NotificationType.SUBSCRIPTION_PURCHASED
+    ) {
+      // We can safely ignore SUBSCRIPTION_PURCHASED because with new subscription, our Android app will send the same token to server for verification
+      // For other type of notification, we query Play Developer API to update our purchase record cache in Firestore
+      return this.purchaseManager.getFromPlayStoreApi(
+        packageName,
+        subscriptionNotification.subscriptionId,
+        subscriptionNotification.purchaseToken,
+        subscriptionNotification.notificationType
+      );
+    }
+
+    return null;
+  }
+
+  async registerToUserAccount(
+    packageName: string,
+    sku: string,
+    purchaseToken: string,
+    userId: string
+  ): Promise<PlayStoreSubscriptionPurchase> {
+    // The original Google Play sample code did not use Google API efficiency
+    // guidelines, the updated version here checks our local Firestore record
+    // first to determine if we've seen the token before, and if not, it will
+    // query Play Developer API to verify the purchase.
+    // https://developer.android.com/google/play/developer-api#subscriptions
+
+    // STEP 1. Check if the purchase record is already in Firestore
+    let purchase = await this.purchaseManager.getStaleCached(purchaseToken);
+    if (!purchase) {
+      // STEP 1b. Query Play Developer API to verify the purchase
+      try {
+        purchase = await this.purchaseManager.getFromPlayStoreApi(
+          packageName,
+          sku,
+          purchaseToken
+        );
+      } catch (err) {
+        // Error when attempt to query purchase. Return invalid token to caller.
+        throw new GoogleIapInvalidPurchaseTokenError(err.message, {
+          info: { purchaseToken, userId },
+        });
+      }
+    }
+
+    // STEP 2. Check if the purchase is registerable.
+    if (!purchase.isRegisterable()) {
+      throw new GoogleIapInvalidPurchaseTokenError(
+        'Purchase is not registerable',
+        { info: { purchaseToken, userId } }
+      );
+    }
+
+    // STEP 3. Check if the purchase has been registered to an user. If it is, then return conflict error to our caller.
+    if (purchase.userId === userId) {
+      // Purchase record already registered to the target user. We'll do nothing.
+      return purchase;
+    } else if (purchase.userId) {
+      this.log.log('purchase already registered', { purchase });
+      // Purchase record already registered to different user. Return 'conflict' to caller
+      throw new GoogleIapConflictError(
+        'Purchase has been registered to another user',
+        { info: { purchaseToken, userId } }
+      );
+    }
+
+    // STEP 3: Register purchase to the user
+    await this.purchaseManager.forceRegisterToUser(purchaseToken, userId);
+
+    return purchase;
+  }
+}

--- a/libs/payments/iap/src/lib/google/types.ts
+++ b/libs/payments/iap/src/lib/google/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { IapExtraStripeInfo } from '../types';
+import { PlayStoreSubscriptionPurchase } from './subscription-purchase';
+
 // This file defines types that are exposed externally to the library consumers.
 
 /* An abstract representation of a purchase made via Google Play Billing
@@ -93,3 +96,6 @@ export enum NotificationType {
   SUBSCRIPTION_REVOKED = 12,
   SUBSCRIPTION_EXPIRED = 13,
 }
+
+export type AppendedPlayStoreSubscriptionPurchase =
+  PlayStoreSubscriptionPurchase & IapExtraStripeInfo;

--- a/libs/payments/iap/src/lib/types.ts
+++ b/libs/payments/iap/src/lib/types.ts
@@ -55,3 +55,9 @@ export interface FirestoreGoogleIapPurchaseRecord {
   verifiedAt: number;
   latestNotificationType?: number;
 }
+
+export type IapExtraStripeInfo = {
+  product_id: string;
+  product_name: string;
+  price_id: string;
+};


### PR DESCRIPTION
## Because

- Move and restructure existing Google IAP methods into the new libs Google IAP Service

## This pull request

- Moves the logic and tests for the methods listed below, with minor restructuring, into GoogleIapService
  - getActiveSubscriptions
  - processNotification
  - registerToUserAccount

## Issue that this pull request solves

Closes: #FXA-10731

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This PR varies slightly from what was initially listed as a requirement in the Jira ticket, since some of the work was done in a previous ticket, and some work is no longer required. The Jira ticket has been updated to reflect the differences.
