### PR TITLE
temporarily skip failing functional test

### DIFF
--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -21,6 +21,10 @@ test.describe('severity-1 #smoke', () => {
       },
       testAccountTracker,
     }) => {
+      test.fixme(
+        target.name !== 'local',
+        'FXA-11542, test is inconsistently failing in smoke tests with a different cached account than expected - suspect failing for react email-first'
+      );
       const { email, password } = testAccountTracker.generateAccountDetails();
       const syncCredentials = await testAccountTracker.signUpSync();
 


### PR DESCRIPTION
## Because

- `signin to OAuth with Sync creds` functional test failing intermittently in smoke tests

## This pull request

- mark the test as fixme until resolved in `FXA-11542`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
