### PR TITLE
task(functional-tests): Setup rate-limits so functional tests can pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ executors:
       HUSKY_SKIP_INSTALL: 1
       AUTH_CLOUDTASKS_USE_LOCAL_EMULATOR: true
       # Seeing if clear customs approach works! RATE_LIMIT__RULES: ""
-      RATE_LIMIT__IGNORE_EMAILS: .*@restmail.net$
+      # RATE_LIMIT__IGNORE_EMAILS: .*@restmail.net$
 
   # Contains a pre-installed fxa stack and browsers for doing ui test
   # automation. Perfect for running smoke tests against remote targets.

--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -38,6 +38,7 @@ export const test = base.extend<TestOptions, WorkerOptions>({
   target: [
     async ({ targetName }, use) => {
       const target = create(targetName);
+      await target.clearRateLimits();
       await use(target);
     },
     { scope: 'worker', auto: true },

--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -43,10 +43,6 @@ test.describe('severity-2 #smoke', () => {
     { signupVersion: v2, changeVersion: v2 },
   ];
 
-  test.beforeEach(async ({ target }) => {
-    await target.clearRateLimits();
-  });
-
   for (const { signupVersion, changeVersion } of TestCases) {
     test(`signs up as v${signupVersion.version} changes password from settings as v${changeVersion.version} for backbone`, async ({
       page,

--- a/packages/functional-tests/tests/misc/authClientV2.spec.ts
+++ b/packages/functional-tests/tests/misc/authClientV2.spec.ts
@@ -34,7 +34,6 @@ test.describe('auth-client-tests', () => {
 
   test.beforeEach(async ({ target }, { project }) => {
     test.skip(project.name === 'production');
-    await target.clearRateLimits();
   });
 
   test('it creates with v1 and signs in', async ({

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -10,11 +10,6 @@ import { SigninPage } from '../../pages/signin';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('change password tests', () => {
-
-    test.beforeEach(async ({ target }) => {
-      await target.clearRateLimits();
-    });
-
     test('change password with an incorrect old password', async ({
       target,
       pages: { page, changePassword, settings, signin },

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -75,10 +75,6 @@ test.describe('severity-1 #smoke', () => {
       }
     });
 
-    test.beforeEach(async ({ target }) => {
-      await target.clearRateLimits();
-    });
-
     test('setup fails with invalid number', async ({
       target,
       pages: { page, settings, signin, recoveryPhone, totp },

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -44,12 +44,6 @@
 
 # Bad Login Attempts - These are specific to login failures. Again, the user hasn't authenticated yet, so we check both
 # email and ip.
-  accountLogin                          : email             : 5             : 15 minutes        : 15 minutes
-  accountLogin                          : ip                : 5             : 10 minutes        : 30 minutes
-  accountDestroy                        : email             : 5             : 15 minutes        : 15 minutes
-  accountDestroy                        : ip                : 5             : 10 minutes        : 30 minutes
-  passwordChange                        : email             : 5             : 15 minutes        : 15 minutes
-  passwordChange                        : ip                : 5             : 10 minutes        : 30 minutes
   authenticatedAccountLogin             : uid               : 5             : 15 minutes        : 15 minutes
   authenticatedPasswordChange           : uid               : 5             : 15 minutes        : 15 minutes
 


### PR DESCRIPTION
## Because

- We want rate limiting in place while testing
- We can clear limits before each test, to mimick 'clean' user interactions

## This pull request

- Resets rate limits prior to each test, so testing is done from a 'fresh' state
- Removes the 'ignore' filter on rest emails for CI pipeline tests
- Removes redundant rules in 'BadLogins' section. A file up has been filed for this.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note, this does not work for smoke tests. This is only applicable for running tests locally and in the test_pull_request pipeline!

Note that the rate limit rules were altered a little bit. The 'Bad Logins' section has been removed. A [follow up](https://mozilla-hub.atlassian.net/browse/FXA-11850) has been filed here. This isn't an abstraction currently supported by the rate-limit library, and we will have to figure out what to do about this.


