### PR TITLE
task: audit yarn resolutions – moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,6 @@
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
     "http-proxy": "^1.18.1",
     "minimist": "^1.2.6",
-    "moment:>2.0.0 <3": ">=2.29.4",
     "node-forge": ">=1.3.0",
     "nest-typed-config/class-validator": "0.14.1",
     "parse-asn1": ">=5.1.7",


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- It doesn't look like this particular resolution does anything

## This pull request

- removes the resolution for `moment`

## Issue that this pull request solves

Closes: FXA-11765

## Other information (Optional)

I tested before and after resolution removal: all `moment` dependencies are at `2.30.1` which satisfy the original resolution.
