### PR TITLE
fix(payments-ui): Update text color for countries when error occurs

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
@@ -84,7 +84,7 @@ export default async function Location({
 
   return (
     <section
-      className="w-full max-w-[576px] bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12"
+      className="w-full max-w-[576px] bg-white rounded-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 text-grey-600 tablet:clip-shadow desktop:px-12 desktop:pb-12"
       aria-label="Determine currency and tax location"
     >
       <h1 className="font-bold text-grey-600 text-xl mt-10">

--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
@@ -284,7 +284,7 @@ const Expanded = ({
                   !serverErrors.missingCountryCode &&
                   !serverErrors.productNotAvailable &&
                   !serverErrors.unsupportedCountry,
-                'border-alert-red text-alert-red shadow-inputError':
+                'border-alert-red shadow-inputError':
                   serverErrors.missingCountryCode ||
                   serverErrors.productNotAvailable ||
                   serverErrors.unsupportedCountry,


### PR DESCRIPTION
## This pull request

- [x] Updates red text color for countries when error occurs
- [x] Fix top border to be rounded as well

## Issue that this pull request solves

Closes: FXA-11570

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
**After**
<img width="630" alt="Screenshot 2025-05-01 at 10 14 16 AM" src="https://github.com/user-attachments/assets/6142c841-ca0b-4353-b06e-a493e6c38cb9" />

**Before**
<img width="639" alt="Screenshot 2025-05-01 at 10 14 52 AM" src="https://github.com/user-attachments/assets/dd16bb8a-a097-4178-ad24-ff83f4d914a5" />
