### PR TITLE
fix(pairing): Remove `/oauth` from react email first rollout

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -27,7 +27,13 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       featureFlagOn: showReactApp.emailFirstRoutes,
       // the order of the routes in the array is important.  do not put '/'
       // first.
-      routes: reactRoute.getRoutes(['authorization', 'oauth', '/']),
+      routes: reactRoute.getRoutes([
+        'authorization',
+        // We have to temporarily remove the `/oauth` because Fx desktop uses
+        // that path to initiate the pairing flow
+        // 'oauth'
+        '/'
+      ]),
       fullProdRollout: true,
     },
     simpleRoutes: {


### PR DESCRIPTION
## Because

- Desktop launches its pairing screen with `/oauth` path containing pairing query params
- React pages try to create an OAuth integration and fails beacause it does not have all the correct oauth params 

## This pull request

- Removes `oauth` from our email first roll out, note that I think this won't have a big impact on other RPs since the `/authorization` endpoint also handles OAuth authenication

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11702

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
