### PR TITLE
task(gql,auth): Add ability to ignore ips from circleci

### DIFF
--- a/libs/accounts/rate-limit/src/lib/config.ts
+++ b/libs/accounts/rate-limit/src/lib/config.ts
@@ -16,6 +16,9 @@ export class RateLimitConfig {
   ignoreIPs!: Array<string>;
 
   @IsArray()
+  ignoreIPsByDns!: Array<string>;
+
+  @IsArray()
   ignoreEmails!: Array<string>;
 
   @IsArray()

--- a/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.provider.ts
@@ -47,6 +47,7 @@ export const RateLimitProvider = {
         rules,
         ignoreEmails: rateLimitConfig.ignoreEmails,
         ignoreIPs: rateLimitConfig.ignoreIPs,
+        ignoreIPsByDns: rateLimitConfig.ignoreIPsByDns,
         ignoreUIDs: rateLimitConfig.ignoreUIDs,
       },
       redis,

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -98,7 +98,7 @@ describe('rate-limit', () => {
     );
   });
 
-  it('can ignore certain emails', () => {
+  it('can ignore certain emails', async () => {
     rateLimit = new RateLimit(
       {
         rules: {},
@@ -108,32 +108,48 @@ describe('rate-limit', () => {
       statsd
     );
 
-    expect(rateLimit.skip({ email: 'foo@mozilla.com' })).toBeTruthy();
-    expect(rateLimit.skip({ email: 'bar@mozilla.com' })).toBeTruthy();
-    expect(rateLimit.skip({ email: 'bar@mozilla.com ' })).toBeFalsy();
-    expect(rateLimit.skip({ email: 'foo@firefox.com' })).toBeTruthy();
-    expect(rateLimit.skip({ email: 'bar@firefox.com ' })).toBeFalsy();
-    expect(rateLimit.skip({})).toBeFalsy();
+    expect(await rateLimit.skip({ email: 'foo@mozilla.com' })).toBeTruthy();
+    expect(await rateLimit.skip({ email: 'bar@mozilla.com' })).toBeTruthy();
+    expect(await rateLimit.skip({ email: 'bar@mozilla.com ' })).toBeFalsy();
+    expect(await rateLimit.skip({ email: 'foo@firefox.com' })).toBeTruthy();
+    expect(await rateLimit.skip({ email: 'bar@firefox.com ' })).toBeFalsy();
+    expect(await rateLimit.skip({})).toBeFalsy();
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.email');
   });
 
-  it('can ignore certain ips', () => {
+  it('can ignore certain ips', async () => {
     rateLimit = new RateLimit(
       {
         rules: {},
         ignoreIPs: ['127.0.0.1'],
+        ignoreIPsByDns: ['all.knownips.circleci.com'],
       },
       redis,
       statsd
     );
 
-    expect(rateLimit.skip({ ip: '127.0.0.1' })).toBeTruthy();
-    expect(rateLimit.skip({ ip: '0.0.0.0' })).toBeFalsy();
-    expect(rateLimit.skip({})).toBeFalsy();
+    expect(await rateLimit.skip({ ip: '127.0.0.1' })).toBeTruthy();
+    expect(await rateLimit.skip({ ip: '3.228.39.90' })).toBeTruthy(); // known circleip
+    expect(await rateLimit.skip({ ip: '0.0.0.0' })).toBeFalsy();
+    expect(await rateLimit.skip({})).toBeFalsy();
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.ip');
   });
 
-  it('can ignore certain uids', () => {
+  it('can ignore certain ips by dns lookup', async () => {
+    rateLimit = new RateLimit(
+      {
+        rules: {},
+        ignoreIPsByDns: ['all.knownips.circleci.com'],
+      },
+      redis,
+      statsd
+    );
+
+    expect(await rateLimit.skip({ ip: '3.228.39.90' })).toBeTruthy();
+    expect(statsd.increment).toBeCalledWith('rate_limit.ignore.ip');
+  });
+
+  it('can ignore certain uids', async () => {
     rateLimit = new RateLimit(
       {
         rules: {},
@@ -143,9 +159,9 @@ describe('rate-limit', () => {
       statsd
     );
 
-    expect(rateLimit.skip({ uid: '000-000-000' })).toBeTruthy();
-    expect(rateLimit.skip({ uid: '000-000-001' })).toBeFalsy();
-    expect(rateLimit.skip({})).toBeFalsy();
+    expect(await rateLimit.skip({ uid: '000-000-000' })).toBeTruthy();
+    expect(await rateLimit.skip({ uid: '000-000-001' })).toBeFalsy();
+    expect(await rateLimit.skip({})).toBeFalsy();
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.uid');
   });
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "class-validator": "0.14.1",
     "clsx": "^2.1.1",
     "diffparser": "^2.0.1",
+    "dns-dig": "^1.3.4",
     "dotenv": "^16.4.5",
     "graphql": "^16.10.0",
     "graphql-request": "^6.1.0",

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2161,6 +2161,12 @@ const convictConf = convict({
     },
   },
   rateLimit: {
+    ignoreIPsByDns: {
+      default: ['all.knownips.circleci.com'],
+      doc: 'Set of dig lookups to run to determine IP filters.',
+      env: 'RATE_LIMIT__IGNORE_IPS_BY_DNS',
+      format: Array,
+    },
     ignoreIPs: {
       default: undefined,
       doc: 'Set of IPs to ignore while rate limiting. Rules will not apply to these values.',

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -299,6 +299,12 @@ const conf = convict({
     },
   },
   rateLimit: {
+    ignoreIPsByDns: {
+      default: ['all.knownips.circleci.com'],
+      doc: 'Set of dig lookups to run to determine IP filters.',
+      env: 'RATE_LIMIT__IGNORE_IPS_BY_DNS',
+      format: Array,
+    },
     rules: {
       format: Array,
       env: 'RATE_LIMIT__RULES',

--- a/yarn.lock
+++ b/yarn.lock
@@ -24739,6 +24739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"child_process@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "child_process@npm:1.0.2"
+  checksum: bd814d82bc8c6e85ed6fb157878978121cd03b5296c09f6135fa3d081fd9a6a617a6d509c50397711df713af403331241a9c0397a7fad30672051485e156c2a1
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:4.0.1":
   version: 4.0.1
   resolution: "chokidar@npm:4.0.1"
@@ -27703,6 +27710,15 @@ __metadata:
   version: 1.1.3
   resolution: "dlv@npm:1.1.3"
   checksum: d7381bca22ed11933a1ccf376db7a94bee2c57aa61e490f680124fa2d1cd27e94eba641d9f45be57caab4f9a6579de0983466f620a2cd6230d7ec93312105ae7
+  languageName: node
+  linkType: hard
+
+"dns-dig@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "dns-dig@npm:1.3.4"
+  dependencies:
+    child_process: ^1.0.2
+  checksum: 5eb55a420a7704aa34a433ab423b7918e2f98a7a2c49daf53f8426c2cd2a21f7c9925533c5bec37d9132b2e144fee0d4a30eb68db1bcb934232f2879deba9d78
   languageName: node
   linkType: hard
 
@@ -32820,6 +32836,7 @@ __metadata:
     class-validator: 0.14.1
     clsx: ^2.1.1
     diffparser: ^2.0.1
+    dns-dig: ^1.3.4
     dotenv: ^16.4.5
     esbuild: ^0.17.15
     esbuild-register: ^3.5.0


### PR DESCRIPTION
## Because
- We want a way to run smoke tests without hitting rate limits

## This pull request

- Adds dns-dig lib
- Adds config option to ignoreIPsByDns
- Uses dig to resolve list of IPs to ignore

## Issue that this pull request solves

Closes: [FXA-11805](https://mozilla-hub.atlassian.net/browse/FXA-11805)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-11805]: https://mozilla-hub.atlassian.net/browse/FXA-11805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ