### PR TITLE
feat(next): improve error recording and display

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -67,7 +67,8 @@ export default async function CheckoutError({
       >
         {
           // Once more conditionals are added, move this to a separate component
-          cart.errorReasonId === CartErrorReasonId.CartEligibilityStatusSame ? (
+          cart.errorReasonId ===
+          CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME ? (
             <Image
               src={checkIcon}
               alt="check-icon"

--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -11,6 +11,8 @@ checkout-error-contact-support-button = Contact Support
 checkout-error-not-eligible = You are not eligible to subscribe to this product - please contact support so we can help you.
 checkout-error-already-subscribed = You’re already subscribed to this product.
 checkout-error-contact-support = Please contact support so we can help you.
+cart-error-currency-not-determined = We were unable to determine the currency for this purchase, please try again.
+checkout-processing-general-error = An unexpected error has occurred while processing your payment, please try again.
 
 ## Processing page and Needs Input page - /checkout and /upgrade
 ## Common strings used in multiple pages

--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -144,13 +144,13 @@ export class CartInvalidPromoCodeError extends CartError {
   }
 }
 
-export class CartInvalidCurrencyError extends CartError {
+export class CartCurrencyNotFoundError extends CartError {
   constructor(
     currency: string | undefined,
     country: string | undefined,
     cartId?: string
   ) {
-    super('Cart specified currency is not supported', {
+    super('Cart currency could not be determined', {
       cartId,
       currency,
       country,

--- a/libs/payments/cart/src/lib/cart.factories.ts
+++ b/libs/payments/cart/src/lib/cart.factories.ts
@@ -94,7 +94,7 @@ export const FinishCartFactory = (
 export const FinishErrorCartFactory = (
   override?: Partial<FinishErrorCart>
 ): FinishErrorCart => ({
-  errorReasonId: CartErrorReasonId.Unknown,
+  errorReasonId: CartErrorReasonId.UNKNOWN,
   ...override,
 });
 

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -89,7 +89,7 @@ import { CartService } from './cart.service';
 import { CheckoutService } from './checkout.service';
 import {
   CartError,
-  CartInvalidCurrencyError,
+  CartCurrencyNotFoundError,
   CartInvalidPromoCodeError,
   CartInvalidStateForActionError,
   CartStateProcessingError,
@@ -568,7 +568,7 @@ describe('CartService', () => {
         .mockResolvedValue([mockAccount]);
 
       await expect(() => cartService.setupCart(args)).rejects.toThrowError(
-        CartInvalidCurrencyError
+        CartCurrencyNotFoundError
       );
 
       expect(cartManager.createCart).not.toHaveBeenCalled();
@@ -609,7 +609,7 @@ describe('CartService', () => {
           eligibilityStatus: CartEligibilityStatus.DOWNGRADE,
           couponCode: args.promoCode,
         },
-        CartErrorReasonId.CartEligibilityStatusDowngrade
+        CartErrorReasonId.CART_ELIGIBILITY_STATUS_DOWNGRADE
       );
       expect(result).toEqual(mockErrorCart);
     });
@@ -649,7 +649,7 @@ describe('CartService', () => {
           eligibilityStatus: CartEligibilityStatus.INVALID,
           couponCode: args.promoCode,
         },
-        CartErrorReasonId.CartEligibilityStatusInvalid
+        CartErrorReasonId.CART_ELIGIBILITY_STATUS_INVALID
       );
       expect(result).toEqual(mockErrorCart);
     });
@@ -689,7 +689,7 @@ describe('CartService', () => {
           eligibilityStatus: CartEligibilityStatus.INVALID,
           couponCode: args.promoCode,
         },
-        CartErrorReasonId.CartEligibilityStatusSame
+        CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME
       );
       expect(result).toEqual(mockErrorCart);
     });
@@ -1113,7 +1113,7 @@ describe('CartService', () => {
             mockCart.version,
             mockUpdateCartInput
           )
-        ).rejects.toBeInstanceOf(CartInvalidCurrencyError);
+        ).rejects.toBeInstanceOf(CartCurrencyNotFoundError);
       });
     });
 

--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -25,7 +25,7 @@ export type FinishCart = {
 
 export type FinishErrorCart = {
   uid?: string;
-  errorReasonId: CartErrorReasonId;
+  errorReasonId: CartErrorReasonId | string;
   amount?: number;
   stripeCustomerId?: string;
 };

--- a/libs/payments/cart/src/lib/cart.utils.spec.ts
+++ b/libs/payments/cart/src/lib/cart.utils.spec.ts
@@ -16,13 +16,13 @@ describe('utils', () => {
     it('should return for type card_error', () => {
       mockStripeError.type = 'card_error';
       const result = stripeErrorToErrorReasonId(mockStripeError);
-      expect(result).toBe(CartErrorReasonId.Unknown);
+      expect(result).toBe(CartErrorReasonId.UNKNOWN);
     });
 
     it('should return for default', () => {
       mockStripeError.type = 'api_error';
       const result = stripeErrorToErrorReasonId(mockStripeError);
-      expect(result).toBe(CartErrorReasonId.Unknown);
+      expect(result).toBe(CartErrorReasonId.UNKNOWN);
     });
   });
 });

--- a/libs/payments/cart/src/lib/cart.utils.ts
+++ b/libs/payments/cart/src/lib/cart.utils.ts
@@ -35,7 +35,7 @@ export const cartEligibilityDetailsMap: Record<
   [EligibilityStatus.DOWNGRADE]: {
     eligibilityStatus: CartEligibilityStatus.DOWNGRADE,
     state: CartState.FAIL,
-    errorReasonId: CartErrorReasonId.CartEligibilityStatusDowngrade,
+    errorReasonId: CartErrorReasonId.CART_ELIGIBILITY_STATUS_DOWNGRADE,
   },
   [EligibilityStatus.BLOCKED_IAP]: {
     eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
@@ -45,12 +45,12 @@ export const cartEligibilityDetailsMap: Record<
   [EligibilityStatus.SAME]: {
     eligibilityStatus: CartEligibilityStatus.INVALID,
     state: CartState.FAIL,
-    errorReasonId: CartErrorReasonId.CartEligibilityStatusSame,
+    errorReasonId: CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME,
   },
   [EligibilityStatus.INVALID]: {
     eligibilityStatus: CartEligibilityStatus.INVALID,
     state: CartState.FAIL,
-    errorReasonId: CartErrorReasonId.CartEligibilityStatusInvalid,
+    errorReasonId: CartErrorReasonId.CART_ELIGIBILITY_STATUS_INVALID,
   },
 };
 
@@ -60,6 +60,6 @@ export function stripeErrorToErrorReasonId(
   switch (stripeError.type) {
     case 'card_error':
     default:
-      return CartErrorReasonId.Unknown;
+      return CartErrorReasonId.UNKNOWN;
   }
 }

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -86,7 +86,7 @@ import {
   CartTotalMismatchError,
   CartAccountNotFoundError,
   CartInvalidPromoCodeError,
-  CartInvalidCurrencyError,
+  CartCurrencyNotFoundError,
   CartUidNotFoundError,
   CartNoTaxAddressError,
 } from './cart.error';
@@ -389,7 +389,7 @@ describe('CheckoutService', () => {
 
         await expect(
           checkoutService.prePaySteps(mockCart, mockCustomerData)
-        ).rejects.toBeInstanceOf(CartInvalidCurrencyError);
+        ).rejects.toBeInstanceOf(CartCurrencyNotFoundError);
       });
 
       it('throws cart eligibility mismatch error', async () => {

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -40,7 +40,7 @@ import {
   CartEligibilityMismatchError,
   CartAccountNotFoundError,
   CartInvalidPromoCodeError,
-  CartInvalidCurrencyError,
+  CartCurrencyNotFoundError,
   CartUidNotFoundError,
   CartError,
   CartNoTaxAddressError,
@@ -99,7 +99,7 @@ export class CheckoutService {
     let version = cart.version;
 
     if (!cart.currency) {
-      throw new CartInvalidCurrencyError(
+      throw new CartCurrencyNotFoundError(
         cart.currency || undefined,
         taxAddress.countryCode
       );

--- a/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
+++ b/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
+import {
+  CartCurrencyNotFoundError,
+  CartStateProcessingError,
+} from '../cart.error';
+import { CheckoutFailedError } from '../checkout.error';
+import { BaseError } from '@fxa/shared/error';
+
+export function resolveErrorInstance(error: Error) {
+  /**
+   * Handle specific errors here. Typically this is necessary
+   * when the CartErrorReasonId has a corresponding frontend error
+   * message.
+   */
+  switch (true) {
+    // Cart Errors
+    case error instanceof CartCurrencyNotFoundError:
+      return CartErrorReasonId.CART_CURRENCY_NOT_DETERMINED;
+    case error instanceof CartStateProcessingError:
+      return CartErrorReasonId.CART_PROCESSING_GENERAL_ERROR;
+
+    // Checkout Errors
+    case error instanceof CheckoutFailedError:
+      return CartErrorReasonId.BASIC_ERROR;
+
+    // Eligibility Errors
+  }
+
+  /**
+   * Handle libs parent errors.
+   * Most should inherit from BaseError. Add any other values as necessary.
+   * Note, these return values do not map to a frontend error message.
+   * However, they can be useful for logging and debugging.
+   */
+  switch (true) {
+    case error instanceof BaseError:
+      return error.constructor.name;
+  }
+
+  return CartErrorReasonId.UNKNOWN;
+}

--- a/libs/payments/ui/src/lib/server/components/SubscriptionTitle/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/SubscriptionTitle/index.tsx
@@ -17,7 +17,7 @@ export function getComponentTitle(cart: CartDTO) {
   const { state, eligibilityStatus, errorReasonId } = cart;
   switch (state) {
     case CartState.FAIL:
-      if (errorReasonId === CartErrorReasonId.CartEligibilityStatusSame) {
+      if (errorReasonId === CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME) {
         return {
           title: 'You’ve already subscribed',
           titleFtl: 'subscription-title-sub-exists',

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -6,7 +6,7 @@ import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
 import { CheckoutParams } from './types';
 
 export function getErrorFtlInfo(
-  reason: CartErrorReasonId | null,
+  reason: CartErrorReasonId | string | null,
   params: CheckoutParams,
   config: {
     contentServerUrl: string;
@@ -14,7 +14,7 @@ export function getErrorFtlInfo(
   }
 ) {
   switch (reason) {
-    case CartErrorReasonId.CartEligibilityStatusDowngrade:
+    case CartErrorReasonId.CART_ELIGIBILITY_STATUS_DOWNGRADE:
       return {
         buttonFtl: 'checkout-error-contact-support-button',
         buttonLabel: 'Contact Support',
@@ -22,7 +22,7 @@ export function getErrorFtlInfo(
         message: 'Please contact support so we can help you.',
         messageFtl: 'checkout-error-contact-support',
       };
-    case CartErrorReasonId.CartEligibilityStatusInvalid:
+    case CartErrorReasonId.CART_ELIGIBILITY_STATUS_INVALID:
       return {
         buttonFtl: 'checkout-error-contact-support-button',
         buttonLabel: 'Contact Support',
@@ -31,7 +31,7 @@ export function getErrorFtlInfo(
           'You are not eligible to subscribe to this product - please contact support so we can help you.',
         messageFtl: 'checkout-error-not-eligible',
       };
-    case CartErrorReasonId.CartEligibilityStatusSame:
+    case CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME:
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
@@ -48,6 +48,25 @@ export function getErrorFtlInfo(
           'You can still get this product — please contact support so we can help you.',
         messageFtl: 'next-iap-upgrade-contact-support',
       };
+    case CartErrorReasonId.CART_CURRENCY_NOT_DETERMINED:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'We were unable to determine the currency for this purchase, please try again.',
+        messageFtl: 'cart-error-currency-not-determined',
+      };
+    case CartErrorReasonId.CART_PROCESSING_GENERAL_ERROR:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'An unexpected error has occurred while processing your payment, please try again.',
+        messageFtl: 'checkout-processing-general-error',
+      };
+
     case CartErrorReasonId.BASIC_ERROR:
     default:
       return {

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -35,10 +35,12 @@ export enum CartErrorReasonId {
   BASIC_ERROR = 'basic-error-message',
   IAP_UPGRADE_CONTACT_SUPPORT = 'iap_upgrade_contact_support',
   SUCCESS_CART_MISSING_REQUIRED = 'success_cart_missing_required',
-  CartEligibilityStatusDowngrade = 'cart_eligibility_status_downgrade',
-  CartEligibilityStatusInvalid = 'cart_eligibility_status_invalid',
-  CartEligibilityStatusSame = 'cart_eligibility_status_same',
-  Unknown = 'unknown',
+  CART_ELIGIBILITY_STATUS_SAME = 'cart_eligibility_status_same',
+  CART_ELIGIBILITY_STATUS_DOWNGRADE = 'cart_eligibility_status_downgrade',
+  CART_ELIGIBILITY_STATUS_INVALID = 'cart_eligibility_status_invalid',
+  CART_CURRENCY_NOT_DETERMINED = 'cart_currency_not_determined',
+  CART_PROCESSING_GENERAL_ERROR = 'cart_processing_general_error',
+  UNKNOWN = 'unknown',
 }
 
 export enum CartEligibilityStatus {
@@ -94,7 +96,7 @@ export interface Carts {
   id: Buffer;
   uid: Buffer | null;
   state: CartState;
-  errorReasonId: CartErrorReasonId | null;
+  errorReasonId: CartErrorReasonId | string | null;
   offeringConfigId: string;
   interval: string;
   experiment: string | null;


### PR DESCRIPTION
## Because

- It is currently not easy to throw an error on the server and display a user friendly message on the frontend.
- When debugging a specific cart, it is not easy to determine what caused the cart to error.

## This pull request

- Create one function to resolve an error instance to a specific CartErrorReasonId, which can be used to display a user friendly message on the frontend.
- For error instances not specifically mapped to a CartErrorReasonId, but still thrown by SubPlat libraries, add the instance name to the cart.errorReasonId field instead, to help with debugging.


## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
