### PR TITLE
task(rate-limit): Create default rate limit rule to fallback to

### DIFF
--- a/libs/accounts/rate-limit/README.md
+++ b/libs/accounts/rate-limit/README.md
@@ -32,6 +32,20 @@ Note that comments can be added by starting a line with '#'.
 - email     - The user's email. This is useful only when the account isn't known and for some reason, we don't want to use ip_email.
 - uid       - The user's account id. This can be useful from stopping a user that has logged in from doing something malicious, like trying to mine data.
 
+### The 'default' Rule
+
+To avoid lots of repetitive configuration, we have one special rule known as the 'default' rule. This rule
+is used as a fallback. In the event an action is supplied to the rate limiter, but it cannot be found in the
+set of configured rules, the default rule will be used instead. The action count is still kept distinct per
+action, but the policy from the default rule is used.
+
+For example, if we were to call
+
+rateLimit.check('foo', { ip:0.0.0.0})
+
+And there was no configuration for foo, but there was a configuration for 'default' and ip. Then
+we'd increment the redis count for action foo blocking on ip, but we'd use the default rule's settings.
+
 ### A quick example:
 
 As an example, to define an existing custom rules, let's say password reset OTP, the following config
@@ -41,12 +55,14 @@ would replicate the pre-existing behavior:
 # ----------------------------------------------------------------------------------------
 #  action                     | blockOn  | maxAttempts  | windowDuration | banDuration
 # ----------------------------------------------------------------------------------------
+   default                    : ip       : 600          : 10 minutes     : 10 minutes
    passwordForgotVerifyOtp    : ip       : 5 attempts   : 24 hours       : 10 minutes
    passwordForgotVerifyOtp    : email    : 5 attempts   : 24 hours       : 10 minutes
    passwordForgotVerifyOtp    : ip       : 10 attempts  : 24 hours       : 24 hours
    passwordForgotVerifyOtp    : email    : 10 attempts  : 24 hours       : 24 hours
 
 ```
+
 
 ### Testing & Development Considerations
 

--- a/libs/accounts/rate-limit/src/lib/config.ts
+++ b/libs/accounts/rate-limit/src/lib/config.ts
@@ -69,8 +69,8 @@ export function parseConfigRules(
       );
     }
 
+    const action = parts[0] as string;
     const rule = {
-      action: parts[0] as string,
       blockingOn: parts[1] as BlockOn,
       maxAttempts: Number.parseInt(parts[2]),
       windowDurationInSeconds: convertDurationToSeconds(parts[3]),
@@ -78,7 +78,7 @@ export function parseConfigRules(
     } satisfies Rule;
 
     // A couple sanity checks to catch bad rule configuration
-    if (!/^[a-zA-Z]*$/.test(rule.action)) {
+    if (!/^[a-zA-Z]*$/.test(action)) {
       throw new InvalidRule(
         `Actions can only contain characters a-zA-Z.`,
         line
@@ -120,13 +120,13 @@ export function parseConfigRules(
     }
 
     // Add the rule to the map.
-    if (ruleMap[rule.action]) {
-      ruleMap[rule.action].push(rule);
+    if (ruleMap[action]) {
+      ruleMap[action].push(rule);
     } else {
-      ruleMap[rule.action] = [rule];
+      ruleMap[action] = [rule];
     }
 
-    keys.push(getKey('attempts', rule, 'check'));
+    keys.push(getKey('attempts', action, rule, 'check'));
   }
 
   checkForDuplicates(keys);

--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -18,8 +18,6 @@ export type BlockReason = 'too-many-attempts';
 
 /** Represents a configuration rule that describes a block scenario. */
 export type Rule = {
-  /** The action to count. */
-  action: string;
   /** The attribute to count on. */
   blockingOn: BlockOn;
   /** The max number of actions or attempts allowed before a block is created. */
@@ -34,6 +32,8 @@ export type Rule = {
 export type BlockRecord = {
   /** The action that was blocked. */
   action: string;
+  /** Indicates if the defacto default rule was used. True means the 'default' rule was used. False means an action specific rule was used. */
+  usedDefaultRule: boolean;
   /** The attribute being checked. */
   blockingOn: BlockOn;
   /** The value of the attribute being checked. */

--- a/libs/accounts/rate-limit/src/lib/util.ts
+++ b/libs/accounts/rate-limit/src/lib/util.ts
@@ -9,11 +9,12 @@ import { BlockRecord, Rule } from './models';
  */
 export function getKey(
   type: 'block' | 'attempts',
+  action: string,
   rule: Rule,
   blockedValue: string
 ) {
   const sanitizedBlockedValue = sanitizeKeyValue(blockedValue);
-  return `rate-limit:${type}:${rule.blockingOn}=${sanitizedBlockedValue}:${rule.action}:${rule.maxAttempts}-${rule.windowDurationInSeconds}-${rule.blockDurationInSeconds}`;
+  return `rate-limit:${type}:${rule.blockingOn}=${sanitizedBlockedValue}:${action}:${rule.maxAttempts}-${rule.windowDurationInSeconds}-${rule.blockDurationInSeconds}`;
 }
 
 /**

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -1,5 +1,14 @@
 #  action                               | blockOn           | maxAttempts   | windowDuration    | banDuration
 # -------------------------------------------------------------------------------------------------------------
+# The default limit that rate limits will fallback to if no other rate limit is found. This is very generous
+# and essentially will block any IP, email, or uid that sustains more than one request per second to a
+# non-configured action within a 10 minute window. Note that actions are still isolated. e.g. ActionA and
+# ActionB will maintain separate counts. So you could make up to 600 requests to action A and up to 600 requests
+# to Action B in a ten minute window without getting blocked.
+  default                               : ip                : 600           : 10 minutes        : 15 minutes
+  default                               : email             : 600           : 10 minutes        : 15 minutes
+  default                               : uid               : 600           : 10 minutes        : 15 minutes
+
 # Account Check Limits - These are unsecured actions. Many of these are designed to slow down the mining of
 # of account details. e.g. Trying random emails until an error code indicates one might exist.
   accountCreate                         : ip                : 100           : 15 minutes        : 15 minutes
@@ -130,7 +139,6 @@
 # MISSING >>>>>>>>>>>>>>>>>>>>>>>>>>>>>  invokeDeviceCommand
 # MISSING >>>>>>>>>>>>>>>>>>>>>>>>>>>>>  devicesNotify|_endpointAction -- TBD, what can be in _endpointAction?
 # passwordChange
-# MISSING >>>>>>>>>>>>>>>>>>>>>>>>>>>>>  getRecoveryKey
 # recoveryPhoneSendResetPasswordCode
 # recoveryPhoneSendSetupCode
 # verifyRecoveryPhoneTotpCode

--- a/packages/fxa-graphql-api/src/config/rate-limit-rules.txt
+++ b/packages/fxa-graphql-api/src/config/rate-limit-rules.txt
@@ -1,5 +1,8 @@
 #  action                               | blockOn       | maxAttempts   | windowDuration    | banDuration
 # ----------------------------------------------------------------------------------------------------------
+  default                               : ip            : 600           : 10 minutes        : 15 minutes
+  default                               : email         : 600           : 10 minutes        : 15 minutes
+  default                               : uid           : 600           : 10 minutes        : 15 minutes
   unblockEmail                          : email         : 10            : 24 hours          : 24 hours
   updateDisplayName                     : ip            : 60            : 15 minutes        : 15 minutes
 #


### PR DESCRIPTION
### Waiting on #18994 to land


## Because

- In many cases a single default pule/policy is fine

## This pull request

- Creates a special case for the 'default' action. That any action can fallback into in the event a policy is not specified.

## Issue that this pull request solves

Closes: FXA-11838

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note, that this won't be truly turned on until we phase out the check for hasSupportedAction in customs.js. For now if an action isn't defined, we will fallback to using the customs server...
