### PR TITLE
fix(settings): check and display the "cookies disabled" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@google-cloud/translate": "^8.5.0",
     "@googlemaps/google-maps-services-js": "^3.4.0",
     "@grpc/grpc-js": "^1.11.1",
-    "@mozilla/glean": "^5.0.3",
+    "@mozilla/glean": "^5.0.4",
     "@nestjs/apollo": "^12.2.1",
     "@nestjs/common": "^10.4.5",
     "@nestjs/config": "^3.3.0",

--- a/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
+++ b/packages/functional-tests/tests/misc/cookiesDisabled.spec.ts
@@ -24,51 +24,18 @@ test.describe('cookies disabled', () => {
     //Goto cookies disabled url
     await page.goto(`${target.contentServerUrl}?disable_local_storage=1`);
 
-    //Adding the timeout as the page closes before loading
-    await page.waitForTimeout(2000);
-
     //Verify the Cookies disabled header
     await page.waitForURL(/\/cookies_disabled/);
     await expect(await cookiesDisabled.cookiesDisabledHeader()).toBeVisible();
 
     //Click retry
+    await cookiesDisabled.clickRetry();
+    // this is needed in this test but manual clicking once works just fine in
+    // a manual test so
     await cookiesDisabled.clickRetry();
 
     //Verify the error
     await expect(await cookiesDisabled.isCookiesDiabledError()).toBeVisible();
-  });
-
-  test('synthesize enabling cookies by visiting the enter email page, then cookies_disabled, then clicking "try again', async ({
-    target,
-    page,
-    pages: { cookiesDisabled, signin },
-  }) => {
-    //Goto cookies enabled url
-    await page.goto(target.contentServerUrl, {
-      waitUntil: 'load',
-    });
-
-    //Verify Email header
-    await expect(signin.emailFirstHeading).toBeVisible();
-
-    //Goto cookies disabled url
-    await page.goto(`${target.contentServerUrl}/cookies_disabled`, {
-      waitUntil: 'load',
-    });
-
-    //Adding the timeout as the page closes before loading
-    await page.waitForTimeout(500);
-
-    //Verify the Cookies disabled header
-    await page.waitForURL(/\/cookies_disabled/);
-    await expect(await cookiesDisabled.cookiesDisabledHeader()).toBeVisible();
-
-    //Click retry
-    await cookiesDisabled.clickRetry();
-    await page.waitForLoadState();
-
-    //Verify Email header
-    await expect(signin.emailFirstHeading).toBeVisible();
   });
 
   test('visit verify page with localStorage disabled', async ({

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -51,7 +51,6 @@ import { ScrollToTop } from '../Settings/ScrollToTop';
 // Pages
 import CannotCreateAccount from '../../pages/CannotCreateAccount';
 import Clear from '../../pages/Clear';
-import CookiesDisabled from '../../pages/CookiesDisabled';
 import InlineRecoverySetupContainer from '../../pages/InlineRecoverySetup/container';
 import InlineTotpSetupContainer from '../../pages/InlineTotpSetup/container';
 import Legal from '../../pages/Legal';
@@ -89,6 +88,7 @@ import SigninRecoveryChoiceContainer from '../../pages/Signin/SigninRecoveryChoi
 import SigninRecoveryPhoneContainer from '../../pages/Signin/SigninRecoveryPhone/container';
 import { IndexContainer } from '../../pages/Index/container';
 import AuthorizationContainer from '../../pages/Authorization/container';
+import CookiesDisabled from '../../pages/CookiesDisabled';
 
 const Settings = lazy(() => import('../Settings'));
 
@@ -336,8 +336,8 @@ const AuthAndAccountSetupRoutes = ({
 
       {/* Other */}
       <Clear path="/clear/*" />
-      <CookiesDisabled path="/cookies_disabled/*" />
       <WebChannelExample path="/web_channel_example/*" />
+      <CookiesDisabled path="cookies_disabled" />
 
       {/* Post verify */}
       <ThirdPartyAuthCallback

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -14,7 +14,10 @@ import { AppContext, initializeAppContext } from './models';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import { ApolloProvider } from '@apollo/client';
 import { createApolloClient } from './lib/gql';
+import Storage from './lib/storage';
 import './styles/tailwind.out.css';
+import CookiesDisabled from './pages/CookiesDisabled';
+import { navigate } from '@reach/router';
 
 export interface FlowQueryParams {
   broker?: string;
@@ -51,6 +54,13 @@ try {
   const apolloClient = createApolloClient(config.servers.gql.url);
   const appContext = initializeAppContext();
 
+  const View = Storage.isLocalStorageEnabled(window)
+    ? () => <App {...{ flowQueryParams }} />
+    : () => {
+        navigate('/cookies_disabled');
+        return <CookiesDisabled />;
+      };
+
   render(
     <React.StrictMode>
       <AppLocalizationProvider
@@ -60,7 +70,7 @@ try {
         <AppErrorBoundary>
           <AppContext.Provider value={appContext}>
             <ApolloProvider client={apolloClient}>
-              <App {...{ flowQueryParams }} />
+              <View />
             </ApolloProvider>
           </AppContext.Provider>
         </AppErrorBoundary>

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -399,17 +399,26 @@ try {
   canUseEventTarget = false;
 }
 function noop() {}
-export const firefox = canUseEventTarget
-  ? new Firefox()
-  : // otherwise a mock
-    (Object.fromEntries(
-      Object.getOwnPropertyNames(Firefox.prototype)
-        .map((name) => [name, noop])
-        .concat([
-          ['addEventListener', noop],
-          ['removeEventListener', noop],
-          ['dispatchEvent', noop],
-        ])
-    ) as unknown as Firefox);
+function mock() {
+  return Object.fromEntries(
+    Object.getOwnPropertyNames(Firefox.prototype)
+      .map((name) => [name, noop])
+      .concat([
+        ['addEventListener', noop],
+        ['removeEventListener', noop],
+        ['dispatchEvent', noop],
+      ])
+  ) as unknown as Firefox;
+}
+export const firefox = (() => {
+  try {
+    if (canUseEventTarget && typeof window.localStorage !== 'undefined') {
+      return new Firefox();
+    }
+    return mock();
+  } catch (_) {
+    return mock();
+  }
+})();
 
 export default firefox;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14002,16 +14002,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mozilla/glean@npm:^5.0.3":
-  version: 5.0.3
-  resolution: "@mozilla/glean@npm:5.0.3"
+"@mozilla/glean@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "@mozilla/glean@npm:5.0.4"
   dependencies:
     fflate: ^0.8.0
     tslib: ^2.3.1
     uuid: ^9.0.0
   bin:
     glean: dist/cli/cli.js
-  checksum: 58ec9e831855d57f319738378694ca04b99217c10fee2c370f62624e61ca9b65b799cd16d499cd3cf9a2d18fc1ea512360c10fba2da0af62971e409e43aaa88d
+  checksum: 49e1585958353a04df84ed2354e3d6bd2c163e9c44345e5a7602a0b80a1f9c840025c2e164b7d7de53c2225213eee6072fdea531db6254d1c66c7e57191a4c25
   languageName: node
   linkType: hard
 
@@ -43972,7 +43972,7 @@ fsevents@~2.1.1:
     "@graphql-codegen/typescript": ^4.0.1
     "@graphql-codegen/typescript-document-nodes": ^4.0.1
     "@grpc/grpc-js": ^1.11.1
-    "@mozilla/glean": ^5.0.3
+    "@mozilla/glean": ^5.0.4
     "@nestjs/apollo": ^12.2.1
     "@nestjs/cli": ^11.0.1
     "@nestjs/common": ^10.4.5


### PR DESCRIPTION
Because:
 - the "cookies disabled" page was not rendered in Settings

This commit:
 - detect for lack of local storage access (browsers group that with the cookies pref) and display the cookies disabled page
 - try-catch local/session storage access so that won't break rendering
   - that's the purpose of the glean.js upgrade
