### PR TITLE
fix(payments-paypal): Customer cannot purchase another product with their saved PayPal account

### DIFF
--- a/libs/payments/paypal/src/lib/paypalBillingAgreement.manager.ts
+++ b/libs/payments/paypal/src/lib/paypalBillingAgreement.manager.ts
@@ -15,7 +15,7 @@ export class PaypalBillingAgreementManager {
   constructor(
     private client: PayPalClient,
     private paypalCustomerManager: PaypalCustomerManager
-  ) { }
+  ) {}
 
   public async retrieveOrCreateId(
     uid: string,
@@ -99,11 +99,16 @@ export class PaypalBillingAgreementManager {
   async retrieveActiveId(uid: string): Promise<string | undefined> {
     const paypalCustomer =
       await this.paypalCustomerManager.fetchPaypalCustomersByUid(uid);
-    const firstRecord = paypalCustomer.at(0);
+    const activeRecords = paypalCustomer.filter(
+      (customer) => customer.status === 'active'
+    );
 
-    if (!firstRecord || firstRecord?.status !== 'active') return;
-    if (paypalCustomer.length > 1)
+    if (activeRecords.length > 1) {
       throw new PaypalCustomerMultipleRecordsError(uid);
+    }
+
+    const firstRecord = activeRecords.at(0);
+    if (!firstRecord) return;
 
     return firstRecord.billingAgreementId;
   }


### PR DESCRIPTION
## Because

- PaypalCustomerMultipleRecordsError was being thrown if there were multiple records when it should only throw if there are multiple active records

## This pull request

- returns the billing agreement ID of the active record and throws when there are multiple active records

## Issue that this pull request solves

Closes: FXA-11772

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.