### PR TITLE
fix(auth): Fix issues with deeplinking third party auth

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -136,6 +136,36 @@ describe('ThirdPartyAuthComponent', () => {
     expect(onContinueWithApple).not.toBeCalled();
   });
 
+  it('should deeplink directly to google auth, if deeplink=`googleLogin`', async () => {
+    renderWith({
+      enabled: true,
+      showSeparator: false,
+      deeplink: 'googleLogin',
+      view: 'index'
+    });
+
+    expect(
+      (await screen.findByTestId('google-signin-form-state')).getAttribute(
+        'value'
+      )
+    ).not.toEqual('');
+  })
+
+  it('should deeplink directly to apple auth, if deeplink=`appleLogin`', async () => {
+    renderWith({
+      enabled: true,
+      showSeparator: false,
+      deeplink: 'appleLogin',
+      view: 'index'
+    });
+
+    expect(
+      (await screen.findByTestId('apple-signin-form-state')).getAttribute(
+        'value'
+      )
+    ).not.toEqual('');
+  })
+
   it('hides separator', async () => {
     renderWith({
       enabled: true,

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useRef, FormEventHandler, useEffect } from 'react';
+import React, { useRef, FormEventHandler, useEffect, useCallback } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 
 import { ReactComponent as GoogleLogo } from './google-logo.svg';
@@ -18,6 +18,7 @@ export type ThirdPartyAuthProps = {
   onContinueWithApple?: FormEventHandler<HTMLFormElement>;
   showSeparator?: boolean;
   viewName?: string;
+  deeplink?: string;
 };
 
 /**
@@ -30,6 +31,7 @@ const ThirdPartyAuth = ({
   onContinueWithApple,
   showSeparator = true,
   viewName = 'unknown',
+                          deeplink,
 }: ThirdPartyAuthProps) => {
   const config = useConfig();
 
@@ -76,6 +78,7 @@ const ThirdPartyAuth = ({
                   </FtlMsg>
                 </>
               ),
+              deeplink
             }}
           />
           <ThirdPartySignInForm
@@ -98,6 +101,7 @@ const ThirdPartyAuth = ({
                   </FtlMsg>
                 </>
               ),
+              deeplink
             }}
           />
         </div>
@@ -125,6 +129,7 @@ const ThirdPartySignInForm = ({
   buttonText,
   onSubmit,
   viewName,
+                                deeplink
 }: {
   party: 'google' | 'apple';
   authorizationEndpoint: string;
@@ -139,11 +144,14 @@ const ThirdPartySignInForm = ({
   buttonText: ReactElement;
   onSubmit?: FormEventHandler<HTMLFormElement>;
   viewName?: string;
+  deeplink?: string;
 }) => {
   const { logViewEventOnce } = useMetrics();
   const stateRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const isDeeplinking = deeplink !== undefined;
 
-  async function onClick() {
+  const onClick = useCallback(async () => {
     logViewEventOnce(`flow.${party}`, 'oauth-start');
 
     switch (`${party}-${viewName}`) {
@@ -165,20 +173,40 @@ const ThirdPartySignInForm = ({
       case 'apple-signup':
         GleanMetrics.thirdPartyAuth.startAppleAuthFromReg();
         break;
+      case 'google-deeplink':
+        GleanMetrics.thirdPartyAuth.googleDeeplink();
+        break;
+      case 'apple-deeplink':
+        GleanMetrics.thirdPartyAuth.appleDeeplink();
+        break;
     }
 
     // wait for all the Glean events to be sent before the page unloads
     await GleanMetrics.isDone();
 
-    stateRef.current!.value = getState();
-  }
+    if (stateRef.current) {
+      stateRef.current.value = getState();
+    }
+  }, [party, viewName, logViewEventOnce]);
+
 
   if (onSubmit === undefined) {
     onSubmit = () => true;
   }
 
+  useEffect(() => {
+    if (deeplink && formRef.current) {
+      // Only deeplink if this is the correct button
+      if ((deeplink === "googleLogin" && party === "google") || (deeplink === "appleLogin" && party === "apple")) {
+        onClick();
+        formRef.current.submit();
+      }
+    }
+
+  }, [deeplink, onClick, party]);
+
   return (
-    <form action={authorizationEndpoint} method="GET" onSubmit={onSubmit}>
+    <form action={authorizationEndpoint} method="GET" onSubmit={onSubmit} ref={formRef}>
       <input
         data-testid={`${party}-signin-form-state`}
         ref={stateRef}
@@ -196,13 +224,15 @@ const ThirdPartySignInForm = ({
         <input type="hidden" name="response_mode" value={responseMode} />
       )}
 
-      <button
-        type="submit"
-        className="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
-        onClick={onClick}
-      >
-        {buttonText}
-      </button>
+      {!isDeeplinking ? (
+        <button
+          type="submit"
+          className="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+          onClick={onClick}
+        >
+          {buttonText}
+        </button>
+      ) : null }
     </form>
   );
 };
@@ -213,7 +243,7 @@ function deleteParams(searchParams: URLSearchParams, paramsToDelete: string[]) {
 }
 
 function getState() {
-  // We stash originating location in the state oauth param
+  // We stash the originating location in the state oauth param
   // because we will need it to use it to reconstruct the redirect URL for RP
   const params = new URLSearchParams(window.location.search);
   // we won't need these params that are used for internal backbone/react navigation
@@ -225,12 +255,11 @@ function getState() {
     'forceExperimentGroup',
     'showReactApp',
   ]);
-  const state = encodeURIComponent(
+  return encodeURIComponent(
     `${window.location.origin}${
       window.location.pathname
     }?${modifiedParams.toString()}`
   );
-  return state;
 }
 
 export default ThirdPartyAuth;

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -415,6 +415,12 @@ const recordEventMetric = (
     case 'third_party_auth_apple_login_start':
       thirdPartyAuth.appleLoginStart.record();
       break;
+    case 'third_party_auth_apple_deeplink':
+      thirdPartyAuth.appleDeeplink.record();
+      break;
+    case 'third_party_auth_google_deeplink':
+      thirdPartyAuth.googleDeeplink.record();
+      break;
     case 'cad_firefox_notnow_submit':
       cadFirefox.notnowSubmit.record();
       break;

--- a/packages/fxa-settings/src/models/pages/index/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/index/query-params.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsEmail, IsOptional } from 'class-validator';
+import { IsEmail, IsIn, IsOptional } from 'class-validator';
 import {
   bind,
   KeyTransforms,
@@ -19,4 +19,9 @@ export class IndexQueryParams extends ModelDataProvider {
   @IsEmail()
   @bind(KeyTransforms.snakeCase)
   loginHint: string | undefined;
+
+  @IsOptional()
+  @IsIn(['googleLogin', 'appleLogin'])
+  @bind()
+  deeplink: string | undefined;
 }

--- a/packages/fxa-settings/src/models/pages/signin/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signin/query-params.ts
@@ -11,6 +11,7 @@ import {
   MaxLength,
   Matches,
   Validate,
+  IsIn,
 } from 'class-validator';
 import {
   bind,
@@ -50,4 +51,9 @@ export class SigninQueryParams extends ModelDataProvider {
   @Validate(IsFxaRedirectToUrl, {})
   @bind(T.snakeCase)
   redirectTo: string | undefined = undefined;
+
+  @IsOptional()
+  @IsIn(['googleLogin', 'appleLogin'])
+  @bind(T.snakeCase)
+  deeplink!: string;
 }

--- a/packages/fxa-settings/src/models/pages/signup/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signup/query-params.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsBoolean, IsEmail, IsOptional } from 'class-validator';
-import { bind, ModelDataProvider } from '../../../lib/model-data';
+import { IsBoolean, IsEmail, IsIn, IsOptional } from 'class-validator';
+import { bind, KeyTransforms as T, ModelDataProvider } from '../../../lib/model-data';
 
 export class SignupQueryParams extends ModelDataProvider {
   // 'email' will be optional once the index page is converted to React
@@ -20,4 +20,9 @@ export class SignupQueryParams extends ModelDataProvider {
   @IsBoolean()
   @bind()
   emailStatusChecked: boolean = false;
+
+  @IsOptional()
+  @IsIn(['googleLogin', 'appleLogin'])
+  @bind(T.snakeCase)
+  deeplink!: string;
 }

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -4,7 +4,7 @@
 
 import * as Sentry from '@sentry/browser';
 
-import { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { isEmail } from 'class-validator';
 
@@ -252,6 +252,7 @@ export const IndexContainer = ({
   }, [ftlMsgResolver, deleteAccountSuccess]);
 
   const initialPrefill = prefillEmail || suggestedEmail;
+  const deeplink = queryParamModel.deeplink;
 
   return isLoading ? (
     <LoadingSpinner fullScreen />
@@ -267,6 +268,7 @@ export const IndexContainer = ({
         errorBannerMessage,
         successBannerMessage,
         tooltipErrorMessage,
+        deeplink
       }}
       prefillEmail={initialPrefill}
     />

--- a/packages/fxa-settings/src/pages/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.test.tsx
@@ -115,6 +115,19 @@ describe('Index page', () => {
     );
   });
 
+  it('does not render when deeplinking third party auth', () => {
+    renderWithLocalizationProvider(
+      <Subject
+        integration={createMockIndexOAuthIntegration({
+          clientId: POCKET_CLIENTIDS[0],
+        })}
+        deeplink="appleLogin"
+      />
+    );
+
+    thirdPartyAuthNotRendered();
+  });
+
   it('renders as expected when client is Pocket', () => {
     renderWithLocalizationProvider(
       <Subject

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -31,6 +31,7 @@ export const Index = ({
   setErrorBannerMessage,
   setSuccessBannerMessage,
   setTooltipErrorMessage,
+  deeplink
 }: IndexProps) => {
   const clientId = integration.getClientId();
   const isSync = integration.isSync();
@@ -42,10 +43,9 @@ export const Index = ({
 
   const emailEngageEventEmitted = useRef(false);
 
+  const isDeeplinking = !!deeplink;
+
   useEffect(() => {
-    // Note we might not need this later due to automatic page load events,
-    // but it's here for now to match parity with Backbone. This will be closely
-    // monitored for the `service=relay` flow for some time.
     GleanMetrics.emailFirst.view();
   }, []);
 
@@ -75,6 +75,11 @@ export const Index = ({
       email: prefillEmail,
     },
   });
+
+  if (isDeeplinking) {
+    // To avoid flickering, we just render third party auth when deeplinking
+    return <ThirdPartyAuth showSeparator={false} viewName="deeplink" deeplink={deeplink} />
+  }
 
   return (
     <AppLayout>

--- a/packages/fxa-settings/src/pages/Index/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Index/interfaces.ts
@@ -31,6 +31,7 @@ export interface IndexProps extends LocationState {
   errorBannerMessage?: string;
   successBannerMessage?: string;
   tooltipErrorMessage?: string;
+  deeplink?: string
 }
 
 export interface IndexFormData {

--- a/packages/fxa-settings/src/pages/Index/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Index/mocks.tsx
@@ -89,6 +89,7 @@ export const Subject = ({
   initialErrorBanner = '',
   initialSuccessBanner = '',
   initialTooltipMessage = '',
+  deeplink,
 }: {
   integration?: IndexIntegration;
   serviceName?: MozServices;
@@ -96,6 +97,7 @@ export const Subject = ({
   initialErrorBanner?: string;
   initialSuccessBanner?: string;
   initialTooltipMessage?: string;
+  deeplink?: string;
 }) => {
   const [errorBannerMessage, setErrorBannerMessage] =
     React.useState(initialErrorBanner);
@@ -118,6 +120,7 @@ export const Subject = ({
           setErrorBannerMessage,
           setSuccessBannerMessage,
           setTooltipErrorMessage,
+          deeplink
         }}
       />
     </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -475,6 +475,8 @@ const SigninContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  const deeplink = queryParamModel.deeplink;
+
   return (
     <Signin
       {...{
@@ -493,6 +495,7 @@ const SigninContainer = ({
         finishOAuthFlowHandler,
         localizedSuccessBannerHeading,
         localizedSuccessBannerDescription,
+        deeplink
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -56,6 +56,7 @@ jest.mock('../../lib/metrics', () => ({
 jest.mock('../../lib/glean', () => ({
   __esModule: true,
   default: {
+    isDone: jest.fn(),
     login: {
       forgotPassword: jest.fn(),
       view: jest.fn(),
@@ -73,6 +74,10 @@ jest.mock('../../lib/glean', () => ({
     },
     thirdPartyAuth: {
       loginNoPwView: jest.fn(),
+      startGoogleAuthFromLogin: jest.fn(),
+      startAppleAuthFromLogin: jest.fn(),
+      appleDeeplink: jest.fn(),
+      googleDeeplink: jest.fn(),
     },
   },
 }));
@@ -780,6 +785,22 @@ describe('Signin component', () => {
       differentAccountLinkRendered();
 
       passwordInputNotRendered();
+    });
+
+    it('does not render when deeplinking third party auth', () => {
+      renderWithLocalizationProvider(
+        <Subject
+          sessionToken={MOCK_SESSION_TOKEN}
+          deeplink="appleLogin"
+        />
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /Continue with Google/ })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Continue with Apple/ })
+      ).not.toBeInTheDocument();
     });
 
     it('emits an event on forgot password link click', async () => {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -61,6 +61,7 @@ const Signin = ({
   finishOAuthFlowHandler,
   localizedSuccessBannerHeading,
   localizedSuccessBannerDescription,
+  deeplink
 }: SigninProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const location = useLocation();
@@ -84,6 +85,8 @@ const Signin = ({
   const isMonitorClient = isOAuth && isClientMonitor(clientId);
   const isRelayClient = isOAuth && isClientRelay(clientId);
   const hasLinkedAccountAndNoPassword = hasLinkedAccount && !hasPassword;
+
+  const isDeeplinking = !!deeplink;
 
   // We must use a ref because we may update this value in a callback
   let isPasswordNeededRef = useRef(
@@ -319,6 +322,11 @@ const Signin = ({
       sessionToken,
     ]
   );
+
+  if (isDeeplinking) {
+    // To avoid flickering, we only render third party auth and navigate
+    return <ThirdPartyAuth showSeparator={false} viewName="deeplink" deeplink={deeplink} />
+  }
 
   return (
     <AppLayout>

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -87,6 +87,7 @@ export interface SigninProps {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   localizedSuccessBannerHeading?: string;
   localizedSuccessBannerDescription?: string;
+  deeplink?: string;
 }
 
 export type BeginSigninHandler = (

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -213,6 +213,7 @@ const SignupContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  const deeplink = queryParamModel.deeplink;
   return (
     <Signup
       {...{
@@ -220,6 +221,7 @@ const SignupContainer = ({
         email,
         beginSignupHandler,
         useSyncEnginesResult,
+        deeplink
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -53,6 +53,7 @@ export const Signup = ({
     setDeclinedSyncEngines,
     selectedEngines,
   },
+  deeplink
 }: SignupProps) => {
   const sensitiveDataClient = useSensitiveDataClient();
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
@@ -256,6 +257,12 @@ export const Signup = ({
       sensitiveDataClient,
     ]
   );
+
+  const isDeeplinking = !!deeplink;
+  if (isDeeplinking) {
+    // To avoid flickering, we only render third party auth and navigate
+    return <ThirdPartyAuth showSeparator={false} viewName="deeplink" deeplink={deeplink} />
+  }
 
   return (
     // TODO: FXA-8268, if force_auth && AuthErrors.is(error, 'DELETED_ACCOUNT'):

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -41,6 +41,7 @@ export interface SignupProps {
   email: string;
   beginSignupHandler: BeginSignupHandler;
   useSyncEnginesResult: ReturnType<typeof useSyncEngines>;
+  deeplink?: string;
 }
 
 export type SignupIntegration = SignupOAuthIntegration | SignupBaseIntegration;

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -151,6 +151,8 @@ export const eventsMap = {
     startGoogleAuthFromLogin: 'third_party_auth_google_login_start',
     startAppleAuthFromLogin: 'third_party_auth_apple_login_start',
     loginNoPwView: 'third_party_auth_login_no_pw_view',
+    googleDeeplink: 'third_party_auth_google_deeplink',
+    appleDeeplink: 'third_party_auth_apple_deeplink',
   },
 
   thirdPartyAuthSetPassword: {


### PR DESCRIPTION
## Because

- This currently does not deeplink into the third party auth flow

## This pull request

- Adds support to deeplink in our React email first pages

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11678

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test goto `http://localhost:8080` and click `Sign In (Google)`. You will need to have Google auth configured locally.
