### PR TITLE
fix(payments): Update error message for customers with active IAP subscription

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -27,22 +27,20 @@ import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
 export const dynamic = 'force-dynamic';
 
-export async function generateMetadata(
-  {
-    params,
-    searchParams,
-  }: {
-    params: CheckoutParams;
-    searchParams: Record<string, string> | undefined;
-  },
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: CheckoutParams;
+  searchParams: Record<string, string> | undefined;
+}): Promise<Metadata> {
   return buildPageMetadata({
     params,
     page: 'error',
     pageType: 'checkout',
     acceptLanguage: headers().get('accept-language'),
     baseUrl: config.paymentsNextHostedUrl,
-    searchParams
+    searchParams,
   });
 }
 
@@ -96,7 +94,7 @@ export default async function CheckoutError({
             />
           )
         }
-        <p className="text-grey-400 max-w-sm text-sm px-7 py-0 mb-4 ">
+        <p className="text-grey-400 max-w-sm text-sm leading-5 px-7 py-0 mb-4 ">
           {l10n.getString(errorReason.messageFtl, errorReason.message)}
         </p>
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -25,22 +25,20 @@ import { Metadata } from 'next';
 // https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config
 export const dynamic = 'force-dynamic';
 
-export async function generateMetadata(
-  {
-    params,
-    searchParams,
-  }: {
-    params: CheckoutParams;
-    searchParams: Record<string, string> | undefined;
-  },
-): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: CheckoutParams;
+  searchParams: Record<string, string> | undefined;
+}): Promise<Metadata> {
   return buildPageMetadata({
     params,
     page: 'error',
     pageType: 'upgrade',
     acceptLanguage: headers().get('accept-language'),
     baseUrl: config.paymentsNextHostedUrl,
-    searchParams
+    searchParams,
   });
 }
 
@@ -78,7 +76,7 @@ export default async function UpgradeError({
         aria-label="Payment error"
       >
         <Image src={errorIcon} alt="" className="mt-16 mb-10" />
-        <p className="text-grey-400 max-w-sm text-sm px-7 py-0 mb-4 ">
+        <p className="text-grey-400 max-w-sm text-sm leading-5 px-7 py-0 mb-4 ">
           {l10n.getString(errorReason.messageFtl, errorReason.message)}
         </p>
 

--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -4,7 +4,7 @@ checkout-error-boundary-basic-error-message = Something went wrong. Please try a
 ## Error pages - /checkout and /upgrade
 ## Common strings used in multiple pages
 next-payment-error-manage-subscription-button = Manage my subscription
-next-iap-upgrade-contact-support = You can still get this product — please contact support so we can help you.
+next-iap-blocked-contact-support = You have a mobile in-app subscription that conflicts with this product — please contact support so we can help you.
 next-payment-error-retry-button = Try again
 next-basic-error-message = Something went wrong. Please try again later.
 checkout-error-contact-support-button = Contact Support

--- a/apps/payments/next/app/[locale]/error.tsx
+++ b/apps/payments/next/app/[locale]/error.tsx
@@ -81,7 +81,7 @@ export default function Error({
           ),
         }}
       >
-        <p className="text-grey-400 max-w-sm text-sm px-7 py-0 mb-4 ">
+        <p className="text-grey-400 max-w-sm text-sm leading-5 px-7 py-0 mb-4 ">
           Something went wrong. Please try again or
           <Link href={SUPPORT_URL} className="underline hover:text-grey-400">
             contact support.

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -645,7 +645,7 @@ describe('CartService', () => {
           eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
           couponCode: args.promoCode,
         },
-        CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT
+        CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT
       );
       expect(result).toEqual(mockErrorCart);
     });
@@ -1280,7 +1280,7 @@ describe('CartService', () => {
 
       const result = await cartService.getCartState(mockCart.id);
       expect(result).toEqual({
-        state: mockCart.state
+        state: mockCart.state,
       });
 
       expect(cartManager.fetchCartById).toHaveBeenCalledWith(mockCart.id);
@@ -1479,9 +1479,11 @@ describe('CartService', () => {
       const mockInvoicePreview = InvoicePreviewFactory();
       const mockFromOfferingId = faker.string.uuid();
       const mockFromPrice = StripePriceFactory({
-        recurring: StripePriceRecurringFactory({ interval: 'month' })
+        recurring: StripePriceRecurringFactory({ interval: 'month' }),
       });
-      const mockPricingForCurrency = PricingForCurrencyFactory({ price: mockFromPrice })
+      const mockPricingForCurrency = PricingForCurrencyFactory({
+        price: mockFromPrice,
+      });
       const mockSubscription = StripeSubscriptionFactory();
 
       jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
@@ -1500,7 +1502,9 @@ describe('CartService', () => {
       jest
         .spyOn(subscriptionManager, 'retrieveForCustomerAndPrice')
         .mockResolvedValue(mockSubscription);
-      jest.spyOn(priceManager, 'retrievePricingForCurrency').mockResolvedValue(mockPricingForCurrency);
+      jest
+        .spyOn(priceManager, 'retrievePricingForCurrency')
+        .mockResolvedValue(mockPricingForCurrency);
 
       const result = await cartService.getCart(mockCart.id);
       expect(result).toEqual({

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -106,8 +106,8 @@ export class CartService {
     private productConfigurationManager: ProductConfigurationManager,
     private promotionCodeManager: PromotionCodeManager,
     private subscriptionManager: SubscriptionManager,
-    @Inject(StatsDService) private statsd: StatsD,
-  ) { }
+    @Inject(StatsDService) private statsd: StatsD
+  ) {}
 
   /**
    * Should be used to wrap any method that mutates an existing cart.
@@ -355,7 +355,7 @@ export class CartService {
     if (cartEligibilityStatus === CartEligibilityStatus.BLOCKED_IAP) {
       return this.cartManager.createErrorCart(
         createCartParams,
-        CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT
+        CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT
       );
     }
 
@@ -390,12 +390,12 @@ export class CartService {
 
       const accountCustomer = oldCart.uid
         ? await this.accountCustomerManager
-          .getAccountCustomerByUid(oldCart.uid)
-          .catch((error) => {
-            if (!(error instanceof AccountCustomerNotFoundError)) {
-              throw error;
-            }
-          })
+            .getAccountCustomerByUid(oldCart.uid)
+            .catch((error) => {
+              if (!(error instanceof AccountCustomerNotFoundError)) {
+                throw error;
+              }
+            })
         : undefined;
 
       if (!(oldCart.taxAddress && oldCart.currency)) {
@@ -782,11 +782,18 @@ export class CartService {
     if (cartEligibilityStatus === CartEligibilityStatus.UPGRADE) {
       assert('fromPrice' in eligibility, 'fromPrice not present for upgrade');
 
-      const { price: priceForCurrency, unitAmountForCurrency } = await this.priceManager.retrievePricingForCurrency(eligibility.fromPrice.id, cart.currency);
+      const { price: priceForCurrency, unitAmountForCurrency } =
+        await this.priceManager.retrievePricingForCurrency(
+          eligibility.fromPrice.id,
+          cart.currency
+        );
       assertNotNull(unitAmountForCurrency);
       assertNotNull(priceForCurrency.recurring);
 
-      const interval = getSubplatInterval(priceForCurrency.recurring.interval, priceForCurrency.recurring.interval_count);
+      const interval = getSubplatInterval(
+        priceForCurrency.recurring.interval,
+        priceForCurrency.recurring.interval_count
+      );
       assert(interval, 'Interval not found but is required');
 
       fromPrice = {

--- a/libs/payments/cart/src/lib/cart.utils.ts
+++ b/libs/payments/cart/src/lib/cart.utils.ts
@@ -40,7 +40,7 @@ export const cartEligibilityDetailsMap: Record<
   [EligibilityStatus.BLOCKED_IAP]: {
     eligibilityStatus: CartEligibilityStatus.BLOCKED_IAP,
     state: CartState.FAIL,
-    errorReasonId: CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT,
+    errorReasonId: CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT,
   },
   [EligibilityStatus.SAME]: {
     eligibilityStatus: CartEligibilityStatus.INVALID,

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -39,14 +39,14 @@ export function getErrorFtlInfo(
         message: 'You’ve already subscribed to this product.',
         messageFtl: 'checkout-error-already-subscribed',
       };
-    case CartErrorReasonId.IAP_UPGRADE_CONTACT_SUPPORT:
+    case CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT:
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
         buttonUrl: `${config.contentServerUrl}/subscriptions`,
         message:
-          'You can still get this product — please contact support so we can help you.',
-        messageFtl: 'next-iap-upgrade-contact-support',
+          'You have a mobile in-app subscription that conflicts with this product — please contact support so we can help you.',
+        messageFtl: 'next-iap-blocked-contact-support',
       };
     case CartErrorReasonId.CART_CURRENCY_NOT_DETERMINED:
       return {

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -33,7 +33,7 @@ export enum CartState {
 
 export enum CartErrorReasonId {
   BASIC_ERROR = 'basic-error-message',
-  IAP_UPGRADE_CONTACT_SUPPORT = 'iap_upgrade_contact_support',
+  IAP_BLOCKED_CONTACT_SUPPORT = 'iap_blocked_contact_support',
   SUCCESS_CART_MISSING_REQUIRED = 'success_cart_missing_required',
   CART_ELIGIBILITY_STATUS_SAME = 'cart_eligibility_status_same',
   CART_ELIGIBILITY_STATUS_DOWNGRADE = 'cart_eligibility_status_downgrade',


### PR DESCRIPTION
## Because

- the error page does not reflect the correct error message

## This pull request

- updates the error message for blocked IAP subs

## Issue that this pull request solves

Closes: FXA-11699

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots
**Mobile**
<img width="377" alt="Screenshot 2025-05-28 at 10 43 40 AM" src="https://github.com/user-attachments/assets/559807de-4458-4020-890d-2e0537ececd2" />

**Tablet**
<img width="649" alt="Screenshot 2025-05-28 at 10 43 22 AM" src="https://github.com/user-attachments/assets/6ca7ed41-5e14-4a74-9912-33a31b54ff8e" />

**Desktop**
<img width="1264" alt="Screenshot 2025-05-28 at 10 42 54 AM" src="https://github.com/user-attachments/assets/ba12614b-26dc-4744-b429-95eeb7e9a2a4" />

