### PR TITLE
fix(cloud tasks): ignore duplicate inactive acct email task error by message

### DIFF
--- a/packages/fxa-auth-server/lib/inactive-accounts/index.ts
+++ b/packages/fxa-auth-server/lib/inactive-accounts/index.ts
@@ -63,7 +63,7 @@ export const requestForGlean = {
 } as unknown as AuthRequest;
 
 export const isCloudTaskAlreadyExistsError = (error) =>
-  error.code === 10 && error.message.includes('entity already exists');
+  error.message.includes('entity already exists');
 
 export type InactiveStatusOAuthDb = Pick<
   typeof OAuthDb,

--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
@@ -543,7 +543,7 @@ const init = async () => {
           // Note that the fxa cloud tasks lib already emitted some statsd metrics
           statsd.increment(
             'cloud-tasks.inactive-account-email.enqueue.error-code',
-            [cloudTaskQueueError.code as unknown as string]
+            { errorCode: cloudTaskQueueError.code as unknown as string }
           );
           await glean.inactiveAccountDeletion.firstEmailTaskRejected(
             requestForGlean,


### PR DESCRIPTION
Because:
 - we saw some "entity already exists" errors reported to Sentry when creating Google Cloud Task for the second inactive account notification email

This commit:
 - updates the error detection to use the error message only
   - I originally used 10 as the error code as that was what I saw in the error during development (and still see at the time of this patch); that value does not match the documented gRPC constant for that type of error.  But this wouldn't be the first time I've noticed a discrepancy between the gRPC stuff and nodejs + REST.
