### PR TITLE
fix(fxa-settings): Fluent attrs require kebob-case aria-label

### DIFF
--- a/packages/fxa-settings/src/components/PreparedImage/index.tsx
+++ b/packages/fxa-settings/src/components/PreparedImage/index.tsx
@@ -38,7 +38,7 @@ export const PreparedImage = (props: PreparedImageProps) => {
   return (
     <>
       {showAriaLabel ? (
-        <FtlMsg id={props.ariaLabelFtlId} attrs={{ ariaLabel: true }}>
+        <FtlMsg id={props.ariaLabelFtlId} attrs={{ "aria-label": true }}>
           <Image role="img" aria-label={props.ariaLabel} {...{ className }} />
         </FtlMsg>
       ) : (


### PR DESCRIPTION
## Because

- Icon aria labels are not being translated; defaulting to English

## This pull request

- Fixes the aria-label key within the attrs prop of the FtlMsg component

## Issue that this pull request solves

Closes: FXA-11374

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)

<img width="1840" alt="Screenshot 2025-05-06 at 4 30 48 PM" src="https://github.com/user-attachments/assets/5fd4ccc8-a4c9-47db-bbf5-2da33370540b" />
