### PR TITLE
task(settings): Full production rollout of react email-first

### DIFF
--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -38,12 +38,14 @@ export class SigninPage extends BaseLayout {
     return this.page.getByRole('button', { name: 'Confirm' });
   }
 
+  // Use /Continue with.*Apple/ because of hidden bidi Unicode characters around "Apple" in its accessible name.
   get continueWithAppleButton() {
-    return this.page.getByRole('button', { name: 'Continue with Apple' });
+    return this.page.getByRole('button', { name: /Continue with .*Apple/ });
   }
 
+  // Use /Continue with.*Google/ because of hidden bidi Unicode characters around "Google" in its accessible name.
   get continueWithGoogleButton() {
-    return this.page.getByRole('button', { name: 'Continue with Google' });
+    return this.page.getByRole('button', { name: /Continue with .*Google/ });
   }
 
   get emailFirstHeading() {

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -27,22 +27,21 @@ test.describe('severity-2 #smoke', () => {
       target,
       page,
       pages: { signin },
-      testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
-
       await page.goto(
         `${target.contentServerUrl}/?redirect_to=javascript:alert(1)`
       );
-      await signin.fillOutEmailFirstForm(credentials.email);
 
-      await expect(page).toHaveURL(/signin/);
-      await expect(signin.badRequestHeading).toBeVisible();
+      // only error message shown on screen in case of xss redirect_to
+      await expect(
+        page.getByRole('heading', { name: /Bad Request/ })
+      ).toBeVisible();
+      await expect(signin.emailFirstHeading).toBeHidden();
     });
 
     test('does not allow bogus redirect_to parameter', async ({
       target,
-      pages: { page, signin },
+      pages: { page, settings, signin },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -54,11 +53,12 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await expect(page).not.toHaveURL(redirectTo);
+      await expect(settings.settingsHeading).toBeVisible();
     });
 
     test('allows valid redirect_to parameter', async ({
       target,
-      pages: { page, signin },
+      pages: { page, changePassword, signin },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -70,6 +70,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await expect(page).toHaveURL(redirectTo);
+      await expect(changePassword.changePasswordHeading).toBeVisible();
     });
   });
 });

--- a/packages/functional-tests/tests/syncV3/signinCached.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signinCached.spec.ts
@@ -9,7 +9,7 @@ import { SigninPage } from '../../pages/signin';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('sync signin cached', () => {
-    test('sign in on desktop then specify a different email on query parameter continues to cache desktop signin', async ({
+    test('sign in on desktop then specify a different email on query parameter', async ({
       target,
       syncBrowserPages: { page, settings, signin, connectAnotherDevice },
       testAccountTracker,
@@ -23,30 +23,34 @@ test.describe('severity-2 #smoke', () => {
       );
       const query = { email: credentials.email };
       const queryParam = new URLSearchParams(query);
-      await page.goto(
-        `${
-          target.contentServerUrl
-        }?context=fx_desktop_v3&service=sync&action=email&${queryParam.toString()}`
-      );
+      await page.goto(`${target.contentServerUrl}?${queryParam.toString()}`);
 
       //Check prefilled email
       await expect(signin.passwordFormHeading).toBeVisible();
       await expect(page.getByText(credentials.email)).toBeVisible();
       await signin.fillOutPasswordForm(credentials.password);
-      await expect(page).toHaveURL(/pair/);
-      await connectAnotherDevice.clickNotNowPair();
-      await page.waitForURL(/settings/);
 
       //Verify logged in on Settings page
       await expect(settings.settingsHeading).toBeVisible();
 
-      //Reset prefill and context
-      await signin.clearSessionStorage();
+      // verify that if we directly go to the index page,
+      // the most recently signed in account is suggested
 
-      //Testing to make sure cached signin comes back after a refresh
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
+      // however (not tested here because Playwright tests can't access browser menu)
+      // if we instead clicked on "manage settings" from the Sync browser menu
+      // the account settings would be loaded for the sync credential account
+
+      await page.goto(target.contentServerUrl);
+      await expect(signin.cachedSigninHeading).toBeVisible();
+      // suggests most recently signed in account
+      await expect(page.getByText(credentials.email)).toBeVisible();
+      await signin.signInButton.click();
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settings.signOut();
+
+      // falls back to suggesting the account signed in to the browser
+      await expect(signin.cachedSigninHeading).toBeVisible();
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
       await signin.useDifferentAccountLink.click();
       await expect(signin.emailFirstHeading).toBeVisible();
@@ -63,30 +67,12 @@ test.describe('severity-2 #smoke', () => {
         signin,
         testAccountTracker
       );
-      const credentials = await testAccountTracker.signUp();
 
       await page.goto(target.contentServerUrl, {
         waitUntil: 'load',
       });
+      // signed in sync account suggested
       await expect(page.getByText(syncCredentials.email)).toBeVisible();
-      await signin.useDifferentAccountLink.click();
-      await expect(signin.emailFirstHeading).toBeVisible();
-      await signin.fillOutEmailFirstForm(credentials.email);
-      await signin.fillOutPasswordForm(credentials.password);
-
-      //Verify logged in on Settings page
-      await expect(settings.settingsHeading).toBeVisible();
-
-      //Reset prefill and context
-      await signin.clearSessionStorage();
-
-      //Testing to make sure cached signin comes back after a refresh
-      await page.goto(target.contentServerUrl, {
-        waitUntil: 'load',
-      });
-      await expect(page.getByText(syncCredentials.email)).toBeVisible();
-      await signin.useDifferentAccountLink.click();
-      await expect(signin.emailFirstHeading).toBeVisible();
     });
   });
 });

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -71,6 +71,6 @@
   },
   "rolloutRates": {
     "keyStretchV2": 1,
-    "generalizedReactApp": 1
+    "generalizedReactApp": 0
   }
 }

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -25,10 +25,10 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
   return {
     emailFirstRoutes: {
       featureFlagOn: showReactApp.emailFirstRoutes,
-      // the order of the routes in teh array is important.  do not put '/'
+      // the order of the routes in the array is important.  do not put '/'
       // first.
       routes: reactRoute.getRoutes(['authorization', 'oauth', '/']),
-      fullProdRollout: false,
+      fullProdRollout: true,
     },
     simpleRoutes: {
       featureFlagOn: showReactApp.simpleRoutes,

--- a/packages/fxa-react/lib/test-utils/localizationProvider.tsx
+++ b/packages/fxa-react/lib/test-utils/localizationProvider.tsx
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React from 'react';
 import { render } from '@testing-library/react';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';

--- a/packages/fxa-react/lib/test-utils/mockWindowLocation.ts
+++ b/packages/fxa-react/lib/test-utils/mockWindowLocation.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function mockWindowLocation({
+  pathname = '/',
+  search = '',
+  hash = '',
+}: {
+  pathname?: string;
+  search?: string;
+  hash?: string;
+}) {
+  delete (window as any).location;
+
+  (window as any).location = {
+    ...window.location,
+    assign: jest.fn(),
+    reload: jest.fn(),
+    replace: jest.fn(),
+    pathname,
+    search,
+    hash,
+    href: `http://localhost${pathname}${search}${hash}`,
+  };
+}

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -356,7 +356,7 @@ describe('SettingsRoutes', () => {
     (useSession as jest.Mock).mockRestore();
   });
 
-  it('redirects to /signin if isSignedIn is false', async () => {
+  it('redirects to email-first if isSignedIn is false', async () => {
     (firefox.requestSignedInUser as jest.Mock).mockResolvedValue(null);
     (currentAccount as jest.Mock).mockReturnValue(null);
     (useIntegration as jest.Mock).mockReturnValue({
@@ -436,6 +436,14 @@ describe('SettingsRoutes', () => {
   });
 
   it('restores sync user when session is valid', async () => {
+    // we only send a webChannel message to check for a sync user
+    // if the userAgent is a version of Firefox
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:118.0) Gecko/20100101 Firefox/118.0',
+      configurable: true,
+    });
+
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
       isDesktopRelay: () => false,

--- a/packages/fxa-settings/src/components/FormPassword/index.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.tsx
@@ -11,9 +11,9 @@ import { UseFormMethods, ValidateResult } from 'react-hook-form';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import InputPassword from '../InputPassword';
 import PasswordValidator from '../../lib/password-validator';
-import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../constants';
 import { logViewEvent, settingsViewName } from '../../lib/metrics';
+import { useNavigate } from '@reach/router';
 
 type FormPasswordProps = {
   formState: UseFormMethods['formState'];

--- a/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
+++ b/packages/fxa-settings/src/components/LinkRememberPassword/index.tsx
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
-import { useLocation, useNavigate } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { isEmailValid } from 'fxa-shared/email/helpers';
-import { useCheckReactEmailFirst } from '../../lib/hooks';
+import { Link, useLocation } from '@reach/router';
 
 export type LinkRememberPasswordProps = {
   email?: string;
@@ -19,43 +18,15 @@ const LinkRememberPassword = ({
   clickHandler,
   textStart,
 }: LinkRememberPasswordProps) => {
-  let linkHref: string;
   const location = useLocation();
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
-
-  const params = new URLSearchParams(location.search);
-  params.delete('email');
-  params.delete('hasLinkedAccount');
-  params.delete('hasPassword');
-  params.delete('showReactApp');
-
-  if (email && isEmailValid(email) && !shouldUseReactEmailFirst) {
-    params.set('prefillEmail', email);
-    linkHref = `/?${params.toString()}`;
-  } else {
-    linkHref = params.size > 0 ? `/?${params.toString()}` : '/';
-  }
 
   const handleClick = (
     event: React.MouseEvent<HTMLAnchorElement, MouseEvent>
   ) => {
-    event.preventDefault();
-
     if (clickHandler) {
-      // additional optional click handlong behavior
+      // additional optional click handling behavior
       clickHandler();
     }
-
-    if (shouldUseReactEmailFirst) {
-      navigate(linkHref, {
-        state: {
-          prefillEmail: email && isEmailValid(email) ? email : undefined,
-        },
-      });
-      return;
-    }
-    hardNavigate(linkHref);
   };
 
   return (
@@ -68,15 +39,17 @@ const LinkRememberPassword = ({
         <p>Remember your password?</p>
       </FtlMsg>
       <FtlMsg id="remember-password-signin-link">
-        {/* TODO in FXA-8636 replace with Link component */}
-        <a
-          href={linkHref}
+        <Link
+          to={`/${location.search}`}
+          state={{
+            prefillEmail: email && isEmailValid(email) ? email : undefined,
+          }}
           className="link-blue"
           id="remember-password"
           onClick={handleClick}
         >
           Sign in
-        </a>
+        </Link>
       </FtlMsg>
     </div>
   );

--- a/packages/fxa-settings/src/components/Settings/LinkedAccounts/LinkedAccount.tsx
+++ b/packages/fxa-settings/src/components/Settings/LinkedAccounts/LinkedAccount.tsx
@@ -11,7 +11,7 @@ import { Modal } from '../Modal';
 import { useAccount, useFtlMsgResolver } from '../../../models';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../../constants';
 import {
   LinkedAccountProviderIds,
@@ -26,7 +26,7 @@ export function LinkedAccount({
 }) {
   const account = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: UnlinkAccountLocationState;
   };
@@ -42,7 +42,7 @@ export function LinkedAccount({
 
   // Keep the user where they were, but update router state
   const resetLocationState = () =>
-    navigate(SETTINGS_PATH + '#linked-accounts', {
+    navigateWithQuery(SETTINGS_PATH + '#linked-accounts', {
       replace: true,
       state: { wantsUnlinkProviderId: undefined },
     });
@@ -73,7 +73,7 @@ export function LinkedAccount({
       // If a user doesn't have a password, they must create one first. We send
       // a navigation state that's passed back to Settings on password create
       // success that we account for here by automatically re-opening the modal.
-      navigate(SETTINGS_PATH + '/create_password', {
+      navigateWithQuery(SETTINGS_PATH + '/create_password', {
         state: { wantsUnlinkProviderId: providerId },
       });
     }

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
@@ -26,14 +26,16 @@ import GleanMetrics from '../../../lib/glean';
 
 export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const session = useSession();
   const account = useAccount();
   const config = useConfig();
   const ftlMsgResolver = useFtlMsgResolver();
 
   const goHome = () =>
-    navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });
+    navigateWithQuery(SETTINGS_PATH + '#two-step-authentication', {
+      replace: true,
+    });
 
   const [subtitle, setSubtitle] = useState<string>(
     ftlMsgResolver.getMsg('tfa-replace-code-1-2', 'Step 1 of 2')
@@ -53,7 +55,9 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
           event: { reason: GleanClickEventType2FA.replace },
         })
     );
-    navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });
+    navigateWithQuery(SETTINGS_PATH + '#two-step-authentication', {
+      replace: true,
+    });
   };
 
   const onRecoveryCodeSubmit = async (_: RecoveryCodeForm) => {

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/buttons.tsx
@@ -4,7 +4,7 @@
 
 import React, { useCallback, useRef } from 'react';
 
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { Localized, useLocalization } from '@fluent/react';
 import { useAccount, useAlertBar } from '../../../models';
 import { SETTINGS_PATH } from '../../../constants';
@@ -28,14 +28,14 @@ const editButtonClass = `mx-1 text-white rounded-full hover:bg-grey-100`;
 const buttonSize = 32;
 
 export const RemovePhotoBtn = () => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const alertBar = useAlertBar();
   const account = useAccount();
   const { l10n } = useLocalization();
   const deleteAvatar = useCallback(async () => {
     try {
       await account.deleteAvatar();
-      navigate(SETTINGS_PATH, { replace: true });
+      navigateWithQuery(SETTINGS_PATH, { replace: true });
     } catch (err) {
       alertBar.error(
         l10n.getString(
@@ -45,7 +45,7 @@ export const RemovePhotoBtn = () => {
         )
       );
     }
-  }, [account, navigate, alertBar, l10n]);
+  }, [account, navigateWithQuery, alertBar, l10n]);
 
   return (
     <div onClick={deleteAvatar} className="cursor-pointer flex-1">
@@ -142,14 +142,14 @@ export const ConfirmBtns = ({
   saveEnabled,
   localizedSaveText,
 }: ConfirmBtnsProps) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
 
   return (
     <div className="flex justify-center mx-auto max-w-64">
       <Localized id="avatar-page-cancel-button">
         <button
           className="cta-neutral cta-base-p mx-2 flex-1"
-          onClick={() => navigate(SETTINGS_PATH, { replace: true })}
+          onClick={() => navigateWithQuery(SETTINGS_PATH, { replace: true })}
           data-testid="close-button"
         >
           Cancel

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { Localized, useLocalization } from '@fluent/react';
 import Webcam from 'react-webcam';
 import Cropper, { Area } from 'react-easy-crop';
@@ -41,7 +41,7 @@ const frameClass = `rounded-full m-auto w-40 object-cover`;
 
 export const PageAddAvatar = (_: RouteComponentProps) => {
   usePageViewEvent('settings.avatar.change');
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const account = useAccount();
   const { l10n } = useLocalization();
   const { avatar } = useAccount();
@@ -77,12 +77,14 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
       try {
         await account.uploadAvatar(file);
         logViewEvent(settingsViewName, 'avatar.crop.submit.change');
-        navigate(SETTINGS_PATH + '#profile-picture', { replace: true });
+        navigateWithQuery(SETTINGS_PATH + '#profile-picture', {
+          replace: true,
+        });
       } catch (e) {
         onFileError();
       }
     },
-    [account, navigate, onFileError]
+    [account, navigateWithQuery, onFileError]
   );
 
   /* Capture State */

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../../constants';
 import {
   logViewEvent,
@@ -51,7 +51,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const account = useAccount();
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const [currentPasswordErrorText, setCurrentPasswordErrorText] =
     useState<string>();
@@ -61,8 +61,8 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
     alertBar.success(
       ftlMsgResolver.getMsg('pw-change-success-alert-2', 'Password updated')
     );
-    navigate(SETTINGS_PATH + '#password', { replace: true });
-  }, [alertBar, ftlMsgResolver, navigate]);
+    navigateWithQuery(SETTINGS_PATH + '#password', { replace: true });
+  }, [alertBar, ftlMsgResolver, navigateWithQuery]);
 
   const onFormSubmit = useCallback(
     async ({ oldPassword, newPassword }: FormData) => {

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
@@ -4,7 +4,7 @@
 
 import { Localized } from '@fluent/react';
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { SETTINGS_PATH } from '../../../constants';
@@ -40,7 +40,7 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
 
   const alertBar = useAlertBar();
   const account = useAccount();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: {
@@ -54,14 +54,14 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
     alertBar.success(
       ftlMsgResolver.getMsg('pw-create-success-alert-2', 'Password set')
     );
-    navigate(
+    navigateWithQuery(
       SETTINGS_PATH + (wantsUnlinkProviderId ? '#linked-account' : '#password'),
       {
         replace: true,
         state: { wantsUnlinkProviderId },
       }
     );
-  }, [alertBar, ftlMsgResolver, navigate, wantsUnlinkProviderId]);
+  }, [alertBar, ftlMsgResolver, navigateWithQuery, wantsUnlinkProviderId]);
 
   const onFormSubmit = useCallback(
     async ({ newPassword }: FormData) => {

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -5,7 +5,7 @@
 import React, { useCallback, useState, ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { useAccount, useAlertBar } from '../../../models';
 import InputPassword from '../../InputPassword';
 import FlowContainer from '../FlowContainer';
@@ -16,12 +16,10 @@ import { Checkbox } from '../Checkbox';
 import { useLocalization } from '@fluent/react';
 import { Localized } from '@fluent/react';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import GleanMetrics from '../../../lib/glean';
 import { useFtlMsgResolver } from '../../../models/hooks';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 type FormData = {
   password: string;
@@ -104,11 +102,10 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const allBoxesChecked = Object.keys(checkboxLabels).every((element) =>
     checkedBoxes.includes(element)
   );
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
   const goHome = useCallback(() => window.history.back(), []);
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const account = useAccount();
 
@@ -145,15 +142,12 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
           'flow.settings.account-delete',
           'confirm-password.success'
         );
-        if (shouldUseReactEmailFirst) {
-          navigate('/', {
-            state: {
-              deleteAccountSuccess: true,
-            },
-          });
-        } else {
-          hardNavigate('/', { delete_account_success: true }, true);
-        }
+
+        navigateWithQuery('/', {
+          state: {
+            deleteAccountSuccess: true,
+          },
+        });
       } catch (e) {
         const localizedError = getLocalizedErrorMessage(ftlMsgResolver, e);
         if (e.errno === AuthUiErrors.INCORRECT_PASSWORD.errno) {
@@ -171,8 +165,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
       setValue,
       alertBar,
       ftlMsgResolver,
-      navigate,
-      shouldUseReactEmailFirst,
+      navigateWithQuery,
     ]
   );
 
@@ -295,7 +288,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                 <button
                   className="cta-neutral mx-2 px-10 py-2"
                   onClick={() =>
-                    navigate(SETTINGS_PATH + '#delete-account', {
+                    navigateWithQuery(SETTINGS_PATH + '#delete-account', {
                       replace: true,
                     })
                   }

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.tsx
@@ -4,13 +4,13 @@
 
 import React, { useCallback } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
 import InputText from '../../InputText';
 import { SETTINGS_PATH } from '../../../constants';
 import { Localized, useLocalization } from '@fluent/react';
 import { useAccount, useAlertBar } from '../../../models';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 const validateDisplayName =
   (currentDisplayName: string) => (newDisplayName: string) =>
@@ -20,8 +20,8 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const account = useAccount();
   const alertBar = useAlertBar();
   const { l10n } = useLocalization();
-  const navigate = useNavigate();
-  const goHome = () => navigate(SETTINGS_PATH, { replace: true });
+  const navigateWithQuery = useNavigateWithQuery();
+  const goHome = () => navigateWithQuery(SETTINGS_PATH, { replace: true });
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
       l10n.getString(
@@ -30,8 +30,8 @@ export const PageDisplayName = (_: RouteComponentProps) => {
         'Display name updated'
       )
     );
-    navigate(SETTINGS_PATH, { replace: true });
-  }, [alertBar, l10n, navigate]);
+    navigateWithQuery(SETTINGS_PATH, { replace: true });
+  }, [alertBar, l10n, navigateWithQuery]);
   const initialValue = account.displayName || '';
   const { register, handleSubmit, formState, trigger } = useForm<{
     displayName: string;

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../../constants';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { useAccount, useFtlMsgResolver } from '../../../models';
@@ -27,7 +27,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
 
   const { recoveryKey, email } = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>('');
@@ -36,7 +36,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
     ? RecoveryKeyAction.Change
     : RecoveryKeyAction.Create;
   const goHome = () =>
-    navigate(SETTINGS_PATH + '#recovery-key', { replace: true });
+    navigateWithQuery(SETTINGS_PATH + '#recovery-key', { replace: true });
 
   const localizedPageTitle = ftlMsgResolver.getMsg(
     'recovery-key-create-page-title',
@@ -49,7 +49,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   );
 
   const navigateBackward = () => {
-    navigate(SETTINGS_PATH);
+    navigateWithQuery(SETTINGS_PATH);
   };
 
   const navigateForward = (e?: React.MouseEvent<HTMLElement>) => {
@@ -57,7 +57,7 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
     if (currentStep + 1 <= numberOfSteps) {
       setCurrentStep(currentStep + 1);
     } else {
-      navigate(SETTINGS_PATH);
+      navigateWithQuery(SETTINGS_PATH);
     }
   };
 

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useCallback } from 'react';
-import { Link, RouteComponentProps, useNavigate } from '@reach/router';
+import { Link, RouteComponentProps } from '@reach/router';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { SETTINGS_PATH } from '../../../constants';
 import CardHeader from '../../CardHeader';
@@ -14,6 +14,7 @@ import { useAccount, useAlertBar, useFtlMsgResolver } from '../../../models';
 import FlowContainer from '../FlowContainer';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import GleanMetrics from '../../../lib/glean';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 // TODO, update this link with #section-heading once the SUMO article is updated (FXA-10918)
 const sumoTwoStepLink = (
@@ -26,7 +27,7 @@ const sumoTwoStepLink = (
 );
 
 const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const account = useAccount();
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -35,7 +36,8 @@ const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
   // Use phoneNumber as a fallback in case nationalFormat is not available
   const formattedFullPhoneNumber = nationalFormat || phoneNumber;
 
-  const goHome = () => navigate(SETTINGS_PATH + '#security', { replace: true });
+  const goHome = () =>
+    navigateWithQuery(SETTINGS_PATH + '#security', { replace: true });
 
   const gleanSuccessView =
     GleanMetrics.accountPref.twoStepAuthPhoneRemoveSuccessView;
@@ -48,8 +50,8 @@ const PageRecoveryPhoneRemove = (props: RouteComponentProps) => {
       ),
       gleanSuccessView
     );
-    navigate(SETTINGS_PATH + '#security', { replace: true });
-  }, [alertBar, ftlMsgResolver, gleanSuccessView, navigate]);
+    navigateWithQuery(SETTINGS_PATH + '#security', { replace: true });
+  }, [alertBar, ftlMsgResolver, gleanSuccessView, navigateWithQuery]);
 
   const clickRemoveRecoveryPhone = useCallback(async () => {
     try {

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../../constants';
 import { useAccount, useFtlMsgResolver } from '../../../models';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
@@ -15,7 +15,7 @@ const numberOfSteps = 2;
 
 export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const account = useAccount();
 
   const [phoneData, setPhoneData] = useState<{
@@ -29,7 +29,9 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
   const [currentStep, setCurrentStep] = useState<number>(1);
 
   const goHome = () =>
-    navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });
+    navigateWithQuery(SETTINGS_PATH + '#two-step-authentication', {
+      replace: true,
+    });
 
   const localizedPageTitle = ftlMsgResolver.getMsg(
     'page-setup-recovery-phone-heading',
@@ -52,7 +54,7 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
     if (currentStep > 1) {
       setCurrentStep(currentStep - 1);
     } else {
-      navigate(SETTINGS_PATH);
+      navigateWithQuery(SETTINGS_PATH);
     }
   };
 
@@ -61,7 +63,7 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
     if (currentStep + 1 <= numberOfSteps) {
       setCurrentStep(currentStep + 1);
     } else {
-      navigate(SETTINGS_PATH);
+      navigateWithQuery(SETTINGS_PATH);
     }
   };
 

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { SETTINGS_PATH } from '../../../constants';
 import InputText from '../../InputText';
@@ -25,17 +25,17 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
     null,
     'Step 1 of 2'
   );
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const alertBar = useAlertBar();
   const account = useAccount();
   const goHome = () =>
-    navigate(SETTINGS_PATH + '#secondary-email', { replace: true });
+    navigateWithQuery(SETTINGS_PATH + '#secondary-email', { replace: true });
 
   const createSecondaryEmail = useCallback(
     async (email: string) => {
       try {
         await account.createSecondaryEmail(email);
-        navigate('emails/verify', { state: { email }, replace: true });
+        navigateWithQuery('emails/verify', { state: { email }, replace: true });
       } catch (e) {
         if (e.errno) {
           const errorText = l10n.getString(
@@ -55,7 +55,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
         }
       }
     },
-    [account, navigate, setErrorText, alertBar, l10n]
+    [account, navigateWithQuery, setErrorText, alertBar, l10n]
   );
 
   const checkEmail = useCallback(

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../../constants';
 import { logViewEvent } from '../../../lib/metrics';
 import { useAccount, useAlertBar } from '../../../models';
@@ -24,10 +24,11 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
       verificationCode: '',
     },
   });
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const goHome = useCallback(
-    () => navigate(SETTINGS_PATH + '#secondary-email', { replace: true }),
-    [navigate]
+    () =>
+      navigateWithQuery(SETTINGS_PATH + '#secondary-email', { replace: true }),
+    [navigateWithQuery]
   );
   const { l10n } = useLocalization();
   const alertBar = useAlertBar();
@@ -41,9 +42,9 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
           `${email} successfully added`
         )
       );
-      navigate(SETTINGS_PATH + '#secondary-email', { replace: true });
+      navigateWithQuery(SETTINGS_PATH + '#secondary-email', { replace: true });
     },
-    [alertBar, l10n, navigate]
+    [alertBar, l10n, navigateWithQuery]
   );
   const subtitleText = l10n.getString(
     'add-secondary-email-step-2',
@@ -84,9 +85,9 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
 
   useEffect(() => {
     if (!email) {
-      navigate(SETTINGS_PATH, { replace: true });
+      navigateWithQuery(SETTINGS_PATH, { replace: true });
     }
-  }, [email, navigate]);
+  }, [email, navigateWithQuery]);
 
   const buttonDisabled =
     !formState.isDirty || !formState.isValid || account.loading;

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
 import InputText from '../../InputText';
@@ -30,11 +30,13 @@ type RecoveryCodeForm = { recoveryCode: string };
 
 export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
   const account = useAccount();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const { l10n } = useLocalization();
   const alertBar = useAlertBar();
   const goHome = () =>
-    navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });
+    navigateWithQuery(SETTINGS_PATH + '#two-step-authentication', {
+      replace: true,
+    });
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
       l10n.getString(
@@ -47,8 +49,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
           event: { reason: GleanClickEventType2FA.setup },
         })
     );
-    navigate(SETTINGS_PATH + '#two-step-authentication', { replace: true });
-  }, [alertBar, l10n, navigate]);
+    navigateWithQuery(SETTINGS_PATH + '#two-step-authentication', {
+      replace: true,
+    });
+  }, [alertBar, l10n, navigateWithQuery]);
 
   const totpForm = useForm<TotpForm>({
     mode: 'onTouched',

--- a/packages/fxa-settings/src/components/Settings/ScrollToTop/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ScrollToTop/index.tsx
@@ -5,22 +5,22 @@
 // See https://github.com/reach/router/issues/242 for a discussion
 
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import React, { useCallback, useLayoutEffect } from 'react';
 
 export const ScrollToTop = (
   props: React.PropsWithChildren<RouteComponentProps>
 ) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const { href, state } = useLocation();
 
   const updateState = useCallback(async () => {
-    await navigate(href, {
+    await navigateWithQuery(href, {
       state: { ...(state as any), scrolled: true },
       replace: true,
     });
     window.scrollTo(0, 0);
-  }, [href, state, navigate]);
+  }, [href, state, navigateWithQuery]);
 
   useLayoutEffect(() => {
     // If there's a hash, let the browser scroll to the id.

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ReactNode, useCallback, useState } from 'react';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { useAccount, Email, useAlertBar } from '../../../models';
 import UnitRow from '../UnitRow';
 import ModalVerifySession from '../ModalVerifySession';
@@ -19,7 +19,7 @@ type UnitRowSecondaryEmailContentAndActionsProps = {
 
 export const UnitRowSecondaryEmail = () => {
   const account = useAccount();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const alertBar = useAlertBar();
   const [queuedAction, setQueuedAction] = useState<() => void>();
   const { l10n } = useLocalization();
@@ -34,7 +34,9 @@ export const UnitRowSecondaryEmail = () => {
     async (email: string) => {
       try {
         await account.resendEmailCode(email);
-        navigate(`${SETTINGS_PATH}/emails/verify`, { state: { email } });
+        navigateWithQuery(`${SETTINGS_PATH}/emails/verify`, {
+          state: { email },
+        });
       } catch (e) {
         alertBar.error(
           l10n.getString(
@@ -45,7 +47,7 @@ export const UnitRowSecondaryEmail = () => {
         );
       }
     },
-    [account, navigate, alertBar, l10n]
+    [account, navigateWithQuery, alertBar, l10n]
   );
 
   const makeEmailPrimary = useCallback(

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -18,7 +18,7 @@ import { SETTINGS_PATH } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { BackupCodesSubRow, BackupPhoneSubRow } from '../SubRow';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { formatPhoneNumber } from '../../../lib/recovery-phone-utils';
 
 const route = `${SETTINGS_PATH}/two_step_authentication`;
@@ -27,7 +27,7 @@ const replaceCodesRoute = `${route}/replace_codes`;
 export const UnitRowTwoStepAuth = () => {
   const alertBar = useAlertBar();
   const account = useAccount();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const session = useSession();
   const {
     backupCodes: { count },
@@ -164,7 +164,7 @@ export const UnitRowTwoStepAuth = () => {
         <BackupCodesSubRow
           numCodesAvailable={count}
           onCtaClick={() => {
-            navigate(replaceCodesRoute, undefined, false);
+            navigateWithQuery(replaceCodesRoute, undefined, false);
           }}
           key={1}
         />
@@ -174,7 +174,7 @@ export const UnitRowTwoStepAuth = () => {
         subRows.push(
           <BackupPhoneSubRow
             onCtaClick={() => {
-              navigate(
+              navigateWithQuery(
                 `${SETTINGS_PATH}/recovery_phone/setup`,
                 undefined,
                 false
@@ -185,7 +185,7 @@ export const UnitRowTwoStepAuth = () => {
               count > 0 && {
                 onDeleteClick: () => {
                   alertBar.hide();
-                  navigate(
+                  navigateWithQuery(
                     `${SETTINGS_PATH}/recovery_phone/remove`,
                     undefined,
                     false

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -28,6 +28,12 @@ jest.mock('./ScrollToTop', () => ({
   ),
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useNavigate: () => mockNavigate,
+}));
+
 describe('App component', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -29,13 +29,13 @@ import { SETTINGS_PATH } from '../../constants';
 import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
 import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import { currentAccount } from '../../lib/cache';
 import { hasAccount, setCurrentAccount } from '../../lib/storage-utils';
 import GleanMetrics from '../../lib/glean';
 import Head from 'fxa-react/components/Head';
 import PageRecoveryPhoneRemove from './PageRecoveryPhoneRemove';
 import { SettingsIntegration } from './interfaces';
+import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 
 export const Settings = ({
   integration,
@@ -43,6 +43,7 @@ export const Settings = ({
   const session = useSession();
   const account = useAccount();
   const location = useLocation();
+  const navigateWithQuery = useNavigateWithQuery();
 
   useEffect(() => {
     /**
@@ -77,7 +78,7 @@ export const Settings = ({
       // signin page
       if (accountUidFromApolloCache === undefined) {
         console.warn('Could not access account.uid from apollo cache!');
-        hardNavigate('/');
+        navigateWithQuery('/');
         return;
       }
 
@@ -103,11 +104,11 @@ export const Settings = ({
       // Either way, we cannot reliable sync up apollo cache and localstorage, so
       // we will direct back to the login page.
       console.warn('Could not locate current account in local storage');
-      hardNavigate('/');
+      navigateWithQuery('/');
     }
     window.addEventListener('focus', handleWindowFocus);
     return () => window.removeEventListener('focus', handleWindowFocus);
-  }, [account, session]);
+  }, [account, navigateWithQuery, session]);
 
   const { loading, error } = useInitialSettingsState();
   const { enabled: gleanEnabled } = GleanMetrics.useGlean();

--- a/packages/fxa-settings/src/lib/hooks.tsx
+++ b/packages/fxa-settings/src/lib/hooks.tsx
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useEffect, useRef } from 'react';
-import { useConfig } from '../models';
-import { isInReactExperiment } from './cache';
 
 // Focus on the element that triggered some action after the first
 // argument changes from `false` to `true` unless a `triggerException`
@@ -56,14 +54,4 @@ export function useChangeFocusEffect() {
   }, []);
 
   return elToFocus;
-}
-
-/*
- * Temporary helper to check that emailFirstRoutes feature flag is on
- * and (if not 100% rolled out) that the user is in the React experiment.
- */
-export function useCheckReactEmailFirst() {
-  const config = useConfig();
-  // TODO with FXA-11221 (100% prod rollout), remove isInReactExperiment() check
-  return config.showReactApp.emailFirstRoutes === true && isInReactExperiment();
 }

--- a/packages/fxa-settings/src/lib/hooks/useNavigateWithQuery/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useNavigateWithQuery/index.tsx
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useNavigate, NavigateOptions } from '@reach/router';
+import { useNavigate, NavigateOptions, useLocation } from '@reach/router';
 
 export function useNavigateWithQuery() {
+  const location = useLocation();
   const navigate = useNavigate();
 
   return (
@@ -12,12 +13,11 @@ export function useNavigateWithQuery() {
     options?: NavigateOptions<{}>,
     includeHash: boolean = true
   ) => {
-    const location = window.location;
     let path = to;
 
     if (to.includes('?')) {
       path = to;
-    } else if (location.search) {
+    } else if (location.search && location.search !== '?') {
       path = `${to}${location.search}`;
     }
 
@@ -25,10 +25,6 @@ export function useNavigateWithQuery() {
       path = `${path}${location.hash}`;
     }
 
-    if (options) {
-      return navigate(path, options);
-    }
-
-    return navigate(path);
+    return options ? navigate(path, options) : navigate(path);
   };
 }

--- a/packages/fxa-settings/src/lib/hooks/useNavigateWithoutRerender/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useNavigateWithoutRerender/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { NavigateOptions } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 import { useCallback } from 'react';
 
@@ -15,13 +15,13 @@ import { useCallback } from 'react';
  * unintentional error.
  */
 export default function useNavigateWithoutRerender() {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const navigateWithoutRerender = useCallback(
     (path: string, options: NavigateOptions<{}>) => {
-      window.requestAnimationFrame(() => navigate(path, options));
+      window.requestAnimationFrame(() => navigateWithQuery(path, options));
     },
-    [navigate]
+    [navigateWithQuery]
   );
 
   return navigateWithoutRerender;

--- a/packages/fxa-settings/src/lib/metrics-flow.test.ts
+++ b/packages/fxa-settings/src/lib/metrics-flow.test.ts
@@ -26,7 +26,7 @@ describe('MetricsFlow', () => {
         global.window.document.body.dataset.flowId
       );
       expect(flowData?.flowBeginTime).toEqual(
-        global.window.document.body.dataset.flowBeginTime
+        Number(global.window.document.body.dataset.flowBeginTime)
       );
       expect(flowData?.deviceId).toBeDefined();
     });
@@ -39,13 +39,15 @@ describe('MetricsFlow', () => {
       );
       const flowData = init();
       expect(flowData?.flowId).toEqual(flowQueryParam.flowId);
-      expect(flowData?.flowBeginTime).toEqual(flowQueryParam.flowBeginTime);
+      expect(flowData?.flowBeginTime).toEqual(
+        Number(flowQueryParam.flowBeginTime)
+      );
     });
 
     it('should initialize the metricsFlow model with the argument', () => {
       const flowData = init(flowArg);
       expect(flowData?.flowId).toEqual(flowArg.flowId);
-      expect(flowData?.flowBeginTime).toEqual(flowArg.flowBeginTime);
+      expect(flowData?.flowBeginTime).toEqual(Number(flowArg.flowBeginTime));
       expect(flowData?.deviceId).toEqual(flowArg.deviceId);
     });
   });

--- a/packages/fxa-settings/src/lib/metrics-flow.ts
+++ b/packages/fxa-settings/src/lib/metrics-flow.ts
@@ -5,15 +5,21 @@
 import { v4 as uuidv4 } from 'uuid';
 import { searchParams } from './utilities';
 
-export type MetricsFlow = {
+export type RawMetricsFlow = {
   flowId: string;
   flowBeginTime: string | number;
   deviceId?: undefined | string;
 };
 
+export type MetricsFlow = {
+  flowId: string;
+  flowBeginTime: number;
+  deviceId?: undefined | string;
+};
+
 let metricsFlow: MetricsFlow | null = null;
 
-function isMetricsFlow(data: any): data is MetricsFlow {
+function isRawMetricsFlow(data: any): data is RawMetricsFlow {
   return (
     data?.flowId &&
     data?.flowBeginTime &&
@@ -32,10 +38,13 @@ function isMetricsFlow(data: any): data is MetricsFlow {
  */
 export function init(flowData?: any) {
   const initWithX = (x: any) => {
-    if (isMetricsFlow(x)) {
+    if (isRawMetricsFlow(x)) {
       metricsFlow = {
         flowId: x.flowId,
-        flowBeginTime: x.flowBeginTime,
+        flowBeginTime:
+          typeof x.flowBeginTime === 'string'
+            ? Number(x.flowBeginTime)
+            : x.flowBeginTime,
         ...(x.deviceId && { deviceId: x.deviceId }),
       };
       return true;

--- a/packages/fxa-settings/src/models/integrations/data/data.ts
+++ b/packages/fxa-settings/src/models/integrations/data/data.ts
@@ -58,7 +58,7 @@ export class IntegrationData extends ModelDataProvider {
 
   @IsOptional()
   @IsString()
-  @bind()
+  @bind(T.snakeCase)
   loginHint: string | undefined;
 
   @IsOptional()

--- a/packages/fxa-settings/src/models/pages/signin/oauth-query-params.test.ts
+++ b/packages/fxa-settings/src/models/pages/signin/oauth-query-params.test.ts
@@ -75,7 +75,7 @@ describe('OAuthQueryParams checks', function () {
 
   it('supports sync signin', () => {
     const queryParams =
-      'showReactApp=true&uniqueUserId=0b4cee0e-900e-45ac-bf0f-bd154146e9b8&access_type=offline&client_id=dcdb5ae7add825d2&pkce_client_id=38a6b9b3a65a1871&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth&scope=profile%20openid&action=signin&state=';
+      'uniqueUserId=0b4cee0e-900e-45ac-bf0f-bd154146e9b8&access_type=offline&client_id=dcdb5ae7add825d2&pkce_client_id=38a6b9b3a65a1871&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth&scope=profile%20openid&action=signin&state=';
 
     expect(validate(queryParams).isValid).toBeTruthy();
   });
@@ -89,7 +89,7 @@ describe('OAuthNativeSyncQueryParameters checks', function () {
   }
   it('supports sync signin', () => {
     const queryParams =
-      'showReactApp=true&uniqueUserId=0b4cee0e-900e-45ac-bf0f-bd154146e9b8&access_type=offline&client_id=dcdb5ae7add825d2&pkce_client_id=38a6b9b3a65a1871&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth&scope=profile%20openid&action=signin&state=jsklfl8jsf8sl';
+      'uniqueUserId=0b4cee0e-900e-45ac-bf0f-bd154146e9b8&access_type=offline&client_id=dcdb5ae7add825d2&pkce_client_id=38a6b9b3a65a1871&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Foauth&scope=profile%20openid&action=signin&state=jsklfl8jsf8sl';
     const result = validate(queryParams);
     expect(result.isValid).toBeTruthy();
   });

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
@@ -40,12 +40,12 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
 
   const createRecoveryKey = useCallback(
     (
-        uid: string,
-        sessionToken: string,
-        unwrapBKey: string,
-        emailForAuth: string,
-        authPW: string
-      ): (() => Promise<CreateRecoveryKeyHandler>) =>
+      uid: string,
+      sessionToken: string,
+      unwrapBKey: string,
+      emailForAuth: string,
+      authPW: string
+    ): (() => Promise<CreateRecoveryKeyHandler>) =>
       async () => {
         try {
           // We must reauth for another `keyFetchToken` because we sent it to Sync
@@ -116,6 +116,7 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
   ) {
     // go to CAD with success messaging, we do not want to re-prompt for password
     const { to } = getSyncNavigate(location.search);
+    // keep hard navigate until pair routes converted to react
     hardNavigate(to);
     return <></>;
   }

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
@@ -37,16 +37,24 @@ import {
   useOAuthKeysCheck,
 } from '../../lib/oauth/hooks';
 import { SensitiveData } from '../../lib/sensitive-data-client';
+import { mockWindowLocation } from 'fxa-react/lib/test-utils/mockWindowLocation';
 
 let mockLocationState = {};
-const mockSearch = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
+const search = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
+
+mockWindowLocation({
+  pathname: '/inline_recovery_setup',
+  search,
+});
+
 const mockLocationHook = () => {
   return {
     pathname: '/inline_recovery_setup',
-    search: mockSearch,
+    search,
     state: mockLocationState,
   };
 };
+
 const mockNavigateHook = jest.fn();
 jest.mock('@reach/router', () => {
   return {
@@ -169,18 +177,18 @@ describe('InlineRecoverySetupContainer', () => {
     it('redirects when user is not signed in', () => {
       mockLocationState = MOCK_SIGNIN_RECOVERY_LOCATION_STATE;
       render({ isSignedIn: false });
-      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${mockSearch}`);
+      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
     });
 
     it('redirects when there is no signin state', () => {
       render();
-      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${mockSearch}`);
+      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
     });
 
     it('redirects when there is no totp token', () => {
       mockLocationState = MOCK_SIGNIN_LOCATION_STATE;
       render();
-      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${mockSearch}`);
+      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
     });
 
     it('redirects when totp is already active', async () => {
@@ -198,7 +206,7 @@ describe('InlineRecoverySetupContainer', () => {
 
       render();
       expect(mockNavigateHook).toHaveBeenCalledWith(
-        `/signin_totp_code${mockSearch}`,
+        `/signin_totp_code${search}`,
         {
           state: MOCK_SIGNIN_LOCATION_STATE,
         }

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -4,7 +4,7 @@
 
 import { useMutation, useQuery } from '@apollo/client';
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState } from 'react';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
@@ -40,7 +40,7 @@ export const InlineRecoverySetupContainer = ({
   integration: Integration;
   serviceName: MozServices;
 } & RouteComponentProps) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const authClient = useAuthClient();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
@@ -127,12 +127,12 @@ export const InlineRecoverySetupContainer = ({
 
   // Some basic sanity checks
   if (!isSignedIn || !signinRecoveryLocationState?.email || !totp) {
-    navigate(`/signup${location.search}`);
+    navigateWithQuery('/signup');
     return <LoadingSpinner fullScreen />;
   }
 
   if (totpStatus?.account.totp.verified) {
-    navigate(`/signin_totp_code${location.search}`, {
+    navigateWithQuery('/signin_totp_code', {
       state: signinLocationState,
     });
     return <LoadingSpinner fullScreen />;

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -5,6 +5,7 @@
 import * as ApolloClientModule from '@apollo/client';
 import * as InlineTotpSetupModule from './index';
 import * as utils from 'fxa-react/lib/utils';
+import { mockWindowLocation } from 'fxa-react/lib/test-utils/mockWindowLocation';
 
 import { ApolloClient } from '@apollo/client';
 import { LocationProvider } from '@reach/router';
@@ -67,9 +68,16 @@ jest.mock('../../lib/glean', () => ({
 }));
 
 function setMocks() {
+  const search = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
+
+  mockWindowLocation({
+    pathname: '/inline_totp_setup',
+    search,
+  });
+
   mockLocationHook.mockReturnValue({
     pathname: '/inline_totp_setup',
-    search: '?' + new URLSearchParams(MOCK_QUERY_PARAMS),
+    search,
     state: MOCK_SIGNIN_LOCATION_STATE,
   });
   mockCheckCode.mockReturnValue(true);
@@ -131,6 +139,10 @@ function render(props = {}) {
 describe('InlineTotpSetupContainer', () => {
   beforeEach(() => {
     setMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   describe('redirects away', () => {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import InlineTotpSetup from '.';
@@ -41,7 +41,7 @@ export const InlineTotpSetupContainer = ({
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: SigninLocationState;
   };
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const session = useSession();
   const metricsContext = queryParamsToMetricsContext(
     flowQueryParams as unknown as Record<string, string>
@@ -60,15 +60,15 @@ export const InlineTotpSetupContainer = ({
   const navTo = useCallback(
     (
       uri:
-        | 'signup'
-        | 'signin_token_code'
-        | 'signin_totp_code'
-        | 'inline_recovery_setup',
+        | '/signup'
+        | '/signin_token_code'
+        | '/signin_totp_code'
+        | '/inline_recovery_setup',
       state?: SigninLocationState | SigninRecoveryLocationState
     ) => {
-      navigate(`/${uri}${location.search}`, { state });
+      navigateWithQuery(uri, { state });
     },
-    [location, navigate]
+    [navigateWithQuery]
   );
 
   // Determine if the session is verified
@@ -109,15 +109,15 @@ export const InlineTotpSetupContainer = ({
   // Once state has settled, determine if user should be directed to another page
   useEffect(() => {
     if (!isSignedIn || !signinState) {
-      navTo('signup');
+      navTo('/signup');
     } else if (sessionVerified === false) {
-      navTo('signin_token_code', signinState ? signinState : undefined);
+      navTo('/signin_token_code', signinState ? signinState : undefined);
     } else if (
       totpStatusLoading === false &&
       totpStatus !== undefined &&
       totpStatus.account.totp.verified
     ) {
-      navTo('signin_totp_code', signinState ? signinState : undefined);
+      navTo('/signin_totp_code', signinState ? signinState : undefined);
     }
   }, [
     sessionVerified,
@@ -155,7 +155,7 @@ export const InlineTotpSetupContainer = ({
         };
         GleanMetrics.accountPref.twoStepAuthQrCodeSuccess();
         navTo(
-          'inline_recovery_setup',
+          '/inline_recovery_setup',
           Object.keys(state).length > 0 ? state : undefined
         );
       } catch (error) {

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect } from 'react';
 import { Link } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { RouteComponentProps } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { usePageViewEvent } from '../../../lib/metrics';
@@ -34,7 +34,7 @@ const Pair = ({
     'pair-qr-code-aria-label',
     'QR code'
   );
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   // TODO: Recreate the QR code logic which previously existed in the content-server.
   // Probably after that we can remove the fallback styles for the QR code div.
 
@@ -50,16 +50,18 @@ const Pair = ({
   useEffect(() => {
     // This will just run at page load.
     if (!isSupported()) {
-      navigate('/pair/unsupported');
+      navigateWithQuery('/pair/unsupported');
     }
     if (isDefaultAccount()) {
       // we have historically needed the "forceView" option to prevent a loop of redirects.
-      navigate('/connect_another_device', { state: { forceView: true } });
+      navigateWithQuery('/connect_another_device', {
+        state: { forceView: true },
+      });
     }
     if (accountIsNotVerifiedOrHasNoSessionToken()) {
-      navigate('/signin');
+      navigateWithQuery('/signin');
     }
-  }, [navigate]);
+  }, [navigateWithQuery]);
 
   const showQRCode =
     entryPoint === ENTRYPOINTS.FIREFOX_MENU_ENTRYPOINT ||

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import SetPassword from '.';
 import { currentAccount } from '../../../lib/cache';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import {
   Integration,
   useAuthClient,
@@ -37,7 +37,7 @@ const SetPasswordContainer = ({
   integration: Integration;
   flowQueryParams: QueryParams;
 } & RouteComponentProps) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const authClient = useAuthClient();
   const storedLocalAccount = currentAccount();
   const email = storedLocalAccount?.email;
@@ -160,7 +160,7 @@ const SetPasswordContainer = ({
   // Users must be already authenticated on this page.
   // This page is currently always for the Sync flow.
   if (!email || !sessionToken || !uid || !integration.isSync()) {
-    navigate('/signin', { replace: true });
+    navigateWithQuery('/signin', { replace: true });
     return <LoadingSpinner />;
   }
   if (oAuthDataError) {

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -17,6 +17,7 @@ import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { handleNavigation } from '../../Signin/utils';
 import { QueryParams } from '../../../index';
 import { MOCK_EMAIL, MOCK_SESSION_TOKEN } from '../../mocks';
+import { LocationProvider } from '@reach/router';
 import { GenericData } from '../../../lib/model-data';
 
 jest.mock('../../../models', () => ({
@@ -100,9 +101,13 @@ function renderWith(
   }
 ) {
   return renderWithLocalizationProvider(
-    <AppContext.Provider value={{ ...mockAppContext(), ...createAppContext() }}>
-      <ThirdPartyAuthCallback {...props} />;
-    </AppContext.Provider>
+    <LocationProvider>
+      <AppContext.Provider
+        value={{ ...mockAppContext(), ...createAppContext() }}
+      >
+        <ThirdPartyAuthCallback {...props} />;
+      </AppContext.Provider>
+    </LocationProvider>
   );
 }
 

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -26,6 +26,7 @@ import VerificationMethods from '../../../constants/verification-methods';
 import VerificationReasons from '../../../constants/verification-reasons';
 import { currentAccount } from '../../../lib/cache';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 type LinkedAccountData = {
   uid: hexstring;
@@ -46,6 +47,7 @@ const ThirdPartyAuthCallback = ({
   const authClient = useAuthClient();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const location = useLocation();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const { finishOAuthFlowHandler } = useFinishOAuthFlowHandler(
     authClient,
@@ -105,10 +107,16 @@ const ThirdPartyAuthCallback = ({
 
       if (navError) {
         // TODO validate what should happen here
-        hardNavigate('/');
+        navigateWithQuery('/');
       }
     },
-    [finishOAuthFlowHandler, integration, location.search, webRedirectCheck]
+    [
+      finishOAuthFlowHandler,
+      integration,
+      location.search,
+      navigateWithQuery,
+      webRedirectCheck,
+    ]
   );
 
   const verifyThirdPartyAuthResponse = useCallback(async () => {
@@ -161,9 +169,15 @@ const ThirdPartyAuthCallback = ({
       );
     } catch (error) {
       // TODO validate what should happen here
-      hardNavigate('/');
+      navigateWithQuery('/');
     }
-  }, [account, flowQueryParams, integration, storeLinkedAccountData]);
+  }, [
+    account,
+    flowQueryParams,
+    integration,
+    navigateWithQuery,
+    storeLinkedAccountData,
+  ]);
 
   const navigateNext = useCallback(
     async (linkedAccount: LinkedAccountData) => {

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/container.tsx
@@ -26,7 +26,7 @@ const AccountRecoveryConfirmKeyContainer = (_: RouteComponentProps) => {
   const account = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
-  const navigate = useNavigateWithQuery();
+  const navigateWithQuery = useNavigateWithQuery();
   const sensitiveDataClient = useSensitiveDataClient();
 
   const {
@@ -72,7 +72,7 @@ const AccountRecoveryConfirmKeyContainer = (_: RouteComponentProps) => {
       kB,
     });
 
-    navigate('/account_recovery_reset_password', {
+    navigateWithQuery('/account_recovery_reset_password', {
       state: {
         accountResetToken: fetchedAccountResetToken,
         email,

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/index.test.tsx
@@ -64,10 +64,8 @@ describe('CompleteResetPassword page', () => {
       expect(screen.getByText('Remember your password?')).toBeVisible();
       const link = screen.getByRole('link', { name: 'Sign in' });
       expect(link).toBeVisible();
-      expect(link).toHaveAttribute(
-        'href',
-        `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
-      );
+      // note: email is passed in location state by the sub-component
+      expect(link).toHaveAttribute('href', '/');
 
       expect(
         screen.queryByRole('link', { name: 'Use account recovery key' })
@@ -159,10 +157,8 @@ describe('CompleteResetPassword page', () => {
       expect(screen.getByText('Remember your password?')).toBeVisible();
       const link = screen.getByRole('link', { name: 'Sign in' });
       expect(link).toBeVisible();
-      expect(link).toHaveAttribute(
-        'href',
-        `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
-      );
+      // prefillEmail is passed as state from the LinkRememberPassword component
+      expect(link).toHaveAttribute('href', '/');
       expect(
         screen.queryByRole('link', { name: 'Use account recovery key' })
       ).not.toBeInTheDocument();

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/container.tsx
@@ -25,7 +25,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const navigate = useNavigateWithQuery();
+  const navigateWithQuery = useNavigateWithQuery();
   let location = useLocation();
 
   const { email, metricsContext } =
@@ -33,7 +33,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
 
   useEffect(() => {
     if (!email || !metricsContext) {
-      navigate(`/reset_password${location.search}`);
+      navigateWithQuery('/reset_password');
     }
   });
 
@@ -48,7 +48,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
     totpExists?: boolean
   ) => {
     if (totpExists && recoveryKeyExists === false) {
-      navigate('/confirm_totp_reset_password', {
+      navigateWithQuery('/confirm_totp_reset_password', {
         state: {
           code,
           email,
@@ -62,7 +62,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
         replace: true,
       });
     } else if (recoveryKeyExists === true) {
-      navigate('/account_recovery_confirm_key', {
+      navigateWithQuery('/account_recovery_confirm_key', {
         state: {
           code,
           email,
@@ -77,7 +77,7 @@ const ConfirmResetPasswordContainer = (_: RouteComponentProps) => {
         replace: true,
       });
     } else {
-      navigate('/complete_reset_password', {
+      navigateWithQuery('/complete_reset_password', {
         state: {
           code,
           email,

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmResetPassword/index.tsx
@@ -6,17 +6,16 @@ import React, { useEffect } from 'react';
 import AppLayout from '../../../components/AppLayout';
 import FormVerifyTotp from '../../../components/FormVerifyTotp';
 import { ConfirmResetPasswordProps } from './interfaces';
-import { RouteComponentProps, useLocation } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
 import { useFtlMsgResolver } from '../../../models';
 import LinkRememberPassword from '../../../components/LinkRememberPassword';
-import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { ResendStatus } from '../../../lib/types';
 import { EmailCodeImage } from '../../../components/images';
 import GleanMetrics from '../../../lib/glean';
 import Banner, { ResendCodeSuccessBanner } from '../../../components/Banner';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 const ConfirmResetPassword = ({
   clearBanners,
@@ -33,9 +32,7 @@ const ConfirmResetPassword = ({
   }, []);
 
   const ftlMsgResolver = useFtlMsgResolver();
-  const location = useLocation();
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const spanElement = <span className="font-bold">{email}</span>;
 
@@ -108,27 +105,11 @@ const ConfirmResetPassword = ({
               e.preventDefault();
               GleanMetrics.passwordReset.emailConfirmationDifferentAccount();
 
-              if (shouldUseReactEmailFirst) {
-                navigate('/', {
-                  state: {
-                    prefillEmail: email,
-                  },
-                });
-              } else {
-                const params = new URLSearchParams(location.search);
-                // Tell content-server to stay on index and prefill the email
-                params.set('prefillEmail', email);
-                // Passing back the 'email' param causes various behaviors in
-                // content-server since it marks the email as "coming from a RP".
-                // Also remove other params that are passed when coming
-                // from content-server to React, see Signup container component
-                // for more info.
-                params.delete('email');
-                params.delete('hasLinkedAccount');
-                params.delete('hasPassword');
-                params.delete('showReactApp');
-                hardNavigate(`/?${params.toString()}`);
-              }
+              navigateWithQuery('/', {
+                state: {
+                  prefillEmail: email,
+                },
+              });
             }}
           >
             Use a different account

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.tsx
@@ -27,12 +27,12 @@ const ConfirmTotpResetPasswordContainer = (_: RouteComponentProps) => {
 
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const navigate = useNavigateWithQuery();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
 
   const onSuccess = () => {
-    navigate('/complete_reset_password', {
+    navigateWithQuery('/complete_reset_password', {
       state: {
         code,
         email,

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/index.tsx
@@ -5,15 +5,14 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 import AppLayout from '../../../components/AppLayout';
 import { useFtlMsgResolver } from '../../../models';
-import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import protectionShieldIcon from '@fxa/shared/assets/images/protection-shield.svg';
 import FormVerifyCode, {
   commonBackupCodeFormAttributes,
   FormAttributes,
 } from '../../../components/FormVerifyCode';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 export type ConfirmTotpResetPasswordProps = {
   verifyCode: (code: string) => Promise<void>;
@@ -30,8 +29,7 @@ const ConfirmTotpResetPassword = ({
 }: ConfirmTotpResetPasswordProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const [showRecoveryCode, setShowRecoveryCode] = useState<boolean>(false);
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const totpFormAttributes: FormAttributes = {
     inputFtlId: 'confirm-totp-reset-password-input-label-v2',
@@ -144,12 +142,7 @@ const ConfirmTotpResetPassword = ({
               className="link-blue text-sm"
               data-glean-id="reset_password_confirm_totp_use_different_account_button"
               onClick={() => {
-                if (shouldUseReactEmailFirst) {
-                  navigate('/');
-                } else {
-                  // Navigate to email first page and keep search params
-                  hardNavigate('/', {}, true);
-                }
+                navigateWithQuery('/');
               }}
             >
               <FtlMsg id="confirm-totp-reset-password-use-different-account">

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/container.tsx
@@ -18,7 +18,7 @@ const ResetPasswordContainer = ({
 }: ResetPasswordContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigateWithQuery();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const [errorMessage, setErrorMessage] = useState<string>('');
 
@@ -33,7 +33,7 @@ const ResetPasswordContainer = ({
     };
     try {
       await authClient.passwordForgotSendOtp(email, options);
-      navigate('/confirm_reset_password', {
+      navigateWithQuery('/confirm_reset_password', {
         state: { email, metricsContext },
       });
     } catch (err) {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/container.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, useLocation } from '@reach/router';
+import { RouteComponentProps } from '@reach/router';
 
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import ResetPasswordConfirmed from '.';
@@ -35,7 +35,6 @@ const ResetPasswordConfirmedContainer = ({
     authClient,
     integration
   );
-  const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
   const sensitiveDataClient = useSensitiveDataClient();
   const [errorMessage, setErrorMessage] = useState('');
@@ -101,7 +100,7 @@ const ResetPasswordConfirmedContainer = ({
   }
 
   if (!verified) {
-    hardNavigate(`/${location.search}`);
+    navigateWithQuery('/');
     return;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
@@ -20,6 +20,7 @@ import AuthClient from 'fxa-auth-client/browser';
 import { MOCK_UID, MOCK_UNBLOCK_CODE } from '../../mocks';
 import { ReportSigninProps } from './interfaces';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { LocationProvider } from '@reach/router';
 
 let currentReportSigninProps: ReportSigninProps | undefined;
 function mockReportSigninModule() {
@@ -84,24 +85,28 @@ function applyMocks() {
 }
 
 async function render(text?: string) {
-  renderWithLocalizationProvider(<ReportSigninContainer />);
+  renderWithLocalizationProvider(
+    <LocationProvider>
+      <ReportSigninContainer />
+    </LocationProvider>
+  );
 
   await screen.findByText(text || 'report signin mock');
 }
 
-describe('report-signin-container', () => {
+describe('ReportSigninContainer', () => {
   beforeEach(() => {
     applyMocks();
   });
 
-  describe('default-state', () => {
-    it('renders', async () => {
+  describe('default state', () => {
+    it('renders component', async () => {
       await render();
       expect(ReportSigninModule.ReportSignin).toBeCalled();
     });
   });
 
-  describe('error-states', () => {
+  describe('error states', () => {
     it('handles invalid uid', async () => {
       jest
         .spyOn(UseValidateModule, 'useValidatedQueryParams')
@@ -177,9 +182,7 @@ describe('report-signin-container', () => {
       expect(currentReportSigninProps).toBeDefined();
       await currentReportSigninProps?.submitReport();
       expect(mockAuthClient.rejectUnblockCode).toHaveBeenCalled();
-      expect(mockNavigate).toHaveBeenCalledWith(
-        '/signin_reported?showReactApp=true'
-      );
+      expect(mockNavigate).toHaveBeenCalledWith('/signin_reported');
       expect(currentReportSigninProps?.errorMessage).toBe('');
     });
 

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.tsx
@@ -4,7 +4,7 @@
 
 import { useState } from 'react';
 import { RouteComponentProps } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { useValidatedQueryParams } from '../../../lib/hooks/useValidate';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import { ReportSigninQueryParams } from '../../../models/pages/signin';
@@ -14,7 +14,7 @@ import { ReportSignin } from './index';
 const ReportSigninContainer = (_: RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsg = useFtlMsgResolver();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const { queryParamModel, validationError } = useValidatedQueryParams(
@@ -27,7 +27,7 @@ const ReportSigninContainer = (_: RouteComponentProps) => {
         queryParamModel.uid,
         queryParamModel.unblockCode
       );
-      navigate('/signin_reported?showReactApp=true');
+      navigateWithQuery('/signin_reported');
     } catch (e) {
       // TODO verify error message to display
       setErrorMessage(

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.test.tsx
@@ -5,39 +5,32 @@
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { MOCK_ACCOUNT, renderWithRouter } from '../../../models/mocks';
-// import { getFtlBundle, testL10n } from 'fxa-react/lib/test-utils';
-// import { FluentBundle } from '@fluent/bundle';
 import SigninBounced, { viewName } from '.';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
-import * as utils from '../../../../../fxa-react/lib/utils';
-import * as ReactUtils from '../../../../../fxa-react/lib/utils';
 
 jest.mock('../../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
 }));
-let hardNavigateSpy: jest.SpyInstance;
+
+const mockLocationHook = jest.fn();
+const mockNavigateHook = jest.fn();
+jest.mock('@reach/router', () => {
+  return {
+    ...jest.requireActual('@reach/router'),
+    useNavigate: () => mockNavigateHook,
+    useLocation: () => mockLocationHook,
+  };
+});
 
 describe('SigninBounced', () => {
-  // TODO: enable l10n tests when they've been updated to handle embedded tags in ftl strings
-  //       in FXA-6461
-  // let bundle: FluentBundle;
-  // beforeAll(async () => {
-  //   bundle = await getFtlBundle('settings');
-  // });
-
-  beforeEach(() => {
-    hardNavigateSpy = jest
-      .spyOn(ReactUtils, 'hardNavigate')
-      .mockImplementationOnce(() => {});
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   it('renders default content as expected', () => {
     renderWithRouter(<SigninBounced email={MOCK_ACCOUNT.primaryEmail.email} />);
-    // testAllL10n(screen, bundle, {
-    //   email:MOCK_EMAIL,
-    // });
     screen.getByRole('heading', {
       name: 'Sorry. We’ve locked your account.',
     });
@@ -72,6 +65,6 @@ describe('SigninBounced', () => {
 
   it('pushes the user to the / page if there is no email address available', () => {
     renderWithRouter(<SigninBounced />);
-    expect(hardNavigateSpy).toHaveBeenCalledWith('/', {}, true);
+    expect(mockNavigateHook).toHaveBeenCalledWith('/');
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -6,15 +6,14 @@ import React, { useEffect } from 'react';
 import { RouteComponentProps /*useNavigate*/ } from '@reach/router';
 import { usePageViewEvent, logViewEvent } from '../../../lib/metrics';
 import { ReactComponent as EmailBounced } from './graphic_email_bounced.svg';
-import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models/hooks';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 import AppLayout from '../../../components/AppLayout';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import CardHeader from '../../../components/CardHeader';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 export type SigninBouncedProps = {
   email?: string;
@@ -34,8 +33,7 @@ const SigninBounced = ({
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const ftlMessageResolver = useFtlMsgResolver();
   const backText = ftlMessageResolver.getMsg('back', 'Back');
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const handleNavigationBack = (event: any) => {
     logViewEvent(viewName, 'link.back', REACT_ENTRYPOINT);
@@ -48,19 +46,15 @@ const SigninBounced = ({
 
   useEffect(() => {
     if (!email) {
-      if (shouldUseReactEmailFirst) {
-        navigate('/');
-      } else {
-        hardNavigate('/', {}, true);
-      }
+      navigateWithQuery('/');
     }
-  }, [email, navigate, shouldUseReactEmailFirst]);
+  }, [email, navigateWithQuery]);
 
   const createAccountHandler = () => {
     logViewEvent(viewName, 'link.create-account', REACT_ENTRYPOINT);
     localStorage.removeItem('__fxa_storage.accounts');
     sessionStorage.clear();
-    navigate('/signup');
+    navigateWithQuery('/signup');
   };
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
@@ -172,7 +172,7 @@ describe('SigninPushCode container', () => {
         mockLocationState = {};
         render();
         expect(CacheModule.currentAccount).toBeCalled();
-        expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+        expect(mockNavigate).toBeCalledWith('/');
         expect(SigninPushCodeModule.default).not.toBeCalled();
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -14,14 +14,12 @@ import {
   useSensitiveDataClient,
 } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useEffect, useState } from 'react';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 export type SigninPushCodeContainerProps = {
   integration: Integration;
@@ -33,8 +31,7 @@ export const SigninPushCodeContainer = ({
   serviceName,
 }: SigninPushCodeContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
     integration
@@ -75,18 +72,14 @@ export const SigninPushCodeContainer = ({
   }
 
   if (!signinState) {
-    if (shouldUseReactEmailFirst) {
-      navigate('/');
-    } else {
-      hardNavigate('/', {}, true);
-    }
+    navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;
   }
 
   // redirect if there is 2FA is set up for the account,
   // but the session is not TOTP verified
   if (totpVerified) {
-    navigate('/signin_totp_code', {
+    navigateWithQuery('/signin_totp_code', {
       state: signinState,
     });
     return <LoadingSpinner fullScreen />;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
@@ -77,10 +77,6 @@ function mockCache(opts: any = {}, isEmpty = false) {
   );
 }
 
-function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
-}
-
 const mockLocation = (pathname: string, mockLocationState: Object) => {
   return {
     ...global.window.location,
@@ -89,11 +85,8 @@ const mockLocation = (pathname: string, mockLocationState: Object) => {
   };
 };
 
-function mockReachRouter(
-  mockNavigate = jest.fn(),
-  pathname = '',
-  mockLocationState = {}
-) {
+const mockNavigate = jest.fn();
+function mockReachRouter(pathname = '', mockLocationState = {}) {
   mockNavigate.mockReset();
   jest.spyOn(ReachRouterModule, 'useNavigate').mockReturnValue(mockNavigate);
   jest
@@ -116,9 +109,8 @@ function applyDefaultMocks() {
   jest.restoreAllMocks();
   mockSigninRecoveryCodeModule();
   mockLoadingSpinnerModule();
-  mockReactUtilsModule();
   mockCache();
-  mockReachRouter(undefined, 'signin_recovery_code', {
+  mockReachRouter('signin_recovery_code', {
     signinState: mockSigninLocationState,
   });
   mockWebIntegration();
@@ -148,24 +140,24 @@ describe('SigninRecoveryCode container', () => {
   });
   describe('initial state', () => {
     it('redirects if page is reached without location state', async () => {
-      mockReachRouter(undefined, 'signin_recovery_code');
+      mockReachRouter('signin_recovery_code');
       mockCache({}, true);
       await render([]);
-      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+      expect(mockNavigate).toBeCalledWith('/');
     });
 
     it('redirects if there is no sessionToken', async () => {
-      mockReachRouter(undefined, 'signin_recovery_code');
+      mockReachRouter('signin_recovery_code');
       mockCache({ sessionToken: '' });
       await render([]);
-      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+      expect(mockNavigate).toBeCalledWith('/');
     });
 
     it('retrieves the session token from local storage if no location state', async () => {
-      mockReachRouter(undefined, 'signin_recovery_code', {});
+      mockReachRouter('signin_recovery_code', {});
       mockCache(MOCK_STORED_ACCOUNT);
       await render([]);
-      expect(ReactUtils.hardNavigate).not.toBeCalledWith('/', {}, true);
+      expect(mockNavigate).not.toBeCalledWith('/');
     });
 
     it('reads data from sensitive data client', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import SigninRecoveryCode from '.';
 import {
   Integration,
@@ -25,8 +24,7 @@ import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError } from '../../../lib/error-utils';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 type SigninRecoveryCodeLocationState = {
   signinState: SigninLocationState;
@@ -49,8 +47,7 @@ export const SigninRecoveryCodeContainer = ({
     (useLocation() as ReturnType<typeof useLocation> & {
       state: SigninRecoveryCodeLocationState;
     }) || {};
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
   const signinState = getSigninState(location.state?.signinState);
   const lastFourPhoneDigits = location.state?.lastFourPhoneDigits;
   const sensitiveDataClient = useSensitiveDataClient();
@@ -91,14 +88,14 @@ export const SigninRecoveryCodeContainer = ({
     }
     try {
       await authClient.recoveryPhoneSigninSendCode(signinState.sessionToken);
-      navigate('/signin_recovery_phone', {
+      navigateWithQuery('/signin_recovery_phone', {
         state: { signinState, lastFourPhoneDigits },
       });
       return;
     } catch (error) {
       const { error: handledError } = getHandledError(error);
       if (handledError.errno === AuthUiErrors.INVALID_TOKEN.errno) {
-        navigate('/signin');
+        navigateWithQuery('/signin');
         return;
       }
       return handledError;
@@ -113,11 +110,7 @@ export const SigninRecoveryCodeContainer = ({
   }
 
   if (!signinState) {
-    if (shouldUseReactEmailFirst) {
-      navigate('/');
-    } else {
-      hardNavigate('/', {}, true);
-    }
+    navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -167,7 +167,7 @@ describe('SigninTokenCode container', () => {
         mockLocationState = {};
         render([]);
         expect(CacheModule.currentAccount).toBeCalled();
-        expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+        expect(mockNavigate).toBeCalledWith('/');
         expect(SigninTokenCodeModule.default).not.toBeCalled();
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import SigninTokenCode from '.';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import {
   Integration,
   useAuthClient,
@@ -35,7 +34,6 @@ import {
   PASSWORD_CHANGE_FINISH_MUTATION,
   PASSWORD_CHANGE_START_MUTATION,
 } from '../gql';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 // The email with token code (verifyLoginCodeEmail) is sent on `/signin`
 // submission if conditions are met.
@@ -45,11 +43,10 @@ const SigninTokenCodeContainer = ({
 }: {
   integration: Integration;
 } & RouteComponentProps) => {
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state?: SigninLocationState;
   };
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
 
   const signinState = getSigninState(location.state);
   const sensitiveDataClient = useSensitiveDataClient();
@@ -96,18 +93,14 @@ const SigninTokenCodeContainer = ({
   }, [authClient, signinState]);
 
   if (!signinState || !signinState.sessionToken) {
-    if (shouldUseReactEmailFirst) {
-      navigate('/');
-    } else {
-      hardNavigate('/', {}, true);
-    }
+    navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;
   }
 
   // redirect if there is 2FA is set up for the account,
   // but the session is not TOTP verified
   if (totpVerified) {
-    navigate('/signin_totp_code', {
+    navigateWithQuery('/signin_totp_code', {
       state: signinState,
     });
     return <LoadingSpinner fullScreen />;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -236,20 +236,19 @@ describe('signin totp code container', () => {
     mockReachRouter();
     mockCache({}, true);
     await render(false);
-    expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+    expect(mockNavigate).toBeCalledWith('/');
   });
 
   it('redirects if there is no sessionToken', async () => {
     mockReachRouter();
     mockCache({ sessionToken: '' });
     await render(false);
-    expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+    expect(mockNavigate).toBeCalledWith('/');
   });
 
   it('redirects if verification method is not totp', async () => {
     mockReachRouter(MOCK_NON_TOTP_LOCATION_STATE);
     await render(false);
-    expect(ReactUtils.hardNavigate).toBeCalledTimes(1);
-    expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+    expect(mockNavigate).toBeCalledWith('/');
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -28,7 +28,6 @@ import {
   useFinishOAuthFlowHandler,
   useOAuthKeysCheck,
 } from '../../../lib/oauth/hooks';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError, HandledError } from '../../../lib/error-utils';
@@ -43,8 +42,7 @@ import {
 } from '../gql';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
@@ -71,8 +69,7 @@ export const SigninTotpCodeContainer = ({
 
   const { queryParamModel } = useValidatedQueryParams(SigninQueryParams);
   const { service } = queryParamModel;
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
 
@@ -164,11 +161,7 @@ export const SigninTotpCodeContainer = ({
     (signinState.verificationMethod &&
       signinState.verificationMethod !== VerificationMethods.TOTP_2FA)
   ) {
-    if (shouldUseReactEmailFirst) {
-      navigate('/');
-    } else {
-      hardNavigate('/', {}, true);
-    }
+    navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;
   }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -4,14 +4,14 @@
 
 import React, { useEffect, useState } from 'react';
 import { Link, RouteComponentProps, useLocation } from '@reach/router';
-import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../../models';
 import { logViewEvent } from '../../../lib/metrics';
 import { MozServices } from '../../../lib/types';
 import AppLayout from '../../../components/AppLayout';
 import GleanMetrics from '../../../lib/glean';
 import { SigninIntegration, SigninLocationState } from '../interfaces';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { handleNavigation } from '../utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { storeAccountData } from '../../../lib/storage-utils';
@@ -24,7 +24,6 @@ import Banner from '../../../components/Banner';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { HeadingPrimary } from '../../../components/HeadingPrimary';
 import FormVerifyTotp from '../../../components/FormVerifyTotp';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
 
 // TODO: show a banner success message if a user is coming from reset password
 // in FXA-6491. This differs from content-server where currently, users only
@@ -53,8 +52,7 @@ export const SigninTotpCode = ({
 }: SigninTotpCodeProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const [bannerError, setBannerError] = useState<string>('');
 
@@ -176,27 +174,11 @@ export const SigninTotpCode = ({
             onClick={(e) => {
               e.preventDefault();
 
-              if (shouldUseReactEmailFirst) {
-                navigate('/', {
-                  state: {
-                    prefillEmail: email,
-                  },
-                });
-              } else {
-                const params = new URLSearchParams(location.search);
-                // Tell content-server to stay on index and prefill the email
-                params.set('prefillEmail', email);
-                // Passing back the 'email' param causes various behaviors in
-                // content-server since it marks the email as "coming from a RP".
-                // Also remove other params that are passed when coming
-                // from content-server to React, see Signup container component
-                // for more info.
-                params.delete('email');
-                params.delete('hasLinkedAccount');
-                params.delete('hasPassword');
-                params.delete('showReactApp');
-                hardNavigate(`/?${params.toString()}`);
-              }
+              navigateWithQuery('/', {
+                state: {
+                  prefillEmail: email,
+                },
+              });
             }}
           >
             Use a different account

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -37,7 +37,6 @@ import {
   ResendUnblockCodeHandler,
   SigninUnblockLocationState,
 } from './interfaces';
-import { hardNavigate } from 'fxa-react/lib/utils';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import { QueryParams } from '../../..';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
@@ -52,8 +51,7 @@ import { SignInOptions } from 'fxa-auth-client/browser';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { isFirefoxService } from '../../../models/integrations/utils';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
-import { useCheckReactEmailFirst } from '../../../lib/hooks';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
 export const SigninUnblockContainer = ({
   integration,
@@ -64,8 +62,7 @@ export const SigninUnblockContainer = ({
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
-  const navigate = useNavigate();
-  const shouldUseReactEmailFirst = useCheckReactEmailFirst();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const location = useLocation() as ReturnType<typeof useLocation> & {
     state: SigninUnblockLocationState;
@@ -221,11 +218,7 @@ export const SigninUnblockContainer = ({
   }
 
   if (!email || !password) {
-    if (shouldUseReactEmailFirst) {
-      navigate('/');
-    } else {
-      hardNavigate('/', {}, true);
-    }
+    navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;
   }
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import { usePageViewEvent } from '../../../lib/metrics';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import CardHeader from '../../../components/CardHeader';
 import AppLayout from '../../../components/AppLayout';
@@ -57,7 +57,7 @@ export const SigninUnblock = ({
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
 
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const redirectTo =
@@ -170,7 +170,7 @@ export const SigninUnblock = ({
       );
       switch (error.errno) {
         case AuthUiErrors.INCORRECT_PASSWORD.errno:
-          navigate(`/signin`, {
+          navigateWithQuery(`/signin`, {
             state: {
               email,
               // TODO: in FXA-9177, retrieve hasLinkedAccount and hasPassword from Apollo cache

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -399,7 +399,7 @@ describe('signin container', () => {
       it('is handled if not provided in query params or location state', async () => {
         render([mockGqlAvatarUseQuery()]);
         expect(CacheModule.currentAccount).toBeCalled();
-        expect(ReactUtils.hardNavigate).toBeCalledWith('/');
+        expect(mockNavigate).toBeCalledWith('/');
         expect(SigninModule.default).not.toBeCalled();
       });
       it('uses local storage value if email is not provided via query param or router state', async () => {
@@ -500,9 +500,9 @@ describe('signin container', () => {
 
       render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith(
-          `/signup?email=from%40queryparams.com&emailStatusChecked=true`
-        );
+        expect(mockNavigate).toHaveBeenCalledWith('/signup', {
+          state: { email: MOCK_QUERY_PARAM_EMAIL, emailStatusChecked: true },
+        });
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -1002,9 +1002,9 @@ describe('Signin component', () => {
           1
         );
       });
-      expect(hardNavigateSpy).toHaveBeenCalledWith(
-        `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
-      );
+      expect(mockNavigate).toHaveBeenCalledWith('/', {
+        state: { prefillEmail: MOCK_EMAIL },
+      });
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -223,9 +223,9 @@ describe('confirm-signup-container', () => {
         expect(screen.getByText('confirm signup code mock')).toBeInTheDocument()
       );
       expect(mockEmailBounceStatusQuery).toBeCalled();
-      expect(ReactUtils.hardNavigate).toBeCalledWith(
-        `/?bouncedEmail=${encodeURIComponent(MOCK_EMAIL)}`
-      );
+      expect(mockNavigate).toBeCalledWith('/', {
+        state: { hasBounced: true, prefillEmail: MOCK_EMAIL },
+      });
     });
 
     it('redirects to signin_bounced if there is a bounce that is not on signup', async () => {
@@ -236,9 +236,7 @@ describe('confirm-signup-container', () => {
         expect(screen.getByText('confirm signup code mock')).toBeInTheDocument()
       );
       expect(mockEmailBounceStatusQuery).toBeCalled();
-      expect(ReactUtils.hardNavigate).toBeCalledWith(
-        `/signin_bounced?bouncedEmail=${encodeURIComponent(MOCK_EMAIL)}`
-      );
+      expect(mockNavigate).toBeCalledWith('/signin_bounced');
     });
   });
 
@@ -253,9 +251,7 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(screen.getByText('loading spinner mock')).toBeInTheDocument()
       );
-      expect(ReactUtils.hardNavigate).toBeCalledWith(
-        expect.stringMatching('/')
-      );
+      expect(mockNavigate).toBeCalledWith('/');
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useNavigateWithQuery as useNavigate } from '../../../lib/hooks/useNavigateWithQuery';
+import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
@@ -65,7 +65,7 @@ const ConfirmSignupCode = ({
     ResendStatus.none
   );
 
-  const navigate = useNavigate();
+  const navigateWithQuery = useNavigateWithQuery();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const isDesktopRelay = integration.isDesktopRelay();
 
@@ -100,7 +100,7 @@ const ConfirmSignupCode = ({
         'Account confirmed successfully'
       )
     );
-    navigate('/settings', { replace: true });
+    navigateWithQuery('/settings', { replace: true });
   }
 
   async function handleResendCode() {
@@ -169,6 +169,7 @@ const ConfirmSignupCode = ({
 
       if (isSyncDesktopV3Integration(integration)) {
         const { to } = getSyncNavigate(location.search);
+        // will navigate to pair route which is still in backbone
         hardNavigate(to);
       } else if (isOAuthIntegration(integration)) {
         // Check to see if the relier wants TOTP.
@@ -181,7 +182,7 @@ const ConfirmSignupCode = ({
 
         // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
-          navigate('oauth/signin');
+          navigateWithQuery('oauth/signin');
           return;
         } else {
           const { redirect, code, state, error } = await finishOAuthFlowHandler(

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -39,7 +39,7 @@ import * as ReactUtils from 'fxa-react/lib/utils';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { screen, waitFor } from '@testing-library/react';
 import SignupContainer from './container';
-import { IntegrationType, useAuthClient } from '../../models';
+import { IntegrationType } from '../../models';
 import { MozServices } from '../../lib/types';
 import { FirefoxCommand } from '../../lib/channels/firefox';
 import { Constants } from '../../lib/constants';
@@ -117,14 +117,9 @@ function mockCryptoModule() {
   });
 }
 
+const mockNavigate = jest.fn();
 function mockReachRouterModule() {
-  jest.spyOn(ReachRouterModule, 'useNavigate').mockReturnValue(function () {
-    return Promise.resolve();
-  });
-}
-
-function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
+  jest.spyOn(ReachRouterModule, 'useNavigate').mockReturnValue(mockNavigate);
 }
 
 // TIP - Sometimes it's useful to have inner mocks. In this case, we hold a reference to
@@ -196,7 +191,6 @@ function applyMocks() {
   mockFirefoxModule();
   mockCryptoModule();
   mockReachRouterModule();
-  mockReactUtilsModule();
   mockLoadingSpinnerModule();
 }
 
@@ -263,7 +257,7 @@ describe('sign-up-container', () => {
       await render('loading spinner mock');
 
       // TODO: Determine if email is valid: https://github.com/mozilla/fxa/pull/16131#discussion_r1418122670
-      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+      expect(mockNavigate).toBeCalledWith('/');
     });
 
     it('handles empty email', async () => {
@@ -283,7 +277,7 @@ describe('sign-up-container', () => {
       await render('loading spinner mock');
 
       // TODO: Show that email is invalid: https://github.com/mozilla/fxa/pull/16131#discussion_r1418122670
-      expect(ReactUtils.hardNavigate).toBeCalledWith('/', {}, true);
+      expect(mockNavigate).toBeCalledWith('/');
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -290,10 +290,9 @@ describe('Signup page', () => {
       });
       await waitFor(() => {
         expect(GleanMetrics.registration.changeEmail).toBeCalledTimes(1);
-        expect(GleanMetrics.isDone).toBeCalledTimes(1);
-        expect(hardNavigateSpy).toHaveBeenCalledWith(
-          `/?prefillEmail=${encodeURIComponent(MOCK_EMAIL)}`
-        );
+        expect(mockNavigate).toHaveBeenCalledWith('/', {
+          state: { prefillEmail: MOCK_EMAIL },
+        });
       });
     });
   });


### PR DESCRIPTION
## Because

* We want to route all traffic to the react app version of the email-first pages

## This pull request

* remove these pages from the experiment
* Set fullProdRollout to true for email first routes
* Update navigation to stay in react app (no hard navigation)
* Clearly name all uses of the `useNavigateWithQuery` to make it clearer that params will persist (no renaming to `useNavigate`/`navigate`)
* Update webChannel on react app start check to only send (and wait for) message if the browser is Firefox/Firefox iOS
* Resolve inconsistent suggested account if signed in to browser and a different account on web at the same time
* Update tests

## Issue that this pull request solves

Closes: FXA-11221

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note to reviewers: Recommend restarting the app locally with these updates and doing some exploratory testing with dev launcher
