### PR TITLE
task(settings): Target sentry tracing to capture metrics for index

### DIFF
--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -48,6 +48,16 @@ try {
     release: config.version,
     sentry: {
       ...config.sentry,
+      tracesSampler: (context) => {
+        let rate = 0;
+        // We only want to sample the index page for now.
+        if (context.name === '/') {
+          if (typeof config.sentry.tracesSampleRate === 'number') {
+            rate = config.sentry.tracesSampleRate;
+          }
+        }
+        return rate;
+      },
     },
   });
 

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -23,6 +23,7 @@ export interface Config {
     dsn: string;
     env: string;
     sampleRate: number;
+    tracesSampleRate: number;
     serverName: string;
     clientName: string;
     version: string;

--- a/packages/fxa-shared/sentry/config-builder.ts
+++ b/packages/fxa-shared/sentry/config-builder.ts
@@ -36,6 +36,7 @@ export function buildSentryConfig(config: SentryConfigOpts, log: ILogger) {
     serverName: config.sentry?.serverName,
     fxaName: config.sentry?.clientName || config.sentry?.serverName,
     tracesSampleRate: config.sentry?.tracesSampleRate,
+    tracesSampler: config.sentry?.tracesSampler,
   };
 
   return opts;

--- a/packages/fxa-shared/sentry/models/SentryConfigOpts.ts
+++ b/packages/fxa-shared/sentry/models/SentryConfigOpts.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { SamplingContext } from '@sentry/core';
 
 export type SentryConfigOpts = {
   /** Name of release */
@@ -27,5 +28,8 @@ export type SentryConfigOpts = {
 
     /** The tracing sample rate. Setting this above 0 will aso result in performance metrics being captured. */
     tracesSampleRate?: number;
+
+    /** Call back to dynamically determine sampling rate. When defined, tracesSampleRate won't be used. */
+    tracesSampler?: (context: SamplingContext) => number | boolean;
   };
 };


### PR DESCRIPTION
## Because
- We want to monitor the index page's performance

## This pull request
- Adds  the tracesSampler callback to the sentry config
- Hard codes this callback to only capture traces for '/'

## Issue that this pull request solves

Closes: FXA-11723

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I was able to validate this manually by setting the `SENTRY_DSN_CONTENT` env, and adding a break point in the `tracesSampler` callback.
