### PR TITLE
task(ci): Bump yarn cache key prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,17 +264,20 @@ commands:
   cache-save-yarn:
     steps:
       - save_cache:
-          key: fxa-yarn-001-{{ checksum "yarn.lock" }}
+          key: fxa-yarn-002-{{ checksum "yarn.lock" }}
           paths:
             - /home/circleci/.yarn
             - /home/circleci/project/.yarn
 
   cache-restore-yarn:
     steps:
+      # Note, this matches keys im a prefixed manner. ie It will try match
+      # the first key which is the exact key. If this fails it'll fallback
+      # to a recent entry that starts with fxa-yarn-002
       - restore_cache:
           keys:
-            - fxa-yarn-001-{{ checksum "yarn.lock" }}
-            - fxa-yarn-001-
+            - fxa-yarn-002-{{ checksum "yarn.lock" }}
+            - fxa-yarn-002-
 
   wait-for-infrastructure:
     steps:


### PR DESCRIPTION
## Because:
- We were getting some flaky behavior on yarn install.
- There were seemingly random node-gyp errors
- We think this might have to with older cached packages and node version 22

## This PR:
- Bumps the key prefix

## Issue that this pull request solves

Closes: FXA-11521

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

See https://circleci.com/docs/caching/#restoring-cache for info on how key matching works for circle ci caches.
