### PR TITLE
fix(payments-server): Update CDN reference

### DIFF
--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -247,10 +247,13 @@ const conf = convict({
       },
       schemaValidation: {
         cdnUrlRegex: {
-          default: '^https://accounts-static.cdn.mozilla.net',
+          default: [
+            '^https://accounts-static.cdn.mozilla.net',
+            '^https://cdn.accounts.firefox.com',
+          ],
           doc: 'CDN URL Regex',
           env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_CDN_URL_REGEX',
-          format: String,
+          format: Array,
         },
       },
     },

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -946,10 +946,13 @@ const convictConf = convict({
       },
       schemaValidation: {
         cdnUrlRegex: {
-          default: '^https://accounts-static.cdn.mozilla.net',
+          default: [
+            '^https://accounts-static.cdn.mozilla.net',
+            '^https://cdn.accounts.firefox.com',
+          ],
           doc: 'CDN URL Regex',
           env: 'SUBSCRIPTIONS_FIRESTORE_CONFIGS_CDN_URL_REGEX',
-          format: String,
+          format: Array,
         },
       },
     },

--- a/packages/fxa-auth-server/test/local/payments/configuration/manager.js
+++ b/packages/fxa-auth-server/test/local/payments/configuration/manager.js
@@ -45,7 +45,7 @@ const mockConfig = {
     },
     productConfigsFirestore: {
       schemaValidation: {
-        cdnUrlRegex: '^https://',
+        cdnUrlRegex: ['^https://'],
       },
     },
   },
@@ -407,9 +407,8 @@ describe('#integration - PaymentConfigManager', () => {
 
   describe('getMergedPlanConfiguration', () => {
     it('returns undefined when the plan is not found', async () => {
-      const actual = await paymentConfigManager.getMergedPlanConfiguration(
-        '404'
-      );
+      const actual =
+        await paymentConfigManager.getMergedPlanConfiguration('404');
       assert.isUndefined(actual);
     });
 

--- a/packages/fxa-auth-server/test/scripts/cancel-subscriptions-to-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/cancel-subscriptions-to-plan.ts
@@ -44,7 +44,7 @@ const mockConfig = {
     },
     productConfigsFirestore: {
       schemaValidation: {
-        cdnUrlRegex: '^http',
+        cdnUrlRegex: ['^http'],
       },
     },
   },

--- a/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.ts
+++ b/packages/fxa-auth-server/test/scripts/convert-customers-to-stripe-automatic-tax.ts
@@ -76,7 +76,7 @@ const mockConfig = {
     },
     productConfigsFirestore: {
       schemaValidation: {
-        cdnUrlRegex: '^http',
+        cdnUrlRegex: ['^http'],
       },
     },
   },
@@ -214,9 +214,8 @@ describe('StripeAutomaticTaxConverter', () => {
         ],
       });
 
-      result = await stripeAutomaticTaxConverter.fetchSubsBatch(
-        mockSubscriptionId
-      );
+      result =
+        await stripeAutomaticTaxConverter.fetchSubsBatch(mockSubscriptionId);
     });
 
     it('returns a list of subscriptions from Firestore', () => {
@@ -424,9 +423,8 @@ describe('StripeAutomaticTaxConverter', () => {
         updateStub = sinon.stub().resolves(mockCustomer);
         stripeStub.customers.update = updateStub;
 
-        result = await stripeAutomaticTaxConverter.enableTaxForCustomer(
-          mockCustomer
-        );
+        result =
+          await stripeAutomaticTaxConverter.enableTaxForCustomer(mockCustomer);
       });
 
       it('does not update customer', () => {

--- a/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/move-customers-to-new-plan.ts
@@ -69,7 +69,7 @@ const mockConfig = {
     },
     productConfigsFirestore: {
       schemaValidation: {
-        cdnUrlRegex: '^http',
+        cdnUrlRegex: ['^http'],
       },
     },
   },

--- a/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
+++ b/packages/fxa-auth-server/test/scripts/stripe-products-and-plans-converter.js
@@ -276,7 +276,7 @@ describe('StripeProductsAndPlansConverter', () => {
         converter.stripeProductToProductConfig(testProduct);
       assert.deepEqual(expectedProductConfig, actualProductConfig);
       const { error } = await ProductConfig.validate(actualProductConfig, {
-        cdnUrlRegex: '^http',
+        cdnUrlRegex: ['^http'],
       });
       assert.isUndefined(error);
     });
@@ -313,7 +313,7 @@ describe('StripeProductsAndPlansConverter', () => {
       const actualPlanConfig = converter.stripePlanToPlanConfig(testPlan);
       assert.deepEqual(expectedPlanConfig, actualPlanConfig);
       const { error } = await PlanConfig.validate(actualPlanConfig, {
-        cdnUrlRegex: '^https://',
+        cdnUrlRegex: ['^https://'],
       });
       assert.isUndefined(error);
     });
@@ -377,7 +377,7 @@ describe('StripeProductsAndPlansConverter', () => {
         },
         productConfigsFirestore: {
           schemaValidation: {
-            cdnUrlRegex: '^http',
+            cdnUrlRegex: ['^http'],
           },
         },
       },
@@ -458,7 +458,7 @@ describe('StripeProductsAndPlansConverter', () => {
         },
         productConfigsFirestore: {
           schemaValidation: {
-            cdnUrlRegex: '^http',
+            cdnUrlRegex: ['^http'],
           },
         },
       },
@@ -542,7 +542,7 @@ describe('StripeProductsAndPlansConverter', () => {
         },
         productConfigsFirestore: {
           schemaValidation: {
-            cdnUrlRegex: '^http',
+            cdnUrlRegex: ['^http'],
           },
         },
       },
@@ -741,9 +741,8 @@ describe('StripeProductsAndPlansConverter', () => {
 
     it('updates existing products and plans', async () => {
       // Put some configs into Firestore
-      const productConfigDocId1 = await paymentConfigManager.storeProductConfig(
-        productConfig1
-      );
+      const productConfigDocId1 =
+        await paymentConfigManager.storeProductConfig(productConfig1);
       await paymentConfigManager.storePlanConfig(
         planConfig1,
         productConfigDocId1

--- a/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.ts
+++ b/packages/fxa-auth-server/test/scripts/update-subscriptions-to-new-plan.ts
@@ -69,7 +69,7 @@ const mockConfig = {
     },
     productConfigsFirestore: {
       schemaValidation: {
-        cdnUrlRegex: '^http',
+        cdnUrlRegex: ['^http'],
       },
     },
   },

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -171,10 +171,10 @@ const conf = convict({
       format: 'url',
     },
     cdnFqdn: {
-      default: 'accounts-static.cdn.mozilla.net',
+      default: ['accounts-static.cdn.mozilla.net', 'cdn.accounts.firefox.com'],
       doc: 'The domain name where the legal doc downloads are hosted.',
       env: 'PAYMENT_LEGAL_DOWNLOAD_FQDN',
-      format: String,
+      format: Array,
     },
     httpResCacheLimit: {
       default: 65536,
@@ -351,7 +351,7 @@ const conf = convict({
     },
     accountsCdn: {
       url: {
-        default: 'https://accounts-static.cdn.mozilla.net',
+        default: 'https://cdn.accounts.firefox.com',
         doc: 'The URL of the Mozilla Accounts static content CDN',
         env: 'FXA_STATIC_CDN_URL',
         format: 'url',

--- a/packages/fxa-payments-server/server/lib/routes/legal-docs.js
+++ b/packages/fxa-payments-server/server/lib/routes/legal-docs.js
@@ -87,7 +87,7 @@ module.exports = {
     const docUrl = new URL(req.query.url);
 
     // Limit the redirect to just the CDN that's hosting the legal docs
-    if (docUrl.hostname !== cdnFqdn) {
+    if (!cdnFqdn.includes(docUrl.hostname)) {
       return res.sendStatus(400).end();
     }
 

--- a/packages/fxa-payments-server/server/lib/routes/legal-docs.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/legal-docs.test.js
@@ -19,7 +19,7 @@ jest.mock('@sentry/node', () => ({
 }));
 
 const legalDocsRoute = require('./legal-docs');
-const validUrl = 'https://accounts-static.cdn.mozilla.net/vpn';
+const validUrl = 'https://cdn.accounts.firefox.com/vpn';
 const noop = () => {};
 const mockRes = {
   sendStatus: jest.fn().mockReturnValue({ end: noop }),

--- a/packages/fxa-shared/subscriptions/configuration/base.ts
+++ b/packages/fxa-shared/subscriptions/configuration/base.ts
@@ -112,7 +112,7 @@ export interface BaseConfig {
 }
 
 export interface ProductConfigSchemaValidation {
-  cdnUrlRegex: string;
+  cdnUrlRegex: string[];
 }
 
 export const minimalConfigSchema = joi.object({
@@ -137,9 +137,9 @@ export const baseConfigSchema = minimalConfigSchema
 
 export function extendBaseConfigSchema(
   baseConfigSchema: joi.ObjectSchema,
-  cdnUrl: string
+  cdnUrls: string[]
 ): joi.ObjectSchema {
-  const pattern: RegExp = new RegExp(`${cdnUrl}`);
+  const pattern: RegExp = new RegExp(cdnUrls.map((url) => `^${url}`).join('|'));
 
   const updatedUrls = urlsSchema.keys({
     webIcon: joi.string().uri().regex(pattern),

--- a/packages/fxa-shared/subscriptions/validation.ts
+++ b/packages/fxa-shared/subscriptions/validation.ts
@@ -7,7 +7,7 @@ import Joi from 'joi';
 export const capabilitiesClientIdPattern = /^capabilities/;
 
 export const legalResourceDomainPattern =
-  /^https:\/\/accounts-static\.cdn\.mozilla\.net\/legal\/(.*)/;
+  /^https:\/\/(accounts-static\.cdn\.mozilla\.net|cdn\.accounts\.firefox\.com)\/legal\/(.*)/;
 
 export const commaArray = Joi.extend((joi) => ({
   base: joi.array(),

--- a/packages/fxa-shared/test/subscriptions/configuration/plan.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/plan.ts
@@ -31,7 +31,7 @@ const localesObject = {
 };
 
 const validSchemaValidation = {
-  cdnUrlRegex: '^https://',
+  cdnUrlRegex: ['^https://'],
 };
 
 describe('PlanConfig', () => {
@@ -92,7 +92,7 @@ describe('PlanConfig', () => {
     const obj = JSON.parse(JSON.stringify(firestoreObject));
     obj.urls.webIcon = 'https://web-icon.com';
     const result = await PlanConfig.validate(obj, {
-      cdnUrlRegex: 'invalidpattern',
+      cdnUrlRegex: ['invalidpattern'],
     });
     assert.isDefined(result.error);
     assert.isUndefined(result.value);
@@ -102,7 +102,7 @@ describe('PlanConfig', () => {
     const obj = JSON.parse(JSON.stringify(firestoreObject));
     obj.locales = localesObject;
     const result = await PlanConfig.validate(obj, {
-      cdnUrlRegex: 'invalidpattern',
+      cdnUrlRegex: ['invalidpattern'],
     });
     assert.isDefined(result.error);
     assert.isUndefined(result.value);

--- a/packages/fxa-shared/test/subscriptions/configuration/product.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/product.ts
@@ -38,7 +38,7 @@ const localesObject = {
 };
 
 const validSchemaValidation = {
-  cdnUrlRegex: '^https://',
+  cdnUrlRegex: ['^https://'],
 };
 
 describe('ProductConfig', () => {
@@ -83,7 +83,7 @@ describe('ProductConfig', () => {
 
   it('validates with error on an invalid URL Regex in productConfig', async () => {
     const result = await ProductConfig.validate(firestoreObject, {
-      cdnUrlRegex: 'invalidpattern',
+      cdnUrlRegex: ['invalidpattern'],
     });
     assert.isDefined(result.error);
     assert.isUndefined(result.value);
@@ -93,7 +93,7 @@ describe('ProductConfig', () => {
     const obj = JSON.parse(JSON.stringify(firestoreObject));
     obj.locales = localesObject;
     const result = await ProductConfig.validate(obj, {
-      cdnUrlRegex: 'invalidpattern',
+      cdnUrlRegex: ['invalidpattern'],
     });
     assert.isDefined(result.error);
     assert.isUndefined(result.value);

--- a/packages/fxa-shared/test/subscriptions/configuration/utils.ts
+++ b/packages/fxa-shared/test/subscriptions/configuration/utils.ts
@@ -205,7 +205,6 @@ describe('product configuration util functions', () => {
         ['de'],
         true
       );
-      console.log('hi', actual, CONFIGURATION_URLS);
       expect(actual).to.equal(CONFIGURATION_URLS);
     });
 


### PR DESCRIPTION
## Because

- we are referencing deprecated CDN

## This pull request

- adds support to new CDN (to remove deprecated one once Stripe metadata has been updated)

## Issue that this pull request solves

Closes: FXA-11869

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
