### PR TITLE
feat(2fa): Auto login user after reset password and 2FA

### DIFF
--- a/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
@@ -129,22 +129,21 @@ test.describe('severity-1 #smoke', () => {
       await resetPassword.fillOutResetPasswordCodeForm(code);
 
       // Fill out the TOTP form
-      let totpCode = await getCode(secret);
+      const totpCode = await getCode(secret);
       await resetPassword.fillOutTotpForm(totpCode);
 
       await resetPassword.fillOutNewPasswordForm(newPassword);
 
-      await expect(page).toHaveURL(/signin/);
+      await expect(page).toHaveURL(/reset_password_verified/);
       await expect(resetPassword.passwordResetSuccessMessage).toBeVisible();
 
-      await expect(signin.passwordFormHeading).toBeVisible();
-      await signin.fillOutPasswordForm(newPassword);
-      await expect(page).toHaveURL(/signin_totp_code/);
-      totpCode = await getCode(secret);
-      await signinTotpCode.fillOutCodeForm(totpCode);
+      await resetPassword.passwordResetConfirmationContinueButton.click();
 
       await expect(page).toHaveURL(target.relierUrl);
       expect(await relier.isLoggedIn()).toBe(true);
+
+      // update password for cleanup function
+      credentials.password = newPassword;
 
       // Goes to settings and disables totp on user's account (required for cleanup)
       await signin.goto();

--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -49,19 +49,13 @@ test.describe('severity-1 #smoke', () => {
     });
 
     // Fill out the TOTP form
-    let totpCode = await getCode(secret);
+    const totpCode = await getCode(secret);
     await resetPassword.fillOutTotpForm(totpCode);
 
     // Create and submit new password
     await resetPassword.fillOutNewPasswordForm(newPassword);
 
-    await expect(page).toHaveURL(/signin/);
-    await expect(resetPassword.passwordResetSuccessMessage).toBeVisible();
-    await signin.fillOutPasswordForm(newPassword);
-
-    totpCode = await getCode(secret);
-    await page.waitForURL(/signin_totp_code/);
-    await signinTotpCode.fillOutCodeForm(totpCode);
+    await expect(settings.alertBar).toHaveText('Your password has been reset');
 
     await expect(settings.settingsHeading).toBeVisible();
 
@@ -121,13 +115,7 @@ test.describe('severity-1 #smoke', () => {
     // Create and submit new password
     await resetPassword.fillOutNewPasswordForm(newPassword);
 
-    await expect(page).toHaveURL(/signin/);
-    await expect(resetPassword.passwordResetSuccessMessage).toBeVisible();
-    await signin.fillOutPasswordForm(newPassword);
-
-    const totpCode = await getCode(secret);
-    await page.waitForURL(/signin_totp_code/);
-    await signinTotpCode.fillOutCodeForm(totpCode);
+    await expect(settings.alertBar).toHaveText('Your password has been reset');
 
     await expect(settings.settingsHeading).toBeVisible();
 
@@ -162,7 +150,7 @@ test.describe('severity-1 #smoke', () => {
     await expect(settings.totp.status).toHaveText('Disabled');
 
     await settings.totp.addButton.click();
-    const { secret } = await totp.fillOutTotpForms();
+    await totp.fillOutTotpForms();
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toHaveText(
@@ -196,25 +184,15 @@ test.describe('severity-1 #smoke', () => {
     await resetPassword.fillOutRecoveryKeyForm(key);
     await resetPassword.fillOutNewPasswordForm(newPassword);
 
-    await expect(page).toHaveURL(/signin/);
-    await expect(
-      resetPassword.passwordResetSuccessRecovyerKeyReminderHeading
-    ).toBeVisible();
-    await expect(
-      resetPassword.passwordResetSuccessRecovyerKeyReminderMessage
-    ).toBeVisible();
+    await expect(resetPassword.passwordResetPasswordSaved).toBeVisible();
 
-    await signin.fillOutPasswordForm(newPassword);
-
-    // Prompted for 2FA on new login
-    const totpCode = await getCode(secret);
-    await page.waitForURL(/signin_totp_code/);
-    await signinTotpCode.fillOutCodeForm(totpCode);
+    await resetPassword.continueWithoutDownloadingRecoveryKey();
+    await resetPassword.recoveryKeyFinishButton.click();
 
     await expect(settings.settingsHeading).toBeVisible();
 
-    // Recovery key has been consumed
-    await expect(settings.recoveryKey.status).toHaveText('Not Set');
+    // Recovery key has been consumed and a new one created
+    await expect(settings.recoveryKey.status).toHaveText('Enabled');
 
     // Remove TOTP before teardown
     await settings.disconnectTotp();
@@ -283,20 +261,13 @@ test.describe('severity-1 #smoke', () => {
     await page.waitForURL(/confirm_totp_reset_password/);
 
     // Fill out the TOTP form
-    let totpCode = await getCode(secret);
+    const totpCode = await getCode(secret);
     await resetPassword.fillOutTotpForm(totpCode);
 
     // Create and submit new password
     await resetPassword.fillOutNewPasswordForm(newPassword);
 
-    await expect(page).toHaveURL(/signin/);
-    await expect(resetPassword.passwordResetSuccessMessage).toBeVisible();
-    await signin.fillOutPasswordForm(newPassword);
-
-    // Prompted for 2FA on new login
-    totpCode = await getCode(secret);
-    await page.waitForURL(/signin_totp_code/);
-    await signinTotpCode.fillOutCodeForm(totpCode);
+    await expect(settings.alertBar).toHaveText('Your password has been reset');
 
     await expect(settings.settingsHeading).toBeVisible();
 

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1687,9 +1687,9 @@ export class AccountHandler {
         } = request.app.ua;
 
         // Since the only way to reach this point is clicking a
-        // link from the user's email, we create a verified sessionToken
-        // **unless** the user has a TOTP token.
-        tokenVerificationId = hasTotpToken ? await random.hex(16) : null;
+        // link from the user's email and verifying TOTP if they have it,
+        // we create a verified session token.
+        tokenVerificationId = null;
 
         const sessionTokenOptions = {
           uid: account.uid,
@@ -1697,7 +1697,7 @@ export class AccountHandler {
           emailCode: account.primaryEmail.emailCode,
           emailVerified: account.primaryEmail.isVerified,
           verifierSetAt: account.verifierSetAt,
-          mustVerify: !!tokenVerificationId,
+          mustVerify: false,
           tokenVerificationId,
           uaBrowser,
           uaBrowserVersion,
@@ -1779,13 +1779,9 @@ export class AccountHandler {
         }
       }
 
-      const verificationMethod = hasTotpToken ? 'totp-2fa' : undefined;
       Object.assign(
         response,
-        this.signinUtils.getSessionVerificationStatus(
-          sessionToken,
-          verificationMethod
-        )
+        this.signinUtils.getSessionVerificationStatus(sessionToken, undefined)
       );
 
       return response;

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -449,12 +449,8 @@ describe('/account/reset', () => {
     it('should return response', () => {
       assert.ok(res.sessionToken, 'return sessionToken');
       assert.ok(res.keyFetchToken, 'return keyFetchToken');
-      assert.equal(res.verified, false, 'return verified false');
-      assert.equal(
-        res.verificationMethod,
-        'totp-2fa',
-        'verification method set'
-      );
+      assert.equal(res.verified, true, 'return verified true');
+      assert.equal(res.verificationMethod, undefined);
     });
 
     it('should have created verified sessionToken', () => {
@@ -469,10 +465,13 @@ describe('/account/reset', () => {
         1,
         'db.createSessionToken was passed one argument'
       );
-      assert.ok(args[0].tokenVerificationId, 'tokenVerificationId is set');
+      assert.notOk(
+        args[0].tokenVerificationId,
+        'tokenVerificationId is not set'
+      );
     });
 
-    it('should have created unverified keyFetchToken', () => {
+    it('should have created verified keyFetchToken', () => {
       assert.equal(
         mockDB.createKeyFetchToken.callCount,
         1,
@@ -484,7 +483,10 @@ describe('/account/reset', () => {
         1,
         'db.createKeyFetchToken was passed one argument'
       );
-      assert.ok(args[0].tokenVerificationId, 'tokenVerificationId is set');
+      assert.notOk(
+        args[0].tokenVerificationId,
+        'tokenVerificationId is not set'
+      );
     });
   });
 

--- a/packages/fxa-auth-server/test/remote/totp_tests.js
+++ b/packages/fxa-auth-server/test/remote/totp_tests.js
@@ -474,15 +474,15 @@ const {
       const res = await client.resetPassword(newPassword, {}, { keys: true });
       assert.equal(
         res.verificationMethod,
-        'totp-2fa',
+        undefined,
         'verificationMethod not set'
       );
       assert.equal(
         res.verificationReason,
-        'login',
+        undefined,
         'verificationMethod not set'
       );
-      assert.equal(res.verified, false);
+      assert.equal(res.verified, true);
       assert.ok(res.keyFetchToken);
       assert.ok(res.sessionToken);
       assert.ok(res.authAt);


### PR DESCRIPTION
## Because

- We don't want users to have to enter 2FA twice during a password reset (one to reset, one to login)

## This pull request

- Updates our frontend parts to handle this case correctly, only prompt for 2FA once and then login after successful password reset

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11225

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate)

## Other information (Optional)


