### PR TITLE
feat(payments): Revise Subscription Management page and Upgrade page to handle credits

### DIFF
--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/en.ftl
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/en.ftl
@@ -14,3 +14,5 @@ upgrade-purchase-details-new-plan-weekly = { $productName } (Weekly)
 upgrade-purchase-details-new-plan-monthly = { $productName } (Monthly)
 upgrade-purchase-details-new-plan-halfyearly = { $productName } (6-month)
 upgrade-purchase-details-new-plan-yearly = { $productName } (Yearly)
+
+upgrade-purchase-details-prorated-credits = Negative balance shown will be applied as credits to your account and used towards future invoices.

--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
@@ -227,6 +227,15 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
               {l10n.getLocalizedCurrencyString(oneTimeCharge, currency)}
             </p>
           </div>
+
+          {oneTimeCharge < 0 && (
+            <p className="pb-4">
+              {l10n.getString(
+                'upgrade-purchase-details-prorated-credits',
+                'Negative balance shown will be applied as credits to your account and used towards future invoices.'
+              )}
+            </p>
+          )}
         </>
       )}
     </div>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -30,8 +30,7 @@ export const PlanUpgradeDetails = ({
 }) => {
   const { navigatorLanguages, config } = useContext(AppContext);
   const invoiceCurrency = invoicePreview.line_items[0].currency;
-  const { product_name, amount, interval, interval_count } =
-    selectedPlan;
+  const { product_name, amount, interval, interval_count } = selectedPlan;
   const formattedInterval = formatPlanInterval({
     interval: interval,
     intervalCount: 1,
@@ -65,13 +64,21 @@ export const PlanUpgradeDetails = ({
         <Localized id="sub-update-current-plan-label">Current plan</Localized>
       </p>
 
-      <PlanDetailsCard className="from-plan" plan={upgradeFromPlan} currency={invoiceCurrency} />
+      <PlanDetailsCard
+        className="from-plan"
+        plan={upgradeFromPlan}
+        currency={invoiceCurrency}
+      />
 
       <p className="plan-label new-plan-label">
         <Localized id="sub-update-new-plan-label">New plan</Localized>
       </p>
 
-      <PlanDetailsCard className="to-plan" plan={selectedPlan} currency={invoiceCurrency} />
+      <PlanDetailsCard
+        className="to-plan"
+        plan={selectedPlan}
+        currency={invoiceCurrency}
+      />
 
       <div className="py-6 border-t-0">
         {showTax && !!subTotal && !!exclusiveTaxRates.length && (
@@ -144,7 +151,7 @@ export const PlanUpgradeDetails = ({
           </div>
         )}
 
-        {oneTimeCharge && (
+        {!!oneTimeCharge && (
           <>
             <hr className="m-0 my-5 unit-row-hr" />
 
@@ -165,6 +172,15 @@ export const PlanUpgradeDetails = ({
                 dataTestId="prorated-amount"
               />
             </div>
+
+            {oneTimeCharge < 0 && (
+              <Localized id="sub-update-prorated-upgrade-credit">
+                <p className="text-base">
+                  Negative balance shown will be applied as credits to your
+                  account and used towards future invoices.
+                </p>
+              </Localized>
+            )}
           </>
         )}
       </div>
@@ -178,7 +194,7 @@ export const PlanDetailsCard = ({
   className = '',
 }: {
   plan: Plan;
-  currency: string,
+  currency: string;
   className?: string;
 }) => {
   const { navigatorLanguages, config } = useContext(AppContext);

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/en.ftl
@@ -22,4 +22,4 @@ sub-update-new-plan-weekly = { $productName } (Weekly)
 sub-update-new-plan-monthly = { $productName } (Monthly)
 sub-update-new-plan-yearly = { $productName } (Yearly)
 
-##
+sub-update-prorated-upgrade-credit = Negative balance shown will be applied as credits to your account and used towards future invoices.

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -93,7 +93,7 @@ async function rendersAsExpected(
   // and interval count match or not.
   const expectedInvoiceDate =
     upgradeFromPlan.interval !== selectedPlan.interval &&
-      selectedPlan.interval_count === upgradeFromPlan.interval_count
+    selectedPlan.interval_count === upgradeFromPlan.interval_count
       ? getLocalizedDateString(invoicePreview.line_items[0].period.end)
       : getLocalizedDateString(customerWebSubscription.current_period_end);
 
@@ -115,12 +115,34 @@ async function rendersAsExpected(
     ).toBeInTheDocument();
   }
 
-  if (!!invoicePreview.one_time_charge && invoicePreview.one_time_charge > 0) {
-    expect(queryByTestId('sub-update-prorated-upgrade')).toBeInTheDocument();
-    expect(queryByTestId('prorated-amount')).toBeInTheDocument();
+  if (!!invoicePreview.one_time_charge) {
+    if (invoicePreview.one_time_charge > 0) {
+      expect(queryByTestId('sub-update-prorated-upgrade')).toBeInTheDocument();
+      expect(queryByTestId('prorated-amount')).toBeInTheDocument();
+      expect(
+        queryByTestId('sub-update-prorated-upgrade-credit')
+      ).not.toBeInTheDocument();
+    } else if (invoicePreview.one_time_charge < 0) {
+      expect(queryByTestId('sub-update-prorated-upgrade')).toBeInTheDocument();
+      expect(queryByTestId('prorated-amount')).toBeInTheDocument();
+      expect(
+        queryByTestId('sub-update-prorated-upgrade-credit')
+      ).toBeInTheDocument();
+    } else {
+      expect(
+        queryByTestId('sub-update-prorated-upgrade')
+      ).not.toBeInTheDocument();
+      expect(
+        queryByTestId('sub-update-prorated-upgrade-credit')
+      ).not.toBeInTheDocument();
+      expect(queryByTestId('prorated-amount')).not.toBeInTheDocument();
+    }
   } else {
     expect(
       queryByTestId('sub-update-prorated-upgrade')
+    ).not.toBeInTheDocument();
+    expect(
+      queryByTestId('sub-update-prorated-upgrade-credit')
     ).not.toBeInTheDocument();
     expect(queryByTestId('prorated-amount')).not.toBeInTheDocument();
   }

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -89,11 +89,11 @@ describe('CancelSubscriptionPanel', () => {
             <CancelSubscriptionPanel {...props} />
           );
 
-          const planPrice = formatPlanPricing(
+          const planPrice = formatPriceAmount(
             props.invoice.total,
             props.plan.currency,
-            props.plan.interval,
-            props.plan.interval_count
+            false,
+            0
           );
           const nextBillDate = getLocalizedDateString(
             props.subsequentInvoice.period_start,
@@ -305,7 +305,7 @@ describe('CancelSubscriptionPanel', () => {
             />
           </LocalizationProvider>
         );
-        expect(queryByText('$20.00 fooly')).toBeInTheDocument();
+        expect(queryByText('$20.00')).toBeInTheDocument();
         expect(queryByText('quuz 13/09/2019')).toBeInTheDocument();
         expect(queryByText('blee')).toBeInTheDocument();
       });
@@ -313,9 +313,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing info with interval > 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-no-tax-day = { $intervalCount ->
-            [one] { $priceAmount } fooly
-            *[other] { $priceAmount } barly { $intervalCount } 24hrs
+          `price-details-no-tax = { $intervalCount ->
+            [one] { $priceAmount }
+            *[other] { $priceAmount }
           }`,
         ].forEach((x) => bundle.addResource(new FluentResource(x)));
         const plan = { ...findMockPlan('plan_daily'), interval_count: 8 };
@@ -325,15 +325,15 @@ describe('CancelSubscriptionPanel', () => {
             <CancelSubscriptionPanel {...baseProps} plan={plan} />
           </LocalizationProvider>
         );
-        expect(queryByText('$20.00 barly 8 24hrs')).toBeInTheDocument();
+        expect(queryByText('$20.00')).toBeInTheDocument();
       });
 
       it('displays the correct pricing and exclusive tax info with interval of 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-tax-day = { $intervalCount ->
-            [one] { $priceAmount } + { $taxAmount } tax fooly
-            *[other] { $priceAmount } + { $taxAmount } tax barly { $intervalCount } 24hrs
+          `price-details-tax = { $intervalCount ->
+            [one] { $priceAmount } + { $taxAmount } tax
+            *[other] { $priceAmount } + { $taxAmount } tax
           }`,
           'payment-cancel-btn = blee',
           `price-details-tax = { $priceAmount } + { $taxAmount } taxes`,
@@ -354,7 +354,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 + $3.00 tax fooly'
+          '$20.00 + $3.00 tax'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $5.00 + $1.23 taxes is due 13/09/2019'
@@ -365,9 +365,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing and exclusive tax info with interval > 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-tax-day = { $intervalCount ->
-            [one] { $priceAmount } + { $taxAmount } tax fooly
-            *[other] { $priceAmount } + { $taxAmount } tax barly { $intervalCount } 24hrs
+          `price-details-tax = { $intervalCount ->
+            [one] { $priceAmount } + { $taxAmount } tax
+            *[other] { $priceAmount } + { $taxAmount } tax
           }`,
           `price-details-tax = { $priceAmount } + { $taxAmount } taxes`,
           `sub-next-bill-tax-1 = Next bill of { $priceAmount } + { $taxAmount } taxes is due { $date }`,
@@ -385,7 +385,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 + $3.00 tax barly 8 24hrs'
+          '$20.00 + $3.00 tax'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $5.00 + $1.23 taxes is due 14/08/2019'
@@ -395,9 +395,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing and exclusive tax with discount info with interval > 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-tax-day = { $intervalCount ->
-            [one] { $priceAmount } + { $taxAmount } tax fooly
-            *[other] { $priceAmount } + { $taxAmount } tax barly { $intervalCount } 24hrs
+          `price-details-tax = { $intervalCount ->
+            [one] { $priceAmount } + { $taxAmount } tax
+            *[other] { $priceAmount } + { $taxAmount } tax
           }`,
           `sub-next-bill-tax-1 = Next bill of { $priceAmount } + { $taxAmount } taxes is due { $date }`,
         ].forEach((x) => bundle.addResource(new FluentResource(x)));
@@ -414,7 +414,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$19.50 + $3.00 tax barly 8 24hrs'
+          '$19.50 + $3.00 tax'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $4.50 + $1.23 taxes is due 14/08/2019'
@@ -424,9 +424,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing and hides tax for zero tax amount', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-tax-day = { $intervalCount ->
-            [one] { $priceAmount } + { $taxAmount } tax fooly
-            *[other] { $priceAmount } + { $taxAmount } tax barly { $intervalCount } 24hrs
+          `price-details-tax = { $intervalCount ->
+            [one] { $priceAmount } + { $taxAmount } tax
+            *[other] { $priceAmount } + { $taxAmount } tax
           }`,
           'payment-cancel-btn = blee',
           `price-details-tax = { $priceAmount } + { $taxAmount } taxes`,
@@ -448,7 +448,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 daily'
+          '$20.00'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $5.00 prices is due 13/09/2019'
@@ -459,9 +459,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing and inclusive tax info with interval of 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-no-tax-day = { $intervalCount ->
-            [one] { $priceAmount } fooly
-            *[other] { $priceAmount } barly { $intervalCount } 24hrs
+          `price-details-no-tax = { $intervalCount ->
+            [one] { $priceAmount }
+            *[other] { $priceAmount }
           }`,
           'payment-cancel-btn = blee',
           `sub-next-bill-no-tax-1 = Next bill of { $priceAmount } prices is due { $date }`,
@@ -481,7 +481,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 fooly'
+          '$20.00'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $5.00 prices is due 13/09/2019'
@@ -492,9 +492,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing and inclusive tax info with interval > 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-no-tax-day = { $intervalCount ->
-            [one] { $priceAmount } fooly
-            *[other] { $priceAmount } barly { $intervalCount } 24hrs
+          `price-details-no-tax = { $intervalCount ->
+            [one] { $priceAmount }
+            *[other] { $priceAmount }
           }`,
           `sub-next-bill-no-tax-1 = Next bill of { $priceAmount } prices is due { $date }`,
         ].forEach((x) => bundle.addResource(new FluentResource(x)));
@@ -511,7 +511,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$20.00 barly 8 24hrs'
+          '$20.00'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $5.00 prices is due 14/08/2019'
@@ -521,9 +521,9 @@ describe('CancelSubscriptionPanel', () => {
       it('displays the correct pricing and inclusive tax with discount info with interval > 1', () => {
         const bundle = new FluentBundle('gd', { useIsolating: false });
         [
-          `price-details-no-tax-day = { $intervalCount ->
-            [one] { $priceAmount } fooly
-            *[other] { $priceAmount } barly { $intervalCount } 24hrs
+          `price-details-no-tax = { $intervalCount ->
+            [one] { $priceAmount }
+            *[other] { $priceAmount }
           }`,
           `sub-next-bill-no-tax-1 = Next bill of { $priceAmount } prices is due { $date }`,
         ].forEach((x) => bundle.addResource(new FluentResource(x)));
@@ -540,7 +540,7 @@ describe('CancelSubscriptionPanel', () => {
           </LocalizationProvider>
         );
         expect(queryByTestId('price-details-standalone')).toHaveTextContent(
-          '$19.50 barly 8 24hrs'
+          '$19.50'
         );
         expect(queryByTestId('sub-next-bill')).toHaveTextContent(
           'Next bill of $4.50 prices is due 14/08/2019'

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -226,8 +226,6 @@ const CancelSubscriptionPanel = ({
                               tax={intervalPriceDetailsData.taxAmount}
                               showTax={intervalPriceDetailsData.showInvoiceTax}
                               currency={invoiceCurrency}
-                              interval={plan.interval}
-                              intervalCount={plan.interval_count}
                               className="font-semibold mb-2"
                               dataTestId="price-details-standalone"
                             />
@@ -241,24 +239,53 @@ const CancelSubscriptionPanel = ({
                             tax={intervalPriceDetailsData.taxAmount}
                             showTax={intervalPriceDetailsData.showInvoiceTax}
                             currency={invoiceCurrency}
-                            interval={plan.interval}
-                            intervalCount={plan.interval_count}
                             className="font-semibold mb-2"
                             dataTestId="price-details-standalone"
                           />
                         </span>
                       </Localized>
-                    ) : (
+                    ) : intervalPriceDetailsData.invoiceDisplayTotal >= 0 ? (
                       <PriceDetails
                         total={intervalPriceDetailsData.invoiceDisplayTotal}
                         tax={intervalPriceDetailsData.taxAmount}
                         showTax={intervalPriceDetailsData.showInvoiceTax}
                         currency={invoiceCurrency}
-                        interval={plan.interval}
-                        intervalCount={plan.interval_count}
                         className="font-semibold mb-2"
                         dataTestId="price-details-standalone"
                       />
+                    ) : (
+                      <Localized
+                        id="subscription-management-account-credit-balance"
+                        elems={{
+                          priceDetails: (
+                            <PriceDetails
+                              total={
+                                intervalPriceDetailsData.invoiceDisplayTotal
+                              }
+                              tax={intervalPriceDetailsData.taxAmount}
+                              showTax={intervalPriceDetailsData.showInvoiceTax}
+                              currency={invoiceCurrency}
+                              className="font-semibold mb-2"
+                              dataTestId="price-details-standalone"
+                            />
+                          ),
+                        }}
+                      >
+                        <span>
+                          This subscription payment resulted in a credit to your
+                          account balance:{' '}
+                          <PriceDetails
+                            total={Math.abs(
+                              intervalPriceDetailsData.invoiceDisplayTotal
+                            )}
+                            tax={intervalPriceDetailsData.taxAmount}
+                            showTax={intervalPriceDetailsData.showInvoiceTax}
+                            currency={invoiceCurrency}
+                            className="font-semibold mb-2"
+                            dataTestId="price-details-standalone"
+                          />
+                        </span>
+                      </Localized>
                     )}
                   </div>
                   <Localized id={nextBillL10nId} vars={nextBillL10nVars}>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/en.ftl
@@ -24,3 +24,5 @@ sub-item-cancel-confirm =
 # Cybersecurity Awareness Month 2023 coupon applied: $11.20 + $0.35 tax
 # Summer Promo VPN coupon applied: $11.20
 sub-promo-coupon-applied = { $promotion_name } coupon applied: <priceDetails></priceDetails>
+
+subscription-management-account-credit-balance = This subscription payment resulted in a credit to your account balance: <priceDetails></priceDetails>


### PR DESCRIPTION
## This pull request

- revises Subscription Management page to remove interval and add credit messaging
- revises Upgrade page to add credit messaging in both 2.0 and 3.0

## Issue that this pull request solves

Closes: FXA-11634

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
### Upgrade page 3.0
**Credit**
<img width="948" alt="Screenshot 2025-05-13 at 12 46 45 PM" src="https://github.com/user-attachments/assets/a94d2a88-fefe-4c1a-9915-2a2288feb841" />

**Prorated**
<img width="939" alt="Screenshot 2025-05-13 at 12 35 36 PM" src="https://github.com/user-attachments/assets/f86d75e2-8d82-4945-84fd-4e9bcc28bd4e" />

**Zero - No additional cost/credit**
<img width="1095" alt="Screenshot 2025-05-13 at 1 07 23 PM" src="https://github.com/user-attachments/assets/dabaae60-e9cd-4c6b-89fd-a743fd89e131" />

### Upgrade page 2.0
**Credit**
<img width="1056" alt="Screenshot 2025-05-13 at 12 34 27 PM" src="https://github.com/user-attachments/assets/ef857130-d0a2-4ec0-965d-747cb9d4beb5" />

**Prorated**
<img width="1060" alt="Screenshot 2025-05-13 at 12 33 54 PM" src="https://github.com/user-attachments/assets/a660bcca-2665-4e59-902c-7f61db1afc5d" />

**Zero - No additional cost/credit**
<img width="1056" alt="Screenshot 2025-05-13 at 12 34 10 PM" src="https://github.com/user-attachments/assets/d520c73c-3be9-4c1c-8a76-f7852633b5ed" />

### Subscription Management page
<img width="660" alt="Screenshot 2025-05-13 at 12 59 48 PM" src="https://github.com/user-attachments/assets/7c85d514-d1be-43fd-a69d-47ef5e637d15" />
