### PR TITLE
task(settings): Improve webpack chunking

### DIFF
--- a/packages/fxa-settings/config/webpack.config.js
+++ b/packages/fxa-settings/config/webpack.config.js
@@ -305,6 +305,30 @@ module.exports = function (webpackEnv) {
         // This is only used in production mode
         new CssMinimizerPlugin(),
       ],
+     splitChunks: isEnvProduction ? {
+        cacheGroups: {
+          presentation: {
+            test: /[\\/]node_modules[\\/]react|react-dom|@reach|@fluent[\\/]/,
+            name: 'presentation-chunk',
+            chunks: 'all',
+          },
+          utils: {
+            test: /[\\/]node_modules[\\/]moment|lodash|ua-parser-js[\\/]/,
+            name: 'utils-chunk',
+            chunks: 'all',
+          },
+          observability: {
+            test: /([\\/]node_modules[\\/]@sentry.*[\\/])|([\\/]glean[\\/])/,
+            name: 'observability-chunk',
+            chunks: 'all',
+          },
+          networking: {
+            test: /([\\/]node_modules[\\/]graphql|graphql-tag|@apollo.*[\\/])|([\\/]fxa-auth-client[\\/])/,
+            name: 'networking-chunk',
+            chunks: 'all',
+          },
+        },
+      } : {}
     },
     resolve: {
       // This allows you to set a fallback for where webpack should look for modules.


### PR DESCRIPTION
## Because
- We can get better cache performance if things that don't change often are chunked into their own packages
- We can getter optimized network behavior with HTTP/2 and modern browsers by splitting up js files this way, ie multiple files can be downloaded concurrently.

## This pull request
- Creates a chunk for react and reach router called the 'presentation' chunk
- Creates a chunk for large utils like moment or ua-parser called utils
- Creates a chunk for observability libs like glean or sentry
- Creates a chunk for network libs like apollo and gql

## Issue that this pull request solves

Closes: FXA-11795
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
