### PR TITLE
bug(customs): Doesn't support long format emails

### DIFF
--- a/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
@@ -210,4 +210,21 @@ describe('rate-limit', () => {
       'action:testBlock',
     ]);
   });
+
+  it('supports long emails', async () => {
+    // Regression test for: FXA-9463
+    rateLimit = new RateLimit(
+      {
+        rules: parseConfigRules(['testBlock:email:1:1s:1hour']),
+      },
+      redis,
+      statsd
+    );
+    const email = Array(255).fill('β').join('') + '@restmail.net';
+    const check1 = await rateLimit.check('testBlock', { email });
+    const check2 = await rateLimit.check('testBlock', { email });
+
+    expect(check1).toBeNull();
+    expect(check2?.reason).toEqual('too-many-attempts');
+  });
 });


### PR DESCRIPTION
## Because

- Evidently customs would choke on very long emails, which could prevent signup in strange edge cases.

## This pull request

- Adds a test validating that this is no longer a problem in v2
- This is likely not a problem in the current implementation either since we are now using redis. It's still worth putting under test though.

## Issue that this pull request solves

Closes: FXA-9463

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This appears to be a non-issue that we are using Redis, but adding the test coverage doesn't hurt.
