### PR TITLE
fix(google): support romanian postal codes

### DIFF
--- a/libs/google/src/lib/google.constants.ts
+++ b/libs/google/src/lib/google.constants.ts
@@ -1,0 +1,53 @@
+/**
+ * We maintain this list because Google Maps does not correctly geocode
+ * Romanian postal codes. This page provides a reference list: https://en.wikipedia.org/wiki/Postal_codes_in_Romania
+ */
+export const ROMANIAN_POSTAL_CODES = [
+  /01\d{4}/, // Bucharest Sector 1
+  /02\d{4}/, // Bucharest Sector 2
+  /03\d{4}/, // Bucharest Sector 3
+  /04\d{4}/, // Bucharest Sector 4
+  /05\d{4}/, // Bucharest Sector 5
+  /06\d{4}/, // Bucharest Sector 6
+  /07\d{4}/, // Ilfov County
+  /08\d{4}/, // Giurgiu County
+  /10\d{4}/, // Prahova County
+  /11\d{4}/, // Argeș County
+  /12\d{4}/, // Buzău County
+  /13\d{4}/, // Dâmbovița County
+  /14\d{4}/, // Teleorman County
+  /20\d{4}/, // Dolj County
+  /21\d{4}/, // Gorj County
+  /22\d{4}/, // Mehedinți County
+  /23\d{4}/, // Olt County
+  /24\d{4}/, // Vâlcea County
+  /30\d{4}/, // Timiș County
+  /31\d{4}/, // Arad County
+  /32\d{4}/, // Caraș-Severin County
+  /33\d{4}/, // Hunedoara County
+  /40\d{4}/, // Cluj County
+  /41\d{4}/, // Bihor County
+  /42\d{4}/, // Bistrița-Năsăud County
+  /43\d{4}/, // Maramureș County
+  /44\d{4}/, // Satu Mare County
+  /45\d{4}/, // Sălaj County
+  /50\d{4}/, // Brașov County
+  /51\d{4}/, // Alba County
+  /52\d{4}/, // Covasna County
+  /53\d{4}/, // Harghita County
+  /54\d{4}/, // Mureș County
+  /55\d{4}/, // Sibiu County
+  /60\d{4}/, // Bacău County
+  /61\d{4}/, // Neamț County
+  /62\d{4}/, // Vrancea County
+  /70\d{4}/, // Iași County
+  /71\d{4}/, // Botoșani County
+  /72\d{4}/, // Suceava County
+  /73\d{4}/, // Vaslui County
+  /80\d{4}/, // Galați County
+  /81\d{4}/, // Brăila County
+  /82\d{4}/, // Tulcea County
+  /90\d{4}/, // Constanța County
+  /91\d{4}/, // Călărași County
+  /92\d{4}/, // Ialomița County
+];

--- a/libs/google/src/lib/google.manager.spec.ts
+++ b/libs/google/src/lib/google.manager.spec.ts
@@ -91,6 +91,67 @@ describe('GoogleManager', () => {
       });
     });
 
+    it('should return true - Romanian bypass', async () => {
+      const mockResponseData = {
+        results: [
+          GeocodeResultFactory({
+            address_components: [
+              {
+                long_name: 'Romania',
+                short_name: 'RO',
+                types: ['country', 'political'] as PlaceType2[],
+              },
+            ],
+            formatted_address: 'Romania',
+            types: ['country', 'political'] as PlaceType2[],
+          }),
+        ],
+        status: 'OK' as Status,
+        error_message: '',
+      };
+
+      jest.spyOn(googleClient, 'geocode').mockResolvedValue(mockResponseData);
+
+      const response = await googleManager.validateAndFormatPostalCode(
+        '010000',
+        'RO'
+      );
+      expect(response).toEqual({
+        isValid: true,
+        formattedPostalCode: '010000',
+      });
+    });
+
+    it('should return false - Romanian non-matching', async () => {
+      const mockResponseData = {
+        results: [
+          GeocodeResultFactory({
+            address_components: [
+              {
+                long_name: 'Romania',
+                short_name: 'RO',
+                types: ['country', 'political'] as PlaceType2[],
+              },
+            ],
+            formatted_address: 'Romania',
+            types: ['country', 'political'] as PlaceType2[],
+          }),
+        ],
+        status: 'OK' as Status,
+        error_message: '',
+      };
+
+      jest.spyOn(googleClient, 'geocode').mockResolvedValue(mockResponseData);
+
+      const response = await googleManager.validateAndFormatPostalCode(
+        '00000',
+        'RO'
+      );
+      expect(response).toEqual({
+        isValid: false,
+      });
+    });
+
     it('should return false - 00000', async () => {
       const mockResponseData = {
         results: [

--- a/libs/google/src/lib/google.manager.ts
+++ b/libs/google/src/lib/google.manager.ts
@@ -5,12 +5,27 @@
 import { Injectable } from '@nestjs/common';
 import { AddressType } from '@googlemaps/google-maps-services-js';
 import { GoogleClient } from './google.client';
+import { ROMANIAN_POSTAL_CODES } from './google.constants';
 
 @Injectable()
 export class GoogleManager {
   constructor(private googleClient: GoogleClient) {}
 
   async validateAndFormatPostalCode(postalCode: string, countryCode: string) {
+    // Google maps does not geocode Romanian postal codes correctly.
+    if (countryCode === 'RO' || countryCode === 'ROU') {
+      const isRomanianPostalCode = ROMANIAN_POSTAL_CODES.some((regex) =>
+        regex.test(postalCode)
+      );
+
+      if (isRomanianPostalCode) {
+        return {
+          isValid: true,
+          formattedPostalCode: postalCode,
+        };
+      }
+    }
+
     const { results } = await this.googleClient.geocode({
       address: postalCode,
       components: `country:${countryCode}|postal_code:${postalCode}`,


### PR DESCRIPTION
## Because

- Google geocode does not place romanian postal codes

## This pull request

- Adds a bypass for romanian postal codes

## Issue that this pull request solves

Closes FXA-11482