### PR TITLE
feat(scripts): accept email args for direct acct reset

### DIFF
--- a/packages/fxa-auth-server/scripts/recorded-future/lib.ts
+++ b/packages/fxa-auth-server/scripts/recorded-future/lib.ts
@@ -184,6 +184,7 @@ export const getCredentials = async (
       salt: account?.normalizedEmail,
     };
   })();
+
   const stretch = await pbkdf2.derive(
     Buffer.from(password),
     hkdf.KWE('quickStretch', salt),
@@ -192,6 +193,7 @@ export const getCredentials = async (
   );
   const authPW = await hkdf(stretch, 'authPW', null, 32);
   const unwrapBKey = await hkdf(stretch, 'unwrapBKey', null, 32);
+
   return { authPW, unwrapBKey };
 };
 


### PR DESCRIPTION
Because:
 - for testing, or scenarios where we know we want to force reset accounts, we want to be able to pass in account email addresses to force reset the accounts

This commit:
 - adds a new repeatable parameter to accept email addresses
 - breaks up and moves code around so that email argument values can be checked for existing accounts and their 2FA status
