### PR TITLE
fix(payments-next):Applied coupon code before sign-in does not remain on checkout page after signing in

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -86,6 +86,8 @@ export default async function Checkout({
     redirectSearchParams.postalCode = cart.taxAddress.postalCode;
   }
 
+  redirectSearchParams.oldCartId = params.cartId;
+
   const redirectTo = buildRedirectUrl(
     params.offeringId,
     params.interval,

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -8,6 +8,7 @@ import {
   validateLocationAction,
   getTaxAddressAction,
   setupCartAction,
+  restartCartAction,
 } from '@fxa/payments/ui/actions';
 import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
 import { BaseParams, buildRedirectUrl } from '@fxa/payments/ui';
@@ -57,6 +58,7 @@ export default async function New({
   const coupon = searchParams.coupon || undefined;
   const countryCode = searchParams.countryCode;
   const postalCode = searchParams.postalCode;
+  const oldCartId = searchParams.oldCartId;
 
   const taxAddress =
     countryCode && postalCode
@@ -95,42 +97,44 @@ export default async function New({
     redirect(locationPageUrl.href);
   }
 
-  let redirectToUrl: URL;
-  try {
-    const cart = await setupCartAction(
-      interval as SubplatInterval,
-      offeringId,
-      taxAddress,
-      undefined,
-      coupon,
-      fxaUid
-    );
-
-    redirectToUrl = getRedirectToUrl(cart, params, searchParams);
-  } catch (error) {
-    if (error.name === 'CartInvalidPromoCodeError') {
-      const cart = await setupCartAction(
+  let cart: ResultCart;
+  if (session?.user && oldCartId) {
+    cart = await restartCartAction(oldCartId);
+  } else {
+    try {
+      cart = await setupCartAction(
         interval as SubplatInterval,
         offeringId,
         taxAddress,
         undefined,
-        undefined,
+        coupon,
         fxaUid
       );
-
-      redirectToUrl = getRedirectToUrl(cart, params, searchParams);
-    } else if (
-      error.name === 'RetrieveStripePriceInvalidOfferingError' ||
-      error.name === 'RetrieveStripePriceNotFoundError'
-    ) {
-      notFound();
-    } else {
-      throw error;
+    } catch (error) {
+      if (error.name === 'CartInvalidPromoCodeError') {
+        cart = await setupCartAction(
+          interval as SubplatInterval,
+          offeringId,
+          taxAddress,
+          undefined,
+          undefined,
+          fxaUid
+        );
+      } else if (
+        error.name === 'RetrieveStripePriceInvalidOfferingError' ||
+        error.name === 'RetrieveStripePriceNotFoundError'
+      ) {
+        notFound();
+      } else {
+        throw error;
+      }
     }
   }
+  const redirectToUrl = getRedirectToUrl(cart, params, searchParams);
 
   redirectToUrl.searchParams.delete('countryCode');
   redirectToUrl.searchParams.delete('postalCode');
+  redirectToUrl.searchParams.delete('oldCartId');
 
   redirect(redirectToUrl.href);
 }


### PR DESCRIPTION
## Because

- Before signing in, a valid coupon was applied to the subscription. However, after signing in, the coupon is no longer on the subscription.

## This pull request

-

## Issue that this pull request solves

Closes: #FXA-11344

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
