### PR TITLE
bug(settings): Make sure experiment info is defined

### DIFF
--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -118,17 +118,19 @@ export function useExperiments(): NimbusResult | null {
     async function fetchExperiments() {
       if (experimentInfo) {
         const exp = await experimentInfo;
-        // Today, we don't need everything from the response so let's only add them as needed.
-        // We map out the response from the doc examples here:
-        // https://github.com/mozilla/experimenter/blob/main/cirrus/README.md
-        setExperiments({
-          features: exp.Features,
-          // The ID we send and the one receive should be the same.
-          // There has been a case were a bug in Nimbus sent us different IDs,
-          // so for now, let us trust our own ID.
-          // See: https://github.com/mozilla/blurts-server/pull/5509
-          nimbusUserId: uniqueUserId,
-        } as NimbusResult);
+        if (exp) {
+          // Today, we don't need everything from the response so let's only add them as needed.
+          // We map out the response from the doc examples here:
+          // https://github.com/mozilla/experimenter/blob/main/cirrus/README.md
+          setExperiments({
+            features: exp.Features,
+            // The ID we send and the one receive should be the same.
+            // There has been a case were a bug in Nimbus sent us different IDs,
+            // so for now, let us trust our own ID.
+            // See: https://github.com/mozilla/blurts-server/pull/5509
+            nimbusUserId: uniqueUserId,
+          } as NimbusResult);
+        }
       }
     }
     fetchExperiments();


### PR DESCRIPTION
## Because

- If experiment info is undefined, we shouldn't set anything.

## This pull request

- Checks that experiment info was actually returned before setting features.

## Issue that this pull request solves

Closes: FXA-11564

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
