### PR TITLE
feat(next): add auth statsd and error page

### DIFF
--- a/apps/payments/next/app/[locale]/auth/error/en.ftl
+++ b/apps/payments/next/app/[locale]/auth/error/en.ftl
@@ -1,0 +1,3 @@
+## Authentication Error page
+
+auth-error-page-title = We Couldn’t Sign You In

--- a/apps/payments/next/app/[locale]/auth/error/page.tsx
+++ b/apps/payments/next/app/[locale]/auth/error/page.tsx
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Image from 'next/image';
+import errorIcon from '@fxa/shared/assets/images/error.svg';
+import mozillaIcon from '@fxa/shared/assets/images/moz-logo-bw-rgb.svg';
+import Link from 'next/link';
+import { cookies } from 'next/headers';
+import { BaseButton, ButtonVariant } from '@fxa/payments/ui';
+import { config } from '../../../../config';
+import { getApp } from '@fxa/payments/ui/server';
+
+export default function AuthErrorPage({
+  searchParams,
+}: {
+  searchParams: Record<string, string>;
+}) {
+  const cookieStore = cookies();
+  const redirectUrl =
+    cookieStore.get('__Secure-authjs.callback-url')?.value ||
+    cookieStore.get('authjs.callback-url')?.value;
+  const supportUrl = config.supportUrl
+  const l10n = getApp().getL10n();
+  getApp().getEmitterService().emit('auth', { type: 'error', errorMessage: searchParams?.error });
+
+  return (
+    <>
+      <header
+        className="bg-white fixed flex justify-between items-center shadow h-16 left-0 top-0 mx-auto my-0 px-4 py-0 w-full z-40 tablet:h-20"
+        role="banner"
+      >
+        <div className="flex items-center">
+          <Image
+            src={mozillaIcon}
+            alt="Mozilla logo"
+            className="object-contain"
+            width={140}
+          />
+        </div>
+      </header>
+      <section
+        className="flex flex-col items-center text-center max-w-lg mx-auto mt-6 p-16 tablet:my-10 gap-16 bg-white shadow tablet:rounded-xl border border-transparent"
+        aria-labelledby='unable-to-signin-heading'
+      >
+        <h1 id="unable-to-signin-heading" className="text-xl font-bold">
+          {l10n.getString('auth-error-page-title', 'We Couldn’t Sign You In')}
+        </h1>
+        <Image src={errorIcon} alt="" />
+        <p className="flex flex-col gap-6 items-center text-grey-400 max-w-md text-sm">
+          <span>
+            {l10n.getFragmentWithSource('checkout-error-boundary-basic-error-message',
+              {
+                elems: {
+                  contactSupportLink: (
+                    <Link href={supportUrl} className="underline hover:text-grey-400">
+                      contact support.
+                    </Link>
+                  )
+                }
+              }
+              ,
+              <>
+                Something went wrong. Please try again or{' '}
+                <Link href={supportUrl} className="underline hover:text-grey-400">
+                  contact support.
+                </Link>
+              </>
+            )}
+          </span>
+          {redirectUrl &&
+            <Link href={redirectUrl}>
+              <BaseButton
+                variant={ButtonVariant.Primary}
+                className="text-base"
+              >
+                Try again
+              </BaseButton>
+            </Link>
+          }
+        </p>
+      </section>
+    </>
+  );
+}
+

--- a/apps/payments/next/app/api/auth/callback/fxa/route.ts
+++ b/apps/payments/next/app/api/auth/callback/fxa/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from 'next/server';
 import { GET as AuthJsGET } from '../../../../../auth';
 import { redirect } from 'next/navigation';
+import { getApp } from '@fxa/payments/ui/server';
 
 export { POST } from '../../../../../auth';
 
@@ -21,6 +22,7 @@ export async function GET(request: NextRequest) {
       cookieStore.get('__Secure-authjs.callback-url') ||
       cookieStore.get('authjs.callback-url');
     if (redirectUrl?.value) {
+      getApp().getEmitterService().emit('auth', { type: 'prompt_none_fail' });
       redirect(redirectUrl.value);
     }
   }

--- a/libs/payments/events/src/lib/emitter.error.ts
+++ b/libs/payments/events/src/lib/emitter.error.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { BaseError } from "@fxa/shared/error";
+
+export class EmitterServiceHandleAuthError extends BaseError {
+  constructor(...args: ConstructorParameters<typeof BaseError>) {
+    super(...args);
+    this.name = 'EmitterServiceHandleAuthError';
+    Object.setPrototypeOf(this, EmitterServiceHandleAuthError.prototype);
+  }
+}
+
+

--- a/libs/payments/events/src/lib/emitter.factories.ts
+++ b/libs/payments/events/src/lib/emitter.factories.ts
@@ -6,6 +6,7 @@ import {
   AdditionalMetricsData,
   SP3RolloutEvent,
   SubscriptionEndedEvents,
+  type AuthEvents,
 } from './emitter.types';
 import {
   CancellationReason,
@@ -13,6 +14,13 @@ import {
   CmsMetricsDataFactory,
 } from '@fxa/payments/metrics';
 import { SubplatInterval } from '@fxa/payments/customer';
+
+export const AuthEventsFactory = (
+  override?: Partial<AuthEvents>
+): AuthEvents => ({
+  type: faker.helpers.arrayElement(['signin', 'signout', 'prompt_none_fail', 'error']),
+  ...override
+})
 
 export const AdditionalMetricsDataFactory = (
   override?: AdditionalMetricsData

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -44,6 +44,11 @@ export type SP3RolloutEvent = {
   shadowMode: boolean;
 };
 
+export type AuthEvents = {
+  type: 'signin' | 'signout' | 'prompt_none_fail' | 'error';
+  errorMessage?: string;
+}
+
 export type PaymentsEmitterEvents = {
   checkoutView: CheckoutEvents;
   checkoutEngage: CheckoutEvents;
@@ -53,6 +58,7 @@ export type PaymentsEmitterEvents = {
   subscriptionEnded: SubscriptionEndedEvents;
   sp3Rollout: SP3RolloutEvent;
   locationView: LocationStatus | TaxChangeAllowedStatus;
+  auth: AuthEvents;
 };
 
 export type AdditionalMetricsData = {


### PR DESCRIPTION
## Because

- In an attempt to have statsd for all 3rd party dependencies, add statsd recording to Auth.js actions and events.
- On auth error, users are navigated to Auth.js default error page

## This pull request

- Add statsd counters signin, signout, prompt_none_fail and error
- Add custom Auth.js error page

## Issue that this pull request solves

Closes: #FXA-11670 #FXA-11754

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

To get to this Error Page follow these steps
1. Navigate to Checkout, enter email and hit "Sign in"
1. When on the FxA page, copy the URL
1. Complete the FxA Sign In, and navigate back to Checkout successfully
1. Open the copied URL into a new tab. This should load the FxA sign in page. Complete Sign In again
1. The new error page should be shown

![image](https://github.com/user-attachments/assets/0364b98e-254a-4562-bb96-5a4b3881bbee)

