### PR TITLE
fix(payments-next): Add localization to page metadata

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -13,6 +13,7 @@ import {
   CheckoutParams,
   SupportedPages,
   getErrorFtlInfo,
+  buildPageMetadata,
 } from '@fxa/payments/ui/server';
 import {
   getCartOrRedirectAction,
@@ -21,7 +22,6 @@ import {
 import { config } from 'apps/payments/next/config';
 import type { Metadata } from 'next';
 import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
-import { buildPageMetadata } from '@fxa/payments/ui';
 
 // forces dynamic rendering
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
@@ -38,8 +38,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Error',
-    description: 'There was an error processing your subscription. If this problem persists, please contact support.',
     page: 'error',
     pageType: 'checkout',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
@@ -7,9 +7,12 @@ import {
   LoadingSpinner,
   StripeWrapper,
   PaymentInputHandler,
-  buildPageMetadata,
 } from '@fxa/payments/ui';
-import { getApp, SupportedPages } from '@fxa/payments/ui/server';
+import {
+  getApp,
+  SupportedPages,
+  buildPageMetadata,
+} from '@fxa/payments/ui/server';
 import { headers } from 'next/headers';
 import { getCartOrRedirectAction } from '@fxa/payments/ui/actions';
 import type { Metadata } from 'next';
@@ -26,8 +29,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Action required',
-    description: 'Please complete the required action to proceed with your payment.',
     page: 'needs_input',
     pageType: 'checkout',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
@@ -6,9 +6,8 @@ import {
   PaymentStateObserver,
   CheckoutParams,
   LoadingSpinner,
-  buildPageMetadata,
 } from '@fxa/payments/ui';
-import { getApp, SupportedPages } from '@fxa/payments/ui/server';
+import { getApp, SupportedPages, buildPageMetadata } from '@fxa/payments/ui/server';
 import { headers } from 'next/headers';
 import { validateCartStateAndRedirectAction } from '@fxa/payments/ui/actions';
 import type { Metadata } from 'next';
@@ -25,8 +24,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Processing',
-    description: 'Please wait while we finish processing your payment.',
     page: 'processing',
     pageType: 'checkout',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -11,13 +11,13 @@ import {
   ButtonVariant,
   PaymentSection,
   SignInForm,
-  buildPageMetadata,
 } from '@fxa/payments/ui';
 import {
   getApp,
   SupportedPages,
   CheckoutParams,
   SignedIn,
+  buildPageMetadata,
 } from '@fxa/payments/ui/server';
 import AppleLogo from '@fxa/shared/assets/images/apple-logo.svg';
 import GoogleLogo from '@fxa/shared/assets/images/google-logo.svg';
@@ -40,10 +40,9 @@ export async function generateMetadata(
     searchParams: Record<string, string> | undefined;
   },
 ): Promise<Metadata> {
+
   return buildPageMetadata({
     params,
-    titlePrefix: 'Checkout',
-    description: 'Enter your payment details to complete your purchase.',
     page: 'start',
     pageType: 'checkout',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -6,7 +6,7 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import Image from 'next/image';
 import { auth } from 'apps/payments/next/auth';
-import { getCardIcon, buildPageMetadata } from '@fxa/payments/ui';
+import { getCardIcon } from '@fxa/payments/ui';
 import {
   fetchCMSData,
   getCartOrRedirectAction,
@@ -16,6 +16,7 @@ import {
   getApp,
   CheckoutParams,
   SupportedPages,
+  buildPageMetadata,
 } from '@fxa/payments/ui/server';
 import { config } from 'apps/payments/next/config';
 
@@ -32,8 +33,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Success',
-    description: 'Congratulations! You have successfully completed your purchase.',
     page: 'success',
     pageType: 'checkout',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -12,6 +12,7 @@ import {
   CheckoutParams,
   SupportedPages,
   getErrorFtlInfo,
+  buildPageMetadata,
 } from '@fxa/payments/ui/server';
 import {
   getCartOrRedirectAction,
@@ -19,7 +20,6 @@ import {
 } from '@fxa/payments/ui/actions';
 import { config } from 'apps/payments/next/config';
 import { Metadata } from 'next';
-import { buildPageMetadata } from '@fxa/payments/ui';
 
 // forces dynamic rendering
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
@@ -36,8 +36,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Error',
-    description: 'There was an error processing your upgrade. If this problem persists, please contact support.',
     page: 'error',
     pageType: 'upgrade',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
@@ -7,9 +7,12 @@ import {
   LoadingSpinner,
   StripeWrapper,
   PaymentInputHandler,
-  buildPageMetadata,
 } from '@fxa/payments/ui';
-import { getApp, SupportedPages } from '@fxa/payments/ui/server';
+import {
+  getApp,
+  SupportedPages,
+  buildPageMetadata,
+} from '@fxa/payments/ui/server';
 import { headers } from 'next/headers';
 import { getCartOrRedirectAction } from '@fxa/payments/ui/actions';
 import { Metadata } from 'next';
@@ -26,8 +29,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Action required',
-    description: 'Please complete the required action to proceed with your payment.',
     page: 'needs_input',
     pageType: 'upgrade',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
@@ -6,9 +6,12 @@ import {
   PaymentStateObserver,
   CheckoutParams,
   LoadingSpinner,
-  buildPageMetadata,
 } from '@fxa/payments/ui';
-import { getApp, SupportedPages } from '@fxa/payments/ui/server';
+import {
+  getApp,
+  SupportedPages,
+  buildPageMetadata,
+} from '@fxa/payments/ui/server';
 import { headers } from 'next/headers';
 import { validateCartStateAndRedirectAction } from '@fxa/payments/ui/actions';
 import { Metadata } from 'next';
@@ -25,8 +28,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Processing',
-    description: 'Please wait while we finish processing your payment.',
     page: 'processing',
     pageType: 'upgrade',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
@@ -4,8 +4,12 @@
 
 import { headers } from 'next/headers';
 import { auth } from 'apps/payments/next/auth';
-import { getCardIcon, buildPageMetadata } from '@fxa/payments/ui';
-import { SupportedPages, getApp } from '@fxa/payments/ui/server';
+import { getCardIcon } from '@fxa/payments/ui';
+import {
+  SupportedPages,
+  getApp,
+  buildPageMetadata,
+} from '@fxa/payments/ui/server';
 import {
   fetchCMSData,
   getCartOrRedirectAction,
@@ -29,8 +33,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Success',
-    description: 'Congratulations! You have successfully completed your upgrade.',
     page: 'success',
     pageType: 'upgrade',
     acceptLanguage: headers().get('accept-language'),

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -8,7 +8,6 @@ import Image from 'next/image';
 import {
   getCardIcon,
   PaymentSection,
-  buildPageMetadata,
 } from '@fxa/payments/ui';
 import {
   fetchCMSData,
@@ -18,6 +17,7 @@ import {
   getApp,
   CheckoutParams,
   SupportedPages,
+  buildPageMetadata,
 } from '@fxa/payments/ui/server';
 import { Metadata } from 'next';
 import { config } from 'apps/payments/next/config';
@@ -35,8 +35,6 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   return buildPageMetadata({
     params,
-    titlePrefix: 'Upgrade',
-    description: 'Enter your payment details to complete your upgrade.',
     page: 'start',
     pageType: 'upgrade',
     acceptLanguage: headers().get('accept-language'),

--- a/libs/payments/ui/src/index.ts
+++ b/libs/payments/ui/src/index.ts
@@ -27,4 +27,3 @@ export * from './lib/utils/types';
 export * from './lib/utils/get-cart';
 export * from './lib/utils/buildRedirectUrl';
 export * from './lib/utils/getCardIcon';
-export * from './lib/utils/pageMetadata';

--- a/libs/payments/ui/src/lib/utils/en.ftl
+++ b/libs/payments/ui/src/lib/utils/en.ftl
@@ -1,0 +1,43 @@
+# Checkout start
+metadata-title-checkout-start = Checkout | { $productTitle }
+metadata-description-checkout-start = Enter your payment details to complete your purchase.
+
+# Checkout processing
+metadata-title-checkout-processing = Processing | { $productTitle }
+metadata-description-checkout-processing = Please wait while we finish processing your payment.
+
+# Checkout error
+metadata-title-checkout-error = Error | { $productTitle }
+metadata-description-checkout-error = There was an error processing your subscription. If this problem persists, please contact support.
+
+# Checkout success
+metadata-title-checkout-success = Success | { $productTitle }
+metadata-description-checkout-success = Congratulations! You have successfully completed your purchase.
+
+# Checkout needs_input
+metadata-title-checkout-needs-input = Action required | { $productTitle }
+metadata-description-checkout-needs-input = Please complete the required action to proceed with your payment.
+
+# Upgrade start
+metadata-title-upgrade-start = Upgrade | { $productTitle }
+metadata-description-upgrade-start = Enter your payment details to complete your upgrade.
+
+# Upgrade processing
+metadata-title-upgrade-processing = Processing | { $productTitle }
+metadata-description-upgrade-processing = Please wait while we finish processing your payment.
+
+# Upgrade error
+metadata-title-upgrade-error = Error | { $productTitle }
+metadata-description-upgrade-error = There was an error processing your upgrade. If this problem persists, please contact support.
+
+# Upgrade success
+metadata-title-upgrade-success = Success | { $productTitle }
+metadata-description-upgrade-success = Congratulations! You have successfully completed your upgrade.
+
+# Upgrade needs_input
+metadata-title-upgrade-needs-input = Action required | { $productTitle }
+metadata-description-upgrade-needs-input = Please complete the required action to proceed with your payment.
+
+# Default
+metadata-title-default = Page not found | { $productTitle }
+metadata-description-default = The page you requested was not found.

--- a/libs/payments/ui/src/lib/utils/getPageMetadataFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getPageMetadataFtlInfo.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type { Page, PageType } from './types';
+
+export function getPageMetadataFtlInfo(
+  page: Page,
+  pageType: PageType,
+  productTitle: string
+) {
+  switch (pageType) {
+    case 'checkout':
+      switch (page) {
+        case 'start':
+          return {
+            titleFtl: 'metadata-title-checkout-start',
+            titleFallback: `Checkout | ${productTitle}`,
+            descriptionFtl: 'metadata-description-checkout-start',
+            descriptionFallback: 'Enter your payment details to complete your purchase.',
+          };
+        case 'processing':
+          return {
+            titleFtl: 'metadata-title-checkout-processing',
+            titleFallback: `Processing | ${productTitle}`,
+            descriptionFtl: 'metadata-description-checkout-processing',
+            descriptionFallback: 'Please wait while we finish processing your payment.',
+          };
+        case 'error':
+          return {
+            titleFtl: 'metadata-title-checkout-error',
+            titleFallback: `Error | ${productTitle}`,
+            descriptionFtl: 'metadata-description-checkout-error',
+            descriptionFallback: 'There was an error processing your subscription. If this problem persists, please contact support.',
+          };
+        case 'success':
+          return {
+            titleFtl: 'metadata-title-checkout-success',
+            titleFallback: `Success | ${productTitle}`,
+            descriptionFtl: 'metadata-description-checkout-success',
+            descriptionFallback: 'Congratulations! You have successfully completed your purchase.',
+          };
+        case 'needs_input':
+          return {
+            titleFtl: 'metadata-title-checkout-needs-input',
+            titleFallback: `Action required | ${productTitle}`,
+            descriptionFtl: 'metadata-description-checkout-needs-input',
+            descriptionFallback: 'Please complete the required action to proceed with your payment.',
+          };
+        default:
+          return {
+            titleFtl: 'metadata-title-default',
+            titleFallback: `Page not found | ${productTitle}`,
+            descriptionFtl: 'metadata-description-default',
+            descriptionFallback: 'The page you requested was not found.',
+          };
+      }
+    case 'upgrade':
+      switch (page) {
+        case 'start':
+          return {
+            titleFtl: 'metadata-title-upgrade-start',
+            titleFallback: `Upgrade | ${productTitle}`,
+            descriptionFtl: 'metadata-description-upgrade-start',
+            descriptionFallback: 'Enter your payment details to complete your upgrade.',
+          };
+        case 'processing':
+          return {
+            titleFtl: 'metadata-title-upgrade-processing',
+            titleFallback: `Processing | ${productTitle}`,
+            descriptionFtl: 'metadata-description-upgrade-processing',
+            descriptionFallback: 'Please wait while we finish processing your payment.',
+          };
+        case 'error':
+          return {
+            titleFtl: 'metadata-title-upgrade-error',
+            titleFallback: `Error | ${productTitle}`,
+            descriptionFtl: 'metadata-description-upgrade-error',
+            descriptionFallback: 'There was an error processing your upgrade. If this problem persists, please contact support.',
+          };
+        case 'success':
+          return {
+            titleFtl: 'metadata-title-upgrade-success',
+            titleFallback: `Success | ${productTitle}`,
+            descriptionFtl: 'metadata-description-upgrade-success',
+            descriptionFallback: 'Congratulations! You have successfully completed your upgrade.',
+          };
+        case 'needs_input':
+          return {
+            titleFtl: 'metadata-title-upgrade-needs-input',
+            titleFallback: `Action required | ${productTitle}`,
+            descriptionFtl: 'metadata-description-upgrade-needs-input',
+            descriptionFallback: 'Please complete the required action to proceed with your payment.',
+          };
+        default:
+          return {
+            titleFtl: 'metadata-title-default',
+            titleFallback: `Page not found | ${productTitle}`,
+            descriptionFtl: 'metadata-description-default',
+            descriptionFallback: 'The page you requested was not found.',
+          };
+      }
+    default:
+      return {
+        titleFtl: 'metadata-title-default',
+        titleFallback: `Page not found | ${productTitle}`,
+        descriptionFtl: 'metadata-description-default',
+        descriptionFallback: 'The page you requested was not found.',
+      };
+  }
+}

--- a/libs/payments/ui/src/lib/utils/pageMetadata.ts
+++ b/libs/payments/ui/src/lib/utils/pageMetadata.ts
@@ -2,60 +2,63 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- import { fetchCMSData } from '@fxa/payments/ui/actions';
- import { buildRedirectUrl } from '@fxa/payments/ui';
- import type { Metadata } from 'next';
- import type { CheckoutParams, } from '@fxa/payments/ui/server';
- import type { Page, PageType } from './types';
+import { fetchCMSData } from '@fxa/payments/ui/actions';
+import { buildRedirectUrl } from '@fxa/payments/ui';
+import type { Metadata } from 'next';
+import { getApp, getPageMetadataFtlInfo } from '@fxa/payments/ui/server';
+import type { CheckoutParams } from '@fxa/payments/ui/server';
+import type { Page, PageType } from './types';
 
- export async function buildPageMetadata(args: {
-   params: CheckoutParams,
-   titlePrefix: string,
-   description: string,
-   page: Page,
-   pageType: PageType,
-   acceptLanguage: string | null,
-   baseUrl: string,
-   searchParams?: Record<string, string> | undefined,
- }): Promise<Metadata> {
-   const {
+export async function buildPageMetadata(args: {
+  params: CheckoutParams,
+  page: Page,
+  pageType: PageType,
+  acceptLanguage: string | null,
+  baseUrl: string,
+  searchParams?: Record<string, string> | undefined,
+}): Promise<Metadata> {
+  const {
     params,
-    titlePrefix,
-    description,
     page,
     pageType,
     acceptLanguage,
     baseUrl,
     searchParams,
-   } = args;
+  } = args;
 
-   const { locale, offeringId } = params;
+  const { locale, offeringId } = params;
+  const l10n = getApp().getL10n(acceptLanguage, params.locale);
 
-   const cms = await fetchCMSData(offeringId, acceptLanguage, locale);
-   const purchaseDetails = cms.defaultPurchase.purchaseDetails;
-   const productTitle = purchaseDetails.localizations.at(0)?.productName || purchaseDetails.productName;
+  const cms = await fetchCMSData(offeringId, acceptLanguage, locale);
+  const purchaseDetails = cms.defaultPurchase.purchaseDetails;
+  const productTitle = purchaseDetails.localizations.at(0)?.productName || purchaseDetails.productName;
 
-   const currentURL = buildRedirectUrl(
-     params.offeringId,
-     params.interval,
-     page,
-     pageType,
+  const metadataFtlInfo = getPageMetadataFtlInfo(page, pageType, productTitle);
+
+  const title = l10n.getString(metadataFtlInfo.titleFtl, { productTitle: productTitle }, metadataFtlInfo.titleFallback);
+  const description = l10n.getString(metadataFtlInfo.descriptionFtl, metadataFtlInfo.descriptionFallback);
+
+  const currentURL = buildRedirectUrl(
+    params.offeringId,
+    params.interval,
+    page,
+    pageType,
      {
        baseUrl,
        locale,
        cartId: params.cartId,
        searchParams: searchParams ?? {},
      }
-   );
+  );
 
-   return {
-     title: `${titlePrefix} | ${productTitle}`,
-     description: description,
-     openGraph: {
-       title: `${titlePrefix} | ${productTitle}`,
-       description: description,
-       url: currentURL,
-       images: [
+  return {
+    title: title,
+    description: description,
+    openGraph: {
+      title: title,
+      description: description,
+      url: currentURL,
+      images: [
          {
            url: purchaseDetails.webIcon,
            width: 800,
@@ -64,6 +67,6 @@
        ],
        locale: locale.replace('-', '_'),
        type: 'website',
-     },
-   };
+    },
+  };
 }

--- a/libs/payments/ui/src/server.ts
+++ b/libs/payments/ui/src/server.ts
@@ -14,3 +14,5 @@ export * from './lib/server/components/UpgradePurchaseDetails';
 export * from './lib/utils/types';
 export * from './lib/utils/getIpAddress';
 export * from './lib/utils/getErrorFtlInfo';
+export * from './lib/utils/getPageMetadataFtlInfo';
+export * from './lib/utils/pageMetadata';


### PR DESCRIPTION
## Because

- titlePrefix and description were hardcoded values and not localized.

## This pull request

- Adds localization to titlePrefix and description.

## Issue that this pull request solves

Closes: #FXA-11717

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
