### PR TITLE
fix(payments-ui): Add Cancel button and fix style/functionality in Chrome and Safari

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
@@ -6,6 +6,7 @@
 
 import { Localized } from '@fluent/react';
 import * as Form from '@radix-ui/react-form';
+import classNames from 'classnames';
 import { useSearchParams } from 'next/navigation';
 import { forwardRef, useEffect } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
@@ -80,13 +81,14 @@ const CouponInput = forwardRef(
     return (
       <Localized attrs={{ placeholder: true }} id="next-coupon-enter-code">
         <input
-          className={`w-full border rounded-md p-3
-            ${
-              error
-                ? 'border-red-700 focus:border-red-700 focus:shadow-input-red-focus'
-                : 'border-black/30 placeholder:text-grey-500 placeholder:font-normal focus:border focus:!border-black/30 focus:!shadow-[0_0_0_3px_rgba(10,132,255,0.3)] focus-visible:outline-none'
+          className={classNames(
+            'w-full border rounded-md p-3 placeholder:text-grey-500 placeholder:font-normal focus:border focus:!border-black/30 focus:!shadow-[0_0_0_3px_rgba(10,132,255,0.3)] focus-visible:outline-none',
+            {
+              'border-black/30': !error && !pending,
+              'border-alert-red text-alert-red shadow-inputError': error,
+              'cursor-not-allowed': pending,
             }
-            ${pending ? 'cursor-not-allowed' : ''}`}
+          )}
           type="text"
           name="coupon"
           data-testid="coupon-input"
@@ -161,7 +163,7 @@ const WithoutCoupon = ({
 
         {error && (
           <Localized id={error}>
-            <div className="text-red-700 mt-4" data-testid="coupon-error">
+            <div className="text-alert-red mt-4" data-testid="coupon-error">
               {getFallbackTextByFluentId(error)}
             </div>
           </Localized>


### PR DESCRIPTION
## This pull request

- [x] Updates font color of error message in CouponForm to use `text-alert-red`
- [x] Updates "Edit" button color to blue
- [x] Adds "Cancel" button and functionality to `<Expanded />`
- [x] Revises `<SelectTaxLocation />` to fix appearance and functionality of selecting a new country in Chrome
- [ ] Confirm changes to Safari on stage
## Issue that this pull request solves

Closes: FXA-11253

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
#### Revised Edit button
<img width="342" alt="Screenshot 2025-04-21 at 2 42 38 PM" src="https://github.com/user-attachments/assets/6387ce5d-ddb5-471d-a3b3-6491c86c43b3" />

#### New Cancel button
<img width="348" alt="Screenshot 2025-04-21 at 2 41 28 PM" src="https://github.com/user-attachments/assets/d17cf1a7-a27e-4d9d-bc30-a4b8f34ab73c" />

#### Chrome
<img width="608" alt="Screenshot 2025-04-21 at 2 41 50 PM" src="https://github.com/user-attachments/assets/43c3d23f-ce10-46e4-bbb0-1d9f45b90685" />
