### PR TITLE
fix(content-server): add 'Last logged:' label to service last access …

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/Service.tsx
@@ -131,7 +131,7 @@ export function Service({
             </div>
             <div className="flex flex-start mobileLandscape:justify-center mobileLandscape:flex-1">
               <p className="text-sm" data-testid="service-last-access">
-                {lastAccessTimeFormatted}
+                last logged : {lastAccessTimeFormatted}
               </p>
             </div>
           </div>


### PR DESCRIPTION
fix(content-server): add 'Last logged:' label to service last access time

Because:  
* improves clarity for the user with minimal text in the limited UI space.

This commit:  
* prepends 'Last logged:' before the last access time in service display.

Closes #16069

---

## Because

- Makes the meaning of the displayed timestamp more clear for the user.
- Small UX improvement with no risk.

## This pull request

- Adds "Last logged:" label before the service last access time.

## Issue that this pull request solves

Closes: #16069

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally. _(UI text change, no test needed.)_
- [x] I have added necessary documentation (if appropriate). _(Not needed for this UI text change.)_
- [x] I have verified that my changes render correctly in RTL (if appropriate). _(Visually verified.)_

## Other information

- Simple visual change with no impact on logic.
- Verified on local environment.
