### PR TITLE
chore(content): Make content-server watch files

### DIFF
--- a/packages/fxa-content-server/pm2.config.js
+++ b/packages/fxa-content-server/pm2.config.js
@@ -13,6 +13,7 @@ apps.push({
   name: 'content',
   script: 'node --inspect=9130 server/bin/fxa-content-server.js',
   cwd: __dirname,
+  watch: ['server/**/*.js', 'server/**/*.html', 'server/**/*.json'],
   env: {
     NODE_ENV: 'development',
     NODE_OPTIONS: '--openssl-legacy-provider --dns-result-order=ipv4first',


### PR DESCRIPTION
## Because

- Content server wouldn't restart on changes, and this could catch developers off guard.

## This pull request

- Adds pm2 watch config for content server

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
