### PR TITLE
fix(payments-next): Sentry reporting 'something went wrong' errors

### DIFF
--- a/apps/payments/next/.env
+++ b/apps/payments/next/.env
@@ -99,6 +99,7 @@ CSP__PAYPAL_API='https://www.sandbox.paypal.com'
 
 # Sentry Config
 SENTRY__DSN=
+SENTRY__CLIENT_DSN=
 SENTRY__ENV=local
 SENTRY__SERVER_NAME=payments-next-server
 SENTRY__CLIENT_NAME=payments-next-client

--- a/apps/payments/next/config/index.ts
+++ b/apps/payments/next/config/index.ts
@@ -38,6 +38,10 @@ class SentryServerConfig {
   @IsString()
   dsn?: string;
 
+  @IsOptional()
+  @IsString()
+  clientDsn?: string;
+
   @IsString()
   env!: string;
 

--- a/apps/payments/next/sentry.server.config.ts
+++ b/apps/payments/next/sentry.server.config.ts
@@ -7,11 +7,15 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 import { initSentryForNextjsServer } from '@fxa/shared/sentry';
 import { config } from './config';
+import { GENERIC_ERROR_MESSAGE } from '@fxa/shared/error/error';
 
 initSentryForNextjsServer(
   {
     release: process.env.version,
-    sentry: config.sentry,
+    sentry: {
+      ...config.sentry,
+      ignoreErrors: [new RegExp(`^${GENERIC_ERROR_MESSAGE}$`)],
+    },
   },
   console
 );

--- a/libs/payments/ui/src/lib/client/providers/ConfigProvider.tsx
+++ b/libs/payments/ui/src/lib/client/providers/ConfigProvider.tsx
@@ -11,8 +11,10 @@ export interface ConfigContextValues {
   paypalClientId: string;
   sentry: {
     dsn?: string;
+    clientDsn?: string;
     env: string;
     clientName: string;
+    ignoreErrors?: (string | RegExp)[];
     sampleRate: number;
     tracesSampleRate: number;
   };
@@ -23,8 +25,10 @@ export const ConfigContext = createContext<ConfigContextValues>({
   paypalClientId: '',
   sentry: {
     dsn: '',
+    clientDsn: '',
     env: '',
     clientName: '',
+    ignoreErrors: [],
     sampleRate: 1,
     tracesSampleRate: 1,
   },

--- a/libs/payments/ui/src/lib/client/providers/Providers.tsx
+++ b/libs/payments/ui/src/lib/client/providers/Providers.tsx
@@ -12,6 +12,7 @@ import {
 } from '@paypal/react-paypal-js';
 import { initSentryForNextjsClient } from '@fxa/shared/sentry/client';
 import { getClient as sentryGetClient } from '@sentry/nextjs';
+import { GENERIC_ERROR_MESSAGE } from '@fxa/shared/error/error';
 
 interface ProvidersProps {
   config: ConfigContextValues;
@@ -38,7 +39,11 @@ export function Providers({
   if (!sentryGetClient()) {
     initSentryForNextjsClient({
       release: process.env.version,
-      sentry: config.sentry,
+      sentry: {
+        ...config.sentry,
+        dsn: config.sentry.clientDsn,
+        ignoreErrors: [new RegExp(`^${GENERIC_ERROR_MESSAGE}$`)],
+      },
     });
   }
 

--- a/libs/shared/error/src/index.ts
+++ b/libs/shared/error/src/index.ts
@@ -1,5 +1,5 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-export { BaseError, BaseMultiError, TypeError } from './lib/error';
+export { BaseError, BaseMultiError, TypeError, GENERIC_ERROR_MESSAGE } from './lib/error';
 export { SanitizeExceptions } from './lib/sanitizeExceptionsDecorator';

--- a/libs/shared/error/src/lib/error.ts
+++ b/libs/shared/error/src/lib/error.ts
@@ -25,3 +25,5 @@ export class TypeError extends BaseError {
     super(...args);
   }
 }
+
+export const GENERIC_ERROR_MESSAGE = 'Something went wrong';

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nextjs';
 import { Inject } from '@nestjs/common';
 import { ILogger } from '@fxa/shared/log';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { GENERIC_ERROR_MESSAGE } from './error';
 
 type Constructor<T> = new (...args: any[]) => T;
 
@@ -97,5 +98,5 @@ function handleException(args: {
     },
   });
 
-  return new Error('Something went wrong');
+  return new Error(GENERIC_ERROR_MESSAGE);
 }

--- a/libs/shared/sentry/src/lib/config-builder.ts
+++ b/libs/shared/sentry/src/lib/config-builder.ts
@@ -36,6 +36,7 @@ export function buildSentryConfig(config: SentryConfigOpts, log: Logger) {
     serverName: config.sentry?.serverName,
     fxaName: config.sentry?.clientName || config.sentry?.serverName,
     tracesSampleRate: config.sentry?.tracesSampleRate,
+    ignoreErrors: config.sentry?.ignoreErrors || [],
   };
 
   return opts;

--- a/libs/shared/sentry/src/lib/models/SentryConfigOpts.ts
+++ b/libs/shared/sentry/src/lib/models/SentryConfigOpts.ts
@@ -21,6 +21,9 @@ export type SentryConfigOpts = {
     clientName?: string;
     /** The name of the active server. */
     serverName?: string;
+    /** The string messages of errors that should be ignored. Strings and regex patterns are permitted.
+     * When using strings, partial matches will be filtered out. If you need to filter by exact match, use regex patterns instead */
+    ignoreErrors?: (string | RegExp)[];
 
     /** When set to true, building a configuration will throw an error critical fields are missing. */
     strict?: boolean;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -71,6 +71,7 @@
         "libs/shared/db/type-cacheable/src/index.ts"
       ],
       "@fxa/shared/error": ["libs/shared/error/src/index.ts"],
+      "@fxa/shared/error/error": ["libs/shared/error/src/lib/error.ts"],
       "@fxa/shared/geodb": ["libs/shared/geodb/src/index.ts"],
       "@fxa/shared/glean": ["libs/shared/metrics/glean/src/index.ts"],
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index.ts"],


### PR DESCRIPTION
Because:

* Sentry should not be recording "something went wrong" errors
* Errors should be separated out to clientside and serverside sentry projects

This commit:

* prevents generic errors from propagating to sentry
* [creates a separate sentry project for payment-next client errors](https://mozilla.sentry.io/issues/?project=4509311130861568&referrer=sidebar&statsPeriod=48h)

Closes #FXA-11331

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
