### PR TITLE
fix(next): show default address on payment element

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -188,10 +188,6 @@ export function CheckoutForm({
             payment_method_data: {
               billing_details: {
                 name: fullName,
-                address: {
-                  country: cart.taxAddress.countryCode,
-                  postal_code: cart.taxAddress.postalCode,
-                },
               },
             },
           }
@@ -326,16 +322,15 @@ export function CheckoutForm({
                 spacedAccordionItems: true,
               },
               readOnly: !formEnabled,
-              fields: {
-                billingDetails: {
-                  address: {
-                    country: 'never',
-                    postalCode: 'never',
-                  },
-                },
-              },
               terms: {
                 card: 'never',
+              },
+              defaultValues: {
+                billingDetails: {
+                  address: {
+                    country: cart.taxAddress.countryCode,
+                  },
+                },
               },
             }}
           />


### PR DESCRIPTION
## Because

- The Payment Element is configured never show the country and postal code.

## This pull request

- Remove config values hiding country and postal.
- By default, set the Country to match the Tax Address country

## Issue that this pull request solves

Closes: FXA-11451

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/88c044e0-f5fb-4418-a31c-4dfb38009dc7)

Changing country in tax location will automatically update the payment element country
![image](https://github.com/user-attachments/assets/1685b333-5a96-426d-a09c-8b99cf47dee3)

