### PR TITLE
feat(type-cacheable): add async local storage adapter

### DIFF
--- a/libs/payments/stripe/src/lib/cacheKeyForClient.ts
+++ b/libs/payments/stripe/src/lib/cacheKeyForClient.ts
@@ -1,0 +1,14 @@
+import { createHash } from 'crypto';
+
+export const cacheKeyForClient = function (
+  methodName: string,
+  resourceId = '',
+  params: object = {}
+): string {
+  // Sort variables prior to stringifying to not be caller order dependent
+  const variablesString = JSON.stringify(params, Object.keys(params).sort());
+  const variableHash = createHash('sha256')
+    .update(variablesString)
+    .digest('hex');
+  return `${methodName}:${resourceId}:${variableHash}`;
+};

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -4,6 +4,7 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import { Stripe } from 'stripe';
+import { Cacheable } from '@type-cacheable/core';
 
 import {
   StripeApiList,
@@ -27,6 +28,12 @@ import {
   StatsD,
   StatsDService,
 } from '@fxa/shared/metrics/statsd';
+import {
+  CacheFirstStrategy,
+  AsyncLocalStorageAdapter,
+  MemoryAdapter,
+} from '@fxa/shared/db/type-cacheable';
+import { cacheKeyForClient } from './cacheKeyForClient';
 
 /**
  * A wrapper for Stripe that enforces that results have deterministic typings
@@ -77,6 +84,12 @@ export class StripeClient {
     );
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('customersRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async customersRetrieve(
     customerId: string,
@@ -129,6 +142,12 @@ export class StripeClient {
     return result as StripeResponse<StripeCustomerSession>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('subscriptionsList', undefined, args[0]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async subscriptionsList(params?: Stripe.SubscriptionListParams) {
     const result = await this.stripe.subscriptions.list({
@@ -168,6 +187,12 @@ export class StripeClient {
     return result as StripeResponse<StripeSubscription>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('subscriptionsRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async subscriptionsRetrieve(
     id: string,
@@ -194,6 +219,12 @@ export class StripeClient {
     return result as StripeResponse<StripeSubscription>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('invoicesRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async invoicesRetrieve(
     id: string,
@@ -206,6 +237,12 @@ export class StripeClient {
     return result as StripeResponse<StripeInvoice>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('invoicesRetrieveUpcoming', undefined, args[0]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async invoicesRetrieveUpcoming(
     params?: Stripe.InvoiceRetrieveUpcomingParams
@@ -265,6 +302,12 @@ export class StripeClient {
     return result as StripeResponse<StripeInvoice>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('paymentIntentRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async paymentIntentRetrieve(
     paymentIntentId: string,
@@ -289,6 +332,12 @@ export class StripeClient {
     return result as StripeResponse<StripePaymentMethod>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('paymentMethodsRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    client: new AsyncLocalStorageAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async paymentMethodRetrieve(
     id: string,
@@ -301,6 +350,13 @@ export class StripeClient {
     return result as StripeResponse<StripePaymentMethod>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('pricesRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    ttlSeconds: 600,
+    client: new MemoryAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async pricesRetrieve(id: string, params?: Stripe.PriceRetrieveParams) {
     const result = await this.stripe.prices.retrieve(id, {
@@ -310,6 +366,13 @@ export class StripeClient {
     return result as StripeResponse<StripePrice>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('productsRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    ttlSeconds: 600,
+    client: new MemoryAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async productsRetrieve(id: string, params?: Stripe.ProductRetrieveParams) {
     const result = await this.stripe.products.retrieve(id, {
@@ -319,6 +382,13 @@ export class StripeClient {
     return result as StripeResponse<StripeProduct>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('promotionCodesList', undefined, args[0]),
+    strategy: new CacheFirstStrategy(),
+    ttlSeconds: 600,
+    client: new MemoryAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async promotionCodesList(params: Stripe.PromotionCodeListParams) {
     const result = await this.stripe.promotionCodes.list({
@@ -328,6 +398,13 @@ export class StripeClient {
     return result as StripeResponse<StripeApiList<StripePromotionCode>>;
   }
 
+  @Cacheable({
+    cacheKey: (args: any) =>
+      cacheKeyForClient('promotionCodesRetrieve', args[0], args[1]),
+    strategy: new CacheFirstStrategy(),
+    ttlSeconds: 600,
+    client: new MemoryAdapter(),
+  })
   @CaptureTimingWithStatsD()
   async promotionCodesRetrieve(
     id: string,

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -55,6 +55,7 @@ import {
   TaxAddress,
   type SubplatInterval,
 } from '@fxa/payments/customer';
+import { WithTypeCachableAsyncLocalStorage } from '@fxa/shared/db/type-cacheable';
 import { GetPayPalCheckoutTokenResult } from './validators/GetPayPalCheckoutTokenResult';
 import { FetchCMSDataActionResult } from './validators/FetchCMSDataActionResult';
 import { getNeedsInputActionResult } from './validators/GetNeedsInputActionResult';
@@ -87,6 +88,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(GetCartActionArgs, GetCartActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async getCart(args: { cartId: string }) {
     const cart = await this.cartService.getCart(args.cartId);
 
@@ -97,6 +99,7 @@ export class NextJSActionsService {
     allowlist: [CartInvalidStateForActionError],
   })
   @NextIOValidator(GetCartActionArgs, GetSuccessCartActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async getSuccessCart(args: { cartId: string }): Promise<SuccessCartDTO> {
     const cart = await this.cartService.getCart(args.cartId);
 
@@ -115,6 +118,7 @@ export class NextJSActionsService {
     ],
   })
   @NextIOValidator(UpdateCartActionArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async updateCart(args: {
     cartId: string;
     version: number;
@@ -136,6 +140,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(RestartCartActionArgs, RestartCartActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async restartCart(args: { cartId: string }) {
     const cart = await this.cartService.restartCart(args.cartId);
 
@@ -146,6 +151,7 @@ export class NextJSActionsService {
     allowlist: [CartInvalidPromoCodeError, ProductConfigError],
   })
   @NextIOValidator(SetupCartActionArgs, SetupCartActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async setupCart(args: {
     interval: SubplatInterval;
     offeringConfigId: string;
@@ -163,6 +169,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(FinalizeCartWithErrorArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async finalizeCartWithError(args: {
     cartId: string;
     errorReasonId: CartErrorReasonId;
@@ -175,12 +182,14 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(FinalizeProcessingCartActionArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async finalizeProcessingCart(args: { cartId: string }) {
     await this.cartService.finalizeProcessingCart(args.cartId);
   }
 
   @SanitizeExceptions()
   @NextIOValidator(GetPayPalCheckoutTokenArgs, GetPayPalCheckoutTokenResult)
+  @WithTypeCachableAsyncLocalStorage()
   async getPayPalCheckoutToken(args: { currencyCode: string }) {
     const token = await this.checkoutTokenManager.get(args.currencyCode);
 
@@ -191,6 +200,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(GetTaxAddressArgs, GetTaxAddressResult)
+  @WithTypeCachableAsyncLocalStorage()
   async getTaxAddress(args: { ipAddress: string }) {
     const taxAddress = this.geodbManager.getTaxAddress(args.ipAddress);
     return { taxAddress };
@@ -198,6 +208,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(CheckoutCartWithPaypalActionArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async checkoutCartWithPaypal(args: {
     cartId: string;
     version: number;
@@ -214,6 +225,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(CheckoutCartWithStripeActionArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async checkoutCartWithStripe(args: {
     cartId: string;
     version: number;
@@ -230,6 +242,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions({ allowlist: [ProductConfigError] })
   @NextIOValidator(FetchCMSDataActionArgs, FetchCMSDataActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async fetchCMSData(args: {
     offeringId: string;
     acceptLanguage?: string | null;
@@ -246,6 +259,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(RecordEmitterEventArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async recordEmitterEvent(args: {
     eventName: string;
     requestArgs: CommonMetrics;
@@ -278,6 +292,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(GetNeedsInputActionArgs, getNeedsInputActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async getNeedsInput(args: { cartId: string }) {
     return await this.cartService.getNeedsInput(args.cartId);
   }
@@ -286,6 +301,7 @@ export class NextJSActionsService {
     allowlist: [CheckoutFailedError],
   })
   @NextIOValidator(SubmitNeedsInputActionArgs, undefined)
+  @WithTypeCachableAsyncLocalStorage()
   async submitNeedsInput(args: { cartId: string }) {
     await this.cartService.submitNeedsInput(args.cartId);
   }
@@ -298,6 +314,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(ValidatePostalCodeActionArgs, ValidatePostalCodeActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async validateAndFormatPostalCode(args: {
     postalCode: string;
     countryCode: string;
@@ -310,6 +327,7 @@ export class NextJSActionsService {
 
   @SanitizeExceptions()
   @NextIOValidator(DetermineCurrencyActionArgs, DetermineCurrencyActionResult)
+  @WithTypeCachableAsyncLocalStorage()
   async determineCurrency(args: { ip: string }) {
     const location = this.geodbManager.getTaxAddress(args.ip);
 

--- a/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
+++ b/libs/shared/cms/src/lib/product-configuration.manager.spec.ts
@@ -54,6 +54,8 @@ jest.mock('@type-cacheable/core', () => ({
 
 jest.mock('@fxa/shared/db/type-cacheable', () => ({
   NetworkFirstStrategy: function () {},
+  AsyncLocalStorageAdapter: function () {},
+  CacheFirstStrategy: function () {},
   MemoryAdapter: function () {},
 }));
 
@@ -423,9 +425,8 @@ describe('productConfigurationManager', () => {
 
       mockOfferingResult.getOffering = jest.fn().mockReturnValue(mockOffering);
 
-      const result = await productConfigurationManager.getOfferingPlanIds(
-        apiIdentifier
-      );
+      const result =
+        await productConfigurationManager.getOfferingPlanIds(apiIdentifier);
       expect(result).toEqual([mockPlan.id]);
     });
   });

--- a/libs/shared/db/type-cacheable/src/index.ts
+++ b/libs/shared/db/type-cacheable/src/index.ts
@@ -1,6 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+export * from './lib/type-cachable-async-local-storage-adapter';
+export * from './lib/type-cachable-async-local-storage-init';
 export * from './lib/type-cachable-cache-first';
 export * from './lib/type-cachable-firestore-adapter';
 export * from './lib/type-cachable-memory-adapter';

--- a/libs/shared/db/type-cacheable/src/lib/type-cachable-async-local-storage-adapter.spec.ts
+++ b/libs/shared/db/type-cacheable/src/lib/type-cachable-async-local-storage-adapter.spec.ts
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import {
+  AsyncLocalStorageAdapter,
+  withTypeCacheableAsyncLocalStorage,
+  TypeCacheableAsyncLocalStorageNotAvailableError,
+} from './type-cachable-async-local-storage-adapter';
+
+describe('AsyncLocalStorageAdapter', () => {
+  let adapter: AsyncLocalStorageAdapter;
+
+  beforeEach(() => {
+    adapter = new AsyncLocalStorageAdapter();
+  });
+
+  it('should return undefined if the key does not exist', () => {
+    const result = withTypeCacheableAsyncLocalStorage(async () => {
+      return await adapter.get(faker.string.uuid());
+    });
+
+    return expect(result).resolves.toBeUndefined();
+  });
+
+  it('should return the value if the key exists', () => {
+    const key = faker.string.uuid();
+    const value = 'somevalue';
+
+    const result = withTypeCacheableAsyncLocalStorage(async () => {
+      await adapter.set(key, value);
+      return await adapter.get(key);
+    });
+
+    return expect(result).resolves.toEqual(value);
+  });
+
+  it('should delete a key', () => {
+    const key = faker.string.uuid();
+    const value = 'somevalue';
+
+    const result = withTypeCacheableAsyncLocalStorage(async () => {
+      await adapter.set(key, value);
+      await adapter.del(key);
+      return await adapter.get(key);
+    });
+
+    return expect(result).resolves.toBeUndefined();
+  });
+
+  it('should list keys in the cache', () => {
+    const key = faker.string.uuid();
+    const value = 'somevalue';
+
+    const result = withTypeCacheableAsyncLocalStorage(async () => {
+      await adapter.set(key, value);
+      return await adapter.keys('');
+    });
+
+    return expect(result).resolves.toContain(key);
+  });
+
+  it('should delete multiple keys', () => {
+    const key1 = faker.string.uuid();
+    const key2 = faker.string.uuid();
+
+    const result = withTypeCacheableAsyncLocalStorage(async () => {
+      await adapter.set(key1, 'value1');
+      await adapter.set(key2, 'value2');
+      await adapter.del([key1, key2]);
+
+      const [res1, res2] = await Promise.all([
+        adapter.get(key1),
+        adapter.get(key2),
+      ]);
+
+      return [res1, res2];
+    });
+
+    return expect(result).resolves.toEqual([undefined, undefined]);
+  });
+
+  it('should not throw if used outside context when throwWhenContextUnavailable is false', async () => {
+    const adapter = new AsyncLocalStorageAdapter(false);
+    await expect(adapter.get(faker.string.uuid())).resolves.toBeUndefined();
+  });
+
+  it('should throw if used outside context when throwWhenContextUnavailable is true', async () => {
+    const adapter = new AsyncLocalStorageAdapter(true);
+    await expect(adapter.get(faker.string.uuid())).rejects.toThrow(
+      TypeCacheableAsyncLocalStorageNotAvailableError
+    );
+  });
+
+  it('should throw when calling delHash', async () => {
+    await expect(adapter.delHash(faker.string.uuid())).rejects.toThrow(
+      'delHash() not supported for cachable AsyncLocalStorageAdapter'
+    );
+  });
+});

--- a/libs/shared/db/type-cacheable/src/lib/type-cachable-async-local-storage-adapter.ts
+++ b/libs/shared/db/type-cacheable/src/lib/type-cachable-async-local-storage-adapter.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import cacheManager, {
+  CacheClient,
+  CacheManagerOptions,
+} from '@type-cacheable/core';
+import { AsyncLocalStorage } from 'async_hooks';
+
+export class TypeCacheableAsyncLocalStorageNotAvailableError extends Error {
+  constructor() {
+    super(
+      'AsyncLocalStorageAdapter was used outside of a typeCacheableAsyncLocalStorage context'
+    );
+  }
+}
+
+type Store = {
+  cacheStore: Map<any, any>;
+};
+
+export const typeCacheableAsyncLocalStorage = new AsyncLocalStorage<Store>();
+
+export const withTypeCacheableAsyncLocalStorage = <T>(fn: () => T): T => {
+  return typeCacheableAsyncLocalStorage.run(
+    {
+      cacheStore: new Map(),
+    },
+    fn
+  );
+};
+
+export class AsyncLocalStorageAdapter implements CacheClient {
+  constructor(private throwWhenContextUnavailable = false) {
+    this.get = this.get.bind(this);
+    this.del = this.del.bind(this);
+    this.delHash = this.delHash.bind(this);
+    this.getClientTTL = this.getClientTTL.bind(this);
+    this.keys = this.keys.bind(this);
+    this.set = this.set.bind(this);
+  }
+
+  private getCacheStoreRef() {
+    const cacheStore = typeCacheableAsyncLocalStorage.getStore()?.cacheStore;
+    if (!cacheStore && this.throwWhenContextUnavailable) {
+      throw new TypeCacheableAsyncLocalStorageNotAvailableError();
+    }
+    if (!cacheStore) {
+      console.warn(
+        'AsyncLocalStorageAdapter was used outside of a typeCacheableAsyncLocalStorage context'
+      );
+    }
+    return cacheStore;
+  }
+
+  public async get(cacheKey: string): Promise<any> {
+    const cacheStore = this.getCacheStoreRef();
+
+    const cacheEntry = cacheStore?.get(cacheKey);
+    if (!cacheEntry) {
+      return undefined;
+    }
+
+    return cacheEntry;
+  }
+
+  public async set(cacheKey: string, value: any): Promise<any> {
+    const cacheStore = this.getCacheStoreRef();
+
+    cacheStore?.set(cacheKey, value);
+  }
+
+  public getClientTTL(): number {
+    return 0;
+  }
+
+  public async del(keyOrKeys: string | string[]): Promise<any> {
+    if (Array.isArray(keyOrKeys) && !keyOrKeys.length) {
+      return 0;
+    }
+
+    const cacheStore = this.getCacheStoreRef();
+
+    const keysToDelete = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+
+    for (const cacheKey of keysToDelete) {
+      cacheStore?.delete(cacheKey);
+    }
+  }
+
+  public async keys(_: string): Promise<string[]> {
+    const cacheStore = this.getCacheStoreRef() || new Map();
+
+    return Promise.resolve(Array.from(cacheStore.keys()));
+  }
+
+  public async delHash(_: string | string[]): Promise<any> {
+    throw new Error(
+      'delHash() not supported for cachable AsyncLocalStorageAdapter'
+    );
+  }
+}
+
+export const useAsyncLocalStorageAdapter = (
+  asFallback?: boolean,
+  options?: CacheManagerOptions
+): AsyncLocalStorageAdapter => {
+  const asyncLocalStorageAdapter = new AsyncLocalStorageAdapter();
+
+  if (asFallback) {
+    cacheManager.setFallbackClient(asyncLocalStorageAdapter);
+  } else {
+    cacheManager.setClient(asyncLocalStorageAdapter);
+  }
+
+  if (options) {
+    cacheManager.setOptions(options);
+  }
+
+  return asyncLocalStorageAdapter;
+};

--- a/libs/shared/db/type-cacheable/src/lib/type-cachable-async-local-storage-init.ts
+++ b/libs/shared/db/type-cacheable/src/lib/type-cachable-async-local-storage-init.ts
@@ -1,0 +1,25 @@
+import { withTypeCacheableAsyncLocalStorage } from './type-cachable-async-local-storage-adapter';
+
+/**
+ * Will instantiate a new AsyncLocalStorage context for this method.
+ * This should only be used at the top level of a call chain, for instance when a request first hits the server.
+ * Stacked useage of this decorator will result in unexpected behavior.
+ */
+export function WithTypeCachableAsyncLocalStorage<Target extends object>() {
+  type Func = (args: any) => Promise<any>;
+
+  return function (
+    _target: Target,
+    key: string,
+    descriptor: TypedPropertyDescriptor<Func>
+  ) {
+    const originalDef = descriptor.value as NonNullable<Func>;
+
+    descriptor.value = async function (input: any): Promise<any> {
+      return withTypeCacheableAsyncLocalStorage(() => {
+        return originalDef.apply(this, [input]);
+      });
+    };
+    return descriptor;
+  };
+}


### PR DESCRIPTION
## Because

- We want to cache things for the request lifetime

## This pull request

- Adds an adapter for type-cachable where we can store things on the async local context to reuse data across services during the request lifecycle.
- Uses this adapter within the nextjs actions service

## Issue that this pull request solves

Closes FXA-11315