### PR TITLE
task: audit yarn resolutions – tap/typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,7 +282,6 @@
     "parse-asn1": ">=5.1.7",
     "plist": "^3.0.6",
     "protobufjs:>6.0.0 <7": ">=6.11.4",
-    "tap/typescript": "^4.5.2",
     "terser:>4.0.0 <5": ">=4.8.1",
     "terser:>5 <6": ">=5.14.2",
     "typescript": "5.5.3",


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- It doesn't look like this particular resolution does anything

## This pull request

- removes tap/typescript resolution

## Issue that this pull request solves

Closes: FXA-11764

## Other information (Optional)

A search for tap/typescript in our repo comes up empty and running `yarn why tap/typescript` results in error.  After removing the resolution and running `yarn install`, the lockfile does not appear changed, suggesting this resolution is obsolete.