### PR TITLE
fix(next): match same eligiblity on product and interval

### DIFF
--- a/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.spec.ts
@@ -543,6 +543,37 @@ describe('EligibilityManager', () => {
       );
     });
 
+    it('returns same if subscribed price and target price have same product and interval', async () => {
+      const mockOverlapResult = [
+        {
+          comparison: OfferingComparison.SAME,
+          priceId: 'price_legacy',
+        },
+      ] as OfferingOverlapResult[];
+      const mockTargetOffering = EligibilityContentOfferingResultFactory();
+      const interval = SubplatInterval.Monthly;
+      const mockTargetPrice = StripePriceFactory({
+        id: 'price_new',
+      });
+      const mockSubscribedPrice = {
+        ...mockTargetPrice,
+        id: 'price_legacy',
+      };
+      jest
+        .spyOn(priceManager, 'retrieveByInterval')
+        .mockResolvedValue(mockTargetPrice);
+
+      const result = await manager.compareOverlap(
+        mockOverlapResult,
+        mockTargetOffering,
+        interval,
+        [mockSubscribedPrice]
+      );
+      expect(result.subscriptionEligibilityResult).toEqual(
+        EligibilityStatus.SAME
+      );
+    });
+
     it('returns downgrade when target price interval is shorter than the subscribed price', async () => {
       const mockTargetOffering = EligibilityContentOfferingResultFactory();
       const mockFromPrice = StripePriceFactory({

--- a/libs/payments/eligibility/src/lib/eligibility.manager.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.manager.ts
@@ -132,7 +132,14 @@ export class EligibilityManager {
       };
     }
 
-    if (overlappingPrice.id === targetPrice.id) {
+    if (
+      overlappingPrice.id === targetPrice.id ||
+      (overlappingPrice.product === targetPrice.product &&
+        overlappingPrice.recurring.interval ===
+          targetPrice.recurring.interval &&
+        overlappingPrice.recurring.interval_count ===
+          targetPrice.recurring.interval_count)
+    ) {
       return {
         subscriptionEligibilityResult: EligibilityStatus.SAME,
       };


### PR DESCRIPTION
## Because

- When a customer is subscribed to a non-multi currency price and attempts to subscribe to the multi currency version of that price, the eligibility manager does not mark these as having a "SAME" overlap.

## This pull request

- Update logic checking if target price is the same as subscribed price, by checking if the product and interval info is the same

## Issue that this pull request solves

Closes: FXA-11252

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To reproduce this issue follow these steps.
* Subscribe to a monthly plan, for product A on SP2 (This will select a non-multi-currency price)
* With the same user, subscribe to a monthly plan for product A on SP3. (This will select a multi-currency price)
* Expected behavior, see screen informing customer they are already subscribed to the product.
