### PR TITLE
fix(tests): Fix and re-enable sync handshake functional tests

### DIFF
--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -19,11 +19,31 @@ test.describe('severity-2 #smoke', () => {
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            signedInUser: null,
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
       await page.goto(
         `${
           target.contentServerUrl
         }?context=fx_desktop_v3&service=sync&${query.toString()}`
       );
+
+      await signin.respondToWebChannelMessage(eventDetailStatus);
+      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+
       await expect(signin.syncSignInHeading).toBeVisible();
       await expect(signin.emailTextbox).toHaveValue('');
     });
@@ -33,10 +53,9 @@ test.describe('severity-2 #smoke', () => {
       syncBrowserPages: { page, signin },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
+      const syncCredentials = await testAccountTracker.signUpSync();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
-        email: credentials.email,
       });
       const eventDetailStatus: FxAStatusResponse = {
         id: 'account_updates',
@@ -44,9 +63,7 @@ test.describe('severity-2 #smoke', () => {
           command: FirefoxCommand.FxAStatus,
           data: {
             clientId: FF_OAUTH_CLIENT_ID,
-            signedInUser: {
-              email: credentials.email,
-            },
+            signedInUser: syncCredentials,
             capabilities: {
               engines: [],
               pairing: false,
@@ -62,8 +79,9 @@ test.describe('severity-2 #smoke', () => {
       );
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      // password confirmation required to sign in to sync
       await expect(signin.passwordFormHeading).toBeVisible();
-      await expect(page.getByText(credentials.email)).toBeVisible();
+      await expect(page.getByText(syncCredentials.email)).toBeVisible();
     });
 
     test('Sync force_auth page - user signed into browser is different to requested user', async ({
@@ -75,7 +93,7 @@ test.describe('severity-2 #smoke', () => {
       const syncCredentials = await testAccountTracker.signUpSync();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
-        email: syncCredentials.email,
+        email: credentials.email,
       });
       const eventDetailStatus: FxAStatusResponse = {
         id: 'account_updates',
@@ -83,9 +101,7 @@ test.describe('severity-2 #smoke', () => {
           command: FirefoxCommand.FxAStatus,
           data: {
             clientId: FF_OAUTH_CLIENT_ID,
-            signedInUser: {
-              email: credentials.email,
-            },
+            signedInUser: syncCredentials,
             capabilities: {
               engines: [],
               pairing: false,
@@ -103,7 +119,8 @@ test.describe('severity-2 #smoke', () => {
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       await expect(signin.passwordFormHeading).toBeVisible();
-      await expect(page.getByText(syncCredentials.email)).toBeVisible();
+      // email param takes precedence
+      await expect(page.getByText(credentials.email)).toBeVisible();
     });
 
     test('Sync - no user signed into browser, user signed in locally', async ({
@@ -111,7 +128,7 @@ test.describe('severity-2 #smoke', () => {
       syncBrowserPages: { page, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUpSync();
+      const credentials = await testAccountTracker.signUp();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
@@ -14,14 +14,8 @@ test.describe('severity-2 #smoke', () => {
   test.describe('Firefox desktop user info handshake', () => {
     test('Non-Sync - no user signed into browser, no user signed in locally', async ({
       target,
-      syncBrowserPages: { configPage, page, signin },
+      pages: { page, signin },
     }) => {
-      const config = await configPage.getConfig();
-      test.fixme(
-        config.showReactApp.emailFirstRoutes === true &&
-          config.rolloutRates.generalizedReactApp > 0,
-        'FXA-11432'
-      );
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
@@ -46,21 +40,122 @@ test.describe('severity-2 #smoke', () => {
       );
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      // nothing to suggest
       await expect(signin.emailTextbox).toHaveValue('');
     });
 
     test('Non-Sync - user signed into browser, no user signed in locally', async ({
       target,
-      syncBrowserPages: { configPage, page, settings, signin },
+      pages: { page, signin },
       testAccountTracker,
     }) => {
-      const config = await configPage.getConfig();
-      test.fixme(
-        config.showReactApp.emailFirstRoutes === true &&
-          config.rolloutRates.generalizedReactApp > 0,
-        'FXA-11432'
+      const syncCredentials = await testAccountTracker.signUpSync();
+      const query = new URLSearchParams({
+        forceUA: uaStrings['desktop_firefox_71'],
+      });
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            signedInUser: syncCredentials,
+            clientId: FF_OAUTH_CLIENT_ID,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
+      await page.goto(
+        `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
+      await signin.respondToWebChannelMessage(eventDetailStatus);
+      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      // account signed into browser suggested
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(syncCredentials.email)).toBeVisible();
+    });
+
+    test('Non-Sync - user signed into browser, user signed in locally', async ({
+      target,
+      pages: { page, settings, signin },
+      testAccountTracker,
+    }) => {
       const credentials = await testAccountTracker.signUp();
+      const syncCredentials = await testAccountTracker.signUpSync();
+      const query = new URLSearchParams({
+        forceUA: uaStrings['desktop_firefox_71'],
+      });
+      // no user signed into browser
+      const eventDetailStatusNoSync: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
+      await page.goto(
+        `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
+      );
+      await signin.respondToWebChannelMessage(eventDetailStatusNoSync);
+      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await expect(settings.settingsHeading).toBeVisible();
+
+      // webChannel message indicating that there is now
+      // also an account signed into the browser
+      const eventDetailStatusSync: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: {
+              email: syncCredentials.email,
+            },
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+
+      await page.goto(
+        `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
+      );
+      await signin.respondToWebChannelMessage(eventDetailStatusSync);
+      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      // currently signed in local account takes precedence
+      await expect(page.getByText(credentials.email)).toBeVisible();
+      await signin.signInButton.click();
+      await page.waitForURL(/settings/);
+      await expect(settings.settingsHeading).toBeVisible();
+    });
+
+    test('Non-Sync force_auth page - user signed into browser is different to requested user', async ({
+      target,
+      pages: { page, signin },
+      testAccountTracker,
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      const syncCredentials = await testAccountTracker.signUpSync();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
         email: credentials.email,
@@ -70,131 +165,9 @@ test.describe('severity-2 #smoke', () => {
         message: {
           command: FirefoxCommand.FxAStatus,
           data: {
-            signedInUser: {
-              email: credentials.email,
-              uid: credentials.uid,
-            },
-            clientId: FF_OAUTH_CLIENT_ID,
-            capabilities: {
-              engines: [],
-              pairing: false,
-              multiService: false,
-            },
-          },
-        },
-      };
-
-      await page.goto(
-        `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
-      );
-      await signin.respondToWebChannelMessage(eventDetailStatus);
-      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-      await expect(signin.passwordFormHeading).toBeVisible();
-      await expect(page.getByText(credentials.email)).toBeVisible();
-      await signin.fillOutPasswordForm(credentials.password);
-      await expect(settings.settingsHeading).toBeVisible();
-    });
-
-    test('Non-Sync - user signed into browser, user signed in locally', async ({
-      target,
-      syncBrowserPages: { configPage, page, settings, signin },
-      testAccountTracker,
-    }) => {
-      const config = await configPage.getConfig();
-      test.fixme(
-        config.showReactApp.emailFirstRoutes === true &&
-          config.rolloutRates.generalizedReactApp > 0,
-        'FXA-11432'
-      );
-      const credentials = await testAccountTracker.signUp();
-      const syncCredentials = await testAccountTracker.signUpSync();
-      const query = new URLSearchParams({
-        forceUA: uaStrings['desktop_firefox_71'],
-      });
-      const eventDetailStatus: FxAStatusResponse = {
-        id: 'account_updates',
-        message: {
-          command: FirefoxCommand.FxAStatus,
-          data: {
-            clientId: FF_OAUTH_CLIENT_ID,
-            signedInUser: null,
-            capabilities: {
-              engines: [],
-              pairing: false,
-              multiService: false,
-            },
-          },
-        },
-      };
-
-      await page.goto(
-        `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
-      );
-      await signin.respondToWebChannelMessage(eventDetailStatus);
-      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-      await signin.fillOutEmailFirstForm(syncCredentials.email);
-      await signin.fillOutPasswordForm(syncCredentials.password);
-      await signin.page.waitForURL(/settings/);
-      await expect(settings.settingsHeading).toBeVisible();
-
-      // Then, sign in the user again, synthesizing the user having signed
-      // into Sync after the initial sign in.
-      const eventDetailStatusSignIn: FxAStatusResponse = {
-        id: 'account_updates',
-        message: {
-          command: FirefoxCommand.FxAStatus,
-          data: {
             clientId: FF_OAUTH_CLIENT_ID,
             signedInUser: {
-              email: credentials.email,
-            },
-            capabilities: {
-              engines: [],
-              pairing: false,
-              multiService: false,
-            },
-          },
-        },
-      };
-
-      await page.goto(
-        `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
-      );
-      await signin.respondToWebChannelMessage(eventDetailStatusSignIn);
-      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
-
-      await expect(signin.cachedSigninHeading).toBeVisible();
-      await expect(page.getByText(syncCredentials.email)).toBeVisible();
-      await signin.signInButton.click();
-      await page.waitForURL(/settings/);
-      await expect(settings.settingsHeading).toBeVisible();
-    });
-
-    test('Non-Sync force_auth page - user signed into browser is different to requested user', async ({
-      target,
-      syncBrowserPages: { configPage, page, signin },
-      testAccountTracker,
-    }) => {
-      const config = await configPage.getConfig();
-      test.fixme(
-        config.showReactApp.emailFirstRoutes === true &&
-          config.rolloutRates.generalizedReactApp > 0,
-        'FXA-11432'
-      );
-      const credentials = await testAccountTracker.signUp();
-      const syncCredentials = await testAccountTracker.signUpSync();
-      const query = new URLSearchParams({
-        forceUA: uaStrings['desktop_firefox_71'],
-        email: syncCredentials.email,
-      });
-      const eventDetailStatus: FxAStatusResponse = {
-        id: 'account_updates',
-        message: {
-          command: FirefoxCommand.FxAStatus,
-          data: {
-            clientId: FF_OAUTH_CLIENT_ID,
-            signedInUser: {
-              email: credentials.email,
+              email: syncCredentials.email,
             },
             capabilities: {
               engines: [],
@@ -212,30 +185,50 @@ test.describe('severity-2 #smoke', () => {
       await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       await expect(signin.passwordFormHeading).toBeVisible();
-      await expect(page.getByText(syncCredentials.email)).toBeVisible();
+      // email param takes precedence over user signed into the browser
+      await expect(page.getByText(credentials.email)).toBeVisible();
     });
 
     test('Non-Sync settings page - no user signed into browser, user signed in locally', async ({
       target,
-      syncBrowserPages: { page, settings, signin },
+      pages: { page, settings, signin },
       testAccountTracker,
     }) => {
-      const syncCredentials = await testAccountTracker.signUpSync();
+      const credentials = await testAccountTracker.signUp();
       const query = new URLSearchParams({
         forceUA: uaStrings['desktop_firefox_71'],
       });
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
-      await signin.fillOutEmailFirstForm(syncCredentials.email);
-      await signin.fillOutPasswordForm(syncCredentials.password);
-      await signin.page.waitForURL(/settings/);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
       await expect(settings.settingsHeading).toBeVisible();
 
-      await settings.goto();
-      await expect(settings.primaryEmail.status).toHaveText(
-        syncCredentials.email
+      await page.goto(
+        `${
+          target.contentServerUrl
+        }?force_auth&automatedBrowser=true&${query.toString()}`
       );
+      const eventDetailStatus: FxAStatusResponse = {
+        id: 'account_updates',
+        message: {
+          command: FirefoxCommand.FxAStatus,
+          data: {
+            clientId: FF_OAUTH_CLIENT_ID,
+            signedInUser: null,
+            capabilities: {
+              engines: [],
+              pairing: false,
+              multiService: false,
+            },
+          },
+        },
+      };
+      await signin.respondToWebChannelMessage(eventDetailStatus);
+      await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      await expect(page.getByText(credentials.email)).toBeVisible();
     });
   });
 });

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -142,6 +142,7 @@ describe('metrics', () => {
   beforeEach(() => {
     //@ts-ignore
     delete window.location;
+    //@ts-ignore
     window.location = {
       ...window.location,
       replace: jest.fn(),
@@ -356,6 +357,16 @@ describe('SettingsRoutes', () => {
   });
 
   it('redirects to /signin if isSignedIn is false', async () => {
+    (firefox.requestSignedInUser as jest.Mock).mockResolvedValue(null);
+    (currentAccount as jest.Mock).mockReturnValue(null);
+    (useIntegration as jest.Mock).mockReturnValue({
+      isSync: () => false,
+      isDesktopRelay: () => false,
+      data: {
+        context: {},
+      },
+    });
+
     let navigateResult: Promise<void>;
     await act(async () => {
       const {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -98,9 +98,6 @@ export const App = ({
   const config = useConfig();
   const session = useSession();
   const integration = useIntegration();
-  const isWebChannelIntegration =
-    integration != null &&
-    (integration.isSync() || integration.isDesktopRelay());
   const { data: isSignedInData } = useLocalSignedInQueryState();
 
   // GQL call for minimal metrics data
@@ -123,33 +120,29 @@ export const App = ({
     (async () => {
       let isValidSession = false;
 
-      if (isWebChannelIntegration) {
-        // Request and update account data/state to match the browser state.
-        // When we are acessing FxA from the browser menu or the user is going through
-        // the service=relay flow, the isWebChannelIntegration flag will
-        // be set to true. If there is a user actively signed into the browser,
-        // we should try to use that user's account when possible.
-        const userFromBrowser = await firefox.requestSignedInUser(
-          integration.data.context,
-          // TODO with React pairing flow, update this if pairing flow
-          false,
-          integration.data.service
-        );
+      // Request and update account data/state to match the browser state.
+      // If there is a user actively signed into the browser,
+      // we should try to use that user's account when possible.
+      const userFromBrowser = await firefox.requestSignedInUser(
+        integration.data.context,
+        // TODO with React pairing flow, update this if pairing flow
+        false,
+        integration.data.service
+      );
 
-        if (userFromBrowser && userFromBrowser.sessionToken) {
-          // If the session is valid, try to set it as the current account
-          isValidSession = await session.isValid(userFromBrowser.sessionToken);
-          if (isValidSession) {
-            const cachedUser = getAccountByUid(userFromBrowser.uid);
-            if (cachedUser) {
-              storeAccountData({
-                ...cachedUser,
-                // Make sure we are apply the session token we validated
-                sessionToken: userFromBrowser.sessionToken,
-              });
-            } else {
-              storeAccountData(userFromBrowser);
-            }
+      if (userFromBrowser && userFromBrowser.sessionToken) {
+        // If the session is valid, try to set it as the current account
+        isValidSession = await session.isValid(userFromBrowser.sessionToken);
+        if (isValidSession) {
+          const cachedUser = getAccountByUid(userFromBrowser.uid);
+          if (cachedUser) {
+            storeAccountData({
+              ...cachedUser,
+              // Make sure we are apply the session token we validated
+              sessionToken: userFromBrowser.sessionToken,
+            });
+          } else {
+            storeAccountData(userFromBrowser);
           }
         }
       } else {
@@ -161,12 +154,7 @@ export const App = ({
 
       setIsSignedIn(isValidSession);
     })();
-  }, [
-    integration,
-    isWebChannelIntegration,
-    isSignedInData?.isSignedIn,
-    session,
-  ]);
+  }, [integration, isSignedInData?.isSignedIn, session]);
 
   // Because this query depends on the result of an initial query (in this case,
   // metrics), we need to run it separately.


### PR DESCRIPTION
## Because

* In React, account status web channel message was only checked when signing in to a browser service
* This did not match backbone and caused test failures

## This pull request

* Always check for web channel message on app start
* Update test cases

## Issue that this pull request solves

Closes: FXA-11432

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Ran functional tests with and without react email-first routes set to full prod rollout
