### PR TITLE
fix(tests): increase timeout for certain slow tests

### DIFF
--- a/packages/functional-tests/tests/resetPassword/oauthResetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPasswordRecoveryKey.spec.ts
@@ -13,6 +13,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, recoveryKey, relier, resetPassword, settings, signin },
       testAccountTracker,
     }) => {
+      test.setTimeout(120000);
+
       const credentials = await testAccountTracker.signUp();
       const newPassword = testAccountTracker.generatePassword();
 

--- a/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
@@ -15,6 +15,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { recoveryKey, resetPassword, settings, signin },
       testAccountTracker,
     }) => {
+      test.setTimeout(120000);
+
       const credentials = await testAccountTracker.signUp();
       const newPassword = testAccountTracker.generatePassword();
 

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -47,6 +47,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, recoveryKey, settings, signin },
       testAccountTracker,
     }) => {
+      test.setTimeout(120000);
+
       const credentials = await signInAccount(
         target,
         page,


### PR DESCRIPTION
## Because

- tests in CI exceed Playwright's default timeout, and locally some tests are flagged as slow

## This pull request

- increases the timeout for the 3 affected tests

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.

