### PR TITLE
task: audit yarn resolutions – browserid-crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -267,7 +267,6 @@
     "@types/react": "18.2.14",
     "asn1.js": ">=5.4.1",
     "bn.js": "^5.2.1",
-    "browserid-crypto": "https://github.com/mozilla-fxa/browserid-crypto.git#5979544d13eeb15a02d0b9a6a7a08a698d54d37d",
     "css-minimizer-webpack-plugin": ">=4 <5",
     "compression": "1.7.4",
     "elliptic": ">=6.5.4",


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- It doesn't look like this particular resolution does anything

## This pull request

- removes the resolution for browserid-crypto

## Issue that this pull request solves

Closes: FXA-11790

## Other information (Optional)

It doesn't appear that browserid-crypto is used anymore – neither directly or as a transitive dependency.  Running `yarn why browserid-crypto` before and after removal returns nothing, and a lockfile is not generated after `yarn install`.
