### PR TITLE
bug(auth): The rule for verifySessionCode should have been on uid

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -68,7 +68,7 @@
   verifyRecoveryCode                    : ip                : 10            : 10 minutes        : 30 minutes
   verifyRecoveryCode                    : email             : 10            : 15 minutes        : 15 minutes
   verifySessionCode                     : ip                : 10            : 10 minutes        : 30 minutes
-  verifySessionCode                     : email             : 10            : 15 minutes        : 15 minutes
+  verifySessionCode                     : uid               : 10            : 15 minutes        : 15 minutes
 
 # Verify TOTP Code Limits
   verifyTotpCode                        : uid               : 10            : 30 seconds        : 15 minutes


### PR DESCRIPTION
## Because

- Rate limit lib was throwing on error when checking on verifySessionCode with `customs.checkAuthenticated`

## This pull request

- Fixes the rate-limit rule

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
