### PR TITLE
fix(feat): Prototype Pollution Vulnerability in Mozilla FxA Account Management

### DIFF
--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -54,13 +54,15 @@ export function currentAccount(
   // Current user can be specified in url params (ex. when clicking
   // `Manage account` from sync prefs.
   const forceUid = searchParam('uid', window.location.search);
-  if (forceUid && all[forceUid]) {
+  if (forceUid && !['__proto__', 'constructor', 'prototype'].includes(forceUid) && all[forceUid]) {
     storage.set('currentAccountUid', forceUid);
   }
 
   const uid = storage.get('currentAccountUid') as hexstring;
   if (account) {
-    all[account.uid] = account;
+    if (!['__proto__', 'constructor', 'prototype'].includes(account.uid)) {
+      all[account.uid] = account;
+    }
     accounts(all);
     return account;
   }


### PR DESCRIPTION
https://github.com/mozilla/fxa/blob/523ccc8d67b66ff9b48b19e70e5314dcd748763d/packages/fxa-settings/src/models/Account.ts#L1359-L1359

fix the issue need to prevent prototype pollution by ensuring that user-controlled keys cannot include dangerous values like `__proto__`, `constructor`, or `prototype`. This can be achieved by validating or sanitizing the keys before they are used in the `accounts` object. Specifically:

1. Modify the `currentAccount()` function in `packages/fxa-settings/src/lib/cache.ts` to validate the `forceUid` and `account.uid` keys before using them.
2. Reject or sanitize any keys that could lead to prototype pollution.

## References
[Object.prototype.proto](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)
[Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-79](https://cwe.mitre.org/data/definitions/79.html)
[CWE-94](https://cwe.mitre.org/data/definitions/94.html)
[CWE-400](https://cwe.mitre.org/data/definitions/400.html)
[CWE-471](https://cwe.mitre.org/data/definitions/471.html)
[CWE-915](https://cwe.mitre.org/data/definitions/915.html)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.