### PR TITLE
task(auth-server): Don't report retryAfter to statsd on customs check events

### DIFF
--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -175,7 +175,19 @@ class CustomsClient {
     }
 
     if (this.statsd) {
-      const tags = { action, block: options.block, ...options };
+      const tags = { action };
+      if (options.block != null) {
+        tags.block = options.block;
+      }
+      if (options.suspect != null) {
+        tags.suspect = options.suspect;
+      }
+      if (options.unblock != null) {
+        tags.unblock = options.unblock;
+      }
+      if (options.blockReason != null) {
+        tags.blockReason = options.blockReason;
+      }
       this.statsd.increment(`${serviceName}.${name}`, tags);
     }
   }

--- a/packages/fxa-auth-server/test/local/customs.js
+++ b/packages/fxa-auth-server/test/local/customs.js
@@ -726,6 +726,15 @@ describe('Customs', () => {
       suspect: true,
       unblock: true,
       blockReason: 'other',
+      // Important! Values with high cardinality like retryAfter
+      // should be sent to statsd!
+      retryAfter: 1111,
+    };
+    const validTags = {
+      block: true,
+      suspect: true,
+      unblock: true,
+      blockReason: 'other',
     };
 
     beforeEach(() => {
@@ -739,10 +748,10 @@ describe('Customs', () => {
         await customsWithUrl.check(request, email, action);
         assert.fail('should have failed');
       } catch (err) {
-        assert.isTrue(
+          assert.isTrue(
           statsd.increment.calledWithExactly('customs.request.check', {
             action,
-            ...tags,
+            ...validTags,
           })
         );
         assert.isTrue(statsd.timing.calledWithMatch('customs.check.success'));
@@ -765,7 +774,7 @@ describe('Customs', () => {
         assert.isTrue(
           statsd.increment.calledWithExactly('customs.request.checkIpOnly', {
             action,
-            ...tags,
+            ...validTags,
           })
         );
         assert.isTrue(


### PR DESCRIPTION
## Because

- We don't want to send values with high cardinality to stats

## This pull request

- Ensures retryAfter isn't sent

## Issue that this pull request solves

Closes: FXA-11492

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
