### PR TITLE
task: audit yarn resolutions – eslint-plugin-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,6 @@
     "css-minimizer-webpack-plugin": ">=4 <5",
     "compression": "1.7.4",
     "elliptic": ">=6.5.4",
-    "eslint-plugin-import": "^2.25.2",
     "fbjs/isomorphic-fetch": "^3.0.0",
     "flat": "5.0.2",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",

--- a/packages/fxa-auth-server/.eslintignore
+++ b/packages/fxa-auth-server/.eslintignore
@@ -1,1 +1,2 @@
 dist/
+storybook-static/

--- a/yarn.lock
+++ b/yarn.lock
@@ -30514,7 +30514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-module-utils@npm:^2.12.0":
+"eslint-module-utils@npm:^2.12.0, eslint-module-utils@npm:^2.9.0":
   version: 2.12.0
   resolution: "eslint-module-utils@npm:2.12.0"
   dependencies:
@@ -30553,7 +30553,35 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"eslint-plugin-import@npm:^2.25.2":
+"eslint-plugin-import@npm:2.30.0":
+  version: 2.30.0
+  resolution: "eslint-plugin-import@npm:2.30.0"
+  dependencies:
+    "@rtsao/scc": ^1.1.0
+    array-includes: ^3.1.8
+    array.prototype.findlastindex: ^1.2.5
+    array.prototype.flat: ^1.3.2
+    array.prototype.flatmap: ^1.3.2
+    debug: ^3.2.7
+    doctrine: ^2.1.0
+    eslint-import-resolver-node: ^0.3.9
+    eslint-module-utils: ^2.9.0
+    hasown: ^2.0.2
+    is-core-module: ^2.15.1
+    is-glob: ^4.0.3
+    minimatch: ^3.1.2
+    object.fromentries: ^2.0.8
+    object.groupby: ^1.0.3
+    object.values: ^1.2.0
+    semver: ^6.3.1
+    tsconfig-paths: ^3.15.0
+  peerDependencies:
+    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+  checksum: 0ec1ad69c0d22f15bc4a49ee97ae757e4adfc3181996f2c4a1ed4d5028bd99bab38e7623e58ef4477ba1db8425f441e4e986367125273efa4c5f7ad2c4467a9a
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-import@npm:^2.25.3, eslint-plugin-import@npm:^2.28.1, eslint-plugin-import@npm:^2.30.0":
   version: 2.31.0
   resolution: "eslint-plugin-import@npm:2.31.0"
   dependencies:


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches and feature adds

## This pull request

- removes the yarn resolution for eslint-plugin-import

## Issue that this pull request solves

Closes: FXA-11693

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.

## Other information (Optional)

After removal, I confirmed all dependent installs of eslint-plugin-import are >= 2.30, which satisfies the original resolution.

As a bonus, I attempted to move all eslint packages to root, but they seem tightly coupled to individual packages with specific plugins and versions.  I got as far as NX breaking when attempting to run lint – I believe we might need to set individual NX project.json files within each FxA package specifying eslint target, or something similar.
