### PR TITLE
bug(auth): unblockEmail rule was missing

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -44,6 +44,7 @@
   sendVerifyCode                        : ip                : 5             : 10 minutes        : 30 minutes
   sendUnblockCode                       : email             : 5             : 15 minutes        : 15 minutes
   sendUnblockCode                       : ip                : 5             : 10 minutes        : 30 minutes
+  unblockEmail                          : email             : 5             : 15 minutes        : 15 minutes
 
 # Bad Login Attempts - These are specific to login failures. Again, the user hasn't authenticated yet, so we check both
 # email and ip.


### PR DESCRIPTION
## Because

- This rules is needed after a block occurs.

## This pull request

- Adds configuration for this rule.

## Issue that this pull request solves

Closes: [FXA-11835](https://mozilla-hub.atlassian.net/browse/FXA-11835)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-11835]: https://mozilla-hub.atlassian.net/browse/FXA-11835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ