### PR TITLE
fix(prompt): Support prompt=none with 2FA, don't send two authorization reqs

### DIFF
--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -13,7 +13,7 @@ import {
   useSession,
 } from '../../models';
 import { cache } from '../../lib/cache';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { currentAccount } from '../../lib/cache';
 import { useFinishOAuthFlowHandler } from '../../lib/oauth/hooks';
 import OAuthDataError from '../../components/OAuthDataError';
@@ -61,11 +61,15 @@ const AuthorizationContainer = ({
     authClient,
     integration
   );
+  const promptNoneCallCount = useRef(0);
+
   if (oAuthDataError) {
     setOauthError(oAuthDataError);
   }
 
   const promptNoneHandler = useCallback(async () => {
+    promptNoneCallCount.current += 1;
+
     const account = currentAccount();
     const relierAccount = convertToRelierAccount(account, authClient);
 
@@ -145,6 +149,10 @@ const AuthorizationContainer = ({
 
   useEffect(() => {
     if (oauthError) {
+      return;
+    }
+
+    if (promptNoneCallCount.current > 0) {
       return;
     }
 

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -149,6 +149,7 @@ const IndexContainer = ({
         if (!isEmail(email)) {
           throw AuthUiErrors.EMAIL_REQUIRED;
         }
+
         const { exists, hasLinkedAccount, hasPassword } =
           await authClient.accountStatusByEmail(email, {
             thirdPartyAuthStatus: true,
@@ -229,6 +230,7 @@ const IndexContainer = ({
     suggestedEmail,
     shouldTrySuggestedEmail,
     integration.data.context,
+    integration
   ]);
 
   useEffect(() => {

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -130,8 +130,8 @@ export interface RecoveryEmailStatusResponse {
 
 export interface CachedSigninHandlerResponse {
   data?: {
-    verificationMethod: VerificationMethods;
-    verificationReason: VerificationReasons;
+    verificationMethod?: VerificationMethods;
+    verificationReason?: VerificationReasons;
     uid: hexstring;
   } & RecoveryEmailStatusResponse;
   error?: AuthUiError;


### PR DESCRIPTION
## Because

- Users that have 2FA enabled are unable to login with prompt=none

## This pull request

- Correctly checks for the verification level of session and continues the flow
- Fixes a bug where it would call the `promptNoneHandler` twice

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11847
Closes: https://mozilla-hub.atlassian.net/browse/FXA-11804

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test, enabled 2FA on your account and go through the prompt=none flow in 123Done.
