### PR TITLE
task: audit yarn resolutions – http-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,6 @@
     "fbjs/isomorphic-fetch": "^3.0.0",
     "flat": "5.0.2",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
-    "http-proxy": "^1.18.1",
     "minimist": "^1.2.6",
     "node-forge": ">=1.3.0",
     "nest-typed-config/class-validator": "0.14.1",


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- It doesn't look like this particular resolution does anything

## This pull request

- removes the resolution for http-proxy

## Issue that this pull request solves

Closes: FXA-11792

## Other information (Optional)

The resolution for http-proxy appears to be noop.  Running `yarn why http-proxy` before and after removal returns the same version `1.18.1`, and a lockfile is not generated after `yarn install`.
