### PR TITLE
feat(payments-next): add metrics for each server action, better tagging

### DIFF
--- a/libs/payments/cart/src/lib/cart.manager.in.spec.ts
+++ b/libs/payments/cart/src/lib/cart.manager.in.spec.ts
@@ -27,6 +27,7 @@ import {
 } from './cart.factories';
 import { CartManager } from './cart.manager';
 import { ResultCart } from './cart.types';
+import { type StatsD } from '@fxa/shared/metrics/statsd';
 
 // Fail action, which sometimes isn't here due to a weird issue defined here:
 // https://github.com/jestjs/jest/issues/11698#issuecomment-922351139
@@ -57,7 +58,9 @@ describe('CartManager', () => {
 
   beforeAll(async () => {
     db = await testAccountDatabaseSetup(['accounts', 'carts']);
-    cartManager = new CartManager(db);
+    cartManager = new CartManager(db, {
+      timing: jest.fn(),
+    } as unknown as StatsD);
     await db
       .insertInto('carts')
       .values({

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -146,6 +146,10 @@ export class CartService {
 
       const errorReasonId = resolveErrorInstance(error);
 
+      this.statsd.increment('checkout_failure_unexpected', {
+        errorReasonId,
+      });
+
       try {
         await this.cartManager.finishErrorCart(cartId, {
           errorReasonId,

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.spec.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.spec.ts
@@ -5,6 +5,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SanitizeExceptions } from './sanitizeExceptionsDecorator';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 
 // Mock Sentry
 jest.mock('@sentry/nextjs', () => ({
@@ -67,6 +68,7 @@ describe('SanitizeExceptions Decorator', () => {
           provide: LOGGER_PROVIDER,
           useValue: mockLogger,
         },
+        MockStatsDProvider
       ],
     }).compile();
 

--- a/libs/shared/metrics/statsd/src/lib/statsd.decorator.spec.ts
+++ b/libs/shared/metrics/statsd/src/lib/statsd.decorator.spec.ts
@@ -48,7 +48,7 @@ describe('CaptureTimingWithStatsD', () => {
 
   it('should call statsd.timing for synchronous methods', () => {
     instance.syncMethod();
-    expect(mockStatsD.timing).toHaveBeenCalledTimes(1);
+    expect(mockStatsD.timing).toHaveBeenCalledTimes(2);
     expect(mockStatsD.timing).toHaveBeenCalledWith(
       'TestClass_syncMethod',
       expect.any(Number),
@@ -60,7 +60,7 @@ describe('CaptureTimingWithStatsD', () => {
 
   it('should call statsd.timing for asynchronous methods', async () => {
     await instance.asyncMethod();
-    expect(mockStatsD.timing).toHaveBeenCalledTimes(1);
+    expect(mockStatsD.timing).toHaveBeenCalledTimes(2);
     expect(mockStatsD.timing).toHaveBeenCalledWith(
       'TestClass_asyncMethod',
       expect.any(Number),

--- a/libs/shared/metrics/statsd/src/lib/statsd.decorator.ts
+++ b/libs/shared/metrics/statsd/src/lib/statsd.decorator.ts
@@ -27,6 +27,10 @@ export function CaptureTimingWithStatsD<
           sourceClass: this.constructor.name,
           ...options?.tags,
         });
+        this.statsd.timing(this.constructor.name, elapsed, {
+          methodName: key,
+          ...options?.tags,
+        });
       };
       const handler = options?.handle || defaultHandler;
 


### PR DESCRIPTION
## Because

- We want to see metrics for each server action

## This pull request

- Adds a statsd counter for each server action

## Issue that this pull request solves

Closes FXA-11593
Closes FXA-11578