### PR TITLE
chore(l10n): Add group comment end

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/en.ftl
@@ -28,3 +28,5 @@ subscriptionCharges-content-tax = Taxes & fees: { $invoiceTaxAmount }
 ##  $invoiceTotal (String) - The amount, after discount, of the subscription invoice, including currency, e.g. $8.00
 subscriptionFirstInvoice-content-charge = Charged { $invoiceTotal } on { $invoiceDateOnly }
 subscriptionFirstInvoice-content-credit = You have received an account credit of { $invoiceTotal }, which will be applied to your future invoices.
+
+##


### PR DESCRIPTION
## Because:

* A group comment appears for unrelated strings due to how strings are concatenated into a single file.

## This commit:

* Adds an ending ## to the comment so it only appears with the intended strings in the l10n file.

