### PR TITLE
bug(settings): Fix errors about `Missing field 'account' while writing result {}`

### DIFF
--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -138,7 +138,13 @@ export function createApolloClient(gqlServerUri: string) {
         data: { isSignedIn: false },
       });
       return new Observable((observer) => {
-        observer.next({ data: {} });
+        // Important! When calling next with fabricated data, we must make sure that required fields
+        // are present. Otherwise, we will get the following error:
+        //     https://www.apollographql.com/docs/react/errors#%7B%22version%22%3A%223.11.1%22%2C%22message%22%3A12%2C%22args%22%3A%5B%22account%22%2C%22%7B%7D%22%5D%7D
+        //
+        // The fact we can't resolve a session token, also means that we can't resolve the current account info. There fore setting the
+        // the account: null here seems like the right thing to do, and also avoids any errors writing to the current cache state.
+        observer.next({ data: { account: null } });
         observer.complete();
       });
     }

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -131,7 +131,7 @@ export const InlineRecoverySetupContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
-  if (totpStatus?.account.totp.verified) {
+  if (totpStatus?.account?.totp.verified) {
     navigateWithQuery('/signin_totp_code', {
       state: signinLocationState,
     });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -88,7 +88,7 @@ export const InlineTotpSetupContainer = ({
   useEffect(() => {
     if (
       totp !== undefined ||
-      totpStatus?.account.totp.verified === true ||
+      totpStatus?.account?.totp.verified === true ||
       isTotpCreating.current
     ) {
       return;
@@ -114,8 +114,7 @@ export const InlineTotpSetupContainer = ({
       navTo('/signin_token_code', signinState ? signinState : undefined);
     } else if (
       totpStatusLoading === false &&
-      totpStatus !== undefined &&
-      totpStatus.account.totp.verified
+      totpStatus?.account?.totp.verified
     ) {
       navTo('/signin_totp_code', signinState ? signinState : undefined);
     }

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -353,7 +353,7 @@ const Signin = ({
         />
       )}
       <div className="mt-9">
-        {sessionToken && avatarData?.account.avatar ? (
+        {sessionToken && avatarData?.account?.avatar ? (
           <Avatar
             className={avatarClassNames}
             avatar={avatarData.account.avatar}


### PR DESCRIPTION
## Because

- This error was showing up in many Sentry bread crumbs and being logged to the console.

## This pull request

- This console corrects the write that was causing this problem.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The call stack gets spliced during this write operation, so it becomes difficult to pin down the location where the bad write actually occurs. It takes quite a bit of debugging to find the exact spot it happens. The best way to validate this fix is to run the app, and navigate to http://localhost:3030. Without this change you should observer the error in the console, then apply the patch and navigate to http://localhost:3030/ again and you should see the error is no longer present.
