### PR TITLE
feat(payments-next): collect metrics for location changes

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as Sentry from '@sentry/nextjs';
 import { headers } from 'next/headers';
 import Image from 'next/image';
 import { notFound, redirect } from 'next/navigation';
@@ -35,8 +34,7 @@ export default async function Location({
 }) {
   const acceptLanguage = headers().get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, params.locale);
-
-  Sentry.captureMessage('Could not locate user by their ip');
+  const emitterService = getApp().getEmitterService();
 
   let cms: PageContentOfferingTransformed | undefined;
   let locationStatus: LocationStatus | undefined;
@@ -57,6 +55,8 @@ export default async function Location({
     ]);
     cms = cmsData;
     locationStatus = locationData.status;
+
+    emitterService.emit('locationView', locationStatus);
   } catch (error) {
     if (error.name === 'FetchCmsInvalidOfferingError') {
       notFound();

--- a/libs/payments/events/src/lib/emitter.service.ts
+++ b/libs/payments/events/src/lib/emitter.service.ts
@@ -6,6 +6,7 @@ import { ProductConfigurationManager } from '@fxa/shared/cms';
 import { Inject, Injectable } from '@nestjs/common';
 import { CartManager } from '@fxa/payments/cart';
 import { PaymentsGleanManager } from '@fxa/payments/metrics';
+import { LocationStatus } from '@fxa/payments/eligibility';
 import {
   CheckoutEvents,
   CheckoutPaymentEvents,
@@ -41,6 +42,7 @@ export class PaymentsEmitterService {
       this.handleSubscriptionEnded.bind(this)
     );
     this.emitter.on('sp3Rollout', this.handleSP3Rollout.bind(this));
+    this.emitter.on('locationView', this.handleLocationView.bind(this));
   }
 
   getEmitter(): Emittery<PaymentsEmitterEvents> {
@@ -203,6 +205,12 @@ export class PaymentsEmitterService {
       offering_id: offeringId,
       interval,
       shadow_mode: shadowMode ? 'true' : 'false',
+    });
+  }
+
+  async handleLocationView(status: LocationStatus) {
+    this.statsd.increment('sp3_location_view', {
+      location_status: status,
     });
   }
 

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -7,6 +7,7 @@ import {
   CommonMetrics,
   PaymentProvidersType,
 } from '@fxa/payments/metrics';
+import { LocationStatus } from '@fxa/payments/eligibility';
 
 export type CheckoutEvents = CommonMetrics;
 export type CheckoutPaymentEvents = CommonMetrics & {
@@ -49,6 +50,7 @@ export type PaymentsEmitterEvents = {
   checkoutFail: CheckoutPaymentEvents;
   subscriptionEnded: SubscriptionEndedEvents;
   sp3Rollout: SP3RolloutEvent;
+  locationView: LocationStatus;
 };
 
 export type AdditionalMetricsData = {


### PR DESCRIPTION
Because:

* we need to understand how often our users are experiencing issues with location changes

This commit:

* Adds statsd collection for counts of ip location failures, unsupported locations, and sactioned locations

Closes #FXA-11481

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
