### PR TITLE
test(function): add back skipped syncV3 test and fix flaky test

### DIFF
--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -161,7 +161,7 @@ export abstract class BaseLayout {
     const expectedCommand = webChannelMessage.message.command;
     const response = webChannelMessage.message.data;
 
-    await this.page.evaluate(
+    await this.page.addInitScript(
       ({ expectedCommand, response }) => {
         function listener(e: CustomEvent) {
           const detail = JSON.parse(e.detail);

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshake.spec.ts
@@ -72,12 +72,13 @@ test.describe('severity-2 #smoke', () => {
           },
         },
       };
+
+      await signin.respondToWebChannelMessage(eventDetailStatus);
       await page.goto(
         `${
           target.contentServerUrl
         }?context=fx_desktop_v3&service=sync&automatedBrowser=true&${query.toString()}`
       );
-      await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       // password confirmation required to sign in to sync
       await expect(signin.passwordFormHeading).toBeVisible();

--- a/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopHandshakeNonSync.spec.ts
@@ -34,11 +34,10 @@ test.describe('severity-2 #smoke', () => {
           },
         },
       };
-
+      await signin.respondToWebChannelMessage(eventDetailStatus);
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
-      await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       // nothing to suggest
       await expect(signin.emailTextbox).toHaveValue('');
@@ -69,10 +68,10 @@ test.describe('severity-2 #smoke', () => {
         },
       };
 
+      await signin.respondToWebChannelMessage(eventDetailStatus);
       await page.goto(
         `${target.contentServerUrl}?automatedBrowser=true&${query.toString()}`
       );
-      await signin.respondToWebChannelMessage(eventDetailStatus);
       await signin.checkWebChannelMessage(FirefoxCommand.FxAStatus);
       // account signed into browser suggested
       await expect(signin.cachedSigninHeading).toBeVisible();

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -121,7 +121,6 @@ test.describe('severity-1 #smoke', () => {
       target,
       testAccountTracker,
     }) => {
-      test.skip(true, 'FXA-9868');
       const credentials = await testAccountTracker.signUpBlocked();
       const nonBlockedEmail = await testAccountTracker.generateEmail();
       const uid = makeUid();


### PR DESCRIPTION
## Because

- We had a skipped and flaky syncV3 test

## This pull request

- Removes the skip on `blocked with an registered email, unregistered uid`
- Fixes a race condition in `Non-Sync - no user signed into browser, no user signed in locally` which has been flaking in CI.

## Issue that this pull request solves

Closes: (FXA-7108)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
