### PR TITLE
fix(settings): make ModalVerifySession's input validation work on the first attempt

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.tsx
@@ -74,8 +74,11 @@ export const ModalVerifySession = ({
     getStatus();
   }, [session, onCompleted]);
 
-  const buttonDisabled =
-    !formState.isDirty || !formState.isValid || account.loading;
+  // Destructure formState in advance to avoid logical operator short-circuiting
+  // causing the isValid field to be conditionally subscribed.
+  const { isDirty, isValid } = formState;
+  const buttonDisabled = !isDirty || !isValid || account.loading;
+
   return (
     !session.verified && (
       <Modal


### PR DESCRIPTION
## Because

- “Verify” button becomes enabled while typing letters during the unverified session state (only happens at the first typing attempt)

## This pull request

- makes ModalVerifySession's input validation work on the first attempt
## Issue that this pull request solves

Closes: FXA-2704

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
