### PR TITLE
task: Resolve vulnerability – multer

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@nestjs/graphql": "^12.2.0",
     "@nestjs/mapped-types": "^2.0.5",
     "@nestjs/passport": "^10.0.3",
-    "@nestjs/platform-express": "^10.4.1",
+    "@nestjs/platform-express": "^10.4.18",
     "@nestjs/schedule": "^4.0.1",
     "@next/bundle-analyzer": "^15.1.6",
     "@nx/next": "19.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7545,19 +7545,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/platform-express@npm:^10.4.1":
-  version: 10.4.17
-  resolution: "@nestjs/platform-express@npm:10.4.17"
+"@nestjs/platform-express@npm:^10.4.18":
+  version: 10.4.18
+  resolution: "@nestjs/platform-express@npm:10.4.18"
   dependencies:
     body-parser: 1.20.3
     cors: 2.8.5
     express: 4.21.2
-    multer: 1.4.4-lts.1
+    multer: 2.0.0
     tslib: 2.8.1
   peerDependencies:
     "@nestjs/common": ^10.0.0
     "@nestjs/core": ^10.0.0
-  checksum: 640d9bdc225bdd9dd6a066c7c125a8573d30f16c0e9aad46c9f7804e50a4e7b3aa957403204a7959adbd99ac409e924b6c0e3138e0261caa1dfb6d38d8369f14
+  checksum: 255b5cdb68e65590416e73bfd3aa30946e708c1718b711da3aa59054fcec0bd1c60233e96345ab16adc22c407b8d4fb35b0a81676e5c5c6caa5320f32a603156
   languageName: node
   linkType: hard
 
@@ -32743,7 +32743,7 @@ __metadata:
     "@nestjs/graphql": ^12.2.0
     "@nestjs/mapped-types": ^2.0.5
     "@nestjs/passport": ^10.0.3
-    "@nestjs/platform-express": ^10.4.1
+    "@nestjs/platform-express": ^10.4.18
     "@nestjs/schedule": ^4.0.1
     "@nestjs/schematics": ^11.0.1
     "@nestjs/testing": ^10.3.4
@@ -41843,9 +41843,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multer@npm:1.4.4-lts.1":
-  version: 1.4.4-lts.1
-  resolution: "multer@npm:1.4.4-lts.1"
+"multer@npm:2.0.0":
+  version: 2.0.0
+  resolution: "multer@npm:2.0.0"
   dependencies:
     append-field: ^1.0.0
     busboy: ^1.0.0
@@ -41854,7 +41854,7 @@ __metadata:
     object-assign: ^4.1.1
     type-is: ^1.6.4
     xtend: ^4.0.0
-  checksum: da04b06efdbff9bd42d9f71297eeb2c0566231a4b9c895f49479c09b163c5e404aa6e58bd1c19f006f82e2114362545e39cbf7e0163ffd8d73d0f88adf4489e2
+  checksum: 0a6f7de5e59ea83cbe8c60071b0f2ae4923c0016516ed21bd94119800d434fca37b2cfd4b4c4b19c057e6a1ff2c0a015705b901a34be3e5addea673b7b1a0ba4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- the current version of multer includes multiple vulnerability alerts

## This pull request

- bumps nestjs/platform-express, which depends on multer
- bumps multer to `2.0` which is the latest/resolved version

## Issue that this pull request solves

Closes: FXA-11800

## Other information (Optional)

Running `yarn why multer` after upgrading nestjs/platform-express confirms nest is using the latest patched 2.0 version of multer.
