### PR TITLE
fix(auth): Fix bug related to flowId and third party auth

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -187,7 +187,7 @@ const ThirdPartySignInForm = ({
     if (stateRef.current) {
       stateRef.current.value = getState();
     }
-  }, [party, viewName, logViewEventOnce]);
+  }, [party, stateRef, viewName, logViewEventOnce]);
 
 
   if (onSubmit === undefined) {

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -136,8 +136,8 @@ const ThirdPartyAuthCallback = ({
 
       // Extract relayed fxa parameters
       const params = new URLSearchParams(fxaParams || '');
-      const flowId = params.get('flowId') || undefined;
-      const flowBeginTime = params.get('flowBeginTime') || undefined;
+      const flowId = params.get('flowId') || params.get('flow_id') || undefined;
+      const flowBeginTime = params.get('flowBeginTime') || params.get('flow_begin_time') || undefined;
       const originalService =
         params.get('service') || params.get('client_id') || undefined;
       const linkedAccount: LinkedAccountData =


### PR DESCRIPTION
## Because

- When we switched over to React email first, the flowId value switched to `flow_id`

## This pull request

- Checks and uses `flow_id` if available

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11706

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="893" alt="Screenshot 2025-05-20 at 10 53 47 AM" src="https://github.com/user-attachments/assets/b168f812-7bbd-4fef-b7ee-0dfbf625f335" />

## Other information (Optional)

Any other information that is important to this pull request.
