### PR TITLE
fix(circleci): update all node images to 22.15.1

### DIFF
--- a/_dev/docker/ci-lockfile-generator/Dockerfile
+++ b/_dev/docker/ci-lockfile-generator/Dockerfile
@@ -5,7 +5,7 @@
 # By running a yarn install inside the same base container that we use in our CI, we can
 # ensure the same checksums are created correctly.
 #
-FROM cimg/node:22.15
+FROM cimg/node:22.15.1
 
 COPY . .
 RUN sudo yarn cache clear --all

--- a/_dev/docker/ci/Dockerfile
+++ b/_dev/docker/ci/Dockerfile
@@ -4,7 +4,7 @@
 
 # Runs tests and common CI operations. Needs minimal install. Assumes
 # workspace will be restored into the project folder.
-FROM cimg/node:22.15 AS test-runner
+FROM cimg/node:22.15.1 AS test-runner
 RUN sudo apt-get update && sudo apt-get install -y \
     python3-venv
 WORKDIR /home/circleci
@@ -29,7 +29,7 @@ RUN yarn install --immutable;
 # Acts as an intermediate stage for adding the firefox install. Note,
 # that a yarn install must happen first to ensure the correct version
 # of firefox is installed. Also note that the functional-test-runner
-# must based on cimg/node:22.14-browsers, which is why this stage
+# must based on cimg/node:22.15.1-browsers, which is why this stage
 # is necessary.
 FROM builder AS playwright-install
 RUN npx playwright install --with-deps firefox chromium webkit;
@@ -37,7 +37,7 @@ RUN npx playwright install --with-deps firefox chromium webkit;
 
 # Runs functional tests in our CI. Needs minimal install. Assumes
 # workspace will be restored into the project folder.
-FROM cimg/node:22.14-browsers AS functional-test-runner
+FROM cimg/node:22.15.1-browsers AS functional-test-runner
 WORKDIR /home/circleci
 COPY --chown=circleci:circleci --from=playwright-install /home/circleci/.cache/ms-playwright .cache/ms-playwright/
 COPY --chown=circleci:circleci project project


### PR DESCRIPTION
## Because

- Mismatch in node versions was causing nx cache misses

## This pull request

- Update all node images to use 22.15.1, matching the current repo required node version.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
