### PR TITLE
fix(next): missing metadata on upgrade

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -522,6 +522,10 @@ export class CheckoutService {
         // Note: These fields are due to missing Fivetran support on Stripe multi-currency plans
         [STRIPE_SUBSCRIPTION_METADATA.Amount]: cart.amount,
         [STRIPE_SUBSCRIPTION_METADATA.Currency]: cart.currency,
+        [STRIPE_SUBSCRIPTION_METADATA.PreviousPlanId]: fromPriceId,
+        [STRIPE_SUBSCRIPTION_METADATA.PlanChangeDate]: Math.floor(
+          Date.now() / 1000
+        ),
       },
     });
   }

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -48,6 +48,8 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   Currency = 'currency',
   Amount = 'amount',
   SubscriptionPromotionCode = 'appliedPromotionCode',
+  PreviousPlanId = 'previous_plan_id',
+  PlanChangeDate = 'plan_change_date',
 }
 
 export enum STRIPE_INVOICE_METADATA {


### PR DESCRIPTION
## Because

- On a subscription upgrade, `plan_change_date` and `previous_plan_id` need to be added to the subscription metadata.

## This pull request

- Adds missing `plan_change_date` and `previous_plan_id` to subscription updates.

## Issue that this pull request solves

Closes: FXA-11540

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/864ddc16-26be-416c-a6dc-900706f40fdf)

