### PR TITLE
feat(payments): cancel redundant plans when upgrading

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -9,8 +9,8 @@ import {
   EligibilityManager,
   EligibilityService,
   EligibilityStatus,
-  SubscriptionEligibilityResultBlockedIAPFactory,
-  SubscriptionEligibilityResultDowngradeFactory,
+  SubscriptionEligibilityResultFactory,
+  SubscriptionEligibilityUpgradeDowngradeResultFactory,
 } from '@fxa/payments/eligibility';
 import {
   MockPaypalClientConfigProvider,
@@ -620,9 +620,11 @@ describe('CartService', () => {
         .spyOn(cartManager, 'createErrorCart')
         .mockResolvedValue(mockErrorCart);
       jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
-      jest
-        .spyOn(eligibilityService, 'checkEligibility')
-        .mockResolvedValue(SubscriptionEligibilityResultBlockedIAPFactory());
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue(
+        SubscriptionEligibilityResultFactory({
+          subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
+        })
+      );
 
       const result = await cartService.setupCart(args);
 
@@ -660,9 +662,11 @@ describe('CartService', () => {
         .spyOn(cartManager, 'createErrorCart')
         .mockResolvedValue(mockErrorCart);
       jest.spyOn(accountManager, 'getAccounts').mockResolvedValue([]);
-      jest
-        .spyOn(eligibilityService, 'checkEligibility')
-        .mockResolvedValue(SubscriptionEligibilityResultDowngradeFactory());
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue(
+        SubscriptionEligibilityUpgradeDowngradeResultFactory({
+          subscriptionEligibilityResult: EligibilityStatus.DOWNGRADE,
+        })
+      );
 
       const result = await cartService.setupCart(args);
 

--- a/libs/payments/cart/src/lib/checkout.factories.ts
+++ b/libs/payments/cart/src/lib/checkout.factories.ts
@@ -5,7 +5,8 @@ import {
 import { PrePayStepsResult } from './checkout.types';
 import { ResultCartFactory } from './cart.factories';
 import { faker } from '@faker-js/faker';
-import { SubscriptionEligibilityResultCreateFactory } from '@fxa/payments/eligibility';
+import { SubscriptionEligibilityResultFactory } from '@fxa/payments/eligibility';
+import { EligibilityStatus } from '@fxa/payments/eligibility';
 
 export const PrePayStepsResultFactory = (
   override?: Partial<PrePayStepsResult>
@@ -18,7 +19,9 @@ export const PrePayStepsResultFactory = (
     customer: StripeCustomerFactory(),
     enableAutomaticTax: true,
     price: StripePriceFactory(),
-    eligibility: SubscriptionEligibilityResultCreateFactory(),
+    eligibility: SubscriptionEligibilityResultFactory({
+      subscriptionEligibilityResult: EligibilityStatus.CREATE,
+    }),
     ...override,
   };
 };

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -50,6 +50,9 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   SubscriptionPromotionCode = 'appliedPromotionCode',
   PreviousPlanId = 'previous_plan_id',
   PlanChangeDate = 'plan_change_date',
+  AutoCancelledRedundantFor = 'autoCancelledRedundantFor',
+  RedundantCancellation = 'redundantCancellation',
+  CancelledForCustomerAt = 'cancelled_for_customer_at',
 }
 
 export enum STRIPE_INVOICE_METADATA {

--- a/libs/payments/eligibility/src/lib/eligibility.factories.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.factories.ts
@@ -1,36 +1,29 @@
-import { faker } from '@faker-js/faker/locale/af_ZA';
 import {
   EligibilityStatus,
   SubscriptionEligibilityResult,
+  type SubscriptionEligibilityUpgradeDowngradeResult,
 } from './eligibility.types';
-import { StripePrice, StripePriceFactory } from '@fxa/payments/stripe';
+import { StripePriceFactory } from '@fxa/payments/stripe';
 
-export const SubscriptionEligibilityResultCreateFactory =
-  (): SubscriptionEligibilityResult => ({
-    subscriptionEligibilityResult: EligibilityStatus.CREATE,
-  });
-
-export const SubscriptionEligibilityResultBlockedIAPFactory =
-  (): SubscriptionEligibilityResult => ({
-    subscriptionEligibilityResult: EligibilityStatus.BLOCKED_IAP,
-  });
-
-export const SubscriptionEligibilityResultUpgradeFactory = (): {
-  subscriptionEligibilityResult: EligibilityStatus.UPGRADE;
-  fromOfferingConfigId: string;
-  fromPrice: StripePrice;
-} => ({
-  subscriptionEligibilityResult: EligibilityStatus.UPGRADE,
-  fromOfferingConfigId: faker.helpers.arrayElement(['vpn']),
-  fromPrice: StripePriceFactory(),
+export const SubscriptionEligibilityResultFactory = (
+  override?: Partial<{
+    subscriptionEligibilityResult:
+      | EligibilityStatus.CREATE
+      | EligibilityStatus.INVALID
+      | EligibilityStatus.SAME
+      | EligibilityStatus.BLOCKED_IAP;
+  }>
+): SubscriptionEligibilityResult => ({
+  subscriptionEligibilityResult: EligibilityStatus.CREATE,
+  ...override,
 });
 
-export const SubscriptionEligibilityResultDowngradeFactory = (): {
-  subscriptionEligibilityResult: EligibilityStatus.DOWNGRADE;
-  fromOfferingConfigId: string;
-  fromPrice: StripePrice;
-} => ({
-  subscriptionEligibilityResult: EligibilityStatus.DOWNGRADE,
-  fromOfferingConfigId: faker.helpers.arrayElement(['vpn']),
+export const SubscriptionEligibilityUpgradeDowngradeResultFactory = (
+  override?: Partial<SubscriptionEligibilityUpgradeDowngradeResult>
+): SubscriptionEligibilityUpgradeDowngradeResult => ({
+  subscriptionEligibilityResult: EligibilityStatus.UPGRADE,
+  fromOfferingConfigId: 'vpn',
   fromPrice: StripePriceFactory(),
+  redundantOverlaps: [],
+  ...override,
 });

--- a/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.spec.ts
@@ -221,7 +221,7 @@ describe('EligibilityService', () => {
         .spyOn(eligibilityManager, 'getOfferingOverlap')
         .mockResolvedValue(mockOverlapResult);
 
-      jest.spyOn(eligibilityManager, 'compareOverlap').mockResolvedValue({
+      jest.spyOn(eligibilityManager, 'compareOverlaps').mockResolvedValue({
         subscriptionEligibilityResult: EligibilityStatus.UPGRADE,
         fromOfferingConfigId: mockFromOfferingId,
         fromPrice: mockFromPrice,
@@ -244,7 +244,7 @@ describe('EligibilityService', () => {
         priceIds: [],
         targetOffering: mockOffering,
       });
-      expect(eligibilityManager.compareOverlap).toHaveBeenCalledWith(
+      expect(eligibilityManager.compareOverlaps).toHaveBeenCalledWith(
         mockOverlapResult,
         mockOffering,
         interval,

--- a/libs/payments/eligibility/src/lib/eligibility.service.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.ts
@@ -95,7 +95,7 @@ export class EligibilityService {
       targetOffering,
     });
 
-    const eligibility = await this.eligibilityManager.compareOverlap(
+    const eligibility = await this.eligibilityManager.compareOverlaps(
       overlaps,
       targetOffering,
       interval,

--- a/libs/payments/eligibility/src/lib/eligibility.types.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.types.ts
@@ -52,11 +52,15 @@ export type SubscriptionEligibilityResult =
         | EligibilityStatus.INVALID
         | EligibilityStatus.SAME
         | EligibilityStatus.BLOCKED_IAP;
+      redundantOverlaps?: undefined;
     }
-  | {
-      subscriptionEligibilityResult:
-        | EligibilityStatus.UPGRADE
-        | EligibilityStatus.DOWNGRADE;
-      fromOfferingConfigId: string;
-      fromPrice: StripePrice;
-    };
+  | SubscriptionEligibilityUpgradeDowngradeResult;
+
+export type SubscriptionEligibilityUpgradeDowngradeResult = {
+  subscriptionEligibilityResult:
+    | EligibilityStatus.UPGRADE
+    | EligibilityStatus.DOWNGRADE;
+  fromOfferingConfigId: string;
+  fromPrice: StripePrice;
+  redundantOverlaps?: SubscriptionEligibilityUpgradeDowngradeResult[];
+};

--- a/libs/payments/webhooks/src/lib/util/determineCancellation.ts
+++ b/libs/payments/webhooks/src/lib/util/determineCancellation.ts
@@ -16,7 +16,7 @@ export const determineCancellation = (
   subscription: StripeSubscription,
   latestInvoice?: StripeInvoice
 ): CancellationReason | undefined => {
-  if (subscription.metadata['redundantCancellation']) {
+  if (subscription.metadata['redundantCancellation'] === 'true') {
     return CancellationReason.Redundant;
   }
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -429,6 +429,7 @@ describe('DirectStripeRoutes', () => {
     stripeHelperMock.stripe = {
       subscriptions: {
         del: sinon.spy(async (uid) => undefined),
+        cancel: sinon.spy(async () => undefined),
       },
     };
     mockCapabilityService.getPlanEligibility = sinon.stub();
@@ -550,9 +551,8 @@ describe('DirectStripeRoutes', () => {
       VALID_REQUEST.app.geo = {};
       buildTaxAddressStub.returns(undefined);
 
-      const actual = await directStripeRoutesInstance.createCustomer(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createCustomer(VALID_REQUEST);
       const callArgs =
         directStripeRoutesInstance.stripeHelper.createPlainCustomer.getCall(0)
           .args[0];
@@ -578,9 +578,8 @@ describe('DirectStripeRoutes', () => {
       };
       buildTaxAddressStub.returns({ countryCode: 'US', postalCode: '92841' });
 
-      const actual = await directStripeRoutesInstance.createCustomer(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createCustomer(VALID_REQUEST);
       const callArgs =
         directStripeRoutesInstance.stripeHelper.createPlainCustomer.getCall(0)
           .args[0];
@@ -603,9 +602,8 @@ describe('DirectStripeRoutes', () => {
       };
       VALID_REQUEST.app.geo = {};
       buildTaxAddressStub.returns(undefined);
-      const actual = await directStripeRoutesInstance.previewInvoice(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.previewInvoice(VALID_REQUEST);
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.customs.check,
         VALID_REQUEST,
@@ -653,9 +651,8 @@ describe('DirectStripeRoutes', () => {
       };
       VALID_REQUEST.app.geo = {};
       buildTaxAddressStub.returns(undefined);
-      const actual = await directStripeRoutesInstance.previewInvoice(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.previewInvoice(VALID_REQUEST);
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.customs.check,
         VALID_REQUEST,
@@ -706,9 +703,8 @@ describe('DirectStripeRoutes', () => {
       };
       buildTaxAddressStub.returns({ countryCode: 'US', postalCode: '92841' });
 
-      const actual = await directStripeRoutesInstance.previewInvoice(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.previewInvoice(VALID_REQUEST);
 
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.customs.check,
@@ -854,9 +850,8 @@ describe('DirectStripeRoutes', () => {
       },
     };
 
-    const actual = await directStripeRoutesInstance.subsequentInvoicePreviews(
-      VALID_REQUEST
-    );
+    const actual =
+      await directStripeRoutesInstance.subsequentInvoicePreviews(VALID_REQUEST);
 
     sinon.assert.calledOnceWithExactly(
       directStripeRoutesInstance.customs.check,
@@ -928,9 +923,10 @@ describe('DirectStripeRoutes', () => {
       });
       VALID_REQUEST.app.geo = {};
 
-      const actual = await directStripeRoutesInstance.subsequentInvoicePreviews(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.subsequentInvoicePreviews(
+          VALID_REQUEST
+        );
 
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.customs.check,
@@ -948,9 +944,10 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(null);
       VALID_REQUEST.app.geo = {};
       const expected = [];
-      const actual = await directStripeRoutesInstance.subsequentInvoicePreviews(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.subsequentInvoicePreviews(
+          VALID_REQUEST
+        );
 
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.customs.check,
@@ -988,9 +985,8 @@ describe('DirectStripeRoutes', () => {
           postalCode: '92841',
         },
       };
-      const actual = await directStripeRoutesInstance.retrieveCouponDetails(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.retrieveCouponDetails(VALID_REQUEST);
 
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.customs.check,
@@ -1239,9 +1235,10 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.extractPromotionCode = sinon.stub().resolves({
         coupon: { id: 'couponId' },
       });
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {
@@ -1262,9 +1259,10 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         true
       );
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {
@@ -1283,9 +1281,10 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.isCustomerTaxableWithSubscriptionCurrency.returns(
         false
       );
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {
@@ -1568,9 +1567,10 @@ describe('DirectStripeRoutes', () => {
         idempotencyKey,
       };
 
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
 
       assert.deepEqual(
         {
@@ -1684,9 +1684,10 @@ describe('DirectStripeRoutes', () => {
         idempotencyKey: uuidv4(),
       };
 
-      const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createSubscriptionWithPMI(
+          VALID_REQUEST
+        );
 
       sinon.assert.notCalled(
         directStripeRoutesInstance.stripeHelper.getPaymentMethod
@@ -1767,9 +1768,8 @@ describe('DirectStripeRoutes', () => {
         idempotencyKey: uuidv4(),
       };
 
-      const actual = await directStripeRoutesInstance.retryInvoice(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.retryInvoice(VALID_REQUEST);
 
       sinon.assert.calledWith(
         directStripeRoutesInstance.customerChanged,
@@ -1809,9 +1809,8 @@ describe('DirectStripeRoutes', () => {
       );
       VALID_REQUEST.payload = {};
 
-      const actual = await directStripeRoutesInstance.createSetupIntent(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.createSetupIntent(VALID_REQUEST);
 
       assert.deepEqual(filterIntent(expected), actual);
     });
@@ -2057,9 +2056,10 @@ describe('DirectStripeRoutes', () => {
         paymentMethodId,
       };
 
-      const actual = await directStripeRoutesInstance.detachFailedPaymentMethod(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.detachFailedPaymentMethod(
+          VALID_REQUEST
+        );
 
       assert.deepEqual(actual, expected);
       sinon.assert.calledOnceWithExactly(
@@ -2081,9 +2081,10 @@ describe('DirectStripeRoutes', () => {
       VALID_REQUEST.payload = {
         paymentMethodId,
       };
-      const actual = await directStripeRoutesInstance.detachFailedPaymentMethod(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.detachFailedPaymentMethod(
+          VALID_REQUEST
+        );
 
       assert.deepEqual(actual, { id: paymentMethodId });
       sinon.assert.notCalled(
@@ -2126,9 +2127,8 @@ describe('DirectStripeRoutes', () => {
       const expected = { subscriptionId: subscription2.id };
 
       directStripeRoutesInstance.stripeHelper.cancelSubscriptionForCustomer.resolves();
-      const actual = await directStripeRoutesInstance.deleteSubscription(
-        deleteSubRequest
-      );
+      const actual =
+        await directStripeRoutesInstance.deleteSubscription(deleteSubRequest);
 
       assert.deepEqual(actual, expected);
     });
@@ -2151,9 +2151,10 @@ describe('DirectStripeRoutes', () => {
 
     it('returns an empty object', async () => {
       directStripeRoutesInstance.stripeHelper.reactivateSubscriptionForCustomer.resolves();
-      const actual = await directStripeRoutesInstance.reactivateSubscription(
-        reactivateRequest
-      );
+      const actual =
+        await directStripeRoutesInstance.reactivateSubscription(
+          reactivateRequest
+        );
 
       assert.isEmpty(actual);
     });
@@ -2193,11 +2194,57 @@ describe('DirectStripeRoutes', () => {
 
       sinon.stub(directStripeRoutesInstance, 'customerChanged').resolves();
 
-      const actual = await directStripeRoutesInstance.updateSubscription(
-        VALID_REQUEST
-      );
+      const actual =
+        await directStripeRoutesInstance.updateSubscription(VALID_REQUEST);
 
       assert.deepEqual(actual, expected);
+    });
+
+    it('cancels redundant subscriptions when upgrading', async () => {
+      const subscriptionId = 'sub_123';
+      VALID_REQUEST.params = { subscriptionId: subscriptionId };
+
+      mockCapabilityService.getPlanEligibility = sinon.stub();
+      mockCapabilityService.getPlanEligibility.resolves({
+        subscriptionEligibilityResult: SubscriptionEligibilityResult.UPGRADE,
+        eligibleSourcePlan: subscription2,
+        redundantOverlaps: [
+          {
+            eligibleSourcePlan: {
+              plan_id:
+                customerFixture.subscriptions.data[0].items.data[0].plan.id,
+            },
+          },
+        ],
+      });
+
+      directStripeRoutesInstance.stripeHelper.changeSubscriptionPlan.resolves();
+      directStripeRoutesInstance.stripeHelper.updateSubscriptionAndBackfill.resolves();
+
+      sinon.stub(directStripeRoutesInstance, 'customerChanged').resolves();
+
+      await directStripeRoutesInstance.updateSubscription(VALID_REQUEST);
+
+      assert.isTrue(
+        directStripeRoutesInstance.stripeHelper.updateSubscriptionAndBackfill.calledOnceWith(
+          customerFixture.subscriptions.data[0],
+          {
+            metadata: {
+              redundantCancellation: 'true',
+              autoCancelledRedundantFor: subscription2.id,
+              cancelled_for_customer_at: Math.floor(Date.now() / 1000),
+            },
+          }
+        ),
+        'Expected updateSubscriptionAndBackfill to be called once'
+      );
+
+      assert.isTrue(
+        directStripeRoutesInstance.stripeHelper.stripe.subscriptions.cancel.calledOnceWith(
+          customerFixture.subscriptions.data[0].id
+        ),
+        'Expected subscription to be cancelled'
+      );
     });
 
     it('throws an error when the new plan is not an upgrade', async () => {
@@ -2300,9 +2347,8 @@ describe('DirectStripeRoutes', () => {
             emptyCustomer
           );
           const expected = [];
-          const actual = await directStripeRoutesInstance.listActive(
-            VALID_REQUEST
-          );
+          const actual =
+            await directStripeRoutesInstance.listActive(VALID_REQUEST);
           assert.deepEqual(actual, expected);
         });
       });
@@ -2361,9 +2407,8 @@ describe('DirectStripeRoutes', () => {
       it('returns an empty array', async () => {
         directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves();
         const expected = [];
-        const actual = await directStripeRoutesInstance.listActive(
-          VALID_REQUEST
-        );
+        const actual =
+          await directStripeRoutesInstance.listActive(VALID_REQUEST);
         assert.deepEqual(actual, expected);
       });
     });

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -220,10 +220,11 @@ export class SubscriptionStripeError extends Error {
 
 export type InvoicePreview = [
   invoicePreview: Stripe.UpcomingInvoice,
-  proratedInvoice?: Stripe.UpcomingInvoice
+  proratedInvoice?: Stripe.UpcomingInvoice,
 ];
 
 export type SubscriptionChangeEligibility = {
   subscriptionEligibilityResult: SubscriptionEligibilityResult;
   eligibleSourcePlan?: AbbrevPlan;
+  redundantOverlaps?: SubscriptionChangeEligibility[];
 };


### PR DESCRIPTION
## Because

- We want to cancel any plans that have an overlap with your upgraded plan

## This pull request

- Cancels any overlapping plans when a user upgrades

## Issue that this pull request solves

Closes FXA-11534
Closes FXA-11535
Closes FXA-11536