### PR TITLE
feat(webchannel): Add support for SYNC_PREFERENCES command

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -13,6 +13,15 @@ export enum FirefoxCommand {
   Error = 'fxError',
   OAuthLogin = 'fxaccounts:oauth_login',
   CanLinkAccount = 'fxaccounts:can_link_account',
+  // opens sync preferences if user is signed in to sync
+  // use as: firefox.send(FirefoxCommand.SyncPreferences, {ok: true});
+  // caveat: if browser does not support the command
+  // or the user is not signed in to sync
+  // there is no response and the command fails silently
+  // As of May 2025, this command is available on desktop
+  // support will be added on Android (https://bugzilla.mozilla.org/show_bug.cgi?id=1968130)
+  // and iOS (https://github.com/mozilla-mobile/firefox-ios/issues/26837)
+  SyncPreferences = 'fxaccounts:sync_preferences',
 }
 
 export interface FirefoxMessageDetail {


### PR DESCRIPTION
## Because

* We will need this webchannel for upcoming changes to sync registration

## This pull request

* Adds the command to available channels in fxa-settings

## Issue that this pull request solves

Closes: FXA-11741

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
