### PR TITLE
feat(customs): Use checkAuthenticated in `/session/verify_code` route

### DIFF
--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -371,10 +371,10 @@ module.exports = function (
         const options = request.payload;
         const sessionToken = request.auth.credentials;
         const { code } = options;
-        const { uid, email } = sessionToken;
+        const { uid } = sessionToken;
         const devices = await request.app.devices;
 
-        await customs.check(request, email, 'verifySessionCode');
+        await customs.checkAuthenticated(request, uid, 'verifySessionCode');
 
         request.emitMetricsEvent('session.verify_code');
 
@@ -618,10 +618,10 @@ module.exports = function (
         log.begin('Session.verify_push', request);
         const options = request.payload;
         const sessionToken = request.auth.credentials;
-        const { uid, email } = sessionToken;
+        const { uid } = sessionToken;
         const { code, tokenVerificationId } = options;
 
-        await customs.check(request, email, 'verifySessionCode');
+        await customs.checkAuthenticated(request, uid, 'verifySessionCode');
         request.emitMetricsEvent('session.verify_push');
 
         const device = await db.deviceFromTokenVerificationId(

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -1204,11 +1204,11 @@ describe('/session/verify_code', () => {
     gleanMock.registration.complete.reset();
     const response = await runTest(route, request);
     assert.deepEqual(response, {});
-    assert.calledOnce(customs.check);
+    assert.calledOnce(customs.checkAuthenticated);
     assert.calledWithExactly(
-      customs.check,
+      customs.checkAuthenticated,
       request,
-      signupCodeAccount.email,
+      signupCodeAccount.uid,
       'verifySessionCode'
     );
     assert.calledOnce(db.account);
@@ -1457,9 +1457,9 @@ describe('/session/verify/verify_push', () => {
     assert.deepEqual(response, {});
 
     assert.calledOnceWithExactly(
-      customs.check,
+      customs.checkAuthenticated,
       request,
-      'foo@example.org',
+      'foo',
       'verifySessionCode'
     );
     assert.calledOnceWithExactly(db.devices, 'foo');
@@ -1522,9 +1522,9 @@ describe('/session/verify/verify_push', () => {
       assert.fail('should have thrown');
     } catch (err) {
       assert.calledOnceWithExactly(
-        customs.check,
+        customs.checkAuthenticated,
         request,
-        'foo@example.org',
+        'foo',
         'verifySessionCode'
       );
 


### PR DESCRIPTION
## Because

- We should use this customs api since the request is authenticated

## This pull request

- calls `checkAuthenticated` instead of `check`

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11784?linkSource=email

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
