### PR TITLE
fix(next): show update price for existing customers

### DIFF
--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -75,16 +75,15 @@ export class InvoiceManager {
       (!customer && taxAddress)
     );
 
-    const shipping =
-      !customer && taxAddress
-        ? {
-            name: '',
-            address: {
-              country: taxAddress.countryCode,
-              postal_code: taxAddress.postalCode,
-            },
-          }
-        : undefined;
+    const shipping = taxAddress
+      ? {
+          name: '',
+          address: {
+            country: taxAddress.countryCode,
+            postal_code: taxAddress.postalCode,
+          },
+        }
+      : undefined;
 
     const requestObject: Stripe.InvoiceRetrieveUpcomingParams = {
       currency,
@@ -102,9 +101,8 @@ export class InvoiceManager {
       discounts: [{ promotion_code: promoCode?.id }],
     };
 
-    const upcomingInvoice = await this.stripeClient.invoicesRetrieveUpcoming(
-      requestObject
-    );
+    const upcomingInvoice =
+      await this.stripeClient.invoicesRetrieveUpcoming(requestObject);
 
     return stripeInvoiceToInvoicePreviewDTO(upcomingInvoice);
   }
@@ -133,9 +131,8 @@ export class InvoiceManager {
       subscription: fromSubscriptionItem.subscription,
     };
 
-    const upcomingInvoice = await this.stripeClient.invoicesRetrieveUpcoming(
-      requestObject
-    );
+    const upcomingInvoice =
+      await this.stripeClient.invoicesRetrieveUpcoming(requestObject);
 
     return stripeInvoiceToInvoicePreviewDTO(upcomingInvoice);
   }


### PR DESCRIPTION
## Because

- When an existing customer changes their location at checkout, which results in a change in price, the new price is not shown as expected, since the customers stored location is used instead.

## This pull request

- If taxAddress is provided to InvoiceManager.previewInvoice, then use the provided taxAddress instead of the customers stored address.

## Issue that this pull request solves

Closes: FXA-11582

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![image](https://github.com/user-attachments/assets/060ecdfa-4c57-45d6-a933-c5d3759c974f)

![image](https://github.com/user-attachments/assets/e990bf74-c5ab-458b-9ca7-428489018b66)

