### PR TITLE
fix(next): location change doesnt update cart amount

### DIFF
--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -128,6 +128,7 @@ export interface TaxAmount {
 }
 
 export type UpdateCart = {
+  amount?: number;
   uid?: string;
   taxAddress?: TaxAddress;
   currency?: string;


### PR DESCRIPTION
## Because

- When a customer changes location that results in price change, the cart isn't update with the new amount, resulting in an error during checkout.

## This pull request

- On location update, if currency is changed, fetch the new subtotal for that price and currency and update the cart.amount

## Issue that this pull request solves

Closes: #FXA-11290

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
