### PR TITLE
fix(settings): Country selector styling and a11y

### DIFF
--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.tsx
@@ -4,6 +4,7 @@
 
 import React, { useState } from 'react';
 import InputText from '../InputText';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { useFtlMsgResolver } from '../../models';
 import { UseFormMethods } from 'react-hook-form';
 
@@ -122,21 +123,59 @@ const InputPhoneNumber = ({
 
   return (
     <div className="flex">
-      <select
-        aria-label={ftlMsgResolver.getMsg(
-          'input-phone-number-country-list-aria-label',
-          'Select country'
-        )}
-        onChange={handleCountryChange}
-        value={selectedCountry.id}
-        className={`bg-transparent border border-grey-200 rounded-md py-2 ps-10 w-[60px] me-2 focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus ${selectedCountry.classNameFlag} bg-no-repeat bg-[length:1.5rem_1rem] bg-[40%_50%] -indent-9999 z-10`}
-      >
-        {sortedLocalizedCountries.map((country) => (
-          <option key={country.id} value={country.id} className="text-black">
-            {country.localizedName} ({country.code})
-          </option>
-        ))}
-      </select>
+      <div className="relative inline-block w-[60px] me-2">
+        <FtlMsg id="input-phone-number-country-list-aria-label">
+          <label id="countryLabel" className="sr-only">
+            Select country
+          </label>
+        </FtlMsg>
+        <select
+          aria-labelledby="countryLabel"
+          onChange={handleCountryChange}
+          value={selectedCountry.id}
+          /* The forced-colors styling is for Windows HCM
+           * keeps label hidden when the select is collapsed without hiding from screen readers
+           */
+          className="
+            w-full h-full
+            px-2
+            border border-grey-200 rounded-md
+            bg-transparent text-transparent
+            focus:border-blue-400 focus:outline-none focus:shadow-input-blue-focus
+            forced-color-adjust:none
+            [@media(forced-colors:active)]:text-[ButtonFace]
+            [@media(forced-colors:active)]:text-shadow-[0_0_0_transparent]
+            appearance-none
+          "
+        >
+          {sortedLocalizedCountries.map((country) => (
+            <option key={country.id} value={country.id} className="text-black">
+              {country.localizedName} ({country.code})
+            </option>
+          ))}
+        </select>
+
+        <span
+          aria-hidden
+          className={`
+              absolute start-1 top-1/2 -translate-y-1/2
+              w-6 h-4 bg-no-repeat bg-[length:1.5rem_1rem]
+              pointer-events-none
+              ${selectedCountry.classNameFlag}
+            `}
+        />
+
+        {/* chevron ▾ */}
+        <svg
+          aria-hidden
+          viewBox="0 0 8 5"
+          className="absolute end-1.5 top-1/2 -translate-y-1/2 w-2.5 h-2.5
+                   fill-current text-current pointer-events-none
+                   [forced-colors:active]:text-[ButtonText]"
+        >
+          <path d="M0 0h8L4 5z" />
+        </svg>
+      </div>
 
       {/* Because the country code may not be unique, the above `select`'s `value` must
        be by country ID. This hidden input allows us to access it in the form data. */}


### PR DESCRIPTION
## Because

* On Windows, country options had extra padding at the start because options inherit styling from select (differs from handling on Mac)
* We want the country selector styling to work on Windows and Mac
* We want the country selector to be accessible for HCM, screen-readers

## This pull request

* Removed the flags styles as background images and replaced with overlayed flag and custom chevron for the collapsed view
* Added some tweaks for Windows High Contrast Mode
* Added an off-screen label for better a11y coverage with screen-readers and braille display

## Issue that this pull request solves

Closes: FXA-11373

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Bug:
<img width="830" alt="Screenshot 2025-04-28 at 4 28 07 PM" src="https://github.com/user-attachments/assets/fc0b47cf-00d2-474c-b343-322860bac8ff" />

After:
(windows, LTR)
<img width="786" alt="Screenshot 2025-04-28 at 4 23 37 PM" src="https://github.com/user-attachments/assets/9ef69a5b-2849-4461-a780-86c09bf3b332" />

(windows, RTL)
<img width="811" alt="Screenshot 2025-04-28 at 4 23 17 PM" src="https://github.com/user-attachments/assets/5962f632-f97c-476b-a74c-daaae97d3611" />

(Mac)
![Screenshot 2025-04-28 at 4 23 56 PM](https://github.com/user-attachments/assets/0b13f517-a1e2-4cf6-8690-d855c3fbdd15)

(HCM)
<img width="786" alt="Screenshot 2025-04-28 at 4 39 16 PM" src="https://github.com/user-attachments/assets/b4d77920-88d5-43a0-adb7-3c0c23991b53" />


## Other information (Optional)

Any other information that is important to this pull request.
