### PR TITLE
feat(settings): new FlowSetup2faBackupCodeDownLoad component

### DIFF
--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -61,10 +61,10 @@ export const DataBlock = ({
   };
 
   return (
-    <div className="w-full flex flex-col gap-3 items-center bg-white rounded-xl border-2 border-grey-100 px-5 pt-5 pb-3">
+    <div className="w-full flex flex-col items-center bg-white rounded-xl border-2 border-grey-100 p-5">
       <ul
         className={classNames(
-          'relative gap-2 w-full text-black text-sm font-mono font-bold',
+          'relative gap-2 mobileLandscape:gap-4 w-full mb-5 text-black text-sm font-mono font-bold',
           valueIsArray ? 'grid grid-cols-2 max-w-sm' : 'flex flex-col max-w-lg'
         )}
         {...{ onCopy }}
@@ -88,7 +88,7 @@ export const DataBlock = ({
               prefixDataTestId={`datablock-${performedAction}`}
               message={actionTypeToNotification[performedAction]}
               anchorPosition="middle"
-              position="bottom"
+              position="top"
               className="mt-1"
             ></Tooltip>
           </FtlMsg>

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -47,7 +47,7 @@ export type GetDataTrioProps = {
 };
 
 const trioButtonClassName =
-  'w-24 h-20 shrink p-1 relative text-grey-600 text-sm rounded-xl flex flex-col items-center justify-center hover:text-blue-600 active:text-blue-500 focus-visible-default outline-offset-2 hover:bg-gradient-to-tr hover:from-blue-600/10 hover:to-purple-500/10 active:bg-gradient-to-tr active:from-blue-600/10 active:to-purple-500/10 focus-visible:bg-gradient-to-tr focus-visible:from-blue-600/10 focus-visible:to-purple-500/10';
+  'w-12 h-12 p-1 relative text-grey-600 text-sm rounded flex flex-col items-center justify-center hover:text-blue-600 active:text-blue-500 focus-visible-default outline-offset-2 hover:bg-gradient-to-tr hover:from-blue-600/10 hover:to-purple-500/10 active:bg-gradient-to-tr active:from-blue-600/10 active:to-purple-500/10 focus-visible:bg-gradient-to-tr focus-visible:from-blue-600/10 focus-visible:to-purple-500/10';
 
 export const GetDataCopySingleton = ({
   value,
@@ -76,7 +76,7 @@ export const GetDataCopySingleton = ({
         data-glean-id={gleanDataAttrs.copy?.id}
         data-glean-type={gleanDataAttrs.copy?.type}
       >
-        <CopyIcon aria-hidden className="w-10 h-10 fill-current" />
+        <CopyIcon aria-hidden className="w-8 h-8 fill-current" />
       </button>
     </FtlMsg>
   );
@@ -169,7 +169,7 @@ export const GetDataTrio = ({
   }, [value, pageTitle]);
 
   return (
-    <div className="flex justify-center w-full">
+    <div className="flex justify-between max-w-52 w-4/5">
       <FtlMsg
         id="get-data-trio-download-2"
         attrs={{ title: true, 'aria-label': true }}
@@ -195,7 +195,7 @@ export const GetDataTrio = ({
           data-glean-id={gleanDataAttrs.download?.id}
           data-glean-type={gleanDataAttrs.download?.type}
         >
-          <DownloadIcon aria-hidden className="w-10 h-10 fill-current" />
+          <DownloadIcon aria-hidden className="w-8 h-8 fill-current" />
         </a>
       </FtlMsg>
 
@@ -225,7 +225,7 @@ export const GetDataTrio = ({
           data-glean-id={gleanDataAttrs.print?.id}
           data-glean-type={gleanDataAttrs.print?.type}
         >
-          <PrintIcon aria-hidden className="w-10 h-10 fill-current" />
+          <PrintIcon aria-hidden className="w-7 h-7 fill-current" />
         </button>
       </FtlMsg>
     </div>

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/en.ftl
@@ -1,0 +1,8 @@
+## The backup codes download step of the setup 2fa flow
+
+flow-setup-2fa-backup-code-dl-heading = Save backup authentication codes
+
+flow-setup-2fa-backup-code-dl-save-these-codes = Keep these in a place you’ll remember. If you don’t have access to your authenticator app you’ll need to enter one to sign in.
+
+# The continue button
+flow-setup-2fa-backup-code-dl-button-continue = Continue

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.stories.tsx
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import SettingsLayout from '../SettingsLayout';
+import { action } from '@storybook/addon-actions';
+import { FlowSetup2faBackupCodeDownLoad } from '.';
+
+export default {
+  title: 'Components/Settings/FlowSetup2faBackupCodeDownLoad',
+  component: FlowSetup2faBackupCodeDownLoad,
+  decorators: [withLocalization],
+} as Meta;
+
+const navigateBackward = async () => {
+  action('navigateBackward')();
+};
+
+const dummyTotpInfo = {
+  recoveryCodes: [
+    'code111111',
+    'code222222',
+    'code333333',
+    'code444444',
+    'code555555',
+    'code666666',
+    'code777777',
+    'code888888',
+  ],
+};
+
+const onContinue = () => {
+  action('onContinue')();
+};
+
+export const Default = () => (
+  <SettingsLayout>
+    <FlowSetup2faBackupCodeDownLoad
+      currentStep={2}
+      numberOfSteps={3}
+      localizedFlowTitle="Two-step authentication"
+      onBackButtonClick={navigateBackward}
+      showProgressBar
+      totpInfo={dummyTotpInfo}
+      onContinue={onContinue}
+    />
+  </SettingsLayout>
+);

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.test.tsx
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FlowSetup2faBackupCodeDownLoad } from '.';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { Account, AppContext } from '../../../models';
+import GleanMetrics from '../../../lib/glean';
+import { mockAppContext } from '../../../models/mocks';
+
+const totp = {
+  qrCodeUrl: 'qr:url',
+  secret: 'JFXE6ULUGM4U4WDHOFVFIRDPKZITATSK',
+  recoveryCodes: ['3594s0tbsq', '0zrg82sdzm', 'wx88yxenfc'],
+};
+
+const acct = {
+  primaryEmail: {
+    email: 'ibicking@mozilla.com',
+  },
+} as unknown as Account;
+
+const renderFlowSetup2faBackupCodeDownload = () => {
+  const onBackButtonClick = jest.fn();
+  const onContinue = jest.fn();
+  return {
+    onBackButtonClick,
+    onContinue,
+    ...renderWithLocalizationProvider(
+      <AppContext.Provider value={mockAppContext({ account: acct })}>
+        <FlowSetup2faBackupCodeDownLoad
+          currentStep={1}
+          numberOfSteps={3}
+          localizedFlowTitle="Two-step authentication"
+          totpInfo={totp}
+          showProgressBar
+          {...{ onBackButtonClick, onContinue }}
+        />
+      </AppContext.Provider>
+    ),
+  };
+};
+
+describe('FlowSetup2faBackupCodeDownload', () => {
+  beforeAll(() => {
+    window.URL.createObjectURL = jest.fn();
+  });
+  it('renders correctly', async () => {
+    const gleanSpy = jest.spyOn(
+      GleanMetrics.accountPref,
+      'twoStepAuthCodesView'
+    );
+    await renderFlowSetup2faBackupCodeDownload();
+    expect(screen.getByRole('progressbar')).toBeVisible();
+    screen
+      .getByTestId('datablock')
+      .querySelectorAll('li')
+      .forEach((li, i) => expect(li).toHaveTextContent(totp.recoveryCodes[i]));
+    expect(screen.getByTestId('databutton-download')).toHaveAttribute(
+      'download',
+      expect.stringContaining('Backup authentication codes')
+    );
+    expect(gleanSpy).toBeCalled();
+  });
+
+  it('calls on when the Cancel button is clicked', async () => {
+    const { onBackButtonClick } = renderFlowSetup2faBackupCodeDownload();
+    const cancelButton = screen.getByRole('button', { name: 'Back' });
+    await userEvent.click(cancelButton);
+    expect(onBackButtonClick).toHaveBeenCalled();
+  });
+
+  it('calls onContinue when the Continue button is clicked', async () => {
+    const { onContinue } = renderFlowSetup2faBackupCodeDownload();
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+    await userEvent.click(continueButton);
+    expect(onContinue).toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.tsx
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect } from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { useAccount } from '../../../models';
+import FlowContainer from '../FlowContainer';
+import ProgressBar from '../ProgressBar';
+import { GleanClickEventType2FA } from '../../../lib/types';
+import DataBlock from '../../DataBlock';
+import GleanMetrics from '../../../lib/glean';
+
+type FlowSetup2faBackupCodeDownloadProps = {
+  currentStep?: number;
+  hideBackButton?: boolean;
+  localizedFlowTitle: string;
+  numberOfSteps?: number;
+  onBackButtonClick?: () => void;
+  showProgressBar?: boolean;
+  totpInfo: {
+    recoveryCodes: string[];
+  };
+  onContinue: () => void;
+  reason?: GleanClickEventType2FA;
+};
+
+export const FlowSetup2faBackupCodeDownLoad = ({
+  currentStep,
+  hideBackButton = false,
+  localizedFlowTitle,
+  numberOfSteps,
+  onBackButtonClick,
+  showProgressBar = true,
+  totpInfo,
+  onContinue,
+  reason = GleanClickEventType2FA.setup,
+}: FlowSetup2faBackupCodeDownloadProps) => {
+  const account = useAccount();
+
+  useEffect(() => {
+    GleanMetrics.accountPref.twoStepAuthCodesView({
+      event: { reason: GleanClickEventType2FA.setup },
+    });
+  }, []);
+
+  return (
+    <FlowContainer
+      title={localizedFlowTitle}
+      {...{ hideBackButton, onBackButtonClick }}
+    >
+      {showProgressBar && currentStep && numberOfSteps && (
+        <ProgressBar {...{ currentStep, numberOfSteps }} />
+      )}
+      <FtlMsg id="flow-setup-2fa-backup-code-dl-heading">
+        <h2 className="font-bold text-[24px] my-2">
+          Save backup authentication codes
+        </h2>
+      </FtlMsg>
+
+      <div className="my-2" data-testid="2fa-recovery-codes">
+        <FtlMsg id="flow-setup-2fa-backup-code-dl-save-these-codes">
+          Keep these in a place you’ll remember. If you don’t have access to
+          your authenticator app you’ll need to enter one to sign in.
+        </FtlMsg>
+        <div className="mt-6 flex flex-col items-center justify-between">
+          <DataBlock
+            value={totpInfo.recoveryCodes}
+            contentType="Backup authentication codes"
+            email={account.primaryEmail.email}
+            gleanDataAttrs={{
+              download: {
+                id: 'two_step_auth_codes_download',
+                type: reason,
+              },
+              copy: {
+                id: 'two_step_auth_codes_copy',
+                type: reason,
+              },
+              print: {
+                id: 'two_step_auth_codes_print',
+                type: reason,
+              },
+            }}
+          />
+        </div>
+      </div>
+      <FtlMsg id="flow-setup-2fa-backup-code-dl-button-continue">
+        <button
+          data-testid="ack-recovery-code"
+          type="submit"
+          className="cta-primary cta-base-p mt-3"
+          onClick={onContinue}
+          data-glean-id="two_step_auth_codes_submit"
+          data-glean-type={GleanClickEventType2FA.setup}
+        >
+          Continue
+        </button>
+      </FtlMsg>
+    </FlowContainer>
+  );
+};


### PR DESCRIPTION
## Because

- The design for 2FA setup has been updated
- We want the UI component to be reusable
- We want to document the component and states in storybook

## This pull request

- Creates a new UI component with l10n, storybook and unit tests
- Tweaks Datablock to match the lastest design
- Does not hook up the component in the setup flow - that will be done in a later ticket

## Issue that this pull request solves

Closes: FXA-11624

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="635" alt="image" src="https://github.com/user-attachments/assets/89bf0523-2a69-4159-94a3-85788535e48c" />

## Other information (Optional)

Any other information that is important to this pull request.
