### PR TITLE
task: audit yarn resolutions – flat

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,7 +274,6 @@
     "css-minimizer-webpack-plugin": ">=4 <5",
     "compression": "1.7.4",
     "elliptic": ">=6.5.4",
-    "flat": "5.0.2",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
     "koa": "^2.16.1",
     "minimist": "^1.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -32850,7 +32850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flat@npm:5.0.2":
+"flat@npm:^5.0.2":
   version: 5.0.2
   resolution: "flat@npm:5.0.2"
   bin:


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches

## This pull request

- removes the resolution for `flat` package

## Issue that this pull request solves

Closes: FXA-11867

## Other information

I added this resolution after running into issues a couple months ago while [bulk-updating packages](https://github.com/mozilla/fxa/pull/18768).  We've done numerous upgrades and resolution removals since then, and I'm hoping it "just works".  After removing the resolution, the package still resolves at `5.0.2` (no change), suggesting this removal is safe.