### PR TITLE
task: audit yarn resolutions – node-forge

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,6 @@
     "flat": "5.0.2",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
     "minimist": "^1.2.6",
-    "node-forge": ">=1.3.0",
     "nest-typed-config/class-validator": "0.14.1",
     "parse-asn1": ">=5.1.7",
     "plist": "^3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -42489,7 +42489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:>=1.3.0":
+"node-forge@npm:^1, node-forge@npm:^1.2.1":
   version: 1.3.1
   resolution: "node-forge@npm:1.3.1"
   checksum: 08fb072d3d670599c89a1704b3e9c649ff1b998256737f0e06fbd1a5bf41cae4457ccaee32d95052d80bbafd9ffe01284e078c8071f0267dc9744e51c5ed42a9


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches

## This pull request

- removes the resolution for node-forge

## Issue that this pull request solves

Closes: FXA-11796

## Other information

After resolution removal, node-forge resolves to `1.3.1`, which satisfies the original intent.
