### PR TITLE
resolve koa vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
     "elliptic": ">=6.5.4",
     "flat": "5.0.2",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
+    "koa": "^2.16.1",
     "minimist": "^1.2.6",
     "nest-typed-config/class-validator": "0.14.1",
     "parse-asn1": ">=5.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39729,38 +39729,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:2.15.4":
-  version: 2.15.4
-  resolution: "koa@npm:2.15.4"
-  dependencies:
-    accepts: ^1.3.5
-    cache-content-type: ^1.0.0
-    content-disposition: ~0.5.2
-    content-type: ^1.0.4
-    cookies: ~0.9.0
-    debug: ^4.3.2
-    delegates: ^1.0.0
-    depd: ^2.0.0
-    destroy: ^1.0.4
-    encodeurl: ^1.0.2
-    escape-html: ^1.0.3
-    fresh: ~0.5.2
-    http-assert: ^1.3.0
-    http-errors: ^1.6.3
-    is-generator-function: ^1.0.7
-    koa-compose: ^4.1.0
-    koa-convert: ^2.0.0
-    on-finished: ^2.3.0
-    only: ~0.0.2
-    parseurl: ^1.3.2
-    statuses: ^1.5.0
-    type-is: ^1.6.16
-    vary: ^1.1.2
-  checksum: cd2bf396fa5f575504d4c1b9e23ba64b9c58cbfa8276dbc4d99ce527ae4f238c38eafb811c22986c2f0f475a61734d05a8f9f5873b22432d78344b4517d83a69
-  languageName: node
-  linkType: hard
-
-"koa@npm:2.16.1":
+"koa@npm:^2.16.1":
   version: 2.16.1
   resolution: "koa@npm:2.16.1"
   dependencies:


### PR DESCRIPTION
## Because

- the koa transitive dependency includes vulnerability alerts

## This pull request

- sets a resolution for minimum resolved koa version (2.16.1)

## Issue that this pull request solves

Closes: FXA-11799

## Other information (Optional)

I wanted to avoid using a resolution, but the vulnerability is a transitive dependency called by `@module-federation/dts-plugin` which eventually traces up to `@nx/react` – which was just upgraded to it's latest version 21.1.2.  Unfortunately the upgrade did not resolve the vulnerability.  

Also, koa is not installed as a caret range which means we can't upgrade it specifically.