### PR TITLE
feat(next): error page for existing sub

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -63,7 +63,7 @@ export default async function CheckoutLayout({
         </div>
       )}
       <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-        <SubscriptionTitle cartState={cart.state} l10n={l10n} />
+        <SubscriptionTitle cart={cart} l10n={l10n} />
 
         <section
           className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:col-end-auto tablet:row-start-1 tablet:row-end-3"

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -11,12 +11,12 @@ import {
   getApp,
   CheckoutParams,
   SupportedPages,
+  getErrorFtlInfo,
 } from '@fxa/payments/ui/server';
 import {
   getCartOrRedirectAction,
   recordEmitterEventAction,
 } from '@fxa/payments/ui/actions';
-import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
 import { config } from 'apps/payments/next/config';
 import { Metadata } from 'next';
 
@@ -28,48 +28,6 @@ export const metadata: Metadata = {
   title: 'Error',
   description:
     'There was an error processing your upgrade. If this problem persists, please contact support.',
-};
-
-const getErrorReason = (
-  reason: CartErrorReasonId | null,
-  params: CheckoutParams
-) => {
-  switch (reason) {
-    case 'cart_eligibility_status_downgrade':
-      return {
-        buttonFtl: 'checkout-error-contact-support-button',
-        buttonLabel: 'Contact Support',
-        buttonUrl: config.supportUrl,
-        message: 'Please contact support so we can help you.',
-        messageFtl: 'checkout-error-contact-support',
-      };
-    case 'cart_eligibility_status_invalid':
-      return {
-        buttonFtl: 'checkout-error-contact-support-button',
-        buttonLabel: 'Contact Support',
-        buttonUrl: config.supportUrl,
-        message:
-          'You are not eligible to subscribe to this product - please contact support so we can help you.',
-        messageFtl: 'checkout-error-not-eligible',
-      };
-    case 'iap_upgrade_contact_support':
-      return {
-        buttonFtl: 'next-payment-error-manage-subscription-button',
-        buttonLabel: 'Manage my subscription',
-        buttonUrl: `${config.contentServerUrl}/subscriptions`,
-        message:
-          'You can still get this product — please contact support so we can help you.',
-        messageFtl: 'next-iap-upgrade-contact-support',
-      };
-    default:
-      return {
-        buttonFtl: 'next-payment-error-retry-button',
-        buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
-        message: 'Something went wrong. Please try again later.',
-        messageFtl: 'next-basic-error-message',
-      };
-  }
 };
 
 export default async function UpgradeError({
@@ -97,7 +55,7 @@ export default async function UpgradeError({
     cart.paymentInfo?.type
   );
 
-  const errorReason = getErrorReason(cart.errorReasonId, params);
+  const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config);
 
   return (
     <>

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
@@ -12,7 +12,6 @@ import {
   SubscriptionTitle,
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
-import { CartEligibilityStatus } from '@fxa/shared/db/mysql/account';
 import { config } from 'apps/payments/next/config';
 
 export default async function UpgradeSuccessLayout({
@@ -34,11 +33,7 @@ export default async function UpgradeSuccessLayout({
   return (
     <MetricsWrapper cart={cart}>
       <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-        <SubscriptionTitle
-          cartState={cart.state}
-          cartEligibilityStatus={CartEligibilityStatus.UPGRADE}
-          l10n={l10n}
-        />
+        <SubscriptionTitle cart={cart} l10n={l10n} />
         <section
           className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:col-end-auto tablet:row-start-1 tablet:row-end-3"
           aria-label="Upgrade details"

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -13,7 +13,6 @@ import {
   TermsAndPrivacy,
   UpgradePurchaseDetails,
 } from '@fxa/payments/ui/server';
-import { CartEligibilityStatus } from '@fxa/shared/db/mysql/account';
 import { config } from 'apps/payments/next/config';
 
 export default async function UpgradeLayout({
@@ -45,11 +44,7 @@ export default async function UpgradeLayout({
   return (
     <MetricsWrapper cart={cart}>
       <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-        <SubscriptionTitle
-          cartState={cart.state}
-          cartEligibilityStatus={CartEligibilityStatus.UPGRADE}
-          l10n={l10n}
-        />
+        <SubscriptionTitle cart={cart} l10n={l10n} />
 
         <section
           className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:col-end-auto tablet:row-start-1 tablet:row-end-3"

--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -9,6 +9,7 @@ next-payment-error-retry-button = Try again
 next-basic-error-message = Something went wrong. Please try again later.
 checkout-error-contact-support-button = Contact Support
 checkout-error-not-eligible = You are not eligible to subscribe to this product - please contact support so we can help you.
+checkout-error-already-subscribed = You’re already subscribed to this product.
 checkout-error-contact-support = Please contact support so we can help you.
 
 ## Processing page and Needs Input page - /checkout and /upgrade

--- a/libs/payments/cart/src/lib/cart.utils.ts
+++ b/libs/payments/cart/src/lib/cart.utils.ts
@@ -17,6 +17,7 @@ export const handleEligibilityStatusMap = {
   [EligibilityStatus.DOWNGRADE]: CartEligibilityStatus.DOWNGRADE,
   [EligibilityStatus.UPGRADE]: CartEligibilityStatus.UPGRADE,
   [EligibilityStatus.INVALID]: CartEligibilityStatus.INVALID,
+  [EligibilityStatus.SAME]: CartEligibilityStatus.INVALID,
 };
 
 export const cartEligibilityDetailsMap: Record<
@@ -40,6 +41,11 @@ export const cartEligibilityDetailsMap: Record<
     eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
     state: CartState.FAIL,
     errorReasonId: CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT,
+  },
+  [EligibilityStatus.SAME]: {
+    eligibilityStatus: CartEligibilityStatus.INVALID,
+    state: CartState.FAIL,
+    errorReasonId: CartErrorReasonId.CartEligibilityStatusSame,
   },
   [EligibilityStatus.INVALID]: {
     eligibilityStatus: CartEligibilityStatus.INVALID,

--- a/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
@@ -30,7 +30,11 @@ import {
 import { CartEligibilityStatus } from '@fxa/shared/db/mysql/account';
 
 import { EligibilityManager } from './eligibility.manager';
-import { OfferingComparison, OfferingOverlapResult } from './eligibility.types';
+import {
+  EligibilityStatus,
+  OfferingComparison,
+  OfferingOverlapResult,
+} from './eligibility.types';
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { faker } from '@faker-js/faker';
@@ -520,7 +524,9 @@ describe('EligibilityManager', () => {
       ] as OfferingOverlapResult[];
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
       const interval = SubplatInterval.Monthly;
-      const mockPrice = StripePriceFactory();
+      const mockPrice = StripePriceFactory({
+        id: 'prod_test1',
+      });
 
       jest
         .spyOn(priceManager, 'retrieveByInterval')
@@ -533,7 +539,7 @@ describe('EligibilityManager', () => {
         [mockPrice]
       );
       expect(result.subscriptionEligibilityResult).toEqual(
-        CartEligibilityStatus.INVALID
+        EligibilityStatus.SAME
       );
     });
 

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -120,12 +120,18 @@ export class EligibilityManager {
       if (
         !overlappingPrice ||
         !overlappingPrice.recurring ||
-        !targetPrice.recurring ||
-        overlappingPrice.id === targetPrice.id
-      )
+        !targetPrice.recurring
+      ) {
         return {
           subscriptionEligibilityResult: EligibilityStatus.INVALID,
         };
+      }
+
+      if (overlappingPrice.id === targetPrice.id) {
+        return {
+          subscriptionEligibilityResult: EligibilityStatus.SAME,
+        };
+      }
 
       if (overlap.comparison === OfferingComparison.DOWNGRADE)
         return {

--- a/libs/payments/eligibility/src/lib/eligibility.types.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.types.ts
@@ -9,6 +9,7 @@ export enum EligibilityStatus {
   UPGRADE = 'upgrade',
   DOWNGRADE = 'downgrade',
   BLOCKED_IAP = 'blocked_iap',
+  SAME = 'same',
   INVALID = 'invalid',
 }
 
@@ -48,7 +49,8 @@ export type SubscriptionEligibilityResult =
   | {
       subscriptionEligibilityResult:
         | EligibilityStatus.CREATE
-        | EligibilityStatus.INVALID;
+        | EligibilityStatus.INVALID
+        | EligibilityStatus.SAME;
     }
   | {
       subscriptionEligibilityResult:

--- a/libs/payments/ui/src/lib/server/components/SubscriptionTitle/en.ftl
+++ b/libs/payments/ui/src/lib/server/components/SubscriptionTitle/en.ftl
@@ -4,6 +4,7 @@ next-subscription-create-title = Set up your subscription
 next-subscription-success-title = Subscription confirmation
 next-subscription-processing-title = Confirming subscription…
 next-subscription-error-title = Error confirming subscription…
+subscription-title-sub-exists = You’ve already subscribed
 subscription-title-plan-change-heading = Review your change
 
 next-sub-guarantee = 30-day money-back guarantee

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
+import { CheckoutParams } from './types';
+
+export function getErrorFtlInfo(
+  reason: CartErrorReasonId | null,
+  params: CheckoutParams,
+  config: {
+    contentServerUrl: string;
+    supportUrl: string;
+  }
+) {
+  switch (reason) {
+    case CartErrorReasonId.CartEligibilityStatusDowngrade:
+      return {
+        buttonFtl: 'checkout-error-contact-support-button',
+        buttonLabel: 'Contact Support',
+        buttonUrl: config.supportUrl,
+        message: 'Please contact support so we can help you.',
+        messageFtl: 'checkout-error-contact-support',
+      };
+    case CartErrorReasonId.CartEligibilityStatusInvalid:
+      return {
+        buttonFtl: 'checkout-error-contact-support-button',
+        buttonLabel: 'Contact Support',
+        buttonUrl: config.supportUrl,
+        message:
+          'You are not eligible to subscribe to this product - please contact support so we can help you.',
+        messageFtl: 'checkout-error-not-eligible',
+      };
+    case CartErrorReasonId.CartEligibilityStatusSame:
+      return {
+        buttonFtl: 'next-payment-error-manage-subscription-button',
+        buttonLabel: 'Manage my subscription',
+        buttonUrl: `${config.contentServerUrl}/subscriptions`,
+        message: 'You’ve already subscribed to this product.',
+        messageFtl: 'checkout-error-already-subscribed',
+      };
+    case CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT:
+      return {
+        buttonFtl: 'next-payment-error-manage-subscription-button',
+        buttonLabel: 'Manage my subscription',
+        buttonUrl: `${config.contentServerUrl}/subscriptions`,
+        message:
+          'You can still get this product — please contact support so we can help you.',
+        messageFtl: 'next-iap-upgrade-contact-support',
+      };
+    case CartErrorReasonId.BASIC_ERROR:
+    default:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message: 'Something went wrong. Please try again later.',
+        messageFtl: 'next-basic-error-message',
+      };
+  }
+}

--- a/libs/payments/ui/src/server.ts
+++ b/libs/payments/ui/src/server.ts
@@ -13,3 +13,4 @@ export * from './lib/server/components/TermsAndPrivacy';
 export * from './lib/server/components/UpgradePurchaseDetails';
 export * from './lib/utils/types';
 export * from './lib/utils/getIpAddress';
+export * from './lib/utils/getErrorFtlInfo';

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -6,9 +6,10 @@
  */
 import type { ColumnType, JSONColumnType } from 'kysely';
 
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 
 export type Json = ColumnType<JsonValue, string, string>;
 
@@ -36,6 +37,7 @@ export enum CartErrorReasonId {
   SUCCESS_CART_MISSING_REQUIRED = 'success_cart_missing_required',
   CartEligibilityStatusDowngrade = 'cart_eligibility_status_downgrade',
   CartEligibilityStatusInvalid = 'cart_eligibility_status_invalid',
+  CartEligibilityStatusSame = 'cart_eligibility_status_same',
   Unknown = 'unknown',
 }
 


### PR DESCRIPTION
## Because

- When a customer attempts to subscribe to a purchase offering that they've already subscribed to, a generic error page is shown, instead of an error page informing they are already subscribed.

## This pull request

- Adds new error message to inform customer when they have an existing subscription to a purchase offering.
- Adds new SubscriptionTitle
- Adds new Icon for error message if a customer has an existing subscription
- Redirects to error page directly from new page when CartService.setupCart results in a cart in error state.

## Issue that this pull request solves

Closes: FXA-11252

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/7bcded30-af03-49a6-b2a6-24e8d53d25f5)

