### PR TITLE
fix(payments-ui): CouponForm - handle pending state and remove console warning

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
@@ -7,12 +7,15 @@
 import { Localized } from '@fluent/react';
 import * as Form from '@radix-ui/react-form';
 import { useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { forwardRef, useEffect } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
 import { ButtonVariant } from '../BaseButton';
 import { SubmitButton } from '../SubmitButton';
 import { updateCartAction } from '../../../actions/updateCart';
-import { getFallbackTextByFluentId } from '../../../utils/error-ftl-messages';
+import {
+  CouponErrorMessageType,
+  getFallbackTextByFluentId,
+} from '../../../utils/error-ftl-messages';
 
 interface WithCouponProps {
   cartId: string;
@@ -60,29 +63,42 @@ const WithCoupon = ({
   );
 };
 
-const CouponInput = ({
-  readOnly,
-  routeCoupon,
-}: {
-  readOnly: boolean;
-  routeCoupon?: string;
-}) => {
-  const { pending } = useFormStatus();
-  return (
-    <Localized attrs={{ placeholder: true }} id="next-coupon-enter-code">
-      <input
-        className="w-full border rounded-md border-black/30 p-3 placeholder:text-grey-500 placeholder:font-normal focus:border focus:!border-black/30 focus:!shadow-[0_0_0_3px_rgba(10,132,255,0.3)] focus-visible:outline-none data-[invalid=true]:border-alert-red data-[invalid=true]:text-alert-red data-[invalid=true]:shadow-inputError"
-        type="text"
-        name="coupon"
-        data-testid="coupon-input"
-        placeholder="Enter code"
-        disabled={pending || readOnly}
-        defaultValue={routeCoupon}
-        maxLength={25}
-      />
-    </Localized>
-  );
-};
+const CouponInput = forwardRef(
+  (
+    {
+      readOnly,
+      routeCoupon,
+      error,
+    }: {
+      readOnly: boolean;
+      routeCoupon?: string;
+      error?: CouponErrorMessageType | null | undefined;
+    },
+    ref
+  ) => {
+    const { pending } = useFormStatus();
+    return (
+      <Localized attrs={{ placeholder: true }} id="next-coupon-enter-code">
+        <input
+          className={`w-full border rounded-md p-3
+            ${
+              error
+                ? 'border-red-700 focus:border-red-700 focus:shadow-input-red-focus'
+                : 'border-black/30 placeholder:text-grey-500 placeholder:font-normal focus:border focus:!border-black/30 focus:!shadow-[0_0_0_3px_rgba(10,132,255,0.3)] focus-visible:outline-none'
+            }
+            ${pending ? 'cursor-not-allowed' : ''}`}
+          type="text"
+          name="coupon"
+          data-testid="coupon-input"
+          placeholder="Enter code"
+          disabled={pending || readOnly}
+          defaultValue={routeCoupon}
+          maxLength={25}
+        />
+      </Localized>
+    );
+  }
+);
 
 interface WithoutCouponProps {
   cartId: string;
@@ -128,7 +144,11 @@ const WithoutCoupon = ({
 
         <div className="mt-4 flex gap-4 justify-between items-center">
           <Form.Control asChild>
-            <CouponInput readOnly={readOnly} routeCoupon={routeCoupon} />
+            <CouponInput
+              readOnly={readOnly}
+              routeCoupon={routeCoupon}
+              error={error}
+            />
           </Form.Control>
           <Form.Submit asChild>
             <SubmitButton


### PR DESCRIPTION
## This pull request

- [x] removes console warning
- [x] adds cursor-not-allowed when CouponForm is in pending state
- [x] adds red border when coupon code is expired/invalid

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
#### Pending state - cursor-not-allowed
<img width="288" alt="Screenshot 2025-04-09 at 11 06 12 AM" src="https://github.com/user-attachments/assets/8000602b-469c-493a-a3d7-d26d73f57b77" />

#### Error state - red border
<img width="348" alt="Screenshot 2025-04-09 at 10 56 14 AM" src="https://github.com/user-attachments/assets/633463fd-ff8c-49eb-82e0-39210317d345" />

<img width="357" alt="Screenshot 2025-04-09 at 10 55 54 AM" src="https://github.com/user-attachments/assets/35c40fd7-c0f3-4613-9a11-cbbde7d17aec" />

#### Removes console warning
<img width="513" alt="Screenshot 2025-04-09 at 10 53 35 AM" src="https://github.com/user-attachments/assets/33b3381d-443e-4afa-8518-3012e70a53f7" />