### PR TITLE
task(rate-limit): Support bans in rate-limit lib

### DIFF
--- a/libs/accounts/rate-limit/src/lib/config.ts
+++ b/libs/accounts/rate-limit/src/lib/config.ts
@@ -1,6 +1,6 @@
 import { duration, unitOfTime } from 'moment';
 import { IsArray, IsString } from 'class-validator';
-import { BlockOn, Rule } from './models';
+import { BlockOn, BlockPolicy, Rule } from './models';
 import { InvalidRule } from './error';
 import { getKey } from './util';
 
@@ -62,9 +62,9 @@ export function parseConfigRules(
 
     const parts = line.split(':').map((x) => x.trim());
 
-    if (parts.length !== 5) {
+    if (parts.length !== 6) {
       throw new InvalidRule(
-        `Issue detected on line ${lineNumber}. Rules must have 5 parts separated delimited by :. `,
+        `Issue detected on line ${lineNumber}. Rules must have 6 parts separated delimited by :. `,
         line
       );
     }
@@ -75,6 +75,7 @@ export function parseConfigRules(
       maxAttempts: Number.parseInt(parts[2]),
       windowDurationInSeconds: convertDurationToSeconds(parts[3]),
       blockDurationInSeconds: convertDurationToSeconds(parts[4]),
+      blockPolicy: (parts[5] || 'block') as BlockPolicy,
     } satisfies Rule;
 
     // A couple sanity checks to catch bad rule configuration
@@ -117,6 +118,9 @@ export function parseConfigRules(
         `Block duration must be a duration greater than 1 seconds.`,
         line
       );
+    }
+    if (!/^block$|^ban$/.test(rule.blockPolicy)) {
+      throw new InvalidRule(`Policy must be block or ban.`, line);
     }
 
     // Add the rule to the map.

--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -13,6 +13,16 @@ export type BlockOnOpts = {
   uid?: string;
 };
 
+/**
+ * Controls how the block is applied.
+ *  - block - only applies to the current action being checked, and is done in isolation.
+ *  - ban - will apply to the current action and all other actions being checked for the given rules ip, email, or uid.
+ **/
+export type BlockPolicy = 'block' | 'ban';
+
+/** Constant for the common error message, too-many-attempts. */
+export const TOO_MANY_ATTEMPTS = 'too-many-attempts';
+
 /** Reasons we might block. Currently only too-many-attempts is supported. */
 export type BlockReason = 'too-many-attempts';
 
@@ -26,6 +36,11 @@ export type Rule = {
   windowDurationInSeconds: number;
   /** The amount of time a block lasts for once it has been created.  */
   blockDurationInSeconds: number;
+  /**
+   * The policy that controls how exactly the block goes into effect.
+   * Be careful with 'ban'! See the 'BlockPolicy' type for more details.
+   **/
+  blockPolicy: BlockPolicy;
 };
 
 /** Represents a block held in redis. Not these objects will be stringified json.*/
@@ -46,6 +61,8 @@ export type BlockRecord = {
   reason: BlockReason;
   /** The attempt number when the block was added. */
   attempts: number;
+  /** Blocking policy to applied */
+  policy: BlockPolicy;
 };
 
 /** Reports back on the status of a check */
@@ -64,4 +81,6 @@ export type BlockStatus = {
   duration: number;
   /** The attempt number when the block was added. */
   attempt: number;
+  /** The type of block which occurred */
+  policy: BlockPolicy;
 };

--- a/libs/accounts/rate-limit/src/lib/rate-limit.provider.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.provider.spec.ts
@@ -25,7 +25,7 @@ describe('RateLimitProvider', () => {
   let rateLimit: RateLimit;
 
   const mockConfig = {
-    rules: ['test : ip : 1 : 1 second : 1 second '],
+    rules: ['test : ip : 1 : 1 second : 1 second : block '],
   };
   const mockConfigService = {
     get: jest.fn().mockImplementation((key: string) => {

--- a/libs/accounts/rate-limit/src/lib/util.ts
+++ b/libs/accounts/rate-limit/src/lib/util.ts
@@ -2,13 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { BlockRecord, Rule } from './models';
+import {
+  BlockOn,
+  BlockRecord,
+  BlockStatus,
+  Rule,
+  TOO_MANY_ATTEMPTS,
+} from './models';
+
+export function getBanKey(blockingOn: BlockOn, blockedValue: string) {
+  const sanitizedBlockedValue = sanitizeKeyValue(blockedValue);
+  return `rate-limit:ban:${blockingOn}=${sanitizedBlockedValue}`;
+}
 
 /**
  * Generates a redis key
  */
 export function getKey(
-  type: 'block' | 'attempts',
+  type: 'attempts' | 'block' | 'ban',
   action: string,
   rule: Rule,
   blockedValue: string
@@ -34,4 +45,80 @@ export function calculateRetryAfter(now: number, block: BlockRecord) {
  */
 export function sanitizeKeyValue(val: string) {
   return val.replace(':', ' ');
+}
+
+export function getLargestRetryAfter(blocks: BlockStatus[]) {
+  if (blocks.length > 0) {
+    return blocks.reduce((max, x) => (x.retryAfter > max.retryAfter ? x : max));
+  }
+  return null;
+}
+
+export function isBlockRecord(obj: any): obj is BlockRecord {
+  const result =
+    typeof obj.action === 'string' &&
+    typeof obj.blockingOn === 'string' &&
+    typeof obj.blockedValue === 'string' &&
+    typeof obj.startTime === 'number' &&
+    typeof obj.duration === 'number' &&
+    typeof obj.reason === 'string' &&
+    typeof obj.attempts === 'number' &&
+    typeof obj.policy === 'string';
+  return result;
+}
+
+export function parseBlockRecord(value: string | null): BlockRecord | null {
+  if (!value) {
+    return null;
+  }
+  const json = JSON.parse(value);
+
+  if (!json) {
+    return null;
+  }
+
+  // policy was not initially present and initially all policies were 'block'
+  if (json.policy == null) {
+    json.policy = 'block';
+  }
+
+  if (isBlockRecord(json)) {
+    return json as BlockRecord;
+  }
+
+  return null;
+}
+
+export function createBlockStatus(now: number, block: BlockRecord) {
+  return {
+    startTime: block.startTime,
+    duration: block.duration,
+    attempt: block.attempts,
+    retryAfter: calculateRetryAfter(now, block),
+    reason: block.reason,
+    action: block.action,
+    blockingOn: block.blockingOn,
+    policy: block.policy,
+  } satisfies BlockStatus;
+}
+
+export function createBlockRecord(
+  now: number,
+  action: string,
+  blockedValue: string,
+  attempts: number,
+  rule: Rule,
+  usedDefaultRule: boolean
+) {
+  return {
+    action: action,
+    startTime: now,
+    duration: rule.blockDurationInSeconds,
+    blockingOn: rule.blockingOn,
+    blockedValue: blockedValue,
+    reason: TOO_MANY_ATTEMPTS,
+    attempts: attempts,
+    usedDefaultRule,
+    policy: rule.blockPolicy,
+  } satisfies BlockRecord;
 }

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -5,78 +5,77 @@
 # non-configured action within a 10 minute window. Note that actions are still isolated. e.g. ActionA and
 # ActionB will maintain separate counts. So you could make up to 600 requests to action A and up to 600 requests
 # to Action B in a ten minute window without getting blocked.
-  default                               : ip                : 600           : 10 minutes        : 15 minutes
-  default                               : email             : 600           : 10 minutes        : 15 minutes
-  default                               : uid               : 600           : 10 minutes        : 15 minutes
+  default                               : ip                : 600           : 10 minutes        : 15 minutes  : block
+
 
 # Account Check Limits - These are unsecured actions. Many of these are designed to slow down the mining of
 # of account details. e.g. Trying random emails until an error code indicates one might exist.
-  accountCreate                         : ip                : 100           : 15 minutes        : 15 minutes
-  accountCreate                         : email             : 100           : 15 minutes        : 15 minutes
-  accountDestroy                        : uid               : 100           : 15 minutes        : 15 minutes
-  passwordForgotSendCode                : ip                : 100           : 15 minutes        : 15 minutes
-  passwordForgotSendCode                : email             : 100           : 15 minutes        : 15 minutes
-  accountStatusCheck                    : ip                : 100           : 15 minutes        : 15 minutes
-  accountStatusCheck                    : email             : 100           : 15 minutes        : 15 minutes
-  sendUnblockCode                       : ip                : 100           : 15 minutes        : 15 minutes
-  sendUnblockCode                       : email             : 100           : 15 minutes        : 15 minutes
-  recoveryKeyExists                     : ip                : 100           : 15 minutes        : 15 minutes
-  recoveryKeyExists                     : email             : 100           : 15 minutes        : 15 minutes
-  getCredentialsStatus                  : ip                : 100           : 15 minutes        : 15 minutes
-  getCredentialsStatus                  : email             : 100           : 15 minutes        : 15 minutes
-  passwordForgotSendOtp                 : ip                : 5             : 10 minutes        : 15 minutes
-  passwordForgotSendOtp                 : email             : 5             : 10 minutes        : 15 minutes
-  passwordForgotVerifyOtp               : ip                : 5             : 10 minutes        : 10 minutes
-  passwordForgotVerifyOtp               : email             : 5             : 10 minutes        : 10 minutes
-  passwordForgotVerifyOtpPerDay         : ip                : 10            : 24 hours          : 24 hours
-  passwordForgotVerifyOtpPerDay         : email             : 10            : 24 hours          : 24 hours
+  accountCreate                         : ip                : 100           : 15 minutes        : 15 minutes  : block
+  accountCreate                         : email             : 100           : 15 minutes        : 15 minutes  : block
+  accountDestroy                        : uid               : 100           : 15 minutes        : 15 minutes  : block
+  passwordForgotSendCode                : ip                : 100           : 15 minutes        : 15 minutes  : block
+  passwordForgotSendCode                : email             : 100           : 15 minutes        : 15 minutes  : block
+  accountStatusCheck                    : ip                : 100           : 15 minutes        : 15 minutes  : block
+  accountStatusCheck                    : email             : 100           : 15 minutes        : 15 minutes  : block
+  sendUnblockCode                       : ip                : 100           : 15 minutes        : 15 minutes  : block
+  sendUnblockCode                       : email             : 100           : 15 minutes        : 15 minutes  : block
+  recoveryKeyExists                     : ip                : 100           : 15 minutes        : 15 minutes  : block
+  recoveryKeyExists                     : email             : 100           : 15 minutes        : 15 minutes  : block
+  getCredentialsStatus                  : ip                : 100           : 15 minutes        : 15 minutes  : block
+  getCredentialsStatus                  : email             : 100           : 15 minutes        : 15 minutes  : block
+  passwordForgotSendOtp                 : ip                : 5             : 10 minutes        : 15 minutes  : block
+  passwordForgotSendOtp                 : email             : 5             : 10 minutes        : 15 minutes  : block
+  passwordForgotVerifyOtp               : ip                : 5             : 10 minutes        : 10 minutes  : block
+  passwordForgotVerifyOtp               : email             : 5             : 10 minutes        : 10 minutes  : block
+  passwordForgotVerifyOtpPerDay         : ip                : 10            : 24 hours          : 24 hours    : block
+  passwordForgotVerifyOtpPerDay         : email             : 10            : 24 hours          : 24 hours    : block
 
 # Email Send - These are limits on rate at which emails can be sent out. We limit both IP and email address
 # since many of these operations do not require authentication. Some operations, however, require sessions
 # and for these we should switch over to using UID. See FXA-11777 for more details.
-  createEmail                           : uid               : 5             : 15 minutes        : 15 minutes
-  recoveryEmailResendCode               : uid               : 5             : 15 minutes        : 15 minutes
-  recoveryEmailSecondaryResendCode      : email             : 5             : 15 minutes        : 15 minutes
-  recoveryEmailSecondaryResendCode      : ip                : 5             : 10 minutes        : 30 minutes
-  passwordForgotSendCode                : email             : 5             : 15 minutes        : 15 minutes
-  passwordForgotSendCode                : ip                : 5             : 10 minutes        : 30 minutes
-  passwordForgotResendCode              : email             : 5             : 15 minutes        : 15 minutes
-  passwordForgotResendCode              : ip                : 5             : 10 minutes        : 30 minutes
-  sendVerifyCode                        : uid               : 5             : 15 minutes        : 15 minutes
-  sendUnblockCode                       : email             : 5             : 15 minutes        : 15 minutes
-  sendUnblockCode                       : ip                : 5             : 10 minutes        : 30 minutes
-  unblockEmail                          : email             : 5             : 15 minutes        : 15 minutes
+  createEmail                           : uid               : 5             : 15 minutes        : 15 minutes  : block
+  recoveryEmailResendCode               : uid               : 5             : 15 minutes        : 15 minutes  : block
+  recoveryEmailSecondaryResendCode      : email             : 5             : 15 minutes        : 15 minutes  : block
+  recoveryEmailSecondaryResendCode      : ip                : 5             : 10 minutes        : 30 minutes  : block
+  passwordForgotSendCode                : email             : 5             : 15 minutes        : 15 minutes  : block
+  passwordForgotSendCode                : ip                : 5             : 10 minutes        : 30 minutes  : block
+  passwordForgotResendCode              : email             : 5             : 15 minutes        : 15 minutes  : block
+  passwordForgotResendCode              : ip                : 5             : 10 minutes        : 30 minutes  : block
+  sendVerifyCode                        : uid               : 5             : 15 minutes        : 15 minutes  : block
+  sendUnblockCode                       : email             : 5             : 15 minutes        : 15 minutes  : block
+  sendUnblockCode                       : ip                : 5             : 10 minutes        : 30 minutes  : block
+  unblockEmail                          : email             : 5             : 15 minutes        : 15 minutes  : block
 
 # Bad Login Attempts - These are specific to login failures. Again, the user hasn't authenticated yet, so we check both
 # email and ip.
-  accountLogin                          : email             : 5             : 15 minutes        : 15 minutes
-  accountLogin                          : ip                : 100           : 24 hours          : 24 hours
-  passwordChange                        : email             : 5             : 15 minutes        : 15 minutes
-  passwordChange                        : ip                : 100           : 24 hours          : 24 hours
-  authenticatedAccountLogin             : uid               : 5             : 15 minutes        : 15 minutes
-  authenticatedPasswordChange           : uid               : 5             : 15 minutes        : 15 minutes
+  accountLogin                          : email             : 5             : 15 minutes        : 15 minutes  : block
+  accountLogin                          : ip                : 100           : 24 hours          : 24 hours    : block
+  passwordChange                        : email             : 5             : 15 minutes        : 15 minutes  : block
+  passwordChange                        : ip                : 100           : 24 hours          : 24 hours    : block
+  authenticatedAccountLogin             : uid               : 5             : 15 minutes        : 15 minutes  : block
+  authenticatedPasswordChange           : uid               : 5             : 15 minutes        : 15 minutes  : block
 
 # Verify Code Limits - Limits the number of attempts a user can make at providing a token code. Note that currently
 # these are all ip/email checks, however, they should probably uid checks. In every use, a uid is available and the
 # user has already procured a session token. See FXA-11777 for more details.
-  recoveryEmailVerifyCode               : ip                : 10            : 10 minutes        : 30 minutes
-  recoveryEmailVerifyCode               : email             : 10            : 15 minutes        : 15 minutes
-  recoveryEmailSecondaryVerifyCode      : ip                : 10            : 10 minutes        : 30 minutes
-  recoveryEmailSecondaryVerifyCode      : email             : 10            : 15 minutes        : 15 minutes
-  passwordForgotVerifyCode              : ip                : 10            : 10 minutes        : 30 minutes
-  passwordForgotVerifyCode              : email             : 10            : 15 minutes        : 15 minutes
-  verifyRecoveryCode                    : ip                : 10            : 10 minutes        : 30 minutes
-  verifyRecoveryCode                    : email             : 10            : 15 minutes        : 15 minutes
-  verifySessionCode                     : uid               : 10            : 15 minutes        : 15 minutes
+  recoveryEmailVerifyCode               : ip                : 10            : 10 minutes        : 30 minutes  : block
+  recoveryEmailVerifyCode               : email             : 10            : 15 minutes        : 15 minutes  : block
+  recoveryEmailSecondaryVerifyCode      : ip                : 10            : 10 minutes        : 30 minutes  : block
+  recoveryEmailSecondaryVerifyCode      : email             : 10            : 15 minutes        : 15 minutes  : block
+  passwordForgotVerifyCode              : ip                : 10            : 10 minutes        : 30 minutes  : block
+  passwordForgotVerifyCode              : email             : 10            : 15 minutes        : 15 minutes  : block
+  verifyRecoveryCode                    : ip                : 10            : 10 minutes        : 30 minutes  : block
+  verifyRecoveryCode                    : email             : 10            : 15 minutes        : 15 minutes  : block
+  verifySessionCode                     : uid               : 10            : 15 minutes        : 15 minutes  : block
 
 # Verify TOTP Code Limits
-  verifyTotpCode                        : uid               : 10            : 30 seconds        : 15 minutes
+  verifyTotpCode                        : uid               : 10            : 30 seconds        : 15 minutes  : block
 
 # Recovery Phone Limits
-  verifyRecoveryPhoneTotpCode           : uid               : 5             : 5 minutes         : 15 minutes
-  recoveryPhoneSendSigninCode           : uid               : 6             : 24 hours          : 24 hours
-  recoveryPhoneSendSetupCode            : uid               : 9             : 24 hours          : 24 hours
-  recoveryPhoneSendResetPasswordCode    : uid               : 9             : 24 hours          : 24 hours
+  verifyRecoveryPhoneTotpCode           : uid               : 5             : 5 minutes         : 15 minutes  : block
+  recoveryPhoneSendSigninCode           : uid               : 6             : 24 hours          : 24 hours    : block
+  recoveryPhoneSendSetupCode            : uid               : 9             : 24 hours          : 24 hours    : block
+  recoveryPhoneSendResetPasswordCode    : uid               : 9             : 24 hours          : 24 hours    : block
 
 ## Code Search Results
 ##

--- a/packages/fxa-graphql-api/src/config/rate-limit-rules.txt
+++ b/packages/fxa-graphql-api/src/config/rate-limit-rules.txt
@@ -1,10 +1,11 @@
-#  action                               | blockOn       | maxAttempts   | windowDuration    | banDuration
-# ----------------------------------------------------------------------------------------------------------
-  default                               : ip            : 600           : 10 minutes        : 15 minutes
-  default                               : email         : 600           : 10 minutes        : 15 minutes
-  default                               : uid           : 600           : 10 minutes        : 15 minutes
-  unblockEmail                          : email         : 10            : 24 hours          : 24 hours
-  updateDisplayName                     : ip            : 60            : 15 minutes        : 15 minutes
+#  action                               | blockOn       | maxAttempts   | windowDuration    | banDuration | Block Policy
+# ------------------------------------------------------------------------------------------------------------------------
+  default                               : ip            : 600           : 10 minutes        : 15 minutes  : block
+  default                               : email         : 600           : 10 minutes        : 15 minutes  : block
+  default                               : uid           : 600           : 10 minutes        : 15 minutes  : block
+  unblockEmail                          : email         : 10            : 24 hours          : 24 hours    : block
+  updateDisplayName                     : ip            : 60            : 15 minutes        : 15 minutes  : block
+
 #
 ## Code Search Results
 ##


### PR DESCRIPTION
## Because

- Some actions need to trigger a ban
- Bans are more aggressive and result in a user being blocked from all other actions

## This pull request

- Updates rules to support allow configuration of a block or ban policy
- Updates rate-limit.check to support bans
- Makes a couple performance improvements by batching async calls with Promise.all


## Issue that this pull request solves

Closes: FXA-11850

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I broke this into two PRs to make review easier. Let's review and lank the PR for supporting ip_email as a blocking field first. Then review and land this one.
