### PR TITLE
task(rate-limit): Support blocking on 'ip_email'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,7 +31,5 @@
     "**/Thumbs.db": true,
     "**/storybook-static": true,
   },
-  "cSpell.words": [
-    "Frontends"
-  ]
+  "cSpell.words": ["Frontends", "obvisosly"]
 }

--- a/libs/accounts/rate-limit/README.md
+++ b/libs/accounts/rate-limit/README.md
@@ -19,6 +19,19 @@ This library is driven by a simple grammar for defining rules. The grammar is as
 Where a 'section' is separated by ':' and leading and trailing whitespace within a section is trimmed.
 Note that comments can be added by starting a line with '#'.
 
+- action - this is the user action being checked. e.g. loginAttempt.
+- blockOn - this is the property we are checking. Options are ip, email, ip_email, and uid.
+- maxAttempts - the number of tries until the rule is considered violated and block (or ban) occurs
+- windowDuration - this the time span over which actions are counted. Once the window ends, actions are allowed again.
+- blockDuration - this is how long the block (or ban) lasts. Note that while active, attempts are being not counted!
+
+### BlockOn
+
+- ip        - The user's IP. This is often useful for 'ban' policies, were we want to flag an IP that is making a large number of requests.
+- ip_email  - The user's ip with the user's email appended. This is useful for ensuring one user cannot impact another user's experience.
+- email     - The user's email. This is useful only when the account isn't known and for some reason, we don't want to use ip_email.
+- uid       - The user's account id. This can be useful from stopping a user that has logged in from doing something malicious, like trying to mine data.
+
 ### A quick example:
 
 As an example, to define an existing custom rules, let's say password reset OTP, the following config

--- a/libs/accounts/rate-limit/src/lib/config.ts
+++ b/libs/accounts/rate-limit/src/lib/config.ts
@@ -84,8 +84,11 @@ export function parseConfigRules(
         line
       );
     }
-    if (!/^ip$|^uid$|^email$/.test(rule.blockingOn)) {
-      throw new InvalidRule(`Blocking on must be ip, email, or uid.`, line);
+    if (!/^ip$|^uid$|^email$|^ip_email$/.test(rule.blockingOn)) {
+      throw new InvalidRule(
+        `Blocking on must be ip, email, uid, or ip_email.`,
+        line
+      );
     }
     if (
       rule.maxAttempts.toString() === 'NaN' ||

--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -3,7 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /** The attributes we can count and block on. */
-export type BlockOn = 'ip' | 'email' | 'uid';
+export type BlockOn = 'ip' | 'email' | 'uid' | 'ip_email';
+
+/** Standard set of fields that can be blocked on. */
+export type BlockOnOpts = {
+  email?: string;
+  ip?: string;
+  ip_email?: string;
+  uid?: string;
+};
 
 /** Reasons we might block. Currently only too-many-attempts is supported. */
 export type BlockReason = 'too-many-attempts';

--- a/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
@@ -32,16 +32,26 @@ describe('rate-limit', () => {
     await redis.flushall();
   });
 
-  for (const blockOn of ['ip', 'email', 'uid']) {
+  for (const blockOn of ['ip', 'email', 'uid', 'ip_email']) {
     it('should block on ' + blockOn, async () => {
       rateLimit = new RateLimit(
-        { rules: parseConfigRules(['testBlock:ip:1:1s:1s']) },
+        { rules: parseConfigRules([`testBlock:${blockOn}:1:1s:1s`]) },
         redis,
         statsd
       );
 
-      const check1 = await rateLimit.check('testBlock', { ip: '127.0.0.1' });
-      const check2 = await rateLimit.check('testBlock', { ip: '127.0.0.1' });
+      const check1 = await rateLimit.check('testBlock', {
+        ip_email: '127.0.0.1_foo@mozilla.com',
+        ip: '127.0.0.1',
+        email: 'foo@mozilla.com',
+        uid: '123',
+      });
+      const check2 = await rateLimit.check('testBlock', {
+        ip_email: '127.0.0.1_foo@mozilla.com',
+        ip: '127.0.0.1',
+        email: 'foo@mozilla.com',
+        uid: '123',
+      });
 
       expect(check1).toBeNull();
       expect(check2?.reason).toEqual('too-many-attempts');
@@ -49,7 +59,7 @@ describe('rate-limit', () => {
 
       expect(mockIncrement).toBeCalledTimes(1);
       expect(mockIncrement).toBeCalledWith('rate_limit.block', [
-        'on:ip',
+        `on:${blockOn}`,
         'action:testBlock',
       ]);
     });


### PR DESCRIPTION
## Because

- We want to be able to block in ip+email

## This pull request

- Adds support for ip_email as a blocking option
- Creates a 'BlockOnOpts' types
- Cleans up method signatures
- Adds some new tests

## Issue that this pull request solves

Closes: FXA-11858 (Partially, #19016 is the second half)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To make review easier, this was broken up into two PRs. See #19016 for the other half of FXA-11858.
