### PR TITLE
test(fxa-auth-server): run tests in parallel to decouple from test_server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -909,12 +909,32 @@ workflows:
           requires:
             - Build (PR)
       - integration-test:
+          name: Integration Test - Servers - Auth - Serial (PR)
+          nx_run: affected --base=main --head=$CIRCLE_SHA1
+          projects: --exclude '*,!tag:scope:server:auth'
+          start_customs: true
+          test_suite: servers-auth-integration-serial
+          target: -t test-integration-serial
+          workflow: test_pull_request
+          requires:
+            - Build (PR)
+      - integration-test:
           name: Integration Test - Servers - Auth V2 (PR)
           nx_run: affected --base=main --head=$CIRCLE_SHA1
           projects: --exclude '*,!tag:scope:server:auth'
           start_customs: true
           target: -t test-integration-v2
           test_suite: servers-auth-v2-integration
+          workflow: test_pull_request
+          requires:
+            - Build (PR)
+      - integration-test:
+          name: Integration Test - Servers - Auth V2 - Serial (PR)
+          nx_run: affected --base=main --head=$CIRCLE_SHA1
+          projects: --exclude '*,!tag:scope:server:auth'
+          start_customs: true
+          test_suite: servers-auth-v2-integration-serial
+          target: -t test-integration-v2-serial
           workflow: test_pull_request
           requires:
             - Build (PR)
@@ -946,7 +966,9 @@ workflows:
             - Integration Test - Frontends (PR)
             - Integration Test - Servers (PR)
             - Integration Test - Servers - Auth (PR)
+            - Integration Test - Servers - Auth - Serial (PR)
             - Integration Test - Servers - Auth V2 (PR)
+            - Integration Test - Servers - Auth V2 - Serial (PR)
             - Integration Test - Libraries (PR)
             - Firefox Functional Tests - Playwright (PR)
             - Deploy Storybooks (PR)
@@ -1137,6 +1159,20 @@ workflows:
           requires:
             - Build
       - integration-test:
+          name: Integration Test - Servers - Auth - Serial
+          projects: --exclude '*,!tag:scope:server:auth'
+          start_customs: true
+          test_suite: servers-auth-integration-serial
+          target: -t test-integration-serial
+          workflow: test_and_deploy_tag
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+          requires:
+            - Build
+      - integration-test:
           name: Integration Test - Servers - Auth V2
           projects: --exclude '*,!tag:scope:server:auth'
           start_customs: true
@@ -1149,6 +1185,20 @@ workflows:
             tags:
               only: /.*/
           nx_run: run-many --no-cloud
+          requires:
+            - Build
+      - integration-test:
+          name: Integration Test - Servers - Auth V2 - Serial
+          projects: --exclude '*,!tag:scope:server:auth'
+          start_customs: true
+          test_suite: servers-auth-v2-integration-serial
+          target: -t test-integration-v2-serial
+          workflow: test_and_deploy_tag
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
           requires:
             - Build
       - integration-test:
@@ -1255,11 +1305,31 @@ workflows:
           requires:
             - Build (nightly)
       - integration-test:
+          name: Integration Test - Servers - Auth - Serial (nightly)
+          projects: --exclude '*,!tag:scope:server:auth'
+          start_customs: true
+          target: -t test-integration-serial
+          test_suite: servers-auth-integration-serial
+          workflow: nightly
+          nx_run: run-many --skipRemoteCache
+          requires:
+            - Build (nightly)
+      - integration-test:
           name: Integration Test - Servers - Auth V2 (nightly)
           projects: --exclude '*,!tag:scope:server:auth'
           start_customs: true
           target: -t test-integration-v2
           test_suite: servers-auth-v2-integration
+          workflow: nightly
+          nx_run: run-many --skipRemoteCache
+          requires:
+            - Build (nightly)
+      - integration-test:
+          name: Integration Test - Servers - Auth V2 - Serial (nightly)
+          projects: --exclude '*,!tag:scope:server:auth'
+          start_customs: true
+          target: -t test-integration-v2-serial
+          test_suite: servers-auth-v2-integration-serial
           workflow: nightly
           nx_run: run-many --skipRemoteCache
           requires:
@@ -1288,7 +1358,9 @@ workflows:
             - Integration Test - Frontends (nightly)
             - Integration Test - Servers (nightly)
             - Integration Test - Servers - Auth (nightly)
+            - Integration Test - Servers - Auth - Serial (nightly)
             - Integration Test - Servers - Auth V2 (nightly)
+            - Integration Test - Servers - Auth V2 - Serial (nightly)
             - Integration Test - Libraries (nightly)
             - Firefox Functional Tests - Playwright (nightly)
       - build-and-deploy-storybooks:

--- a/nx.json
+++ b/nx.json
@@ -116,7 +116,31 @@
       ],
       "cache": true
     },
+    "test-integration-serial": {
+      "dependsOn": ["build", "gen-keys"],
+      "inputs": ["test", "^test"],
+      "outputs": [
+        "{workspaceRoot}/artifacts/tests",
+        "{projectRoot}/coverage",
+        "{projectRoot}/.nyc_output",
+        "{projectRoot}/test-results.xml",
+        "{projectRoot}/test/scripts/test_output"
+      ],
+      "cache": true
+    },
     "test-integration-v2": {
+      "dependsOn": ["build", "gen-keys"],
+      "inputs": ["test", "^test"],
+      "outputs": [
+        "{workspaceRoot}/artifacts/tests",
+        "{projectRoot}/coverage",
+        "{projectRoot}/.nyc_output",
+        "{projectRoot}/test-results.xml",
+        "{projectRoot}/test/scripts/test_output"
+      ],
+      "cache": true
+    },
+    "test-integration-v2-serial": {
       "dependsOn": ["build", "gen-keys"],
       "inputs": ["test", "^test"],
       "outputs": [

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -41,7 +41,9 @@
     "test": "VERIFIER_VERSION=0 scripts/test-local.sh",
     "test-unit": "VERIFIER_VERSION=0 TEST_TYPE=unit scripts/test-ci.sh",
     "test-integration": "VERIFIER_VERSION=0 TEST_TYPE=integration scripts/test-ci.sh",
+    "test-integration-serial": "VERIFIER_VERSION=0 TEST_TYPE=integration-serial scripts/test-ci.sh",
     "test-integration-v2": "VERIFIER_VERSION=0 TEST_TYPE=integration-v2 scripts/test-ci.sh",
+    "test-integration-v2-serial": "VERIFIER_VERSION=0 TEST_TYPE=integration-v2-serial scripts/test-ci.sh",
     "populate-firestore-customers": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/populate-firestore-customers.ts",
     "populate-vat-taxes": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/populate-vat-taxes.ts",
     "paypal-processor": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/paypal-processor.ts",
@@ -198,7 +200,7 @@
   },
   "mocha": {
     "reporter": "mocha-multi",
-    "reporterOptions": "spec=-,mocha-junit-reporter=-"
+    "reporterOptions": "spec=-"
   },
   "nx": {
     "tags": [

--- a/packages/fxa-auth-server/scripts/test-ci.sh
+++ b/packages/fxa-auth-server/scripts/test-ci.sh
@@ -6,11 +6,41 @@ cd "$DIR/.."
 export NODE_ENV=dev
 export CORS_ORIGIN="http://foo,http://bar"
 
-DEFAULT_ARGS="--require esbuild-register --require tsconfig-paths/register --recursive --timeout 20000 --exit --parallel=1 "
-if [ "$TEST_TYPE" == 'unit' ]; then GREP_TESTS="--grep #integration --invert "; fi;
-if [ "$TEST_TYPE" == 'integration' ]; then GREP_TESTS="--grep /#integration\s-/"; fi;
-if [ "$TEST_TYPE" == 'integration-v2' ]; then GREP_TESTS="--grep /#integrationV2\s-/"; fi;
+DEFAULT_ARGS="\
+  --require esbuild-register \
+  --require tsconfig-paths/register \
+  --recursive \
+  --timeout 30000 \
+  --reporter xunit \
+  --reporter spec \
+  --exit "
 
+if [ "$TEST_TYPE" == 'unit' ]; then
+  GREP_TESTS="--grep #integration --invert"
+fi
+
+# integration and integration-v2 tests are run in parallel
+# but we must set the jobs limit, otherwise tests run wild and
+# consume too much memory, causing mysql to crash and the tests to fail.
+if [ "$TEST_TYPE" == 'integration' ]; then
+  GREP_TESTS="--grep /(?=.*#integration\s-)(?!.*#serial)/"
+  DEFAULT_ARGS="$DEFAULT_ARGS --parallel --jobs=4"
+fi
+if [ "$TEST_TYPE" == 'integration-v2' ]; then
+  GREP_TESTS="--grep /(?=.*#integrationV2\s-)(?!.*#serial)/"
+  DEFAULT_ARGS="$DEFAULT_ARGS --parallel --jobs=4"
+fi
+
+# If there are integration tests that need to start the test_server
+# in a unique way that can't be shared with other tests (i.e., mocking,
+#    flag overrides for payments, etc.).
+# Then the test should be tagged with `#serial` and it'll be picked up here
+if [ "$TEST_TYPE" == 'integration-serial' ]; then
+  GREP_TESTS="--grep /(?=.*#integration\s-)(?=.*#serial\s-)/"
+fi
+if [ "$TEST_TYPE" == 'integration-v2-serial' ]; then
+  GREP_TESTS="--grep /(?=.*#integrationV2\s-)(?=.*#serial\s-)/"
+fi
 
 TESTS=(local oauth remote scripts)
 if [ -z "$1" ]; then
@@ -21,9 +51,25 @@ fi
 
 for t in "${TESTS[@]}"; do
   echo -e "\n\nTesting: $t"
+  # We do this check because we only need to run the server_setup
+  # for tests in the remote/ dir. However, there's a risk of cross-contamination
+  # between "TESTS", so we set LOCAL_ARGS each iteration to prevent that.
+  LOCAL_ARGS="$DEFAULT_ARGS"
 
-  #./scripts/mocha-coverage.js $DEFAULT_ARGS $GREP_TESTS --reporter-options mochaFile="../../artifacts/tests/fxa-auth-server/$t/test-results.xml" "test/$t"
-  MOCHA_FILE=../../artifacts/tests/$npm_package_name/fxa-auth-server-mocha-$TEST_TYPE-$t-results.xml mocha $DEFAULT_ARGS $GREP_TESTS test/$t
+  if [ "$t" == "remote" ] && { [ "$TEST_TYPE" == "integration" ] || [ "$TEST_TYPE" == "integration-v2" ]; }; then
+    LOCAL_ARGS="$LOCAL_ARGS --require test/server_setup.js"
+  fi
+
+  REPORT_FILE=../../artifacts/tests/$npm_package_name/fxa-auth-server-mocha-$TEST_TYPE-$t-results.xml
+
+  echo "Running mocha with args: $LOCAL_ARGS, grep: $GREP_TESTS, dir: test/$t, mochaFile: $REPORT_FILE"
+
+  mocha \
+    $LOCAL_ARGS \
+    $GREP_TESTS \
+    test/$t \
+    --reporter-options output="$REPORT_FILE"
+
 done
 
 if [ "$TEST_TYPE" == 'integration' ]; then

--- a/packages/fxa-auth-server/test/lib/util.js
+++ b/packages/fxa-auth-server/test/lib/util.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const config = require('../../config').default.getProperties();
+const crypto = require('crypto');
 const assert = require('assert');
 const ORIGINAL_STDOUT_WRITE = process.stdout.write;
 const LOGS_REGEX = /^\[1mfxa-oauth-server/i; // eslint-disable-line no-control-regex
@@ -51,9 +53,45 @@ function assertSecurityHeaders(res, expect = {}) {
   });
 }
 
+/**
+ * Generates a unique email address for testing, optionally with a specified domain.
+ * If a domain is not provided, it defaults to '@restmail.net'.
+ *
+ * The email can be prefixed to enable customs by providing the configOverride with
+ * `enableCustomsChecks` set to true.
+ * @param {string} domain The domain for the email address, defaults to '@restmail.net'
+ * @param {{enableCustomsChecks: boolean}} configOverride Optional configuration override to control customs checks
+ * @returns {string} A unique email address
+ */
+function uniqueEmail(domain, configOverride) {
+  const cfg = configOverride || config;
+  if (!domain) {
+    domain = '@restmail.net';
+  }
+  const base = crypto.randomBytes(10).toString('hex');
+
+  // The enable_customs_ prefix will skip the 'isAllowedEmail' check in customs
+  // that is typically used to by pass customs during testing... This can
+  // be useful if a test that expects customs to activate is run.
+  const prefix = cfg.enableCustomsChecks ? 'enable_customs_' : '';
+  return `${prefix}${base}${domain}`;
+};
+
+/**
+ * Generates a unique email address for testing with Unicode characters.
+ * @returns {string} A unique email address
+ */
+function uniqueUnicodeEmail() {
+  return `${
+    crypto.randomBytes(10).toString('hex') + String.fromCharCode(1234)
+  }@${String.fromCharCode(5678)}restmail.net`;
+};
+
 module.exports = {
   assertSecurityHeaders,
   decodeJWT,
   disableLogs,
   restoreStdoutWrite,
+  uniqueEmail,
+  uniqueUnicodeEmail,
 };

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -8,9 +8,9 @@ const AppError = require('../../../lib/error');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const { AccountManager } = require('@fxa/shared/account/account');
-
 const sinon = require('sinon');
 const assert = { ...sinon.assert, ...chai.assert };
+
 const mocks = require('../../mocks');
 const { recoveryPhoneRoutes } = require('../../../lib/routes/recovery-phone');
 const {
@@ -20,10 +20,11 @@ const {
   RecoveryPhoneRegistrationLimitReached,
 } = require('@fxa/accounts/recovery-phone');
 
+chai.use(chaiAsPromised);
+
 const { getRoute } = require('../../routes_helpers');
 const { mockRequest } = require('../../mocks');
 const { Container } = require('typedi');
-chai.use(chaiAsPromised);
 
 describe('/recovery_phone', () => {
   const sandbox = sinon.createSandbox();

--- a/packages/fxa-auth-server/test/mailbox.js
+++ b/packages/fxa-auth-server/test/mailbox.js
@@ -7,6 +7,13 @@
 const request = require('request');
 const EventEmitter = require('events').EventEmitter;
 
+/**
+ * Manager for getting emails and email codes from the test mailbox.
+ * @param {*} host
+ * @param {*} port
+ * @param {*} printLogs
+ * @returns
+ */
 /* eslint-disable no-console */
 module.exports = function (host, port, printLogs) {
   host = host || 'localhost';
@@ -35,6 +42,7 @@ module.exports = function (host, port, printLogs) {
 
   function loop(name, tries, cb) {
     const url = `http://${host}:${port}/mail/${encodeURIComponent(name)}`;
+
     log('checking mail', url);
     request({ url: url, method: 'GET' }, (err, res, body) => {
       if (err) {

--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const url = require('url');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
 const { assert } = require('chai');
 const nock = require('nock');
 const buf = require('buf').hex;

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -21,8 +21,7 @@ import jwt from '../../lib/oauth/jwt';
 
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote account create`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote account create`, function () {
     let server;
 
     before(async function () {

--- a/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
@@ -6,29 +6,21 @@
 'use strict';
 
 const assert = require('../assert');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
 const otplib = require('otplib');
+const mailbox = require('../mailbox')()
+const { uniqueEmail } = require('../lib/util');
 
 // Note, intentionally not indenting for code review.
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote account create with sign-up code`, function () {
-  this.timeout(60000);
   const password = '4L6prUdlLNfxGIoj';
-  let server, client, email, emailStatus, emailData;
-
-  before(async () => {
-    server = await TestServer.start(config);
-  });
-
-  after(async function () {
-    await TestServer.stop(server);
-  });
+  let client, email, emailStatus, emailData;
 
   it('create and verify sync account', async () => {
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
@@ -40,7 +32,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
     emailStatus = await client.emailStatus();
     assert.equal(emailStatus.verified, false);
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     await client.verifyShortCodeEmail(
@@ -50,7 +42,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
       }
     );
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.include(emailData.headers['x-link'], config.smtp.syncUrl);
 
     emailStatus = await client.emailStatus();
@@ -58,7 +50,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
   });
 
   it('create and verify account', async () => {
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
@@ -69,7 +61,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
     emailStatus = await client.emailStatus();
     assert.equal(emailStatus.verified, false);
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     await client.verifyShortCodeEmail(emailData.headers['x-verify-short-code']);
@@ -82,14 +74,14 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
     // that there wasn't anything in the queue before it.
     await client.forgotPassword();
 
-    const code = await server.mailbox.waitForCode(email);
+    const code = await mailbox.waitForCode(email);
     assert.ok(code, 'the next email was reset-password, not post-verify');
   });
 
   it('throws for expired code', async () => {
     // To generate an expired code, you have to retrieve the accounts `emailCode`
     // and create the otp authenticator with the previous time window.
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
@@ -97,11 +89,11 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
     });
     assert.ok(client.authAt, 'authAt was set');
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     await client.requestVerifyEmail();
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verify');
 
     const secret = emailData.headers['x-verify-code'];
@@ -121,7 +113,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
   });
 
   it('throws for invalid code', async () => {
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
@@ -129,7 +121,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
     });
     assert.ok(client.authAt, 'authAt was set');
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     const invalidCode = emailData.headers['x-verify-short-code'] + 1;
@@ -141,14 +133,14 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
   });
 
   it('create and resend authentication code', async () => {
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
       verificationMethod: 'email-otp',
     });
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     const originalMessageId = emailData['messageId'];
     const originalCode = emailData.headers['x-verify-short-code'];
 
@@ -156,7 +148,7 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
 
     await client.resendVerifyShortCodeEmail();
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     assert.notEqual(
@@ -172,18 +164,18 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
   });
 
   it('should verify code from previous code window', async () => {
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
       verificationMethod: 'email-otp',
     });
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     await client.requestVerifyEmail();
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
 
     // Each code window is 10 minutes
     const secret = emailData.headers['x-verify-code'];
@@ -203,18 +195,18 @@ describe(`#integration${testOptions.version} - remote account create with sign-u
   });
 
   it('should not verify code from future code window', async () => {
-    email = server.uniqueEmail();
+    email = uniqueEmail();
 
     client = await Client.create(config.publicUrl, email, password, {
       ...testOptions,
       verificationMethod: 'email-otp',
     });
 
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'verifyShortCode');
 
     await client.requestVerifyEmail();
-    emailData = await server.mailbox.waitForEmail(email);
+    emailData = await mailbox.waitForEmail(email);
 
     // Each code window is 10 minutes
     const secret = emailData.headers['x-verify-code'];

--- a/packages/fxa-auth-server/test/remote/account_destroy_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_destroy_tests.js
@@ -14,8 +14,7 @@ const config = require('../../config').default.getProperties();
 
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote account destroy`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote account destroy`, function () {
     let server;
     let tempConfigValue;
 

--- a/packages/fxa-auth-server/test/remote/account_locale_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_locale_tests.js
@@ -7,17 +7,15 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
-
 const config = require('../../config').default.getProperties();
-config.redis.sessionTokens.enabled = false;
 
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote account locale`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote account locale`, function () {
     let server;
 
     before(async () => {
+      config.redis.sessionTokens.enabled = false;
       server = await TestServer.start(config);
     });
 

--- a/packages/fxa-auth-server/test/remote/account_profile_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_profile_tests.js
@@ -5,9 +5,10 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
+const mailbox = require('../mailbox')();
+const { uniqueEmail, uniqueUnicodeEmail } = require('../lib/util');
 
 const CLIENT_ID = config.oauthServer.clients.find(
   (client) => client.trusted && client.canGrant && client.publicClient
@@ -17,26 +18,19 @@ const CLIENT_ID = config.oauthServer.clients.find(
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - fetch user profile data`, function () {
-  this.timeout(60000);
 
-  let server, client, email, password;
+  let client, email, password;
   before(async () => {
-    if (config.subscriptions) {
-      config.subscriptions.enabled = false;
-    }
-    config.oauth.url = 'http://localhost:9000';
-    server = await TestServer.start(config, false);
   });
 
   after(async () => {
-    await TestServer.stop(server);
   });
 
   describe('when a request is authenticated with a session token', async () => {
     beforeEach(async () => {
       client = await Client.create(
         config.publicUrl,
-        server.uniqueEmail(),
+        uniqueEmail(),
         'password',
         {
           ...testOptions,
@@ -68,13 +62,13 @@ describe(`#integration${testOptions.version} - fetch user profile data`, functio
     let token;
 
     async function initialize(scope) {
-      email = server.uniqueEmail();
+      email = uniqueEmail();
       password = 'test password';
       client = await Client.createAndVerify(
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         { ...testOptions, lang: 'en-US' }
       );
 
@@ -219,7 +213,7 @@ describe(`#integration${testOptions.version} - fetch user profile data`, functio
   describe('when the profile data is not default', async () => {
     describe('when the email address is unicode', async () => {
       it('returns the email address correctly with the profile data', async () => {
-        const email = server.uniqueUnicodeEmail();
+        const email = uniqueUnicodeEmail();
 
         client = await Client.create(config.publicUrl, email, 'password', testOptions);
         const response = await client.accountProfile();
@@ -231,9 +225,9 @@ describe(`#integration${testOptions.version} - fetch user profile data`, functio
       it('returns correct TOTP status in profile data', async () => {
         client = await Client.createAndVerifyAndTOTP(
           config.publicUrl,
-          server.uniqueEmail(),
+          uniqueEmail(),
           'password',
-          server.mailbox,
+          mailbox,
           { ...testOptions, lang: 'en-US' }
         );
 
@@ -262,13 +256,13 @@ describe(`#integration${testOptions.version} - fetch user profile data`, functio
 
     describe('when the locale is empty', async () => {
       it('returns the profile data successfully', async () => {
-        email = server.uniqueEmail();
+        email = uniqueEmail();
         password = 'test password';
         client = await Client.createAndVerify(
           config.publicUrl,
           email,
           password,
-          server.mailbox,
+          mailbox,
           testOptions
         );
 

--- a/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
@@ -8,18 +8,21 @@ const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
-config.redis.sessionTokens.enabled = false;
 const url = require('url');
-
 const mocks = require('../mocks');
 
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote account signin verification`, function () {
-    this.timeout(60000);
+  /**
+   * Note, these tests are run in #serial because they modify the
+   * config from it's defaults and require the unique config when
+   * starting the test server.
+   */
+  describe(`#integration${testOptions.version} - #serial - remote account signin verification`, function () {
     let server;
 
     before(async () => {
+      config.redis.sessionTokens.enabled = false;
       config.securityHistory.ipProfiling.allowedRecency = 0;
       config.signinConfirmation.skipForNewAccounts.enabled = false;
       server = await TestServer.start(config);

--- a/packages/fxa-auth-server/test/remote/account_unlock_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_unlock_tests.js
@@ -5,29 +5,19 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
-
 const config = require('../../config').default.getProperties();
+const { uniqueEmail } = require('../lib/util');
 
 // Note, intentionally not indenting for code review.
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote account unlock`, function () {
-  this.timeout(60000);
-  let server;
-  before(async () => {
-    server = await TestServer.start(config);
-  });
-
-  after(async () => {
-    await TestServer.stop(server);
-  });
 
   it('/account/lock is no longer supported', () => {
     return Client.create(
       config.publicUrl,
-      server.uniqueEmail(),
+      uniqueEmail(),
       'password',
       testOptions
     )
@@ -47,7 +37,7 @@ describe(`#integration${testOptions.version} - remote account unlock`, function 
   it('/account/unlock/resend_code is no longer supported', () => {
     return Client.create(
       config.publicUrl,
-      server.uniqueEmail(),
+      uniqueEmail(),
       'password',
       testOptions
     )
@@ -67,7 +57,7 @@ describe(`#integration${testOptions.version} - remote account unlock`, function 
   it('/account/unlock/verify_code is no longer supported', () => {
     return Client.create(
       config.publicUrl,
-      server.uniqueEmail(),
+      uniqueEmail(),
       'password',
       testOptions
     )

--- a/packages/fxa-auth-server/test/remote/attached_clients_tests.js
+++ b/packages/fxa-auth-server/test/remote/attached_clients_tests.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
 const tokens = require('../../lib/tokens')({ trace: () => {} }, config);
@@ -13,6 +12,8 @@ const testUtils = require('../lib/util');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const buf = require('buf').hex;
 const hashRefreshToken = require('fxa-shared/auth/encrypt').hash;
+const mailbox = require('../mailbox')();
+const { uniqueEmail } = require('../lib/util');
 
 const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
 
@@ -21,32 +22,23 @@ const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - attached clients listing`, function () {
-  this.timeout(60000);
-  let server, oauthServerDb;
+  let oauthServerDb;
   before(async () => {
-    config.lastAccessTimeUpdates = {
-      enabled: true,
-      sampleRate: 1,
-      earliestSaneTimestamp: config.lastAccessTimeUpdates.earliestSaneTimestamp,
-    };
-    testUtils.disableLogs();
-    server = await TestServer.start(config, false);
     oauthServerDb = require('../../lib/oauth/db');
   });
 
   after(async () => {
-    await TestServer.stop(server);
     testUtils.restoreStdoutWrite();
   });
 
   it('correctly lists a variety of attached clients', async () => {
-    const email = server.uniqueEmail();
+    const email = uniqueEmail();
     const password = 'test password';
     const client = await Client.createAndVerify(
       config.publicUrl,
       email,
       password,
-      server.mailbox,
+      mailbox,
       testOptions
     );
     const mySessionTokenId = (
@@ -111,13 +103,13 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
   });
 
   it('correctly deletes by device id', async () => {
-    const email = server.uniqueEmail();
+    const email = uniqueEmail();
     const password = 'test password';
     const client = await Client.createAndVerify(
       config.publicUrl,
       email,
       password,
-      server.mailbox,
+      mailbox,
       testOptions
     );
     const mySessionTokenId = (
@@ -148,13 +140,13 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
   });
 
   it('correctly deletes by sessionTokenId', async () => {
-    const email = server.uniqueEmail();
+    const email = uniqueEmail();
     const password = 'test password';
     const client = await Client.createAndVerify(
       config.publicUrl,
       email,
       password,
-      server.mailbox,
+      mailbox,
       testOptions
     );
     const mySessionTokenId = (
@@ -184,13 +176,13 @@ describe(`#integration${testOptions.version} - attached clients listing`, functi
   });
 
   it('correctly deletes by refreshTokenId', async () => {
-    const email = server.uniqueEmail();
+    const email = uniqueEmail();
     const password = 'test password';
     const client = await Client.createAndVerify(
       config.publicUrl,
       email,
       password,
-      server.mailbox,
+      mailbox,
       testOptions
     );
     const mySessionTokenId = (

--- a/packages/fxa-auth-server/test/remote/base_path_tests.js
+++ b/packages/fxa-auth-server/test/remote/base_path_tests.js
@@ -5,26 +5,14 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const superagent = require('superagent');
+const config = require('../../config').default.getProperties();
 
 // Note, intentionally not indenting for code review.
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - remote base path`, function () {
-  this.timeout(60000);
-  let server, config;
-  before(async () => {
-    config = require('../../config').default.getProperties();
-    config.publicUrl = 'http://localhost:9000/auth';
-
-    server = await TestServer.start(config);
-  });
-
-  after(async () => {
-    await TestServer.stop(server);
-  });
 
   function testVersionRoute(path) {
     return () => {

--- a/packages/fxa-auth-server/test/remote/concurrent_tests.js
+++ b/packages/fxa-auth-server/test/remote/concurrent_tests.js
@@ -12,7 +12,7 @@ const config = require('../../config').default.getProperties();
 
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
-describe(`#integration${testOptions.version} - remote concurrent`, function () {
+describe(`#integration${testOptions.version} - #serial - remote concurrent`, function () {
   this.timeout(60000);
   let server;
 

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -9,13 +9,13 @@ const base64url = require('base64url');
 const config = require('../../config').default.getProperties();
 const crypto = require('crypto');
 const sinon = require('sinon');
-const TestServer = require('../test_server');
 const UnblockCode = require('../../lib/crypto/random').base32(
   config.signinUnblock.codeLength
 );
 const uuid = require('uuid');
 const { normalizeEmail } = require('fxa-shared').email.helpers;
 const ioredis = require('ioredis');
+const { uniqueEmail } = require('../lib/util');
 
 const log = { debug() {}, trace() {}, info() {}, error() {} };
 
@@ -72,8 +72,7 @@ const zeroBuffer32 = Buffer.from(
 let account, secondEmail;
 
 describe(`#integration - remote db`, function () {
-  this.timeout(60000);
-  let dbServer, db, redis;
+  let db, redis;
 
   before(async () => {
     redis = ioredis.createClient({
@@ -83,19 +82,17 @@ describe(`#integration - remote db`, function () {
       prefix: config.redis.sessionTokens.prefix,
       enable_offline_queue: false,
     });
-    dbServer = await TestServer.start(config);
     db = await DB.connect(config);
   });
 
   after(async () => {
-    await TestServer.stop(dbServer);
     await db.close();
   });
 
   beforeEach(() => {
     account = {
       uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
-      email: dbServer.uniqueEmail(),
+      email: uniqueEmail(),
       emailCode: zeroBuffer16,
       emailVerified: false,
       verifierVersion: 1,
@@ -116,7 +113,7 @@ describe(`#integration - remote db`, function () {
             'account.uid is the same as the input account.uid'
           );
 
-          secondEmail = dbServer.uniqueEmail();
+          secondEmail = uniqueEmail();
           const emailData = {
             email: secondEmail,
             emailCode: crypto.randomBytes(16).toString('hex'),

--- a/packages/fxa-auth-server/test/remote/device_tests.js
+++ b/packages/fxa-auth-server/test/remote/device_tests.js
@@ -5,34 +5,19 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
 const crypto = require('crypto');
 const base64url = require('base64url');
 const mocks = require('../mocks');
+const mailbox = require('../mailbox')();
+const { uniqueEmail } = require('../lib/util');
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote device`, function () {
-    this.timeout(60000);
-    let server;
-    before(async () => {
-      config.lastAccessTimeUpdates = {
-        enabled: true,
-        sampleRate: 1,
-        earliestSaneTimestamp:
-          config.lastAccessTimeUpdates.earliestSaneTimestamp,
-      };
-
-      server = await TestServer.start(config);
-    });
-
-    after(async () => {
-      await TestServer.stop(server);
-    });
 
     it('device registration after account creation', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -136,7 +121,7 @@ const mocks = require('../mocks');
     });
 
     it('device registration without optional parameters', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -226,7 +211,7 @@ const mocks = require('../mocks');
     });
 
     it('device registration with unicode characters in the name', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -263,7 +248,7 @@ const mocks = require('../mocks');
     });
 
     it('device registration without required name parameter', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -278,7 +263,7 @@ const mocks = require('../mocks');
     });
 
     it('device registration without required type parameter', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const deviceName = 'test device';
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
@@ -294,8 +279,8 @@ const mocks = require('../mocks');
 
     it('update device fails with bad callbackUrl', () => {
       const badPushCallback =
-        'https://updates.push.services.mozilla.com.different-push-server.technology';
-      const email = server.uniqueEmail();
+        'https://updates.push.services.mozilla.com.different-push-technology';
+      const email = uniqueEmail();
       const password = 'test password';
       const deviceInfo = {
         id: crypto.randomBytes(16).toString('hex'),
@@ -333,7 +318,7 @@ const mocks = require('../mocks');
     it('update device fails with non-normalized callbackUrl', () => {
       const badPushCallback =
         'https://updates.push.services.mozilla.com/invalid/\u010D/char';
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       const deviceInfo = {
         id: crypto.randomBytes(16).toString('hex'),
@@ -370,7 +355,7 @@ const mocks = require('../mocks');
 
     it('update device works with stage servers', () => {
       const goodPushCallback = 'https://updates-autopush.stage.mozaws.net';
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -405,7 +390,7 @@ const mocks = require('../mocks');
 
     it('update device works with dev servers', () => {
       const goodPushCallback = 'https://updates-autopush.dev.mozaws.net';
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -441,7 +426,7 @@ const mocks = require('../mocks');
       const goodPushCallback =
         'https://updates.push.services.mozilla.com:443/wpush/v1/gAAAAABbkq0Eafe6IANS4OV3pmoQ5Z8AhqFSGKtozz5FIvu0CfrTGmcv07CYziPaysTv_9dgisB0yr3UjEIlGEyoprRFX1WU5VA4nG-9tofPdA3FYREPf6xh3JL1qBhTa9mEFS2dSn--';
 
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -475,7 +460,7 @@ const mocks = require('../mocks');
 
     it('update device works with callback urls that :4430 as a port', () => {
       const goodPushCallback = 'https://updates.push.services.mozilla.com:4430';
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -510,7 +495,7 @@ const mocks = require('../mocks');
     it('update device works with callback urls that a custom port', () => {
       const goodPushCallback =
         'https://updates.push.services.mozilla.com:10332';
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -544,7 +529,7 @@ const mocks = require('../mocks');
 
     it('update device fails with bad dev callbackUrl', () => {
       const badPushCallback = 'https://evil.mozaws.net';
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       const deviceInfo = {
         id: crypto.randomBytes(16).toString('hex'),
@@ -579,7 +564,7 @@ const mocks = require('../mocks');
     });
 
     it('device registration ignores deprecated "capabilities" field', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       return Client.create(config.publicUrl, email, password, testOptions).then(
         (client) => {
@@ -603,7 +588,7 @@ const mocks = require('../mocks');
     });
 
     it('device registration from a different session', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       const deviceInfo = [
         {
@@ -619,7 +604,7 @@ const mocks = require('../mocks');
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         testOptions
       ).then((client) => {
         return Client.login(config.publicUrl, email, password, testOptions)
@@ -701,7 +686,7 @@ const mocks = require('../mocks');
     });
 
     it('ensures all device push fields appear together', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       const deviceInfo = {
         name: 'test device',
@@ -752,7 +737,7 @@ const mocks = require('../mocks');
     });
 
     it('invalid public keys are cleanly rejected', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'test password';
       const invalidPublicKey = Buffer.alloc(65);
       invalidPublicKey.fill('\0');
@@ -767,7 +752,7 @@ const mocks = require('../mocks');
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         testOptions
       ).then((client) => {
         return client.updateDevice(deviceInfo).then(

--- a/packages/fxa-auth-server/test/remote/email_validity_tests.js
+++ b/packages/fxa-auth-server/test/remote/email_validity_tests.js
@@ -7,15 +7,12 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
-
 const config = require('../../config').default.getProperties();
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote email validity`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote email validity`, function () {
     let server;
     const temp = {};
-
     before(async () => {
       temp.requireVerifiedAccount =
         config.accountDestroy.requireVerifiedAccount;
@@ -36,49 +33,52 @@ const config = require('../../config').default.getProperties();
       await TestServer.stop(server);
     });
 
-    it('/account/create with a variety of malformed email addresses', () => {
-      const pwd = '123456';
+    const invalidEmails = [
+      'notAnEmailAddress',
+      '\n@example.com',
+      'me@hello world.com',
+      'me@hello+world.com',
+      'me@.example',
+      'me@example',
+      'me@example.com-',
+      'me@example..com',
+      'me@example-.com',
+      'me@example.-com',
+      '\uD83D\uDCA9@unicodepooforyou.com',
+    ];
 
-      const emails = [
-        'notAnEmailAddress',
-        '\n@example.com',
-        'me@hello world.com',
-        'me@hello+world.com',
-        'me@.example',
-        'me@example',
-        'me@example.com-',
-        'me@example..com',
-        'me@example-.com',
-        'me@example.-com',
-        '\uD83D\uDCA9@unicodepooforyou.com',
-      ];
-      emails.forEach((email, i) => {
-        emails[i] = Client.create(
+    invalidEmails.forEach(email => {
+      // these are currently getting a false positive
+      // they're getting a `400` back, but the
+      it(`/account/create rejects malformed email address: ${email}`, () => {
+        const pwd = '123456';
+        return Client.create(
           config.publicUrl,
           email,
           pwd,
           testOptions
         ).then(assert.fail, (err) => {
           assert.equal(err.code, 400, 'http 400 : malformed email is rejected');
+          assert.equal(err.errno, 107, 'errno 107 : malformed email is rejected');
+          assert.equal(err.message, "Invalid parameter in request body", )
         });
       });
-
-      return Promise.all(emails);
     });
 
-    it('/account/create with a variety of unusual but valid email addresses', () => {
-      const pwd = '123456';
+    const validEmails = [
+      'tim@tim-example.net',
+      'a+b+c@example.com',
+      '#!?-@t-e-s-assert.c-o-m',
+      `${String.fromCharCode(1234)}@example.com`,
+      `test@${String.fromCharCode(5678)}.com`,
+    ];
 
-      const emails = [
-        'tim@tim-example.net',
-        'a+b+c@example.com',
-        '#!?-@t-e-s-assert.c-o-m',
-        `${String.fromCharCode(1234)}@example.com`,
-        `test@${String.fromCharCode(5678)}.com`,
-      ];
-
-      emails.forEach((email, i) => {
-        emails[i] = Client.create(
+    // iterate over each and individually test so
+    // that, should one email fail, we still test the others
+    validEmails.forEach((email) => {
+      it(`/account/create allows unusual but valid email addresses: ${email}`, () => {
+        const pwd = '123456';
+        return Client.create(
           config.publicUrl,
           email,
           pwd,
@@ -88,6 +88,11 @@ const config = require('../../config').default.getProperties();
             return c.destroyAccount();
           },
           (_err) => {
+            console.debug('An email address that should have been allowed was rejected:',
+              {
+                email,
+                _err
+              });
             assert(
               false,
               `Email address ${email} should have been allowed, but it wasn't`
@@ -95,8 +100,6 @@ const config = require('../../config').default.getProperties();
           }
         );
       });
-
-      return Promise.all(emails);
     });
   });
 });

--- a/packages/fxa-auth-server/test/remote/flow_tests.js
+++ b/packages/fxa-auth-server/test/remote/flow_tests.js
@@ -6,34 +6,26 @@
 
 const { assert } = require('chai');
 const Client = require('../client')();
-const TestServer = require('../test_server');
+const mailbox = require('../mailbox')();
+const { uniqueEmail } = require('../lib/util');
 
 const config = require('../../config').default.getProperties();
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote flow`, function () {
-    this.timeout(60000);
-    let server;
-    let email1;
-    config.signinConfirmation.skipForNewAccounts.enabled = true;
+    let email;
     before(async () => {
-      server = await TestServer.start(config);
-      email1 = server.uniqueEmail();
-    });
-
-    after(async () => {
-      await TestServer.stop(server);
+      email = uniqueEmail();
     });
 
     it('Create account flow', () => {
-      const email = email1;
       const password = 'allyourbasearebelongtous';
       let client = null;
       return Client.createAndVerify(
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         {
           ...testOptions,
           keys: true,
@@ -56,7 +48,6 @@ const config = require('../../config').default.getProperties();
     });
 
     it('Login flow', () => {
-      const email = email1;
       const password = 'allyourbasearebelongtous';
       let client = null;
       return Client.login(config.publicUrl, email, password, {

--- a/packages/fxa-auth-server/test/remote/misc_tests.js
+++ b/packages/fxa-auth-server/test/remote/misc_tests.js
@@ -6,22 +6,16 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const superagent = require('superagent');
+const mailbox = require('../mailbox')();
+const { uniqueEmail } = require('../lib/util');
 
 const config = require('../../config').default.getProperties();
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote misc`, function () {
-    this.timeout(60000);
-    let server;
-    before(async () => {
-      server = await TestServer.start(config);
-    });
-    after(async () => {
-      await TestServer.stop(server);
-    });
+    this.timeout(30000);
 
     function testVersionRoute(route) {
       return () => {
@@ -143,7 +137,7 @@ const config = require('../../config').default.getProperties();
     });
 
     it('timestamp header', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'allyourbasearebelongtous';
       let url = null;
       let client = null;
@@ -151,7 +145,7 @@ const config = require('../../config').default.getProperties();
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         testOptions
       )
         .then((c) => {
@@ -250,7 +244,7 @@ const config = require('../../config').default.getProperties();
     });
 
     it('ignores fail on hawk payload mismatch', () => {
-      const email = server.uniqueEmail();
+      const email = uniqueEmail();
       const password = 'allyourbasearebelongtous';
       let url = null;
       let client = null;
@@ -258,7 +252,7 @@ const config = require('../../config').default.getProperties();
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         testOptions
       )
         .then((c) => {

--- a/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
 const {
@@ -14,6 +13,7 @@ const {
 } = require('fxa-shared/oauth/constants');
 const error = require('../../lib/error');
 const testUtils = require('../lib/util');
+const mailbox = require('../mailbox')();
 
 const OAUTH_CLIENT_NAME = 'Android Components Reference Browser';
 const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
@@ -23,30 +23,26 @@ const MOCK_CODE_CHALLENGE = 'YPhkZqm08uTfwjNSiYcx80-NPT9Zn94kHboQW97KyV0';
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
 describe(`#integration${testOptions.version} - /oauth/ session token scope`, function () {
-  this.timeout(60000);
   let client;
   let email;
   let password;
-  let server;
 
   before(async () => {
     testUtils.disableLogs();
-    server = await TestServer.start(config, false);
   });
 
   after(async () => {
-    await TestServer.stop(server);
     testUtils.restoreStdoutWrite();
   });
 
   beforeEach(async () => {
-    email = server.uniqueEmail();
+    email = testUtils.uniqueEmail();
     password = 'test password';
     client = await Client.createAndVerify(
       config.publicUrl,
       email,
       password,
-      server.mailbox,
+      mailbox,
       testOptions
     );
   });

--- a/packages/fxa-auth-server/test/remote/password_change_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_change_tests.js
@@ -18,8 +18,7 @@ function getSessionTokenId(sessionTokenHex) {
 }
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote password change`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote password change`, function () {
     let server;
     before(async () => {
       config.securityHistory.ipProfiling.allowedRecency = 0;

--- a/packages/fxa-auth-server/test/remote/password_forgot_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_forgot_tests.js
@@ -2,449 +2,439 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- 'use strict';
+'use strict';
 
- const chai = require('chai');
- const chaiAsPromised = require('chai-as-promised');
- const url = require('url');
- const Client = require('../client')();
- const TestServer = require('../test_server');
- const crypto = require('crypto');
- const base64url = require('base64url');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const url = require('url');
+const Client = require('../client')();
+const mailbox = require('../mailbox')();
+const crypto = require('crypto');
+const base64url = require('base64url');
+const { uniqueEmail } = require('../lib/util');
 
- const config = require('../../config').default.getProperties();
- const mocks = require('../mocks');
+const config = require('../../config').default.getProperties();
+const mocks = require('../mocks');
 
- chai.use(chaiAsPromised);
- const { assert } = chai;
+chai.use(chaiAsPromised);
+const { assert } = chai;
 
- [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-   describe(`#integration${testOptions.version} - remote password forgot`, function () {
-     this.timeout(15000);
-     let server;
-     before(async () => {
-       config.securityHistory.ipProfiling.allowedRecency = 0;
-       config.signinConfirmation.skipForNewAccounts.enabled = true;
-       server = await TestServer.start(config)
-     });
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - remote password forgot`, function () {
+    this.timeout(15000);
 
-     after(async () => {
-      await TestServer.stop(server);
+    it('forgot password', () => {
+      const email = uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+      let wrapKb = null;
+      let kA = null;
+      let client = null;
+      const options = {
+        ...testOptions,
+        keys: true,
+        metricsContext: mocks.generateMetricsContext(),
+      };
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        mailbox,
+        options
+      )
+        .then((x) => {
+          client = x;
+          return client.keys();
+        })
+        .then((keys) => {
+          wrapKb = keys.wrapKb;
+          kA = keys.kA;
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          assert.equal(
+            emailData.headers['x-flow-begin-time'],
+            options.metricsContext.flowBeginTime,
+            'flow begin time set'
+          );
+          assert.equal(
+            emailData.headers['x-flow-id'],
+            options.metricsContext.flowId,
+            'flow id set'
+          );
+          assert.equal(emailData.headers['x-template-name'], 'recovery');
+          return emailData.headers['x-recovery-code'];
+        })
+        .then((code) => {
+          assert.isRejected(client.resetPassword(newPassword));
+          return resetPassword(client, code, newPassword, undefined, options);
+        })
+        .then(() => {
+          return mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          const link = emailData.headers['x-link'];
+          const query = url.parse(link, true).query;
+          assert.ok(query.email, 'email is in the link');
+
+          assert.equal(
+            emailData.headers['x-flow-begin-time'],
+            options.metricsContext.flowBeginTime,
+            'flow begin time set'
+          );
+          assert.equal(
+            emailData.headers['x-flow-id'],
+            options.metricsContext.flowId,
+            'flow id set'
+          );
+          assert.equal(emailData.headers['x-template-name'], 'passwordReset');
+        })
+        .then(() => {
+          return upgradeCredentials(email, newPassword);
+        })
+        .then(
+          // make sure we can still login after password reset
+          () => {
+            return Client.login(config.publicUrl, email, newPassword, {
+              ...testOptions,
+              keys: true,
+            });
+          }
+        )
+        .then((x) => {
+          client = x;
+          return client.keys();
+        })
+        .then((keys) => {
+          assert.equal(typeof keys.wrapKb, 'string', 'yep, wrapKb');
+          assert.notEqual(wrapKb, keys.wrapKb, 'wrapKb was reset');
+          assert.equal(kA, keys.kA, 'kA was not reset');
+          assert.equal(typeof client.kB, 'string');
+          assert.equal(client.kB.length, 64, 'kB exists, has the right length');
+        });
     });
 
-     it('forgot password', () => {
-       const email = server.uniqueEmail();
-       const password = 'allyourbasearebelongtous';
-       const newPassword = 'ez';
-       let wrapKb = null;
-       let kA = null;
-       let client = null;
-       const options = {
-         ...testOptions,
-         keys: true,
-         metricsContext: mocks.generateMetricsContext(),
-       };
-       return Client.createAndVerify(
-         config.publicUrl,
-         email,
-         password,
-         server.mailbox,
-         options
-       )
-         .then((x) => {
-           client = x;
-           return client.keys();
-         })
-         .then((keys) => {
-           wrapKb = keys.wrapKb;
-           kA = keys.kA;
-           return client.forgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForEmail(email);
-         })
-         .then((emailData) => {
-           assert.equal(
-             emailData.headers['x-flow-begin-time'],
-             options.metricsContext.flowBeginTime,
-             'flow begin time set'
-           );
-           assert.equal(
-             emailData.headers['x-flow-id'],
-             options.metricsContext.flowId,
-             'flow id set'
-           );
-           assert.equal(emailData.headers['x-template-name'], 'recovery');
-           return emailData.headers['x-recovery-code'];
-         })
-         .then((code) => {
-           assert.isRejected(client.resetPassword(newPassword));
-           return resetPassword(client, code, newPassword, undefined, options);
-         })
-         .then(() => {
-           return server.mailbox.waitForEmail(email);
-         })
-         .then((emailData) => {
-           const link = emailData.headers['x-link'];
-           const query = url.parse(link, true).query;
-           assert.ok(query.email, 'email is in the link');
+    it('forgot password limits verify attempts', () => {
+      let code = null;
+      const email = uniqueEmail();
+      const password = 'hothamburger';
+      let client = null;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        password,
+        mailbox,
+        testOptions
+      )
+        .then(() => {
+          client = new Client(config.publicUrl, testOptions);
+          client.email = email;
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForCode(email);
+        })
+        .then((c) => {
+          code = c;
+        })
+        .then(() => {
+          return client.reforgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForCode(email);
+        })
+        .then((c) => {
+          assert.equal(code, c, 'same code as before');
+        })
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with bad code');
+          },
+          (err) => {
+            assert.equal(err.tries, 2, 'used a try');
+            assert.equal(
+              err.message,
+              'Invalid confirmation code',
+              'bad attempt 1'
+            );
+          }
+        )
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with bad code');
+          },
+          (err) => {
+            assert.equal(err.tries, 1, 'used a try');
+            assert.equal(
+              err.message,
+              'Invalid confirmation code',
+              'bad attempt 2'
+            );
+          }
+        )
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with bad code');
+          },
+          (err) => {
+            assert.equal(err.tries, 0, 'used a try');
+            assert.equal(
+              err.message,
+              'Invalid confirmation code',
+              'bad attempt 3'
+            );
+          }
+        )
+        .then(() => {
+          return resetPassword(
+            client,
+            '00000000000000000000000000000000',
+            'password'
+          );
+        })
+        .then(
+          () => {
+            assert(false, 'reset password with invalid token');
+          },
+          (err) => {
+            assert.equal(
+              err.message,
+              'Invalid authentication token: Missing authentication',
+              'token is now invalid'
+            );
+          }
+        );
+    });
 
-           assert.equal(
-             emailData.headers['x-flow-begin-time'],
-             options.metricsContext.flowBeginTime,
-             'flow begin time set'
-           );
-           assert.equal(
-             emailData.headers['x-flow-id'],
-             options.metricsContext.flowId,
-             'flow id set'
-           );
-           assert.equal(emailData.headers['x-template-name'], 'passwordReset');
-         })
-         .then(() => {
-           return upgradeCredentials(email, newPassword);
-         })
-         .then(
-           // make sure we can still login after password reset
-           () => {
-             return Client.login(config.publicUrl, email, newPassword, {
-               ...testOptions,
-               keys: true,
-             });
-           }
-         )
-         .then((x) => {
-           client = x;
-           return client.keys();
-         })
-         .then((keys) => {
-           assert.equal(typeof keys.wrapKb, 'string', 'yep, wrapKb');
-           assert.notEqual(wrapKb, keys.wrapKb, 'wrapKb was reset');
-           assert.equal(kA, keys.kA, 'kA was not reset');
-           assert.equal(typeof client.kB, 'string');
-           assert.equal(client.kB.length, 64, 'kB exists, has the right length');
-         });
-     });
+    it('recovery email link', () => {
+      const email = uniqueEmail();
+      const password = 'something';
+      let client = null;
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
+        service: 'sync',
+      };
+      return Client.create(config.publicUrl, email, password, options)
+        .then((c) => {
+          client = c;
+        })
+        .then(() => {
+          return mailbox.waitForEmail(email);
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          const link = emailData.headers['x-link'];
+          const query = url.parse(link, true).query;
+          assert.ok(query.token, 'uid is in link');
+          assert.ok(query.code, 'code is in link');
+          assert.equal(
+            query.redirectTo,
+            options.redirectTo,
+            'redirectTo is in link'
+          );
+          assert.equal(query.service, options.service, 'service is in link');
+          assert.equal(query.email, email, 'email is in link');
+        });
+    });
 
-     it('forgot password limits verify attempts', () => {
-       let code = null;
-       const email = server.uniqueEmail();
-       const password = 'hothamburger';
-       let client = null;
-       return Client.createAndVerify(
-         config.publicUrl,
-         email,
-         password,
-         server.mailbox,
-         testOptions
-       )
-         .then(() => {
-           client = new Client(config.publicUrl, testOptions);
-           client.email = email;
-           return client.forgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForCode(email);
-         })
-         .then((c) => {
-           code = c;
-         })
-         .then(() => {
-           return client.reforgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForCode(email);
-         })
-         .then((c) => {
-           assert.equal(code, c, 'same code as before');
-         })
-         .then(() => {
-           return resetPassword(
-             client,
-             '00000000000000000000000000000000',
-             'password'
-           );
-         })
-         .then(
-           () => {
-             assert(false, 'reset password with bad code');
-           },
-           (err) => {
-             assert.equal(err.tries, 2, 'used a try');
-             assert.equal(
-               err.message,
-               'Invalid confirmation code',
-               'bad attempt 1'
-             );
-           }
-         )
-         .then(() => {
-           return resetPassword(
-             client,
-             '00000000000000000000000000000000',
-             'password'
-           );
-         })
-         .then(
-           () => {
-             assert(false, 'reset password with bad code');
-           },
-           (err) => {
-             assert.equal(err.tries, 1, 'used a try');
-             assert.equal(
-               err.message,
-               'Invalid confirmation code',
-               'bad attempt 2'
-             );
-           }
-         )
-         .then(() => {
-           return resetPassword(
-             client,
-             '00000000000000000000000000000000',
-             'password'
-           );
-         })
-         .then(
-           () => {
-             assert(false, 'reset password with bad code');
-           },
-           (err) => {
-             assert.equal(err.tries, 0, 'used a try');
-             assert.equal(
-               err.message,
-               'Invalid confirmation code',
-               'bad attempt 3'
-             );
-           }
-         )
-         .then(() => {
-           return resetPassword(
-             client,
-             '00000000000000000000000000000000',
-             'password'
-           );
-         })
-         .then(
-           () => {
-             assert(false, 'reset password with invalid token');
-           },
-           (err) => {
-             assert.equal(
-               err.message,
-               'Invalid authentication token: Missing authentication',
-               'token is now invalid'
-             );
-           }
-         );
-     });
+    it('password forgot status with valid token', () => {
+      const email = uniqueEmail();
+      const password = 'something';
+      return Client.create(config.publicUrl, email, password, testOptions).then(
+        (c) => {
+          return c
+            .forgotPassword()
+            .then(() => {
+              return c.api.passwordForgotStatus(c.passwordForgotToken);
+            })
+            .then((x) => {
+              assert.equal(x.tries, 3, 'three tries remaining');
+              assert.ok(
+                x.ttl > 0 && x.ttl <= config.tokenLifetimes.passwordForgotToken,
+                'ttl is ok'
+              );
+            });
+        }
+      );
+    });
 
-     it('recovery email link', () => {
-       const email = server.uniqueEmail();
-       const password = 'something';
-       let client = null;
-       const options = {
-         ...testOptions,
-         redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
-         service: 'sync',
-       };
-       return Client.create(config.publicUrl, email, password, options)
-         .then((c) => {
-           client = c;
-         })
-         .then(() => {
-           return server.mailbox.waitForEmail(email);
-         })
-         .then(() => {
-           return client.forgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForEmail(email);
-         })
-         .then((emailData) => {
-           const link = emailData.headers['x-link'];
-           const query = url.parse(link, true).query;
-           assert.ok(query.token, 'uid is in link');
-           assert.ok(query.code, 'code is in link');
-           assert.equal(
-             query.redirectTo,
-             options.redirectTo,
-             'redirectTo is in link'
-           );
-           assert.equal(query.service, options.service, 'service is in link');
-           assert.equal(query.email, email, 'email is in link');
-         });
-     });
+    it('password forgot status with invalid token', () => {
+      const client = new Client(config.publicUrl, testOptions);
+      return client.api
+        .passwordForgotStatus(
+          '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
+        )
+        .then(
+          () => assert(false),
+          (err) => {
+            assert.equal(err.errno, 110, 'invalid token');
+          }
+        );
+    });
 
-     it('password forgot status with valid token', () => {
-       const email = server.uniqueEmail();
-       const password = 'something';
-       return Client.create(config.publicUrl, email, password, testOptions).then(
-         (c) => {
-           return c
-             .forgotPassword()
-             .then(() => {
-               return c.api.passwordForgotStatus(c.passwordForgotToken);
-             })
-             .then((x) => {
-               assert.equal(x.tries, 3, 'three tries remaining');
-               assert.ok(
-                 x.ttl > 0 && x.ttl <= config.tokenLifetimes.passwordForgotToken,
-                 'ttl is ok'
-               );
-             });
-         }
-       );
-     });
+    it('/password/forgot/verify_code should set an unverified account as verified', () => {
+      const email = uniqueEmail();
+      const password = 'something';
+      let client = null;
+      return Client.create(config.publicUrl, email, password, testOptions)
+        .then((c) => {
+          client = c;
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, false, 'email unverified');
+        })
+        .then(() => {
+          return mailbox.waitForCode(email); // ignore this code
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForCode(email);
+        })
+        .then((code) => {
+          return client.verifyPasswordResetCode(code);
+        })
+        .then(() => {
+          return client.emailStatus();
+        })
+        .then((status) => {
+          assert.equal(status.verified, true, 'account unverified');
+        });
+    });
 
-     it('password forgot status with invalid token', () => {
-       const client = new Client(config.publicUrl, testOptions);
-       return client.api
-         .passwordForgotStatus(
-           '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
-         )
-         .then(
-           () => assert(false),
-           (err) => {
-             assert.equal(err.errno, 110, 'invalid token');
-           }
-         );
-     });
+    it('forgot password with service query parameter', () => {
+      const email = uniqueEmail();
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
+        serviceQuery: 'sync',
+      };
+      let client;
+      return Client.create(config.publicUrl, email, 'wibble', options)
+        .then((c) => {
+          client = c;
+        })
+        .then(() => {
+          return mailbox.waitForEmail(email);
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForEmail(email);
+        })
+        .then((emailData) => {
+          const link = emailData.headers['x-link'];
+          const query = url.parse(link, true).query;
+          assert.equal(
+            query.service,
+            options.serviceQuery,
+            'service is in link'
+          );
+        });
+    });
 
-     it('/password/forgot/verify_code should set an unverified account as verified', () => {
-       const email = server.uniqueEmail();
-       const password = 'something';
-       let client = null;
-       return Client.create(config.publicUrl, email, password, testOptions)
-         .then((c) => {
-           client = c;
-         })
-         .then(() => {
-           return client.emailStatus();
-         })
-         .then((status) => {
-           assert.equal(status.verified, false, 'email unverified');
-         })
-         .then(() => {
-           return server.mailbox.waitForCode(email); // ignore this code
-         })
-         .then(() => {
-           return client.forgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForCode(email);
-         })
-         .then((code) => {
-           return client.verifyPasswordResetCode(code);
-         })
-         .then(() => {
-           return client.emailStatus();
-         })
-         .then((status) => {
-           assert.equal(status.verified, true, 'account unverified');
-         });
-     });
+    it('forgot password, then get device list', () => {
+      const email = uniqueEmail();
+      const newPassword = 'foo';
+      let client;
+      return Client.createAndVerify(
+        config.publicUrl,
+        email,
+        'bar',
+        mailbox,
+        testOptions
+      )
+        .then((c) => {
+          client = c;
+          return client.updateDevice({
+            name: 'baz',
+            type: 'mobile',
+            pushCallback: 'https://updates.push.services.mozilla.com/qux',
+            pushPublicKey: mocks.MOCK_PUSH_KEY,
+            pushAuthKey: base64url(crypto.randomBytes(16)),
+          });
+        })
+        .then(() => {
+          return client.devices();
+        })
+        .then((devices) => {
+          assert.equal(devices.length, 1, 'devices list contains 1 item');
+        })
+        .then(() => {
+          return client.forgotPassword();
+        })
+        .then(() => {
+          return mailbox.waitForCode(email);
+        })
+        .then((code) => {
+          return resetPassword(client, code, newPassword);
+        })
+        .then(() => {
+          return upgradeCredentials(email, newPassword);
+        })
+        .then(() => {
+          return Client.login(
+            config.publicUrl,
+            email,
+            newPassword,
+            testOptions
+          );
+        })
+        .then((client) => {
+          return client.devices();
+        })
+        .then((devices) => {
+          assert.equal(devices.length, 0, 'devices list is empty');
+        });
+    });
 
-     it('forgot password with service query parameter', () => {
-       const email = server.uniqueEmail();
-       const options = {
-         ...testOptions,
-         redirectTo: `https://sync.${config.smtp.redirectDomain}/`,
-         serviceQuery: 'sync',
-       };
-       let client;
-       return Client.create(config.publicUrl, email, 'wibble', options)
-         .then((c) => {
-           client = c;
-         })
-         .then(() => {
-           return server.mailbox.waitForEmail(email);
-         })
-         .then(() => {
-           return client.forgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForEmail(email);
-         })
-         .then((emailData) => {
-           const link = emailData.headers['x-link'];
-           const query = url.parse(link, true).query;
-           assert.equal(
-             query.service,
-             options.serviceQuery,
-             'service is in link'
-           );
-         });
-     });
+    async function resetPassword(client, code, newPassword, headers, options) {
+      await client.verifyPasswordResetCode(code, headers, options);
+      await client.resetPassword(newPassword, {}, options);
+    }
 
-     it('forgot password, then get device list', () => {
-       const email = server.uniqueEmail();
-       const newPassword = 'foo';
-       let client;
-       return Client.createAndVerify(
-         config.publicUrl,
-         email,
-         'bar',
-         server.mailbox,
-         testOptions
-       )
-         .then((c) => {
-           client = c;
-           return client.updateDevice({
-             name: 'baz',
-             type: 'mobile',
-             pushCallback: 'https://updates.push.services.mozilla.com/qux',
-             pushPublicKey: mocks.MOCK_PUSH_KEY,
-             pushAuthKey: base64url(crypto.randomBytes(16)),
-           });
-         })
-         .then(() => {
-           return client.devices();
-         })
-         .then((devices) => {
-           assert.equal(devices.length, 1, 'devices list contains 1 item');
-         })
-         .then(() => {
-           return client.forgotPassword();
-         })
-         .then(() => {
-           return server.mailbox.waitForCode(email);
-         })
-         .then((code) => {
-           return resetPassword(client, code, newPassword);
-         })
-         .then(() => {
-           return upgradeCredentials(email, newPassword);
-         })
-         .then(() => {
-           return Client.login(
-             config.publicUrl,
-             email,
-             newPassword,
-             testOptions
-           );
-         })
-         .then((client) => {
-           return client.devices();
-         })
-         .then((devices) => {
-           assert.equal(devices.length, 0, 'devices list is empty');
-         });
-     });
-
-
-     async function resetPassword(client, code, newPassword, headers, options) {
-       await client.verifyPasswordResetCode(code, headers, options);
-       await client.resetPassword(newPassword, {}, options);
-     }
-
-     async function upgradeCredentials(email, newPassword) {
-       if (testOptions.version === 'V2') {
-         await Client.upgradeCredentials(config.publicUrl, email, newPassword, {
-           version: '',
-           key: true,
-         });
-       }
-     }
-   });
- });
+    async function upgradeCredentials(email, newPassword) {
+      if (testOptions.version === 'V2') {
+        await Client.upgradeCredentials(config.publicUrl, email, newPassword, {
+          version: '',
+          key: true,
+        });
+      }
+    }
+  });
+});

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -12,7 +12,6 @@ const proxyquire = require('proxyquire');
 const log = { trace() {}, info() {}, error() {}, debug() {}, warn() {} };
 
 const config = require('../../config').default.getProperties();
-const TestServer = require('../test_server');
 const Token = require('../../lib/tokens')(log);
 const { createDB } = require('../../lib/db');
 const mockStatsD = { increment: () => {} };
@@ -51,16 +50,13 @@ const mockLog = {
 };
 
 describe(`#integration - remote push db`, function () {
-  this.timeout(60000);
 
-  let dbServer, db;
+  let db;
   before(async () => {
-    dbServer = await TestServer.start(config);
     db = await DB.connect(config);
   });
 
   after(async () => {
-    await TestServer.stop(dbServer);
     await db.close();
   });
 

--- a/packages/fxa-auth-server/test/remote/recovery_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_code_tests.js
@@ -12,8 +12,7 @@ const otplib = require('otplib');
 const BASE_36 = require('../../lib/routes/validators').BASE_36;
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote backup authentication codes`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote backup authentication codes`, function () {
 
     let server, client, email, recoveryCodes;
     const recoveryCodeCount = 9;

--- a/packages/fxa-auth-server/test/remote/recovery_email_change_email.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_change_email.js
@@ -5,20 +5,19 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
+const config = require('../../config').default.getProperties();
+const TestServer = require('../test_server');
 
-let config, server, client, email, secondEmail;
-const password = 'allyourbasearebelongtous',
-  newPassword = 'newpassword';
+let client, email, secondEmail;
+const password = 'allyourbasearebelongtous';
+const newPassword = 'newpassword';
 
 [ {version:""}, {version:"V2"}].forEach((testOptions) => {
 
-describe(`#integration${testOptions.version} - remote change email`, function () {
-  this.timeout(60000);
-
+describe(`#integration${testOptions.version} - #serial - remote change email`, function () {
+  let server;
   before(async () => {
-    config = require('../../config').default.getProperties();
     config.securityHistory.ipProfiling = {};
     server = await TestServer.start(config);
   });

--- a/packages/fxa-auth-server/test/remote/recovery_email_emails.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_emails.js
@@ -14,8 +14,7 @@ const password = 'allyourbasearebelongtous';
 
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
-describe(`#integration${testOptions.version} - remote emails`, function () {
-  this.timeout(60000);
+describe(`#integration${testOptions.version} - #serial - remote emails`, function () {
 
   before(async function () {
     config = require('../../config').default.getProperties();

--- a/packages/fxa-auth-server/test/remote/recovery_email_resend_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_resend_code_tests.js
@@ -12,8 +12,7 @@ const config = require('../../config').default.getProperties();
 
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
-describe(`#integration${testOptions.version} - remote recovery email resend code`, function () {
-  this.timeout(60000);
+describe(`#integration${testOptions.version} - #serial - remote recovery email resend code`, function () {
   let server;
   before(async () => {
     config.securityHistory.ipProfiling.allowedRecency = 0;

--- a/packages/fxa-auth-server/test/remote/recovery_email_verify_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_verify_tests.js
@@ -7,25 +7,16 @@
 const { assert } = require('chai');
 const url = require('url');
 const Client = require('../client')();
-const TestServer = require('../test_server');
-
+const mailbox = require('../mailbox')();
 const config = require('../../config').default.getProperties();
+const { uniqueEmail } = require('../lib/util');
+
 
 [{version:""},{version:"V2"}].forEach((testOptions) => {
-
 describe(`#integration${testOptions.version} - remote recovery email verify`, function () {
-  this.timeout(60000);
-  let server;
-  before(async () => {
-    server = await TestServer.start(config);
-  });
-
-  after(async () => {
-    await TestServer.stop(server);
-  });
 
   it('create account verify with incorrect code', () => {
-    const email = server.uniqueEmail();
+    const email = uniqueEmail();
     const password = 'allyourbasearebelongtous';
     let client = null;
     return Client.create(config.publicUrl, email, password, testOptions)
@@ -62,7 +53,7 @@ describe(`#integration${testOptions.version} - remote recovery email verify`, fu
   });
 
   it('verification email link', () => {
-    const email = server.uniqueEmail();
+    const email = uniqueEmail();
     const password = 'something';
     const options = {
       ...testOptions,
@@ -71,7 +62,7 @@ describe(`#integration${testOptions.version} - remote recovery email verify`, fu
     };
     return Client.create(config.publicUrl, email, password, options)
       .then(() => {
-        return server.mailbox.waitForEmail(email);
+        return mailbox.waitForEmail(email);
       })
       .then((emailData) => {
         const link = emailData.headers['x-link'];

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -7,14 +7,14 @@
 const { assert } = require('chai');
 const config = require('../../config').default.getProperties();
 const crypto = require('crypto');
-const TestServer = require('../test_server');
 const Client = require('../client')();
+const mailbox = require('../mailbox')();
+const { uniqueEmail } = require('../lib/util');
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote recovery keys`, function () {
-    this.timeout(60000);
 
-    let server, client, email;
+    let client, email;
     const password = '(-.-)Zzz...';
 
     let recoveryKeyId;
@@ -40,20 +40,18 @@ const Client = require('../client')();
     }
 
     before(async () => {
-      server = await TestServer.start(config);
     });
 
     after(async () => {
-      await TestServer.stop(server);
     });
 
-    beforeEach(() => {
-      email = server.uniqueEmail();
-      return Client.createAndVerify(
+    beforeEach(async () => {
+      email = uniqueEmail();
+      await Client.createAndVerify(
         config.publicUrl,
         email,
         password,
-        server.mailbox,
+        mailbox,
         {
           ...testOptions,
           keys: true,
@@ -75,7 +73,7 @@ const Client = require('../client')();
             return client
               .createRecoveryKey(result.recoveryKeyId, result.recoveryData)
               .then((res) => assert.ok(res, 'empty response'))
-              .then(() => server.mailbox.waitForEmail(email))
+              .then(() => mailbox.waitForEmail(email))
               .then((emailData) => {
                 assert.equal(
                   emailData.headers['x-template-name'],
@@ -87,7 +85,7 @@ const Client = require('../client')();
     });
 
     it('should get account recovery key', () => {
-      return getAccountResetToken(client, server, email)
+      return getAccountResetToken(client, email)
         .then(() => client.getRecoveryKey(recoveryKeyId))
         .then((res) => {
           assert.equal(res.recoveryData, recoveryData, 'recoveryData returned');
@@ -95,7 +93,7 @@ const Client = require('../client')();
     });
 
     it('should fail to get unknown account recovery key', () => {
-      return getAccountResetToken(client, server, email)
+      return getAccountResetToken(client, email)
         .then(() => client.getRecoveryKey('abce1234567890'))
         .then(assert.fail, (err) => {
           assert.equal(err.errno, 159, 'account recovery key is not valid');
@@ -103,7 +101,7 @@ const Client = require('../client')();
     });
 
     async function checkPayloadV2(mutate, restore) {
-      await getAccountResetToken(client, server, email);
+      await getAccountResetToken(client, email);
       await client.getRecoveryKey(recoveryKeyId);
       let err;
       try {
@@ -181,7 +179,7 @@ const Client = require('../client')();
         return this.skip();
       }
 
-      return getAccountResetToken(client, server, email)
+      return getAccountResetToken(client, email)
         .then(() => client.getRecoveryKey(recoveryKeyId))
         .then((res) =>
           assert.equal(res.recoveryData, recoveryData, 'recoveryData returned')
@@ -205,7 +203,7 @@ const Client = require('../client')();
         return this.skip();
       }
 
-      return getAccountResetToken(client, server, email)
+      return getAccountResetToken(client, email)
         .then(() => client.getRecoveryKey(recoveryKeyId))
         .then((res) =>
           assert.equal(res.recoveryData, recoveryData, 'recoveryData returned')
@@ -225,7 +223,7 @@ const Client = require('../client')();
     });
 
     it('should reset password while keeping kB', async () => {
-      await getAccountResetToken(client, server, email);
+      await getAccountResetToken(client, email);
       let res = await client.getRecoveryKey(recoveryKeyId);
       assert.equal(res.recoveryData, recoveryData, 'recoveryData returned');
 
@@ -241,7 +239,7 @@ const Client = require('../client')();
       assert.equal(res.uid, client.uid, 'uid returned');
       assert.ok(res.sessionToken, 'sessionToken return');
 
-      const emailData = await server.mailbox.waitForEmail(email);
+      const emailData = await mailbox.waitForEmail(email);
       assert.equal(
         emailData.headers['x-template-name'],
         'passwordResetAccountRecovery',
@@ -278,7 +276,7 @@ const Client = require('../client')();
           .then((result) => {
             assert.equal(result.exists, false, 'account recovery key deleted');
           })
-          .then(() => server.mailbox.waitForEmail(email))
+          .then(() => mailbox.waitForEmail(email))
           .then((emailData) => {
             assert.equal(
               emailData.headers['x-template-name'],
@@ -303,18 +301,19 @@ const Client = require('../client')();
     describe('check account recovery key status', () => {
       describe('with sessionToken', () => {
         it('should return true if account recovery key exists and enabled', () => {
+          console.debug('staring problem test');
           return client.getRecoveryKeyExists().then((res) => {
             assert.equal(res.exists, true, 'account recovery key exists');
           });
         });
 
         it("should return false if account recovery key doesn't exist", () => {
-          email = server.uniqueEmail();
+          email = uniqueEmail();
           return Client.createAndVerify(
             config.publicUrl,
             email,
             password,
-            server.mailbox,
+            mailbox,
             {
               ...testOptions,
               keys: true,
@@ -334,12 +333,12 @@ const Client = require('../client')();
         });
 
         it('should return false if account recovery key exist but not enabled', async () => {
-          const email2 = server.uniqueEmail();
+          const email2 = uniqueEmail();
           const client2 = await Client.createAndVerify(
             config.publicUrl,
             email2,
             password,
-            server.mailbox,
+            mailbox,
             {
               ...testOptions,
               keys: true,
@@ -363,10 +362,10 @@ const Client = require('../client')();
     });
   });
 
-  function getAccountResetToken(client, server, email) {
+  function getAccountResetToken(client, email) {
     return client
       .forgotPassword()
-      .then(() => server.mailbox.waitForCode(email))
+      .then(() => mailbox.waitForCode(email))
       .then((code) =>
         client.verifyPasswordResetCode(
           code,

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -58,7 +58,7 @@ const isTwilioConfiguredForTest =
   config.twilio.testAuthToken?.length >= 24 &&
   config.twilio.credentialMode === 'test';
 
-describe(`#integration - recovery phone`, function () {
+describe(`#integration - #serial - recovery phone`, function () {
   // TODO: Something flakes... figure out where the slowdown is.
   this.timeout(10000);
 
@@ -285,7 +285,7 @@ describe(`#integration - recovery phone`, function () {
   });
 });
 
-describe('#integration - recovery phone - feature flag check', () => {
+describe('#integration - #serial - recovery phone - feature flag check', () => {
   let server;
   const temp = {};
 
@@ -333,7 +333,7 @@ describe('#integration - recovery phone - feature flag check', () => {
   });
 });
 
-describe(`#integration - recovery phone - customs checks`, function () {
+describe(`#integration - #serial - recovery phone - customs checks`, function () {
   let email;
   let client;
   let server;

--- a/packages/fxa-auth-server/test/remote/security_events.js
+++ b/packages/fxa-auth-server/test/remote/security_events.js
@@ -20,8 +20,7 @@
  }
 
  [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-   describe(`#integration${testOptions.version} - remote securityEvents`, function () {
-     this.timeout(60000);
+   describe(`#integration${testOptions.version} - #serial - remote securityEvents`, function () {
      let server;
 
      before(async function () {

--- a/packages/fxa-auth-server/test/remote/session_tests.js
+++ b/packages/fxa-auth-server/test/remote/session_tests.js
@@ -10,11 +10,10 @@ const Client = require('../client')();
 const config = require('../../config').default.getProperties();
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote session`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote session`, function () {
     let server;
-    config.signinConfirmation.skipForNewAccounts.enabled = false;
     before(async () => {
+      config.signinConfirmation.skipForNewAccounts.enabled = false;
       server = await TestServer.start(config);
     });
     after(async () => {

--- a/packages/fxa-auth-server/test/remote/sign_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/sign_key_tests.js
@@ -8,12 +8,11 @@ const { assert } = require('chai');
 const superagent = require('superagent');
 const TestServer = require('../test_server');
 const path = require('path');
+const config = require('../../config').default.getProperties();
 
-describe(`#integration - remote sign key`, function () {
-  this.timeout(60000);
+describe(`#integration - #serial - remote sign key`, function () {
   let server;
   before(async () => {
-    const config = require('../../config').default.getProperties();
     config.oldPublicKeyFile = path.resolve(
       __dirname,
       '../../config/public-key.json'

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -36,8 +36,7 @@ const PRODUCT_ID = 'megaProductHooray';
 const PRODUCT_NAME = 'All Done Pro';
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote subscriptions:`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote subscriptions:`, function () {
 
     before(async () => {
       config.subscriptions.stripeApiKey = null;

--- a/packages/fxa-auth-server/test/remote/token_expiry_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_expiry_tests.js
@@ -21,8 +21,7 @@ function fail() {
 
 [{version:""},{version:"V2"}].forEach((testOptions) => {
 
-describe(`#integration${testOptions.version} - remote token expiry`, function () {
-  this.timeout(60000);
+describe(`#integration${testOptions.version} -  #serial - remote token expiry`, function () {
   let server, config;
 
   before(async () => {

--- a/packages/fxa-auth-server/test/remote/totp_tests.js
+++ b/packages/fxa-auth-server/test/remote/totp_tests.js
@@ -7,9 +7,9 @@
 const { assert } = require('chai');
 const crypto = require('crypto');
 const config = require('../../config').default.getProperties();
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const otplib = require('otplib');
+const TestServer = require('../test_server');
 const { default: Container } = require('typedi');
 const {
   PlaySubscriptions,
@@ -19,8 +19,7 @@ const {
 } = require('../../lib/payments/iap/apple-app-store/subscriptions');
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
-  describe(`#integration${testOptions.version} - remote totp`, function () {
-    this.timeout(60000);
+  describe(`#integration${testOptions.version} - #serial - remote totp`, function () {
 
     let server, client, email, totpToken, authenticator;
     const password = 'pssssst';

--- a/packages/fxa-auth-server/test/remote/verifier_upgrade_tests.js
+++ b/packages/fxa-auth-server/test/remote/verifier_upgrade_tests.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const TestServer = require('../test_server');
 const Client = require('../client')();
 const log = { trace() {}, info() {}, debug() {}, warn() {}, error() {} };
 
@@ -34,9 +33,8 @@ const {
 
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
   describe(`#integration${testOptions.version} - remote verifier upgrade`, function () {
-    this.timeout(60000);
 
-    let client, db, server;
+    let client, db;
 
     before(async () => {
       config.verifierVersion = 0;
@@ -45,12 +43,10 @@ const {
       Container.set(PlaySubscriptions, {});
       Container.set(AppStoreSubscriptions, {});
 
-      server = await TestServer.start(config);
       db = await DB.connect(config);
     });
 
     after(async () => {
-      await TestServer.stop(server);
       await db.close();
     });
 
@@ -67,10 +63,8 @@ const {
       let account = await db.account(client.uid);
 
       assert.equal(account.verifierVersion, 0, 'wrong version');
-      await TestServer.stop(server);
 
       config.verifierVersion = 1;
-      server = await TestServer.start(config);
 
       client = await Client.login(
         config.publicUrl,

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.js
@@ -109,8 +109,7 @@ describe('#integration - scripts/bulk-mailer', function () {
   });
 
   it('fails if --input missing', () => {
-    return cp
-      .execAsync(
+    return execAsync(
         'node -r esbuild-register scripts/bulk-mailer --method sendVerifyEmail',
         execOptions
       )
@@ -123,8 +122,7 @@ describe('#integration - scripts/bulk-mailer', function () {
   });
 
   it('fails if --input file missing', () => {
-    return cp
-      .execAsync(
+    return execAsync(
         'node -r esbuild-register scripts/bulk-mailer --input does_not_exist --method sendVerifyEmail',
         execOptions
       )
@@ -137,8 +135,7 @@ describe('#integration - scripts/bulk-mailer', function () {
   });
 
   it('fails if --method missing', () => {
-    return cp
-      .execAsync(
+    return execAsync(
         'node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH}',
         execOptions
       )
@@ -151,8 +148,7 @@ describe('#integration - scripts/bulk-mailer', function () {
   });
 
   it('fails if --method is invalid', () => {
-    return cp
-      .execAsync(
+    return execAsync(
         'node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method doesNotExist',
         execOptions
       )
@@ -166,8 +162,7 @@ describe('#integration - scripts/bulk-mailer', function () {
 
   it('succeeds with valid input file and method, writing files to disk', () => {
     this.timeout(10000);
-    return cp
-      .execAsync(
+    return execAsync(
         `node -r esbuild-register scripts/bulk-mailer --input ${USER_DUMP_PATH} --method sendPasswordChangedEmail --write ${OUTPUT_DIRECTORY}`,
         execOptions
       )

--- a/packages/fxa-auth-server/test/scripts/check-users.js
+++ b/packages/fxa-auth-server/test/scripts/check-users.js
@@ -45,12 +45,11 @@ function createRandomEmailAddr(template) {
   return `${Math.random() + template}`;
 }
 
-describe('#integration - scripts/check-users:', function () {
-  this.timeout(60000);
-
+describe('#integration - #series - scripts/check-users:', function () {
   let server, db, validClient, invalidClient, filename;
 
   before(async () => {
+    this.timeout(15000);
     server = await TestServer.start(config);
     db = await DB.connect(config);
     validClient = await AuthClient.create(

--- a/packages/fxa-auth-server/test/scripts/prune-tokens.js
+++ b/packages/fxa-auth-server/test/scripts/prune-tokens.js
@@ -45,7 +45,6 @@ const redis = require('../../lib/redis')(
 );
 
 describe('#integration - scripts/prune-tokens', function () {
-  this.timeout(10000);
   let db;
 
   const toRandomBuff = (size) =>

--- a/packages/fxa-auth-server/test/server_setup.js
+++ b/packages/fxa-auth-server/test/server_setup.js
@@ -1,0 +1,19 @@
+const TestServer = require('./test_server');
+const config = require('../config').default.getProperties();
+
+
+let serverInstance = null;
+
+exports.mochaGlobalSetup = async function () {
+  serverInstance = await TestServer.start(config, false, { });
+  console.debug('✅ TestServer started.');
+}
+
+exports.mochaGlobalTeardown = async function () {
+  if (!serverInstance) {
+    console.warn('⚠️ No TestServer instance to stop, skipping teardown.');
+    return;
+  }
+    await TestServer.stop(serverInstance);
+    serverInstance = null;
+}

--- a/packages/fxa-auth-server/test/test_server.js
+++ b/packages/fxa-auth-server/test/test_server.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -70,17 +71,21 @@ TestServer.start = async function (config, printLogs, options) {
 };
 
 TestServer.prototype.start = async function () {
-  const { authServerMockDependencies = {} } = this.options;
-  const createAuthServer = proxyquire(
-    '../bin/key_server',
-    authServerMockDependencies
-  );
+  try {
+    const { authServerMockDependencies = {} } = this.options;
+    const createAuthServer = proxyquire(
+      '../bin/key_server',
+      authServerMockDependencies
+    );
+    this.server = await createAuthServer(this.config);
+    this.mail = await createMailHelper(this.printLogs);
 
-  this.server = await createAuthServer(this.config);
-  this.mail = await createMailHelper(this.printLogs);
-
-  if (this.config.profileServer.url) {
-    this.profileServer = await createProfileHelper();
+    if (this.config.profileServer.url) {
+      this.profileServer = await createProfileHelper();
+    }
+  } catch (err) {
+    console.error('❌ Error starting TestServer:', err);
+    throw err;
   }
 };
 
@@ -89,6 +94,7 @@ TestServer.stop = async function (server) {
     throw new Error('Server must be provided');
   }
   await server.stop();
+
 };
 
 TestServer.prototype.stop = async function () {


### PR DESCRIPTION
## Because

- fxa-auth-server integration tests cannot run in parallel

## This pull request

- Decouples most of the fxa-auth-server integration tests from the test server
- Adds a step to start and stop the test server with mochaGlobalBefore/After hooks
- Tags tests that cannot be run with the default config with "#series" so they can be run in series
- Adds a new workflow job to run the new series tests parallel to other test/build steps

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
