### PR TITLE
fix(content): Encode URL components

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -699,9 +699,16 @@ Router = Router.extend({
 
   createReactViewHandler(routeName, additionalParams) {
     if (routeName === '/') {
-      const queryParams = new URLSearchParams(this.window.location.search);
-      queryParams.set('showReactApp', 'true');
-      this.navigateAway(`/?${queryParams.toString()}`);
+      // We intentionally avoid using URLSearchParams because it converts '+'
+      // characters to spaces per the application/x-www-form-urlencoded
+      // standard. This can corrupt email addresses (e.g., "user+alias@example.com").
+      // Instead, we use our custom objToSearchString function, which leverages
+      // encodeURIComponent to correctly preserve and encode all valid email characters.
+      const rawSearch = window.location.search.substring(1);
+      const paramsObject = Url.searchParams(rawSearch);
+      paramsObject.showReactApp = 'true';
+      const newSearchString = Url.objToSearchString(paramsObject);
+      this.navigateAway(`/${newSearchString}`);
     } else {
       const { deviceId, flowBeginTime, flowId } =
         this.metrics.getFlowEventMetadata();

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -15,6 +15,7 @@
 
   <!--iOS App Banner-->
   <meta name="apple-itunes-app" content="app-id=989804926, affiliate-data=ct=smartbanner-fxa" />
+  <script src="%PUBLIC_URL%/query-fix.js"></script>
 </head>
 
 <body data-flow-id="__FLOW_ID__" data-flow-begin-time="__FLOW_BEGIN_TIME__">

--- a/packages/fxa-settings/public/query-fix.js
+++ b/packages/fxa-settings/public/query-fix.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* This script re-encodes the current URL’s query parameters to ensure that any special
+ * characters (such as '+') are properly encoded. This re-encoding is necessary due to
+ * backwards compatibility requirements for clients (e.g., the VPN client) that send
+ * unencoded query components, which can cause issues with parameter validation in the app.
+ *
+ * The script works by:
+ *   1. Reading the current query string from window.location.
+ *   2. Decoding each parameter value and then re-encoding it using encodeURIComponent.
+ *   3. Replacing the query string in the browser's address bar using window.history.replaceState
+ *      if the new query string differs from the original.
+ *
+ * This external file is loaded via an absolute path in index.html (e.g., <script src="%PUBLIC_URL%/query-fix.js"></script>)
+ * and is executed as early as possible—before the main bundle loads—to ensure that subsequent
+ * application logic (e.g., routing, query parameter parsing) sees the updated URL. */
+
+(function encodeUrlQuery() {
+  const { search } = window.location;
+  if (!search) return;
+  const newSearch =
+    '?' +
+    search
+      .slice(1)
+      .split('&')
+      .map((pair) => {
+        const [key, value = ''] = pair.split('=');
+        return `${key}=${encodeURIComponent(decodeURIComponent(value))}`;
+      })
+      .join('&');
+  if (newSearch !== search) {
+    window.history.replaceState({}, '', newSearch);
+  }
+})();


### PR DESCRIPTION
## Because

* Some relying parties have legacy code that passes partially unencoded query parameters (specifically, + signs)
* We added stricter validation and now see validation errors because of this encoding issue
* Using URLSearchParams introduces other encoding issues, with + sign converted to space

## This pull request

* Use custom functions in content-server and settings to correctly preserve and encode email characters
* Encode query params before settings bundle load

## Issue that this pull request solves

Closes: FXA-11327

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
