### PR TITLE
feat(emails): Update postAddTwoStepAuthentication email with recovery method info

### DIFF
--- a/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
+++ b/libs/accounts/recovery-phone/src/lib/recovery-phone.service.ts
@@ -442,6 +442,24 @@ export class RecoveryPhoneService {
   }
 
   /**
+   * Masks a phone number by replacing all but the last N digits with dots.
+   *
+   * This is useful for displaying a phone number in a privacy-preserving format,
+   * such as `••••••1234`.
+   *
+   * @param phoneNumber The actual phone number
+   * @param lastN The number of digits at the end of the phone number to show
+   * @returns A string with masked characters followed by the last N digits
+   */
+  public maskPhoneNumber(phoneNumber: string, lastN = 4): string {
+    const digits = phoneNumber.replace(/\D/g, '');
+    const visible = digits.slice(-lastN);
+    const numMasked = Math.max(digits.length - lastN, 0);
+    const mask = '•'.repeat(numMasked);
+    return `${mask}${visible}`;
+  }
+
+  /**
    * Sends a new totp code to a user and revokes any previous unconfirmed codes.
    *
    * @param uid Account id

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1431,6 +1431,8 @@ module.exports = function (log, config, bounces, statsd) {
     log.trace('mailer.postAddTwoStepAuthenticationEmail', {
       email: message.email,
       uid: message.uid,
+      recoveryMethod: message.maskedPhoneNumber ? 'phone' : 'codes',
+      maskedPhoneNumber: message.maskedPhoneNumber,
     });
 
     const templateName = 'postAddTwoStepAuthentication';
@@ -1455,9 +1457,11 @@ module.exports = function (log, config, bounces, statsd) {
         email: message.email,
         iosLink: links.iosLink,
         link: links.link,
+        maskedPhoneNumber: message.maskedPhoneNumber,
         passwordChangeLink: links.passwordChangeLink,
         passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
         privacyUrl: links.privacyUrl,
+        recoveryMethod: message.maskedPhoneNumber ? 'phone' : 'codes',
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         time,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -40,7 +40,7 @@
   "verifyLoginCode": 8,
   "verifyShortCode": 5,
   "verifySecondaryCode": 3,
-  "postAddTwoStepAuthentication": 9,
+  "postAddTwoStepAuthentication": 10,
   "postRemoveTwoStepAuthentication": 9,
   "postConsumeRecoveryCode": 8,
   "postNewRecoveryCodes": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en.ftl
@@ -1,6 +1,10 @@
-postAddTwoStepAuthentication-subject-2 = Two-step authentication turned on
+postAddTwoStepAuthentication-subject-v3 = Two-step authentication is on
 postAddTwoStepAuthentication-title-2 = You turned on two-step authentication
 # After the colon, there is a description of the device that the user used to enable two-step authentication
-postAddTwoStepAuthentication-from-device = You enabled it from:
+postAddTwoStepAuthentication-from-device-v2 = You requested this from:
 postAddTwoStepAuthentication-action = Manage account
-postAddTwoStepAuthentication-code-required-2 = Security codes from your authentication app are now required every time you sign in.
+postAddTwoStepAuthentication-code-required-v3 = You now need to use your authenticator app every time you sign in.
+postAddTwoStepAuthentication-recovery-method-codes = You also added backup authentication codes as your recovery method.
+# Variables:
+#  $maskedPhoneNumber (String) - A bullet point mask with the last four digits of the user's phone number, e.g. ••••••1234
+postAddTwoStepAuthentication-recovery-method-phone = You also added { $maskedPhoneNumber } as your recovery phone number.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/includes.json
@@ -1,7 +1,7 @@
 {
   "subject": {
-    "id": "postAddTwoStepAuthentication-subject-2",
-    "message": "Two-step authentication turned on"
+    "id": "postAddTwoStepAuthentication-subject-v3",
+    "message": "Two-step authentication is on"
   },
   "action": {
     "id": "postAddTwoStepAuthentication-action",

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
@@ -9,10 +9,25 @@
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postAddTwoStepAuthentication-code-required-2">Security codes from your authentication app are now required every time you sign in.</span>
+      <span data-l10n-id="postAddTwoStepAuthentication-code-required-v3">You now need to use your authenticator app every time you sign in.</span>
     </mj-text>
+
+    <% if (locals.recoveryMethod === 'codes') { %>
+      <mj-text css-class="text-body">
+        <span data-l10n-id="postAddTwoStepAuthentication-recovery-method-codes">
+          You also added backup authentication codes as your recovery method.
+        </span>
+      </mj-text>
+    <% } %>
+
+    <% if (locals.recoveryMethod === 'phone' && locals.maskedPhoneNumber) { %>
+      <mj-text css-class="text-body">
+        <span dir="ltr" data-l10n-id="postAddTwoStepAuthentication-recovery-method-phone" data-l10n-args="<%= JSON.stringify({ maskedPhoneNumber }) %>">You also added <%- maskedPhoneNumber %> as your recovery phone number.</span>
+      </mj-text>
+    <% } %>
+
     <mj-text css-class="text-body-no-margin">
-      <span data-l10n-id="postAddTwoStepAuthentication-from-device">You enabled it from:</span>
+      <span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'postAddTwoStepAuthentication',
-  'Sent to notify the account is linked to another account.',
+  'Sent to notify that two step authentication was enabled.',
   {
     ...MOCK_USER_INFO,
     link: 'http://localhost:3030/settings',
@@ -20,4 +20,17 @@ const createStory = storyWithProps(
   }
 );
 
-export const PostAddTwoStepAuthentication = createStory();
+export const postAddTwoStepAuthenticationWithCodes = createStory(
+  {
+    recoveryMethod: 'codes',
+  },
+  'With backup authentication codes'
+);
+
+export const postAddTwoStepAuthenticationWithPhone = createStory(
+  {
+    recoveryMethod: 'phone',
+    maskedPhoneNumber: '••••••1234',
+  },
+  'With recovery phone'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
@@ -1,8 +1,16 @@
 postAddTwoStepAuthentication-title-2 = "You turned on two-step authentication"
 
-postAddTwoStepAuthentication-code-required-2 = "Security codes from your authentication app are now required every time you sign in."
+postAddTwoStepAuthentication-code-required-v3 = "You now need to use your authenticator app every time you sign in."
 
-postAddTwoStepAuthentication-from-device = "You enabled it from:"
+<% if (locals.recoveryMethod === 'codes') { %>
+postAddTwoStepAuthentication-recovery-method-codes = "You also added backup authentication codes as your recovery method."
+<% } %>
+
+<% if (locals.recoveryMethod === 'phone' && locals.maskedPhoneNumber) { %>
+postAddTwoStepAuthentication-recovery-method-phone = "You also added <%- maskedPhoneNumber %> as your recovery phone number."
+<% } %>
+
+postAddTwoStepAuthentication-from-device-v2 = "You requested this from:"
 <%- include('/partials/userInfo/index.txt') %>
 
 <%- include('/partials/manageAccount/index.txt') %>

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -28,6 +28,7 @@ let log,
 
 const glean = mocks.mockGlean();
 const mockRecoveryPhoneService = {
+  hasConfirmed: sinon.fake(),
   removePhoneNumber: sinon.fake.resolves(true),
 };
 const mockBackupCodeManager = {
@@ -330,6 +331,8 @@ describe('totp', () => {
         // correct emails sent
         assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
         assert.equal(mailer.sendPostAddTwoStepAuthenticationEmail.callCount, 1);
+
+        assert.equal(mockRecoveryPhoneService.hasConfirmed.callCount, 1, 'check for recovery phone');
 
         assert.calledWithExactly(accountEventsManager.recordSecurityEvent, db, {
           name: 'account.two_factor_added',

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1160,7 +1160,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
   ])],
 
   ['postAddTwoStepAuthenticationEmail', new Map<string, Test | any>([
-    ['subject', { test: 'equal', expected: 'Two-step authentication turned on' }],
+    ['subject', { test: 'equal', expected: 'Two-step authentication is on' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddTwoStepAuthentication') }],
@@ -1169,7 +1169,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: 'You turned on two-step authentication' },
-      { test: 'include', expected: 'Security codes from your authentication app are now required every time you sign in.' },
+      { test: 'include', expected: 'You now need to use your authenticator app every time you sign in.' },
       { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid')) },
       { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')) },
       { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-two-step-enabled', 'privacy')) },
@@ -1181,7 +1181,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
     ['text', [
       { test: 'include', expected: 'You turned on two-step authentication' },
-      { test: 'include', expected: 'Security codes from your authentication app are now required every time you sign in.' },
+      { test: 'include', expected: 'You now need to use your authenticator app every time you sign in.' },
       { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid')}` },
       { test: 'include', expected: `change your password right away:\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')}` },
       { test: 'include', expected: `Mozilla Accounts Privacy Notice\n${configUrl('privacyUrl', 'account-two-step-enabled', 'privacy')}` },
@@ -1192,6 +1192,48 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  // Test for postAddTwoStepAuthentication with recovery phone added as recovery method
+  [
+    'postAddTwoStepAuthenticationEmail',
+    new Map<string, Test | any>([
+      ['html', [
+        { test: 'include', expected: 'You also added ••••••1234 as your recovery phone number.' },
+        { test: 'notInclude', expected: /backup authentication codes'/ }, // make sure the codes copy is *not* present
+      ]],
+      ['text', [
+        { test: 'include', expected: 'You also added ••••••1234 as your recovery phone number.' },
+        { test: 'notInclude', expected: 'Backup authentication codes help you' },
+      ]],
+    ]),
+    {
+      updateTemplateValues: v => ({
+        ...v,
+        maskedPhoneNumber: '••••••1234',
+      }),
+    }
+  ],
+
+  // Test for postAddTwoStepAuthentication with recovery codes added as recovery method (default)
+  [
+    'postAddTwoStepAuthenticationEmail',
+    new Map<string, Test | any>([
+      ['html', [
+        { test: 'include', expected: 'You also added backup authentication codes as your recovery method.' },
+        { test: 'notInclude', expected: /recovery phone/ },
+      ]],
+      ['text', [
+        { test: 'include', expected: 'You also added backup authentication codes as your recovery method.' },
+        { test: 'notInclude', expected: /recovery phone/ },
+      ]],
+    ]),
+    {
+      updateTemplateValues: v => ({
+        ...v,
+        maskedPhoneNumber: undefined,
+      }),
+    }
+  ],
 
   ['postAddRecoveryPhoneEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Recovery phone added' }],


### PR DESCRIPTION
## Because

* We want to add information about recovery methods in postAddTwoStepAuthentication email
* This will be enabled with the updated setup flow that allows users to choose between backup authentication codes and recovery phone during initial 2FA setup

## This pull request

* Update template with conditional text
* Update sender to receive the optional recovery method information
* Update l10n strings
* Update tests

## Issue that this pull request solves

Closes: FXA-10211

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
