### PR TITLE
feat(recovery phone): add feature flag for password reset routes

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -232,6 +232,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN',
     },
+    recoveryPhonePasswordReset2fa: {
+      default: false,
+      doc: 'Enables recovery phone codes for 2FA in password reset',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA',
+    },
   },
   showReactApp: {
     emailFirstRoutes: {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -91,6 +91,7 @@ export interface Config {
   featureFlags?: {
     keyStretchV2?: boolean;
     recoveryCodeSetupOnSyncSignIn?: boolean;
+    recoveryPhonePasswordReset2fa?: boolean;
   };
   nimbusPreview: boolean;
 }
@@ -169,6 +170,7 @@ export function getDefault() {
     },
     featureFlags: {
       recoveryCodeSetupOnSyncSignIn: false,
+      recoveryPhonePasswordReset2fa: false,
     },
     nimbusPreview: false,
   } as Config;


### PR DESCRIPTION
Because:
 - we want to have a feature flag for using a recovery phone code for 2FA during password reset

This commit:
 - add a feature flag to Settings, defaults to false
