### PR TITLE
fix(payments-next): Handle Stripe coupon errors

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -31,6 +31,10 @@ function getRedirectToUrl(
       ? 'upgrade'
       : 'checkout';
 
+  if (searchParams.coupon && pageType === CartEligibilityStatus.UPGRADE) {
+    delete searchParams.coupon;
+  }
+
   return new URL(
     buildRedirectUrl(offeringId, interval, page, pageType, {
       locale,
@@ -119,7 +123,10 @@ export default async function New({
 
     redirectToUrl = getRedirectToUrl(cart, params, searchParams);
   } catch (error) {
-    if (error.name === 'CartInvalidPromoCodeError') {
+    if (
+      error.name === 'CartSetupInvalidPromoCodeError' ||
+      error.name === 'CouponErrorCannotRedeem'
+    ) {
       cart = await setupCartAction(
         interval as SubplatInterval,
         offeringId,
@@ -128,7 +135,6 @@ export default async function New({
         undefined,
         fxaUid
       );
-
       redirectToUrl = getRedirectToUrl(cart, params, searchParams);
     } else if (
       error.name === 'RetrieveStripePriceInvalidOfferingError' ||

--- a/libs/payments/customer/src/lib/customer.error.ts
+++ b/libs/payments/customer/src/lib/customer.error.ts
@@ -87,10 +87,10 @@ export class PromotionCodeCustomerSubscriptionMismatchError extends PromotionCod
 }
 
 export class PromotionCodePriceNotValidError extends PromotionCodeError {
-  constructor(promotionCode: string, priceId: string, productId?: string) {
+  constructor(promotionId: string, priceId: string, productId?: string) {
     super(
       "Promotion code restricted to a product that doesn't match the product on this subscription",
-      { promotionCode, priceId, productId }
+      { promotionId, priceId, productId }
     );
     this.name = 'PromotionCodePriceNotValidError';
   }
@@ -124,6 +124,16 @@ export class PromotionCodeSanitizedError extends PromotionCodeError {
   constructor(message: string, code: string) {
     super(message, { name: code });
     this.name = 'PromotionCodeGenericError';
+  }
+}
+
+export class CouponErrorCannotRedeem extends PromotionCodeSanitizedError {
+  constructor() {
+    super(
+      'The code you entered cannot be applied — your account has a previous subscription to one of our services.',
+      'CouponErrorCannotRedeem'
+    );
+    this.name = 'CouponErrorCannotRedeem';
   }
 }
 

--- a/libs/payments/customer/src/lib/util/assertPromotionCodeApplicableToPrice.spec.ts
+++ b/libs/payments/customer/src/lib/util/assertPromotionCodeApplicableToPrice.spec.ts
@@ -17,7 +17,11 @@ describe('assertPromotionCodeApplicableToPrice', () => {
     const mockPromoCode = StripePromotionCodeFactory();
 
     expect(() =>
-      assertPromotionCodeApplicableToPrice(mockPromoCode, mockPrice, undefined)
+      assertPromotionCodeApplicableToPrice(
+        mockPromoCode.id,
+        mockPrice,
+        undefined
+      )
     ).toThrowError(PromotionCodePriceNotValidError);
   });
 

--- a/libs/payments/customer/src/lib/util/assertPromotionCodeApplicableToPrice.ts
+++ b/libs/payments/customer/src/lib/util/assertPromotionCodeApplicableToPrice.ts
@@ -7,9 +7,7 @@ import {
   StripeProduct,
   StripePromotionCode,
 } from '@fxa/payments/stripe';
-import {
-  PromotionCodePriceNotValidError,
-} from '../customer.error';
+import { PromotionCodePriceNotValidError } from '../customer.error';
 import { STRIPE_PRICE_METADATA, STRIPE_PRODUCT_METADATA } from '../types';
 
 export const assertPromotionCodeApplicableToPrice = (

--- a/libs/payments/ui/src/lib/actions/applyCoupon.ts
+++ b/libs/payments/ui/src/lib/actions/applyCoupon.ts
@@ -5,7 +5,6 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-
 import { getApp } from '../nestapp/app';
 import { CouponErrorMessageType } from '../utils/error-ftl-messages';
 
@@ -26,12 +25,15 @@ export const applyCouponAction = async (
     });
   } catch (err) {
     switch (err.name) {
+      case 'CouponErrorCannotRedeem':
+        return CouponErrorMessageType.CannotRedeem;
       case 'CouponErrorExpired':
         return CouponErrorMessageType.Expired;
       case 'CouponErrorGeneric':
         return CouponErrorMessageType.Generic;
       case 'CouponErrorLimitReached':
         return CouponErrorMessageType.LimitReached;
+      case 'CouponErrorInvalid':
       default:
         return CouponErrorMessageType.Invalid;
     }

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -53,6 +53,7 @@ import type {
 import { GetCartActionResult } from './validators/GetCartActionResult';
 import { GetSuccessCartActionResult } from './validators/GetSuccessCartActionResult';
 import {
+  CouponErrorCannotRedeem,
   PromotionCodeSanitizedError,
   TaxAddress,
   type SubplatInterval,
@@ -102,7 +103,7 @@ export class NextJSActionsService {
     private eligibilityService: EligibilityService,
     private productConfigurationManager: ProductConfigurationManager,
     @Inject(StatsDService) public statsd: StatsD
-  ) { }
+  ) {}
 
   @SanitizeExceptions()
   @NextIOValidator(GetCartStateActionArgs, GetCartStateActionResult)
@@ -169,10 +170,7 @@ export class NextJSActionsService {
   @NextIOValidator(GetCouponArgs, GetCouponResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async getCoupon(args: {
-    cartId: string;
-    version: number;
-  }) {
+  async getCoupon(args: { cartId: string; version: number }) {
     const couponCode = await this.cartService.getCoupon({
       cartId: args.cartId,
       version: args.version,
@@ -191,7 +189,11 @@ export class NextJSActionsService {
   }
 
   @SanitizeExceptions({
-    allowlist: [InvalidPromoCodeCartError, ProductConfigError],
+    allowlist: [
+      CouponErrorCannotRedeem,
+      InvalidPromoCodeCartError,
+      ProductConfigError,
+    ],
   })
   @NextIOValidator(SetupCartActionArgs, SetupCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
@@ -256,8 +258,8 @@ export class NextJSActionsService {
     );
 
     return {
-      result
-    }
+      result,
+    };
   }
 
   @SanitizeExceptions()
@@ -423,13 +425,13 @@ export class NextJSActionsService {
     uid?: string;
   }): Promise<
     | {
-      ok: true;
-      taxAddress: TaxAddress;
-    }
+        ok: true;
+        taxAddress: TaxAddress;
+      }
     | {
-      ok: false;
-      error: string;
-    }
+        ok: false;
+        error: string;
+      }
   > {
     const { cartId, version, offeringId, taxAddress, uid } = args;
 

--- a/libs/payments/ui/src/lib/utils/en.ftl
+++ b/libs/payments/ui/src/lib/utils/en.ftl
@@ -37,6 +37,7 @@ metadata-description-default = The page you requested was not found.
 
 ## Coupon Error Messages
 
+next-coupon-error-cannot-redeem = The code you entered cannot be redeemed — your account has a previous subscription to one of our services.
 next-coupon-error-expired = The code you entered has expired.
 next-coupon-error-generic = An error occurred processing the code. Please try again.
 next-coupon-error-invalid = The code you entered is invalid.

--- a/libs/payments/ui/src/lib/utils/error-ftl-messages.ts
+++ b/libs/payments/ui/src/lib/utils/error-ftl-messages.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export enum CouponErrorMessageType {
+  CannotRedeem = 'next-coupon-error-cannot-redeem',
   Expired = 'next-coupon-error-expired',
   Generic = 'next-coupon-error-generic',
   Invalid = 'next-coupon-error-invalid',
@@ -16,6 +17,8 @@ const BASIC_ERROR = 'next-basic-error-message';
 const getFallbackTextByFluentId = (key: string) => {
   switch (key) {
     // coupon error messages
+    case CouponErrorMessageType.CannotRedeem:
+      return 'The code you entered cannot be redeemed — your account has a previous subscription to one of our services.';
     case CouponErrorMessageType.Expired:
       return 'The code you entered has expired.';
     case CouponErrorMessageType.Generic:


### PR DESCRIPTION
## Because

- we don't allow coupons to be applied during upgrades
- there was an unhandled error for first-time coupons

## This pull request

- [x] prevents coupons from being applied on upgrade flows
- [x] adds and displays new coupon error message when existing customers attempting to redeem a first-time coupon on another product

## Issue that this pull request solves

Closes: FXA-11583

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x]  If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
<img width="975" alt="Screenshot 2025-06-12 at 10 06 39 AM" src="https://github.com/user-attachments/assets/b83e99b1-968c-45d2-80ab-67f2022237ba" />
