### PR TITLE
fix(payments-next): SP3 invalid coupon code not localized

### DIFF
--- a/libs/payments/ui/src/lib/utils/en.ftl
+++ b/libs/payments/ui/src/lib/utils/en.ftl
@@ -1,43 +1,46 @@
+## Page Metadata Information
+## $productTitle (String) - The name of the product to create subscription, e.g. Mozilla VPN
+
 # Checkout start
 metadata-title-checkout-start = Checkout | { $productTitle }
 metadata-description-checkout-start = Enter your payment details to complete your purchase.
-
 # Checkout processing
 metadata-title-checkout-processing = Processing | { $productTitle }
 metadata-description-checkout-processing = Please wait while we finish processing your payment.
-
 # Checkout error
 metadata-title-checkout-error = Error | { $productTitle }
 metadata-description-checkout-error = There was an error processing your subscription. If this problem persists, please contact support.
-
 # Checkout success
 metadata-title-checkout-success = Success | { $productTitle }
 metadata-description-checkout-success = Congratulations! You have successfully completed your purchase.
-
 # Checkout needs_input
 metadata-title-checkout-needs-input = Action required | { $productTitle }
 metadata-description-checkout-needs-input = Please complete the required action to proceed with your payment.
-
 # Upgrade start
 metadata-title-upgrade-start = Upgrade | { $productTitle }
 metadata-description-upgrade-start = Enter your payment details to complete your upgrade.
-
 # Upgrade processing
 metadata-title-upgrade-processing = Processing | { $productTitle }
 metadata-description-upgrade-processing = Please wait while we finish processing your payment.
-
 # Upgrade error
 metadata-title-upgrade-error = Error | { $productTitle }
 metadata-description-upgrade-error = There was an error processing your upgrade. If this problem persists, please contact support.
-
 # Upgrade success
 metadata-title-upgrade-success = Success | { $productTitle }
 metadata-description-upgrade-success = Congratulations! You have successfully completed your upgrade.
-
 # Upgrade needs_input
 metadata-title-upgrade-needs-input = Action required | { $productTitle }
 metadata-description-upgrade-needs-input = Please complete the required action to proceed with your payment.
-
 # Default
 metadata-title-default = Page not found | { $productTitle }
 metadata-description-default = The page you requested was not found.
+
+## Coupon Error Messages
+
+next-coupon-error-expired = The code you entered has expired.
+next-coupon-error-generic = An error occurred processing the code. Please try again.
+next-coupon-error-invalid = The code you entered is invalid.
+# "Limit" refers to the maximum number of times a coupon can be redeemed.
+next-coupon-error-limit-reached = The code you entered has reached its limit.
+
+##


### PR DESCRIPTION
## Because

- The coupon error messages were not being localized, and were hard coded to be in English.

## This pull request

- Puts the error messages in an .ftl file instead of just relying on the hard coded values.

## Issue that this pull request solves

Closes: #FXA-11758

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
