### PR TITLE
task: audit yarn resolutions – fbjs/isomorphic-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -270,7 +270,6 @@
     "css-minimizer-webpack-plugin": ">=4 <5",
     "compression": "1.7.4",
     "elliptic": ">=6.5.4",
-    "fbjs/isomorphic-fetch": "^3.0.0",
     "flat": "5.0.2",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
     "minimist": "^1.2.6",


### PR DESCRIPTION
## Because

- It doesn't look like this resolution does anything; it's not a valid package identifier
- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches

## This pull request

- removes the resolution for fbjs/isomorphic-fetch

## Issue that this pull request solves

Closes: FXA-11798

## Other information

After resolution removal, no lockfile is generated, further confirming this resolution does nothing.  The base package `fbjs` is also unchanged.
