### PR TITLE
fix(payments-next): TaxLocation component should only be editable on Checkout and hidden on other pages

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -89,28 +89,30 @@ export default async function CheckoutLayout({
               />
             }
           />
-          <div
-            className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8"
-            aria-label="Tax location form"
-          >
-            <h2 className="m-0 mb-4 font-semibold text-grey-600">
-              {l10n.getString('select-tax-location-title', 'Location')}
-            </h2>
-            <SelectTaxLocation
-              saveAction={async (countryCode, postalCode) => {
-                'use server';
-                await updateCartAction(cart.id, cart.version, {
-                  taxAddress: { countryCode, postalCode },
-                });
-              }}
-              cmsCountries={cms.countries}
-              locale={locale.substring(0, 2)}
-              productName={purchaseDetails.productName}
-              unsupportedLocations={config.subscriptionsUnsupportedLocations}
-              countryCode={cart.taxAddress?.countryCode}
-              postalCode={cart.taxAddress?.postalCode}
-            />
-          </div>
+          {cart.state === CartState.START && (
+            <div
+              className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8"
+              aria-label="Tax location form"
+            >
+              <h2 className="m-0 mb-4 font-semibold text-grey-600">
+                {l10n.getString('select-tax-location-title', 'Location')}
+              </h2>
+              <SelectTaxLocation
+                saveAction={async (countryCode, postalCode) => {
+                  'use server';
+                  await updateCartAction(cart.id, cart.version, {
+                    taxAddress: { countryCode, postalCode },
+                  });
+                }}
+                cmsCountries={cms.countries}
+                locale={locale.substring(0, 2)}
+                productName={purchaseDetails.productName}
+                unsupportedLocations={config.subscriptionsUnsupportedLocations}
+                countryCode={cart.taxAddress?.countryCode}
+                postalCode={cart.taxAddress?.postalCode}
+              />
+            </div>
+          )}
           <CouponForm
             cartId={cart.id}
             cartVersion={cart.version}


### PR DESCRIPTION
## Because

- customers should only be able to edit their tax location on /checkout
- the Tax Location should not be seen after `start`

## This pull request

- updates the Checkout layout so that the TaxLocation is only editable when cart state is `start`

## Issue that this pull request solves

Closes: FXA-11456

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots
#### Not signed in
<img width="1023" alt="Screenshot 2025-04-11 at 2 16 28 PM" src="https://github.com/user-attachments/assets/9ab00f15-ae6c-4f9d-9815-b5d70619f8da" />

#### Signed in
<img width="1048" alt="Screenshot 2025-04-11 at 2 17 23 PM" src="https://github.com/user-attachments/assets/e9bc9d83-5b1e-4717-80e7-993b784d8d85" />

#### Processing
<img width="1059" alt="Screenshot 2025-04-11 at 2 17 55 PM" src="https://github.com/user-attachments/assets/fbc788b3-b77d-43fd-9a85-29bdd3956931" />

#### Success
<img width="1059" alt="Screenshot 2025-04-11 at 2 18 09 PM" src="https://github.com/user-attachments/assets/b98a6b74-3b7c-4f60-8d14-1041a34cf5f2" />

#### Error
<img width="1021" alt="Screenshot 2025-04-11 at 2 18 45 PM" src="https://github.com/user-attachments/assets/98dc3109-5d97-4247-81a1-08f9a02594e4" />
