### PR TITLE
bug(auth,graphql): Exercise customs rules during local functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ executors:
       HUSKY_SKIP_INSTALL: 1
       AUTH_CLOUDTASKS_USE_LOCAL_EMULATOR: true
       # Seeing if clear customs approach works! RATE_LIMIT__RULES: ""
-      RATE_LIMIT__IGNORE_EMAILS: .*@restmail.net$
+      # RATE_LIMIT__IGNORE_EMAILS: .*@restmail.net$
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
   # automation. Perfect for running smoke tests against remote targets.

--- a/libs/shared/nestjs/customs/src/lib/customs.service.spec.ts
+++ b/libs/shared/nestjs/customs/src/lib/customs.service.spec.ts
@@ -112,6 +112,7 @@ describe('Customs Service', () => {
         errno: 114,
         error: 'Too Many Requests',
         'retry-after': 100,
+        action: 'test',
         // Since an 'acceptLanguage' of 'fr' was provided
         retryAfterLocalized: 'dans quelques secondes',
         // Since we mocked an unblock being allowed.
@@ -178,6 +179,7 @@ describe('Customs Service', () => {
         errno: 114,
         error: 'Too Many Requests',
         'retry-after': 101,
+        action: test,
         retryAfterLocalized: 'dans quelques secondes',
       });
     });

--- a/libs/shared/nestjs/customs/src/lib/customs.service.ts
+++ b/libs/shared/nestjs/customs/src/lib/customs.service.ts
@@ -87,6 +87,7 @@ export class CustomsService {
         const extraData: any = {
           // Not using pascal case to maintain backwards compat with auth-server
           'retry-after': response.retryAfter,
+          action: options.action
         };
 
         // Respect user's preferred locale

--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -38,6 +38,7 @@ export const test = base.extend<TestOptions, WorkerOptions>({
   target: [
     async ({ targetName }, use) => {
       const target = create(targetName);
+      await target.clearRateLimits();
       await use(target);
     },
     { scope: 'worker', auto: true },

--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -43,10 +43,6 @@ test.describe('severity-2 #smoke', () => {
     { signupVersion: v2, changeVersion: v2 },
   ];
 
-  test.beforeEach(async ({ target }) => {
-    await target.clearRateLimits();
-  });
-
   for (const { signupVersion, changeVersion } of TestCases) {
     test(`signs up as v${signupVersion.version} changes password from settings as v${changeVersion.version} for backbone`, async ({
       page,

--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -34,7 +34,6 @@ test.describe('auth-client-tests', () => {
 
   test.beforeEach(async ({ target }, { project }) => {
     test.skip(project.name === 'production');
-    await target.clearRateLimits();
   });
 
   test('it creates with v1 and signs in', async ({

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -10,11 +10,6 @@ import { SigninPage } from '../../pages/signin';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('change password tests', () => {
-
-    test.beforeEach(async ({ target }) => {
-      await target.clearRateLimits();
-    });
-
     test('change password with an incorrect old password', async ({
       target,
       pages: { page, changePassword, settings, signin },

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -75,10 +75,6 @@ test.describe('severity-1 #smoke', () => {
       }
     });
 
-    test.beforeEach(async ({ target }) => {
-      await target.clearRateLimits();
-    });
-
     test('setup fails with invalid number', async ({
       target,
       pages: { page, settings, signin, recoveryPhone, totp },

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -4,11 +4,11 @@
 # of account details. e.g. Trying random emails until an error code indicates one might exist.
   accountCreate                         : ip                : 100           : 15 minutes        : 15 minutes
   accountCreate                         : email             : 100           : 15 minutes        : 15 minutes
-  accountLogin                          : ip                : 100           : 15 minutes        : 15 minutes
-  accountLogin                          : email             : 100           : 15 minutes        : 15 minutes
+  # accountLogin                          : ip                : 100           : 15 minutes        : 15 minutes
+  # accountLogin                          : email             : 100           : 15 minutes        : 15 minutes
   accountDestroy                        : uid               : 100           : 15 minutes        : 15 minutes
-  passwordChange                        : ip                : 100           : 15 minutes        : 15 minutes
-  passwordChange                        : email             : 100           : 15 minutes        : 15 minutes
+  # passwordChange                        : ip                : 100           : 15 minutes        : 15 minutes
+  # passwordChange                        : email             : 100           : 15 minutes        : 15 minutes
   passwordForgotSendCode                : ip                : 100           : 15 minutes        : 15 minutes
   passwordForgotSendCode                : email             : 100           : 15 minutes        : 15 minutes
   accountStatusCheck                    : ip                : 100           : 15 minutes        : 15 minutes
@@ -46,8 +46,8 @@
 # email and ip.
   accountLogin                          : email             : 5             : 15 minutes        : 15 minutes
   accountLogin                          : ip                : 5             : 10 minutes        : 30 minutes
-  accountDestroy                        : email             : 5             : 15 minutes        : 15 minutes
-  accountDestroy                        : ip                : 5             : 10 minutes        : 30 minutes
+  # accountDestroy                        : email             : 5             : 15 minutes        : 15 minutes
+  # accountDestroy                        : ip                : 5             : 10 minutes        : 30 minutes
   passwordChange                        : email             : 5             : 15 minutes        : 15 minutes
   passwordChange                        : ip                : 5             : 10 minutes        : 30 minutes
   authenticatedAccountLogin             : uid               : 5             : 15 minutes        : 15 minutes

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -114,7 +114,7 @@ class CustomsClient {
     });
 
     this.optionallyReportStatsD('request.check', action, result);
-    return this.handleCustomsResult(request, result);
+    return this.handleCustomsResult(request, result, action);
   }
 
   async checkAuthenticated(request, uid, email, action) {
@@ -218,7 +218,7 @@ class CustomsClient {
     }
   }
 
-  handleCustomsResult(request, result) {
+  handleCustomsResult(request, result, action) {
     if (!result) {
       return;
     }
@@ -243,7 +243,8 @@ class CustomsClient {
         throw this.error.tooManyRequests(
           result.retryAfter,
           retryAfterLocalized,
-          unblock
+          unblock,
+          action || ''
         );
       }
 
@@ -315,9 +316,9 @@ class CustomsClient {
     const skip = this.rateLimit.skip(opts);
     if (skip) {
       this.statsd.increment(`${serviceName}.check.v2.skip`, [
-        opts.ip ? 'ip':'',
-        opts.email ? 'email':'',
-        opts.uid ? 'uid':'',
+        opts.ip ? 'ip' : '',
+        opts.email ? 'email' : '',
+        opts.uid ? 'uid' : '',
       ]);
       return true;
     }
@@ -339,7 +340,6 @@ class CustomsClient {
       block: result != null,
       blockReason: result?.reason || '',
     });
-
 
     // If no result, we exit. Check essentially passes.
     if (result == null) {
@@ -371,9 +371,9 @@ class CustomsClient {
     throw this.error.tooManyRequests(
       result.retryAfter,
       retryAfterLocalized,
-      canUnblock
+      canUnblock,
+      action
     );
-
   }
   // #endregion
 }

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -413,7 +413,8 @@ AppError.requestBodyTooLarge = function () {
 AppError.tooManyRequests = function (
   retryAfter,
   retryAfterLocalized,
-  canUnblock
+  canUnblock,
+  action
 ) {
   if (!retryAfter) {
     retryAfter = 30;
@@ -437,11 +438,12 @@ AppError.tooManyRequests = function (
       code: 429,
       error: 'Too Many Requests',
       errno: ERRNO.THROTTLED,
-      message: 'Client has sent too many requests',
+      message: `Client has sent too many requests`,
     },
     extraData,
     {
       'retry-after': retryAfter,
+      action,
     }
   );
 


### PR DESCRIPTION
## Because

- We want to be able to use customs when running functionally tests locally or the CI
- When running tests against stage/ prod, there's no easy way to reset the counts, so we will skip the checks in this scenario.

## This pull request

- Resets customs counts before each test functional test scenario during 'local' testing.
- Smoke tests will have to rely on email filters.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
