### PR TITLE
fix(next): update metrics flow action result validation

### DIFF
--- a/libs/payments/content-server/src/lib/content-server.types.ts
+++ b/libs/payments/content-server/src/lib/content-server.types.ts
@@ -4,6 +4,6 @@
 
 export type MetricsFlow = {
   flowId: string;
-  flowBeginTime: string | number;
+  flowBeginTime: number;
   deviceId?: undefined | string;
 };

--- a/libs/payments/ui/src/lib/nestapp/validators/GetMetricsFlowActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetMetricsFlowActionResult.ts
@@ -8,9 +8,8 @@ export class GetMetricsFlowActionResult {
   @IsString()
   flowId!: string;
 
-  @IsString()
   @IsNumber()
-  flowBeginTime!: string | number;
+  flowBeginTime!: number;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## Because

- The getMetricsFlow action was failing due to invalid result validation.

## This pull request

- Updates MetricsFlow type to match the type in fxa-settings and updates the result validation accordingly.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

URL includes flowId and flowBeginTime params
![image](https://github.com/user-attachments/assets/bf066dd8-3dca-4b5c-92f0-c240accdfd32)

