### PR TITLE
fix(settings): Show correct heading for sync signin with no password set

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -758,6 +758,19 @@ describe('Signin component', () => {
           screen.queryByRole('button', { name: 'Sign in' })
         ).not.toBeInTheDocument();
       });
+
+      it('renders third party auth options for sync with linked account', () => {
+        const integration = createMockSigninOAuthNativeSyncIntegration();
+        render({ integration, hasPassword: false, hasLinkedAccount: true });
+
+        signInHeaderRendered();
+        expect(
+          screen.queryByRole('button', { name: /Continue with Google/ })
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: /Continue with Apple/ })
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -331,7 +331,7 @@ const Signin = ({
           }}
         />
       )}
-      {isPasswordNeededRef.current ? (
+      {isPasswordNeededRef.current && hasPassword ? (
         <CardHeader
           headingText="Enter your password"
           headingAndSubheadingFtlId="signin-password-needed-header-2"


### PR DESCRIPTION
## Because

* For sync sign in with an account that has a linked account but no password, show "Sign in" heading and not "Enter your password"

## This pull request

* Updates the condition for the heading selection

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

<img width="544" alt="Screenshot 2025-05-20 at 10 56 58 AM" src="https://github.com/user-attachments/assets/4579f9b4-7fbd-4930-b994-05cc96a88f95" />

## Other information (Optional)

Any other information that is important to this pull request.
