### PR TITLE
fix(next): paypal invoice should not auto advance

### DIFF
--- a/libs/payments/customer/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.spec.ts
@@ -368,7 +368,8 @@ describe('InvoiceManager', () => {
         taxAmountInCents: mockInvoice.tax,
       });
       expect(stripeClient.invoicesFinalizeInvoice).toHaveBeenCalledWith(
-        mockInvoice.id
+        mockInvoice.id,
+        { auto_advance: false }
       );
       expect(stripeClient.invoicesUpdate).toHaveBeenNthCalledWith(
         1,
@@ -484,7 +485,8 @@ describe('InvoiceManager', () => {
         taxAmountInCents: mockInvoice.tax,
       });
       expect(stripeClient.invoicesFinalizeInvoice).toHaveBeenCalledWith(
-        mockInvoice.id
+        mockInvoice.id,
+        { auto_advance: false }
       );
       expect(stripeClient.invoicesUpdate).toHaveBeenNthCalledWith(
         1,
@@ -548,7 +550,8 @@ describe('InvoiceManager', () => {
         taxAmountInCents: mockInvoice.tax,
       });
       expect(stripeClient.invoicesFinalizeInvoice).toHaveBeenCalledWith(
-        mockInvoice.id
+        mockInvoice.id,
+        { auto_advance: false }
       );
       expect(stripeClient.invoicesUpdate).toHaveBeenNthCalledWith(
         1,
@@ -619,7 +622,8 @@ describe('InvoiceManager', () => {
         taxAmountInCents: mockInvoice.tax,
       });
       expect(stripeClient.invoicesFinalizeInvoice).toHaveBeenCalledWith(
-        mockInvoice.id
+        mockInvoice.id,
+        { auto_advance: false }
       );
       expect(stripeClient.invoicesUpdate).toHaveBeenNthCalledWith(
         1,

--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -102,9 +102,8 @@ export class InvoiceManager {
       discounts: [{ promotion_code: promoCode?.id }],
     };
 
-    const upcomingInvoice = await this.stripeClient.invoicesRetrieveUpcoming(
-      requestObject
-    );
+    const upcomingInvoice =
+      await this.stripeClient.invoicesRetrieveUpcoming(requestObject);
 
     return stripeInvoiceToInvoicePreviewDTO(upcomingInvoice);
   }
@@ -133,9 +132,8 @@ export class InvoiceManager {
       subscription: fromSubscriptionItem.subscription,
     };
 
-    const upcomingInvoice = await this.stripeClient.invoicesRetrieveUpcoming(
-      requestObject
-    );
+    const upcomingInvoice =
+      await this.stripeClient.invoicesRetrieveUpcoming(requestObject);
 
     return stripeInvoiceToInvoicePreviewDTO(upcomingInvoice);
   }
@@ -262,7 +260,7 @@ export class InvoiceManager {
       // Charge the PayPal customer after the invoice is finalized to prevent charges with a failed invoice
       try {
         // Duplicate calls to finalizeInvoice can be made due to race conditions. Failures from re-finalizing an invoice can be ignored.
-        await this.stripeClient.invoicesFinalizeInvoice(invoice.id);
+        await this.finalizeWithoutAutoAdvance(invoice.id);
       } catch (err) {
         // This is Stripe's only unique way of identifying this error. Remove as part of FXA-11460
         if (


### PR DESCRIPTION
## Because

- Invoices with PayPal as the payment provider should not auto advance, since, PayPal invoices are paid out of band and will be manually marked as paid.

## This pull request

- Updates non zero PayPal payment methods to finalize invoice without auto advance.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
