### PR TITLE
fix(next): allow all payment methods if no active subs

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
@@ -47,6 +47,7 @@ export default async function NeedsInputPage({
         amount={cart.amount}
         currency={cart.currency.toLowerCase()}
         locale={locale}
+        cart={cart}
       >
         <PaymentInputHandler cartId={params.cartId} />
       </StripeWrapper>

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
@@ -47,6 +47,7 @@ export default async function NeedsInputPage({
         amount={cart.amount}
         currency={cart.currency.toLowerCase()}
         locale={locale}
+        cart={cart}
       >
         <PaymentInputHandler cartId={params.cartId} />
       </StripeWrapper>

--- a/libs/payments/customer/src/lib/util/determinePaymentMethodType.ts
+++ b/libs/payments/customer/src/lib/util/determinePaymentMethodType.ts
@@ -22,19 +22,24 @@ export const determinePaymentMethodType = (
   customer?: StripeCustomer,
   subscriptions?: StripeSubscription[]
 ): PaymentMethodTypeResponse => {
+  // First check if payment method is PayPal
+  // Note, this needs to happen first since a customer could also have a
+  // default payment method. However if PayPal is set as the payment method,
+  // it should take precedence.
+  if (
+    subscriptions?.length &&
+    subscriptions[0].collection_method === 'send_invoice'
+  ) {
+    return {
+      type: 'external_paypal',
+    };
+  }
+
   if (customer?.invoice_settings.default_payment_method) {
     return {
       type: 'stripe',
       paymentMethodId: customer.invoice_settings.default_payment_method,
     };
-  } else if (subscriptions?.length) {
-    const firstListedSubscription = subscriptions[0];
-    // fetch payment method info
-    if (firstListedSubscription.collection_method === 'send_invoice') {
-      return {
-        type: 'external_paypal',
-      };
-    }
   }
 
   return null;

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -84,12 +84,6 @@ export class StripeClient {
     );
   }
 
-  @Cacheable({
-    cacheKey: (args: any) =>
-      cacheKeyForClient('customersRetrieve', args[0], args[1]),
-    strategy: new CacheFirstStrategy(),
-    client: new AsyncLocalStorageAdapter(),
-  })
   @CaptureTimingWithStatsD()
   async customersRetrieve(
     customerId: string,

--- a/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
@@ -38,6 +38,7 @@ interface PaymentFormProps {
       brand?: string;
       customerSessionClientSecret?: string;
     };
+    hasActiveSubscriptions: boolean;
   };
   locale: string;
 }
@@ -52,7 +53,7 @@ export function PaymentSection({
     <StripeWrapper
       amount={paymentsInfo.amount}
       currency={paymentsInfo.currency}
-      paymentInfo={cart.paymentInfo}
+      cart={cart}
       locale={locale}
     >
       <CheckoutForm

--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -73,15 +73,18 @@ function isStripeElementLocale(locale: string): locale is StripeElementLocale {
 interface StripeWrapperProps {
   amount: number;
   currency: string;
-  paymentInfo?: {
-    type:
-      | Stripe.PaymentMethod.Type
-      | 'google_iap'
-      | 'apple_iap'
-      | 'external_paypal';
-    last4?: string;
-    brand?: string;
-    customerSessionClientSecret?: string;
+  cart: {
+    paymentInfo?: {
+      type:
+        | Stripe.PaymentMethod.Type
+        | 'google_iap'
+        | 'apple_iap'
+        | 'external_paypal';
+      last4?: string;
+      brand?: string;
+      customerSessionClientSecret?: string;
+    };
+    hasActiveSubscriptions?: boolean;
   };
   children: React.ReactNode;
   locale: string;
@@ -90,7 +93,7 @@ interface StripeWrapperProps {
 export function StripeWrapper({
   amount,
   currency,
-  paymentInfo,
+  cart,
   locale,
   children,
 }: StripeWrapperProps) {
@@ -104,7 +107,7 @@ export function StripeWrapper({
     currency,
     paymentMethodCreation: 'manual',
     externalPaymentMethodTypes: ['external_paypal'],
-    customerSessionClientSecret: paymentInfo?.customerSessionClientSecret,
+    customerSessionClientSecret: cart.paymentInfo?.customerSessionClientSecret,
     appearance: {
       variables: {
         fontFamily:
@@ -134,9 +137,12 @@ export function StripeWrapper({
     },
   };
 
+  // Remove external_paypal if the customer has an active subscription
+  // paid with non-external_paypal payment method
   if (
-    paymentInfo?.type !== 'external_paypal' &&
-    paymentInfo?.customerSessionClientSecret
+    cart.paymentInfo?.type !== 'external_paypal' &&
+    cart.paymentInfo?.customerSessionClientSecret &&
+    cart.hasActiveSubscriptions
   ) {
     delete options.externalPaymentMethodTypes;
   }

--- a/libs/payments/ui/src/lib/nestapp/validators/GetNeedsInputActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetNeedsInputActionResult.ts
@@ -2,11 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Equals } from 'class-validator';
-import { GetCartActionResult } from './GetCartActionResult';
-import { CartState } from '@fxa/shared/db/mysql/account';
+import { IsEnum, IsString, ValidateNested } from 'class-validator';
+import { NeedsInputType } from '@fxa/payments/cart';
+import { Type } from 'class-transformer';
 
-export class getNeedsInputActionResult extends GetCartActionResult {
-  @Equals(CartState.NEEDS_INPUT)
-  state!: CartState.NEEDS_INPUT;
+class NextActionData {
+  @IsString()
+  clientSecret!: string;
+}
+
+export class getNeedsInputActionResult {
+  @IsEnum(NeedsInputType)
+  inputType!: NeedsInputType;
+
+  @ValidateNested()
+  @Type(() => NextActionData)
+  data!: NextActionData;
 }


### PR DESCRIPTION
## Because

- If a customer has existing payment methods on file, but no active subscriptions, then allow customers to pay with any payment method

## This pull request

- Do not remove external_paypal as a payment method option if a customer has no active subscriptions.
- If a customer has active subscriptions, only allow the current payment method on file.

## Issue that this pull request solves

Closes: FXA-11453

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/69b6fa5c-8e33-4ead-9db9-fef414bca85f)
