### PR TITLE
fix(next): sign out retains current location

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -4,6 +4,7 @@
 import { headers } from 'next/headers';
 import {
   CouponForm,
+  Header,
   MetricsWrapper,
   PurchaseDetails,
   SelectTaxLocation,
@@ -22,7 +23,7 @@ import {
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
 import { CartState } from '@fxa/shared/db/mysql/account';
-import { auth } from 'apps/payments/next/auth';
+import { auth, signOut } from 'apps/payments/next/auth';
 import { config } from 'apps/payments/next/config';
 
 export interface CheckoutSearchParams {
@@ -57,6 +58,16 @@ export default async function CheckoutLayout({
     cms.defaultPurchase.purchaseDetails;
   return (
     <MetricsWrapper cart={cart}>
+      <Header
+        auth={{
+          user: session?.user,
+          signOut: async () => {
+            'use server';
+            await signOut({ redirect: false });
+          },
+        }}
+        cart={cart}
+      />
       {session?.user?.email && (
         <div className="mb-8 tablet:hidden">
           <SignedIn email={session.user.email} />

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -56,8 +56,13 @@ export default async function New({
 
   const fxaUid = session?.user?.id;
   const coupon = searchParams.coupon || undefined;
+  const countryCode = searchParams.countryCode;
+  const postalCode = searchParams.postalCode;
 
-  const taxAddress = await getTaxAddressAction(ipAddress, fxaUid);
+  const taxAddress =
+    countryCode && postalCode
+      ? { countryCode, postalCode }
+      : await getTaxAddressAction(ipAddress, fxaUid);
 
   // Check if the customer is in a location not supported by Subscription Platform
   // or whether the product is not available in the customer's location

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { headers } from 'next/headers';
-import { MetricsWrapper, PurchaseDetails } from '@fxa/payments/ui';
+import { Header, MetricsWrapper, PurchaseDetails } from '@fxa/payments/ui';
 import { fetchCMSData, getCartAction } from '@fxa/payments/ui/actions';
 import {
   getApp,
@@ -13,6 +13,7 @@ import {
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
 import { config } from 'apps/payments/next/config';
+import { auth, signOut } from 'apps/payments/next/auth';
 
 export default async function UpgradeSuccessLayout({
   children,
@@ -26,12 +27,27 @@ export default async function UpgradeSuccessLayout({
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const cartDataPromise = getCartAction(params.cartId);
   const cmsDataPromise = fetchCMSData(params.offeringId, locale);
-  const [cms, cart] = await Promise.all([cmsDataPromise, cartDataPromise]);
+  const sessionPromise = auth();
+  const [cms, cart, session] = await Promise.all([
+    cmsDataPromise,
+    cartDataPromise,
+    sessionPromise,
+  ]);
   const purchaseDetails =
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;
   return (
     <MetricsWrapper cart={cart}>
+      <Header
+        auth={{
+          user: session?.user,
+          signOut: async () => {
+            'use server';
+            await signOut({ redirect: false });
+          },
+        }}
+        cart={cart}
+      />
       <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
         <SubscriptionTitle cart={cart} l10n={l10n} />
         <section

--- a/apps/payments/next/app/[locale]/layout.tsx
+++ b/apps/payments/next/app/[locale]/layout.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { getApp } from '@fxa/payments/ui/server';
 import { headers } from 'next/headers';
-import { Header, Providers } from '@fxa/payments/ui';
+import { Providers } from '@fxa/payments/ui';
 import { config } from 'apps/payments/next/config';
-import { auth, signOut } from '../../auth';
 
 export default async function RootProviderLayout({
   params,
@@ -23,8 +22,6 @@ export default async function RootProviderLayout({
     params.locale
   );
 
-  const session = await auth();
-
   return (
     <Providers
       config={{
@@ -37,15 +34,6 @@ export default async function RootProviderLayout({
       fetchedMessages={fetchedMessages}
       nonce={nonce}
     >
-      <Header
-        auth={{
-          user: session?.user,
-          signOut: async () => {
-            'use server';
-            await signOut({ redirect: false });
-          },
-        }}
-      />
       {children}
     </Providers>
   );


### PR DESCRIPTION
## Because

- When a customer has manually changed their location on the checkout page, and then signs out, the previously set location is not retained. This could result in the user being navigated to their default location instead of the location selected before sign out.

## This pull request

- Moves the Heading component into checkout and upgrade layouts
- Pass countryCode and postalCode to the /new page when a customers signs out and is redirected there.

## Issue that this pull request solves

Closes: FXA-11452

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
