### PR TITLE
chore(build): serve Settings locally without proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ packages/fxa-content-server/rerun.txt
 packages/fxa-content-server/.tmp
 packages/fxa-content-server/.tscompiled
 packages/fxa-content-server/public/locales
+# serving Settings static files
+packages/fxa-content-server/app/settings
 
 # fxa-customs-server
 packages/fxa-customs-server/test/mocks/temp.netset

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -16,6 +16,7 @@
     "build-react-stage": "SKIP_PREFLIGHT_CHECK=true INLINE_RUNTIME_CHUNK=false NODE_OPTIONS=--openssl-legacy-provider BUILD_PATH=build/stage node scripts/build.js",
     "build-react-prod": "SKIP_PREFLIGHT_CHECK=true INLINE_RUNTIME_CHUNK=false NODE_OPTIONS=--openssl-legacy-provider BUILD_PATH=build/prod node scripts/build.js",
     "clean": "rimraf dist",
+    "copy-dev-build": "mkdir -p ../fxa-content-server/app/settings ; NODE_ENV=production yarn build-react-dev && cp -R build/dev ../fxa-content-server/app/settings",
     "compile": "tsc --noEmit",
     "gql-extract": "persistgraphql src ../../configs/gql/allowlist/fxa-settings.json --js --extension=ts ",
     "l10n-bundle": "yarn l10n:bundle packages/fxa-settings branding,react,settings",

--- a/packages/fxa-settings/scripts/build.js
+++ b/packages/fxa-settings/scripts/build.js
@@ -27,7 +27,7 @@ switch (buildDirTarget) {
     break;
   default:
     // This is for local development, and will result in everything being relative.
-    process.env.PUBLIC_URL = undefined;
+    process.env.PUBLIC_URL = process.env.PUBLIC_URL || '';
     break;
 }
 console.log(


### PR DESCRIPTION
Because:
 - we want to verify/test the production build of Settings locally

This commit:
 - adds 'script' to copy the build into content-server
 - serves the static files when in development and proxy is off
 - fixes 'undefined' being in the paths of the dev build

