### PR TITLE
bug(content): Fix statsd call for cirrus.response-time

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
+++ b/packages/fxa-content-server/server/lib/routes/post-nimbus-experiments.js
@@ -64,7 +64,7 @@ module.exports = function (options = {}, statsd) {
         const requestCompletedTime = Date.now();
         const responseTime = requestCompletedTime - requestReceivedTime;
         if (statsd) {
-          statsd.increment('cirrus.response-time', { responseTime });
+          statsd.timing('cirrus.response-time', responseTime);
         }
       }
     },


### PR DESCRIPTION
## Because

- Increment is the wrong type of statsd call to use here.
- This call was causing issues for telegraph

## This pull request

- Fixes the call by using `statsd.timing` instead

## Issue that this pull request solves

Closes: FXA-11466

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
