### PR TITLE
fix(payments-ui): Update SubscriptionTitle

### DIFF
--- a/libs/payments/ui/src/lib/server/components/SubscriptionTitle/en.ftl
+++ b/libs/payments/ui/src/lib/server/components/SubscriptionTitle/en.ftl
@@ -6,5 +6,6 @@ next-subscription-processing-title = Confirming subscription…
 next-subscription-error-title = Error confirming subscription…
 subscription-title-sub-exists = You’ve already subscribed
 subscription-title-plan-change-heading = Review your change
+subscription-title-not-supported = This subscription plan change is not supported
 
 next-sub-guarantee = 30-day money-back guarantee

--- a/libs/payments/ui/src/lib/server/components/SubscriptionTitle/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/SubscriptionTitle/index.tsx
@@ -22,6 +22,15 @@ export function getComponentTitle(cart: CartDTO) {
           title: 'You’ve already subscribed',
           titleFtl: 'subscription-title-sub-exists',
         };
+      } else if (
+        errorReasonId === CartErrorReasonId.CART_ELIGIBILITY_STATUS_DOWNGRADE ||
+        errorReasonId === CartErrorReasonId.CART_ELIGIBILITY_STATUS_INVALID ||
+        errorReasonId === CartErrorReasonId.IAP_BLOCKED_CONTACT_SUPPORT
+      ) {
+        return {
+          title: 'This subscription plan change is not supported',
+          titleFtl: 'subscription-title-not-supported',
+        };
       } else {
         return {
           title: 'Error confirming subscription…',


### PR DESCRIPTION
## This pull request

- Revises title to `This subscription plan change is not supported` when `CartErrorReasonId` is either downgrade, invalid, or a blocked IAP

## Issue that this pull request solves

Closes: FXA-11839

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
<img width="1279" alt="Screenshot 2025-06-11 at 2 40 38 PM" src="https://github.com/user-attachments/assets/45509041-9776-4b8e-9569-d40619455c24" />