### PR TITLE
feat(payments): Update SubscriptionEventsService to check subscription metadata for redundantCancellation property

### DIFF
--- a/libs/payments/events/src/lib/emitter.factories.ts
+++ b/libs/payments/events/src/lib/emitter.factories.ts
@@ -8,6 +8,7 @@ import {
   SubscriptionEndedEvents,
 } from './emitter.types';
 import {
+  CancellationReason,
   CartMetricsFactory,
   CmsMetricsDataFactory,
 } from '@fxa/payments/metrics';
@@ -29,7 +30,7 @@ export const SubscriptionEndedFactory = (
   priceInterval: faker.helpers.arrayElement(['month', 'year']),
   priceIntervalCount: faker.number.int({ min: 1, max: 12 }),
   providerEventId: faker.string.uuid(),
-  voluntaryCancellation: faker.datatype.boolean(),
+  cancellationReason: faker.helpers.enumValue(CancellationReason),
   uid: faker.string.uuid(),
   ...override,
 });

--- a/libs/payments/events/src/lib/emitter.service.spec.ts
+++ b/libs/payments/events/src/lib/emitter.service.spec.ts
@@ -365,7 +365,7 @@ describe('PaymentsEmitterService', () => {
     const subscriptionCancellationData = {
       offeringId: mockOfferingId,
       interval: mockSubplatInterval,
-      voluntaryCancellation: cancellationEventData.voluntaryCancellation,
+      cancellationReason: cancellationEventData.cancellationReason,
       providerEventId: cancellationEventData.providerEventId,
     };
 

--- a/libs/payments/events/src/lib/emitter.service.ts
+++ b/libs/payments/events/src/lib/emitter.service.ts
@@ -156,7 +156,7 @@ export class PaymentsEmitterService {
       priceInterval,
       priceIntervalCount,
       providerEventId,
-      voluntaryCancellation,
+      cancellationReason,
       uid,
     } = eventData;
     let offeringId: string | undefined;
@@ -188,7 +188,7 @@ export class PaymentsEmitterService {
           subscriptionCancellationData: {
             offeringId,
             interval,
-            voluntaryCancellation,
+            cancellationReason,
             providerEventId,
           },
         },

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import {
+  CancellationReason,
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
@@ -21,7 +22,7 @@ export type SubscriptionEndedEvents = {
   priceIntervalCount?: number;
   paymentProvider?: PaymentProvidersType;
   providerEventId: string;
-  voluntaryCancellation: boolean;
+  cancellationReason: CancellationReason;
   uid?: string;
 };
 

--- a/libs/payments/metrics/src/lib/glean/glean.factory.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.factory.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { faker } from '@faker-js/faker';
 import {
+  CancellationReason,
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
@@ -74,7 +75,7 @@ export const SubscriptionCancellationDataFactory = (
       'mdnplus',
     ]),
     interval: faker.helpers.enumValue(SubplatInterval),
-    voluntaryCancellation: faker.datatype.boolean(),
+    cancellationReason: faker.helpers.enumValue(CancellationReason),
     providerEventId: faker.string.uuid(),
     ...override,
   };

--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -1,7 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import {
+  CancellationReason,
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
@@ -150,7 +152,7 @@ export class PaymentsGleanManager {
     const emptySubscriptionCancellationData: SubscriptionCancellationData = {
       offeringId: '',
       interval: '',
-      voluntaryCancellation: false,
+      cancellationReason: CancellationReason.Involuntary,
       providerEventId: '',
     };
     const commonMetricsData =

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -37,10 +37,16 @@ export type CmsMetricsData = {
   priceId: string;
 };
 
+export enum CancellationReason {
+  CustomerInitiated = 'customer_initiated',
+  Involuntary = 'involuntary',
+  Redundant = 'redundant',
+}
+
 export type SubscriptionCancellationData = {
   offeringId?: string;
   interval?: string;
-  voluntaryCancellation: boolean;
+  cancellationReason: CancellationReason;
   providerEventId: string;
 };
 

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.spec.ts
@@ -2,20 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { mapSubscriptionCancellation } from './mapSubscriptionCancellation';
+import { CancellationReason } from '../glean.types';
 
 describe('mapSubscriptionCancellation', () => {
   it('should map all values', () => {
     const result = mapSubscriptionCancellation({
       offeringId: 'offeringId',
       interval: 'interval',
-      voluntaryCancellation: true,
+      cancellationReason: CancellationReason.CustomerInitiated,
       providerEventId: 'providerEventId',
     });
     expect(result).toEqual({
       subscription_offering_id: 'offeringId',
       subscription_interval: 'interval',
       subscription_provider_event_id: 'providerEventId',
-      subscription_voluntary_cancellation: true,
+      subscription_cancellation_reason: CancellationReason.CustomerInitiated,
     });
   });
 
@@ -23,14 +24,14 @@ describe('mapSubscriptionCancellation', () => {
     const result = mapSubscriptionCancellation({
       offeringId: undefined,
       interval: undefined,
-      voluntaryCancellation: false,
+      cancellationReason: CancellationReason.Involuntary,
       providerEventId: 'providerEventId',
     });
     expect(result).toEqual({
       subscription_offering_id: '',
       subscription_interval: '',
       subscription_provider_event_id: 'providerEventId',
-      subscription_voluntary_cancellation: false,
+      subscription_cancellation_reason: CancellationReason.Involuntary,
     });
   });
 });

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscriptionCancellation.ts
@@ -7,13 +7,13 @@ import { normalizeGleanFalsyValues } from './normalizeGleanFalsyValues';
 export function mapSubscriptionCancellation({
   offeringId,
   interval,
-  voluntaryCancellation,
+  cancellationReason,
   providerEventId,
 }: SubscriptionCancellationData) {
   return {
     subscription_offering_id: normalizeGleanFalsyValues(offeringId),
     subscription_interval: normalizeGleanFalsyValues(interval),
     subscription_provider_event_id: normalizeGleanFalsyValues(providerEventId),
-    subscription_voluntary_cancellation: voluntaryCancellation,
+    subscription_cancellation_reason: cancellationReason,
   };
 }

--- a/libs/payments/webhooks/src/index.ts
+++ b/libs/payments/webhooks/src/index.ts
@@ -5,3 +5,4 @@
 export * from './lib/stripeWebhooks.service';
 export * from './lib/stripeEvents.manager';
 export * from './lib/subscriptionHandler.service';
+export * from './lib/types';

--- a/libs/payments/webhooks/src/lib/util/determineCancellation.ts
+++ b/libs/payments/webhooks/src/lib/util/determineCancellation.ts
@@ -5,20 +5,34 @@
 import { PaymentProvidersType } from '@fxa/payments/metrics';
 import { StripeInvoice, StripeSubscription } from '@fxa/payments/stripe';
 
+export enum CancellationReason {
+  CustomerInitiated = 'customer_initiated',
+  Involuntary = 'involuntary',
+  Redundant = 'redundant',
+}
+
 export const determineCancellation = (
   paymentProvider: PaymentProvidersType,
   subscription: StripeSubscription,
   latestInvoice?: StripeInvoice
-) => {
+): CancellationReason | undefined => {
+  if (subscription.metadata['redundantCancellation']) {
+    return CancellationReason.Redundant;
+  }
+
   if (paymentProvider === 'external_paypal') {
     if (!latestInvoice) {
       return undefined;
     } else {
-      return latestInvoice.status !== 'uncollectible';
+      return latestInvoice.status !== 'uncollectible'
+        ? CancellationReason.CustomerInitiated
+        : CancellationReason.Involuntary;
     }
   } else if (paymentProvider === 'card') {
     return subscription.cancellation_details
       ? subscription.cancellation_details?.reason === 'cancellation_requested'
+        ? CancellationReason.CustomerInitiated
+        : CancellationReason.Involuntary
       : undefined;
   } else {
     return undefined;

--- a/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
+++ b/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
@@ -310,10 +310,14 @@ subscription:
     data_sensitivity:
       - interaction
     extra_keys:
-      subscription_voluntary_cancellation:
+      subscription_cancellation_reason:
         description: |
-          Whether the user cancelled the subscription (`true`) or not (`false`)
-        type: boolean
+          Reason for the subscription cancellation - customer initiated, involuntary, or redundant.
+        type: string
+        enum:
+          - customer_initiated
+          - involuntary
+          - redundant
   provider_event_id:
     description: |
       A unique identifier for the subscription notification from a payment provider.


### PR DESCRIPTION
## This pull request

- Updates determineCancellation to return one of 3 reasons for cancellation: “customer_initiated”, “involuntary”, “redundant”

## Issue that this pull request solves

Closes: FXA-11537

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.