### PR TITLE
feat(settings): create new FlowSetup2faBackupChoice component

### DIFF
--- a/packages/fxa-settings/src/components/FormChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/index.stories.tsx
@@ -8,6 +8,10 @@ import FormChoice from '.';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import AppLayout from '../AppLayout';
 import { commonFormChoiceProps } from './mocks';
+import {
+  BackupAuthenticationCodesImage,
+  BackupRecoveryPhoneSmsImage,
+} from '../images';
 
 export default {
   title: 'components/FormChoice',
@@ -20,8 +24,58 @@ export const DefaultLeftAlignedImages = () => (
     <FormChoice {...commonFormChoiceProps} />
   </AppLayout>
 );
+
+export const WithBadges = () => (
+  <AppLayout>
+    <FormChoice
+      {...commonFormChoiceProps}
+      formChoices={[
+        {
+          ...commonFormChoiceProps.formChoices[0],
+          localizedChoiceBadge: '1st badge',
+        },
+        {
+          ...commonFormChoiceProps.formChoices[1],
+          localizedChoiceBadge: '2nd badge',
+        },
+      ]}
+    />
+  </AppLayout>
+);
+
+export const TopAlignedImages = () => (
+  <AppLayout>
+    <FormChoice
+      {...commonFormChoiceProps}
+      contentAlignVertical="top"
+      formChoices={[
+        {
+          ...commonFormChoiceProps.formChoices[0],
+          localizedChoiceBadge: '1st badge',
+          image: (
+            <BackupRecoveryPhoneSmsImage
+              ariaHidden
+              className="max-h-44 mt-[6px]"
+            />
+          ),
+        },
+        {
+          ...commonFormChoiceProps.formChoices[1],
+          localizedChoiceBadge: '2nd badge',
+          image: (
+            <BackupAuthenticationCodesImage
+              ariaHidden
+              className="max-h-44 mt-[6px]"
+            />
+          ),
+        },
+      ]}
+    />
+  </AppLayout>
+);
+
 export const RightAlignedImages = () => (
   <AppLayout>
-    <FormChoice alignImage="end" {...commonFormChoiceProps} />
+    <FormChoice imagePosition="end" {...commonFormChoiceProps} />
   </AppLayout>
 );

--- a/packages/fxa-settings/src/components/FormChoice/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/index.test.tsx
@@ -10,10 +10,28 @@ import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 function render({
-  alignImage = 'start',
-}: Pick<FormChoiceProps, 'alignImage'> = {}) {
+  imagePosition = 'start',
+}: Pick<FormChoiceProps, 'imagePosition'> = {}) {
   renderWithLocalizationProvider(
-    <FormChoice {...commonFormChoiceProps} {...{ alignImage }} />
+    <FormChoice {...commonFormChoiceProps} {...{ imagePosition }} />
+  );
+}
+
+function renderWithBadges() {
+  renderWithLocalizationProvider(
+    <FormChoice
+      {...commonFormChoiceProps}
+      formChoices={[
+        {
+          ...commonFormChoiceProps.formChoices[0],
+          localizedChoiceBadge: '1st badge',
+        },
+        {
+          ...commonFormChoiceProps.formChoices[1],
+          localizedChoiceBadge: '2nd badge',
+        },
+      ]}
+    />
   );
 }
 
@@ -55,8 +73,17 @@ describe('FormChoice', () => {
     expect(firstImage?.nextElementSibling).toBe(firstTextContainer);
   });
 
+  it('renders badges when provided', () => {
+    renderWithBadges();
+    const firstBadge = screen.getByText('1st badge');
+    const secondBadge = screen.getByText('2nd badge');
+
+    expect(firstBadge).toBeInTheDocument();
+    expect(secondBadge).toBeInTheDocument();
+  });
+
   it('renders as expected when `alignImage` is `end`', () => {
-    render({ alignImage: 'end' });
+    render({ imagePosition: 'end' });
     const firstLabel = screen.getAllByRole('radio')[0].closest('label');
     const firstImage = firstLabel?.querySelector('svg');
     const firstTextContainer = firstLabel?.querySelector('div:nth-child(1)');

--- a/packages/fxa-settings/src/components/FormChoice/index.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/index.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import classNames from 'classnames';
 import React, { ReactElement } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -9,13 +10,15 @@ export type FormChoiceOption = {
   id: string;
   value: FormChoiceData['choice'];
   image: ReactElement;
+  localizedChoiceBadge?: string;
   localizedChoiceTitle: string;
   localizedChoiceInfo: string;
 };
 
 export type FormChoiceProps = {
   legendEl: ReactElement;
-  alignImage?: 'start' | 'end';
+  imagePosition?: 'start' | 'end';
+  contentAlignVertical?: 'top' | 'center';
   formChoices: FormChoiceOption[];
   onSubmit: (data: FormChoiceData) => void;
   isSubmitting: boolean;
@@ -26,20 +29,23 @@ export const CHOICES = {
   code: 'code',
 } as const;
 
+export type Choice = (typeof CHOICES)[keyof typeof CHOICES];
+
 export type FormChoiceData = {
-  choice: (typeof CHOICES)[keyof typeof CHOICES];
+  choice: Choice;
 };
 
 const FormChoice = ({
   legendEl,
-  alignImage = 'start',
+  imagePosition = 'start',
+  contentAlignVertical = 'center',
   formChoices,
   onSubmit,
   isSubmitting,
 }: FormChoiceProps) => {
   const { register, handleSubmit, watch } = useForm<FormChoiceData>();
   const selectedOption = watch('choice');
-  const startAlignImage = alignImage === 'start';
+  const startAlignImage = imagePosition === 'start';
 
   return (
     <form noValidate onSubmit={handleSubmit(onSubmit)}>
@@ -59,7 +65,10 @@ const FormChoice = ({
               ref={register({ required: true })}
             />
             <label
-              className="input-radio-label w-full items-center"
+              className={classNames(
+                'input-radio-label w-full',
+                contentAlignVertical === 'center' && 'items-center'
+              )}
               htmlFor={choice.id}
             >
               {startAlignImage && <div>{choice.image}</div>}
@@ -67,6 +76,11 @@ const FormChoice = ({
                 <strong className="block mb-1 text-base">
                   {choice.localizedChoiceTitle}
                 </strong>
+                {choice.localizedChoiceBadge && (
+                  <span className="h-6 px-2 py-1 mb-1 flex w-fit bg-blue-50 rounded items-center text-sm text-blue-900 font-semibold">
+                    {choice.localizedChoiceBadge}
+                  </span>
+                )}
                 <span className="text-sm">{choice.localizedChoiceInfo}</span>
               </div>
               {!startAlignImage && <div>{choice.image}</div>}

--- a/packages/fxa-settings/src/components/FormChoice/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormChoice/mocks.tsx
@@ -21,14 +21,14 @@ export const commonFormChoiceProps = {
     {
       id: 'recovery-choice-phone',
       value: CHOICES.phone,
-      image: <BackupRecoveryPhoneSmsImage />,
+      image: <BackupRecoveryPhoneSmsImage ariaHidden />,
       localizedChoiceTitle: '1st Choice Example',
       localizedChoiceInfo: '1st example description',
     },
     {
       id: 'recovery-choice-code',
       value: CHOICES.code,
-      image: <BackupAuthenticationCodesImage />,
+      image: <BackupAuthenticationCodesImage ariaHidden />,
       localizedChoiceTitle: '2nd Choice Example',
       localizedChoiceInfo: '2nd example description',
     },

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/en.ftl
@@ -1,0 +1,18 @@
+## The step to choose the two step authentication method in the two step
+## authentication setup flow.
+
+flow-setup-2fa-backup-choice-heading = Choose a recovery method
+flow-setup-2fa-backup-choice-description = This allows you to sign in if you can’t access your mobile device or authenticator app.
+
+flow-setup-2fa-backup-choice-phone-title = Recovery phone
+flow-setup-2fa-backup-choice-phone-badge = Easiest
+flow-setup-2fa-backup-choice-phone-info = Get a recovery code via text message. Currently available in the USA and Canada.
+
+flow-setup-2fa-backup-choice-code-title = Backup authentication codes
+flow-setup-2fa-backup-choice-code-badge = Safest
+flow-setup-2fa-backup-choice-code-info = Create and save one-time-use authentication codes.
+
+# This link points to https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication
+flow-setup-2fa-backup-choice-learn-more-link = Learn about recovery and SIM swap risk
+
+##

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.stories.tsx
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import SettingsLayout from '../SettingsLayout';
+import { action } from '@storybook/addon-actions';
+import { FlowSetup2faBackupChoice } from '.';
+
+export default {
+  title: 'Components/Settings/FlowSetup2faBackupChoice',
+  decorators: [withLocalization],
+} as Meta;
+
+const navigateBackward = async () => {
+  action('navigateBackward')();
+};
+
+const onSubmitCb = async (choice: string) => {
+  action('onSubmitCb')(choice);
+};
+
+export const Default = () => (
+  <SettingsLayout>
+    <FlowSetup2faBackupChoice
+      currentStep={2}
+      numberOfSteps={3}
+      localizedFlowTitle="Two-step authentication"
+      onBackButtonClick={navigateBackward}
+      showProgressBar
+      onSubmitCb={onSubmitCb}
+    />
+  </SettingsLayout>
+);

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.test.tsx
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { FlowSetup2faBackupChoice } from '.';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import GleanMetrics from '../../../lib/glean';
+import { GleanClickEventType2FA } from '../../../lib/types';
+import { CHOICES } from '../../FormChoice';
+
+const renderFlowSetup2faBackupChoice = () => {
+  const onBackButtonClick = jest.fn();
+  const onSubmitCb = jest.fn();
+  return {
+    onBackButtonClick,
+    onSubmitCb,
+    ...renderWithLocalizationProvider(
+      <FlowSetup2faBackupChoice
+        currentStep={2}
+        numberOfSteps={3}
+        localizedFlowTitle="Two-step authentication"
+        onBackButtonClick={onBackButtonClick}
+        showProgressBar
+        onSubmitCb={onSubmitCb}
+      />
+    ),
+  };
+};
+
+describe('FlowSetup2faBackupCodeDownload', () => {
+  it('renders correctly', () => {
+    renderFlowSetup2faBackupChoice();
+    expect(screen.getByRole('progressbar')).toBeVisible();
+    expect(
+      screen.getByRole('radio', {
+        name: /Recovery phone/,
+      })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('radio', {
+        name: /Backup authentication codes/,
+      })
+    ).toBeVisible();
+  });
+
+  it('sets up Glean metrics correctly', async () => {
+    const gleanViewSpy = jest.spyOn(
+      GleanMetrics.accountPref,
+      'twoStepAuthBackupChoiceView'
+    );
+    const gleanSubmitSpy = jest.spyOn(
+      GleanMetrics.accountPref,
+      'twoStepAuthBackupChoiceSubmit'
+    );
+    renderFlowSetup2faBackupChoice();
+    expect(gleanViewSpy).toHaveBeenCalled();
+    expect(screen.getByRole('link', { name: /Learn about/ })).toHaveAttribute(
+      'data-glean-id',
+      'two_step_auth_backup_choice_learn_more_link'
+    );
+    expect(screen.getByRole('link', { name: /Learn about/ })).toHaveAttribute(
+      'data-glean-type',
+      GleanClickEventType2FA.setup
+    );
+    await userEvent.click(
+      screen.getByRole('radio', { name: /Backup authentication codes/ })
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(gleanSubmitSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: {
+          reason: GleanClickEventType2FA.setup,
+          choice: CHOICES.code,
+        },
+      })
+    );
+  });
+
+  it('calls onBackButtonClick when the back button is clicked', async () => {
+    const { onBackButtonClick } = renderFlowSetup2faBackupChoice();
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    await userEvent.click(backButton);
+    expect(onBackButtonClick).toHaveBeenCalled();
+  });
+
+  it('calls onSubmitCb when the Continue button is clicked', async () => {
+    const { onSubmitCb } = renderFlowSetup2faBackupChoice();
+    await userEvent.click(
+      screen.getByRole('radio', { name: /Backup authentication codes/ })
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(onSubmitCb).toHaveBeenCalledWith('code');
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.tsx
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import FlowContainer from '../FlowContainer';
+import ProgressBar from '../ProgressBar';
+import { GleanClickEventType2FA } from '../../../lib/types';
+import GleanMetrics from '../../../lib/glean';
+import {
+  BackupAuthenticationCodesImage,
+  BackupRecoveryPhoneSmsImage,
+} from '../../images';
+import { useFtlMsgResolver } from '../../../models';
+import FormChoice, { Choice, CHOICES, FormChoiceData } from '../../FormChoice';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+
+type FlowSetup2faBackupChoiceProps = {
+  currentStep?: number;
+  numberOfSteps?: number;
+  hideBackButton?: boolean;
+  localizedFlowTitle: string;
+  onBackButtonClick?: () => void;
+  showProgressBar?: boolean;
+  onSubmitCb: (choice: Choice) => void;
+  reason?: GleanClickEventType2FA;
+};
+
+export const FlowSetup2faBackupChoice = ({
+  currentStep,
+  numberOfSteps,
+  hideBackButton = false,
+  localizedFlowTitle,
+  onBackButtonClick,
+  showProgressBar = true,
+  onSubmitCb,
+  reason = GleanClickEventType2FA.setup,
+}: FlowSetup2faBackupChoiceProps) => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    GleanMetrics.accountPref.twoStepAuthBackupChoiceView({
+      event: { reason },
+    });
+  }, [reason]);
+
+  const onSubmit = useCallback(
+    ({ choice }: FormChoiceData) => {
+      setIsSubmitting(true);
+      GleanMetrics.accountPref.twoStepAuthBackupChoiceSubmit({
+        event: { reason, choice },
+      });
+      onSubmitCb(choice);
+      setIsSubmitting(false);
+    },
+    [onSubmitCb, reason]
+  );
+
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  return (
+    <FlowContainer
+      title={localizedFlowTitle}
+      {...{ hideBackButton, onBackButtonClick }}
+    >
+      {showProgressBar && currentStep != null && numberOfSteps != null && (
+        <ProgressBar {...{ currentStep, numberOfSteps }} />
+      )}
+      <FormChoice
+        legendEl={
+          <>
+            <legend>
+              <FtlMsg id="flow-setup-2fa-backup-choice-heading">
+                <h2 className="font-bold text-xl my-2">
+                  Choose a recovery method
+                </h2>
+              </FtlMsg>
+            </legend>
+            <FtlMsg id="flow-setup-2fa-backup-choice-description">
+              <p className="mb-4">
+                This allows you to sign in if you can’t access your mobile
+                device or authenticator app.
+              </p>
+            </FtlMsg>
+          </>
+        }
+        contentAlignVertical="top"
+        formChoices={[
+          {
+            id: 'backup-choice-phone',
+            value: CHOICES.phone,
+            localizedChoiceTitle: ftlMsgResolver.getMsg(
+              'flow-setup-2fa-backup-choice-phone-title',
+              'Recovery phone'
+            ),
+            localizedChoiceBadge: ftlMsgResolver.getMsg(
+              'flow-setup-2fa-backup-choice-phone-badge',
+              'Easiest'
+            ),
+            localizedChoiceInfo: ftlMsgResolver.getMsg(
+              'flow-setup-2fa-backup-choice-phone-info',
+              'Get a recovery code via text message. Currently available in the USA and Canada.'
+            ),
+            image: (
+              <BackupRecoveryPhoneSmsImage
+                className="max-h-44 mt-[6px]"
+                ariaHidden
+              />
+            ),
+          },
+          {
+            id: 'backup-choice-code',
+            value: CHOICES.code,
+            localizedChoiceTitle: ftlMsgResolver.getMsg(
+              'flow-setup-2fa-backup-choice-code-title',
+              'Backup authentication codes'
+            ),
+            localizedChoiceBadge: ftlMsgResolver.getMsg(
+              'flow-setup-2fa-backup-choice-code-badge',
+              'Safest'
+            ),
+            localizedChoiceInfo: ftlMsgResolver.getMsg(
+              'flow-setup-2fa-backup-choice-code-info',
+              'Create and save one-time-use authentication codes.'
+            ),
+            image: (
+              <BackupAuthenticationCodesImage
+                className="max-h-44 mt-[6px]"
+                ariaHidden
+              />
+            ),
+          },
+        ]}
+        onSubmit={onSubmit}
+        isSubmitting={isSubmitting}
+      />
+      <FtlMsg id="flow-setup-2fa-backup-choice-learn-more-link">
+        <LinkExternal
+          href="https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication"
+          className="link-blue mt-5 text-sm mx-auto"
+          gleanDataAttrs={{
+            id: 'two_step_auth_backup_choice_learn_more_link',
+            type: reason,
+          }}
+        >
+          Learn about recovery and SIM swap risk
+        </LinkExternal>
+      </FtlMsg>
+    </FlowContainer>
+  );
+};

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -479,6 +479,17 @@ const recordEventMetric = (
         reason: gleanPingMetrics?.event?.['reason'] || '',
       });
       break;
+    case 'account_pref_two_step_auth_backup_choice_view':
+      accountPref.twoStepAuthBackupChoiceView.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
+    case 'account_pref_two_step_auth_backup_choice_submit':
+      accountPref.twoStepAuthBackupChoiceSubmit.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+        choice: gleanPingMetrics?.event?.['choice'] || '',
+      });
+      break;
     case 'account_pref_change_password_submit':
       accountPref.changePasswordSubmit.record();
       break;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -40,6 +40,23 @@ event:
     data_sensitivity:
       - interaction
 
+  choice:
+    description: the choice made by the user in a given event
+    type: string
+    lifetime: ping
+    send_in_pings:
+      - accounts-events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10235
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+
   third_party_links:
     description: boolean, additional context-dependent (on event.name) info related to third party auth links
     type: boolean
@@ -2320,6 +2337,51 @@ account_pref:
     extra_keys:
       reason:
         description: Page is viewed to "setup" or "replace" backup authentication codes
+        type: string
+  two_step_auth_backup_choice_view:
+    type: event
+    description: |
+      User viewed the backup choice page of the flow to choose between using a recovery phone or backup authentication codes.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10235
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: Page is viewed to "setup", "inline setup" or "replace" 2FA.
+        type: string
+  two_step_auth_backup_choice_submit:
+    type: event
+    description: |
+      User chose and submitted their backup method on the backup choice page.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10235
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: Page is viewed to "setup", "inline setup" or "replace" 2FA.
+        type: string
+      choice:
+        description: User's choice of backup method, either 'phone' or 'code'
         type: string
   two_step_auth_phone_verify_view:
     type: event

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -367,6 +367,44 @@ export const secondaryEmailSubmit = new EventMetricType(
 );
 
 /**
+ * User chose and submitted their backup method on the backup choice page.
+ *
+ * Generated from `account_pref.two_step_auth_backup_choice_submit`.
+ */
+export const twoStepAuthBackupChoiceSubmit = new EventMetricType<{
+  choice?: string;
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'two_step_auth_backup_choice_submit',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['choice', 'reason']
+);
+
+/**
+ * User viewed the backup choice page of the flow to choose between using a
+ * recovery phone or backup authentication codes.
+ *
+ * Generated from `account_pref.two_step_auth_backup_choice_view`.
+ */
+export const twoStepAuthBackupChoiceView = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'two_step_auth_backup_choice_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
  * User viewed the backup codes page (step 2) of the 2FA setup funnel.
  *
  * Generated from `account_pref.two_step_auth_codes_view`.

--- a/packages/fxa-shared/metrics/glean/web/event.ts
+++ b/packages/fxa-shared/metrics/glean/web/event.ts
@@ -8,6 +8,19 @@ import BooleanMetricType from '@mozilla/glean/private/metrics/boolean';
 import StringMetricType from '@mozilla/glean/private/metrics/string';
 
 /**
+ * the choice made by the user in a given event
+ *
+ * Generated from `event.choice`.
+ */
+export const choice = new StringMetricType({
+  category: 'event',
+  name: 'choice',
+  sendInPings: ['accounts-events'],
+  lifetime: 'ping',
+  disabled: false,
+});
+
+/**
  * The name of the event
  *
  * Generated from `event.name`.

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -22,7 +22,11 @@ export type GleanMetricsConfig = {
 };
 
 export const booleanEventPropertyNames = ['thirdPartyLinks'] as const;
-export const stringEventPropertyNames = ['reason', 'nimbusUserId'] as const;
+export const stringEventPropertyNames = [
+  'reason',
+  'nimbusUserId',
+  'choice',
+] as const;
 
 export type PropertyNameStringT = typeof stringEventPropertyNames;
 export type PropertyNameString = PropertyNameStringT[number];
@@ -195,6 +199,10 @@ export const eventsMap = {
     twoStepAuthEnterCodeView: 'account_pref_two_step_auth_enter_code_view',
     twoStepAuthEnterCodeSuccessView:
       'account_pref_two_step_auth_enter_code_success_view',
+    twoStepAuthBackupChoiceView:
+      'account_pref_two_step_auth_backup_choice_view',
+    twoStepAuthBackupChoiceSubmit:
+      'account_pref_two_step_auth_backup_choice_submit',
     twoStepAuthPhoneVerifyView: 'account_pref_two_step_auth_phone_verify_view',
     twoStepAuthPhoneRemoveSuccessView:
       'account_pref_two_step_auth_phone_remove_success_view',


### PR DESCRIPTION
## Because

- The design for 2FA setup has been updated, and we have this new step in the flow

## This pull request

- Creates a new UI component with l10n, Glean metrics, storybook and unit tests
- Does not hook up the component in the setup flow - that will be done in a later ticket

## Issue that this pull request solves

Closes: FXA-10235

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="607" alt="image" src="https://github.com/user-attachments/assets/8ad72fb0-2e50-4620-95da-130b7aec9a42" />

## Other information (Optional)

Any other information that is important to this pull request.
