### PR TITLE
Support rate limit allow lists

### DIFF
--- a/libs/accounts/rate-limit/README.md
+++ b/libs/accounts/rate-limit/README.md
@@ -34,3 +34,18 @@ would replicate the pre-existing behavior:
    passwordForgotVerifyOtp    : email    : 10 attempts  : 24 hours       : 24 hours
 
 ```
+
+### Testing & Development Considerations
+
+When developing new features, running functional test suites locally, or running smoke tests remotely, rate-limiting behavior can be annoying — or even downright disruptive. To work around this, there are a few options:
+
+#### Disable the rules:
+You can simply remove the rate-limiting rules. Our servers typically hold the rules as a string in the environment, e.g., RATE_LIMIT__RULES=['some','rules']. Override this value with an empty string, and rate limiting will effectively be disabled. Want to test a single rate limit? Just specify that one rule. It doesn’t get much simpler than that.
+
+#### Exclude specific attributes like ip, email, or UID
+When running smoke tests against a remote server, the first approach may not work — so we also support excluding specific emails, user IDs (UIDs), or IP addresses from being checked by the rate limiter. To do this, define these values in your server's config file and pass them to the rate limiter.
+
+ - Email ignore values can use regex filters.
+ - IP addresses and UIDs must be exact string matches.
+
+Ideally, the IP filter should be used. This is the preferred method because all requests contain an IP address, making it the lowest common denominator for rate-limiting attributes. Other advantages of using the IP filter include its consistency and ease of configuration.

--- a/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
@@ -24,7 +24,7 @@ describe('rate-limit', () => {
 
   beforeEach(async () => {
     await redis.flushall();
-    rateLimit = new RateLimit({}, redis, statsd);
+    rateLimit = new RateLimit({ rules: {} }, redis, statsd);
     mockIncrement.mockReset();
   });
 
@@ -35,7 +35,7 @@ describe('rate-limit', () => {
   for (const blockOn of ['ip', 'email', 'uid']) {
     it('should block on ' + blockOn, async () => {
       rateLimit = new RateLimit(
-        parseConfigRules(['testBlock:ip:1:1s:1s']),
+        { rules: parseConfigRules(['testBlock:ip:1:1s:1s']) },
         redis,
         statsd
       );
@@ -57,7 +57,7 @@ describe('rate-limit', () => {
 
   it(`should not block after window clears`, async () => {
     rateLimit = new RateLimit(
-      parseConfigRules(['testWindowCleared:ip:1:1s:1s']),
+      { rules: parseConfigRules(['testWindowCleared:ip:1:1s:1s']) },
       redis,
       statsd
     );
@@ -76,7 +76,12 @@ describe('rate-limit', () => {
 
   it('can block multiple rules on a single action', async () => {
     rateLimit = new RateLimit(
-      parseConfigRules(['testMulti:ip:2:10s:2s', 'testMulti:email:2:10s:3s']),
+      {
+        rules: parseConfigRules([
+          'testMulti:ip:2:10s:2s',
+          'testMulti:email:2:10s:3s',
+        ]),
+      },
       redis,
       statsd
     );
@@ -120,10 +125,12 @@ describe('rate-limit', () => {
 
   it('can block a doubled up rule', async () => {
     rateLimit = new RateLimit(
-      parseConfigRules([
-        'testDouble:email:2:10s:2s',
-        'testDouble:email:3:10s:4s',
-      ]),
+      {
+        rules: parseConfigRules([
+          'testDouble:email:2:10s:2s',
+          'testDouble:email:3:10s:4s',
+        ]),
+      },
       redis,
       statsd
     );
@@ -153,7 +160,9 @@ describe('rate-limit', () => {
      * Note that once the ban kicks in the window disappears. So despite
      */
     rateLimit = new RateLimit(
-      parseConfigRules(['test:ip:1:20s:1s']),
+      {
+        rules: parseConfigRules(['test:ip:1:20s:1s']),
+      },
       redis,
       statsd
     );
@@ -174,7 +183,9 @@ describe('rate-limit', () => {
 
   it('can unblock', async () => {
     rateLimit = new RateLimit(
-      parseConfigRules(['testBlock:ip:1:1s:1s']),
+      {
+        rules: parseConfigRules(['testBlock:ip:1:1s:1s']),
+      },
       redis,
       statsd
     );

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -227,7 +227,16 @@ async function run(config) {
     ...config.redis,
     ...config.redis.customs,
   });
-  const rateLimit = new RateLimit(rules, rateLimitRedis, statsd);
+  const rateLimit = new RateLimit(
+    {
+      rules,
+      ignoreIPs: config.rateLimit.ignoreIPs,
+      ignoreEmails: config.rateLimit.ignoreEmails,
+      ignoreUIDs: config.rateLimit.ignoreUIDs,
+    },
+    rateLimitRedis,
+    statsd
+  );
   Container.set(RateLimit, rateLimit);
 
   // Create Recovery Phone Service

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2161,6 +2161,24 @@ const convictConf = convict({
     },
   },
   rateLimit: {
+    ignoreIPs: {
+      default: undefined,
+      doc: 'Set of IPs to ignore while rate limiting. Rules will not apply to these values.',
+      env: 'RATE_LIMIT__IGNORE_IPS',
+      format: Array,
+    },
+    ignoreUIDs: {
+      default: undefined,
+      doc: 'Set of UIDs to ignore while rate limiting. Rules will not apply to these values.',
+      env: 'RATE_LIMIT__IGNORE_UIDS',
+      format: Array,
+    },
+    ignoreEmails: {
+      default: undefined,
+      doc: 'Set of emails to ignore while rate limiting. Rules will not apply to these values. Values can be a string or parsable regex.',
+      env: 'RATE_LIMIT__IGNORE_EMAILS',
+      format: Array,
+    },
     rules: {
       default: [
         'unblockEmail          : email  : 10   : 24 hours    : 24 hours    ',

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -306,6 +306,18 @@ class CustomsClient {
       return false;
     }
 
+    // The config can specify that certain ips, emails, or uids should be excluded
+    // from rate limit checks.
+    const skip = this.rateLimit.skip(opts);
+    if (skip) {
+      this.statsd.increment(`${serviceName}.check.v2.skip`, [
+        opts.ip ? 'ip':'',
+        opts.email ? 'email':'',
+        opts.uid ? 'uid':'',
+      ]);
+      return true;
+    }
+
     // Otherwise, call the new nx lib instead of the legacy service
     this.statsd?.increment(`${serviceName}.check.v2`, [`action:${action}`]);
     const result = await this.rateLimit.check(action, opts);


### PR DESCRIPTION
## Because

- We want the ability to skip customs checks for certain emails, ips, or uids.
- This was supported in the previous version of customs, and useful for development or smoke testing.

## This pull request

- Adds ability to configure and ignore certain ips, email, uids
- Wires this up in auth-server

## Issue that this pull request solves

Closes: FXA-11663

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
