### PR TITLE
feat(payments-next): add attribution fields to subscription metadata

### DIFF
--- a/libs/payments/cart/src/index.ts
+++ b/libs/payments/cart/src/index.ts
@@ -9,5 +9,6 @@ export * from './lib/cart.utils';
 export { CartInvalidStateForActionError } from './lib/cart.error';
 export * from './lib/checkout.service';
 export * from './lib/checkout.error';
+export * from './lib/checkout.types';
 export * from './lib/tax.service';
 export * from './lib/tax.types';

--- a/libs/payments/cart/src/lib/cart.factories.ts
+++ b/libs/payments/cart/src/lib/cart.factories.ts
@@ -21,6 +21,7 @@ import {
   UpdateCart,
   UpdateCartInput,
 } from './cart.types';
+import type { SubscriptionAttributionParams } from './checkout.types';
 
 const OFFERING_CONFIG_IDS = [
   'vpn',
@@ -39,6 +40,23 @@ export const CheckoutCustomerDataFactory = (
   displayName: faker.person.fullName(),
   ...override,
 });
+
+export const SubscriptionAttributionFactory = (
+  override?: Partial<SubscriptionAttributionParams>
+): SubscriptionAttributionParams => {
+  return {
+    utm_campaign: faker.lorem.words(3),
+    utm_content: faker.lorem.words(3),
+    utm_medium: faker.lorem.words(3),
+    utm_source: faker.lorem.words(3),
+    utm_term: faker.lorem.words(3),
+    session_flow_id: faker.string.uuid(),
+    session_entrypoint: faker.internet.url(),
+    session_entrypoint_experiment: faker.lorem.words(3),
+    session_entrypoint_variation: faker.lorem.words(3),
+    ...override,
+  };
+};
 
 export const SetupCartFactory = (override?: Partial<SetupCart>): SetupCart => ({
   offeringConfigId: faker.helpers.arrayElement(OFFERING_CONFIG_IDS),

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -86,6 +86,7 @@ import { SubmitNeedsInputFailedError } from './checkout.error';
 import { CheckoutService } from './checkout.service';
 import { resolveErrorInstance } from './util/resolveErrorInstance';
 import { isPaymentIntentId } from './util/isPaymentIntentId';
+import type { SubscriptionAttributionParams } from './checkout.types';
 
 type Constructor<T> = new (...args: any[]) => T;
 interface WrapWithCartCatchOptions {
@@ -472,6 +473,7 @@ export class CartService {
     version: number,
     confirmationTokenId: string,
     customerData: CheckoutCustomerData,
+    attribution: SubscriptionAttributionParams,
     sessionUid?: string
   ) {
     return this.wrapWithCartCatch(cartId, async () => {
@@ -497,6 +499,7 @@ export class CartService {
           updatedCart,
           confirmationTokenId,
           customerData,
+          attribution,
           sessionUid
         );
       });
@@ -508,6 +511,7 @@ export class CartService {
     cartId: string,
     version: number,
     customerData: CheckoutCustomerData,
+    attribution: SubscriptionAttributionParams,
     sessionUid?: string,
     token?: string
   ) {
@@ -533,6 +537,7 @@ export class CartService {
         await this.checkoutService.payWithPaypal(
           updatedCart,
           customerData,
+          attribution,
           sessionUid,
           token
         );

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -49,12 +49,15 @@ import {
   CartUidNotFoundError,
   CartNoTaxAddressError,
   PrepayCartCurrencyNotFoundError,
-  CartUidMismatchError
+  CartUidMismatchError,
 } from './cart.error';
 import { CartManager } from './cart.manager';
 import { CheckoutCustomerData, ResultCart } from './cart.types';
 import { handleEligibilityStatusMap } from './cart.utils';
-import { PrePayStepsResult } from './checkout.types';
+import type {
+  PrePayStepsResult,
+  SubscriptionAttributionParams,
+} from './checkout.types';
 import assert from 'assert';
 import {
   InvalidInvoiceStateCheckoutError,
@@ -289,6 +292,7 @@ export class CheckoutService {
     cart: ResultCart,
     confirmationTokenId: string,
     customerData: CheckoutCustomerData,
+    attribution: SubscriptionAttributionParams,
     sessionUid?: string
   ) {
     const {
@@ -332,6 +336,23 @@ export class CheckoutService {
                 // Note: These fields are due to missing Fivetran support on Stripe multi-currency plans
                 [STRIPE_SUBSCRIPTION_METADATA.Amount]: unitAmountForCurrency,
                 [STRIPE_SUBSCRIPTION_METADATA.Currency]: cart.currency,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmCampaign]:
+                  attribution.utm_campaign,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmContent]:
+                  attribution.utm_content,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmMedium]:
+                  attribution.utm_medium,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmSource]:
+                  attribution.utm_source,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmTerm]: attribution.utm_term,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionFlowId]:
+                  attribution.session_flow_id,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypoint]:
+                  attribution.session_entrypoint,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypointExperiment]:
+                  attribution.session_entrypoint_experiment,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypointVariation]:
+                  attribution.session_entrypoint_variation,
               },
             },
             {
@@ -343,7 +364,8 @@ export class CheckoutService {
             price.id,
             eligibility.fromPrice.id,
             cart,
-            eligibility.redundantOverlaps || []
+            eligibility.redundantOverlaps || [],
+            attribution
           );
 
     // Get payment/setup intent for subscription
@@ -425,6 +447,7 @@ export class CheckoutService {
   async payWithPaypal(
     cart: ResultCart,
     customerData: CheckoutCustomerData,
+    attribution: SubscriptionAttributionParams,
     sessionUid?: string,
     token?: string
   ) {
@@ -482,6 +505,23 @@ export class CheckoutService {
                 // Note: These fields are due to missing Fivetran support on Stripe multi-currency plans
                 [STRIPE_SUBSCRIPTION_METADATA.Amount]: unitAmountForCurrency,
                 [STRIPE_SUBSCRIPTION_METADATA.Currency]: cart.currency,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmCampaign]:
+                  attribution.utm_campaign,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmContent]:
+                  attribution.utm_content,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmMedium]:
+                  attribution.utm_medium,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmSource]:
+                  attribution.utm_source,
+                [STRIPE_SUBSCRIPTION_METADATA.UtmTerm]: attribution.utm_term,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionFlowId]:
+                  attribution.session_flow_id,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypoint]:
+                  attribution.session_entrypoint,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypointExperiment]:
+                  attribution.session_entrypoint_experiment,
+                [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypointVariation]:
+                  attribution.session_entrypoint_variation,
               },
             },
             {
@@ -493,7 +533,8 @@ export class CheckoutService {
             price.id,
             eligibility.fromPrice.id,
             cart,
-            eligibility.redundantOverlaps || []
+            eligibility.redundantOverlaps || [],
+            attribution
           );
 
     await this.paypalCustomerManager.deletePaypalCustomersByUid(uid);
@@ -549,7 +590,8 @@ export class CheckoutService {
     toPriceId: string,
     fromPriceId: string,
     cart: ResultCart,
-    redundantOverlaps: SubscriptionEligibilityUpgradeDowngradeResult[]
+    redundantOverlaps: SubscriptionEligibilityUpgradeDowngradeResult[],
+    attribution: SubscriptionAttributionParams
   ) {
     const upgradeSubscription =
       await this.subscriptionManager.retrieveForCustomerAndPrice(
@@ -596,6 +638,19 @@ export class CheckoutService {
           [STRIPE_SUBSCRIPTION_METADATA.PlanChangeDate]: Math.floor(
             Date.now() / 1000
           ),
+          [STRIPE_SUBSCRIPTION_METADATA.UtmCampaign]: attribution.utm_campaign,
+          [STRIPE_SUBSCRIPTION_METADATA.UtmContent]: attribution.utm_content,
+          [STRIPE_SUBSCRIPTION_METADATA.UtmMedium]: attribution.utm_medium,
+          [STRIPE_SUBSCRIPTION_METADATA.UtmSource]: attribution.utm_source,
+          [STRIPE_SUBSCRIPTION_METADATA.UtmTerm]: attribution.utm_term,
+          [STRIPE_SUBSCRIPTION_METADATA.SessionFlowId]:
+            attribution.session_flow_id,
+          [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypoint]:
+            attribution.session_entrypoint,
+          [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypointExperiment]:
+            attribution.session_entrypoint_experiment,
+          [STRIPE_SUBSCRIPTION_METADATA.SessionEntrypointVariation]:
+            attribution.session_entrypoint_variation,
         },
       }
     );

--- a/libs/payments/cart/src/lib/checkout.types.ts
+++ b/libs/payments/cart/src/lib/checkout.types.ts
@@ -14,3 +14,15 @@ export type PrePayStepsResult = Pick<ResultCart, 'version'> & {
   price: StripePrice;
   eligibility: SubscriptionEligibilityResult;
 };
+
+export type SubscriptionAttributionParams = {
+  utm_campaign: string;
+  utm_content: string;
+  utm_medium: string;
+  utm_source: string;
+  utm_term: string;
+  session_flow_id: string;
+  session_entrypoint: string;
+  session_entrypoint_experiment: string;
+  session_entrypoint_variation: string;
+};

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -26,7 +26,7 @@ export interface Interval {
 }
 
 export interface PricingForCurrency {
-  price: StripePrice,
+  price: StripePrice;
   unitAmountForCurrency: number | null;
   currencyOptionForCurrency: Stripe.Price.CurrencyOptions;
 }
@@ -60,6 +60,15 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   AutoCancelledRedundantFor = 'autoCancelledRedundantFor',
   RedundantCancellation = 'redundantCancellation',
   CancelledForCustomerAt = 'cancelled_for_customer_at',
+  UtmCampaign = 'utm_campaign',
+  UtmContent = 'utm_content',
+  UtmMedium = 'utm_medium',
+  UtmSource = 'utm_source',
+  UtmTerm = 'utm_term',
+  SessionFlowId = 'session_flow_id',
+  SessionEntrypoint = 'session_entrypoint',
+  SessionEntrypointExperiment = 'session_entrypoint_experiment',
+  SessionEntrypointVariation = 'session_entrypoint_variation',
 }
 
 export enum STRIPE_INVOICE_METADATA {

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
@@ -5,19 +5,21 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import type { SubscriptionAttributionParams } from '@fxa/payments/cart';
 
 export const checkoutCartWithPaypal = async (
   cartId: string,
   version: number,
   customerData: { locale: string; displayName: string },
+  attribution: SubscriptionAttributionParams,
   sessionUid?: string,
   token?: string
 ) => {
-
   await getApp().getActionsService().checkoutCartWithPaypal({
     cartId,
     version,
     customerData,
+    attribution,
     sessionUid,
     token,
   });

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
@@ -5,6 +5,7 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import type { SubscriptionAttributionParams } from '@fxa/payments/cart';
 
 export const checkoutCartWithStripe = async (
   cartId: string,
@@ -14,14 +15,15 @@ export const checkoutCartWithStripe = async (
     locale: string;
     displayName: string;
   },
-  sessionUid?: string,
+  attribution: SubscriptionAttributionParams,
+  sessionUid?: string
 ) => {
-
   getApp().getActionsService().checkoutCartWithStripe({
     cartId,
     version,
     customerData,
     confirmationTokenId,
+    attribution,
     sessionUid,
   });
 };

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -17,7 +17,12 @@ import {
   StripePaymentElementChangeEvent,
 } from '@stripe/stripe-js';
 import Image from 'next/image';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import {
+  ReadonlyURLSearchParams,
+  useParams,
+  useRouter,
+  useSearchParams,
+} from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { BaseButton, ButtonVariant, CheckoutCheckbox } from '@fxa/payments/ui';
@@ -35,6 +40,21 @@ import { CartErrorReasonId } from '@fxa/shared/db/mysql/account/kysely-types';
 import { PaymentProvidersType } from '@fxa/payments/cart';
 import PaypalIcon from '@fxa/shared/assets/images/payment-methods/paypal.svg';
 import spinnerWhiteImage from '@fxa/shared/assets/images/spinnerwhite.svg';
+
+const getAttributionParams = (searchParams: ReadonlyURLSearchParams) => {
+  const paramsRecord = Object.fromEntries(searchParams);
+  return {
+    utm_campaign: paramsRecord['utm_campaign'] ?? '',
+    utm_content: paramsRecord['utm_content'] ?? '',
+    utm_medium: paramsRecord['utm_medium'] ?? '',
+    utm_source: paramsRecord['utm_source'] ?? '',
+    utm_term: paramsRecord['utm_term'] ?? '',
+    session_flow_id: paramsRecord['flow_id'] ?? '',
+    session_entrypoint: paramsRecord['entrypoint'] ?? '',
+    session_entrypoint_experiment: paramsRecord['entrypoint_experiment'] ?? '',
+    session_entrypoint_variation: paramsRecord['entrypoint_variation'] ?? '',
+  };
+};
 
 interface CheckoutFormProps {
   cmsCommonContent: {
@@ -154,11 +174,15 @@ export function CheckoutForm({
         'external_paypal'
       );
 
-      await checkoutCartWithPaypal(cart.id, cart.version, {
-        locale,
-        displayName: '',
-      },
-        sessionUid,
+      await checkoutCartWithPaypal(
+        cart.id,
+        cart.version,
+        {
+          locale,
+          displayName: '',
+        },
+        getAttributionParams(searchParams),
+        sessionUid
       );
 
       const queryParamString = searchParams.toString()
@@ -221,12 +245,16 @@ export function CheckoutForm({
       selectedPaymentMethod as PaymentProvidersType
     );
 
-    await checkoutCartWithStripe(cart.id, cart.version, confirmationToken.id,
+    await checkoutCartWithStripe(
+      cart.id,
+      cart.version,
+      confirmationToken.id,
       {
-      locale,
-      displayName: fullName,
+        locale,
+        displayName: fullName,
       },
-      sessionUid,
+      getAttributionParams(searchParams),
+      sessionUid
     );
 
     const queryParamString = searchParams.toString()
@@ -365,6 +393,7 @@ export function CheckoutForm({
                       locale,
                       displayName: '',
                     },
+                    getAttributionParams(searchParams),
                     sessionUid,
                     data.orderID
                   );

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -82,6 +82,7 @@ import {
 } from '@fxa/shared/metrics/statsd';
 import { GetCartStateActionArgs } from './validators/GetCartStateActionArgs';
 import { GetCartStateActionResult } from './validators/GetCartStateActionResult';
+import type { SubscriptionAttributionParams } from '@fxa/payments/cart';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -102,7 +103,7 @@ export class NextJSActionsService {
     private eligibilityService: EligibilityService,
     private productConfigurationManager: ProductConfigurationManager,
     @Inject(StatsDService) public statsd: StatsD
-  ) { }
+  ) {}
 
   @SanitizeExceptions()
   @NextIOValidator(GetCartStateActionArgs, GetCartStateActionResult)
@@ -169,10 +170,7 @@ export class NextJSActionsService {
   @NextIOValidator(GetCouponArgs, GetCouponResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async getCoupon(args: {
-    cartId: string;
-    version: number;
-  }) {
+  async getCoupon(args: { cartId: string; version: number }) {
     const couponCode = await this.cartService.getCoupon({
       cartId: args.cartId,
       version: args.version,
@@ -256,8 +254,8 @@ export class NextJSActionsService {
     );
 
     return {
-      result
-    }
+      result,
+    };
   }
 
   @SanitizeExceptions()
@@ -268,6 +266,7 @@ export class NextJSActionsService {
     cartId: string;
     version: number;
     customerData: { locale: string; displayName: string };
+    attribution: SubscriptionAttributionParams;
     sessionUid?: string;
     token?: string;
   }) {
@@ -275,6 +274,7 @@ export class NextJSActionsService {
       args.cartId,
       args.version,
       args.customerData,
+      args.attribution,
       args.sessionUid,
       args.token
     );
@@ -289,6 +289,7 @@ export class NextJSActionsService {
     version: number;
     confirmationTokenId: string;
     customerData: { locale: string; displayName: string };
+    attribution: SubscriptionAttributionParams;
     sessionUid?: string;
   }) {
     await this.cartService.checkoutCartWithStripe(
@@ -296,6 +297,7 @@ export class NextJSActionsService {
       args.version,
       args.confirmationTokenId,
       args.customerData,
+      args.attribution,
       args.sessionUid
     );
   }
@@ -423,13 +425,13 @@ export class NextJSActionsService {
     uid?: string;
   }): Promise<
     | {
-      ok: true;
-      taxAddress: TaxAddress;
-    }
+        ok: true;
+        taxAddress: TaxAddress;
+      }
     | {
-      ok: false;
-      error: string;
-    }
+        ok: false;
+        error: string;
+      }
   > {
     const { cartId, version, offeringId, taxAddress, uid } = args;
 

--- a/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithPaypalActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithPaypalActionArgs.ts
@@ -10,6 +10,46 @@ import {
   ValidateNested,
 } from 'class-validator';
 
+export class CheckoutCartWithPaypalActionUtmAttributionData {
+  @IsString()
+  campaign!: string;
+
+  @IsString()
+  content!: string;
+
+  @IsString()
+  medium!: string;
+
+  @IsString()
+  source!: string;
+
+  @IsString()
+  term!: string;
+}
+
+export class CheckoutCartWithPaypalActionSessionAttributionData {
+  @IsString()
+  flow_id!: string;
+
+  @IsString()
+  entrypoint!: string;
+
+  @IsString()
+  entrypoint_experiment!: string;
+
+  @IsString()
+  entrypoint_variation!: string;
+}
+export class CheckoutCartWithPaypalActionAttributionData {
+  @Type(() => CheckoutCartWithPaypalActionUtmAttributionData)
+  @ValidateNested()
+  utm!: CheckoutCartWithPaypalActionUtmAttributionData;
+
+  @Type(() => CheckoutCartWithPaypalActionSessionAttributionData)
+  @ValidateNested()
+  session!: CheckoutCartWithPaypalActionSessionAttributionData;
+}
+
 export class CheckoutCartWithPaypalActionCustomerData {
   @IsString()
   locale!: string;
@@ -36,4 +76,8 @@ export class CheckoutCartWithPaypalActionArgs {
   @Type(() => CheckoutCartWithPaypalActionCustomerData)
   @ValidateNested()
   customerData!: CheckoutCartWithPaypalActionCustomerData;
+
+  @Type(() => CheckoutCartWithPaypalActionAttributionData)
+  @ValidateNested()
+  attributionData!: CheckoutCartWithPaypalActionAttributionData;
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithStripeActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CheckoutCartWithStripeActionArgs.ts
@@ -5,6 +5,47 @@
 import { Type } from 'class-transformer';
 import { IsNumber, IsString, ValidateNested, IsOptional } from 'class-validator';
 
+export class CheckoutCartWithStripeActionUtmAttributionData {
+  @IsString()
+  campaign!: string;
+
+  @IsString()
+  content!: string;
+
+  @IsString()
+  medium!: string;
+
+  @IsString()
+  source!: string;
+
+  @IsString()
+  term!: string;
+}
+
+export class CheckoutCartWithStripeActionSessionAttributionData {
+  @IsString()
+  flow_id!: string;
+
+  @IsString()
+  entrypoint!: string;
+
+  @IsString()
+  entrypoint_experiment!: string;
+
+  @IsString()
+  entrypoint_variation!: string;
+}
+export class CheckoutCartWithStripeActionAttributionData {
+  @Type(() => CheckoutCartWithStripeActionUtmAttributionData)
+  @ValidateNested()
+  utm!: CheckoutCartWithStripeActionUtmAttributionData;
+
+  @Type(() => CheckoutCartWithStripeActionSessionAttributionData)
+  @ValidateNested()
+  session!: CheckoutCartWithStripeActionSessionAttributionData;
+}
+
+
 export class CheckoutCartWithStripeActionCustomerData {
   @IsString()
   locale!: string;
@@ -30,4 +71,8 @@ export class CheckoutCartWithStripeActionArgs {
   @IsString()
   @IsOptional()
   sessionUid?: string;
+
+  @Type(() => CheckoutCartWithStripeActionAttributionData)
+  @ValidateNested()
+  attributionData!: CheckoutCartWithStripeActionAttributionData;
 }


### PR DESCRIPTION
Because:

* With the changes to SP3 glean metrics reporting, we lose the ability to associate utm and session parameters with an fxa account, but this is necessary for marketing to analyze the success of thecapaigns

This commit:

* passes attribution data from the front end through to the subscription creation/update event

Closes #FXA-11879

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
