### PR TITLE
fix(settings): make tooltip text start-aligned instead of centered

### DIFF
--- a/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
@@ -28,6 +28,17 @@ export const Default = () => (
     <Tooltip message="My tooltip message here" />
   </>
 );
+
+export const MultilineMessage = () => (
+  <>
+    <p>Default tooltip pointing to this text</p>
+    <Tooltip
+      message="This is a very very very very very very long message"
+      anchorPosition="start"
+    />
+  </>
+);
+
 export const Bottom = () => (
   <>
     <p>Default tooltip pointing to this text</p>

--- a/packages/fxa-settings/src/components/Tooltip/index.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.tsx
@@ -49,14 +49,14 @@ export const Tooltip = ({
       data-testid={formatDataTestId('tooltip')}
       aria-live="polite"
       className={classNames(
-        `z-50 absolute py-2 px-6 text-center text-white
+        `z-50 absolute py-2 px-6 text-white
          rounded text-xs font-header font-bold
           shadow-tooltip-grey-drop border-transparent border border-solid
          `,
         type === 'error' ? 'bg-red-600' : 'bg-grey-500',
         className,
         {
-          'ltr:left-1/2 ltr:-translate-x-1/2 rtl:right-1/2 rtl:translate-x-1/2':
+          'ltr:left-1/2 ltr:-translate-x-1/2 rtl:right-1/2 rtl:translate-x-1/2 w-max max-w-full':
             anchorPosition === 'middle',
           'start-0': anchorPosition === 'start',
           'end-0 me-1': anchorPosition === 'end',


### PR DESCRIPTION
## Because

- Error tooltip text is centered and should be RTL or LTR

## This pull request

- makes tooltip text start-aligned instead of centered.
- fixes the bug where a tooltip is limited to have half the width of its parent when anchor position is set to middle.

## Issue that this pull request solves

Closes: FXA-11351

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

LTR:

<img width="513" alt="image" src="https://github.com/user-attachments/assets/3caa2c8e-131f-436b-81d3-cfeb193a6407" />

RTL:

<img width="508" alt="image" src="https://github.com/user-attachments/assets/7a1079fc-08e0-4b1b-8821-a016b6aead6b" />

anchor at middle:

<img width="324" alt="image" src="https://github.com/user-attachments/assets/240c7d4f-b0ee-4064-9c94-554e04727d7c" />

## Other information (Optional)

Any other information that is important to this pull request.
