### PR TITLE
fix(profile-server): unit tests missing public dir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -662,6 +662,9 @@ jobs:
           name: Build shared libs
           command: NODE_OPTIONS="--max-old-space-size=7168" npx nx run-many -t build --projects=tag:scope:shared:lib --parallel=2
       - run:
+          name: create `var/public` dir for fxa-profile-server
+          command: yarn workspace fxa-profile-server prebuild
+      - run:
           name: Run unit tests
           command: NODE_OPTIONS="--max-old-space-size=7168" npx nx << parameters.nx_run >> --parallel=2 -t test-unit
           environment:


### PR DESCRIPTION
## Because

- the recent enabling of NX cache appears to have broken profile-server unit tests, complaining of missing folder that is created via prebuild script

## This pull request

- explicitly creates the missing folder as a CI step

## Issue that this pull request solves

Closes: FXA-11885

## Other information

The profile-server unit tests fail in CI because `var/public` is missing, and NX doesn’t run the prebuild script that creates it, or NX cache discards the empty dir. This issue is hidden locally since NX cache is off and the folder gets created. 
