### PR TITLE
feat(payments-next): Enable no-charge payments with stripe

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -209,3 +209,14 @@ export class CartSubscriptionNotFoundError extends CartError {
     Object.setPrototypeOf(this, CartSubscriptionNotFoundError.prototype);
   }
 }
+
+export class PaidInvoiceOnFailedCartError extends CartError {
+  constructor(cartId: string, args?: Record<string, any>) {
+    super('Paid invoice found on failed cart', {
+      cartId,
+      ...args,
+    });
+    this.name = 'PaidInvoiceOnFailedCartError';
+    Object.setPrototypeOf(this, PaidInvoiceOnFailedCartError.prototype);
+  }
+}

--- a/libs/payments/customer/src/lib/customer.manager.ts
+++ b/libs/payments/customer/src/lib/customer.manager.ts
@@ -105,4 +105,8 @@ export class CustomerManager {
   isTaxEligible(customer: StripeCustomer) {
     return isCustomerTaxEligible(customer);
   }
+
+  async getDefaultPaymentMethod(customerId: string) {
+    return this.stripeClient.customerDefaultPaymentMethodRetrieve(customerId);
+  }
 }

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -325,6 +325,16 @@ export class StripeClient {
     return result as StripeResponse<StripePaymentMethod>;
   }
 
+  @CaptureTimingWithStatsD()
+  async customerDefaultPaymentMethodRetrieve(customerId: string) {
+    const result = await this.stripe.customers.retrieve(customerId, {
+      expand: ['invoice_settings.default_payment_method'],
+    });
+    if (result.deleted) return undefined;
+    return result.invoice_settings
+      .default_payment_method as StripeResponse<StripePaymentMethod>;
+  }
+
   @Cacheable({
     cacheKey: (args: any) =>
       cacheKeyForClient('pricesRetrieve', args[0], args[1]),


### PR DESCRIPTION
Because:

* Stripe payments for a free purchase or for a reimbursement do not generate a payment intent as part of the payment process. The existing code throws an error for payments missing a payment intent

This commit:

* Adds in a special case for payments with a total amount of 0. Both "negative" payments (e.g. an upgrade to a lower price) and free purchases result in invoices with a total of 0, and a 'paid' status. Stripe automatically handles the application of negative purchase amounts towards the customer's account as a credit.

Closes #FXA-11413

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
