### PR TITLE
fix(metrics): Set flowId when user verifies totp session

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1766,6 +1766,7 @@ export default class AuthClient {
     code: string,
     options: {
       service?: string;
+      metricsContext?: MetricsContext;
     } = {},
     headers?: Headers
   ) {

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -491,6 +491,7 @@ module.exports = (
               .required()
               .description(DESCRIPTION.codeTotp),
             service: validators.service,
+            metricsContext: METRICS_CONTEXT_SCHEMA
           }),
         },
         response: {

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -199,10 +199,14 @@ export class AccountResolver {
     @Args('input', { type: () => VerifyTotpInput })
     input: VerifyTotpInput
   ): Promise<VerifyTotpPayload> {
+    const options = {
+      service: input.service,
+      metricsContext: input.metricsContext,
+    };
     const result = await this.authAPI.verifyTotpCode(
       token,
       input.code,
-      input.service ? { service: input.service } : undefined,
+      options,
       headers
     );
     return {

--- a/packages/fxa-graphql-api/src/gql/dto/input/verify-totp.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/verify-totp.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Field, InputType } from '@nestjs/graphql';
+import { MetricsContext } from './metrics-context';
 
 @InputType()
 export class VerifyTotpInput {
@@ -16,4 +17,7 @@ export class VerifyTotpInput {
 
   @Field({ nullable: true })
   public service?: string;
+
+  @Field(() => MetricsContext, { nullable: true })
+  public metricsContext?: MetricsContext;
 }

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -522,7 +522,7 @@ const AuthAndAccountSetupRoutes = ({
         />
         <SigninTotpCodeContainer
           path="/signin_totp_code/*"
-          {...{ integration, serviceName }}
+          {...{ integration, serviceName, flowQueryParams }}
         />
         <SigninPushCodeContainer
           path="/signin_push_code/*"

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -43,15 +43,19 @@ import {
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import { queryParamsToMetricsContext } from '../../../lib/metrics';
+import { searchParams } from '../../../lib/utilities';
+import { QueryParams } from '../../../index';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
   serviceName: MozServices;
+  flowQueryParams?: QueryParams;
 };
 
 export const SigninTotpCodeContainer = ({
   integration,
-  serviceName,
+  serviceName, flowQueryParams
 }: SigninTotpCodeContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
@@ -105,6 +109,9 @@ export const SigninTotpCodeContainer = ({
           input: {
             code,
             service,
+            metricsContext: queryParamsToMetricsContext(
+              flowQueryParams as ReturnType<typeof searchParams>
+            )
           },
         },
         update: (cache, { data }) => {


### PR DESCRIPTION
## Because

- These flowId were missing

## This pull request

- Sets the flowId in settings and progagates them through gql and auth server

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11697

## Checklist

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We have a lot of endpoints that don't specify `metricsContext` but could use them. I think we should try to find a way to automatically set this if avaiable.
