### PR TITLE
fix(payments-next):Do not report expected errors to Sentry

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -92,6 +92,13 @@ interface WrapWithCartCatchOptions {
   errorAllowList: Constructor<Error>[];
 }
 
+const IGNORED_EXPECTED_ERRORS_STATSD = new Set([
+  'PromotionCodePriceNotValidError',
+  'PromotionCodeNotFoundError',
+  'CouponErrorInvalidCode',
+  'AssertionError'
+]);
+
 @Injectable()
 export class CartService {
   constructor(
@@ -151,6 +158,12 @@ export class CartService {
         options.errorAllowList.some((ErrorClass) => error instanceof ErrorClass)
       ) {
         throw error;
+      }
+
+      if (error.name && IGNORED_EXPECTED_ERRORS_STATSD.has(error.name)) {
+        this.statsd.increment('checkout_failure_ignored_error', {
+          errorName: error.name
+        });
       }
 
       const errorReasonId = resolveErrorInstance(error);

--- a/libs/shared/sentry/src/lib/models/SentryConfigOpts.ts
+++ b/libs/shared/sentry/src/lib/models/SentryConfigOpts.ts
@@ -2,6 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { ErrorEvent } from '@sentry/core';
+
+export type ExtraOpts = {
+    integrations?: any[];
+    eventFilters?: Array<(event: ErrorEvent, hint: any) => ErrorEvent>;
+};
+
+export type InitSentryOpts = SentryConfigOpts & ExtraOpts;
+
 export type SentryConfigOpts = {
   /** Name of release */
   release?: string;

--- a/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { tagFxaName } from './tagFxaName';
+import { InitSentryOpts } from '../models/SentryConfigOpts';
+import { ErrorEvent } from '@sentry/core';
+
+const EXPECTED_ERRORS = new Set([
+  'PromotionCodePriceNotValidError',
+  'PromotionCodeNotFoundError',
+  'CouponErrorInvalidCode',
+  'AssertionError'
+]);
+
+export const beforeSend = function (event: ErrorEvent, hint: any, config: InitSentryOpts ) {
+
+  if (event.exception?.values) {
+    for (const value of event.exception.values) {
+      if (value.type && EXPECTED_ERRORS.has(value.type)) {
+        return null;
+      }
+    }
+  }
+
+  event = tagFxaName(event, config.sentry?.serverName || 'unknown');
+
+  config.eventFilters?.forEach((filter) => {
+    event = filter(event, hint);
+  });
+  return event;
+};


### PR DESCRIPTION
## Because

- The following errors don't seem appropriate for Sentry.

## This pull request

- Does not report expected errors to Sentry but records them to StatsD.

## Issue that this pull request solves

Closes: #FXA-11630

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
