### PR TITLE
task(auth): Apply default rate limiting to all end points

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -360,7 +360,8 @@ async function run(config) {
     routes,
     database,
     statsd,
-    glean
+    glean,
+    customs
   );
 
   try {

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2185,6 +2185,24 @@ const convictConf = convict({
       env: 'RATE_LIMIT__RULES',
       format: String,
     },
+    checkAllEndpoints: {
+      default: true,
+      doc: 'Enables automatic rate limiting checks on all end points. Action will be {HTTP_METHOD}_${PATH.replaceAll("/","_")}',
+      env: 'RATE_LIMIT__CHECK_ALL_ENDPOINTS',
+      format: Boolean,
+    },
+    skipEndpoints: {
+      default: [
+        '__lbheartbeat__',
+        'config',
+        '__heartbeat__',
+        '__version__',
+        '',
+      ],
+      doc: 'When checkAllEndpoints is true, this is allows certain endpoints to be skipped from the automatic customs check.',
+      env: 'RATE_LIMIT__SKIP_ENDPOINTS',
+      format: Array
+    }
   },
   recoveryPhone: {
     enabled: {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -34,7 +34,8 @@ const CUSTOMS_METHOD_NAMES = [
   'checkIpOnly',
   'flag',
   'reset',
-  'v2Enabled'
+  'v2Enabled',
+  'checkV2',
 ];
 
 const DB_METHOD_NAMES = [


### PR DESCRIPTION
## Because

- We'd like all endpoints to be rate limited to some degree.

## This pull request

- Introduces rate limiting to all endpoints by hooking into hapi's onRequest event.
- With a defualt rate limit in place, all endoints will now be rate limitted.
- Specific endpoints can be adjusted beyond the default rate limit by specifying a rule with an action name like: 
`${HTTP METHOD}__${PATH}` and the rule name is lower case, and any `/` is replaced with `_`.

## Issue that this pull request solves

Closes: FXA-11890

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
