### PR TITLE
Fix Incorrect title in “Recovery phone added” email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/en.ftl
@@ -1,6 +1,6 @@
 postAddRecoveryPhone-subject = Recovery phone added
 postAddRecoveryPhone-preview = Account protected by two-step authentication
-postAddRecoveryPhone-title = You created a recovery phone number
+postAddRecoveryPhone-title-v2 = You added a recovery phone number
 # Variables:
 #  $maskedLastFourPhoneNumber (String) - A bullet point mask with the last four digits of the user's phone number, e.g. ••••••1234
 postAddRecoveryPhone-description-v2 = You added { $maskedLastFourPhoneNumber } as your recovery phone number

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postAddRecoveryPhone-title">You created a recovery phone number</span>
+      <span data-l10n-id="postAddRecoveryPhone-title-v2">You added a recovery phone number</span>
     </mj-text>
 
     <mj-text css-class="text-body-no-margin">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddRecoveryPhone/index.txt
@@ -1,4 +1,4 @@
-postAddRecoveryPhone-title = "You created a recovery phone number"
+postAddRecoveryPhone-title-v2 = "You added a recovery phone number"
 
 postAddRecoveryPhone-description-v2 = "You added <%- maskedLastFourPhoneNumber %> as your recovery phone number"
 

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1202,7 +1202,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'recovery-phone-added', 'manage-account', 'email', 'uid') }],
     ])],
     ['html', [
-      { test: 'include', expected: 'You created a recovery phone number' },
+      { test: 'include', expected: 'You added a recovery phone number' },
       { test: 'include', expected: 'You added ••••••1234 as your recovery phone number' },
       // TODO, update test with FXA-10918
       { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
@@ -1217,7 +1217,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: 'You created a recovery phone number' },
+      { test: 'include', expected: 'You added a recovery phone number' },
       { test: 'include', expected: 'You added ••••••1234 as your recovery phone number' },
       // TODO, update test with FXA-10918
       { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },


### PR DESCRIPTION
## Because

- The incorrect title is displayed in the email received: “You created a recovery phone number”

## This pull request

- Fixes the copy to read “You added a recovery phone number”

## Issue that this pull request solves

Closes: FXA-11194

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

