### PR TITLE
fix(next): do not allow special chars in postal code

### DIFF
--- a/libs/google/src/lib/factories.ts
+++ b/libs/google/src/lib/factories.ts
@@ -8,6 +8,7 @@ import {
   LocationType,
   PlaceType2,
 } from '@googlemaps/google-maps-services-js';
+import { GeocodeRequestParamsOnly } from './types';
 
 export const GeocodeResultFactory = (
   override?: Partial<GeocodeResult>
@@ -45,5 +46,11 @@ export const GeocodeResultFactory = (
   },
   partial_match: faker.datatype.boolean(),
   place_id: faker.string.uuid(),
+  ...override,
+});
+
+export const GeocodeRequestParamsOnlyFactory = (
+  override?: Partial<GeocodeRequestParamsOnly>
+): GeocodeRequestParamsOnly => ({
   ...override,
 });

--- a/libs/google/src/lib/google.client.spec.ts
+++ b/libs/google/src/lib/google.client.spec.ts
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Test } from '@nestjs/testing';
-import { GeocodeResultFactory } from './factories';
+import {
+  GeocodeRequestParamsOnlyFactory,
+  GeocodeResultFactory,
+} from './factories';
 import { GoogleClient } from './google.client';
 import { MockGoogleClientConfigProvider } from './google.client.config';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
@@ -44,7 +47,9 @@ describe('GoogleClient', () => {
   describe('geocode', () => {
     it('should return a response', async () => {
       const mockPostalCode = '90210';
-      const mockCountryCode = 'US';
+      const params = GeocodeRequestParamsOnlyFactory({
+        address: mockPostalCode,
+      });
       const mockResponse = {
         data: {
           results: [
@@ -57,10 +62,13 @@ describe('GoogleClient', () => {
 
       mockGoogleMapsGeocode.mockResolvedValue(mockResponse);
 
-      const result = await googleClient.geocode(
-        mockPostalCode,
-        mockCountryCode
-      );
+      const result = await googleClient.geocode(params);
+      expect(mockGoogleMapsGeocode).toHaveBeenCalledWith({
+        params: {
+          ...params,
+          key: expect.any(String),
+        },
+      });
       expect(result).toEqual(mockResponse.data);
     });
   });

--- a/libs/google/src/lib/google.client.ts
+++ b/libs/google/src/lib/google.client.ts
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  Client,
-  GeocodeResponseData,
-} from '@googlemaps/google-maps-services-js';
+import { Client } from '@googlemaps/google-maps-services-js';
 import { Inject, Injectable } from '@nestjs/common';
 import { GoogleClientConfig } from './google.client.config';
 import {
@@ -13,6 +10,7 @@ import {
   StatsDService,
   type StatsD,
 } from '@fxa/shared/metrics/statsd';
+import type { GeocodeRequestParamsOnly } from './types';
 
 @Injectable()
 export class GoogleClient {
@@ -29,15 +27,14 @@ export class GoogleClient {
    * https://developers.google.com/maps/documentation/geocoding/overview
    */
   @CaptureTimingWithStatsD()
-  async geocode(address: string, countryCode: string) {
+  async geocode(params: GeocodeRequestParamsOnly) {
     const response = await this.google.geocode({
       params: {
-        address,
-        components: `country:${countryCode}`,
+        ...params,
         key: this.googleClientConfig.googleMapsApiKey,
       },
     });
 
-    return response.data as GeocodeResponseData;
+    return response.data;
   }
 }

--- a/libs/google/src/lib/google.manager.spec.ts
+++ b/libs/google/src/lib/google.manager.spec.ts
@@ -28,15 +28,15 @@ describe('GoogleManager', () => {
     googleManager = module.get<GoogleManager>(GoogleManager);
   });
 
-  describe('isValidPostalCode', () => {
+  describe('validateAndFormatPostalCode', () => {
     it('should return true - US', async () => {
       const mockResponseData = {
         results: [
           GeocodeResultFactory({
             address_components: [
               {
-                long_name: 'United States',
-                short_name: 'US',
+                long_name: '90210',
+                short_name: '90210',
                 types: ['postal_code'] as PlaceType2[],
               },
             ],
@@ -50,8 +50,14 @@ describe('GoogleManager', () => {
 
       jest.spyOn(googleClient, 'geocode').mockResolvedValue(mockResponseData);
 
-      const response = await googleManager.isValidPostalCode('90210', 'US');
-      expect(response).toBe(true);
+      const response = await googleManager.validateAndFormatPostalCode(
+        '90210',
+        'US'
+      );
+      expect(response).toEqual({
+        isValid: true,
+        formattedPostalCode: '90210',
+      });
     });
 
     it('should return true - CA', async () => {
@@ -60,8 +66,8 @@ describe('GoogleManager', () => {
           GeocodeResultFactory({
             address_components: [
               {
-                long_name: 'Canada',
-                short_name: 'CA',
+                long_name: 'A1A 1A1',
+                short_name: 'A1A 1A1',
                 types: ['postal_code'] as PlaceType2[],
               },
             ],
@@ -75,8 +81,14 @@ describe('GoogleManager', () => {
 
       jest.spyOn(googleClient, 'geocode').mockResolvedValue(mockResponseData);
 
-      const response = await googleManager.isValidPostalCode('A1A 1A1', 'CA');
-      expect(response).toBe(true);
+      const response = await googleManager.validateAndFormatPostalCode(
+        'A1A1A1',
+        'CA'
+      );
+      expect(response).toEqual({
+        isValid: true,
+        formattedPostalCode: 'A1A 1A1',
+      });
     });
 
     it('should return false - 00000', async () => {
@@ -100,8 +112,13 @@ describe('GoogleManager', () => {
 
       jest.spyOn(googleClient, 'geocode').mockResolvedValue(mockResponseData);
 
-      const response = await googleManager.isValidPostalCode('00000', 'US');
-      expect(response).toBe(false);
+      const response = await googleManager.validateAndFormatPostalCode(
+        '00000',
+        'US'
+      );
+      expect(response).toEqual({
+        isValid: false,
+      });
     });
 
     it('should return false - 1234', async () => {
@@ -124,8 +141,13 @@ describe('GoogleManager', () => {
       };
       jest.spyOn(googleClient, 'geocode').mockResolvedValue(mockResponseData);
 
-      const response = await googleManager.isValidPostalCode('1234', 'US');
-      expect(response).toBe(false);
+      const response = await googleManager.validateAndFormatPostalCode(
+        '1234',
+        'US'
+      );
+      expect(response).toEqual({
+        isValid: false,
+      });
     });
   });
 });

--- a/libs/google/src/lib/types.ts
+++ b/libs/google/src/lib/types.ts
@@ -1,0 +1,6 @@
+import { GeocodeRequest } from '@googlemaps/google-maps-services-js';
+
+export type GeocodeRequestParamsOnly = Pick<
+  GeocodeRequest['params'],
+  'place_id' | 'address' | 'bounds' | 'region' | 'language' | 'components'
+>;

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -20,4 +20,4 @@ export { finalizeCartWithError } from './finalizeCartWithError';
 export { finalizeProcessingCartAction } from './finalizeProcessingCart';
 export { getNeedsInputAction } from './getNeedsInput';
 export { submitNeedsInputAndRedirectAction } from './submitNeedsInputAndRedirect';
-export { validatePostalCode } from './validatePostalCode';
+export { validateAndFormatPostalCode } from './validateAndFormatPostalCode';

--- a/libs/payments/ui/src/lib/actions/validateAndFormatPostalCode.ts
+++ b/libs/payments/ui/src/lib/actions/validateAndFormatPostalCode.ts
@@ -6,8 +6,11 @@
 
 import { getApp } from '../nestapp/app';
 
-export const validatePostalCode = (postalCode: string, countryCode: string) => {
-  return getApp().getActionsService().validatePostalCode({
+export const validateAndFormatPostalCode = (
+  postalCode: string,
+  countryCode: string
+) => {
+  return getApp().getActionsService().validateAndFormatPostalCode({
     postalCode,
     countryCode,
   });

--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
@@ -9,7 +9,7 @@ import * as Form from '@radix-ui/react-form';
 import countries from 'i18n-iso-countries';
 import { useEffect, useState } from 'react';
 import { ButtonVariant, SubmitButton } from '@fxa/payments/ui';
-import { validatePostalCode } from '@fxa/payments/ui/actions';
+import { validateAndFormatPostalCode } from '@fxa/payments/ui/actions';
 import { useSearchParams } from 'next/navigation';
 
 interface CollapsedProps {
@@ -173,15 +173,19 @@ const Expanded = ({
 
     try {
       if (selectedCountryCode && selectedPostalCode) {
-        const { isValid } = await validatePostalCode(
-          selectedPostalCode,
-          selectedCountryCode
-        );
+        const { isValid, formattedPostalCode } =
+          await validateAndFormatPostalCode(
+            selectedPostalCode,
+            selectedCountryCode
+          );
 
         if (!isValid) {
           setServerErrors((prev) => ({ ...prev, invalidPostalCode: true }));
         } else {
-          saveAction(selectedCountryCode, selectedPostalCode);
+          saveAction(
+            selectedCountryCode,
+            formattedPostalCode || selectedPostalCode
+          );
         }
       }
     } catch (err) {

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -298,15 +298,14 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(ValidatePostalCodeActionArgs, ValidatePostalCodeActionResult)
-  async validatePostalCode(args: { postalCode: string; countryCode: string }) {
-    const isValid = await this.googleManager.isValidPostalCode(
+  async validateAndFormatPostalCode(args: {
+    postalCode: string;
+    countryCode: string;
+  }) {
+    return await this.googleManager.validateAndFormatPostalCode(
       args.postalCode,
       args.countryCode
     );
-
-    return {
-      isValid,
-    };
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/ValidatePostalCodeActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/ValidatePostalCodeActionResult.ts
@@ -2,9 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsBoolean } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class ValidatePostalCodeActionResult {
   @IsBoolean()
   isValid!: boolean;
+
+  @IsString()
+  @IsOptional()
+  formattedPostalCode?: string;
 }


### PR DESCRIPTION
## Because

- Postal code currently allows special characters to be saved as a valid postal code.

## This pull request

- Validate postal code action returns formatted postal code
- Update Google geocode to validate postal code specifically

## Issue that this pull request solves

Closes: #FXA-11359

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

(Note in the image below, white space is manually added to the start and end of the postal code. These are automatically removed by Google Geocode)
![image](https://github.com/user-attachments/assets/87128fc6-ccf7-47c0-8451-474602c096ef)

![image](https://github.com/user-attachments/assets/2c666f4f-2a6c-4f82-b7e8-612a024c959e)


## Other information (Optional)

Any other information that is important to this pull request.
