### PR TITLE
bug(auth): Fix broken functional tests due to rate-limiting

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -67,7 +67,6 @@
   passwordForgotVerifyCode              : email             : 10            : 15 minutes        : 15 minutes
   verifyRecoveryCode                    : ip                : 10            : 10 minutes        : 30 minutes
   verifyRecoveryCode                    : email             : 10            : 15 minutes        : 15 minutes
-  verifySessionCode                     : ip                : 10            : 10 minutes        : 30 minutes
   verifySessionCode                     : uid               : 10            : 15 minutes        : 15 minutes
 
 # Verify TOTP Code Limits

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -117,7 +117,7 @@ class CustomsClient {
     return this.handleCustomsResult(request, result);
   }
 
-  async checkAuthenticated(request, uid, action) {
+  async checkAuthenticated(request, uid, email, action) {
     const checked = await this.checkV2(request, 'checkAuthenticated', action, {
       ip: request?.app?.clientAddress,
       uid,

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -322,6 +322,7 @@ module.exports = (
         let { ttl } = request.payload;
         const credentials = request.auth.credentials;
         const uid = credentials.uid;
+        const email = credentials.email;
         const sender = credentials.deviceId;
 
         if (
@@ -331,7 +332,12 @@ module.exports = (
           throw new error.featureNotEnabled();
         }
 
-        await customs.checkAuthenticated(request, uid, 'invokeDeviceCommand');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          email,
+          'invokeDeviceCommand'
+        );
 
         const targetDevice = await db.device(uid, target);
 
@@ -468,6 +474,7 @@ module.exports = (
         const body = request.payload;
         const sessionToken = request.auth.credentials;
         const uid = sessionToken.uid;
+        const email = sessionToken.email;
         const payload = body.payload;
         const endpointAction = body._endpointAction || 'devicesNotify';
 
@@ -484,7 +491,7 @@ module.exports = (
         }
 
         let [, deviceArray] = await Promise.all([
-          customs.checkAuthenticated(request, uid, endpointAction),
+          customs.checkAuthenticated(request, uid, email, endpointAction),
           request.app.devices,
         ]);
 

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -108,6 +108,7 @@ module.exports = function (
           await customs.checkAuthenticated(
             request,
             sessionToken.uid,
+            sessionToken.email,
             customs.v2Enabled()
               ? 'authenticatedPasswordChange'
               : 'passwordChange'

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -203,7 +203,7 @@ module.exports = (
         log.begin('verifyRecoveryKey', request);
 
         const sessionToken = request.auth.credentials;
-        const { uid } = sessionToken;
+        const { uid, email } = sessionToken;
 
         try {
           if (sessionToken.tokenVerificationId) {
@@ -212,7 +212,12 @@ module.exports = (
 
           // This route can let you check if a key is valid therefore we
           // rate limit it.
-          await customs.checkAuthenticated(request, uid, 'getRecoveryKey');
+          await customs.checkAuthenticated(
+            request,
+            uid,
+            email,
+            'getRecoveryKey'
+          );
 
           const { recoveryKeyId } = request.payload;
 
@@ -278,10 +283,10 @@ module.exports = (
       handler: async function (request) {
         log.begin('getRecoveryKey', request);
 
-        const { uid } = request.auth.credentials;
+        const { uid, email } = request.auth.credentials;
         const { recoveryKeyId } = request.params;
 
-        await customs.checkAuthenticated(request, uid, 'getRecoveryKey');
+        await customs.checkAuthenticated(request, uid, email, 'getRecoveryKey');
 
         const { recoveryData } = await db.getRecoveryKey(uid, recoveryKeyId);
 

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -48,6 +48,7 @@ export type Customs = {
   checkAuthenticated: (
     req: AuthRequest,
     uid: string,
+    email: string,
     action: string
   ) => Promise<void>;
 };
@@ -202,6 +203,7 @@ class RecoveryPhoneHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
+      email,
       'recoveryPhoneSendResetPasswordCode'
     );
 
@@ -285,6 +287,7 @@ class RecoveryPhoneHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
+      email,
       'recoveryPhoneSendSetupCode'
     );
 
@@ -381,6 +384,7 @@ class RecoveryPhoneHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
+      email,
       'verifyRecoveryPhoneTotpCode'
     );
 
@@ -645,6 +649,7 @@ class RecoveryPhoneHandler {
     await this.customs.checkAuthenticated(
       request,
       uid,
+      email,
       'verifyRecoveryPhoneTotpCode'
     );
 
@@ -665,10 +670,7 @@ class RecoveryPhoneHandler {
     }
 
     if (success) {
-      await this.db.verifyPasswordForgotTokenWithMethod(
-        id,
-        'totp-2fa'
-      );
+      await this.db.verifyPasswordForgotTokenWithMethod(id, 'totp-2fa');
 
       await this.glean.resetPassword.recoveryPhoneCodeComplete(request);
 

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -371,10 +371,15 @@ module.exports = function (
         const options = request.payload;
         const sessionToken = request.auth.credentials;
         const { code } = options;
-        const { uid } = sessionToken;
+        const { uid, email } = sessionToken;
         const devices = await request.app.devices;
 
-        await customs.checkAuthenticated(request, uid, 'verifySessionCode');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          email,
+          'verifySessionCode'
+        );
 
         request.emitMetricsEvent('session.verify_code');
 
@@ -618,10 +623,15 @@ module.exports = function (
         log.begin('Session.verify_push', request);
         const options = request.payload;
         const sessionToken = request.auth.credentials;
-        const { uid } = sessionToken;
+        const { uid, email } = sessionToken;
         const { code, tokenVerificationId } = options;
 
-        await customs.checkAuthenticated(request, uid, 'verifySessionCode');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          email,
+          'verifySessionCode'
+        );
         request.emitMetricsEvent('session.verify_push');
 
         const device = await db.deviceFromTokenVerificationId(

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -346,6 +346,7 @@ module.exports = (
         await customs.checkAuthenticated(
           request,
           passwordForgotToken.uid,
+          passwordForgotToken.email,
           'verifyTotpCode'
         );
 
@@ -505,7 +506,7 @@ module.exports = (
         const sessionToken = request.auth.credentials;
         const { uid, email } = sessionToken;
 
-        await customs.checkAuthenticated(request, uid, 'verifyTotpCode');
+        await customs.checkAuthenticated(request, uid, email, 'verifyTotpCode');
 
         const token = await db.totpToken(sessionToken.uid);
         const sharedSecret = token.sharedSecret;

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -139,6 +139,7 @@ module.exports = (
             await customs.checkAuthenticated(
               request,
               checkAuthenticatedUid,
+              email,
               customs.v2Enabled ? 'authenticatedAccountLogin' : 'accountLogin'
             );
           } else {

--- a/packages/fxa-auth-server/test/local/customs.js
+++ b/packages/fxa-auth-server/test/local/customs.js
@@ -511,6 +511,7 @@ describe('Customs', () => {
 
     action = 'devicesNotify';
     const uid = 'foo';
+    const email = 'bar@mozilla.com';
 
     function checkRequestBody(body) {
       assert.deepEqual(
@@ -540,14 +541,14 @@ describe('Customs', () => {
       .reply(200, '{"block":true,"retryAfter":10001}');
 
     return customsWithUrl
-      .checkAuthenticated(request, uid, action)
+      .checkAuthenticated(request, uid, email, action)
       .then((result) => {
         assert.equal(
           result,
           undefined,
           'Nothing is returned when /checkAuthenticated succeeds - 1'
         );
-        return customsWithUrl.checkAuthenticated(request, uid, action);
+        return customsWithUrl.checkAuthenticated(request, uid, email, action);
       })
       .then((result) => {
         assert.equal(
@@ -555,7 +556,7 @@ describe('Customs', () => {
           undefined,
           'Nothing is returned when /checkAuthenticated succeeds - 2'
         );
-        return customsWithUrl.checkAuthenticated(request, uid, action);
+        return customsWithUrl.checkAuthenticated(request, uid, email, action);
       })
       .then((result) => {
         assert.equal(
@@ -563,7 +564,7 @@ describe('Customs', () => {
           undefined,
           'Nothing is returned when /checkAuthenticated succeeds - 3'
         );
-        return customsWithUrl.checkAuthenticated(request, uid, action);
+        return customsWithUrl.checkAuthenticated(request, uid, email, action);
       })
       .then((result) => {
         assert.equal(
@@ -571,11 +572,11 @@ describe('Customs', () => {
           undefined,
           'Nothing is returned when /checkAuthenticated succeeds - 4'
         );
-        return customsWithUrl.checkAuthenticated(request, uid, action);
+        return customsWithUrl.checkAuthenticated(request, uid, email, action);
       })
       .then(() => {
         // request is blocked
-        return customsWithUrl.checkAuthenticated(request, uid, action);
+        return customsWithUrl.checkAuthenticated(request, uid, email, action);
       })
       .then(
         () => {
@@ -861,7 +862,12 @@ describe('Customs', () => {
       });
 
       try {
-        await customsWithUrl.checkAuthenticated(request, 'uid', action);
+        await customsWithUrl.checkAuthenticated(
+          request,
+          'uid',
+          'email',
+          action
+        );
         assert.fail('should have failed');
       } catch (err) {
         assert.isTrue(

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -806,6 +806,7 @@ describe('/password', () => {
       const mockRequest = mocks.mockRequest({
         credentials: {
           uid,
+          email: TEST_EMAIL,
         },
         payload: {
           email: TEST_EMAIL,
@@ -847,6 +848,7 @@ describe('/password', () => {
         mockCustoms.checkAuthenticated,
         mockRequest,
         uid,
+        TEST_EMAIL,
         'authenticatedPasswordChange'
       );
       sinon.assert.calledWith(mockDB.accountRecord, TEST_EMAIL);

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -355,10 +355,11 @@ describe('POST /recoveryKey', () => {
     it('called customs.checkAuthenticated correctly', () => {
       assert.equal(customs.checkAuthenticated.callCount, 1);
       const args = customs.checkAuthenticated.args[0];
-      assert.equal(args.length, 3);
+      assert.equal(args.length, 4);
       assert.deepEqual(args[0], request);
       assert.equal(args[1], uid);
-      assert.equal(args[2], 'getRecoveryKey');
+      assert.equal(args[2], email);
+      assert.equal(args[3], 'getRecoveryKey');
     });
 
     it('called db.updateRecoveryKey correctly', () => {
@@ -531,10 +532,11 @@ describe('GET /recoveryKey/{recoveryKeyId}', () => {
     it('called customs.checkAuthenticated correctly', () => {
       assert.equal(customs.checkAuthenticated.callCount, 1);
       const args = customs.checkAuthenticated.args[0];
-      assert.equal(args.length, 3);
+      assert.equal(args.length, 4);
       assert.deepEqual(args[0], request);
       assert.equal(args[1], uid);
-      assert.equal(args[2], 'getRecoveryKey');
+      assert.equal(args[2], email);
+      assert.equal(args[3], 'getRecoveryKey');
     });
 
     it('called db.getRecoveryKey correctly', () => {

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -237,8 +237,9 @@ describe('/recovery_phone', () => {
 
       assert.equal(mockCustoms.checkAuthenticated.callCount, 1);
       assert.equal(mockCustoms.checkAuthenticated.getCall(0).args[1], uid);
+      assert.equal(mockCustoms.checkAuthenticated.getCall(0).args[2], email);
       assert.equal(
-        mockCustoms.checkAuthenticated.getCall(0).args[2],
+        mockCustoms.checkAuthenticated.getCall(0).args[3],
         'recoveryPhoneSendResetPasswordCode'
       );
 
@@ -363,8 +364,9 @@ describe('/recovery_phone', () => {
 
       assert.equal(mockCustoms.checkAuthenticated.callCount, 1);
       assert.equal(mockCustoms.checkAuthenticated.getCall(0).args[1], uid);
+      assert.equal(mockCustoms.checkAuthenticated.getCall(0).args[2], email);
       assert.equal(
-        mockCustoms.checkAuthenticated.getCall(0).args[2],
+        mockCustoms.checkAuthenticated.getCall(0).args[3],
         'recoveryPhoneSendSetupCode'
       );
       assert.calledOnceWithExactly(

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -1209,6 +1209,7 @@ describe('/session/verify_code', () => {
       customs.checkAuthenticated,
       request,
       signupCodeAccount.uid,
+      signupCodeAccount.email,
       'verifySessionCode'
     );
     assert.calledOnce(db.account);
@@ -1459,7 +1460,8 @@ describe('/session/verify/verify_push', () => {
     assert.calledOnceWithExactly(
       customs.checkAuthenticated,
       request,
-      'foo',
+      signupCodeAccount.uid,
+      signupCodeAccount.email,
       'verifySessionCode'
     );
     assert.calledOnceWithExactly(db.devices, 'foo');
@@ -1525,6 +1527,7 @@ describe('/session/verify/verify_push', () => {
         customs.checkAuthenticated,
         request,
         'foo',
+        'foo@example.org',
         'verifySessionCode'
       );
 

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -597,6 +597,7 @@ describe('totp', () => {
         customs.checkAuthenticated,
         request,
         'uid',
+        TEST_EMAIL,
         'verifyTotpCode'
       );
     });
@@ -618,6 +619,7 @@ describe('totp', () => {
         customs.checkAuthenticated,
         request,
         'uid',
+        TEST_EMAIL,
         'verifyTotpCode'
       );
     });


### PR DESCRIPTION
## Because
- We were tripping rate limits during functional tests

## This pull request
- Adds email to `customs.checkAuthenticated`
- Fixes the verifySessionCode check. We can check on UID here, so we don't need to also check IP since the endpoint is protected by a session token.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
