### PR TITLE
task: audit yarn resolutions – @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,7 @@
     "twilio": "5.3.5",
     "typedi": "^0.8.0",
     "uuid": "^10.0.0",
-    "winston": "^3.17.0",
-    "zod": "^3.25.7"
+    "winston": "^3.17.0"
   },
   "engines": {
     "node": "^22.15.1"
@@ -265,7 +264,6 @@
     "@react-pdf/layout": "3.9.1",
     "@react-pdf/textkit": "4.3.0",
     "@svgr/webpack": "^8.0.1",
-    "@types/node": "^20.11.1",
     "@types/react": "18.2.14",
     "asn1.js": ">=5.4.1",
     "bn.js": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18821,12 +18821,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.11.1":
-  version: 20.17.44
-  resolution: "@types/node@npm:20.17.44"
+"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:>=8.1.0, @types/node@npm:^22.13.5":
+  version: 22.15.19
+  resolution: "@types/node@npm:22.15.19"
   dependencies:
-    undici-types: ~6.19.2
-  checksum: 46ae4504ee490705ce9b19973ec9dc6581f3cbbd987bc64b939d7c24b1b401a55412de2376004790649b58551e098c6fb8077050c8acd4b5d9357678cfbca3b4
+    undici-types: ~6.21.0
+  checksum: 5aa45bf93c62bba1193bf07a56dddd84b74f89a554a08e1bd7772610f529d8dc6f828d464bc28c10001bd0092b6b3d11736544b52e154f25f5ca0ed93f04c32b
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^16.0.0":
+  version: 16.18.126
+  resolution: "@types/node@npm:16.18.126"
+  checksum: 86112e7499f8a4d1bb60696cab0bf464adf3c141fca4bc5451e8f3aba5736529b76d4b4396edb21e5d7c19592852f7d6cb81ee70074fd13bde2db2d0db720467
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.0.0":
+  version: 18.19.101
+  resolution: "@types/node@npm:18.19.101"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: f914672092008bcebb6eedbd98b5791a9400b3821cf27a91736d6c64a1827c8551c6a7549663f94303656a6c8159df9d7f8a80632fd9b1d3d77b2c63141c9efe
   languageName: node
   linkType: hard
 
@@ -33114,7 +33130,6 @@ __metadata:
     typescript: 5.5.3
     uuid: ^10.0.0
     winston: ^3.17.0
-    zod: ^3.25.7
   languageName: unknown
   linkType: soft
 
@@ -54649,10 +54664,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.19.2":
-  version: 6.19.8
-  resolution: "undici-types@npm:6.19.8"
-  checksum: de51f1b447d22571cf155dfe14ff6d12c5bdaec237c765085b439c38ca8518fc360e88c70f99469162bf2e14188a7b0bcb06e1ed2dc031042b984b0bb9544017
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 46331c7d6016bf85b3e8f20c159d62f5ae471aba1eb3dc52fff35a0259d58dcc7d592d4cc4f00c5f9243fa738a11cfa48bd20203040d4a9e6bc25e807fab7ab3
   languageName: node
   linkType: hard
 
@@ -57667,13 +57689,6 @@ __metadata:
   version: 3.24.4
   resolution: "zod@npm:3.24.4"
   checksum: 62829789765a9187bd72bed3972a7c1a39fdfe6c59bc752eedabec5f99af701658471b8577d22e0fee2081e6e35d4efc93c02c90e13350755a36feadbf72bbbc
-  languageName: node
-  linkType: hard
-
-"zod@npm:^3.25.7":
-  version: 3.25.7
-  resolution: "zod@npm:3.25.7"
-  checksum: b2ca317f082a6b2715efe10c9bdff682bf0d9b5b9c9b9880c3098e3b1ed23fc5a76cac14391756c8e81bf28fe29acb38abf3dbf8929f4607456f23e6993e68c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches and feature adds

## This pull request

- removes the yarn resolution for @types/node

## Issue that this pull request solves

Closes: FXA-11707

## Other information (Optional)

This also removes `zod` which was temp-installed as a noop cache-buster for updated Node version.

I attempted to also remove @types/react but it's a transitive dep of other packages that cannot be easily updated (@material-ui/core, @types/react-is, tap)
