### PR TITLE
fix(payments-next): [SP3][Taxes] Taxes are not being updated when user is logging in

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -9,6 +9,7 @@ import {
   getTaxAddressAction,
   setupCartAction,
   updateCartUidAction,
+  updateTaxAddressAction
 } from '@fxa/payments/ui/actions';
 import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
 import { BaseParams, buildRedirectUrl } from '@fxa/payments/ui';
@@ -105,6 +106,18 @@ export default async function New({
       Number(searchParams.cartVersion),
       fxaUid,
     );
+
+    const updateTaxResult = await updateTaxAddressAction(
+      cart.id,
+      cart.version,
+      offeringId,
+      taxAddress,
+      fxaUid
+    );
+    if (updateTaxResult.ok) {
+      searchParams.countryCode = updateTaxResult.taxAddress.countryCode;
+      searchParams.postalCode  = updateTaxResult.taxAddress.postalCode;
+    }
 
     redirectToUrl = getRedirectToUrl(cart, params, searchParams);
   } else {


### PR DESCRIPTION
## Because

- Tax information was not getting updated if a customer has an existing shipping address.

## This pull request

- Updates cart's tax address information based on customer's saved shipping address, if exists.

## Issue that this pull request solves

Closes: #FXA-11691

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

https://github.com/user-attachments/assets/918d6d8c-9577-459f-9134-0b6286909b47

