### PR TITLE
chore: upgrade axios to major version 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "agentkeepalive": "^4.6.0",
     "app-store-server-api": "^0.16.0",
     "aws-sdk": "^2.1691.0",
-    "axios": "^0.29.0",
+    "axios": "1.8.4",
     "base64url": "^3.0.1",
     "bn.js": "^5.2.1",
     "class-transformer": "^0.5.1",

--- a/packages/fxa-event-broker/jest.config.js
+++ b/packages/fxa-event-broker/jest.config.js
@@ -14,6 +14,9 @@ module.exports = {
       },
     ],
   },
+  transformIgnorePatterns: [
+    "/node_modules/(?!axios/)",
+  ],
   coverageDirectory: './coverage',
   testEnvironment: 'node',
 };

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.758.0",
     "@types/sinon": "10.0.1",
-    "axios": "^0.29.0",
+    "axios": "1.8.4",
     "convict": "^6.2.4",
     "convict-format-with-moment": "^6.2.0",
     "convict-format-with-validator": "^6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30963,14 +30963,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.29.0":
-  version: 0.29.0
-  resolution: "axios@npm:0.29.0"
+"axios@npm:1.8.4":
+  version: 1.8.4
+  resolution: "axios@npm:1.8.4"
   dependencies:
-    follow-redirects: ^1.15.4
+    follow-redirects: ^1.15.6
     form-data: ^4.0.0
     proxy-from-env: ^1.1.0
-  checksum: b365fa0471ff62472521932c68f152e98650804c016fc6a9fe337a6cd67201141baf14d29161527cce5189b9eba8f14cb5781e02c56e69f56784e9a23385d7e7
+  checksum: e901dc1730bdcd769839b3d93ae6d6457a53d79b19a0eb623ebfea333441259ab51e63ca118baa47a5156567401466ac739f31087b4ee5e6770ab2e227484538
   languageName: node
   linkType: hard
 
@@ -43402,7 +43402,7 @@ fsevents@~2.1.1:
     "@typescript-eslint/eslint-plugin": ^5.59.0
     "@typescript-eslint/parser": ^7.1.1
     audit-filter: ^0.5.0
-    axios: ^0.29.0
+    axios: 1.8.4
     chance: ^1.1.8
     convict: ^6.2.4
     convict-format-with-moment: ^6.2.0
@@ -44043,7 +44043,7 @@ fsevents@~2.1.1:
     app-store-server-api: ^0.16.0
     autoprefixer: ^10.4.14
     aws-sdk: ^2.1691.0
-    axios: ^0.29.0
+    axios: 1.8.4
     babel-jest: ^29.7.0
     base64url: ^3.0.1
     bn.js: ^5.2.1


### PR DESCRIPTION
## Because

Our older version of Axios (0.29) has multiple security vulnerabilities

## This pull request

Upgrades Axios to the latest version 1.8.4

## Issue that this pull request solves

Closes: FXA-6043

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

- Because this version of Axios now uses ESM, we had to add it to `transformIgnorePatterns` so that Jest process it correctly.

- There was an attempt to replace Axios altogether with native Node Fetch, which is now standard and much more prevalent in our codebase: https://github.com/mozilla/fxa/pull/18698  Unfortunately due to the extensive amount of test incompatibilities and changes required, this was abandoned for now.
