### PR TITLE
perf(front-end): Don't request product data without product ID

### DIFF
--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -203,6 +203,7 @@ export function useProductInfoState() {
   return useQuery<{ productInfo: RelierSubscriptionInfo }>(GET_PRODUCT_INFO, {
     client: apolloClient,
     variables: { input: productId },
+    skip: !productId,
   });
 }
 


### PR DESCRIPTION
Because:
* We send a GQL request when we don't need to, if product ID isn't present

This commit:
* Skips the request if it's not present

fixes FXA-11878

---

I filed an issue for this and then realized it's a 1-line fix, woot.