### PR TITLE
feat(payments-next): Record glean data for subscription deletion event

### DIFF
--- a/libs/payments/events/src/lib/emitter.factories.ts
+++ b/libs/payments/events/src/lib/emitter.factories.ts
@@ -5,7 +5,7 @@ import { faker } from '@faker-js/faker';
 import {
   AdditionalMetricsData,
   SP3RolloutEvent,
-  SubscriptionEnded,
+  SubscriptionEndedEvents,
 } from './emitter.types';
 import {
   CartMetricsFactory,
@@ -22,13 +22,15 @@ export const AdditionalMetricsDataFactory = (
 });
 
 export const SubscriptionEndedFactory = (
-  override?: Partial<SubscriptionEnded>
-): SubscriptionEnded => ({
+  override?: Partial<SubscriptionEndedEvents>
+): SubscriptionEndedEvents => ({
   productId: `prod_${faker.string.alphanumeric({ length: 24 })}`,
   priceId: `price_${faker.string.alphanumeric({ length: 24 })}`,
+  priceInterval: faker.helpers.arrayElement(['month', 'year']),
+  priceIntervalCount: faker.number.int({ min: 1, max: 12 }),
   providerEventId: faker.string.uuid(),
-  subscriptionId: `sub_${faker.string.alphanumeric({ length: 24 })}`,
-  voluntaryCancellation: true,
+  voluntaryCancellation: faker.datatype.boolean(),
+  uid: faker.string.uuid(),
   ...override,
 });
 

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -13,15 +13,15 @@ export type CheckoutPaymentEvents = CommonMetrics & {
   paymentProvider?: PaymentProvidersType;
 };
 
-export type SubscriptionEnded = {
+export type SubscriptionEndedEvents = {
   productId: string;
   priceId: string;
   priceInterval?: string;
   priceIntervalCount?: number;
   paymentProvider?: PaymentProvidersType;
   providerEventId: string;
-  subscriptionId: string;
-  voluntaryCancellation?: boolean;
+  voluntaryCancellation: boolean;
+  uid?: string;
 };
 
 export const PaymentsEmitterEventsKeys = [
@@ -47,7 +47,7 @@ export type PaymentsEmitterEvents = {
   checkoutSubmit: CheckoutPaymentEvents;
   checkoutSuccess: CheckoutPaymentEvents;
   checkoutFail: CheckoutPaymentEvents;
-  subscriptionEnded: SubscriptionEnded;
+  subscriptionEnded: SubscriptionEndedEvents;
   sp3Rollout: SP3RolloutEvent;
 };
 

--- a/libs/payments/metrics/src/lib/glean/glean.factory.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.factory.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { faker } from '@faker-js/faker';
-import { CartMetrics, CmsMetricsData, CommonMetrics } from './glean.types';
+import {
+  CartMetrics,
+  CmsMetricsData,
+  CommonMetrics,
+  SubscriptionCancellationData,
+} from './glean.types';
 import { ResultCartFactory } from '@fxa/payments/cart';
 import { SubplatInterval } from '@fxa/payments/customer';
 
@@ -56,3 +61,21 @@ export const CmsMetricsDataFactory = (
   priceId: `price_${faker.string.alphanumeric({ length: 14 })}`,
   ...override,
 });
+
+export const SubscriptionCancellationDataFactory = (
+  override?: Partial<SubscriptionCancellationData>
+): SubscriptionCancellationData => {
+  return {
+    offeringId: faker.helpers.arrayElement([
+      'vpn',
+      'relay-phone',
+      'relay-email',
+      'hubs',
+      'mdnplus',
+    ]),
+    interval: faker.helpers.enumValue(SubplatInterval),
+    voluntaryCancellation: faker.datatype.boolean(),
+    providerEventId: faker.string.uuid(),
+    ...override,
+  };
+};

--- a/libs/payments/metrics/src/lib/glean/glean.manager.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.spec.ts
@@ -7,6 +7,7 @@ import {
   CartMetricsFactory,
   CmsMetricsDataFactory,
   CommonMetricsFactory,
+  SubscriptionCancellationDataFactory,
 } from './glean.factory';
 import { PaymentsGleanProvider } from './glean.types';
 import { MockPaymentsGleanFactory } from './glean.test-provider';
@@ -19,6 +20,7 @@ const mockCommonMetricsData = {
   commonMetricsData: CommonMetricsFactory(),
   cartMetricsData: CartMetricsFactory(),
   cmsMetricsData: CmsMetricsDataFactory(),
+  subscriptionCancellationData: SubscriptionCancellationDataFactory(),
 };
 const mockCommonMetrics = { common: 'metrics' };
 const mockPaymentProvider = 'card';
@@ -158,6 +160,39 @@ describe('PaymentsGleanManager', () => {
       );
       expect(
         paymentsGleanServerEventsLogger.recordPaySetupFail
+      ).toHaveBeenCalledWith({
+        ...mockCommonMetrics,
+        subscription_payment_provider: mockPaymentProvider,
+      });
+    });
+  });
+
+  describe('recordFxaSubscriptionEnded', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(paymentsGleanServerEventsLogger, 'recordSubscriptionEnded')
+        .mockReturnValue({});
+      spyPopulateCommonMetrics = jest
+        .spyOn(paymentsGleanManager as any, 'populateCommonMetrics')
+        .mockReturnValue(mockCommonMetrics);
+    });
+
+    it('should record subscribe - subscription_ended', () => {
+      paymentsGleanManager.recordFxaSubscriptionEnded(
+        {
+          cmsMetricsData: mockCommonMetricsData.cmsMetricsData,
+          subscriptionCancellationData:
+            mockCommonMetricsData.subscriptionCancellationData,
+        },
+        mockPaymentProvider
+      );
+      expect(spyPopulateCommonMetrics).toHaveBeenCalledWith({
+        cmsMetricsData: mockCommonMetricsData.cmsMetricsData,
+        subscriptionCancellationData:
+          mockCommonMetricsData.subscriptionCancellationData,
+      });
+      expect(
+        paymentsGleanServerEventsLogger.recordSubscriptionEnded
       ).toHaveBeenCalledWith({
         ...mockCommonMetrics,
         subscription_payment_provider: mockPaymentProvider,

--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -7,6 +7,7 @@ import {
   CommonMetrics,
   PaymentProvidersType,
   PaymentsGleanProvider,
+  SubscriptionCancellationData,
 } from './glean.types';
 import { Inject, Injectable } from '@nestjs/common';
 import { type PaymentsGleanServerEventsLogger } from './glean.provider';
@@ -16,6 +17,7 @@ import { mapSubscription } from './utils/mapSubscription';
 import { mapRelyingParty } from './utils/mapRelyingParty';
 import { normalizeGleanFalsyValues } from './utils/normalizeGleanFalsyValues';
 import { PaymentsGleanConfig } from './glean.config';
+import { mapSubscriptionCancellation } from './utils/mapSubscriptionCancellation';
 
 @Injectable()
 export class PaymentsGleanManager {
@@ -104,10 +106,29 @@ export class PaymentsGleanManager {
     }
   }
 
+  recordFxaSubscriptionEnded(
+    metrics: {
+      cmsMetricsData: CmsMetricsData;
+      subscriptionCancellationData: SubscriptionCancellationData;
+    },
+    paymentProvider?: PaymentProvidersType
+  ) {
+    const commonMetrics = this.populateCommonMetrics(metrics);
+
+    if (this.paymentsGleanConfig.enabled) {
+      this.paymentsGleanServerEventsLogger.recordSubscriptionEnded({
+        ...commonMetrics,
+        subscription_payment_provider:
+          normalizeGleanFalsyValues(paymentProvider),
+      });
+    }
+  }
+
   private populateCommonMetrics(metrics: {
     commonMetricsData?: CommonMetrics;
     cartMetricsData?: CartMetrics;
     cmsMetricsData?: CmsMetricsData;
+    subscriptionCancellationData?: SubscriptionCancellationData;
   }) {
     const emptyCommonMetricsData: CommonMetrics = {
       ipAddress: '',
@@ -126,10 +147,18 @@ export class PaymentsGleanManager {
       priceId: '',
       productId: '',
     };
+    const emptySubscriptionCancellationData: SubscriptionCancellationData = {
+      offeringId: '',
+      interval: '',
+      voluntaryCancellation: false,
+      providerEventId: '',
+    };
     const commonMetricsData =
       metrics.commonMetricsData || emptyCommonMetricsData;
     const cartMetricsData = metrics.cartMetricsData || emptyCartMetricsData;
     const cmsMetricsData = metrics.cmsMetricsData || emptyCmsMetricsData;
+    const subscriptionCancellationData =
+      metrics.subscriptionCancellationData || emptySubscriptionCancellationData;
     return {
       user_agent: commonMetricsData.userAgent,
       ip_address: commonMetricsData.ipAddress,
@@ -144,6 +173,7 @@ export class PaymentsGleanManager {
         cmsMetricsData,
       }),
       ...mapUtm(commonMetricsData.searchParams),
+      ...mapSubscriptionCancellation(subscriptionCancellationData),
     };
   }
 }

--- a/libs/payments/metrics/src/lib/glean/glean.test-provider.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.test-provider.ts
@@ -14,5 +14,6 @@ export const MockPaymentsGleanFactory = {
       recordPaySetupSubmit: () => {},
       recordPaySetupSuccess: () => {},
       recordPaySetupFail: () => {},
-    } as any),
+      recordSubscriptionEnded: () => {},
+    }) as any,
 };

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -37,6 +37,13 @@ export type CmsMetricsData = {
   priceId: string;
 };
 
+export type SubscriptionCancellationData = {
+  offeringId?: string;
+  interval?: string;
+  voluntaryCancellation: boolean;
+  providerEventId: string;
+};
+
 export const PaymentsGleanProvider = Symbol('GleanServerEventsProvider');
 
 export type PaymentsGleanServerEventsLoggerTester = {
@@ -45,4 +52,5 @@ export type PaymentsGleanServerEventsLoggerTester = {
   recordPaySetupSubmit: (data: any) => void;
   recordPaySetupSuccess: (data: any) => void;
   recordPaySetupFail: (data: any) => void;
+  recordSubscriptionEnded: (data: any) => void;
 };

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.spec.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { mapSubscriptionCancellation } from './mapSubscriptionCancellation';
+
+describe('mapSubscriptionCancellation', () => {
+  it('should map all values', () => {
+    const result = mapSubscriptionCancellation({
+      offeringId: 'offeringId',
+      interval: 'interval',
+      voluntaryCancellation: true,
+      providerEventId: 'providerEventId',
+    });
+    expect(result).toEqual({
+      subscription_offering_id: 'offeringId',
+      subscription_interval: 'interval',
+      subscription_provider_event_id: 'providerEventId',
+      subscription_voluntary_cancellation: true,
+    });
+  });
+
+  it('should return empty strings if values are not present', () => {
+    const result = mapSubscriptionCancellation({
+      offeringId: undefined,
+      interval: undefined,
+      voluntaryCancellation: false,
+      providerEventId: 'providerEventId',
+    });
+    expect(result).toEqual({
+      subscription_offering_id: '',
+      subscription_interval: '',
+      subscription_provider_event_id: 'providerEventId',
+      subscription_voluntary_cancellation: false,
+    });
+  });
+});

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { SubscriptionCancellationData } from '../glean.types';
+import { normalizeGleanFalsyValues } from './normalizeGleanFalsyValues';
+
+export function mapSubscriptionCancellation({
+  offeringId,
+  interval,
+  voluntaryCancellation,
+  providerEventId,
+}: SubscriptionCancellationData) {
+  return {
+    subscription_offering_id: normalizeGleanFalsyValues(offeringId),
+    subscription_interval: normalizeGleanFalsyValues(interval),
+    subscription_provider_event_id: normalizeGleanFalsyValues(providerEventId),
+    subscription_voluntary_cancellation: voluntaryCancellation,
+  };
+}

--- a/libs/payments/webhooks/src/lib/subscriptionHandler.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/subscriptionHandler.service.spec.ts
@@ -212,7 +212,7 @@ describe('SubscriptionEventsService', () => {
           expect.any(String),
           expect.objectContaining({
             paymentProvider: undefined,
-            voluntaryCancellation: undefined,
+            voluntaryCancellation: false,
           })
         );
       });

--- a/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
+++ b/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
@@ -11,6 +11,7 @@ relying_party:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -28,7 +29,8 @@ relying_party:
     send_in_pings:
       - events
     notification_emails:
-      - fxa-staff@mozilla.com
+      - dalvarez@mozilla.com
+      - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
     data_reviews:
@@ -45,6 +47,7 @@ session:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -62,6 +65,7 @@ session:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -78,6 +82,7 @@ session:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -95,6 +100,7 @@ session:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -112,6 +118,7 @@ session:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -132,6 +139,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -147,6 +155,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -157,11 +166,12 @@ subscription:
       - interaction
   product_id:
     type: string
-    description: Product ID of a subscription.
+    description: Stripe product ID of a subscription.
     lifetime: application
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -177,6 +187,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -187,11 +198,12 @@ subscription:
       - interaction
   offering_id:
     type: string
-    description: ID of the offering a customer subscribed to
+    description: The API ID of the offering a customer subscribed to
     lifetime: application
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -207,6 +219,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -222,6 +235,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -237,6 +251,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -252,6 +267,7 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -267,11 +283,53 @@ subscription:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
+    expires: never
+    data_sensitivity:
+      - interaction
+  ended:
+    type: event
+    lifetime: ping
+    description: |
+      A subscription has ended.
+    send_in_pings:
+      - events
+    notification_emails:
+      - dalvarez@mozilla.com
+      - subplat-team@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-11139
+    data_reviews:
+      - https://github.com/mozilla/fxa/issues/18696
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      subscription_voluntary_cancellation:
+        description: |
+          Whether the user cancelled the subscription (`true`) or not (`false`)
+        type: boolean
+  provider_event_id:
+    description: |
+      A unique identifier for the subscription notification from a payment provider.
+      For Stripe and Stripe-managed providers like PayPal, this is the Stripe webhook event id.
+      This will be used to deduplicate notifications that may have been sent multiple times by the payment provider.
+    type: string
+    lifetime: application
+    send_in_pings:
+      - events
+    notification_emails:
+      - dalvarez@mozilla.com
+      - subplat-team@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-11139
+    data_reviews:
+      - https://github.com/mozilla/fxa/issues/18696
     expires: never
     data_sensitivity:
       - interaction
@@ -290,6 +348,7 @@ utm:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -313,6 +372,7 @@ utm:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -335,6 +395,7 @@ utm:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -357,6 +418,7 @@ utm:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -380,6 +442,7 @@ utm:
     send_in_pings:
       - events
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7265
@@ -395,6 +458,7 @@ pay_setup:
     description: Checkout view event
     type: event
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -407,6 +471,7 @@ pay_setup:
     description: Checkout engage event
     type: event
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -419,6 +484,7 @@ pay_setup:
     description: Checkout submit event
     type: event
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -431,6 +497,7 @@ pay_setup:
     description: Checkout engage event
     type: event
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
@@ -443,6 +510,7 @@ pay_setup:
     description: Checkout fail event
     type: event
     notification_emails:
+      - dalvarez@mozilla.com
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531


### PR DESCRIPTION
Because:

* We need to get the subscription platform to the data recording state of SP2.5

This commit:

* Alters the subplat-backend-metrics.yaml file to add newly recorded fields, and the subscription.ended event
* Uses the handleSubscriptionEnded event on the emitter service to record the data in glean

Closes #FXA-11139

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
