### PR TITLE
feat(payments-cart): Updates amount in metadata to unit amount

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2082,7 +2082,9 @@ export class StripeHelper extends StripeHelperBase {
    */
   async changeSubscriptionPlan(
     subscription: Stripe.Subscription,
-    newPlanId: string
+    newPlanId: string,
+    newPlanAmount: number,
+    newPlanCurrency: string
   ): Promise<Stripe.Subscription> {
     const currentPlanId = subscription.items.data[0].plan.id;
     if (currentPlanId === newPlanId) {
@@ -2091,6 +2093,8 @@ export class StripeHelper extends StripeHelperBase {
 
     const updatedMetadata = {
       ...subscription.metadata,
+      amount: newPlanAmount,
+      currency: newPlanCurrency,
       previous_plan_id: currentPlanId,
       plan_change_date: moment().unix(),
     };

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3811,6 +3811,8 @@ describe('#integration - StripeHelper', () => {
       const subscription = deepCopy(subscription1);
       subscription.metadata = {
         key: 'value',
+        amount: 1000,
+        currency: 'usd',
         previous_plan_id: 'plan_123',
         plan_change_date: 12345678,
       };
@@ -3822,7 +3824,9 @@ describe('#integration - StripeHelper', () => {
 
       const actual = await stripeHelper.changeSubscriptionPlan(
         subscription,
-        'plan_G93mMKnIFCjZek'
+        'plan_G93mMKnIFCjZek',
+        1000,
+        'usd'
       );
 
       assert.deepEqual(actual, subscription2);
@@ -3840,6 +3844,8 @@ describe('#integration - StripeHelper', () => {
           proration_behavior: 'always_invoice',
           metadata: {
             key: 'value',
+            amount: 1000,
+            currency: 'usd',
             previous_plan_id: subscription1.items.data[0].plan.id,
             plan_change_date: unixTimestamp,
           },


### PR DESCRIPTION
## This pull request

- updates the amount for subscription metadata from the cart amount to the unit amount upon subscription creation and upgrade via 3.0 for multi-currency prices
- adds currency and (unit) amount to subscription metadata for subscription upgrade via 2.0

## Issue that this pull request solves

Closes: FXA-11683

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
### [Upgrade to 123Foxkeh ($1/mo) using test card](https://dashboard.stripe.com/test/subscriptions/sub_1RRDqhBVqmGyQTMaWpAUUA2k)
<img width="330" alt="Screenshot 2025-05-20 at 3 51 14 PM" src="https://github.com/user-attachments/assets/4e78bea0-1ba3-46c8-b5fb-bac9d32520c4" />

