### PR TITLE
fix(next): stricter postal code validation for romania

### DIFF
--- a/libs/google/src/lib/google.constants.ts
+++ b/libs/google/src/lib/google.constants.ts
@@ -3,51 +3,51 @@
  * Romanian postal codes. This page provides a reference list: https://en.wikipedia.org/wiki/Postal_codes_in_Romania
  */
 export const ROMANIAN_POSTAL_CODES = [
-  /01\d{4}/, // Bucharest Sector 1
-  /02\d{4}/, // Bucharest Sector 2
-  /03\d{4}/, // Bucharest Sector 3
-  /04\d{4}/, // Bucharest Sector 4
-  /05\d{4}/, // Bucharest Sector 5
-  /06\d{4}/, // Bucharest Sector 6
-  /07\d{4}/, // Ilfov County
-  /08\d{4}/, // Giurgiu County
-  /10\d{4}/, // Prahova County
-  /11\d{4}/, // Argeș County
-  /12\d{4}/, // Buzău County
-  /13\d{4}/, // Dâmbovița County
-  /14\d{4}/, // Teleorman County
-  /20\d{4}/, // Dolj County
-  /21\d{4}/, // Gorj County
-  /22\d{4}/, // Mehedinți County
-  /23\d{4}/, // Olt County
-  /24\d{4}/, // Vâlcea County
-  /30\d{4}/, // Timiș County
-  /31\d{4}/, // Arad County
-  /32\d{4}/, // Caraș-Severin County
-  /33\d{4}/, // Hunedoara County
-  /40\d{4}/, // Cluj County
-  /41\d{4}/, // Bihor County
-  /42\d{4}/, // Bistrița-Năsăud County
-  /43\d{4}/, // Maramureș County
-  /44\d{4}/, // Satu Mare County
-  /45\d{4}/, // Sălaj County
-  /50\d{4}/, // Brașov County
-  /51\d{4}/, // Alba County
-  /52\d{4}/, // Covasna County
-  /53\d{4}/, // Harghita County
-  /54\d{4}/, // Mureș County
-  /55\d{4}/, // Sibiu County
-  /60\d{4}/, // Bacău County
-  /61\d{4}/, // Neamț County
-  /62\d{4}/, // Vrancea County
-  /70\d{4}/, // Iași County
-  /71\d{4}/, // Botoșani County
-  /72\d{4}/, // Suceava County
-  /73\d{4}/, // Vaslui County
-  /80\d{4}/, // Galați County
-  /81\d{4}/, // Brăila County
-  /82\d{4}/, // Tulcea County
-  /90\d{4}/, // Constanța County
-  /91\d{4}/, // Călărași County
-  /92\d{4}/, // Ialomița County
+  /^01\d{4}$/, // Bucharest Sector 1
+  /^02\d{4}$/, // Bucharest Sector 2
+  /^03\d{4}$/, // Bucharest Sector 3
+  /^04\d{4}$/, // Bucharest Sector 4
+  /^05\d{4}$/, // Bucharest Sector 5
+  /^06\d{4}$/, // Bucharest Sector 6
+  /^07\d{4}$/, // Ilfov County
+  /^08\d{4}$/, // Giurgiu County
+  /^10\d{4}$/, // Prahova County
+  /^11\d{4}$/, // Argeș County
+  /^12\d{4}$/, // Buzău County
+  /^13\d{4}$/, // Dâmbovița County
+  /^14\d{4}$/, // Teleorman County
+  /^20\d{4}$/, // Dolj County
+  /^21\d{4}$/, // Gorj County
+  /^22\d{4}$/, // Mehedinți County
+  /^23\d{4}$/, // Olt County
+  /^24\d{4}$/, // Vâlcea County
+  /^30\d{4}$/, // Timiș County
+  /^31\d{4}$/, // Arad County
+  /^32\d{4}$/, // Caraș-Severin County
+  /^33\d{4}$/, // Hunedoara County
+  /^40\d{4}$/, // Cluj County
+  /^41\d{4}$/, // Bihor County
+  /^42\d{4}$/, // Bistrița-Năsăud County
+  /^43\d{4}$/, // Maramureș County
+  /^44\d{4}$/, // Satu Mare County
+  /^45\d{4}$/, // Sălaj County
+  /^50\d{4}$/, // Brașov County
+  /^51\d{4}$/, // Alba County
+  /^52\d{4}$/, // Covasna County
+  /^53\d{4}$/, // Harghita County
+  /^54\d{4}$/, // Mureș County
+  /^55\d{4}$/, // Sibiu County
+  /^60\d{4}$/, // Bacău County
+  /^61\d{4}$/, // Neamț County
+  /^62\d{4}$/, // Vrancea County
+  /^70\d{4}$/, // Iași County
+  /^71\d{4}$/, // Botoșani County
+  /^72\d{4}$/, // Suceava County
+  /^73\d{4}$/, // Vaslui County
+  /^80\d{4}$/, // Galați County
+  /^81\d{4}$/, // Brăila County
+  /^82\d{4}$/, // Tulcea County
+  /^90\d{4}$/, // Constanța County
+  /^91\d{4}$/, // Călărași County
+  /^92\d{4}$/, // Ialomița County
 ];


### PR DESCRIPTION
## Because

- Our postal code validation for romanian postal codes was too permissive

## This pull request

- Increases the strictness of our postal code validation for romania

## Issue that this pull request solves

Closes FXA-11482
