### PR TITLE
task: audit yarn resolutions – @graphql-typed-document-node/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,6 @@
     "packages/*"
   ],
   "resolutions": {
-    "@graphql-typed-document-node/core": "3.2.0",
     "@react-pdf/layout": "3.9.1",
     "@react-pdf/textkit": "4.3.0",
     "@svgr/webpack": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,7 +5047,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-typed-document-node/core@npm:3.2.0":
+"@graphql-typed-document-node/core@npm:3.2.0, @graphql-typed-document-node/core@npm:^3.1.1, @graphql-typed-document-node/core@npm:^3.2.0":
   version: 3.2.0
   resolution: "@graphql-typed-document-node/core@npm:3.2.0"
   peerDependencies:


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches and feature adds


## This pull request

- removes the yarn resolution for @graphql-typed-document-node/core

## Issue that this pull request solves

Closes: FXA-11701

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Other information (Optional)

At the time of this writing, the latest @graphql-typed-document-node/core release is 3.2.0 (which was pinned via resolution).  After removing the resolution and auditing via `yarn why`, the resolved transitive dependencies remain at the latest 3.2.0 version.