### PR TITLE
chore(deps): Remove age check field in signup

### DIFF
--- a/packages/functional-tests/pages/config.ts
+++ b/packages/functional-tests/pages/config.ts
@@ -13,6 +13,7 @@ export class ConfigPage extends BaseLayout {
       const page = await this.page.context().newPage();
 
       await page.goto(this.baseUrl);
+      await page.waitForURL(this.baseUrl);
 
       // config is stored in the `meta` tag of the html page
       // we can check this tag to see if feature flags are enabled

--- a/packages/functional-tests/pages/signup.ts
+++ b/packages/functional-tests/pages/signup.ts
@@ -126,20 +126,18 @@ export class SignupPage extends BaseLayout {
     await this.submitButton.click();
   }
 
-  async fillOutSignupForm(password: string, age: string) {
+  async fillOutSignupForm(password: string) {
     await expect(this.signupFormHeading).toBeVisible();
 
     await this.passwordTextbox.fill(password);
-    await this.ageTextbox.fill(age);
     await this.createAccountButton.click();
   }
 
-  async fillOutSyncSignupForm(password: string, age: string) {
+  async fillOutSyncSignupForm(password: string) {
     await expect(this.signupFormHeading).toBeVisible();
 
     await this.passwordTextbox.fill(password);
     await this.verifyPasswordTextbox.fill(password);
-    await this.ageTextbox.fill(age);
     await this.createAccountButton.click();
   }
 }

--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -5,8 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
-const AGE_21 = '21';
-
 /**
  * These tests represent various permutations between interacting with V1 and V2
  * key stretched passwords. We need to ensure that operations are interchangeable!
@@ -58,7 +56,7 @@ test.describe('severity-2 #smoke', () => {
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
       );
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
 
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
@@ -111,7 +109,7 @@ test.describe('severity-2 #smoke', () => {
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
       );
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -5,7 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
-const AGE_21 = '21';
 const HINT = 'secret key location';
 
 /**
@@ -85,7 +84,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await page.waitForURL(/\//);
       await signup.fillOutEmailForm(accountDetails.email);
-      await signup.fillOutSignupForm(accountDetails.password, AGE_21);
+      await signup.fillOutSignupForm(accountDetails.password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(
         accountDetails.email

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKeyUpgrade.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKeyUpgrade.spec.ts
@@ -4,7 +4,6 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 
-const AGE_21 = '21';
 const HINT = 'secret key location';
 
 test.describe('severity-2 #smoke', () => {
@@ -19,7 +18,7 @@ test.describe('severity-2 #smoke', () => {
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&stretch=1`
     );
     await signup.fillOutEmailForm(email);
-    await signup.fillOutSignupForm(password, AGE_21);
+    await signup.fillOutSignupForm(password);
 
     await expect(page).toHaveURL(/confirm_signup_code/);
 

--- a/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/resetPassword.spec.ts
@@ -5,8 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
-const AGE_21 = '21';
-
 /**
  * These tests represent various permutations between interacting with V1 and V2
  * key stretched passwords. We need to ensure that operations are interchangeable!
@@ -65,7 +63,7 @@ test.describe('severity-2 #smoke', () => {
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
       );
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signinBlocked.spec.ts
@@ -7,8 +7,6 @@ import { BaseTarget } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
 import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 
-const AGE_21 = '21';
-
 /**
  * These tests represent various permutations between interacting with V1 and V2
  * key stretched passwords. We need to ensure that operations are interchangeable!
@@ -51,7 +49,7 @@ test.describe('severity-2 #smoke', () => {
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
       );
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/key-stretching-v2/signup.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signup.spec.ts
@@ -5,8 +5,6 @@
 import { expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget } from '../../lib/targets/base';
 
-const AGE_21 = '21';
-
 /**
  * These tests represent various permutations between interacting with V1 and V2
  * key stretched passwords. We need to ensure that operations are interchangeable!
@@ -38,7 +36,7 @@ test.describe('severity-2 #smoke', () => {
     const { email, password } = testAccountTracker.generateAccountDetails();
     await page.goto(target.contentServerUrl);
     await signup.fillOutEmailForm(email);
-    await signup.fillOutSignupForm(password, AGE_21);
+    await signup.fillOutSignupForm(password);
     await expect(page).toHaveURL(/confirm_signup_code/);
     const code = await target.emailClient.getVerifyShortCode(email);
     await confirmSignupCode.fillOutCodeForm(code);
@@ -69,7 +67,7 @@ test.describe('severity-2 #smoke', () => {
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
     );
     await signup.fillOutEmailForm(email);
-    await signup.fillOutSignupForm(password, AGE_21);
+    await signup.fillOutSignupForm(password);
     await expect(page).toHaveURL(/confirm_signup_code/);
     const code = await target.emailClient.getVerifyShortCode(email);
     await confirmSignupCode.fillOutCodeForm(code);
@@ -100,7 +98,7 @@ test.describe('severity-2 #smoke', () => {
     const { email, password } = testAccountTracker.generateAccountDetails();
     await page.goto(target.contentServerUrl);
     await signup.fillOutEmailForm(email);
-    await signup.fillOutSignupForm(password, AGE_21);
+    await signup.fillOutSignupForm(password);
     await expect(page).toHaveURL(/confirm_signup_code/);
     const code = await target.emailClient.getVerifyShortCode(email);
     await confirmSignupCode.fillOutCodeForm(code);
@@ -131,7 +129,7 @@ test.describe('severity-2 #smoke', () => {
       `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react`
     );
     await signup.fillOutEmailForm(email);
-    await signup.fillOutSignupForm(password, AGE_21);
+    await signup.fillOutSignupForm(password);
     await expect(page).toHaveURL(/confirm_signup_code/);
     const code = await target.emailClient.getVerifyShortCode(email);
     await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
@@ -5,8 +5,6 @@
 import { getCode } from 'fxa-settings/src/lib/totp';
 import { expect, test } from '../../lib/fixtures/standard';
 
-const AGE_21 = '21';
-
 /**
  * These tests represent various permutations between interacting with V1 and V2
  * key stretched passwords. We need to ensure that operations are interchangeable!
@@ -41,7 +39,7 @@ test.describe('severity-2 #smoke', () => {
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
       );
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const signupCode = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(signupCode);

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -27,7 +27,7 @@ test.describe('recovery key promo', () => {
       );
       await page.waitForURL(/\//);
       await signup.fillOutEmailForm(credentials.email);
-      await signup.fillOutSyncSignupForm(credentials.password, '21');
+      await signup.fillOutSyncSignupForm(credentials.password);
       await signup.page.waitForURL(/confirm_signup_code/);
 
       const code = await target.emailClient.getVerifyShortCode(

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -7,8 +7,6 @@ import { expect, test } from '../../lib/fixtures/standard';
 import { relayDesktopOAuthQueryParams } from '../../lib/query-params';
 import { getCode } from 'packages/fxa-settings/src/lib/totp';
 
-const AGE_21 = '21';
-
 test.describe('relay integration', () => {
   test('signup with Relay desktop', async ({
     target,
@@ -34,7 +32,6 @@ test.describe('relay integration', () => {
     ).toBeVisible();
 
     await signup.passwordTextbox.fill(password);
-    await signup.ageTextbox.fill(AGE_21);
     await signup.createAccountButton.click();
 
     await page.waitForURL(/confirm_signup_code/);

--- a/packages/functional-tests/tests/oauth/signin.spec.ts
+++ b/packages/functional-tests/tests/oauth/signin.spec.ts
@@ -116,7 +116,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.goto();
       await relier.clickEmailFirst();
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, '21');
+      await signup.fillOutSignupForm(password);
       // Dont verify account and attempt to login via relier
       await page.waitForURL(/confirm_signup_code/);
       await expect(page).toHaveURL(/confirm_signup_code/);
@@ -149,7 +149,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickChooseFlow();
       // Don't verify account and attempt to login via relier
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, '21');
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       // go back to the OAuth app, the /oauth flow should
       // now suggest a cached login

--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -4,8 +4,6 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 
-const AGE_21 = '21';
-
 test.describe('severity-1 #smoke', () => {
   test.describe('signin with OAuth after Sync', () => {
     test('signin to OAuth with Sync creds', async ({
@@ -46,7 +44,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickEmailFirst();
       await signin.useDifferentAccountLink.click();
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const signupCode = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(signupCode);
@@ -83,7 +81,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.goto();
       await relier.clickEmailFirst();
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const signupCode = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(signupCode);

--- a/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignin.spec.ts
@@ -4,8 +4,6 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 
-const AGE_21 = '21';
-
 test.describe('severity-1 #smoke', () => {
   test.describe('react OAuth signin', () => {
     test('verified account, no email confirmation required', async ({
@@ -129,7 +127,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.goto();
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       // confirm reached confirm_signup_code page but do not confirm
       await expect(page).toHaveURL(/confirm_signup_code/);
 
@@ -167,7 +165,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.fillOutEmailForm(email);
       await expect(signup.signupFormHeading).toBeVisible();
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthSignup.spec.ts
@@ -6,8 +6,6 @@ import { FirefoxCommand } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
 
-const AGE_21 = '21';
-
 test.describe('severity-1 #smoke', () => {
   test.describe('signup react', () => {
     test('signup oauth', async ({
@@ -24,7 +22,7 @@ test.describe('severity-1 #smoke', () => {
       await relier.clickEmailFirst();
 
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
@@ -61,7 +59,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(page).toHaveURL(/^((?!redirect_uri).)*$/);
 
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);
@@ -92,7 +90,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(signup.CWTSEngineBookmarks).toBeVisible();
       await expect(signup.CWTSEngineHistory).toBeVisible();
 
-      await signup.fillOutSyncSignupForm(password, AGE_21);
+      await signup.fillOutSyncSignupForm(password);
 
       await expect(page).toHaveURL(/confirm_signup_code/);
 

--- a/packages/functional-tests/tests/react-conversion/signup.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signup.spec.ts
@@ -6,9 +6,6 @@ import { FirefoxCommand, LinkAccountResponse } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import { syncDesktopV3QueryParams } from '../../lib/query-params';
 
-const AGE_12 = '12';
-const AGE_21 = '21';
-
 const eventDetailLinkAccount: LinkAccountResponse = {
   id: 'account_updates',
   message: {
@@ -32,7 +29,7 @@ test.describe('severity-1 #smoke', () => {
 
       await signup.goto();
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
 
       await expect(page).toHaveURL(/confirm_signup_code/);
 
@@ -74,7 +71,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(signup.CWTSEngineCreditCards).toBeVisible();
       await expect(signup.CWTSEngineAddresses).toBeHidden();
 
-      await signup.fillOutSyncSignupForm(password, AGE_21);
+      await signup.fillOutSyncSignupForm(password);
 
       await signup.checkWebChannelMessage(FirefoxCommand.Login);
       await expect(page).toHaveURL(/confirm_signup_code/);
@@ -114,23 +111,6 @@ test.describe('severity-2 #smoke', () => {
       ).toBeVisible();
     });
 
-    test('coppa is too young', async ({
-      page,
-      pages: { signup },
-      testAccountTracker,
-    }) => {
-      const { email, password } =
-        testAccountTracker.generateSignupAccountDetails();
-      await signup.goto();
-
-      await signup.fillOutEmailForm(email);
-
-      await signup.fillOutSignupForm(password, AGE_12);
-
-      await expect(page).toHaveURL(/cannot_create_account/);
-      await expect(signup.cannotCreateAccountHeading).toBeVisible();
-    });
-
     test('signup via product subscription page and redirect after confirm', async ({
       page,
       target,
@@ -159,7 +139,7 @@ test.describe('severity-2 #smoke', () => {
       // Click the sign in link
       await subscribe.signinLink.click();
       await signup.fillOutEmailForm(email);
-      await signup.fillOutSignupForm(password, AGE_21);
+      await signup.fillOutSignupForm(password);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(email);
       await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -180,7 +180,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Try creating a new account with the same secondary email as previous account and new password
       await signup.fillOutEmailForm(newEmail);
-      await signup.fillOutSignupForm(newPassword, '21');
+      await signup.fillOutSignupForm(newPassword);
       await expect(page).toHaveURL(/confirm_signup_code/);
       const code = await target.emailClient.getVerifyShortCode(newEmail);
       await confirmSignupCode.fillOutCodeForm(code);
@@ -206,9 +206,8 @@ test.describe('severity-1 #smoke', () => {
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
       await secondaryEmail.fillOutEmail(newEmail);
-      const code: string = await target.emailClient.getVerifySecondaryCode(
-        newEmail
-      );
+      const code: string =
+        await target.emailClient.getVerifySecondaryCode(newEmail);
       await secondaryEmail.fillOutVerificationCode(code);
 
       await expect(settings.alertBar).toHaveText(/successfully added/);

--- a/packages/functional-tests/tests/settings/multitab.spec.ts
+++ b/packages/functional-tests/tests/settings/multitab.spec.ts
@@ -56,7 +56,7 @@ test.describe('severity-1 #smoke', () => {
     await signin.useDifferentAccountLink.click();
 
     await signup.fillOutEmailForm(email2);
-    await signup.fillOutSignupForm(password2, '21');
+    await signup.fillOutSignupForm(password2);
     const code = await target.emailClient.getVerifyShortCode(email2);
     await expect(newTab).toHaveURL(/confirm_signup_code/);
     await confirmSignupCode.fillOutCodeForm(code);

--- a/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signUpWithCWTS.spec.ts
@@ -11,8 +11,6 @@ import {
 import { expect, test } from '../../lib/fixtures/standard';
 import uaStrings from '../../lib/ua-strings';
 
-const AGE_21 = '21';
-
 test.describe('severity-1 #smoke', () => {
   test.describe('Sync v3 sign up and CWTS', () => {
     test.beforeEach(async ({ pages: { configPage } }) => {
@@ -72,7 +70,6 @@ test.describe('severity-1 #smoke', () => {
       await login.clickSubmit();
       await login.setPassword(password);
       await login.confirmPassword(password);
-      await login.setAge(AGE_21);
 
       // The CWTS form is on the same signup page
       await expect(login.CWTSEngineHeader).toBeVisible();
@@ -133,7 +130,6 @@ test.describe('severity-1 #smoke', () => {
       await login.clickSubmit();
       await login.setPassword(password);
       await login.confirmPassword(password);
-      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes
@@ -186,7 +182,6 @@ test.describe('severity-1 #smoke', () => {
       await login.clickSubmit();
       await login.setPassword(password);
       await login.confirmPassword(password);
-      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes
@@ -231,7 +226,6 @@ test.describe('severity-1 #smoke', () => {
       await login.clickSubmit();
       await login.setPassword(password);
       await login.confirmPassword(password);
-      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes
@@ -277,7 +271,6 @@ test.describe('severity-1 #smoke', () => {
       await login.clickSubmit();
       await login.setPassword(password);
       await login.confirmPassword(password);
-      await login.setAge(AGE_21);
       await login.submit();
 
       // Verify the CWTS page and the checkboxes

--- a/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
+++ b/packages/fxa-settings/src/components/FormSetupAccount/index.tsx
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { FtlMsg } from 'fxa-react/lib/utils';
 import FormPasswordWithBalloons from '../FormPasswordWithBalloons';
-import InputText from '../InputText';
-import LinkExternal from 'fxa-react/components/LinkExternal';
-import GleanMetrics from '../../lib/glean';
 import ChooseNewsletters from '../ChooseNewsletters';
 import ChooseWhatToSync from '../ChooseWhatToSync';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
@@ -30,10 +26,6 @@ export const FormSetupAccount = ({
   setDeclinedSyncEngines,
   isDesktopRelay,
   setSelectedNewsletterSlugs,
-  ageCheckErrorText,
-  setAgeCheckErrorText,
-  onFocusAgeInput,
-  onBlurAgeInput,
   submitButtonGleanId,
 }: FormSetupAccountProps) => {
   const showCWTS = () => {
@@ -76,54 +68,6 @@ export const FormSetupAccount = ({
       passwordFormType="signup"
       requirePasswordConfirmation={isSync}
     >
-      {setAgeCheckErrorText &&
-        setAgeCheckErrorText &&
-        onFocusAgeInput &&
-        onBlurAgeInput && (
-          <>
-            {/* TODO: original component had a SR-only label that is not straightforward to implement with existing InputText component
-SR-only text: "How old are you? To learn why we ask for your age, follow the “why do we ask” link below. */}
-            <FtlMsg id="signup-age-check-label" attrs={{ label: true }}>
-              <InputText
-                name="age"
-                label="How old are you?"
-                inputMode="numeric"
-                className="mb-4"
-                pattern="[0-9]*"
-                maxLength={3}
-                onChange={() => {
-                  // clear error tooltip if user types in the field
-                  if (ageCheckErrorText) {
-                    setAgeCheckErrorText('');
-                  }
-                }}
-                inputRef={register({
-                  pattern: /^[0-9]*$/,
-                  maxLength: 3,
-                  required: true,
-                })}
-                onFocusCb={onFocusAgeInput}
-                onBlurCb={onBlurAgeInput}
-                errorText={ageCheckErrorText}
-                tooltipPosition="bottom"
-                anchorPosition="end"
-                prefixDataTestId="age"
-              />
-            </FtlMsg>
-            <FtlMsg id="signup-coppa-check-explanation-link">
-              <LinkExternal
-                href="https://www.ftc.gov/business-guidance/resources/childrens-online-privacy-protection-rule-not-just-kids-sites"
-                className={`link-blue text-sm py-1 -mt-2 self-start ${
-                  isDesktopRelay ? 'mb-8' : 'mb-4'
-                }`}
-                onClick={() => GleanMetrics.registration.whyWeAsk()}
-              >
-                Why do we ask?
-              </LinkExternal>
-            </FtlMsg>
-          </>
-        )}
-
       {isSync
         ? showCWTS()
         : !isDesktopRelay &&

--- a/packages/fxa-settings/src/components/FormSetupAccount/interfaces.ts
+++ b/packages/fxa-settings/src/components/FormSetupAccount/interfaces.ts
@@ -25,10 +25,5 @@ export type FormSetupAccountProps = {
   setDeclinedSyncEngines: React.Dispatch<React.SetStateAction<string[]>>;
   isDesktopRelay: boolean;
   setSelectedNewsletterSlugs?: React.Dispatch<React.SetStateAction<string[]>>;
-  // Age check props, if not provided it will not be rendered
-  ageCheckErrorText?: string;
-  setAgeCheckErrorText?: React.Dispatch<React.SetStateAction<string>>;
-  onFocusAgeInput?: () => void;
-  onBlurAgeInput?: () => void;
   submitButtonGleanId?: string;
 };

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -428,18 +428,6 @@ describe('lib/glean', () => {
         );
         sinon.assert.calledOnce(spy);
       });
-
-      it('submits a ping with the reg_why_do_we_ask_link_click event name', async () => {
-        GleanMetrics.registration.whyWeAsk();
-        const spy = sandbox.spy(reg.whyDoWeAskLinkClick, 'record');
-        await GleanMetrics.isDone();
-        sinon.assert.calledOnce(setEventNameStub);
-        sinon.assert.calledWith(
-          setEventNameStub,
-          'reg_why_do_we_ask_link_click'
-        );
-        sinon.assert.calledOnce(spy);
-      });
     });
 
     describe('signup confirmation code', () => {

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -208,11 +208,6 @@ const SignupContainer = ({
     ]
   );
 
-  // TODO: probably a better way to read this?
-  if (window.document.cookie.indexOf('tooyoung') > -1) {
-    navigateWithQuery('/cannot_create_account');
-  }
-
   if (validationError || !email) {
     navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;

--- a/packages/fxa-settings/src/pages/Signup/en.ftl
+++ b/packages/fxa-settings/src/pages/Signup/en.ftl
@@ -11,9 +11,3 @@ signup-pocket-info-banner = Why do I need to create this account?
 signup-pocket-info-banner-link = Find out here
 # Clicking on this link returns the user to the beginning of the flow so they can enter a new email address
 signup-change-email-link = Change email
-# Checking the user's age is required by COPPA. To register for an account, the user must indicate their age (number only)
-signup-age-check-label =
-  .label = How old are you?
-# Link goes to https://www.ftc.gov/business-guidance/resources/childrens-online-privacy-protection-rule-not-just-kids-sites
-# This link appears just below signup-age-check-input-label
-signup-coppa-check-explanation-link = Why do we ask?

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -73,7 +73,6 @@ export const Signup = ({
 
   const [beginSignupLoading, setBeginSignupLoading] = useState<boolean>(false);
   const [bannerErrorText, setBannerErrorText] = useState<string>('');
-  const [ageCheckErrorText, setAgeCheckErrorText] = useState<string>('');
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [
     isAccountSuggestionBannerVisible,
@@ -86,7 +85,6 @@ export const Signup = ({
     string[]
   >([]);
   const [client, setClient] = useState<MozServices | undefined>(undefined);
-  const [hasAgeInputFocused, setHasAgeInputFocused] = useState<boolean>(false);
 
   useEffect(() => {
     if (isOAuth) {
@@ -112,20 +110,10 @@ export const Signup = ({
         email,
         newPassword: '',
         confirmPassword: '',
-        age: '',
       },
     });
 
   const ftlMsgResolver = useFtlMsgResolver();
-
-  const localizedAgeIsRequiredError = ftlMsgResolver.getMsg(
-    'auth-error-1031',
-    'You must enter your age to sign up'
-  );
-  const localizedValidAgeError = ftlMsgResolver.getMsg(
-    'auth-error-1032',
-    'You must enter a valid age to sign up'
-  );
 
   const onFocus = () => {
     if (!isFocused) {
@@ -134,41 +122,13 @@ export const Signup = ({
     }
   };
 
-  const onFocusAgeInput = () => {
-    setAgeCheckErrorText('');
-    if (!hasAgeInputFocused) {
-      GleanMetrics.registration.engage({ event: { reason: 'age' } });
-      setHasAgeInputFocused(true);
-    }
-  };
-
-  const onBlurAgeInput = () => {
-    getValues().age === '' && setAgeCheckErrorText(localizedAgeIsRequiredError);
-  };
-
   // TODO: Add metrics events to match parity with content-server in FXA-8302
   // The legacy amplitude events will eventually be replaced by Glean,
   // but until that is ready we must ensure the expected metrics continue to be emitted
   // to avoid breaking dashboards.
   const onSubmit = useCallback(
-    async ({ newPassword, age }: SignupFormData) => {
+    async ({ newPassword }: SignupFormData) => {
       GleanMetrics.registration.submit();
-      if (Number(age) < 13) {
-        // this is a session cookie. It will go away once:
-        // 1. the user closes the tab
-        // and
-        // 2. the user closes the browser
-        // Both of these have to happen or else the cookie
-        // hangs around like a bad smell.
-
-        // TODO: probably a better way to set this?
-        document.cookie = 'tooyoung=1;';
-        navigateWithQuery('/cannot_create_account');
-        return;
-      } else if (Number(age) > 130) {
-        setAgeCheckErrorText(localizedValidAgeError);
-        return;
-      }
 
       // Disable creating accounts with email masks
       if (isEmailMask(email)) {
@@ -291,7 +251,6 @@ export const Signup = ({
       offeredSyncEngines,
       selectedEngines,
       isSyncOAuth,
-      localizedValidAgeError,
       isDesktopRelay,
       isOAuth,
       sensitiveDataClient,
@@ -390,10 +349,6 @@ export const Signup = ({
           setDeclinedSyncEngines,
           isDesktopRelay,
           setSelectedNewsletterSlugs,
-          ageCheckErrorText,
-          setAgeCheckErrorText,
-          onFocusAgeInput,
-          onBlurAgeInput,
         }}
         loading={beginSignupLoading}
         onSubmit={handleSubmit(onSubmit)}

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -71,5 +71,4 @@ export interface SignupFormData {
   email: string;
   newPassword: string;
   confirmPassword: string;
-  age: string;
 }

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -69,7 +69,6 @@ export const eventsMap = {
     ageInvalid: 'reg_age_invalid',
     marketing: 'reg_marketing_engage',
     changeEmail: 'reg_change_email_link_click',
-    whyWeAsk: 'reg_why_do_we_ask_link_click',
   },
 
   signupConfirmation: {


### PR DESCRIPTION
## Because

- We want to remove the age check requirement to improve registration conversion and simplfy our code

## This pull request

- Removes the age input field, error handling, and "Why do we ask?" link from the signup form
- Updates signup page logic to remove age validation, `tooyoung` cookie, and redirection to `/cannot_create_account`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11545

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot 2025-05-01 at 1 10 04 PM](https://github.com/user-attachments/assets/f4db6388-0b5e-4118-8011-ad9fd5c19ff6)

![Screenshot 2025-05-01 at 1 09 41 PM](https://github.com/user-attachments/assets/0214b322-b4a9-41e1-ab95-b3ff93bb7092)
