### PR TITLE
task(settings): Improve error handling for gql errors and network errors

### DIFF
--- a/packages/fxa-settings/src/lib/nimbus/index.ts
+++ b/packages/fxa-settings/src/lib/nimbus/index.ts
@@ -54,6 +54,10 @@ export async function initializeNimbus(
       return (await resp.json()) as NimbusResult;
     }
   } catch (err) {
+    // Important, if this fails it will just show up in Sentry as a
+    // TypeError: NetworkError when attempting to fetch resource.
+    // Look at the previous fetch bread crumb to understand what
+    // request is actually failing.
     Sentry.captureException(err, {
       tags: {
         source: 'nimbus-experiments',


### PR DESCRIPTION
## Because

- We were seeing network errors in sentry, but couldn't tell where they originated.

## This pull request

- Adds apollo links so we can get more visibility into gql queries
- Adds a comment about how sentry records failed fetch events, since the Sentry UI is a little ambiguous

## Issue that this pull request solves

Closes: FXA-10879 (Partially)

(This should help us determine what GQL are actually failing. The issue will still persist until the underlying problems are corrected.)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
