### PR TITLE
fix(metrics): Add a small delay before hard navigating away from React app

### DIFF
--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -7,6 +7,8 @@ import { Message, Pattern } from '@fluent/bundle/esm/ast';
 import { Localized, LocalizedProps, ReactLocalization } from '@fluent/react';
 import React from 'react';
 
+const DEFAULT_NAVIGATE_TIMEOUT_MS = 200;
+
 // There maybe situations where we are navigating away from the react app. For example when
 // directing back to an RP or the content-server. Let's use this function to make it clear this behavior is
 // intentional.
@@ -33,10 +35,16 @@ export function hardNavigate(
     url.searchParams.append(key, value);
   });
 
+  // We use setTimeout to ensure that the navigation happens after any pending
+  // metrics have been sent.
   if (replace) {
-    window.location.replace(url.href);
+    setTimeout(() => {
+      window.location.replace(url.href);
+    }, DEFAULT_NAVIGATE_TIMEOUT_MS);
   } else {
-    window.location.href = url.href;
+    setTimeout(() => {
+      window.location.href = url.href;
+    }, DEFAULT_NAVIGATE_TIMEOUT_MS);
   }
 }
 


### PR DESCRIPTION
## Because

- Our metrics before a hard navigate (ie navigating to an RP), might get dropped

## This pull request

- Adds a small delay before navigating away from React app

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11872

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

The Glean team wants a bugzilla and additionall steps to help troubleshoot. While we wait for that, I think its ok to land this change since it is small and gives incremental improvement. The 200ms delay is not noticable. 
