### PR TITLE
feat(payments-next): Improve payments-next logging

### DIFF
--- a/apps/payments/next/instrumentation.ts
+++ b/apps/payments/next/instrumentation.ts
@@ -6,7 +6,10 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('./sentry.server.config');
     const { getApp } = await import('@fxa/payments/ui/server');
+    const { monkeyPatchServerLogging } = await import('@fxa/shared/log');
 
     await getApp().initialize();
+
+    monkeyPatchServerLogging();
   }
 }

--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -22,24 +22,32 @@ export class CartError extends BaseError {
       cause,
       info,
     });
+    this.name = 'CartError';
+    Object.setPrototypeOf(this, CartError.prototype);
   }
 }
 
 export class CartNotCreatedError extends CartError {
   constructor(data: SetupCart, cause: Error) {
     super('Cart not created', data, cause);
+    this.name = 'CartNotCreatedError';
+    Object.setPrototypeOf(this, CartNotCreatedError.prototype);
   }
 }
 
 export class CartNotFoundError extends CartError {
   constructor(cartId: string, cause: Error) {
     super('Cart not found', { cartId }, cause);
+    this.name = 'CartNotFoundError';
+    Object.setPrototypeOf(this, CartNotFoundError.prototype);
   }
 }
 
 export class CartVersionMismatchError extends CartError {
   constructor(cartId: string) {
     super('Cart version mismatch', { cartId });
+    this.name = 'CartVersionMismatchError';
+    Object.setPrototypeOf(this, CartVersionMismatchError.prototype);
   }
 }
 
@@ -57,30 +65,40 @@ export class CartNotUpdatedError extends CartError {
       },
       cause
     );
+    this.name = 'CartNotUpdatedError';
+    Object.setPrototypeOf(this, CartNotUpdatedError.prototype);
   }
 }
 
 export class CartStateProcessingError extends CartError {
   constructor(cartId: string, cause: Error) {
     super('Cart state not changed to processing', { cartId }, cause);
+    this.name = 'CartStateProcessingError';
+    Object.setPrototypeOf(this, CartStateProcessingError.prototype);
   }
 }
 
 export class CartStateFinishedError extends CartError {
   constructor() {
     super('Cart state is already finished', {});
+    this.name = 'CartStateFinishedError';
+    Object.setPrototypeOf(this, CartStateFinishedError.prototype);
   }
 }
 
 export class CartNotDeletedError extends CartError {
   constructor(cartId: string, cause?: Error) {
     super('Cart not deleted', { cartId }, cause);
+    this.name = 'CartNotDeletedError';
+    Object.setPrototypeOf(this, CartNotDeletedError.prototype);
   }
 }
 
 export class CartNotRestartedError extends CartError {
   constructor(previousCartId: string, cause: Error) {
     super('Cart not created', { previousCartId }, cause);
+    this.name = 'CartNotRestartedError';
+    Object.setPrototypeOf(this, CartNotRestartedError.prototype);
   }
 }
 
@@ -91,12 +109,16 @@ export class CartInvalidStateForActionError extends CartError {
       state,
       action,
     });
+    this.name = 'CartInvalidStateForActionError';
+    Object.setPrototypeOf(this, CartInvalidStateForActionError.prototype);
   }
 }
 
 export class CartTotalMismatchError extends CartError {
   constructor(cartId: string, cartAmount: number, invoiceAmount: number) {
     super('Cart total mismatch', { cartId, cartAmount, invoiceAmount });
+    this.name = 'CartTotalMismatchError';
+    Object.setPrototypeOf(this, CartTotalMismatchError.prototype);
   }
 }
 
@@ -111,6 +133,8 @@ export class CartEligibilityMismatchError extends CartError {
       cartEligibility,
       incomingEligibility,
     });
+    this.name = 'CartEligibilityMismatchError';
+    Object.setPrototypeOf(this, CartEligibilityMismatchError.prototype);
   }
 }
 
@@ -119,6 +143,8 @@ export class CartAccountNotFoundError extends CartError {
     super('Cart account not found for uid', {
       cartId,
     });
+    this.name = 'CartAccountNotFoundError';
+    Object.setPrototypeOf(this, CartAccountNotFoundError.prototype);
   }
 }
 
@@ -127,6 +153,8 @@ export class CartUidNotFoundError extends CartError {
     super('Cart uid not found', {
       cartId,
     });
+    this.name = 'CartUidNotFoundError';
+    Object.setPrototypeOf(this, CartUidNotFoundError.prototype);
   }
 }
 
@@ -141,6 +169,8 @@ export class CartInvalidPromoCodeError extends CartError {
       undefined,
       'CartInvalidPromoCodeError'
     );
+    this.name = 'CartInvalidPromoCodeError';
+    Object.setPrototypeOf(this, CartInvalidPromoCodeError.prototype);
   }
 }
 
@@ -155,6 +185,8 @@ export class CartCurrencyNotFoundError extends CartError {
       currency,
       country,
     });
+    this.name = 'CartCurrencyNotFoundError';
+    Object.setPrototypeOf(this, CartCurrencyNotFoundError.prototype);
   }
 }
 
@@ -163,6 +195,8 @@ export class CartNoTaxAddressError extends CartError {
     super('Cart tax address not found', {
       cartId,
     });
+    this.name = 'CartNoTaxAddressError';
+    Object.setPrototypeOf(this, CartNoTaxAddressError.prototype);
   }
 }
 
@@ -171,5 +205,7 @@ export class CartSubscriptionNotFoundError extends CartError {
     super('Cart subscription not found', {
       cartId,
     });
+    this.name = 'CartSubscriptionNotFoundError';
+    Object.setPrototypeOf(this, CartSubscriptionNotFoundError.prototype);
   }
 }

--- a/libs/payments/cart/src/lib/cart.manager.ts
+++ b/libs/payments/cart/src/lib/cart.manager.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { NotFoundError } from 'objection';
 import { v4 as uuidv4 } from 'uuid';
-
+import type { LoggerService } from '@nestjs/common';
 import { AccountDbProvider, CartState } from '@fxa/shared/db/mysql/account';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 import {
   CartInvalidStateForActionError,
@@ -35,7 +35,11 @@ import type {
   CartErrorReasonId,
 } from '@fxa/shared/db/mysql/account';
 import assert from 'assert';
-import { CaptureTimingWithStatsD, StatsDService, type StatsD } from '@fxa/shared/metrics/statsd';
+import {
+  CaptureTimingWithStatsD,
+  StatsDService,
+  type StatsD,
+} from '@fxa/shared/metrics/statsd';
 // For an action to be executed, the cart state needs to be in one of
 // valid states listed in the array of CartStates below
 const ACTIONS_VALID_STATE = {
@@ -60,7 +64,8 @@ const isAction = (action: string): action is keyof typeof ACTIONS_VALID_STATE =>
 export class CartManager {
   constructor(
     @Inject(AccountDbProvider) private db: AccountDatabase,
-    @Inject(StatsDService) public statsd: StatsD
+    @Inject(StatsDService) public statsd: StatsD,
+    @Inject(Logger) private log: LoggerService
   ) {}
 
   /**
@@ -123,7 +128,7 @@ export class CartManager {
         currency: cart.currency,
       };
     } catch (error) {
-      console.log(error);
+      this.log.error(error);
       throw new CartNotCreatedError(input, error);
     }
   }
@@ -159,7 +164,7 @@ export class CartManager {
         currency: cart.currency,
       };
     } catch (error) {
-      console.log(error);
+      this.log.error(error);
       throw new CartNotCreatedError(input, error);
     }
   }

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { LoggerService } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import assert from 'assert';
@@ -51,7 +51,6 @@ import {
   CartState,
 } from '@fxa/shared/db/mysql/account';
 import { SanitizeExceptions } from '@fxa/shared/error';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
 
 import {
@@ -99,7 +98,7 @@ export class CartService {
     private customerSessionManager: CustomerSessionManager,
     private eligibilityService: EligibilityService,
     private invoiceManager: InvoiceManager,
-    @Inject(LOGGER_PROVIDER) private log: LoggerService,
+    @Inject(Logger) private log: LoggerService,
     private paymentMethodManager: PaymentMethodManager,
     private paymentIntentManager: PaymentIntentManager,
     private priceManager: PriceManager,
@@ -220,11 +219,14 @@ export class CartService {
               'checkout_failure_subscription_not_cancelled'
             );
 
-            this.log.log('checkout failed, subscription not canceled', {
-              eligibility_status: cart.eligibilityStatus,
-              offering_id: cart.offeringConfigId,
-              interval: cart.interval,
-            });
+            this.log.log(
+              'cartService.wrapWithCartCatch.subscriptionNotCancelled',
+              {
+                eligibilityStatus: cart.eligibilityStatus,
+                offeringId: cart.offeringConfigId,
+                interval: cart.interval,
+              }
+            );
           }
         }
       } catch (e) {
@@ -358,7 +360,6 @@ export class CartService {
         CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT
       );
     }
-
     return this.cartManager.createCart(createCartParams);
   }
 

--- a/libs/payments/cart/src/lib/checkout.error.ts
+++ b/libs/payments/cart/src/lib/checkout.error.ts
@@ -7,23 +7,31 @@ import { BaseError } from '@fxa/shared/error';
 export class CheckoutError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'CheckoutError';
+    Object.setPrototypeOf(this, CheckoutError.prototype);
   }
 }
 
 export class CheckoutPaymentError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'CheckoutPaymentError';
+    Object.setPrototypeOf(this, CheckoutPaymentError.prototype);
   }
 }
 
 export class CheckoutFailedError extends CheckoutError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'CheckoutFailedError';
+    Object.setPrototypeOf(this, CheckoutFailedError.prototype);
   }
 }
 
 export class CheckoutUpgradeError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'CheckoutUpgradeError';
+    Object.setPrototypeOf(this, CheckoutUpgradeError.prototype);
   }
 }

--- a/libs/payments/currency/src/lib/currency.error.ts
+++ b/libs/payments/currency/src/lib/currency.error.ts
@@ -7,6 +7,8 @@ import { BaseError } from '@fxa/shared/error';
 export class CurrencyError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'CurrencyError';
+    Object.setPrototypeOf(this, CurrencyError.prototype);
   }
 }
 
@@ -18,6 +20,8 @@ export class CurrencyCodeInvalidError extends CurrencyError {
       },
       cause,
     });
+    this.name = 'CurrencyCodeInvalidError';
+    Object.setPrototypeOf(this, CurrencyCodeInvalidError.prototype);
   }
 }
 
@@ -29,6 +33,8 @@ export class CountryCodeInvalidError extends CurrencyError {
       },
       cause,
     });
+    this.name = 'CountryCodeInvalidError';
+    Object.setPrototypeOf(this, CountryCodeInvalidError.prototype);
   }
 }
 
@@ -41,5 +47,7 @@ export class CurrencyCountryMismatchError extends CurrencyError {
       },
       cause,
     });
+    this.name = 'CurrencyCountryMismatchError';
+    Object.setPrototypeOf(this, CurrencyCountryMismatchError.prototype);
   }
 }

--- a/libs/payments/customer/src/lib/error.ts
+++ b/libs/payments/customer/src/lib/error.ts
@@ -7,30 +7,40 @@ import { BaseError } from '@fxa/shared/error';
 export class PaymentsCustomerError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'PaymentsCustomerError';
+    Object.setPrototypeOf(this, PaymentsCustomerError.prototype);
   }
 }
 
 export class CustomerDeletedError extends PaymentsCustomerError {
   constructor() {
     super('Customer deleted');
+    this.name = 'CustomerDeletedError';
+    Object.setPrototypeOf(this, CustomerDeletedError.prototype);
   }
 }
 
 export class CustomerNotFoundError extends PaymentsCustomerError {
   constructor() {
     super('Customer not found');
+    this.name = 'CustomerNotFoundError';
+    Object.setPrototypeOf(this, CustomerNotFoundError.prototype);
   }
 }
 
 export class PlanIntervalMultiplePlansError extends PaymentsCustomerError {
   constructor() {
     super('Interval has mulitple plans');
+    this.name = 'PlanIntervalMultiplePlansError';
+    Object.setPrototypeOf(this, PlanIntervalMultiplePlansError.prototype);
   }
 }
 
 export class PriceForCurrencyNotFoundError extends PaymentsCustomerError {
   constructor(priceId: string, currency: string) {
     super('Price for currency not found', { info: { priceId, currency } });
+    this.name = 'PriceForCurrencyNotFoundError';
+    Object.setPrototypeOf(this, PriceForCurrencyNotFoundError.prototype);
   }
 }
 
@@ -53,6 +63,8 @@ export class PromotionCodeCouldNotBeAttachedError extends PaymentsCustomerError 
     this.customerId = data?.customerId;
     this.subscriptionId = data?.subscriptionId;
     this.promotionId = data?.promotionId;
+    this.name = 'PromotionCodeCouldNotBeAttachedError';
+    Object.setPrototypeOf(this, PromotionCodeCouldNotBeAttachedError.prototype);
   }
 }
 
@@ -64,6 +76,8 @@ export class CouponErrorExpired extends PromotionCodeCouldNotBeAttachedError {
       undefined,
       'CouponErrorExpired'
     );
+    this.name = 'CouponErrorExpired';
+    Object.setPrototypeOf(this, CouponErrorExpired.prototype);
   }
 }
 
@@ -75,6 +89,8 @@ export class CouponErrorGeneric extends PromotionCodeCouldNotBeAttachedError {
       undefined,
       'CouponErrorGeneric'
     );
+    this.name = 'CouponErrorGeneric';
+    Object.setPrototypeOf(this, CouponErrorGeneric.prototype);
   }
 }
 
@@ -86,6 +102,8 @@ export class CouponErrorInvalid extends PromotionCodeCouldNotBeAttachedError {
       undefined,
       'CouponErrorInvalid'
     );
+    this.name = 'CouponErrorInvalid';
+    Object.setPrototypeOf(this, CouponErrorInvalid.prototype);
   }
 }
 
@@ -97,30 +115,43 @@ export class CouponErrorLimitReached extends PromotionCodeCouldNotBeAttachedErro
       undefined,
       'CouponErrorLimitReached'
     );
+    this.name = 'CouponErrorLimitReached';
+    Object.setPrototypeOf(this, CouponErrorLimitReached.prototype);
   }
 }
 
 export class StripeNoMinimumChargeAmountAvailableError extends PaymentsCustomerError {
   constructor() {
     super('Currency does not have a minimum charge amount available.');
+    this.name = 'StripeNoMinimumChargeAmountAvailableError';
+    Object.setPrototypeOf(
+      this,
+      StripeNoMinimumChargeAmountAvailableError.prototype
+    );
   }
 }
 
 export class PaymentIntentNotFoundError extends PaymentsCustomerError {
   constructor() {
     super('Payment intent not found');
+    this.name = 'PaymentIntentNotFoundError';
+    Object.setPrototypeOf(this, PaymentIntentNotFoundError.prototype);
   }
 }
 
 export class InvalidPaymentIntentError extends PaymentsCustomerError {
   constructor() {
     super('Invalid payment intent');
+    this.name = 'InvalidPaymentIntentError';
+    Object.setPrototypeOf(this, InvalidPaymentIntentError.prototype);
   }
 }
 
 export class InvalidInvoiceError extends PaymentsCustomerError {
   constructor(message: string) {
     super(message);
+    this.name = 'InvalidInvoiceError';
+    Object.setPrototypeOf(this, InvalidInvoiceError.prototype);
   }
 }
 
@@ -131,18 +162,27 @@ export class UpgradeCustomerMissingCurrencyInvoiceError extends PaymentsCustomer
         customerId,
       },
     });
+    this.name = 'UpgradeCustomerMissingCurrencyInvoiceError';
+    Object.setPrototypeOf(
+      this,
+      UpgradeCustomerMissingCurrencyInvoiceError.prototype
+    );
   }
 }
 
 export class StripePayPalAgreementNotFoundError extends PaymentsCustomerError {
   constructor(customerId: string) {
     super(`PayPal agreement not found for Stripe customer ${customerId}`);
+    this.name = 'StripePayPalAgreementNotFoundError';
+    Object.setPrototypeOf(this, StripePayPalAgreementNotFoundError.prototype);
   }
 }
 
 export class PayPalPaymentFailedError extends PaymentsCustomerError {
   constructor(status?: string) {
     super(`PayPal payment failed with status ${status ?? 'undefined'}`);
+    this.name = 'PayPalPaymentFailedError';
+    Object.setPrototypeOf(this, PayPalPaymentFailedError.prototype);
   }
 }
 
@@ -151,11 +191,15 @@ export class SubscriptionItemMultipleItemsError extends PaymentsCustomerError {
     super('Multiple subscription items not supported', {
       info: { subscriptionId },
     });
+    this.name = 'SubscriptionItemMultipleItemsError';
+    Object.setPrototypeOf(this, SubscriptionItemMultipleItemsError.prototype);
   }
 }
 
 export class SubscriptionItemMissingItemError extends PaymentsCustomerError {
   constructor(subscriptionId: string) {
     super('Subscription item missing', { info: { subscriptionId } });
+    this.name = 'SubscriptionItemMissingItemError';
+    Object.setPrototypeOf(this, SubscriptionItemMissingItemError.prototype);
   }
 }

--- a/libs/payments/eligibility/src/lib/eligibility.error.ts
+++ b/libs/payments/eligibility/src/lib/eligibility.error.ts
@@ -3,5 +3,7 @@ import { BaseError } from '@fxa/shared/error';
 export class EligibilityError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'EligibilityError';
+    Object.setPrototypeOf(this, EligibilityError.prototype);
   }
 }

--- a/libs/payments/events/src/lib/emitter.service.spec.ts
+++ b/libs/payments/events/src/lib/emitter.service.spec.ts
@@ -46,6 +46,7 @@ import {
 } from '@fxa/shared/db/mysql/account';
 import { AccountManager } from '@fxa/shared/account/account';
 import { retrieveAdditionalMetricsData } from './util/retrieveAdditionalMetricsData';
+import { Logger } from '@nestjs/common';
 
 jest.mock('./util/retrieveAdditionalMetricsData');
 const mockedRetrieveAdditionalMetricsData = jest.mocked(
@@ -69,10 +70,18 @@ describe('PaymentsEmitterService', () => {
     paymentProvider: 'stripe' as PaymentProvidersType,
   };
   let retrieveOptOutMock: jest.SpyInstance<any, unknown[], any>;
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+  };
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
         MockPaymentsGleanConfigProvider,
         MockAccountDatabaseNestFactory,
         MockPaymentsGleanFactory,

--- a/libs/payments/events/src/lib/util/retrieveAdditionalMetricsdata.spec.ts
+++ b/libs/payments/events/src/lib/util/retrieveAdditionalMetricsdata.spec.ts
@@ -16,6 +16,7 @@ import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { Test } from '@nestjs/testing';
 import { CheckoutParamsFactory } from '@fxa/payments/metrics';
 import { retrieveAdditionalMetricsData } from './retrieveAdditionalMetricsData';
+import { Logger } from '@nestjs/common';
 
 const mockStripePlan = StripePriceFactory();
 const mockCart = ResultCartFactory();
@@ -45,10 +46,18 @@ const emptyCartMetricsData = {
 describe('retrieveAdditionalMetricsData', () => {
   let productConfigurationManager: ProductConfigurationManager;
   let cartManager: CartManager;
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+  };
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
         MockAccountDatabaseNestFactory,
         MockStrapiClientConfigProvider,
         MockStripeConfigProvider,

--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
@@ -223,13 +223,7 @@ export class AppleIapPurchaseManager {
       const libraryError = new AppleIapUnknownError('Unknown error', {
         cause: err,
       });
-      this.log.error(
-        'querySubscriptionPurchase.PurchaseQueryError.OtherError',
-        {
-          err: libraryError,
-          originalTransactionId,
-        }
-      );
+      this.log.error(libraryError);
       throw libraryError;
     }
   }

--- a/libs/payments/iap/src/lib/apple/apple-iap.error.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.error.ts
@@ -7,41 +7,58 @@ import { BaseError } from '@fxa/shared/error';
 export class AppleIapError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'AppleIapError';
+    Object.setPrototypeOf(this, AppleIapError.prototype);
   }
 }
 
 export class AppleIapInvalidOriginalTransactionIdError extends AppleIapError {
   constructor(...args: ConstructorParameters<typeof AppleIapError>) {
     super(...args);
+    this.name = 'AppleIapInvalidOriginalTransactionIdError';
+    Object.setPrototypeOf(
+      this,
+      AppleIapInvalidOriginalTransactionIdError.prototype
+    );
   }
 }
 
 export class AppleIapConflictError extends AppleIapError {
   constructor(...args: ConstructorParameters<typeof AppleIapError>) {
     super(...args);
+    this.name = 'AppleIapConflictError';
+    Object.setPrototypeOf(this, AppleIapConflictError.prototype);
   }
 }
 
 export class AppleIapUnknownError extends AppleIapError {
   constructor(...args: ConstructorParameters<typeof AppleIapError>) {
     super(...args);
+    this.name = 'AppleIapUnknownError';
+    Object.setPrototypeOf(this, AppleIapUnknownError.prototype);
   }
 }
 
 export class AppleIapNotFoundError extends AppleIapError {
   constructor(...args: ConstructorParameters<typeof AppleIapError>) {
     super(...args);
+    this.name = 'AppleIapNotFoundError';
+    Object.setPrototypeOf(this, AppleIapNotFoundError.prototype);
   }
 }
 
 export class AppleIapNoTransactionsFoundError extends AppleIapError {
   constructor(...args: ConstructorParameters<typeof AppleIapError>) {
     super(...args);
+    this.name = 'AppleIapNoTransactionsFoundError';
+    Object.setPrototypeOf(this, AppleIapNoTransactionsFoundError.prototype);
   }
 }
 
 export class AppleIapMissingCredentialsError extends AppleIapError {
   constructor(bundleId: string) {
     super(`No App Store credentials found for app with bundleId: ${bundleId}.`);
+    this.name = 'AppleIapMissingCredentialsError';
+    Object.setPrototypeOf(this, AppleIapMissingCredentialsError.prototype);
   }
 }

--- a/libs/payments/iap/src/lib/apple/apple-iap.service.spec.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.service.spec.ts
@@ -108,11 +108,7 @@ describe('AppleIapService', () => {
       ).rejects.toThrowError(AppleIapInvalidOriginalTransactionIdError);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'registerToUserAccount.PurchaseUpdateError.InvalidOriginalTransactionId',
-        {
-          err: expect.any(AppleIapInvalidOriginalTransactionIdError),
-          originalTransactionId: mockOriginalTransactionId,
-        }
+        expect.any(AppleIapInvalidOriginalTransactionIdError)
       );
     });
 
@@ -134,11 +130,7 @@ describe('AppleIapService', () => {
       ).rejects.toThrowError(AppleIapConflictError);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
-        'registerToUserAccount.PurchaseUpdateError.Conflict',
-        {
-          err: expect.any(AppleIapConflictError),
-          originalTransactionId: mockOriginalTransactionId,
-        }
+        expect.any(AppleIapConflictError)
       );
     });
   });

--- a/libs/payments/iap/src/lib/apple/apple-iap.service.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap.service.ts
@@ -47,13 +47,7 @@ export class AppleIapService {
           'Invalid original transaction id',
           { cause: err }
         );
-        this.log.error(
-          'registerToUserAccount.PurchaseUpdateError.InvalidOriginalTransactionId',
-          {
-            err: libraryError,
-            originalTransactionId,
-          }
-        );
+        this.log.error(libraryError);
         throw libraryError;
       }
     }
@@ -73,10 +67,7 @@ export class AppleIapService {
       const libraryError = new AppleIapConflictError(
         'Purchase has been registered to another user'
       );
-      this.log.error('registerToUserAccount.PurchaseUpdateError.Conflict', {
-        err: libraryError,
-        originalTransactionId,
-      });
+      this.log.error(libraryError);
       throw libraryError;
     }
 

--- a/libs/payments/iap/src/lib/google/google-iap-store.manager.ts
+++ b/libs/payments/iap/src/lib/google/google-iap-store.manager.ts
@@ -21,10 +21,7 @@ export class GoogleIapPurchaseManager {
       this.log.debug('rtdn', { message });
       return message;
     } catch (err) {
-      this.log.error('rtdn', {
-        message: 'Failure to load message payload',
-        err,
-      });
+      this.log.error(err);
       throw new GoogleIapInvalidMessagePayloadError('Invalid message payload');
     }
   }

--- a/libs/payments/iap/src/lib/google/google-iap.error.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.error.ts
@@ -7,35 +7,47 @@ import { BaseError } from '@fxa/shared/error';
 export class GoogleIapError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'GoogleIapError';
+    Object.setPrototypeOf(this, GoogleIapError.prototype);
   }
 }
 
 export class GoogleIapTokenNotFoundError extends GoogleIapError {
   constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
     super(...args);
+    this.name = 'GoogleIapTokenNotFoundError';
+    Object.setPrototypeOf(this, GoogleIapTokenNotFoundError.prototype);
   }
 }
 
 export class GoogleIapInvalidMessagePayloadError extends GoogleIapError {
   constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
     super(...args);
+    this.name = 'GoogleIapInvalidMessagePayloadError';
+    Object.setPrototypeOf(this, GoogleIapInvalidMessagePayloadError.prototype);
   }
 }
 
 export class GoogleIapUnknownError extends GoogleIapError {
   constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
     super(...args);
+    this.name = 'GoogleIapUnknownError';
+    Object.setPrototypeOf(this, GoogleIapUnknownError.prototype);
   }
 }
 
 export class GoogleIapInvalidPurchaseTokenError extends GoogleIapError {
   constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
     super(...args);
+    this.name = 'GoogleIapInvalidPurchaseTokenError';
+    Object.setPrototypeOf(this, GoogleIapInvalidPurchaseTokenError.prototype);
   }
 }
 
 export class GoogleIapConflictError extends GoogleIapError {
   constructor(...args: ConstructorParameters<typeof GoogleIapError>) {
     super(...args);
+    this.name = 'GoogleIapConflictError';
+    Object.setPrototypeOf(this, GoogleIapConflictError.prototype);
   }
 }

--- a/libs/payments/paypal/src/lib/paypal.error.ts
+++ b/libs/payments/paypal/src/lib/paypal.error.ts
@@ -59,9 +59,10 @@ export class PayPalClientError extends BaseMultiError {
 
   constructor(errors: PayPalNVPError[], raw: string, data: NVPErrorResponse) {
     super(errors);
-    this.name = 'PayPalClientError';
     this.raw = raw;
     this.data = data;
+    this.name = 'PayPalClientError';
+    Object.setPrototypeOf(this, PayPalClientError.prototype);
   }
 
   getPrimaryError(): PayPalNVPError {
@@ -103,7 +104,6 @@ export class PayPalNVPError extends BaseError {
   constructor(raw: string, data: NVPErrorResponse, params: any) {
     const { message, cause, errorCode } = params;
     super(message, {
-      name: 'PayPalNVPError',
       cause,
       info: {
         raw,
@@ -114,6 +114,8 @@ export class PayPalNVPError extends BaseError {
     this.raw = raw;
     this.data = data;
     this.errorCode = errorCode;
+    this.name = 'PayPalNVPError';
+    Object.setPrototypeOf(this, PayPalNVPError.prototype);
   }
 }
 
@@ -122,12 +124,16 @@ export class PaymentsCustomError extends BaseError {
     super(message, {
       cause,
     });
+    this.name = 'PaymentsCustomError';
+    Object.setPrototypeOf(this, PaymentsCustomError.prototype);
   }
 }
 
 export class PaypalBillingAgreementManagerError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'PaypalBillingAgreementManagerError';
+    Object.setPrototypeOf(this, PaypalBillingAgreementManagerError.prototype);
   }
 }
 
@@ -138,29 +144,39 @@ export class AmountExceedsPayPalCharLimitError extends BaseError {
         amountInCents,
       },
     });
+    this.name = 'AmountExceedsPayPalCharLimitError';
+    Object.setPrototypeOf(this, AmountExceedsPayPalCharLimitError.prototype);
   }
 }
 
 export class UnexpectedPayPalError extends PaymentsCustomError {
   constructor(error: Error) {
     super('An unexpected PayPal error occured', error);
+    this.name = 'UnexpectedPayPalError';
+    Object.setPrototypeOf(this, UnexpectedPayPalError.prototype);
   }
 }
 
 export class UnexpectedPayPalErrorCode extends PaymentsCustomError {
   constructor(error: Error) {
     super('Encountered an unexpected PayPal error code', error);
+    this.name = 'UnexpectedPayPalErrorCode';
+    Object.setPrototypeOf(this, UnexpectedPayPalErrorCode.prototype);
   }
 }
 
 export class PayPalPaymentMethodError extends PaymentsCustomError {
   constructor(error: Error) {
     super('PayPal payment method failed', error);
+    this.name = 'PayPalPaymentMethodError';
+    Object.setPrototypeOf(this, PayPalPaymentMethodError.prototype);
   }
 }
 
 export class PayPalServiceUnavailableError extends PaymentsCustomError {
   constructor(error: Error) {
     super('PayPal service is temporarily unavailable', error);
+    this.name = 'PayPalServiceUnavailableError';
+    Object.setPrototypeOf(this, PayPalServiceUnavailableError.prototype);
   }
 }

--- a/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.error.ts
+++ b/libs/payments/paypal/src/lib/paypalCustomer/paypalCustomer.error.ts
@@ -10,6 +10,8 @@ import {
 export class PaypalCustomerManagerError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'PaypalCustomerManagerError';
+    Object.setPrototypeOf(this, PaypalCustomerManagerError.prototype);
   }
 }
 
@@ -19,6 +21,8 @@ export class PaypalCustomerNotCreatedError extends PaypalCustomerManagerError {
       info: data,
       cause,
     });
+    this.name = 'PaypalCustomerNotCreatedError';
+    Object.setPrototypeOf(this, PaypalCustomerNotCreatedError.prototype);
   }
 }
 
@@ -30,6 +34,8 @@ export class PaypalCustomerNotFoundError extends PaypalCustomerManagerError {
       },
       cause,
     });
+    this.name = 'PaypalCustomerNotFoundError';
+    Object.setPrototypeOf(this, PaypalCustomerNotFoundError.prototype);
   }
 }
 export class PaypalCustomerNotUpdatedError extends PaypalCustomerManagerError {
@@ -47,6 +53,8 @@ export class PaypalCustomerNotUpdatedError extends PaypalCustomerManagerError {
       },
       cause,
     });
+    this.name = 'PaypalCustomerNotUpdatedError';
+    Object.setPrototypeOf(this, PaypalCustomerNotUpdatedError.prototype);
   }
 }
 export class PaypalCustomerNotDeletedError extends PaypalCustomerManagerError {
@@ -58,6 +66,8 @@ export class PaypalCustomerNotDeletedError extends PaypalCustomerManagerError {
       },
       cause,
     });
+    this.name = 'PaypalCustomerNotDeletedError';
+    Object.setPrototypeOf(this, PaypalCustomerNotDeletedError.prototype);
   }
 }
 
@@ -69,5 +79,7 @@ export class PaypalCustomerMultipleRecordsError extends PaypalCustomerManagerErr
       },
       cause,
     });
+    this.name = 'PaypalCustomerMultipleRecordsError';
+    Object.setPrototypeOf(this, PaypalCustomerMultipleRecordsError.prototype);
   }
 }

--- a/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.error.ts
+++ b/libs/payments/stripe/src/lib/accountCustomer/accountCustomer.error.ts
@@ -11,6 +11,8 @@ import {
 export class AccountCustomerManagerError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'AccountCustomerManagerError';
+    Object.setPrototypeOf(this, AccountCustomerManagerError.prototype);
   }
 }
 
@@ -22,6 +24,8 @@ export class AccountCustomerNotCreatedError extends AccountCustomerManagerError 
       },
       cause,
     });
+    this.name = 'AccountCustomerNotCreatedError';
+    Object.setPrototypeOf(this, AccountCustomerNotCreatedError.prototype);
   }
 }
 
@@ -33,6 +37,8 @@ export class AccountCustomerNotFoundError extends AccountCustomerManagerError {
       },
       cause,
     });
+    this.name = 'AccountCustomerNotFoundError';
+    Object.setPrototypeOf(this, AccountCustomerNotFoundError.prototype);
   }
 }
 
@@ -45,6 +51,8 @@ export class AccountCustomerNotUpdatedError extends AccountCustomerManagerError 
       },
       cause,
     });
+    this.name = 'AccountCustomerNotUpdatedError';
+    Object.setPrototypeOf(this, AccountCustomerNotUpdatedError.prototype);
   }
 }
 
@@ -56,5 +64,7 @@ export class AccountCustomerNotDeletedError extends AccountCustomerManagerError 
       },
       cause,
     });
+    this.name = 'AccountCustomerNotDeletedError';
+    Object.setPrototypeOf(this, AccountCustomerNotDeletedError.prototype);
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/app.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.ts
@@ -5,14 +5,13 @@
 import 'server-only';
 
 import { NestFactory } from '@nestjs/core';
-
-import { logger } from '@fxa/shared/log';
 import { AppModule } from './app.module';
 import { LocalizerRscFactory } from '@fxa/shared/l10n/server';
 import { singleton } from '../utils/singleton';
 import { NextJSActionsService } from './nextjs-actions.service';
 import { PaymentsEmitterService } from '@fxa/payments/events';
 import { StripeWebhookService } from '@fxa/payments/webhooks';
+import { winstonLogger } from '@fxa/shared/log';
 
 class AppSingleton {
   private app!: Awaited<
@@ -22,7 +21,7 @@ class AppSingleton {
   async initialize() {
     if (!this.app) {
       this.app = await NestFactory.createApplicationContext(AppModule, {
-        logger,
+        logger: winstonLogger('NestApplication')
       });
     }
   }

--- a/libs/payments/webhooks/src/lib/stripeEvents.manager.spec.ts
+++ b/libs/payments/webhooks/src/lib/stripeEvents.manager.spec.ts
@@ -43,14 +43,24 @@ import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { StripeEventCustomerSubscriptionDeletedFactory } from 'libs/payments/stripe/src/lib/factories/event.factory';
+import { Logger } from '@nestjs/common';
 
 describe('StripeEventManager', () => {
   let stripeEventManager: StripeEventManager;
   let stripeClient: StripeClient;
 
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
         MockStripeConfigProvider,
         StripeClient,
         StripeEventManager,

--- a/libs/payments/webhooks/src/lib/stripeWebhooks.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/stripeWebhooks.service.spec.ts
@@ -40,6 +40,7 @@ import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import * as Sentry from '@sentry/node';
+import { Logger } from '@nestjs/common';
 
 jest.mock('@sentry/node', () => ({
   captureException: jest.fn(),
@@ -49,9 +50,18 @@ describe('StripeWebhookService', () => {
   let stripeEventManager: StripeEventManager;
   let stripeWebhookService: StripeWebhookService;
 
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
         MockStripeConfigProvider,
         StripeClient,
         StripeEventManager,

--- a/libs/payments/webhooks/src/lib/subscriptionHandler.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/subscriptionHandler.service.spec.ts
@@ -52,6 +52,7 @@ import {
   CancellationReason,
   determineCancellation,
 } from './util/determineCancellation';
+import { Logger } from '@nestjs/common';
 
 jest.mock('@fxa/payments/customer');
 const mockDeterminePaymentMethodType = jest.mocked(determinePaymentMethodType);
@@ -68,6 +69,10 @@ describe('SubscriptionEventsService', () => {
   const mockEmitter = {
     emit: jest.fn(),
   };
+  const mockLogger = {
+    error: jest.fn(),
+    log: jest.fn(),
+  };
 
   const { event: mockEvent, eventObjectData: mockEventObjectData } =
     CustomerSubscriptionDeletedResponseFactory();
@@ -75,6 +80,10 @@ describe('SubscriptionEventsService', () => {
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
+        {
+          provide: Logger,
+          useValue: mockLogger,
+        },
         MockStripeConfigProvider,
         StripeClient,
         StripeEventManager,

--- a/libs/profile/client/src/lib/profile.client.spec.ts
+++ b/libs/profile/client/src/lib/profile.client.spec.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Test } from '@nestjs/testing';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { ProfileClient } from './profile.client';
 import { MockProfileClientConfigProvider } from './profile.config';
+import { Logger } from '@nestjs/common';
 
 describe('ProfileClient', () => {
   let profileClient: ProfileClient;
@@ -20,7 +20,7 @@ describe('ProfileClient', () => {
       providers: [
         MockProfileClientConfigProvider,
         {
-          provide: LOGGER_PROVIDER,
+          provide: Logger,
           useValue: mockLogger,
         },
         ProfileClient,

--- a/libs/profile/client/src/lib/profile.client.ts
+++ b/libs/profile/client/src/lib/profile.client.ts
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { LoggerService } from '@nestjs/common';
 import Agent from 'agentkeepalive';
 import axios, { AxiosInstance } from 'axios';
@@ -26,7 +25,7 @@ type SupportedMethods = 'post' | 'delete';
 export class ProfileClient {
   private axiosInstance: AxiosInstance;
   constructor(
-    @Inject(LOGGER_PROVIDER) private log: LoggerService,
+    @Inject(Logger) private log: LoggerService,
     private config: ProfileClientConfig
   ) {
     this.axiosInstance = axios.create({
@@ -46,9 +45,8 @@ export class ProfileClient {
     });
 
     // Authorization header is required for all requests to the profile server
-    this.axiosInstance.defaults.headers.common[
-      'Authorization'
-    ] = `Bearer ${config.secretBearerToken}`;
+    this.axiosInstance.defaults.headers.common['Authorization'] =
+      `Bearer ${config.secretBearerToken}`;
   }
 
   private async makeRequest(
@@ -85,9 +83,9 @@ export class ProfileClient {
         {},
         'delete'
       );
-    } catch (err) {
-      this.log.error('profile.deleteCache.failed', uid, err);
-      throw err;
+    } catch (error) {
+      this.log.error(error);
+      throw error;
     }
   }
 
@@ -98,9 +96,9 @@ export class ProfileClient {
         { name },
         'post'
       );
-    } catch (err) {
-      this.log.error('profile.updateDisplayName.failed', uid, name, err);
-      throw err;
+    } catch (error) {
+      this.log.error(error);
+      throw error;
     }
   }
 }

--- a/libs/profile/client/src/lib/profile.error.ts
+++ b/libs/profile/client/src/lib/profile.error.ts
@@ -8,6 +8,8 @@ import { Options } from 'verror';
 export class ProfileClientError extends BaseError {
   constructor(cause: Error) {
     super('Profile Client Error', { cause });
+    this.name = 'ProfileClientError';
+    Object.setPrototypeOf(this, ProfileClientError.prototype);
   }
 }
 
@@ -22,5 +24,7 @@ export class ProfileClientServiceFailureError extends BaseError {
       },
     };
     super('Profile Client service failure', options);
+    this.name = 'ProfileClientServiceFailureError';
+    Object.setPrototypeOf(this, ProfileClientServiceFailureError.prototype);
   }
 }

--- a/libs/shared/account/account/src/lib/account.error.ts
+++ b/libs/shared/account/account/src/lib/account.error.ts
@@ -9,6 +9,8 @@ export class AccountError extends BaseError {
       name: 'AccountError',
       cause,
     });
+    this.name = 'AccountError';
+    Object.setPrototypeOf(this, AccountError.prototype);
   }
 }
 
@@ -18,6 +20,8 @@ export class AccountAlreadyExistsError extends AccountError {
   constructor(email: string) {
     super('Account already exists: ' + email);
     this.email = email;
+    this.name = 'AccountAlreadyExistsError';
+    Object.setPrototypeOf(this, AccountAlreadyExistsError.prototype);
   }
 }
 
@@ -27,6 +31,8 @@ export class AccountNotCreatedError extends AccountError {
   constructor(email: string, cause: Error) {
     super('Account not created: ' + email, cause);
     this.email = email;
+    this.name = 'AccountNotCreatedError';
+    Object.setPrototypeOf(this, AccountNotCreatedError.prototype);
   }
 }
 
@@ -35,5 +41,7 @@ export class AccountNotFoundError extends AccountError {
   constructor(accountId: string, cause: Error) {
     super('Account not found', cause);
     this.accountId = accountId;
+    this.name = 'AccountNotFoundError';
+    Object.setPrototypeOf(this, AccountNotFoundError.prototype);
   }
 }

--- a/libs/shared/cms/src/lib/cms.error.ts
+++ b/libs/shared/cms/src/lib/cms.error.ts
@@ -10,18 +10,24 @@ import { BaseError, BaseMultiError } from '@fxa/shared/error';
 export class CMSError extends BaseMultiError {
   constructor(...args: ConstructorParameters<typeof BaseMultiError>) {
     super(...args);
+    this.name = 'CMSError';
+    Object.setPrototypeOf(this, CMSError.prototype);
   }
 }
 
 export class ProductConfigError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'ProductConfigError';
+    Object.setPrototypeOf(this, ProductConfigError.prototype);
   }
 }
 
 export class QueriesUtilError extends BaseError {
   constructor(...args: ConstructorParameters<typeof BaseError>) {
     super(...args);
+    this.name = 'QueriesUtilError';
+    Object.setPrototypeOf(this, QueriesUtilError.prototype);
   }
 }
 
@@ -32,6 +38,8 @@ export class FetchCmsInvalidOfferingError extends ProductConfigError {
       cause: error,
       info: { offeringId },
     });
+    this.name = 'FetchCmsInvalidOfferingError';
+    Object.setPrototypeOf(this, FetchCmsInvalidOfferingError.prototype);
   }
 }
 
@@ -41,6 +49,8 @@ export class RetrieveStripePriceNotFoundError extends ProductConfigError {
       name: 'RetrieveStripePriceNotFoundError',
       info: { offeringId, interval },
     });
+    this.name = 'RetrieveStripePriceNotFoundError';
+    Object.setPrototypeOf(this, RetrieveStripePriceNotFoundError.prototype);
   }
 }
 
@@ -51,17 +61,26 @@ export class RetrieveStripePriceInvalidOfferingError extends ProductConfigError 
       cause: error,
       info: { offeringId },
     });
+    this.name = 'RetrieveStripePriceInvalidOfferingError';
+    Object.setPrototypeOf(
+      this,
+      RetrieveStripePriceInvalidOfferingError.prototype
+    );
   }
 }
 
 export class OfferingNotFoundError extends QueriesUtilError {
   constructor() {
     super('Offering not found');
+    this.name = 'OfferingNotFoundError';
+    Object.setPrototypeOf(this, OfferingNotFoundError.prototype);
   }
 }
 
 export class OfferingMultipleError extends QueriesUtilError {
   constructor() {
     super('More than one offering found');
+    this.name = 'OfferingMultipleError';
+    Object.setPrototypeOf(this, OfferingMultipleError.prototype);
   }
 }

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
@@ -3,9 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as Sentry from '@sentry/nextjs';
-import { Inject } from '@nestjs/common';
-import { ILogger } from '@fxa/shared/log';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import { Inject, Logger } from '@nestjs/common';
 import { GENERIC_ERROR_MESSAGE } from './error';
 import { StatsDService, type StatsD } from '@fxa/shared/metrics/statsd';
 
@@ -20,7 +18,7 @@ type Constructor<T> = new (...args: any[]) => T;
 export function SanitizeExceptions(
   { allowlist }: { allowlist: Constructor<Error>[] } = { allowlist: [] }
 ) {
-  const injectLogger = Inject(LOGGER_PROVIDER);
+  const injectLogger = Inject(Logger);
   const injectStatsD = Inject(StatsDService);
 
   return function (
@@ -76,15 +74,12 @@ function handleException(args: {
   className: string;
   methodName: string;
   allowlist: Constructor<Error>[];
-  logger: ILogger;
+  logger: Logger;
   statsd: StatsD;
 }): Error {
   const { error, className, methodName, allowlist, logger } = args;
 
-  logger.error(
-    `Error caught by SanitizeExceptions decorator in ${className}.${methodName}`,
-    error
-  );
+  logger.error(error);
 
   const isAllowedError =
     error instanceof Error &&

--- a/libs/shared/geodb/src/lib/geodb.error.ts
+++ b/libs/shared/geodb/src/lib/geodb.error.ts
@@ -6,17 +6,23 @@ import { BaseError } from '@fxa/shared/error';
 export class GeoDBError extends BaseError {
   constructor(message: string) {
     super(message);
+    this.name = 'GeoDBError';
+    Object.setPrototypeOf(this, GeoDBError.prototype);
   }
 }
 
 export class GeoDBInvalidIp extends GeoDBError {
   constructor() {
     super('IP is invalid');
+    this.name = 'GeoDBInvalidIp';
+    Object.setPrototypeOf(this, GeoDBInvalidIp.prototype);
   }
 }
 
 export class GeoDBFetchDataFailed extends GeoDBError {
   constructor() {
     super('Unable to fetch data');
+    this.name = 'GeoDBFetchDataFailed';
+    Object.setPrototypeOf(this, GeoDBFetchDataFailed.prototype);
   }
 }

--- a/libs/shared/log/src/index.ts
+++ b/libs/shared/log/src/index.ts
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * from './lib/logging';
+export * from './lib/types';
+export * from './lib/util';
 export { monkeyPatchServerLogging } from './lib/monkey-patch';
 export { LoggingModule, LOGGER_PROVIDER } from './lib/nest/logging.module';
 export type { Logger } from './lib/nest/logging.module';

--- a/libs/shared/log/src/lib/monkey-patch.ts
+++ b/libs/shared/log/src/lib/monkey-patch.ts
@@ -1,4 +1,4 @@
-import { logger } from './logging';
+import { winstonLogger } from './logging';
 
 type ConsoleFn = typeof console.log;
 
@@ -32,7 +32,8 @@ const consoleLogWrapper = (logFn: ConsoleFn) =>
 export const monkeyPatchServerLogging = () => {
   // NextJS internally uses console functions directly, eg on error. It's also
   // rare to load a logging library in react code.
-  console.log = consoleLogWrapper(logger.info.bind(logger));
+  const logger = winstonLogger('PaymentsNext');
+  console.log = consoleLogWrapper(logger.log.bind(logger));
   console.warn = consoleLogWrapper(logger.warn.bind(logger));
   console.error = consoleLogWrapper(logger.error.bind(logger));
 };

--- a/libs/shared/log/src/lib/types.ts
+++ b/libs/shared/log/src/lib/types.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type HekaJson = {
+  Type: string;
+  Logger: string;
+  Timestamp: number;
+  Severity: number;
+  Fields: Record<string, any>;
+  [key: string]: any;
+};
+
+export type ILogger = {
+  error: (type: string, data: any) => void;
+  debug: (type: string, data: any) => void;
+  info: (type: string, data: any) => void;
+  warn: (type: string, data: any) => void;
+};

--- a/libs/shared/log/src/lib/util.ts
+++ b/libs/shared/log/src/lib/util.ts
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { TransformableInfo } from 'logform';
+import { format, addColors } from 'winston';
+import { stringify } from 'safe-stable-stringify';
+import { MESSAGE } from 'triple-beam';
+import { HekaJson } from './types';
+
+export const winstonNestLike = format((info, app) => {
+  info[MESSAGE] = fprintNestlike({ ...info, app });
+  return info;
+});
+const fprintNestlike = ({
+  timestamp,
+  level,
+  message,
+  context,
+  app,
+  error,
+  stack,
+}: TransformableInfo) => {
+  const colorizer = format.colorize();
+  addColors({ ok: 'green', warn: 'yellow', error: 'red' });
+  level = level.toUpperCase();
+  let coloredLevel: string;
+  let coloredMessage: string;
+
+  if (error instanceof Error) {
+    message = error.name
+  }
+
+  switch (level) {
+    case 'INFO':
+      coloredLevel = colorizer.colorize('ok', 'LOG');
+      coloredMessage = colorizer.colorize('ok', message as string);
+      break;
+    case 'ERROR':
+      coloredLevel = colorizer.colorize('error', level);
+      coloredMessage = colorizer.colorize('error', message as string);
+      break;
+    case 'WARN':
+      coloredLevel = colorizer.colorize('warn', level);
+      coloredMessage = colorizer.colorize('warn', message as string);
+      break;
+    default:
+      coloredLevel = colorizer.colorize('ok', level);
+      coloredMessage = colorizer.colorize('ok', message as string);
+  }
+  const coloredNestapp = colorizer.colorize('warn', `[${app}]`);
+  const contextString = context
+    ? ` - ${JSON.stringify(context, null, '\t')}`
+    : ``;
+  let log = `${timestamp}\t${coloredLevel} ${coloredNestapp} ${coloredMessage}${contextString}`;
+
+  if (stack) {
+    log = `${log}\n${stack}`;
+  }
+  if (error && Object.keys(error as any).length > 0) {
+    log = `${log}\n${JSON.stringify(error, null, 2)}`;
+  }
+  return log;
+};
+
+export const formatToHeka = format((info, app) => {
+  info[MESSAGE] = stringify(toHekaJson({ ...info, app }));
+  return info;
+});
+const toHekaJson = ({
+  timestamp,
+  level,
+  message,
+  context,
+  app,
+  error,
+  stack,
+}: TransformableInfo): HekaJson => {
+  level = level.toUpperCase();
+  let severity = 6;
+  switch (level) {
+    case 'TRACE':
+    case 'VERBOSE':
+    case 'DEBUG':
+      severity = 7;
+      break;
+    case 'LOG':
+      severity = 6;
+      break;
+    case 'WARN':
+      severity = 4;
+      break;
+    case 'ERROR':
+      severity = 2;
+      break;
+    case 'CRITICAL':
+      severity = 0;
+  }
+  const fields = {
+    ...(context as any),
+    ...(error && Object.keys(error as any).length > 1
+      ? { error: stringify(error) }
+      : undefined),
+    ...(stack ? { stack: stringify(stack) } : undefined),
+  };
+
+  if (error instanceof Error) {
+    message = error.name;
+  }
+
+  return {
+    Type: message as string,
+    Logger: app as string,
+    Timestamp: new Date(timestamp as string).valueOf() * 1000000,
+    Severity: severity,
+    Fields: fields as any,
+  };
+};

--- a/packages/fxa-admin-server/src/gql/cart.module.ts
+++ b/packages/fxa-admin-server/src/gql/cart.module.ts
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Module, Provider } from '@nestjs/common';
+import { Logger, Module, Provider } from '@nestjs/common';
 import { CartManager } from '@fxa/payments/cart';
 import { AccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { AppConfig } from '../config';
 import { MySQLConfig } from '@fxa/shared/db/mysql/core';
 import { ConfigService } from '@nestjs/config';
 import { LegacyStatsDProvider } from '@fxa/shared/metrics/statsd';
+import { MozLoggerService } from '@fxa/shared/mozlog';
 
 export const MySQLConfigFactory: Provider<MySQLConfig> = {
   provide: MySQLConfig,
@@ -20,7 +21,17 @@ export const MySQLConfigFactory: Provider<MySQLConfig> = {
 };
 
 @Module({
-  providers: [MySQLConfigFactory, AccountDatabaseNestFactory, CartManager, LegacyStatsDProvider],
+  providers: [
+    MySQLConfigFactory,
+    AccountDatabaseNestFactory,
+    CartManager,
+    LegacyStatsDProvider,
+    MozLoggerService,
+    {
+      provide: Logger,
+      useClass: MozLoggerService,
+    },
+  ],
   exports: [CartManager],
 })
-export class CartModule { }
+export class CartModule {}


### PR DESCRIPTION
Because:

* Current logs to bigquery from payments next are malformed and not queriable

This commit:

* Addresses formatting issues of the logs

Closes #FXA-11639

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![Screenshot 2025-05-20 at 5 41 43 PM](https://github.com/user-attachments/assets/2061043b-05e4-4202-a211-1070ac96c377)


## Other information (Optional)

Any other information that is important to this pull request.
