### PR TITLE
task: audit yarn resolutions – compression

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,7 +272,6 @@
     "asn1.js": ">=5.4.1",
     "bn.js": "^5.2.1",
     "css-minimizer-webpack-plugin": ">=4 <5",
-    "compression": "1.7.4",
     "elliptic": ">=6.5.4",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
     "koa": "^2.16.1",

--- a/packages/fxa-payments-server/.rescriptsrc.js
+++ b/packages/fxa-payments-server/.rescriptsrc.js
@@ -5,12 +5,17 @@
 const {
   permitAdditionalJSImports,
   suppressRuntimeErrorOverlay,
+  configureDevServerCompression,
   setModuleNameMapper,
 } = require('fxa-react/configs/rescripts');
 const tsconfigBase = require('../../tsconfig.base.json')
 
 module.exports = {
   webpack: permitAdditionalJSImports,
-  devServer: suppressRuntimeErrorOverlay,
+  devServer: (config) => {
+    let newConfig = suppressRuntimeErrorOverlay(config);
+    newConfig = configureDevServerCompression(newConfig);
+    return newConfig;
+  },
   jest: setModuleNameMapper(tsconfigBase),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -22567,7 +22567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"accepts@npm:^1.3.5, accepts@npm:~1.3.4, accepts@npm:~1.3.5, accepts@npm:~1.3.8":
+"accepts@npm:^1.3.5, accepts@npm:~1.3.4, accepts@npm:~1.3.8":
   version: 1.3.8
   resolution: "accepts@npm:1.3.8"
   dependencies:
@@ -25140,13 +25140,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.0.0":
-  version: 3.0.0
-  resolution: "bytes@npm:3.0.0"
-  checksum: a2b386dd8188849a5325f58eef69c3b73c51801c08ffc6963eddc9be244089ba32d19347caf6d145c86f315ae1b1fc7061a32b0c1aa6379e6a719090287ed101
-  languageName: node
-  linkType: hard
-
 "bytes@npm:3.1.2, bytes@npm:^3.0.0, bytes@npm:^3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
@@ -26631,7 +26624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compressible@npm:~2.0.16":
+"compressible@npm:~2.0.18":
   version: 2.0.18
   resolution: "compressible@npm:2.0.18"
   dependencies:
@@ -26640,18 +26633,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compression@npm:1.7.4":
-  version: 1.7.4
-  resolution: "compression@npm:1.7.4"
+"compression@npm:^1.7.4":
+  version: 1.8.0
+  resolution: "compression@npm:1.8.0"
   dependencies:
-    accepts: ~1.3.5
-    bytes: 3.0.0
-    compressible: ~2.0.16
+    bytes: 3.1.2
+    compressible: ~2.0.18
     debug: 2.6.9
+    negotiator: ~0.6.4
     on-headers: ~1.0.2
-    safe-buffer: 5.1.2
+    safe-buffer: 5.2.1
     vary: ~1.1.2
-  checksum: 35c0f2eb1f28418978615dc1bc02075b34b1568f7f56c62d60f4214d4b7cc00d0f6d282b5f8a954f59872396bd770b6b15ffd8aa94c67d4bce9b8887b906999b
+  checksum: 12ca3e326b4ccb6b6e51e1d14d96fafd058ddb3be08fe888487d367d42fb4f81f25d4bf77acc517ba724370e7d74469280688baf2da8cad61062bdf62eb9fd45
   languageName: node
   linkType: hard
 
@@ -43349,7 +43342,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^0.6.3":
+"negotiator@npm:^0.6.3, negotiator@npm:~0.6.4":
   version: 0.6.4
   resolution: "negotiator@npm:0.6.4"
   checksum: 7ded10aa02a0707d1d12a9973fdb5954f98547ca7beb60e31cb3a403cc6e8f11138db7a3b0128425cf836fc85d145ec4ce983b2bdf83dca436af879c2d683510


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches

## This pull request

- removes the resolution for `compression` transitive dependency

## Issue that this pull request solves

Closes: FXA-11866

## Other information

I originally added this resolution.  After removing it, `webpack-dev-server` installs `compression` v1.8.0, and we experience  failed functional tests due to "content encoding" errors. This can occur when compressing small files, and `compression` [provides a "threshold" property](https://expressjs.com/en/resources/middleware/compression.html) to mitigate.  Unfortunately `webpack-dev-server` [does not allow setting threshold for compression](https://webpack.js.org/configuration/dev-server/#devservercompress); it's boolean on or off.

Therefore, this PR also disables `webpack-dev-server` built-in compression, and reintroduces `compression` directly, customized with a 4kb threshold. By managing `compression` directly, we can prevent the encoding errors while maintaining compression for larger assets.