### PR TITLE
fix(metrics): Redirect user to signin if missing keyFetchToken or unwrapBKey during confirm code

### DIFF
--- a/packages/functional-tests/lib/ratelimit.ts
+++ b/packages/functional-tests/lib/ratelimit.ts
@@ -37,8 +37,7 @@ export class RateLimitClient {
       );
       cursor = nextCursor;
       if (keys.length > 0) {
-        const deletedCount = await this.redis.del(...keys);
-        console.log(`Deleted ${deletedCount} keys from redis.`);
+        await this.redis.del(...keys);
       }
     } while (cursor !== '0');
   }

--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -20,3 +20,5 @@ signin-password-button-label = Password
 # tab. Firefox will attempt to send the user back to their original tab to use an email mask after
 # they successfully sign in or sign up for a Mozilla account to receive a free email mask.
 signin-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.
+
+signin-code-expired-error = Code expired. Please sign in again.

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -308,10 +308,9 @@ describe('confirm-signup-container', () => {
         unwrapBKey: undefined,
       });
       render();
-      screen.getByText('Bad Request');
-      screen.getByText(
-        'Something went wrong. Please close this tab and try again.'
-      );
+      expect(mockNavigate).toBeCalledWith('/signin', {
+        state: { localizedErrorMessage: 'Code expired. Please sign in again.' },
+      });
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -13,6 +13,7 @@ import {
 import {
   Integration,
   useAuthClient,
+  useFtlMsgResolver,
   useSensitiveDataClient,
 } from '../../../models';
 import ConfirmSignupCode from '.';
@@ -54,6 +55,7 @@ const SignupConfirmCodeContainer = ({
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const sensitiveDataClient = useSensitiveDataClient();
+  const ftlMsg = useFtlMsgResolver();
   const { keyFetchToken, unwrapBKey } =
     sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
 
@@ -135,6 +137,18 @@ const SignupConfirmCodeContainer = ({
     return <OAuthDataError error={oAuthDataError} gleanMetric={GleanMetrics.signupConfirmation.error} />;
   }
   if (oAuthKeysCheckError) {
+    if (!keyFetchToken || !unwrapBKey) {
+      const localizedErrorMessage = ftlMsg.getMsg(
+        'signin-code-expired-error',
+        'Code expired. Please sign in again.'
+      )
+      navigateWithQuery('/signin', {
+        state: {
+          localizedErrorMessage
+        }
+      });
+      return <LoadingSpinner fullScreen />;
+    }
     return <OAuthDataError error={oAuthKeysCheckError} gleanMetric={GleanMetrics.signupConfirmation.error}/>;
   }
 


### PR DESCRIPTION
## Because

- Users could end up in a deadend screen if keyFetchToken or unwrapBkey is not set in the confirm email code page

## This pull request

- Redirect the user to login again if those values are missing

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11810

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
![Screenshot 2025-06-13 at 4 15 52 PM](https://github.com/user-attachments/assets/dd97d538-fa94-454a-99bc-9e2a50b205ac)

After: 
![Screenshot 2025-06-13 at 4 06 40 PM](https://github.com/user-attachments/assets/1cce7a35-4301-4947-9d78-fce52bc5e0ce)

## Other information (Optional)

This might happen if a page/browser crashed. In order to continue that flow, they would need to close the tab and signin again.
