### PR TITLE
task(auth,graphql): Configure separate redis instance for rate limiting

### DIFF
--- a/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
@@ -19,7 +19,7 @@ export const RateLimitRedisProvider: Provider = {
       throw new Error('Missing config for redis');
     }
 
-    const redisRateLimitConfig = config.get<RedisOptions>('redis.customs');
+    const redisRateLimitConfig = config.get<RedisOptions>('redis.ratelimit');
     if (redisRateLimitConfig == null) {
       throw new Error('Missing config for redis.customs');
     }

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -225,7 +225,7 @@ async function run(config) {
   const rules = parseConfigRules(config.rateLimit.rules);
   const rateLimitRedis = new Redis({
     ...config.redis,
-    ...config.redis.customs,
+    ...config.redis.ratelimit,
   });
   const rateLimit = new RateLimit(
     {

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -199,33 +199,33 @@ const conf = convict({
         doc: 'Key prefix for access tokens in Redis',
       },
     },
-    customs: {
+    ratelimit: {
       enabled: {
-        default: false,
+        default: true,
         doc: 'Enable Redis for customs server rate limiting',
         format: Boolean,
-        env: 'CUSTOMS_REDIS_ENABLED',
+        env: 'RATELIMIT_REDIS_ENABLED',
       },
       host: {
         default: 'localhost',
-        env: 'CUSTOMS_REDIS_HOST',
+        env: 'RATELIMIT_REDIS_HOST',
         format: String,
       },
       port: {
         default: 6379,
-        env: 'CUSTOMS_REDIS_PORT',
+        env: 'RATELIMIT_REDIS_PORT',
         format: 'port',
       },
       password: {
         default: '',
-        env: 'CUSTOMS_REDIS_PASSWORD',
+        env: 'RATELIMIT_REDIS_PASSWORD',
         format: String,
         sensitive: true,
         doc: `Password for connecting to redis`,
       },
       prefix: {
-        default: 'customs:',
-        env: 'CUSTOMS_REDIS_KEY_PREFIX',
+        default: 'ratelimit:',
+        env: 'RATELIMIT_REDIS_KEY_PREFIX',
         format: String,
         doc: 'Key prefix for custom server records in Redis',
       },

--- a/packages/fxa-shared/db/config.ts
+++ b/packages/fxa-shared/db/config.ts
@@ -308,6 +308,38 @@ export function makeRedisConfig() {
       },
     },
 
+    ratelimit: {
+      enabled: {
+        default: true,
+        doc: 'Enable Redis for customs server rate limiting',
+        format: Boolean,
+        env: 'RATELIMIT_REDIS_ENABLED',
+      },
+      host: {
+        default: 'localhost',
+        env: 'RATELIMIT_REDIS_HOST',
+        format: String,
+      },
+      port: {
+        default: 6379,
+        env: 'RATELIMIT_REDIS_PORT',
+        format: 'port',
+      },
+      password: {
+        default: '',
+        env: 'RATELIMIT_REDIS_PASSWORD',
+        format: String,
+        sensitive: true,
+        doc: `Password for connecting to redis`,
+      },
+      prefix: {
+        default: 'ratelimit:',
+        env: 'RATELIMIT_REDIS_KEY_PREFIX',
+        format: String,
+        doc: 'Key prefix for custom server records in Redis',
+      },
+    },
+
     metrics: {
       enabled: {
         default: true,


### PR DESCRIPTION
## Because
- We wanted to have a clean slate for rate limiting db state
- We've stood up a separate instance in staging

## This pull request
- Adds config for a 'ratelimit' Redis instance


## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Initially it seemed like we could just use the the custom's server redis instance, but ultimately decided it would be better to keep these DBs separate. There's a couple reasons for this:

- Easier to roll back
- Ensures no impact to existing customs service
- Allows us to scale individually
- Don't have to worry about old keys sticking around after fully migrating to new customs approach