### PR TITLE
fix(payments-next):Truncated price in upgrade page

### DIFF
--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
@@ -227,7 +227,7 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
               )}
             </h3>
             <p
-              className="overflow-hidden text-ellipsis whitespace-nowrap"
+              className="flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap"
               data-testid="prorated-price"
             >
               {l10n.getLocalizedCurrencyString(oneTimeCharge, currency, locale)}


### PR DESCRIPTION
## Because

- Prorated amount is cut off in certain languages.

## This pull request

- Prevents prorated price from shrinking.

## Issue that this pull request solves

Closes: #FXA-11648

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
