### PR TITLE
Fix error on signin with multiple accounts

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -91,7 +91,23 @@ import OAuthDataError from '../../components/OAuthDataError';
  */
 
 function getAccountInfo(email?: string) {
-  const storedLocalAccount = currentAccount() || lastStoredAccount();
+
+  const storedLocalAccount = (() => {
+    let account = currentAccount();
+    if (account) {
+      return account;
+    }
+
+    // Important, a lot of the code following this assumes that if a session
+    // token is provided, it belongs to the current account. If this assumption
+    // is violated, weird things happen! Maybe this is the 'fix'?
+    account = lastStoredAccount();
+    if (account) {
+      setCurrentAccount(account.uid);
+    }
+
+    return account;
+  })();
 
   if (email) {
     // Try to use local storage values if email matches the email in local storage
@@ -107,7 +123,6 @@ function getAccountInfo(email?: string) {
   }
 
   if (storedLocalAccount) {
-    setCurrentAccount(storedLocalAccount.uid);
     return {
       email: storedLocalAccount.email,
       sessionToken: storedLocalAccount.sessionToken,


### PR DESCRIPTION
## Because

- When a user has multiple accounts they can hit an expected error on sign in.
- This happens when the `lastStoredAccount()` exists but the `currentAccount()` does not.
- This can occur by signing into several different accounts and then logging out of settings.

## This pull request

- Ensures that `currentAcount()` is always set.

## Issue that this pull request solves

Closes: FXA-11843

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

When following the STR for FXA-11843, this patch fixes the error. Unfortunately there's still a glitchy UX where you sometimes have to click the sign in button twice. I feel like this patch is still worthwhile since the error is very disruptive. I'm still a bit perplexed what causes this strange UX behavior though.
