### PR TITLE
fix(next): sp2 redirect shadow mode redirect

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/landing/route.ts
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/landing/route.ts
@@ -99,27 +99,28 @@ export async function GET(
 
         if (config.sp2redirect.shadowMode) {
           console.log('SP2 Redirect Shadow Mode enabled', { sp2RedirectUrl });
-          sp2RedirectUrl = undefined;
         }
       } catch (error) {
         console.log(error);
       } finally {
-        if (!sp2RedirectUrl) {
-          const pageNotFoundUrl = new URL(
-            buildRedirectUrl(
-              params.offeringId,
-              params.interval,
-              'page-not-found',
-              'checkout',
-              {
-                locale: params.locale,
-                baseUrl: config.paymentsNextHostedUrl,
-              }
-            )
-          );
-          sp2RedirectUrl = pageNotFoundUrl.href;
+        if (!config.sp2redirect.shadowMode) {
+          if (!sp2RedirectUrl) {
+            const pageNotFoundUrl = new URL(
+              buildRedirectUrl(
+                params.offeringId,
+                params.interval,
+                'page-not-found',
+                'checkout',
+                {
+                  locale: params.locale,
+                  baseUrl: config.paymentsNextHostedUrl,
+                }
+              )
+            );
+            sp2RedirectUrl = pageNotFoundUrl.href;
+          }
+          redirect(sp2RedirectUrl);
         }
-        redirect(sp2RedirectUrl);
       }
     } else {
       emitterService.emit('sp3Rollout', {


### PR DESCRIPTION
## Because

- With shadow mode enabled the SP2 redirect loads a not found page for valid offering and interval

## This pull request

- With shadow mode enabled, do not redirect to SP2 URL.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
