### PR TITLE
fix(paypal): do not return inactive billing agreemnt ids

### DIFF
--- a/libs/payments/paypal/src/lib/paypalBillingAgreement.manager.spec.ts
+++ b/libs/payments/paypal/src/lib/paypalBillingAgreement.manager.spec.ts
@@ -81,7 +81,7 @@ describe('PaypalBillingAgreementManager', () => {
       const mockBillingAgreementId = faker.string.uuid();
 
       jest
-        .spyOn(paypalBillingAgreementManager, 'retrieveId')
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
         .mockResolvedValue(undefined);
 
       jest
@@ -258,8 +258,8 @@ describe('PaypalBillingAgreementManager', () => {
     });
   });
 
-  describe('getCustomerBillingAgreementId', () => {
-    it("returns the customer's current PayPal billing agreement ID", async () => {
+  describe('retrieveActiveId', () => {
+    it("returns the customer's current active PayPal billing agreement ID", async () => {
       const uid = faker.string.uuid();
       const mockPayPalCustomer = ResultPaypalCustomerFactory();
 
@@ -267,7 +267,7 @@ describe('PaypalBillingAgreementManager', () => {
         .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
         .mockResolvedValue([mockPayPalCustomer]);
 
-      const result = await paypalBillingAgreementManager.retrieveId(uid);
+      const result = await paypalBillingAgreementManager.retrieveActiveId(uid);
       expect(result).toEqual(mockPayPalCustomer.billingAgreementId);
     });
 
@@ -278,7 +278,19 @@ describe('PaypalBillingAgreementManager', () => {
         .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
         .mockResolvedValue([]);
 
-      const result = await paypalBillingAgreementManager.retrieveId(uid);
+      const result = await paypalBillingAgreementManager.retrieveActiveId(uid);
+      expect(result).toEqual(undefined);
+    });
+
+    it('returns undefined if billing agreement is not active', async () => {
+      const uid = faker.string.uuid();
+      const mockPayPalCustomer = ResultPaypalCustomerFactory({ status: 'Cancelled' });
+
+      jest
+        .spyOn(paypalCustomerManager, 'fetchPaypalCustomersByUid')
+        .mockResolvedValue([mockPayPalCustomer]);
+
+      const result = await paypalBillingAgreementManager.retrieveActiveId(uid);
       expect(result).toEqual(undefined);
     });
 
@@ -292,7 +304,7 @@ describe('PaypalBillingAgreementManager', () => {
         .mockResolvedValue([mockPayPalCustomer1, mockPayPalCustomer2]);
 
       await expect(
-        paypalBillingAgreementManager.retrieveId(uid)
+        paypalBillingAgreementManager.retrieveActiveId(uid)
       ).rejects.toBeInstanceOf(PaypalCustomerMultipleRecordsError);
     });
   });

--- a/libs/payments/paypal/src/lib/paypalBillingAgreement.manager.ts
+++ b/libs/payments/paypal/src/lib/paypalBillingAgreement.manager.ts
@@ -15,14 +15,14 @@ export class PaypalBillingAgreementManager {
   constructor(
     private client: PayPalClient,
     private paypalCustomerManager: PaypalCustomerManager
-  ) {}
+  ) { }
 
   public async retrieveOrCreateId(
     uid: string,
     hasSubscriptions: boolean,
     token?: string
   ) {
-    const existingBillingAgreementId = await this.retrieveId(uid);
+    const existingBillingAgreementId = await this.retrieveActiveId(uid);
     if (existingBillingAgreementId) return existingBillingAgreementId;
 
     if (hasSubscriptions) {
@@ -96,12 +96,12 @@ export class PaypalBillingAgreementManager {
    * Retrieves the customer’s current paypal billing agreement ID from the
    * auth database via the Paypal repository
    */
-  async retrieveId(uid: string): Promise<string | undefined> {
+  async retrieveActiveId(uid: string): Promise<string | undefined> {
     const paypalCustomer =
       await this.paypalCustomerManager.fetchPaypalCustomersByUid(uid);
     const firstRecord = paypalCustomer.at(0);
 
-    if (!firstRecord) return;
+    if (!firstRecord || firstRecord?.status !== 'active') return;
     if (paypalCustomer.length > 1)
       throw new PaypalCustomerMultipleRecordsError(uid);
 


### PR DESCRIPTION
## Because

- PaypalBillingAgreementManager returns billing agreement even if its status is not active.

## This pull request

- Update method to only return active billing agreement ids.

## Issue that this pull request solves

Closes: #FXA-11679

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
