### PR TITLE
task(auth): Use customs.checkAuthenticated where possible

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -6,8 +6,7 @@
   accountCreate                         : email             : 100           : 15 minutes        : 15 minutes
   accountLogin                          : ip                : 100           : 15 minutes        : 15 minutes
   accountLogin                          : email             : 100           : 15 minutes        : 15 minutes
-  accountDestroy                        : ip                : 100           : 15 minutes        : 15 minutes
-  accountDestroy                        : email             : 100           : 15 minutes        : 15 minutes
+  accountDestroy                        : uid               : 100           : 15 minutes        : 15 minutes
   passwordChange                        : ip                : 100           : 15 minutes        : 15 minutes
   passwordChange                        : email             : 100           : 15 minutes        : 15 minutes
   passwordForgotSendCode                : ip                : 100           : 15 minutes        : 15 minutes
@@ -30,18 +29,15 @@
 # Email Send - These are limits on rate at which emails can be sent out. We limit both IP and email address
 # since many of these operations do not require authentication. Some operations, however, require sessions
 # and for these we should switch over to using UID. See FXA-11777 for more details.
-  createEmail                           : email             : 5             : 15 minutes        : 15 minutes
-  createEmail                           : ip                : 5             : 10 minutes        : 30 minutes
-  recoveryEmailResendCode               : email             : 5             : 15 minutes        : 15 minutes
-  recoveryEmailResendCode               : ip                : 5             : 10 minutes        : 30 minutes
+  createEmail                           : uid               : 5             : 15 minutes        : 15 minutes
+  recoveryEmailResendCode               : uid               : 5             : 15 minutes        : 15 minutes
   recoveryEmailSecondaryResendCode      : email             : 5             : 15 minutes        : 15 minutes
   recoveryEmailSecondaryResendCode      : ip                : 5             : 10 minutes        : 30 minutes
   passwordForgotSendCode                : email             : 5             : 15 minutes        : 15 minutes
   passwordForgotSendCode                : ip                : 5             : 10 minutes        : 30 minutes
   passwordForgotResendCode              : email             : 5             : 15 minutes        : 15 minutes
   passwordForgotResendCode              : ip                : 5             : 10 minutes        : 30 minutes
-  sendVerifyCode                        : email             : 5             : 15 minutes        : 15 minutes
-  sendVerifyCode                        : ip                : 5             : 10 minutes        : 30 minutes
+  sendVerifyCode                        : uid               : 5             : 15 minutes        : 15 minutes
   sendUnblockCode                       : email             : 5             : 15 minutes        : 15 minutes
   sendUnblockCode                       : ip                : 5             : 10 minutes        : 30 minutes
   unblockEmail                          : email             : 5             : 15 minutes        : 15 minutes

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -120,6 +120,7 @@ class CustomsClient {
   async checkAuthenticated(request, uid, email, action) {
     const checked = await this.checkV2(request, 'checkAuthenticated', action, {
       ip: request?.app?.clientAddress,
+      email,
       uid,
     });
     if (checked) {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -822,7 +822,7 @@ export class AccountHandler {
     const account = await this.db.account(uid as string);
     const email = account.primaryEmail?.email;
 
-    await this.customs.check(request, email, 'setPassword');
+    await this.customs.checkAuthenticated(request, uid, email, 'setPassword');
 
     const response: Record<string, any> = {};
     response.uid = uid;
@@ -1823,7 +1823,12 @@ export class AccountHandler {
       authenticatorAssuranceLevel?: number;
     }
 
-    await this.customs.check(request, emailAddress, 'accountDestroy');
+    await this.customs.checkAuthenticated(
+      request,
+      sessionToken.uid,
+      sessionToken.email,
+      'accountDestroy'
+    );
 
     let accountRecord: Account;
     try {

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -273,8 +273,9 @@ module.exports = (
           return {};
         }
 
-        await customs.check(
+        await customs.checkAuthenticated(
           request,
+          sessionToken.uid,
           sessionToken.email,
           'recoveryEmailResendCode'
         );
@@ -577,7 +578,12 @@ module.exports = (
           uid: uid,
         };
 
-        await customs.check(request, primaryEmail, 'createEmail');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          primaryEmail,
+          'createEmail'
+        );
 
         const account = await db.account(uid);
         const secondaryEmails = account.emails.filter(
@@ -724,7 +730,12 @@ module.exports = (
         const primaryEmail = sessionToken.email;
         const email = request.payload.email;
 
-        await customs.check(request, primaryEmail, 'deleteEmail');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          primaryEmail,
+          'deleteEmail'
+        );
         const account = await db.account(uid);
 
         if (sessionToken.tokenVerificationId) {
@@ -789,7 +800,12 @@ module.exports = (
 
         log.begin('Account.RecoveryEmailSetPrimary', request);
 
-        await customs.check(request, currentEmail, 'setPrimaryEmail');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          currentEmail,
+          'setPrimaryEmail'
+        );
 
         if (sessionToken.tokenVerificationId) {
           throw error.unverifiedSession();
@@ -902,8 +918,9 @@ module.exports = (
         const geoData = request.app.geo;
         const { email } = request.payload;
 
-        await customs.check(
+        await customs.checkAuthenticated(
           request,
+          sessionToken.uid,
           sessionToken.email,
           'recoveryEmailSecondaryResendCode'
         );
@@ -988,8 +1005,9 @@ module.exports = (
         const sessionToken = request.auth.credentials;
         const { email, code } = request.payload;
 
-        await customs.check(
+        await customs.checkAuthenticated(
           request,
+          sessionToken.uid,
           sessionToken.email,
           'recoveryEmailSecondaryVerifyCode'
         );

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -207,7 +207,12 @@ module.exports = (log, db, config, customs, mailer, glean) => {
           uid,
         } = request.auth.credentials;
 
-        await customs.check(request, email, 'verifyRecoveryCode');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          email,
+          'verifyRecoveryCode'
+        );
 
         const { code } = request.payload;
         const { remaining } = await db.consumeRecoveryCode(uid, code);

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -130,7 +130,12 @@ class RecoveryPhoneHandler {
       throw AppError.invalidToken();
     }
 
-    await this.customs.check(request, email, 'recoveryPhoneSendSigninCode');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'recoveryPhoneSendSigninCode'
+    );
 
     const getFormattedMessage = async (code: string) => {
       const localizedMessage = await this.getLocalizedMessage(

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -454,8 +454,9 @@ module.exports = function (
         const account = await db.account(sessionToken.uid);
         const secret = account.primaryEmail.emailCode;
 
-        await customs.check(
+        await customs.checkAuthenticated(
           request,
+          account.uid,
           account.primaryEmail.normalizedEmail,
           'sendVerifyCode'
         );

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -38,8 +38,9 @@ export class MozillaSubscriptionHandler {
     );
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(
+    await this.customs.checkAuthenticated(
       request,
+      uid,
       email,
       'mozillaSubscriptionsCustomerBillingAndSubscriptions'
     );
@@ -84,8 +85,9 @@ export class MozillaSubscriptionHandler {
     this.log.begin('mozillaSubscriptions.validatePlanEligibility', request);
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(
+    await this.customs.checkAuthenticated(
       request,
+      uid,
       email,
       'mozillaSubscriptionsValidatePlanEligibility'
     );

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -59,8 +59,13 @@ export class PayPalHandler extends StripeWebhookHandler {
    */
   async getCheckoutToken(request: AuthRequest) {
     this.log.begin('subscriptions.getCheckoutToken', request);
-    const { email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'getCheckoutToken');
+    const { uid, email } = await handleAuth(this.db, request.auth, true);
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'getCheckoutToken'
+    );
 
     const { currencyCode } = request.payload as Record<string, string>;
     const token = await this.paypalHelper.getCheckoutToken({ currencyCode });
@@ -87,7 +92,12 @@ export class PayPalHandler extends StripeWebhookHandler {
     );
 
     try {
-      await this.customs.check(request, email, 'createSubscriptionWithPaypal');
+      await this.customs.checkAuthenticated(
+        request,
+        uid,
+        email,
+        'createSubscriptionWithPaypal'
+      );
 
       const taxAddress = buildTaxAddress(
         this.log,
@@ -370,7 +380,12 @@ export class PayPalHandler extends StripeWebhookHandler {
   async updatePaypalBillingAgreement(request: AuthRequest) {
     this.log.begin('subscriptions.updatePaypalBillingAgreement', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'updatePaypalBillingAgreement');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'updatePaypalBillingAgreement'
+    );
 
     const customer = await this.stripeHelper.fetchCustomer(uid, [
       'subscriptions',

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -159,7 +159,12 @@ export class StripeHandler {
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
 
-    await this.customs.check(request, email, 'deleteSubscription');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'deleteSubscription'
+    );
 
     const subscriptionId = request.params.subscriptionId;
 
@@ -184,7 +189,12 @@ export class StripeHandler {
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
 
-    await this.customs.check(request, email, 'reactivateSubscription');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'reactivateSubscription'
+    );
 
     const { subscriptionId } = request.payload as Record<string, string>;
 
@@ -209,7 +219,12 @@ export class StripeHandler {
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
 
-    await this.customs.check(request, email, 'updateSubscription');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'updateSubscription'
+    );
 
     const { subscriptionId } = request.params;
     const { planId } = request.payload as Record<string, string>;
@@ -401,7 +416,12 @@ export class StripeHandler {
   ): Promise<DeepPartial<Stripe.Customer>> {
     this.log.begin('subscriptions.createCustomer', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'createCustomer');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'createCustomer'
+    );
 
     let customer = await this.stripeHelper.fetchCustomer(uid);
     if (customer) {
@@ -433,7 +453,7 @@ export class StripeHandler {
   async retryInvoice(request: AuthRequest) {
     this.log.begin('subscriptions.retryInvoice', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'retryInvoice');
+    await this.customs.checkAuthenticated(request, uid, email, 'retryInvoice');
 
     const { stripeCustomerId } = (await getAccountCustomerByUid(uid)) || {};
     if (!stripeCustomerId) {
@@ -470,7 +490,12 @@ export class StripeHandler {
     let customer: Stripe.Customer | void = undefined;
     if (request.auth.credentials) {
       const { uid, email } = await handleAuth(this.db, request.auth, true);
-      await this.customs.check(request, email, 'previewInvoice');
+      await this.customs.checkAuthenticated(
+        request,
+        uid,
+        email,
+        'previewInvoice'
+      );
       try {
         customer = await this.stripeHelper.fetchCustomer(uid, [
           'subscriptions',
@@ -551,7 +576,12 @@ export class StripeHandler {
   ): Promise<invoiceDTO.subsequentInvoicePreviewsSchema> {
     this.log.begin('subscriptions.subsequentInvoicePreview', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'subsequentInvoicePreviews');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'subsequentInvoicePreviews'
+    );
 
     const customer = await this.stripeHelper.fetchCustomer(uid, [
       'subscriptions',
@@ -586,8 +616,13 @@ export class StripeHandler {
     >;
 
     if (request.auth.credentials) {
-      const { email } = await handleAuth(this.db, request.auth, true);
-      await this.customs.check(request, email, 'retrieveCouponDetails');
+      const { uid, email } = await handleAuth(this.db, request.auth, true);
+      await this.customs.checkAuthenticated(
+        request,
+        uid,
+        email,
+        'retrieveCouponDetails'
+      );
     } else {
       await this.customs.checkIpOnly(request, 'retrieveCouponDetails');
     }
@@ -614,8 +649,9 @@ export class StripeHandler {
     this.log.begin('subscriptions.applyPromotionCodeToSubscription', request);
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(
+    await this.customs.checkAuthenticated(
       request,
+      uid,
       email,
       'applyPromotionCodeToSubscription'
     );
@@ -665,7 +701,12 @@ export class StripeHandler {
       request.auth,
       true
     );
-    await this.customs.check(request, email, 'createSubscriptionWithPMI');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'createSubscriptionWithPMI'
+    );
 
     const taxAddress = buildTaxAddress(
       this.log,
@@ -819,7 +860,12 @@ export class StripeHandler {
   async createSetupIntent(request: AuthRequest) {
     this.log.begin('subscriptions.createSetupIntent', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'createSetupIntent');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'createSetupIntent'
+    );
 
     const { stripeCustomerId } = (await getAccountCustomerByUid(uid)) || {};
     if (!stripeCustomerId) {
@@ -837,7 +883,12 @@ export class StripeHandler {
   async updateDefaultPaymentMethod(request: AuthRequest) {
     this.log.begin('subscriptions.updateDefaultPaymentMethod', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'updateDefaultPaymentMethod');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'updateDefaultPaymentMethod'
+    );
 
     let customer = await this.stripeHelper.fetchCustomer(uid);
     if (!customer) {
@@ -902,7 +953,12 @@ export class StripeHandler {
   async detachFailedPaymentMethod(request: AuthRequest) {
     this.log.begin('subscriptions.detachFailedPaymentMethod', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    await this.customs.check(request, email, 'detachFailedPaymentMethod');
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'detachFailedPaymentMethod'
+    );
 
     const customer = await this.stripeHelper.fetchCustomer(uid, [
       'subscriptions',

--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
@@ -32,7 +32,7 @@ export const supportRoutes = (
       return handleAuth(db, request.auth, true);
     }
 
-    // auth stratey is supportSecret here.
+    // auth strategy is supportSecret here.
     // The ticket might not be from a FxA user at all.
     const { email } = request.payload as Record<string, any>;
 
@@ -98,7 +98,7 @@ export const supportRoutes = (
 
         const { uid, email } = await getAccountInfo(request);
         const { location } = request.app.geo;
-        await customs.check(request, email, 'supportRequest');
+        await customs.checkAuthenticated(request, uid, email, 'supportRequest');
 
         const {
           productName,

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -93,7 +93,12 @@ module.exports = (
         const sessionToken = request.auth.credentials;
         const uid = sessionToken.uid;
 
-        await customs.check(request, sessionToken.email, 'totpCreate');
+        await customs.checkAuthenticated(
+          request,
+          uid,
+          sessionToken.email,
+          'totpCreate'
+        );
 
         if (sessionToken.tokenVerificationId) {
           throw errors.unverifiedSession();
@@ -166,7 +171,12 @@ module.exports = (
         const sessionToken = request.auth.credentials;
         const { uid } = sessionToken;
 
-        await customs.check(request, sessionToken.email, 'totpDestroy');
+        await customs.checkAuthenticated(
+          request,
+          sessionToken.uid,
+          sessionToken.email,
+          'totpDestroy'
+        );
 
         // If a TOTP token is not verified, we should be able to safely delete regardless of session
         // verification state.

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -80,9 +80,8 @@ const makeRoutes = function (options = {}, requireMocks = {}) {
     options.Password || require('../../../lib/crypto/password')(log, config);
   const db = options.db || mocks.mockDB();
   const customs = options.customs || {
-    check: () => {
-      return Promise.resolve(true);
-    },
+    check: () => Promise.resolve(true),
+    checkAuthenticated: () => Promise.resolve(true),
   };
   const signinUtils =
     options.signinUtils ||
@@ -2142,6 +2141,7 @@ describe('/account/login', () => {
   const mockPush = mocks.mockPush();
   const mockCustoms = {
     check: () => Promise.resolve(),
+    checkAuthenticated: () => Promise.resolve(),
     flag: () => Promise.resolve(),
   };
   const mockCadReminders = mocks.mockCadReminders();

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -171,9 +171,8 @@ const makeRoutes = function (options = {}, requireMocks) {
   const log = options.log || mocks.mockLog();
   db = options.db || mocks.mockDB();
   const customs = options.customs || {
-    check: function () {
-      return Promise.resolve(true);
-    },
+    check: () => Promise.resolve(),
+    checkAuthenticated: () => Promise.resolve(),
   };
   const push = options.push || require('../../../lib/push')(log, db, {});
   const mailer = options.mailer || {};

--- a/packages/fxa-auth-server/test/local/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-codes.js
@@ -251,8 +251,9 @@ describe('backup authentication codes', () => {
         (err) => {
           assert.equal(err.errno, error.ERRNO.RECOVERY_CODE_NOT_FOUND);
           assert.calledWithExactly(
-            customs.check,
+            customs.checkAuthenticated,
             request,
+            UID,
             TEST_EMAIL,
             'verifyRecoveryCode'
           );

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -130,10 +130,11 @@ describe('/recovery_phone', () => {
       assert.equal(mockGlean.twoStepAuthPhoneCode.sent.callCount, 1);
       assert.equal(mockGlean.twoStepAuthPhoneCode.sendError.callCount, 0);
 
-      assert.equal(mockCustoms.check.callCount, 1);
-      assert.equal(mockCustoms.check.getCall(0).args[1], email);
+      assert.equal(mockCustoms.checkAuthenticated.callCount, 1);
+      assert.equal(mockCustoms.checkAuthenticated.getCall(0).args[1], uid);
+      assert.equal(mockCustoms.checkAuthenticated.getCall(0).args[2], email);
       assert.equal(
-        mockCustoms.check.getCall(0).args[2],
+        mockCustoms.checkAuthenticated.getCall(0).args[3],
         'recoveryPhoneSendSigninCode'
       );
 

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -1287,7 +1287,10 @@ describe('/session/resend_code', () => {
     log = mocks.mockLog();
     mailer = mocks.mockMailer();
     push = mocks.mockPush();
-    customs = { check: sinon.stub() };
+    customs = {
+      check: sinon.stub(),
+      checkAuthenticated: sinon.stub(),
+    };
     const config = {};
     const routes = makeRoutes({ log, config, db, mailer, push, customs });
     route = getRoute(routes, '/session/resend_code');
@@ -1318,8 +1321,9 @@ describe('/session/resend_code', () => {
     assert.equal(args[2].timeZone, 'America/Los_Angeles');
 
     sinon.assert.calledWithExactly(
-      customs.check,
+      customs.checkAuthenticated,
       request,
+      signupCodeAccount.uid,
       signupCodeAccount.email,
       'sendVerifyCode'
     );

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -195,8 +195,9 @@ describe('subscriptions payPalRoutes', () => {
         defaultRequestOptions
       );
       sinon.assert.calledOnceWithExactly(
-        customs.check,
+        customs.checkAuthenticated,
         request,
+        UID,
         TEST_EMAIL,
         'getCheckoutToken'
       );

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -605,8 +605,9 @@ describe('DirectStripeRoutes', () => {
       const actual =
         await directStripeRoutesInstance.previewInvoice(VALID_REQUEST);
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'previewInvoice'
       );
@@ -654,8 +655,9 @@ describe('DirectStripeRoutes', () => {
       const actual =
         await directStripeRoutesInstance.previewInvoice(VALID_REQUEST);
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'previewInvoice'
       );
@@ -707,8 +709,9 @@ describe('DirectStripeRoutes', () => {
         await directStripeRoutesInstance.previewInvoice(VALID_REQUEST);
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'previewInvoice'
       );
@@ -854,8 +857,9 @@ describe('DirectStripeRoutes', () => {
       await directStripeRoutesInstance.subsequentInvoicePreviews(VALID_REQUEST);
 
     sinon.assert.calledOnceWithExactly(
-      directStripeRoutesInstance.customs.check,
+      directStripeRoutesInstance.customs.checkAuthenticated,
       VALID_REQUEST,
+      UID,
       TEST_EMAIL,
       'subsequentInvoicePreviews'
     );
@@ -929,8 +933,9 @@ describe('DirectStripeRoutes', () => {
         );
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'subsequentInvoicePreviews'
       );
@@ -950,8 +955,9 @@ describe('DirectStripeRoutes', () => {
         );
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'subsequentInvoicePreviews'
       );
@@ -989,8 +995,9 @@ describe('DirectStripeRoutes', () => {
         await directStripeRoutesInstance.retrieveCouponDetails(VALID_REQUEST);
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'retrieveCouponDetails'
       );
@@ -1149,8 +1156,9 @@ describe('DirectStripeRoutes', () => {
         );
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.customs.check,
+        directStripeRoutesInstance.customs.checkAuthenticated,
         VALID_REQUEST,
+        UID,
         TEST_EMAIL,
         'applyPromotionCodeToSubscription'
       );


### PR DESCRIPTION
## Because

- Check authenticated is a better option when a route requires a sessionToken

## This pull request

- Switches over to using `checkAuthenticated`
- Adds email as a parameter to the `checkAuthenticated` call, which allows us to use emails filters

## Issue that this pull request solves

Closes: FXA-11777

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
