### PR TITLE
fix(gql-api): remove GqlCustomsGuard from select resolvers

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -167,7 +167,7 @@ export class AccountResolver {
     description:
       'Create a new randomly generated TOTP token for a user if they do not currently have one.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   public async createTotp(
     @GqlSessionToken() token: string,
     @GqlXHeaders() headers: Headers,
@@ -191,7 +191,7 @@ export class AccountResolver {
     description:
       'Verifies the current session if the passed TOTP code is valid.',
   })
-  @UseGuards(UnverifiedSessionGuard, GqlCustomsGuard)
+  @UseGuards(UnverifiedSessionGuard)
   @CatchGatewayError
   public async verifyTotp(
     @GqlSessionToken() token: string,
@@ -214,7 +214,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Deletes the current TOTP token for the user.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async deleteTotp(
     @GqlSessionToken() token: string,
@@ -231,7 +231,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Deletes the current recovery key for the user.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async deleteRecoveryKey(
     @GqlSessionToken() token: string,
@@ -249,7 +249,7 @@ export class AccountResolver {
     description:
       'Return new backup authentication codes while removing old ones.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async changeRecoveryCodes(
     @GqlSessionToken() token: string,
@@ -326,7 +326,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Create a secondary email for the signed in account.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async createSecondaryEmail(
     @GqlSessionToken() token: string,
@@ -347,7 +347,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Reset the verification code to a secondary email.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async resendSecondaryEmailCode(
     @GqlSessionToken() token: string,
@@ -365,7 +365,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Verify the email address with a code.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async verifySecondaryEmail(
     @GqlSessionToken() token: string,
@@ -384,7 +384,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Remove the secondary email for the signed in account.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async deleteSecondaryEmail(
     @GqlSessionToken() token: string,
@@ -399,7 +399,7 @@ export class AccountResolver {
     description:
       'Change users primary email address, this email address must belong to the user and be verified.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async updatePrimaryEmail(
     @GqlSessionToken() token: string,
@@ -433,7 +433,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Send a session verification email.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async sendSessionVerificationCode(
     @GqlSessionToken() token: string,
@@ -448,7 +448,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Verify the session via an email code.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async verifySession(
     @GqlSessionToken() token: string,

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -39,7 +39,7 @@ export class SessionResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Logs out the current session',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   public async destroySession(
     @GqlSessionToken() token: string,
     @GqlXHeaders() headers: Headers,
@@ -106,7 +106,7 @@ export class SessionResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Resend a verify code.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async resendVerifyCode(
     @GqlSessionToken() token: string,
@@ -122,7 +122,7 @@ export class SessionResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Verify a OTP code.',
   })
-  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
+  @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async verifyCode(
     @GqlSessionToken() token: string,
@@ -145,7 +145,7 @@ export class SessionResolver {
     description:
       'Verify session with a 2FA backup authentication (recovery) code',
   })
-  @UseGuards(UnverifiedSessionGuard, GqlCustomsGuard)
+  @UseGuards(UnverifiedSessionGuard)
   @CatchGatewayError
   public async consumeRecoveryCode(
     @GqlSessionToken() token: string,


### PR DESCRIPTION
Because:
 - we are doubling the ip based counts in customs when _both_ gql-api and auth-server (in response to gql-api) check customs on an action
 - a lot has changed since GqlCustomsGuard was added as some sort of preventive measure to denial-of-service from service call fan-out
   - we've added gql allowlist
   - we use Cloud Armor for ip based rate limiting
 - when GqlCustomsGuard rate limits a user, they see a generic error on the frontend

This commit:
 - removes GqlCustomsGuard if the resolver calls an auth-server API endpoint that also checks customs
