### PR TITLE
Zimzor static analysis update

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,8 +30,8 @@ jobs:
     steps:
       - id: determine
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.git_tag }}" != "" ]]; then
-            tag="${{ inputs.git_tag }}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${GIT_TAG}" != "" ]]; then
+            tag="${GIT_TAG}"
           elif [[ "${{ github.event_name }}" == "check_run" ]]; then
             echo ${CIRCLECI_EXTERNAL_ID}
             CIRCLECI_WORKFLOW_ID=$(echo "${CIRCLECI_EXTERNAL_ID}" | jq -r '."workflow-id"')
@@ -53,6 +53,8 @@ jobs:
             echo "Trigger docker build & push on ${{ github.event_name }} and cannot determine tag" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+        env:
+          GIT_TAG: "${{ inputs.git_tag }}"
 
   docker:
     name: Docker build and push to GAR
@@ -74,10 +76,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.GIT_TAG }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
-        with:
-          cache: yarn
 
       - run: ./_scripts/l10n/clone.sh
 
@@ -86,6 +87,8 @@ jobs:
       - run: ./_scripts/create-version-json.sh
 
       - uses: docker/setup-buildx-action@v3
+        with:
+          cache-binary: false
 
       - id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,12 +86,12 @@ jobs:
 
       - run: ./_scripts/create-version-json.sh
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3
         with:
           cache-binary: false
 
       - id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5
         with:
           images: |
             ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY}}/${{ env.IMAGE}}
@@ -100,26 +100,26 @@ jobs:
             type=raw,${{ env.GIT_TAG }}
 
       - id: gcp-auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f #v2
         with:
           token_format: 'access_token'
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID}}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - id: dockerhub-auth
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3
         with:
           registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 #v6
         with:
           context: .
           file: _dev/docker/mono/Dockerfile

--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: main
 
+permissions: {}
+
 jobs:
   glean-probe-scraper:
     uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main

--- a/.github/workflows/l10n-gettext-extract.yml
+++ b/.github/workflows/l10n-gettext-extract.yml
@@ -3,8 +3,11 @@ on:
   pull_request:
     paths:
       - 'packages/fxa-content-server/**'
+
 jobs:
   extract:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Install Linux packages
@@ -23,11 +26,13 @@ jobs:
         with:
           repository: mozilla/fxa-content-server-l10n
           path: 'fxa-l10n'
+          persist-credentials: false
       - name: Clone FxA code repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
           path: 'fxa-code'
+          persist-credentials: false
       - name: Install npm packages
         run: |
           cd fxa-l10n

--- a/.github/workflows/pull-legal-docs.yml
+++ b/.github/workflows/pull-legal-docs.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           path: fxa
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Clone legal-docs repository
         uses: actions/checkout@v4
@@ -26,6 +27,7 @@ jobs:
           ref: prod
           path: legal-docs
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Pull pdfs from legal-docs and push changes to FxA
         run: |

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Fetch all git tags
         run: git fetch --tags origin
@@ -36,8 +38,10 @@ jobs:
 
       - name: Initialize mandatory git config
         run: |
-          git config user.name "${{ github.triggering_actor }}"
+          git config user.name "${TRIGGERING_ACTOR }"
           git config user.email "noreply@github.com"
+        env:
+          TRIGGERING_ACTOR: "${{ github.triggering_actor }}"
 
       - name: Commit update to branch
         if: env.versionNumber != ''

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Configure Stage AWS credentials
         uses: aws-actions/configure-aws-credentials@master

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Configure Stage AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@4d5f2395c037584ea85572b7fc12e63c9156a46e
         with:
           aws-region: us-east-1
           role-to-assume: arn:aws:iam::142069644989:role/fxa-content-cdn-stage-asset-upload
@@ -39,7 +39,7 @@ jobs:
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment  assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
 
       - name: Configure Production AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@4d5f2395c037584ea85572b7fc12e63c9156a46e
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::361527076523:role/fxa-content-cdn-prod-asset-upload
@@ -52,7 +52,7 @@ jobs:
           aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment   assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
 
       - name: Configure Stage GCP credentials
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f #v2
         with:
           service_account: gke-cdn-upload-stage@${{ secrets.GCP_NONPROD_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
@@ -64,7 +64,7 @@ jobs:
           gcloud storage cp --cache-control='public,max-age=86400' --content-disposition=attachment -r assets/legal/* gs://fxa-content-cdn-stage-distbucket/legal/
 
       - name: Configure Prod GCP credentials
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f #v2
         with:
           service_account: gke-cdn-upload-prod@${{ secrets.GCP_PROD_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
@@ -76,7 +76,7 @@ jobs:
           gcloud storage cp --cache-control='public,max-age=86400' --content-disposition=attachment -r assets/legal/* gs://fxa-content-cdn-prod-distbucket/legal/
 
       - name: "Post to fxa-team Slack channel"
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 #v1.27.0
         with:
           channel-id: 'CLV3KMZ8B'
           slack-message: "New assets have been uploaded to CDN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+# https://github.com/woodruffw/zizmor
+name: GitHub Actions Security Analysis with Zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["*"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Zizmor latest via Cargo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - run: python -m pip install zizmor
+        shell: bash
+      - name: Run zizmor
+        run: zizmor .


### PR DESCRIPTION
## This pull request


Zizmor is a Static Analysis tool for GitHub Actions https://woodruffw.github.io/zizmor/usage/#use-in-github-actions

Ran Zizmor locally to fix up any open issues on existing GitHub Actions. There are some caching features which were disabled based on https://woodruffw.github.io/zizmor/audits/#cache-poisoning

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This was originally done in https://github.com/mozilla/fxa/pull/18628 but reverted. Requiring pinning was released after that PR was put up causing some issues. Going forward you may need to adjust things in Zizmor or other Github Actions as new checks are added to the tool.
