### PR TITLE
bug(content): Pre-connects weren't getting replaced in 'static' html

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -142,6 +142,24 @@ function preconnect(val) {
   return `<link rel="preconnect" href="${val}">`;
 }
 
+function resolvePreConnectDirectives(settingsConfig) {
+   // Using '?' will breaks l10n extraction :9
+  let gqlUrl, authUrl, oauthUrl, sentryUrl;
+  try { gqlUrl = settingsConfig.servers.gql.url; } catch (e) {}
+  try { authUrl = settingsConfig.servers.auth.url; } catch (e) {}
+  try { oauthUrl = settingsConfig.servers.oauth.url; } catch (e) {}
+  try { sentryUrl = settingsConfig.sentry.dsn.replace(/\/\d*$/, ''); } catch (e) {}
+
+  return {
+    __GQL_URL_PRECONNECT__: preconnect(gqlUrl),
+    __AUTH_URL_PRECONNECT__: preconnect(authUrl),
+    __OAUTH_URL_PRECONNECT__: preconnect(oauthUrl),
+    __SENTRY_URL_PRECONNECT__: preconnect(sentryUrl),
+  }
+}
+
+
+
 // Conditionally modify the response
 function modifyProxyRes(proxyRes, req, res) {
   const bodyChunks = [];
@@ -166,22 +184,11 @@ function modifyProxyRes(proxyRes, req, res) {
     ) {
       let html = body.toString();
       const flowEventData = flowMetrics.create(FLOW_ID_KEY);
-
-      // Using '?' will breaks l10n extraction :9
-      let gqlUrl, authUrl, oauthUrl, sentryUrl;
-      try { gqlUrl = settingsConfig.servers.gql.url; } catch (e) {}
-      try { authUrl = settingsConfig.servers.auth.url; } catch (e) {}
-      try { oauthUrl = settingsConfig.servers.oauth.url; } catch (e) {}
-      try { sentryUrl = settingsConfig.sentry.dsn.replace(/\/\d*$/, ''); } catch (e) {}
-
       html = swapBetaMeta(html, {
         __SERVER_CONFIG__: settingsConfig,
         __FLOW_ID__: flowEventData.flowId,
         __FLOW_BEGIN_TIME__: flowEventData.flowBeginTime,
-        __GQL_URL_PRECONNECT__: preconnect(gqlUrl),
-        __AUTH_URL_PRECONNECT__: preconnect(authUrl),
-        __OAUTH_URL_PRECONNECT__: preconnect(oauthUrl),
-        __SENTRY_URL_PRECONNECT__: preconnect(sentryUrl),
+        ...resolvePreConnectDirectives(settingsConfig)
       });
       res.send(new Buffer.from(html));
     } else {
@@ -217,6 +224,7 @@ const modifySettingsStatic = function (req, res) {
       __SERVER_CONFIG__: settingsConfig,
       __FLOW_ID__: flowEventData.flowId,
       __FLOW_BEGIN_TIME__: flowEventData.flowBeginTime,
+      ...resolvePreConnectDirectives(settingsConfig)
     })
   );
 };


### PR DESCRIPTION
## Because

- Static html that is generated and then deployed to the CDN didn't get preconnect directives replaced.

## This pull request

- Makes sure static html that is deployed to CDN also gets its preconnect directives updated.

## Issue that this pull request solves

Closes: FXA-11692

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
