### PR TITLE
test(apps/libs): output Junit XML unit test reports

### DIFF
--- a/apps/payments/next/jest.config.ts
+++ b/apps/payments/next/jest.config.ts
@@ -3,7 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* eslint-disable */
-export default {
+import { Config } from 'jest';
+
+const config: Config = {
   displayName: 'payments-next',
   preset: '../../../jest.preset.js',
   transform: {
@@ -11,4 +13,16 @@ export default {
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/next/babel'] }],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-next',
+        outputName: 'payments-next-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/apps/payments/next/tests/app/page.test.tsx
+++ b/apps/payments/next/tests/app/page.test.tsx
@@ -8,7 +8,7 @@ import Index from '../../app/page';
 
 describe('Page', () => {
   it('renders Page as expected', async () => {
-    render(await Index());
+    render(Index());
 
     const header = screen.getByRole('heading', { level: 1 });
     expect(header).toHaveTextContent('Welcome');

--- a/libs/accounts/recovery-phone/jest.config.ts
+++ b/libs/accounts/recovery-phone/jest.config.ts
@@ -1,5 +1,7 @@
+import { Config } from 'jest';
+
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'recovery-phone',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +10,16 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/accounts/recovery-phone',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/recovery-phone',
+        outputName: 'recovery-phone-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/accounts/two-factor/jest.config.ts
+++ b/libs/accounts/two-factor/jest.config.ts
@@ -1,5 +1,8 @@
 /* eslint-disable */
-export default {
+
+import { Config } from 'jest';
+
+const config: Config = {
   displayName: 'accounts-two-factor',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +11,16 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/accounts/two-factor',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/accounts-two-factor',
+        outputName: 'accounts-two-factor-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/google/jest.config.ts
+++ b/libs/google/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'google',
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
@@ -27,4 +28,16 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/google',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/google',
+        outputName: 'google-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/capability/jest.config.ts
+++ b/libs/payments/capability/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-capability',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/capability',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-capability',
+        outputName: 'payments-capability-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/cart/jest.config.ts
+++ b/libs/payments/cart/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-cart',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/cart',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-cart',
+        outputName: 'payments-cart-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/content-server/jest.config.ts
+++ b/libs/payments/content-server/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-content-server',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/content-server',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-content-server',
+        outputName: 'payments-content-server-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/currency/jest.config.ts
+++ b/libs/payments/currency/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-currency',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/currency',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-currency',
+        outputName: 'payments-currency-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/customer/jest.config.ts
+++ b/libs/payments/customer/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-customer',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/customer',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-customer',
+        outputName: 'payments-customer-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/eligibility/jest.config.ts
+++ b/libs/payments/eligibility/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-eligibility',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/eligibility',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-eligibility',
+        outputName: 'payments-eligibility-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/events/jest.config.ts
+++ b/libs/payments/events/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-events',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -27,4 +28,16 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/payments/events',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-events',
+        outputName: 'payments-events-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/iap/jest.config.ts
+++ b/libs/payments/iap/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-iap',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/iap',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-iap',
+        outputName: 'payments-iap-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/legacy/jest.config.ts
+++ b/libs/payments/legacy/jest.config.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { Config } from 'jest';
 
 // Reading the SWC compilation config and remove the "exclude"
 // for the test files to be compiled by SWC
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-legacy',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,16 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/legacy',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-legacy',
+        outputName: 'payments-legacy-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+
+export default config;

--- a/libs/payments/metrics/jest.config.ts
+++ b/libs/payments/metrics/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-metrics',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -27,4 +28,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/payments/metrics',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-metrics',
+        outputName: 'payments-metrics-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/payments/paypal/jest.config.ts
+++ b/libs/payments/paypal/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-paypal',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/paypal',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-paypal',
+        outputName: 'payments-paypal-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/payments/stripe/jest.config.ts
+++ b/libs/payments/stripe/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-stripe',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/stripe',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-stripe',
+        outputName: 'payments-stripe-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/payments/ui/jest.config.ts
+++ b/libs/payments/ui/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-ui',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/payments/ui',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-ui',
+        outputName: 'payments-ui-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/payments/webhooks/jest.config.ts
+++ b/libs/payments/webhooks/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'payments-webhooks',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -27,4 +28,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/payments/webhooks',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-webhooks',
+        outputName: 'payments-webhooks-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/profile/client/jest.config.ts
+++ b/libs/profile/client/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'profile-client',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -27,4 +28,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/profile/client',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/profile-client',
+        outputName: 'profile-client-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/account/account/jest.config.ts
+++ b/libs/shared/account/account/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-account-account',
   preset: '../../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/account/account',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-account-account',
+        outputName: 'shared-account-account-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/assets/jest.config.ts
+++ b/libs/shared/assets/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-assets',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/assets',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-assets',
+        outputName: 'shared-assets-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/cloud-tasks/jest.config.ts
+++ b/libs/shared/cloud-tasks/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'cloud-tasks',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/cloud-tasks',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-cloud-tasks',
+        outputName: 'shared-cloud-tasks-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/cms/jest.config.ts
+++ b/libs/shared/cms/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-cms',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/cms',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-cms',
+        outputName: 'shared-cms-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/db/firestore/jest.config.ts
+++ b/libs/shared/db/firestore/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-db-firestore',
   preset: '../../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/db/firestore',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-db-firestore',
+        outputName: 'shared-db-firestore-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/db/mysql/account/jest.config.ts
+++ b/libs/shared/db/mysql/account/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-db-mysql-account',
   preset: '../../../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../../../coverage/libs/shared/db/mysql/account',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-db-mysql-account',
+        outputName: 'shared-db-mysql-account-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/db/mysql/core/jest.config.ts
+++ b/libs/shared/db/mysql/core/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-db-mysql-core',
   preset: '../../../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../../../coverage/libs/shared/db/mysql/core',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-db-mysql-core',
+        outputName: 'shared-db-mysql-core-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/db/type-cacheable/jest.config.ts
+++ b/libs/shared/db/type-cacheable/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-db-type-cacheable',
   preset: '../../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/db/type-cacheable',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-db-type-cacheable',
+        outputName: 'shared-db-type-cacheable-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/error/jest.config.ts
+++ b/libs/shared/error/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-error',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/error',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-error',
+        outputName: 'shared-error-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/geodb/jest.config.ts
+++ b/libs/shared/geodb/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-geodb',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/geodb',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-geodb',
+        outputName: 'shared-geodb-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/l10n/jest.config.ts
+++ b/libs/shared/l10n/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-l10n',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -12,4 +13,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/l10n',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-l10n',
+        outputName: 'shared-l10n-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/log/jest.config.ts
+++ b/libs/shared/log/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-log',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/log',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-log',
+        outputName: 'shared-log-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/metrics/glean/jest.config.ts
+++ b/libs/shared/metrics/glean/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-glean',
   preset: '../../../../jest.preset.js',
   testEnvironment: 'node',
@@ -27,4 +28,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../../coverage/libs/shared/metrics/glean',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-glean',
+        outputName: 'shared-glean-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/metrics/statsd/jest.config.ts
+++ b/libs/shared/metrics/statsd/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-metrics-statsd',
   preset: '../../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../../coverage/libs/shared/metrics/statsd',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-metrics-statsd',
+        outputName: 'shared-metrics-statsd-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/mozlog/jest.config.ts
+++ b/libs/shared/mozlog/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-mozlog',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/mozlog',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-mozlog',
+        outputName: 'shared-mozlog-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/notifier/jest.config.ts
+++ b/libs/shared/notifier/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'notifier',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/notifier',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-notifier',
+        outputName: 'shared-notifier-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/otel/jest.config.ts
+++ b/libs/shared/otel/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-otel',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/otel',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-otel',
+        outputName: 'shared-otel-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/otp/jest.config.ts
+++ b/libs/shared/otp/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'otp',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/otp',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/otp',
+        outputName: 'otp-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/pem-jwk/jest.config.ts
+++ b/libs/shared/pem-jwk/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'pem-jwk',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/pem-jwk',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/pem-jwk',
+        outputName: 'pem-jwk-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/react/jest.config.ts
+++ b/libs/shared/react/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'shared-react',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/react',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-react',
+        outputName: 'shared-react-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/sentry-browser/jest.config.ts
+++ b/libs/shared/sentry-browser/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-sentry-browser',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/sentry-browser',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-sentry-browser',
+        outputName: 'shared-sentry-browser-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/sentry-nest/jest.config.ts
+++ b/libs/shared/sentry-nest/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-sentry-nest',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/sentry-nest',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-sentry-nest',
+        outputName: 'shared-sentry-nest-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/sentry-next/jest.config.ts
+++ b/libs/shared/sentry-next/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-sentry-next',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/sentry-next',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-sentry-next',
+        outputName: 'shared-sentry-next-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/sentry-node/jest.config.ts
+++ b/libs/shared/sentry-node/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-sentry-node',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/sentry-node',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-sentry-node',
+        outputName: 'shared-sentry-node-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/sentry-utils/jest.config.ts
+++ b/libs/shared/sentry-utils/jest.config.ts
@@ -1,5 +1,6 @@
+import { Config } from 'jest';
 /* eslint-disable */
-export default {
+const config: Config = {
   displayName: 'shared-sentry-utils',
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
@@ -8,4 +9,15 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../../coverage/libs/shared/sentry-utils',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-sentry-utils',
+        outputName: 'shared-sentry-utils-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/shared/sentry/jest.config.ts
+++ b/libs/shared/sentry/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'sentry',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/shared/sentry',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/shared-sentry',
+        outputName: 'shared-sentry-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/vendored/common-password-list/jest.config.ts
+++ b/libs/vendored/common-password-list/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'common-password-list',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/common-password-list',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/common-password-list',
+        outputName: 'common-password-list-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/vendored/crypto-relier/jest.config.ts
+++ b/libs/vendored/crypto-relier/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'crypto-relier',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/crypto-relier',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/crypto-relier',
+        outputName: 'crypto-relier-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/vendored/incremental-encoder/jest.config.ts
+++ b/libs/vendored/incremental-encoder/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'incremental-encoder',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/incremental-encoder',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/incremental-encoder',
+        outputName: 'incremental-encoder-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/vendored/jwtool/jest.config.ts
+++ b/libs/vendored/jwtool/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'jwtool',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/jwtool',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/jwtool',
+        outputName: 'jwtool-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;

--- a/libs/vendored/typesafe-node-firestore/jest.config.ts
+++ b/libs/vendored/typesafe-node-firestore/jest.config.ts
@@ -1,3 +1,4 @@
+import { Config } from 'jest';
 /* eslint-disable */
 import { readFileSync } from 'fs';
 
@@ -18,7 +19,7 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
-export default {
+const config: Config = {
   displayName: 'typesafe-node-firestore',
   preset: '../../../jest.preset.js',
   transform: {
@@ -27,4 +28,15 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   testEnvironment: 'node',
   coverageDirectory: '../../../coverage/libs/vendored/typesafe-node-firestore',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/typesafe-node-firestore',
+        outputName: 'typesafe-node-firestore-jest-unit-results.xml',
+      },
+    ],
+  ],
 };
+export default config;


### PR DESCRIPTION
## Because

- We want to capture test results from `apps/*` and `libs/*`

## This pull request

- Adds the `reporters` option to all jest configs to output their results in the correct folder

## Issue that this pull request solves

Closes: FXA-11333

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There is a warning about "unknown option `reporters`" that is thrown when running the Jest tests for `payments-next`. This is a [known issue](https://github.com/nrwl/nx/issues/22152) with `29.x.x` versions of Jest, but appears to no prevent producing the appropriate file.
