### PR TITLE
task(settings): Fast follow for allowing invalid emails

### DIFF
--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -159,7 +159,7 @@ describe('IndexContainer', () => {
       </LocationProvider>
     );
     expect(container).toBeDefined();
-    expect(mockUseValidatedQueryParams).toBeCalledWith(IndexQueryParams, true);
+    expect(mockUseValidatedQueryParams).toBeCalledWith(IndexQueryParams, false);
   });
 
   it('should render the Index component when no redirection is required', async () => {


### PR DESCRIPTION
## Because

- In a previous PR, it was pointed out that maybe we shouldn't fail if a bad email is provided.
- It's questionable if our email validation logic and RP's email validation logic is aligned...

## This pull request

- Allows loginHint query param to be an invalid email address.
- Allows email query param to be an invalid email address.
- Captures errors in Sentry so we can monitor how much of a problem this really is.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This commit is based on feedback that arose while addressing FXA-11297.
