### PR TITLE
feat(settings): Remove password confirmation field in signup

### DIFF
--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -130,6 +130,14 @@ export class SignupPage extends BaseLayout {
     await expect(this.signupFormHeading).toBeVisible();
 
     await this.passwordTextbox.fill(password);
+    await this.ageTextbox.fill(age);
+    await this.createAccountButton.click();
+  }
+
+  async fillOutSyncSignupForm(password: string, age: string) {
+    await expect(this.signupFormHeading).toBeVisible();
+
+    await this.passwordTextbox.fill(password);
     await this.verifyPasswordTextbox.fill(password);
     await this.ageTextbox.fill(age);
     await this.createAccountButton.click();

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -27,7 +27,7 @@ test.describe('recovery key promo', () => {
       );
       await page.waitForURL(/\//);
       await signup.fillOutEmailForm(credentials.email);
-      await signup.fillOutSignupForm(credentials.password, '21');
+      await signup.fillOutSyncSignupForm(credentials.password, '21');
       await signup.page.waitForURL(/confirm_signup_code/);
 
       const code = await target.emailClient.getVerifyShortCode(

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -34,7 +34,6 @@ test.describe('relay integration', () => {
     ).toBeVisible();
 
     await signup.passwordTextbox.fill(password);
-    await signup.verifyPasswordTextbox.fill(password);
     await signup.ageTextbox.fill(AGE_21);
     await signup.createAccountButton.click();
 

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -92,7 +92,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(signup.CWTSEngineBookmarks).toBeVisible();
       await expect(signup.CWTSEngineHistory).toBeVisible();
 
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSyncSignupForm(password, AGE_21);
 
       await expect(page).toHaveURL(/confirm_signup_code/);
 

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -74,7 +74,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(signup.CWTSEngineCreditCards).toBeVisible();
       await expect(signup.CWTSEngineAddresses).toBeHidden();
 
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSyncSignupForm(password, AGE_21);
 
       await signup.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(page).toHaveURL(/confirm_signup_code/);

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
@@ -22,98 +22,149 @@ describe('FormPasswordWithBalloons component', () => {
   beforeAll(async () => {
     bundle = await getFtlBundle('settings');
   });
-  it('renders as expected for the reset form type', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
-    testAllL10n(screen, bundle);
 
-    await waitFor(() => {
-      screen.getByLabelText('New password');
+  describe('signup form type', () => {
+    describe('with password confirmation', () => {
+      it('renders as expected', async () => {
+        renderWithLocalizationProvider(<Subject />);
+
+        await waitFor(() => {
+          screen.getByLabelText('Password');
+        });
+        screen.getByLabelText('Repeat password');
+        screen.getByRole('button', { name: 'Create account' });
+      });
+
+      it('displays the PasswordStrengthBalloon when the new password field is in focus', async () => {
+        renderWithLocalizationProvider(<Subject />);
+        const newPasswordField = screen.getByLabelText('Password');
+
+        fireEvent.focus(newPasswordField);
+
+        await waitFor(() => screen.getByText('Password requirements'));
+      });
+
+      it('displays the PasswordInfoBalloon for the signup form type when the confirm password field is in focus', async () => {
+        renderWithLocalizationProvider(<Subject />);
+        const passwordField = screen.getByLabelText('Password');
+        const confirmPasswordField = screen.getByLabelText('Repeat password');
+
+        fireEvent.change(passwordField, { target: { value: MOCK_PASSWORD } });
+        fireEvent.focus(confirmPasswordField);
+
+        await waitFor(
+          () =>
+            expect(
+              screen.queryByText(
+                'You need this password to access any encrypted data you store with us.'
+              )
+            ).toBeVisible(),
+          { timeout: SHOW_BALLOON_TIMEOUT + 200 }
+        );
+      });
+
+      // TODO in FXA-7482, review our password requirements and best way to display them
+      it('disallows space-only passwords', async () => {
+        renderWithLocalizationProvider(<Subject />);
+        const passwordField = screen.getByLabelText('Password');
+        user.type(passwordField, '        ');
+
+        await waitFor(() => screen.getByText('Password requirements'));
+        expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
+        const passwordMinCharRequirement = screen.getByTestId(
+          'password-min-char-req'
+        );
+        const imageElement = within(passwordMinCharRequirement).getByRole(
+          'img'
+        );
+        expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
+      });
+
+      it('disallows common passwords', async () => {
+        renderWithLocalizationProvider(<Subject />);
+        const passwordField = screen.getByLabelText('Password');
+        user.type(passwordField, 'mozilla accounts');
+        await waitFor(() => screen.getByText('Password requirements'));
+        expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
+
+        const passwordNotCommonRequirement = screen.getByTestId(
+          'password-not-common-req'
+        );
+        const imageElement = within(passwordNotCommonRequirement).getByRole(
+          'img'
+        );
+        expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
+      });
     });
-    screen.getByLabelText('Re-enter password');
-    screen.getByRole('button', { name: 'Reset password' });
-  });
 
-  it('renders as expected for the signup form type', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
+    describe('without password confirmation', () => {
+      it('renders as expected', async () => {
+        renderWithLocalizationProvider(
+          <Subject requirePasswordConfirmation={false} />
+        );
 
-    await waitFor(() => {
-      screen.getByLabelText('Password');
-    });
-    screen.getByLabelText('Repeat password');
-    screen.getByRole('button', { name: 'Create account' });
-  });
+        await waitFor(() => {
+          screen.getByLabelText('Password');
+        });
+        expect(
+          screen.queryByLabelText('Repeat password')
+        ).not.toBeInTheDocument();
+        screen.getByRole('button', { name: 'Create account' });
+      });
 
-  it('displays the PasswordStrengthBalloon when the new password field is in focus', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
-    const newPasswordField = screen.getByLabelText('New password');
+      it('allows users to show and hide password input', async () => {
+        renderWithLocalizationProvider(<Subject />);
 
-    fireEvent.focus(newPasswordField);
+        const newPasswordInput = screen.getByLabelText('Password');
 
-    await waitFor(() => screen.getByText('Password requirements'));
-  });
-
-  it('does not display the PasswordInfoBalloon for the reset form type', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
-    const passwordField = screen.getByLabelText('New password');
-    const confirmPasswordField = screen.getByLabelText('Re-enter password');
-
-    fireEvent.change(passwordField, { target: { value: MOCK_PASSWORD } });
-    fireEvent.focus(confirmPasswordField);
-
-    await waitFor(() => {
-      expect(
-        screen.queryByText(
-          'You need this password to access any encrypted data you store with us.'
-        )
-      ).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(newPasswordInput).toHaveAttribute('type', 'password');
+        });
+        expect(newPasswordInput).toHaveAttribute('type', 'password');
+        fireEvent.click(screen.getByTestId('new-password-visibility-toggle'));
+        expect(newPasswordInput).toHaveAttribute('type', 'text');
+        fireEvent.click(screen.getByTestId('new-password-visibility-toggle'));
+        expect(newPasswordInput).toHaveAttribute('type', 'password');
+      });
     });
   });
 
-  it('displays the PasswordInfoBalloon for the signup form type when the confirm password field is in focus', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
-    const passwordField = screen.getByLabelText('Password');
-    const confirmPasswordField = screen.getByLabelText('Repeat password');
+  describe('reset password form type', () => {
+    it('renders as expected for the reset form type', async () => {
+      renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
+      testAllL10n(screen, bundle);
 
-    fireEvent.change(passwordField, { target: { value: MOCK_PASSWORD } });
-    fireEvent.focus(confirmPasswordField);
+      await waitFor(() => {
+        screen.getByLabelText('New password');
+      });
+      screen.getByLabelText('Re-enter password');
+      screen.getByRole('button', { name: 'Reset password' });
+    });
 
-    await waitFor(
-      () =>
+    it('displays the PasswordStrengthBalloon when the new password field is in focus', async () => {
+      renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
+      const newPasswordField = screen.getByLabelText('New password');
+
+      fireEvent.focus(newPasswordField);
+
+      await waitFor(() => screen.getByText('Password requirements'));
+    });
+
+    it('does not display the PasswordInfoBalloon for the reset form type', async () => {
+      renderWithLocalizationProvider(<Subject passwordFormType="reset" />);
+      const passwordField = screen.getByLabelText('New password');
+      const confirmPasswordField = screen.getByLabelText('Re-enter password');
+
+      fireEvent.change(passwordField, { target: { value: MOCK_PASSWORD } });
+      fireEvent.focus(confirmPasswordField);
+
+      await waitFor(() => {
         expect(
           screen.queryByText(
             'You need this password to access any encrypted data you store with us.'
           )
-        ).toBeVisible(),
-      { timeout: SHOW_BALLOON_TIMEOUT + 200 }
-    );
-  });
-
-  // TODO in FXA-7482, review our password requirements and best way to display them
-  it('disallows space-only passwords', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
-    const passwordField = screen.getByLabelText('Password');
-    user.type(passwordField, '        ');
-
-    await waitFor(() => screen.getByText('Password requirements'));
-    expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
-    const passwordMinCharRequirement = screen.getByTestId(
-      'password-min-char-req'
-    );
-    const imageElement = within(passwordMinCharRequirement).getByRole('img');
-    expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
-  });
-
-  it('disallows common passwords', async () => {
-    renderWithLocalizationProvider(<Subject passwordFormType="signup" />);
-    const passwordField = screen.getByLabelText('Password');
-    user.type(passwordField, 'mozilla accounts');
-    await waitFor(() => screen.getByText('Password requirements'));
-    expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
-
-    const passwordNotCommonRequirement = screen.getByTestId(
-      'password-not-common-req'
-    );
-    const imageElement = within(passwordNotCommonRequirement).getByRole('img');
-    expect(imageElement).toHaveTextContent('icon-warning-red-50.svg');
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -28,6 +28,7 @@ export type FormPasswordWithBalloonsProps = {
   children?: React.ReactNode;
   disableButtonUntilValid?: boolean;
   submitButtonGleanId?: string;
+  requirePasswordConfirmation?: boolean;
 };
 
 const getTemplateValues = (passwordFormType: PasswordFormType) => {
@@ -77,6 +78,7 @@ export const FormPasswordWithBalloons = ({
   children,
   disableButtonUntilValid = false,
   submitButtonGleanId,
+  requirePasswordConfirmation = true,
 }: FormPasswordWithBalloonsProps) => {
   const passwordValidator = new PasswordValidator(email);
   const [passwordMatchErrorText, setPasswordMatchErrorText] =
@@ -349,44 +351,49 @@ export const FormPasswordWithBalloons = ({
           </span>
         </div>
 
-        <div className=" relative mb-4">
-          <FtlMsg
-            id={templateValues.confirmPasswordFtlId}
-            attrs={{ label: true }}
-          >
-            <InputPassword
-              name="confirmPassword"
-              label={templateValues.confirmPasswordLabel}
-              className="text-start"
-              // onFocusCb and onBlurCb control visibility of PasswordInfoBalloon
-              // Only used for the 'signup' page
-              onFocusCb={onFocusConfirmPassword}
-              onBlurCb={onBlurConfirmPassword}
-              onChange={() => onChangePassword('confirmPassword')}
-              hasErrors={errors.confirmPassword && passwordMatchErrorText}
-              errorText={passwordMatchErrorText}
-              inputRef={register({
-                required: true,
-                validate: (value: string) => value === getValues().newPassword,
-              })}
-              anchorPosition="end"
-              tooltipPosition="bottom"
-              prefixDataTestId="verify-password"
-              aria-describedby="repeat-password-information"
-            />
-          </FtlMsg>
+        {requirePasswordConfirmation && (
+          <div className=" relative mb-4">
+            <FtlMsg
+              id={templateValues.confirmPasswordFtlId}
+              attrs={{ label: true }}
+            >
+              <InputPassword
+                name="confirmPassword"
+                label={templateValues.confirmPasswordLabel}
+                className="text-start"
+                // onFocusCb and onBlurCb control visibility of PasswordInfoBalloon
+                // Only used for the 'signup' page
+                onFocusCb={onFocusConfirmPassword}
+                onBlurCb={onBlurConfirmPassword}
+                onChange={() => onChangePassword('confirmPassword')}
+                hasErrors={errors.confirmPassword && passwordMatchErrorText}
+                errorText={passwordMatchErrorText}
+                inputRef={register({
+                  required: true,
+                  validate: (value: string) =>
+                    value === getValues().newPassword,
+                })}
+                anchorPosition="end"
+                tooltipPosition="bottom"
+                prefixDataTestId="verify-password"
+                aria-describedby="repeat-password-information"
+              />
+            </FtlMsg>
 
-          <span
-            id="repeat-password-information"
-            aria-live="polite"
-            className="text-xs"
-          >
-            {isConfirmPwdBalloonVisible && <PasswordInfoBalloon />}
-            {srOnlyConfirmPwdFeedbackMessage && (
-              <span className="sr-only">{srOnlyConfirmPwdFeedbackMessage}</span>
-            )}
-          </span>
-        </div>
+            <span
+              id="repeat-password-information"
+              aria-live="polite"
+              className="text-xs"
+            >
+              {isConfirmPwdBalloonVisible && <PasswordInfoBalloon />}
+              {srOnlyConfirmPwdFeedbackMessage && (
+                <span className="sr-only">
+                  {srOnlyConfirmPwdFeedbackMessage}
+                </span>
+              )}
+            </span>
+          </div>
+        )}
 
         {children}
         <FtlMsg id={templateValues.buttonFtlId}>

--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/mocks.tsx
@@ -4,14 +4,13 @@
 
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import FormPasswordWithBalloons, { PasswordFormType } from '.';
+import FormPasswordWithBalloons, { FormPasswordWithBalloonsProps } from '.';
 import { MOCK_ACCOUNT } from '../../models/mocks';
 
-type SubjectProps = {
-  passwordFormType: PasswordFormType;
-};
-
-export const Subject = ({ passwordFormType }: SubjectProps) => {
+export const Subject = ({
+  passwordFormType = 'signup',
+  requirePasswordConfirmation,
+}: Partial<FormPasswordWithBalloonsProps>) => {
   type FormData = {
     oldPassword?: string;
     newPassword: string;
@@ -41,6 +40,7 @@ export const Subject = ({ passwordFormType }: SubjectProps) => {
         register,
         getValues,
         passwordFormType,
+        requirePasswordConfirmation,
       }}
       onSubmit={handleSubmit(onFormSubmit)}
       email={MOCK_ACCOUNT.primaryEmail.email}

--- a/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
+++ b/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
@@ -34,7 +34,7 @@ export const FormSetupAccount = ({
   setAgeCheckErrorText,
   onFocusAgeInput,
   onBlurAgeInput,
-  submitButtonGleanId
+  submitButtonGleanId,
 }: FormSetupAccountProps) => {
   const showCWTS = () => {
     if (isSync) {
@@ -71,9 +71,10 @@ export const FormSetupAccount = ({
         disableButtonUntilValid: true,
         onSubmit,
         loading,
-        submitButtonGleanId
+        submitButtonGleanId,
       }}
       passwordFormType="signup"
+      requirePasswordConfirmation={isSync}
     >
       {setAgeCheckErrorText &&
         setAgeCheckErrorText &&


### PR DESCRIPTION
## Because

* We want to reduce registration friction

## This pull request

* Remove password confirmation field in non-sync registration form
* Maintains password confirmation field for sync signup
* Update tests

## Issue that this pull request solves

Closes: FXA-10467

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/eadb0e9b-40b3-4dd9-bbb0-ed4c17a44b83)

## Other information (Optional)

Any other information that is important to this pull request.
