### PR TITLE
fix(functional-tests): Increase local timeout for playwright tests

### DIFF
--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -50,7 +50,9 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
   timeout: 60000, // 1 minute
 
   // Total allowable time spent for each assertion. Defaults to 5 seconds.
-  expect: { timeout: 10000 }, // 10 seconds
+  // Increased timeout locally vs CI because putting strain on local machine
+  // can cause services/network calls to take longer to respond.
+  expect: CI ? { timeout: 10000 } : { timeout: 15000 }, // 10 seconds on CI, 15 seconds locally
 
   // Report slow tests, but only the top 10 slowest tests.
   reportSlowTests: {
@@ -77,7 +79,7 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
             },
             trace: 'retain-on-failure',
           },
-        } as Project)
+        }) as Project
     ),
   ],
   reporter: CI


### PR DESCRIPTION
## Because

* Standard timeout was causing multiple test failures when the suite was run as a whole
* The failed tests were passing when run as a limited set

## This pull request

* Increase the timeout for local test runs only
* Keep the previous timeout for CI runs

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Success rate is not 100% on first run with this setting, but failures are down from dozens to just a few.
