### PR TITLE
feat(next): upgrade shows incorrect interval

### DIFF
--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -2,14 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { TaxAddress } from '@fxa/payments/customer';
+import { TaxAddress, type SubplatInterval } from '@fxa/payments/customer';
 import {
   Cart,
   CartEligibilityStatus,
   CartErrorReasonId,
   CartState,
 } from '@fxa/shared/db/mysql/account';
-import { StripePrice } from '@fxa/payments/stripe';
 import Stripe from 'stripe';
 
 export type CheckoutCustomerData = {
@@ -64,8 +63,8 @@ export type ResultCart = Readonly<Omit<Cart, 'id' | 'uid'>> & {
 
 export type FromPrice = {
   currency: string;
-  interval: NonNullable<StripePrice['recurring']>['interval'];
-  listAmount: number;
+  interval: SubplatInterval;
+  unitAmount: number;
 };
 
 export type BaseCartDTO = Omit<ResultCart, 'state'> & {

--- a/libs/payments/customer/src/index.ts
+++ b/libs/payments/customer/src/index.ts
@@ -13,6 +13,7 @@ export * from './lib/product.manager';
 export * from './lib/promotionCode.manager';
 export * from './lib/subscription.manager';
 export * from './lib/types';
+export * from './lib/factories/pricing-for-currency.factory';
 export * from './lib/factories/tax-address.factory';
 export * from './lib/error';
 export * from './lib/util/stripeInvoiceToFirstInvoicePreviewDTO';

--- a/libs/payments/customer/src/lib/error.ts
+++ b/libs/payments/customer/src/lib/error.ts
@@ -28,6 +28,12 @@ export class PlanIntervalMultiplePlansError extends PaymentsCustomerError {
   }
 }
 
+export class PriceForCurrencyNotFoundError extends PaymentsCustomerError {
+  constructor(priceId: string, currency: string) {
+    super('Price for currency not found', { info: { priceId, currency } });
+  }
+}
+
 export class PromotionCodeCouldNotBeAttachedError extends PaymentsCustomerError {
   customerId?: string;
   subscriptionId?: string;

--- a/libs/payments/customer/src/lib/factories/pricing-for-currency.factory.ts
+++ b/libs/payments/customer/src/lib/factories/pricing-for-currency.factory.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { type PricingForCurrency } from '../types';
+import { StripePriceFactory } from '@fxa/payments/stripe';
+
+export const PricingForCurrencyFactory = (
+  override?: Partial<PricingForCurrency>
+): PricingForCurrency => {
+  const price = override?.price || StripePriceFactory();
+  return {
+    price,
+    unitAmountForCurrency: price.unit_amount,
+    currencyOptionForCurrency: price.currency_options[0],
+    ...override,
+  }
+};
+

--- a/libs/payments/customer/src/lib/subscription.manager.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.ts
@@ -16,7 +16,7 @@ import { InvalidPaymentIntentError, PaymentIntentNotFoundError } from './error';
 
 @Injectable()
 export class SubscriptionManager {
-  constructor(private stripeClient: StripeClient) {}
+  constructor(private stripeClient: StripeClient) { }
 
   async cancel(
     subscriptionId: string,

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { StripePrice } from '@fxa/payments/stripe';
+import { Stripe } from 'stripe';
 
 export type InvoicePreview = {
   currency: string;
@@ -22,6 +23,12 @@ export type InvoicePreview = {
 export interface Interval {
   interval: NonNullable<StripePrice['recurring']>['interval'];
   intervalCount: number;
+}
+
+export interface PricingForCurrency {
+  price: StripePrice,
+  unitAmountForCurrency: number | null;
+  currencyOptionForCurrency: Stripe.Price.CurrencyOptions;
 }
 
 export interface TaxAmount {

--- a/libs/payments/customer/src/lib/util/determinePriceUnitAmount.spec.ts
+++ b/libs/payments/customer/src/lib/util/determinePriceUnitAmount.spec.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StripePriceFactory } from "@fxa/payments/stripe"
+import { StripePriceCurrencyOptionFactory } from "libs/payments/stripe/src/lib/factories/price.factory"
+import { determinePriceUnitAmount } from "./determinePriceUnitAmount"
+
+describe('determinePriceUnitAmount', () => {
+  describe('When passed a StripePrice', () => {
+    const mockPriceWithUnitAmount = StripePriceFactory({
+      unit_amount: 1000,
+      unit_amount_decimal: '1000.00'
+    })
+    const mockPriceWithUnitAmountDecimal = StripePriceFactory({
+      unit_amount_decimal: '1000.31',
+      unit_amount: null
+    })
+
+    it('returns unit_amount when unit_amount is present', () => {
+      expect(determinePriceUnitAmount(mockPriceWithUnitAmount)).toEqual(1000);
+    })
+
+    it('returns unit_amount_decimal when unit_amount is not present', () => {
+      expect(determinePriceUnitAmount(mockPriceWithUnitAmountDecimal)).toEqual(1000);
+    })
+  })
+
+  describe('When passed a Stripe.Price.CurrencyOption', () => {
+    const mockCurrencyOptionWithUnitAmount = StripePriceCurrencyOptionFactory({
+      unit_amount: 1000,
+      unit_amount_decimal: '1000.00'
+    })
+    const mockCurrencyOptionWithUnitAmountDecimal = StripePriceCurrencyOptionFactory({
+      unit_amount: null,
+      unit_amount_decimal: '1000.31'
+    })
+
+    it('returns unit_amount when unit_amount is present', () => {
+      expect(determinePriceUnitAmount(mockCurrencyOptionWithUnitAmount)).toEqual(1000);
+    })
+
+    it('returns unit_amount_decimal when unit_amount is not present', () => {
+      expect(determinePriceUnitAmount(mockCurrencyOptionWithUnitAmountDecimal)).toEqual(1000);
+    })
+  })
+})

--- a/libs/payments/customer/src/lib/util/determinePriceUnitAmount.ts
+++ b/libs/payments/customer/src/lib/util/determinePriceUnitAmount.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { StripePrice } from "@fxa/payments/stripe";
+import { Stripe } from "stripe";
+
+/**
+ * Returns the unit amount in cents
+ * Note, decimal places in unit_amount_decimal are not supported
+ * and only unit amounts in cents will be returned.
+ */
+export function determinePriceUnitAmount({ unit_amount, unit_amount_decimal }: StripePrice | Stripe.Price.CurrencyOptions) {
+  return (!unit_amount && unit_amount_decimal) ? parseInt(unit_amount_decimal) : unit_amount;
+}

--- a/libs/payments/eligibility/src/lib/eligibility.service.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.service.ts
@@ -27,7 +27,7 @@ export class EligibilityService {
     private subscriptionManager: SubscriptionManager,
     private googleIapPurchaseManager: GoogleIapPurchaseManager,
     private appleIapPurchaseManager: AppleIapPurchaseManager
-  ) {}
+  ) { }
 
   /**
    * Checks if user is eligible to subscribe to price
@@ -122,8 +122,8 @@ export class EligibilityService {
 
     const isSanctionedLocation = countryCode
       ? this.locationConfig.subscriptionsUnsupportedLocations.includes(
-          countryCode
-        )
+        countryCode
+      )
       : undefined;
 
     const isSupportedLocation = countryCode

--- a/libs/payments/stripe/src/lib/factories/price.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/price.factory.ts
@@ -4,31 +4,53 @@
 
 import { faker } from '@faker-js/faker';
 import { StripePrice } from '../stripe.client.types';
+import { Stripe } from 'stripe';
 
-export const StripePriceFactory = (
-  override?: Partial<StripePrice>
-): StripePrice => ({
-  id: `price_${faker.string.alphanumeric({ length: 24 })}`,
-  object: 'price',
-  active: true,
-  billing_scheme: 'per_unit',
-  created: faker.number.int(),
-  currency: faker.finance.currencyCode(),
+export const StripePriceCurrencyOptionFactory = (
+  override?: Partial<Stripe.Price.CurrencyOptions>
+): Stripe.Price.CurrencyOptions => ({
   custom_unit_amount: null,
-  livemode: false,
-  lookup_key: null,
-  metadata: {},
-  nickname: null,
-  product: `prod_${faker.string.alphanumeric({ length: 14 })}`,
-  recurring: StripePriceRecurringFactory(),
   tax_behavior: 'exclusive',
-  tiers_mode: null,
-  transform_quantity: null,
-  type: 'recurring',
   unit_amount: faker.number.int({ max: 1000 }),
   unit_amount_decimal: faker.commerce.price({ min: 1000 }),
   ...override,
-});
+})
+
+export const StripePriceFactory = (
+  override?: Partial<StripePrice>
+): StripePrice => {
+  const currency = override?.currency || faker.finance.currencyCode().toLowerCase();
+  const unit_amount = override?.unit_amount || faker.number.int({ max: 1000 });
+  const unit_amount_decimal = override?.unit_amount_decimal || faker.commerce.price({ min: 1000 });
+  return {
+    id: `price_${faker.string.alphanumeric({ length: 24 })}`,
+    object: 'price',
+    active: true,
+    billing_scheme: 'per_unit',
+    created: faker.number.int(),
+    currency,
+    currency_options: {
+      [currency]: StripePriceCurrencyOptionFactory({
+        unit_amount,
+        unit_amount_decimal,
+      }),
+    },
+    custom_unit_amount: null,
+    livemode: false,
+    lookup_key: null,
+    metadata: {},
+    nickname: null,
+    product: `prod_${faker.string.alphanumeric({ length: 14 })}`,
+    recurring: StripePriceRecurringFactory(),
+    tax_behavior: 'exclusive',
+    tiers_mode: null,
+    transform_quantity: null,
+    type: 'recurring',
+    unit_amount,
+    unit_amount_decimal,
+    ...override,
+  }
+}
 
 export const StripePriceRecurringFactory = (
   override?: Partial<StripePrice['recurring']>

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -336,7 +336,7 @@ export class StripeClient {
   async pricesRetrieve(id: string, params?: Stripe.PriceRetrieveParams) {
     const result = await this.stripe.prices.retrieve(id, {
       ...params,
-      expand: undefined,
+      expand: ['currency_options'],
     });
     return result as StripeResponse<StripePrice>;
   }

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -17,37 +17,37 @@ type NegotiateExpanded<
     StripeObj,
     UnexpandedProperties
   >]: StripeObj[key] extends Array<any> // Stripe types can be in the form of Array<Stripe.XYZ | string | null>
-    ? // Extract and return type Array<string | null> out of Array<Stripe.XYZ | string | null>
-      Array<Extract<StripeObj[key][0], string | null | undefined>>
-    : // Stripe types can be in the form of (Array<Stripe.XYZ | string | null> | null)
-      StripeObj[key] extends Array<any> | null
-      ? // Extract and return type (Array<string | null> | null) out of (Array<Stripe.XYZ | string | null> | null)
-        Array<
-          Extract<NonNullable<StripeObj[key]>[0], string | null | undefined>
-        > | null
-      : // Extract and return type (string | null) out of (Stripe.XYZ | string | null)
-        Extract<StripeObj[key], string | null | undefined>;
+  ? // Extract and return type Array<string | null> out of Array<Stripe.XYZ | string | null>
+  Array<Extract<StripeObj[key][0], string | null | undefined>>
+  : // Stripe types can be in the form of (Array<Stripe.XYZ | string | null> | null)
+  StripeObj[key] extends Array<any> | null
+  ? // Extract and return type (Array<string | null> | null) out of (Array<Stripe.XYZ | string | null> | null)
+  Array<
+    Extract<NonNullable<StripeObj[key]>[0], string | null | undefined>
+  > | null
+  : // Extract and return type (string | null) out of (Stripe.XYZ | string | null)
+  Extract<StripeObj[key], string | null | undefined>;
 } & {
-  // For specified unexpanded properties
-  [key in keyof Pick<
-    StripeObj,
-    ExpandedProperties
-  >]-?: StripeObj[key] extends Array<any> // Stripe types can be in the form of Array<Stripe.XYZ | string | null>
+    // For specified unexpanded properties
+    [key in keyof Pick<
+      StripeObj,
+      ExpandedProperties
+    >]-?: StripeObj[key] extends Array<any> // Stripe types can be in the form of Array<Stripe.XYZ | string | null>
     ? // Extract and return type Array<Stripe.XYZ | null> out of Array<Stripe.XYZ | string | null>
-      Array<Exclude<StripeObj[key][0], string>>
+    Array<Exclude<StripeObj[key][0], string>>
     : // Stripe types can be in the form of (Array<Stripe.XYZ | string | null> | null)
-      StripeObj[key] extends Array<any> | null
-      ? // Extract and return type (Array<Stripe.XYZ | null> | null) out of (Array<Stripe.XYZ | string | null> | null)
-        Array<Exclude<NonNullable<StripeObj[key]>[0], string>> | null
-      : // Extract and return type (Stripe.XYZ | null) out of (Stripe.XYZ | string | null)
-        Exclude<StripeObj[key], string>;
-} & {
-  // All other unspecified properties return their original typing
-  [key in keyof Omit<
-    StripeObj,
-    UnexpandedProperties | ExpandedProperties
-  >]: StripeObj[key];
-};
+    StripeObj[key] extends Array<any> | null
+    ? // Extract and return type (Array<Stripe.XYZ | null> | null) out of (Array<Stripe.XYZ | string | null> | null)
+    Array<Exclude<NonNullable<StripeObj[key]>[0], string>> | null
+    : // Extract and return type (Stripe.XYZ | null) out of (Stripe.XYZ | string | null)
+    Exclude<StripeObj[key], string>;
+  } & {
+    // All other unspecified properties return their original typing
+    [key in keyof Omit<
+      StripeObj,
+      UnexpandedProperties | ExpandedProperties
+    >]: StripeObj[key];
+  };
 
 /**
  * Replaces some properties nested inside of an object, overriding anything in the first argument with values from the second, if provided.
@@ -272,9 +272,9 @@ export type StripePlan = NegotiateExpanded<
  * Stripe.Price with expanded fields removed
  */
 export type StripePrice = NegotiateExpanded<
-  never,
+  'currency_options',
   Stripe.Price,
-  'product' | 'currency_options' | 'tiers'
+  'product' | 'tiers'
 >;
 
 /**

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -54,10 +54,10 @@ interface CheckoutFormProps {
     };
     paymentInfo?: {
       type:
-        | Stripe.PaymentMethod.Type
-        | 'google_iap'
-        | 'apple_iap'
-        | 'external_paypal';
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -185,12 +185,12 @@ export function CheckoutForm({
     const confirmationTokenParams: ConfirmationTokenCreateParams | undefined =
       !isSavedPaymentMethod
         ? {
-            payment_method_data: {
-              billing_details: {
-                name: fullName,
-              },
+          payment_method_data: {
+            billing_details: {
+              name: fullName,
             },
-          }
+          },
+        }
         : undefined;
 
     // Create the ConfirmationToken using the details collected by the Payment Element

--- a/libs/payments/ui/src/lib/nestapp/validators/GetCartActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetCartActionResult.ts
@@ -92,7 +92,7 @@ class FromPriceInfo {
   interval!: string;
 
   @IsNumber()
-  listAmount!: number;
+  unitAmount!: number;
 }
 
 export class GetCartActionResult {

--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
@@ -12,7 +12,7 @@ type UpgradePurchaseDetailsProps = {
   fromPrice: {
     currency: string;
     interval: string;
-    listAmount: number;
+    unitAmount: number;
   };
   fromPurchaseDetails: {
     subtitle: string | null;
@@ -74,7 +74,7 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
           <p className="text-grey-400 mt-1 mb-0">
             <PriceInterval
               l10n={l10n}
-              amount={fromPrice.listAmount}
+              amount={fromPrice.unitAmount}
               currency={fromPrice.currency}
               interval={fromPrice.interval}
             />


### PR DESCRIPTION
## Because

- The purchase details component for upgrades shows the incorrect interval and currency amount during an upgrade.

## This pull request

- Fetches the correct price amounts for the customers currency
- Converts Stripe intervals to SubplatIntervals

## Issue that this pull request solves

Closes: #FXA-11605 #FXA-11457

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
