### PR TITLE
feat(payments-next):(SubPlat) Remove pocket references on Subscription Management & SP3 Checkout

### DIFF
--- a/libs/payments/ui/src/lib/client/components/Header/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/Header/en.ftl
@@ -20,7 +20,6 @@ payments-header-bento-firefox-mobile = { -brand-firefox } Browser for Mobile
 payments-header-bento-monitor = { -product-mozilla-monitor }
 payments-header-bento-firefox-relay = { -product-firefox-relay }
 payments-header-bento-vpn = { -product-mozilla-vpn }
-payments-header-bento-pocket = { -product-pocket }
 payments-header-bento-made-by-mozilla = Made by { -brand-mozilla }
 
 payments-header-avatar =

--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -15,7 +15,6 @@ import mobileIcon from '@fxa/shared/assets/images/mobile.svg';
 import monitorIcon from '@fxa/shared/assets/images/monitor.svg';
 import relayIcon from '@fxa/shared/assets/images/relay.svg';
 import vpnIcon from '@fxa/shared/assets/images/vpn-logo.svg';
-import pocketIcon from '@fxa/shared/assets/images/pocket.svg';
 import signOutIcon from '@fxa/shared/assets/images/sign-out.svg';
 import { LinkExternal } from '@fxa/shared/react';
 import { Localized } from '@fluent/react';
@@ -138,8 +137,7 @@ export const Header = ({ auth, cart }: HeaderProps) => {
       'bento',
       'vpn',
       'permanent'
-    ),
-    pocket: OFFERING_LINKS.pocket,
+    )
   };
 
   const iconClassNames = 'inline-block w-5 -mb-1 me-1';
@@ -299,19 +297,6 @@ export const Header = ({ auth, cart }: HeaderProps) => {
                           </div>
                           <Localized id="payments-header-bento-vpn">
                             <span>Mozilla VPN</span>
-                          </Localized>
-                        </LinkExternal>
-                      </li>
-                      <li>
-                        <LinkExternal
-                          href={links.pocket}
-                          className="block p-2 ps-6 hover:bg-grey-100"
-                        >
-                          <div className={iconClassNames}>
-                            <Image src={pocketIcon} alt="" />
-                          </div>
-                          <Localized id="payments-header-bento-pocket">
-                            <span>Pocket</span>
                           </Localized>
                         </LinkExternal>
                       </li>

--- a/libs/payments/ui/src/lib/constants.ts
+++ b/libs/payments/ui/src/lib/constants.ts
@@ -15,7 +15,5 @@ export const OFFERING_LINKS = {
   mobile: 'https://www.mozilla.org/firefox/mobile/',
   monitor: 'https://monitor.mozilla.org/',
   relay: 'https://relay.firefox.com/',
-  vpn: 'https://vpn.mozilla.org/',
-  pocket:
-    'https://app.adjust.com/hr2n0yz?redirect_macos=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&redirect_windows=https%3A%2F%2Fgetpocket.com%2Fpocket-and-firefox&engagement_type=fallback_click&fallback=https%3A%2F%2Fgetpocket.com%2Ffirefox_learnmore%3Fsrc%3Dff_bento&fallback_lp=https%3A%2F%2Fapps.apple.com%2Fapp%2Fpocket-save-read-grow%2Fid309601447',
+  vpn: 'https://vpn.mozilla.org/'
 };

--- a/packages/fxa-payments-server/src/routes/Subscriptions/en.ftl
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/en.ftl
@@ -55,8 +55,3 @@ invoice-not-found = Subsequent invoice not found
 sub-item-no-such-subsequent-invoice = Subsequent invoice not found for this subscription.
 sub-invoice-preview-error-title = Invoice preview not found
 sub-invoice-preview-error-text = Invoice preview not found for this subscription
-
-## Routes - Subscriptions - Pocket Subscription
-
-manage-pocket-title-2 = Looking for your { -product-pocket } premium subscription?
-manage-pocket-body-2 = To manage it, <linkExternal>click here</linkExternal>.

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -235,23 +235,3 @@
     padding: 0;
   }
 }
-
-.pocket-external {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
-
-  p:first-child {
-    margin-top: 0;
-  }
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.pocket-icon {
-  width: 26px;
-  height: 23px;
-  vertical-align: text-top;
-}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -201,15 +201,6 @@ describe('routes/Subscriptions', () => {
     expect(queryByTestId('no-subscriptions-available')).not.toBeInTheDocument();
   });
 
-  it('displays pocket subscription link', async () => {
-    initApiMocks({
-      mockCustomer: MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
-    });
-    const { findByTestId } = renderWithLocalizationProvider(<Subject />);
-    await findByTestId('manage-pocket-title');
-    await findByTestId('manage-pocket-link');
-  });
-
   it('displays upgrade CTA when available for a subscription', async () => {
     // Use mocks for subscription lists that exercise multiple plans
     initApiMocks({

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -23,7 +23,6 @@ import AlertBar from '../../components/AlertBar';
 import DialogMessage from '../../components/DialogMessage';
 import FetchErrorDialogMessage from '../../components/FetchErrorDialogMessage';
 import { LoadingOverlay } from '../../components/LoadingOverlay';
-import { ReactComponent as PocketIcon } from '../../images/pocket-icon.svg';
 import { getLocalizedDate, getLocalizedDateString } from '../../lib/formats';
 
 import PaymentUpdateForm, {
@@ -39,7 +38,6 @@ import {
   WebSubscription,
 } from 'fxa-shared/subscriptions/types';
 import SubscriptionIapItem from './SubscriptionIapItem/SubscriptionIapItem';
-import LinkExternal from 'fxa-react/components/LinkExternal';
 
 export type SubscriptionsProps = {
   profile: SelectorReturns['profile'];
@@ -407,45 +405,6 @@ export const Subscriptions = ({
                   />
                 ))
             )}
-
-          <section className="settings-unit" aria-labelledby="pocket-external">
-            <div className="subscription pocket-external">
-              <div>
-                <PocketIcon className="pocket-icon" />
-              </div>
-              <div>
-                <p id="pocket-external" data-testid="manage-pocket-title">
-                  <Localized id="manage-pocket-title-2">
-                    <b>Looking for your Pocket Premium subscription?</b>
-                  </Localized>
-                </p>
-                <Localized
-                  id="manage-pocket-body-2"
-                  elems={{
-                    linkExternal: (
-                      <LinkExternal
-                        href="https://getpocket.com/premium/manage"
-                        data-testid="manage-pocket-link"
-                      >
-                        click here
-                      </LinkExternal>
-                    ),
-                  }}
-                >
-                  <p>
-                    To manage it,{' '}
-                    <LinkExternal
-                      href="https://getpocket.com/premium/manage"
-                      data-testid="manage-pocket-link"
-                    >
-                      click here
-                    </LinkExternal>
-                    .
-                  </p>
-                </Localized>
-              </div>
-            </div>
-          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Because

- Pocket apps are shutting down and SubPlat needs to remove the banner redirecting pocket subscribers from the subscription management page as well as from the Header.

## This pull request

- Removes references to Pocket from Subscriptions Management and Sp3 Checkout Header.

## Issue that this pull request solves

Closes: #FXA-11742

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![image](https://github.com/user-attachments/assets/7ed82a7a-f3e6-4b29-ac3f-05c0b9460385)
![image](https://github.com/user-attachments/assets/483983e9-5b53-417b-973c-03d7ee5cccaf)


## Other information (Optional)

Any other information that is important to this pull request.
