### PR TITLE
fix(auth): Send SubscriptionReplacedEmail for redundant cancellations

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/subscription_replaced.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/subscription_replaced.json
@@ -1,0 +1,122 @@
+{
+  "id": "evt_1GB4fgKb9q6OnNsLBGVcHQST",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1581450323,
+  "data": {
+    "object": {
+      "id": "sub_GiX3TpyO37x5BW",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing_cycle_anchor": 1581449989,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": 1581450078,
+      "collection_method": "charge_automatically",
+      "created": 1581449989,
+      "current_period_end": 1583955589,
+      "current_period_start": 1581449989,
+      "customer": "cus_GiX3P6izX4lG5p",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "discount": null,
+      "ended_at": 1581450323,
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_GiVbZCo1K4JXci",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1581449989,
+            "metadata": {},
+            "plan": {
+              "id": "plan_FiJ55YK6UYftPa",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 999,
+              "amount_decimal": "999",
+              "billing_scheme": "per_unit",
+              "created": 1567103726,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+                "successActionButtonURL": "https://stage.guardian.nonprod.cloudops.mozgcp.net/vpn/download?utm_medium=email&utm_source=email&utm_campaign=subscription-download"
+              },
+              "nickname": "guardian_monthly",
+              "product": "prod_FiJ42WCzZNRSbS",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "subscription": "sub_GiVbeUvwkJj6x1",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_GiVbeUvwkJj6x1"
+      },
+      "latest_invoice": "in_1GB4aHKb9q6OnNsLC9pbVY5a",
+      "livemode": false,
+      "metadata": {
+        "amount": "500",
+        "autoCancelledRedundantFor": "sub_1RM8vLBVqmGyQTMaqE7jLIRh",
+        "cancelled_for_customer_at": "1746628021",
+        "currency": "USD",
+        "redundantCancellation": "true"
+      },
+      "next_pending_invoice_item_invoice": null,
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "plan_FiJ55YK6UYftPa",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 999,
+        "amount_decimal": "999",
+        "billing_scheme": "per_unit",
+        "created": 1567103726,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+          "successActionButtonURL": "https://stage.guardian.nonprod.cloudops.mozgcp.net/vpn/download?utm_medium=email&utm_source=email&utm_campaign=subscription-download"
+        },
+        "nickname": "guardian_monthly",
+        "product": "prod_FiJ42WCzZNRSbS",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1581449989,
+      "status": "canceled",
+      "tax_percent": null,
+      "trial_end": null,
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_0Hhb1j3UqSE7Pr",
+    "idempotency_key": null
+  },
+  "type": "customer.subscription.deleted"
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -6720,32 +6720,6 @@ describe('#integration - StripeHelper', () => {
           showOutstandingBalance: true,
         });
       });
-
-      it('extracts expected details for a subscription replacement', async () => {
-        const event = deepCopy(eventCustomerSubscriptionUpdated);
-        const subscription = event.data.object;
-        subscription.metadata = {
-          autoCancelledRedundantFor: 'REPLACEMENT_SUB_ID',
-        };
-        const result =
-          await stripeHelper.extractSubscriptionUpdateCancellationDetailsForEmail(
-            event.data.object,
-            expectedBaseUpdateDetails,
-            mockInvoice,
-            undefined
-          );
-        assert.deepEqual(result, {
-          updateType: SUBSCRIPTION_UPDATE_TYPES.REDUNDANT_OVERLAP,
-          email,
-          uid,
-          productId,
-          planId,
-          planConfig: {},
-          planEmailIconURL: productIconURLNew,
-          productName,
-          productMetadata: expectedBaseUpdateDetails.productMetadata,
-        });
-      });
     });
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -2239,8 +2239,6 @@ describe('StripeWebhookHandler', () => {
           'sendSubscriptionReactivationEmail',
         [SUBSCRIPTION_UPDATE_TYPES.CANCELLATION]:
           'sendSubscriptionCancellationEmail',
-        [SUBSCRIPTION_UPDATE_TYPES.REDUNDANT_OVERLAP]:
-          'sendSubscriptionCancellationEmail',
       }[updateType];
 
       assert.calledWith(
@@ -2277,13 +2275,6 @@ describe('StripeWebhookHandler', () => {
       'sends a cancellation email on subscription cancellation',
       commonSendSubscriptionUpdatedEmailTest(
         SUBSCRIPTION_UPDATE_TYPES.CANCELLATION
-      )
-    );
-
-    it(
-      'sends a replaced email on subscription replacement',
-      commonSendSubscriptionUpdatedEmailTest(
-        SUBSCRIPTION_UPDATE_TYPES.REDUNDANT_OVERLAP
       )
     );
   });


### PR DESCRIPTION
## This pull request

- sends subscriptionReplacedEmail for redundant cancellation

## Issue that this pull request solves

Closes: FXA-11538

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.