### PR TITLE
feat(oauth): Remove BrowserID assertion logic from oauth server

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/assertion.js
+++ b/packages/fxa-auth-server/lib/oauth/assertion.js
@@ -4,20 +4,13 @@
 
 'use stict';
 
-/* Utilities for verifing signed identity assertions.
+/* Utilities for verifying signed identity assertions.
  *
- * This service accepts two different kinds of identity assertions
+ * This service accepts one kind of identity assertions
  * for authenticating the caller:
  *
  *  - A JWT, signed by one of a fixed set of trusted server-side secret
  *    HMAC keys.
- *  - A BrowserID assertion bundle, signed via BrowserID's public key
- *    discovery mechanisms.
- *
- * The former is much simpler and easier to verify, so much so that
- * we do it inline in the server process. The later is much more
- * complicated and we need to call out to an external verifier process.
- * We hope to eventually phase out support for BrowserID assertions.
  *
  */
 
@@ -49,77 +42,23 @@ const CLAIMS_SCHEMA = Joi.object({
 const AUDIENCE = config.get('oauthServer.audience');
 const ALLOWED_ISSUER = config.get('oauthServer.browserid.issuer');
 
-const request = require('request').defaults({
-  url: config.get('oauthServer.browserid.verificationUrl'),
-  pool: {
-    maxSockets: config.get('oauthServer.browserid.maxSockets'),
-  },
-});
-
 function error(assertion, msg, val) {
   throw OauthError.invalidAssertion();
 }
 
-// Verify a BrowserID assertion,
-// by posting to an external verifier service.
-
-async function verifyBrowserID(assertion) {
-  const [res, body] = await new Promise((resolve, reject) => {
-    request(
-      {
-        method: 'POST',
-        json: {
-          assertion: assertion,
-          audience: AUDIENCE,
-        },
-      },
-      (err, res, body) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve([res, body]);
-      }
-    );
-  });
-
-  if (!res || !body || body.status !== 'okay') {
-    return error(assertion, 'non-okay response', body);
-  }
-
-  const email = body.email;
-  const parts = email.split('@');
-  if (parts.length !== 2 || parts[1] !== ALLOWED_ISSUER) {
-    return error(assertion, 'invalid email', email);
-  }
-  if (body.issuer !== ALLOWED_ISSUER) {
-    return error(assertion, 'invalid issuer', body.issuer);
-  }
-  const uid = parts[0];
-
-  const claims = body.idpClaims || {};
-  claims.uid = uid;
-  return claims;
-}
-
 module.exports = async function verifyAssertion(assertion) {
-  // We can differentiate between JWTs and BrowserID assertions
-  // because the former cannot contain "~" while the later always do.
   let claims;
-  if (/~/.test(assertion)) {
-    claims = await verifyBrowserID(assertion);
-  } else {
-    try {
-      claims = await verifyJWT(
-        assertion,
-        AUDIENCE,
-        ALLOWED_ISSUER,
-        config.get('oauthServer.authServerSecrets'),
-        error
-      );
-      claims.uid = claims.sub;
-    } catch (err) {
-      return error(assertion, err.message);
-    }
+  try {
+    claims = await verifyJWT(
+      assertion,
+      AUDIENCE,
+      ALLOWED_ISSUER,
+      config.get('oauthServer.authServerSecrets'),
+      error
+    );
+    claims.uid = claims.sub;
+  } catch (err) {
+    return error(assertion, err.message);
   }
   try {
     return await CLAIMS_SCHEMA.validateAsync(claims);

--- a/packages/fxa-auth-server/lib/routes/defaults.js
+++ b/packages/fxa-auth-server/lib/routes/defaults.js
@@ -56,10 +56,6 @@ module.exports = (log, config, db) => {
         // We should consider it deprecated but removing it isn't a high priority.
         log.begin('Defaults.config', request);
         return {
-          browserid: {
-            issuer: config.oauthServer.browserid.issuer,
-            verificationUrl: config.oauthServer.browserid.verificationUrl,
-          },
           contentUrl: config.oauthServer.contentUrl,
         };
       },


### PR DESCRIPTION
## Because

- BrowserID assertions are complex and we no longer use them in our services
- We want to reduce code and service complexity

## This pull request

- Removes BrowserID assertion support from the OAuth server
- Updates the `verifyAssertion` function to exclusively handle JWT verification
- Removes BrowserID configuration fields (`issuer`, `verificationUrl`) from the `/config` endpoint in `lib/routes/defaults.js`
- Replaces BrowserID assertion mocks with JWT-based equivalents in the test suite (`test/oauth/api.js`, `test/oauth/assertion.js`)
- Removes BrowserID-specific test cases and updates integration tests to use JWT assertions for all OAuth flows.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

N/A - No user interface changes.

## Other information (Optional)