### PR TITLE
feat(next): location shows updates optimistically

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -11,7 +11,7 @@ import {
 import {
   fetchCMSData,
   getCartAction,
-  updateCartAction,
+  updateTaxAddressAction,
 } from '@fxa/payments/ui/actions';
 import {
   getApp,
@@ -100,8 +100,9 @@ export default async function CheckoutLayout({
               <SelectTaxLocation
                 saveAction={async (countryCode, postalCode) => {
                   'use server';
-                  await updateCartAction(cart.id, cart.version, {
-                    taxAddress: { countryCode, postalCode },
+                  return updateTaxAddressAction(cart.id, cart.version, {
+                    countryCode,
+                    postalCode,
                   });
                 }}
                 cmsCountries={cms.countries}

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -541,7 +541,7 @@ export class CartService {
     cartId: string,
     version: number,
     cartDetailsInput: UpdateCartInput
-  ) {
+  ): Promise<ResultCart> {
     return this.wrapWithCartCatch(
       cartId,
       { errorAllowList: [PromotionCodeCouldNotBeAttachedError] },
@@ -603,6 +603,8 @@ export class CartService {
         }
 
         await this.cartManager.updateFreshCart(cartId, version, cartDetails);
+
+        return this.cartManager.fetchCartById(cartId);
       }
     );
   }
@@ -797,9 +799,8 @@ export class CartService {
       throw new CartSubscriptionNotFoundError(cartId);
     }
 
-    const paymentIntent = await this.subscriptionManager.getLatestPaymentIntent(
-      subscription
-    );
+    const paymentIntent =
+      await this.subscriptionManager.getLatestPaymentIntent(subscription);
     if (!paymentIntent) {
       throw new CartError('no payment intent found for cart subscription', {
         cartId,

--- a/libs/payments/ui/src/lib/actions/applyCoupon.ts
+++ b/libs/payments/ui/src/lib/actions/applyCoupon.ts
@@ -6,14 +6,13 @@
 
 import { revalidatePath } from 'next/cache';
 
-import { UpdateCartInput } from '@fxa/payments/cart';
 import { getApp } from '../nestapp/app';
 import { CouponErrorMessageType } from '../utils/error-ftl-messages';
 
-export const updateCartAction = async (
+export const applyCouponAction = async (
   cartId: string,
   version: number,
-  cartDetails: UpdateCartInput
+  couponCode?: string
 ) => {
   const actionsService = getApp().getActionsService();
 
@@ -21,7 +20,9 @@ export const updateCartAction = async (
     await actionsService.updateCart({
       cartId,
       version,
-      cartDetails,
+      cartDetails: {
+        couponCode,
+      },
     });
   } catch (err) {
     if (err.name === 'CouponErrorExpired') {
@@ -36,7 +37,7 @@ export const updateCartAction = async (
   }
 
   revalidatePath(
-    '/[locale]/[offeringId]/[interval]/checkout/[cartId]/start',
+    `/[locale]/[offeringId]/[interval]/checkout/[cartId]/start`,
     'page'
   );
 

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+export { applyCouponAction } from './applyCoupon';
 export { checkoutCartWithPaypal } from './checkoutCartWithPaypal';
 export { checkoutCartWithStripe } from './checkoutCartWithStripe';
 export { determineCurrencyAction } from './determineCurrency';
@@ -17,7 +18,7 @@ export { handleStripeErrorAction } from './handleStripeError';
 export { recordEmitterEventAction } from './recordEmitterEvent';
 export { restartCartAction } from './restartCart';
 export { setupCartAction } from './setupCart';
-export { updateCartAction } from './updateCart';
+export { updateTaxAddressAction } from './updateTaxAddress';
 export { finalizeCartWithError } from './finalizeCartWithError';
 export { finalizeProcessingCartAction } from './finalizeProcessingCart';
 export { getNeedsInputAction } from './getNeedsInput';

--- a/libs/payments/ui/src/lib/actions/updateTaxAddress.ts
+++ b/libs/payments/ui/src/lib/actions/updateTaxAddress.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { UpdateCartInput } from '@fxa/payments/cart';
+import { getApp } from '../nestapp/app';
+
+export const updateTaxAddressAction = async (
+  cartId: string,
+  version: number,
+  taxAddress: UpdateCartInput['taxAddress']
+) => {
+  const actionsService = getApp().getActionsService();
+
+  const { taxAddress: cartTaxAddress } = await actionsService.updateCart({
+    cartId,
+    version,
+    cartDetails: {
+      taxAddress,
+    },
+  });
+
+  if (!cartTaxAddress) {
+    throw new Error('Cart address not updated');
+  }
+
+  revalidatePath(
+    '/[locale]/[offeringId]/[interval]/checkout/[cartId]/start',
+    'page'
+  );
+
+  return cartTaxAddress;
+};

--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.tsx
@@ -11,11 +11,11 @@ import { forwardRef, useEffect } from 'react';
 import { useFormState, useFormStatus } from 'react-dom';
 import { ButtonVariant } from '../BaseButton';
 import { SubmitButton } from '../SubmitButton';
-import { updateCartAction } from '../../../actions/updateCart';
 import {
   CouponErrorMessageType,
   getFallbackTextByFluentId,
 } from '../../../utils/error-ftl-messages';
+import { applyCouponAction } from '@fxa/payments/ui/actions';
 
 interface WithCouponProps {
   cartId: string;
@@ -30,7 +30,7 @@ const WithCoupon = ({
   readOnly,
 }: WithCouponProps) => {
   async function removeCoupon() {
-    await updateCartAction(cartId, cartVersion, { couponCode: '' });
+    await applyCouponAction(cartId, cartVersion, '');
   }
 
   return (
@@ -114,9 +114,7 @@ const WithoutCoupon = ({
   async function applyCoupon(_: any, formData: FormData) {
     const promotionCode = formData.get('coupon') as string;
 
-    return updateCartAction(cartId, cartVersion, {
-      couponCode: promotionCode,
-    });
+    return applyCouponAction(cartId, cartVersion, promotionCode);
   }
   const routeCoupon = useSearchParams().get('coupon') || undefined;
   useEffect(() => {

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -73,6 +73,8 @@ import { GetTaxAddressResult } from './validators/GetTaxAddressResult';
 import { CartInvalidPromoCodeError } from 'libs/payments/cart/src/lib/cart.error';
 import { GetIsTaxLockedArgs } from './validators/GetIsTaxLockedArgs';
 import { GetIsTaxLockedResult } from './validators/GetIsTaxLockedResult';
+import { UpdateCartActionResult } from './validators/UpdateCartActionResult';
+
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
  * ALL server actions must use this service as a proxy to other NestJS services.
@@ -91,7 +93,7 @@ export class NextJSActionsService {
     private currencyManager: CurrencyManager,
     private eligibilityService: EligibilityService,
     private productConfigurationManager: ProductConfigurationManager
-  ) {}
+  ) { }
 
   @SanitizeExceptions()
   @NextIOValidator(GetCartActionArgs, GetCartActionResult)
@@ -124,7 +126,7 @@ export class NextJSActionsService {
       CouponErrorLimitReached,
     ],
   })
-  @NextIOValidator(UpdateCartActionArgs, undefined)
+  @NextIOValidator(UpdateCartActionArgs, UpdateCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   async updateCart(args: {
     cartId: string;
@@ -138,7 +140,7 @@ export class NextJSActionsService {
       couponCode?: string;
     };
   }) {
-    await this.cartService.updateCart(
+    return this.cartService.updateCart(
       args.cartId,
       args.version,
       args.cartDetails

--- a/libs/payments/ui/src/lib/nestapp/validators/UpdateCartActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/UpdateCartActionResult.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+class TaxAddress {
+  @IsString()
+  countryCode!: string;
+
+  @IsString()
+  postalCode!: string;
+}
+
+export class UpdateCartActionResult {
+  @IsString()
+  id!: string;
+
+  @IsOptional()
+  @IsString()
+  uid?: string;
+
+  @IsEnum(CartState)
+  state!: CartState;
+
+  @IsString()
+  offeringConfigId!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsOptional()
+  @IsString()
+  experiment?: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TaxAddress)
+  taxAddress?: TaxAddress;
+
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @IsNumber()
+  createdAt!: number;
+
+  @IsNumber()
+  updatedAt!: number;
+
+  @IsOptional()
+  @IsString()
+  couponCode?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeCustomerId?: string;
+
+  @IsOptional()
+  @IsString()
+  stripeSubscriptionId?: string;
+
+  @IsOptional()
+  @IsString()
+  email?: string;
+
+  @IsNumber()
+  amount!: number;
+
+  @IsNumber()
+  version!: number;
+
+  @IsEnum(CartEligibilityStatus)
+  eligibilityStatus!: CartEligibilityStatus;
+}


### PR DESCRIPTION
## Because

- After changing location through the location picker, the collapsed view shows the previous values before flashing to the new value.

## This pull request

- Split updateCartAction into function specific actions applyCouponAction and updateTaxAddressAction.
- Modify updateCart functions to return updated Cart.
- Add local state to SelectTaxLocation component to show new tax location before cart is revalidated.

## Issue that this pull request solves

Closes: #FXA-11030

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

