### PR TITLE
task(auth-server): Replace accountStatusCheck customs rule with new rate limit library call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ executors:
       CUSTOMS_SERVER_URL: none
       HUSKY_SKIP_INSTALL: 1
       AUTH_CLOUDTASKS_USE_LOCAL_EMULATOR: true
+      RATE_LIMIT__RULES: ""
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
   # automation. Perfect for running smoke tests against remote targets.

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -33,6 +33,17 @@ describe('rate-limit', () => {
     expect(rateLimit).toBeDefined();
   });
 
+  it('can determine if action is supported', () => {
+    rateLimit = new RateLimit(
+      parseConfigRules(['test:ip:1:1s:1s']),
+      redis,
+      statsd
+    );
+
+    expect(rateLimit.supportsAction('test')).toBeTruthy();
+    expect(rateLimit.supportsAction('foo')).toBeFalsy();
+  });
+
   it('throws if no action can be found', async () => {
     rateLimit = new RateLimit({}, redis, statsd);
     expect(rateLimit.check('foo', {})).rejects.toThrow(

--- a/libs/accounts/rate-limit/src/lib/rate-limit.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.ts
@@ -53,6 +53,15 @@ export class RateLimit {
   }
 
   /**
+   * Checks to see if there are rules for a given action.
+   * @param action - Name of action
+   * @returns - True if action has rules, otherwise false.
+   */
+  supportsAction(action:string) {
+    return this.rules[action] != null;
+  }
+
+  /**
    * Checks to see if a rate limit has been exceeded.
    * @param action The action being conducted. Important, if the action is not defined, a runtime error will occur!
    * @param opts Pass as many of these in as possible! If a rule requires one of these options
@@ -73,7 +82,7 @@ export class RateLimit {
       throw new ActionNotFound(action);
     }
 
-    const openBlocks = [];
+    const openBlocks = new Array<BlockStatus>();
 
     // Important! Set timestamp of check upfront.
     // This reduces small variance because of wait on IO operations.
@@ -159,9 +168,7 @@ export class RateLimit {
       //    - Open question, do we also want to no blocks with shorter bans? Or just the block with largest
       //      ban (ie the biggest retryAfter value).
 
-      return {
-        ...block,
-      };
+      return block;
     }
 
     // Made it through the gauntlet of rules. No blocks found!

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2160,6 +2160,18 @@ const convictConf = convict({
       },
     },
   },
+  rateLimit: {
+    rules: {
+      default: [
+        'unblockEmail          : email  : 10   : 24 hours    : 24 hours    ',
+        'accountStatusCheck    : ip     : 20   : 15 minutes  : 15 minutes  ',
+        'accountStatusCheck    : email  : 20   : 15 minutes  : 15 minutes  ',
+      ],
+      doc: 'Rules for rate limiting user actions. These are essentially customs v2 rules.',
+      env: 'RATE_LIMIT__RULES',
+      format: Array,
+    },
+  },
   recoveryPhone: {
     enabled: {
       default: false,

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -432,7 +432,7 @@ AppError.tooManyRequests = function (
     extraData.verificationReason = 'login';
   }
 
-  return new AppError(
+  const error = new AppError(
     {
       code: 429,
       error: 'Too Many Requests',
@@ -444,6 +444,8 @@ AppError.tooManyRequests = function (
       'retry-after': retryAfter,
     }
   );
+
+  return error;
 };
 
 AppError.requestBlocked = function (canUnblock) {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -1544,6 +1544,7 @@ describe('/account/status', () => {
     );
     const mockMailer = mocks.mockMailer();
     const mockPush = mocks.mockPush();
+    const mockCustoms = mocks.mockCustoms();
     const verificationReminders = mocks.mockVerificationReminders();
     const subscriptionAccountReminders = mocks.mockVerificationReminders();
     const accountRoutes = makeRoutes({
@@ -1551,6 +1552,7 @@ describe('/account/status', () => {
       db: mockDB,
       log: mockLog,
       mailer: mockMailer,
+      customs: mockCustoms,
       Password: function () {
         return {
           unwrap: function () {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -352,6 +352,7 @@ function mockCustoms(errors) {
   return mockObject(CUSTOMS_METHOD_NAMES)({
     checkAuthenticated: optionallyThrow(errors, 'checkAuthenticated'),
     checkIpOnly: optionallyThrow(errors, 'checkIpOnly'),
+    checkV2: sinon.spy(() => false),
   });
 }
 


### PR DESCRIPTION
## Because

- We want to test out the new customs library with a single call


## This pull request

- Wires up the new rate limit library into auth-server's customs wrapper
- Ensures metrics are preserved
- Injects rate limit instance into auth-server's customs wrapper
- Adds config for accountStatusCheck rate limit rule
- Fixes tsc compiler error that wasn't caught by esbuild in the rate-limit lib.
- Adds switch to existing customs.js module so that if a new rule has been configured for the supplied action, the new rate limit will be used instead of the customs server.
- Disables rate-limit rules for functional tests

## Issue that this pull request solves

Closes: FXA-11607

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The format for customs rules configuration is specified in `libs/accounts/rate-limit/readme.md`. In the future, as more rules are added, `auth-server` may opt to load the rules in a different manner. e.g. A file containing rules maybe used instead of an environment variable. This will only be changed, however, if managing the customs rules becomes a burden.
