### PR TITLE
resolve tar-fs vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -53532,7 +53532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar-fs@npm:^2.0.0":
+"tar-fs@npm:^2.0.0, tar-fs@npm:^2.1.1":
   version: 2.1.3
   resolution: "tar-fs@npm:2.1.3"
   dependencies:
@@ -53541,18 +53541,6 @@ __metadata:
     pump: ^3.0.0
     tar-stream: ^2.1.4
   checksum: 8dd66c20779c1fe535df5cf2ab5132705c12aba3ab95283f225a798329c5aaa8bbe92144c8e21bc9404f46a0d3ce59fc4997f5c42bafc55b6a225d4ad15aa966
-  languageName: node
-  linkType: hard
-
-"tar-fs@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "tar-fs@npm:2.1.2"
-  dependencies:
-    chownr: ^1.1.1
-    mkdirp-classic: ^0.5.2
-    pump: ^3.0.0
-    tar-stream: ^2.1.4
-  checksum: 6b4fcd38a644b5cd3325f687b9f1f48cd19809b63cbc8376fe794f68361849a17120d036833b3a97de6acb1df588844476309b8c2d0bcaf53f19da2d56ac07de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- the tar-fs transitive dependency includes vulnerability alerts

## This pull request

- updates the tar-fs transitive dependency alone

## Issue that this pull request solves

Closes: FXA-11832

## Other information

The vulnerability is a transitive dependency of `storybook`, which requires a major bump to 8 in order to upgrade.  Thankfully, `tar-fs` is installed with caret which allows us to simply reinstall it to pick up the patched `2.1.3` version.