### PR TITLE
feat(react): navigate to RPs without adding to browser history

### DIFF
--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -13,7 +13,8 @@ import React from 'react';
 export function hardNavigate(
   href: string,
   additionalQueryParams = {},
-  includeCurrentQueryParams = false
+  includeCurrentQueryParams = false,
+  replace: boolean = false,
 ) {
   // If there are any query params in the href, we automatically include them in the new url.
   const url = new URL(href, window.location.origin);
@@ -32,7 +33,11 @@ export function hardNavigate(
     url.searchParams.append(key, value);
   });
 
-  window.location.href = url.href;
+  if (replace) {
+    window.location.replace(url.href);
+  } else {
+    window.location.href = url.href;
+  }
 }
 
 export enum LocalizedDateOptions {
@@ -98,7 +103,7 @@ export class FtlMsgResolver {
   constructor(
     public readonly l10n: ReactLocalization,
     public readonly strict: boolean
-  ) {}
+  ) { }
 
   /**
    * A wrapper around l10n.getString that provides more safety. When strict is true, using this function ensures:

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
@@ -98,7 +98,7 @@ function mockSigninPushCodeModule() {
 }
 
 function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => { });
 }
 
 // Set this when testing local storage
@@ -224,7 +224,10 @@ describe('SigninPushCode container', () => {
 
       await waitFor(() =>
         expect(ReactUtils.hardNavigate).toBeCalledWith(
-          '/pair?showSuccessMessage=true'
+          '/pair?showSuccessMessage=true',
+          undefined,
+          undefined,
+          false
         )
       );
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -51,7 +51,7 @@ jest.mock('@reach/router', () => {
     __esModule: true,
     ...jest.requireActual('@reach/router'),
     navigate: jest.fn(),
-    useLocation: () => () => {},
+    useLocation: () => () => { },
   };
 });
 
@@ -69,7 +69,7 @@ function render(
 }
 
 function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => { });
 }
 
 const serviceRelayText =
@@ -107,7 +107,7 @@ describe('SigninTokenCode page', () => {
       (_, element) =>
         element?.tagName === 'P' &&
         element?.textContent ===
-          `Enter the code that was sent to ${MOCK_EMAIL} within 5 minutes.`
+        `Enter the code that was sent to ${MOCK_EMAIL} within 5 minutes.`
     );
     screen.getByLabelText('Enter 6-digit code');
     screen.getByRole('button', { name: 'Confirm' });
@@ -237,7 +237,7 @@ describe('SigninTokenCode page', () => {
       beforeEach(() => {
         hardNavigateSpy = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementation(() => {});
+          .mockImplementation(() => { });
       });
       afterEach(() => {
         hardNavigateSpy.mockRestore();
@@ -260,7 +260,7 @@ describe('SigninTokenCode page', () => {
 
         await expectSuccessGleanEvents();
         expect(mockOnSessionVerified).toHaveBeenCalledTimes(1);
-        expect(navigate).toHaveBeenCalledWith('/settings');
+        expect(navigate).toHaveBeenCalledWith('/settings', { replace: false });
       });
       it('when verificationReason is a force password change', async () => {
         session = mockSession();
@@ -286,13 +286,13 @@ describe('SigninTokenCode page', () => {
         const integration = createMockSigninOAuthIntegration();
         const hardNavigate = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementation(() => {});
+          .mockImplementation(() => { });
 
         render({ finishOAuthFlowHandler, integration });
         submitCode();
         await expectSuccessGleanEvents();
         await waitFor(() => {
-          expect(hardNavigate).toHaveBeenCalledWith('someUri');
+          expect(hardNavigate).toHaveBeenCalledWith('someUri', undefined, undefined, true);
         });
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -154,7 +154,7 @@ describe('Sign in with TOTP code page', () => {
       expect(GleanMetrics.totpForm.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(1);
-      expect(navigate).toHaveBeenCalledWith('/settings');
+      expect(navigate).toHaveBeenCalledWith('/settings', { replace: false });
     });
 
     describe('fxaLogin webchannel message', () => {
@@ -164,7 +164,7 @@ describe('Sign in with TOTP code page', () => {
         fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
         hardNavigateSpy = jest
           .spyOn(utils, 'hardNavigate')
-          .mockImplementation(() => {});
+          .mockImplementation(() => { });
       });
       it('is sent if Sync integration and navigates to pair', async () => {
         const integration = createMockSigninOAuthNativeSyncIntegration();
@@ -173,7 +173,10 @@ describe('Sign in with TOTP code page', () => {
         );
         expect(fxaLoginSpy).toHaveBeenCalled();
         expect(hardNavigateSpy).toHaveBeenCalledWith(
-          '/pair?showSuccessMessage=true'
+          '/pair?showSuccessMessage=true',
+          undefined,
+          undefined,
+          true
         );
       });
       it('is not sent otherwise', async () => {
@@ -215,7 +218,7 @@ describe('Sign in with TOTP code page', () => {
           .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
         const hardNavigate = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementationOnce(() => {});
+          .mockImplementationOnce(() => { });
 
         await waitFor(() =>
           renderAndSubmitTotpCode({}, finishOAuthFlowHandler, integration)
@@ -224,7 +227,7 @@ describe('Sign in with TOTP code page', () => {
         expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
         expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(1);
         await waitFor(() =>
-          expect(hardNavigate).toHaveBeenCalledWith('someUri')
+          expect(hardNavigate).toHaveBeenCalledWith('someUri', undefined, undefined, true)
         );
       });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.test.tsx
@@ -245,7 +245,7 @@ describe('SigninUnblock', () => {
       await waitFor(() => {
         expect(signinWithUnblockCode).toHaveBeenCalledTimes(1);
       });
-      expect(navigate).toHaveBeenCalledWith('/settings');
+      expect(navigate).toHaveBeenCalledWith('/settings', { replace: false });
     });
 
     it('emits expected metrics events', async () => {
@@ -286,7 +286,7 @@ describe('SigninUnblock', () => {
     beforeEach(() => {
       hardNavigateSpy = jest
         .spyOn(utils, 'hardNavigate')
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
     });
 
     afterEach(() => {
@@ -304,7 +304,7 @@ describe('SigninUnblock', () => {
       submitButton.click();
 
       await waitFor(() => {
-        expect(hardNavigateSpy).toHaveBeenCalledWith(redirectTo);
+        expect(hardNavigateSpy).toHaveBeenCalledWith(redirectTo, undefined, undefined, false);
       });
     });
 
@@ -321,7 +321,7 @@ describe('SigninUnblock', () => {
       submitButton.click();
 
       await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('/settings');
+        expect(navigate).toHaveBeenCalledWith('/settings', { replace: false });
       });
     });
 
@@ -334,7 +334,7 @@ describe('SigninUnblock', () => {
       submitButton.click();
 
       await waitFor(() => {
-        expect(navigate).toHaveBeenCalledWith('/settings');
+        expect(navigate).toHaveBeenCalledWith('/settings', { replace: false });
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -310,6 +310,7 @@ describe('Signin component', () => {
             enterPasswordAndSubmit();
             await waitFor(() => {
               expect(navigate).toHaveBeenCalledWith('/signin_totp_code', {
+                replace: false,
                 state: {
                   email: MOCK_EMAIL,
                   uid: MOCK_UID,
@@ -334,6 +335,7 @@ describe('Signin component', () => {
             enterPasswordAndSubmit();
             await waitFor(() => {
               expect(navigate).toHaveBeenCalledWith('/confirm_signup_code', {
+                replace: false,
                 state: {
                   email: MOCK_EMAIL,
                   uid: MOCK_UID,
@@ -357,6 +359,7 @@ describe('Signin component', () => {
             enterPasswordAndSubmit();
             await waitFor(() => {
               expect(navigate).toHaveBeenCalledWith('/signin_token_code', {
+                replace: false,
                 state: {
                   email: MOCK_EMAIL,
                   uid: MOCK_UID,
@@ -385,6 +388,7 @@ describe('Signin component', () => {
               expect(navigate).toHaveBeenCalledWith(
                 '/inline_recovery_key_setup?',
                 {
+                  replace: true,
                   state: {
                     email: MOCK_EMAIL,
                     uid: MOCK_UID,
@@ -407,7 +411,7 @@ describe('Signin component', () => {
 
             enterPasswordAndSubmit();
             await waitFor(() => {
-              expect(navigate).toHaveBeenCalledWith('/settings');
+              expect(navigate).toHaveBeenCalledWith('/settings', { replace: false });
             });
           });
 
@@ -419,7 +423,7 @@ describe('Signin component', () => {
               fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
               hardNavigateSpy = jest
                 .spyOn(utils, 'hardNavigate')
-                .mockImplementation(() => {});
+                .mockImplementation(() => { });
             });
             it('is sent if Sync integration and navigates to CAD', async () => {
               const beginSigninHandler = jest.fn().mockReturnValueOnce(
@@ -446,7 +450,7 @@ describe('Signin component', () => {
                 });
               });
               expect(hardNavigateSpy).toHaveBeenCalledWith(
-                '/pair?showSuccessMessage=true'
+                '/pair?showSuccessMessage=true', undefined, undefined, false
               );
             });
             it('is not sent if user has 2FA enabled', async () => {
@@ -479,7 +483,7 @@ describe('Signin component', () => {
               fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
               hardNavigateSpy = jest
                 .spyOn(utils, 'hardNavigate')
-                .mockImplementation(() => {});
+                .mockImplementation(() => { });
               finishOAuthFlowHandler = jest
                 .fn()
                 .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
@@ -503,6 +507,7 @@ describe('Signin component', () => {
               enterPasswordAndSubmit();
               await waitFor(() => {
                 expect(navigate).toHaveBeenCalledWith('/confirm_signup_code', {
+                  replace: false,
                   state: {
                     email: MOCK_EMAIL,
                     uid: MOCK_UID,
@@ -531,6 +536,7 @@ describe('Signin component', () => {
               enterPasswordAndSubmit();
               await waitFor(() => {
                 expect(navigate).toHaveBeenCalledWith('/confirm_signup_code', {
+                  replace: false,
                   state: {
                     email: MOCK_EMAIL,
                     uid: MOCK_UID,
@@ -559,7 +565,10 @@ describe('Signin component', () => {
               await waitFor(() => {
                 expect(fxaOAuthLoginSpy).not.toHaveBeenCalled();
                 expect(hardNavigateSpy).toHaveBeenCalledWith(
-                  MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect
+                  MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect,
+                  undefined,
+                  undefined,
+                  true
                 );
               });
             });
@@ -599,7 +608,7 @@ describe('Signin component', () => {
                 expect(fxaLoginCallOrder).toBeLessThan(fxaOAuthLoginCallOrder);
 
                 expect(hardNavigateSpy).toHaveBeenCalledWith(
-                  '/pair?showSuccessMessage=true'
+                  '/pair?showSuccessMessage=true', undefined, undefined, true
                 );
               });
             });
@@ -642,7 +651,7 @@ describe('Signin component', () => {
                 // Ensure fxaLogin is called first
                 expect(fxaLoginCallOrder).toBeLessThan(fxaOAuthLoginCallOrder);
 
-                expect(navigate).toHaveBeenCalledWith('/settings');
+                expect(navigate).toHaveBeenCalledWith('/settings', { replace: true });
               });
             });
           });
@@ -852,7 +861,7 @@ describe('Signin component', () => {
         beforeEach(() => {
           hardNavigateSpy = jest
             .spyOn(utils, 'hardNavigate')
-            .mockImplementation(() => {});
+            .mockImplementation(() => { });
         });
 
         afterEach(() => {
@@ -884,7 +893,7 @@ describe('Signin component', () => {
 
           enterPasswordAndSubmit();
           await waitFor(() => {
-            expect(hardNavigateSpy).toHaveBeenCalledWith('someUri');
+            expect(hardNavigateSpy).toHaveBeenCalledWith('someUri', undefined, undefined, true);
           });
         });
         it('handles error due to TOTP required or insufficent ARC value', async () => {
@@ -910,6 +919,7 @@ describe('Signin component', () => {
           expect(GleanMetrics.login.error).toHaveBeenCalledTimes(1);
 
           expect(navigate).toHaveBeenCalledWith('/inline_totp_setup', {
+            replace: true,
             state: {
               email: MOCK_EMAIL,
               keyFetchToken: signinResponse.data.signIn.keyFetchToken,
@@ -1015,7 +1025,7 @@ describe('Signin component', () => {
     beforeEach(() => {
       hardNavigateSpy = jest
         .spyOn(utils, 'hardNavigate')
-        .mockImplementation(() => {});
+        .mockImplementation(() => { });
     });
     afterEach(() => {
       hardNavigateSpy.mockRestore();

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -34,16 +34,16 @@ export type SigninUnblockIntegration = Pick<
 
 export type SigninIntegration =
   | Pick<
-      Integration,
-      | 'type'
-      | 'isSync'
-      | 'getService'
-      | 'getClientId'
-      | 'wantsKeys'
-      | 'data'
-      | 'isDesktopSync'
-      | 'isDesktopRelay'
-    >
+    Integration,
+    | 'type'
+    | 'isSync'
+    | 'getService'
+    | 'getClientId'
+    | 'wantsKeys'
+    | 'data'
+    | 'isDesktopSync'
+    | 'isDesktopRelay'
+  >
   | SigninOAuthIntegration;
 
 export type SigninOAuthIntegration = Pick<
@@ -201,6 +201,7 @@ export interface NavigationOptions {
   integration: SigninIntegration;
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   redirectTo?: string;
+  replace?: boolean;
   queryParams: string;
   showInlineRecoveryKeySetup?: boolean;
   isSignInWithThirdPartyAuth?: boolean;

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -32,6 +32,7 @@ interface NavigationTarget {
   shouldHardNavigate?: boolean;
   oauthData?: OAuthData;
   error?: undefined;
+  replace?: boolean;
 }
 interface NavigationTargetError {
   to?: undefined;
@@ -221,7 +222,7 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
         state: oauthData.state,
       });
     }
-    performNavigation({ to, locationState, shouldHardNavigate });
+    performNavigation({ to, locationState, shouldHardNavigate, replace: true });
   }
 
   return { error: undefined };
@@ -305,14 +306,15 @@ function performNavigation({
   to,
   shouldHardNavigate = false,
   locationState,
-}: Pick<NavigationTarget, 'to' | 'locationState' | 'shouldHardNavigate'>) {
+  replace = false,
+}: Pick<NavigationTarget, 'to' | 'locationState' | 'shouldHardNavigate' | 'replace'>) {
   if (shouldHardNavigate) {
     // Hard navigate to RP, or (temp until CAD/pair is Reactified)
-    hardNavigate(to);
+    hardNavigate(to, undefined, undefined, replace);
   } else if (locationState) {
-    navigate(to, { state: locationState });
+    navigate(to, { state: locationState, replace });
   } else {
-    navigate(to);
+    navigate(to, { replace });
   }
 }
 


### PR DESCRIPTION
## Because

- When navigating to RPs the oauth signin page is added to the browser history.

## This pull request

- Use location.replace() instead of location.href so that hardNavidations do not add a new record to history.

## Issue that this pull request solves

Closes: #FXA-11700 #FXA-11728

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before - Note the additional Mozilla Accounts
![image](https://github.com/user-attachments/assets/d7b4fdc5-a7e0-4262-a405-aee4131b713c)

After
![image](https://github.com/user-attachments/assets/86172cdf-60c1-45ff-89b7-0c84e0c34efe)
