### PR TITLE
fix(reset): pass state to back 2fa code page from sms code error

### DIFF
--- a/packages/functional-tests/pages/resetPassword.ts
+++ b/packages/functional-tests/pages/resetPassword.ts
@@ -156,6 +156,12 @@ export class ResetPasswordPage extends BaseLayout {
     return this.page.getByRole('button', { name: 'Continue' });
   }
 
+  get errorBannerBackupCodeLink() {
+    return this.page.getByRole('link', {
+      name: 'Use backup authentication codes instead?',
+    });
+  }
+
   goto(route = '/reset_password', query?: string) {
     const url = query
       ? `${this.target.contentServerUrl}${route}?${query}`
@@ -233,10 +239,10 @@ export class ResetPasswordPage extends BaseLayout {
   }
 
   async clickChoosePhone() {
-    return this.page.locator('.input-radio-wrapper').first().click();
+    await this.page.locator('.input-radio-wrapper').first().click();
   }
 
   async clickContinueButton() {
-    return this.page.getByRole('button', { name: 'Continue' });
+    await this.page.getByRole('button', { name: 'Continue' }).click();
   }
 }

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -100,6 +100,7 @@ export const Banner = ({
               className="text-sm link-blue"
               to={link.path}
               {...(link.gleanId && { 'data-glean-id': link.gleanId })}
+              {...(link.locationState && { state: link.locationState })}
             >
               {link.localizedText}
             </Link>

--- a/packages/fxa-settings/src/components/Banner/interfaces.ts
+++ b/packages/fxa-settings/src/components/Banner/interfaces.ts
@@ -62,6 +62,7 @@ export type ExternalLinkProps = {
   localizedText: string;
   gleanId?: string;
   path?: never;
+  locationState?: never;
 };
 
 export type InternalLinkProps = {
@@ -69,6 +70,7 @@ export type InternalLinkProps = {
   localizedText: string;
   gleanId?: string;
   url?: never;
+  locationState?: Record<string, any>;
 };
 
 export type DismissButtonProps = {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.tsx
@@ -10,9 +10,7 @@ import { ResetPasswordRecoveryPhoneLocationState } from './interfaces';
 import { useAuthClient } from '../../../models';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 
-const ResetPasswordRecoveryPhoneContainer = (
-  _: RouteComponentProps
-) => {
+const ResetPasswordRecoveryPhoneContainer = (_: RouteComponentProps) => {
   const authClient = useAuthClient();
   const navigateWithQuery = useNavigateWithQuery();
 
@@ -20,7 +18,7 @@ const ResetPasswordRecoveryPhoneContainer = (
     state: ResetPasswordRecoveryPhoneLocationState;
   };
 
-  const lastFourPhoneDigits = locationState.state.lastFourPhoneDigits || "";
+  const lastFourPhoneDigits = locationState.state.lastFourPhoneDigits || '';
 
   const handleSuccess = async () => {
     try {
@@ -35,7 +33,10 @@ const ResetPasswordRecoveryPhoneContainer = (
 
   const verifyCode = async (otpCode: string) => {
     try {
-      await authClient.recoveryPhoneResetPasswordConfirm(locationState.state.token, otpCode)
+      await authClient.recoveryPhoneResetPasswordConfirm(
+        locationState.state.token,
+        otpCode
+      );
 
       await handleSuccess();
       return;
@@ -63,6 +64,7 @@ const ResetPasswordRecoveryPhoneContainer = (
         lastFourPhoneDigits,
         verifyCode,
         resendCode,
+        location: locationState,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.test.tsx
@@ -37,7 +37,9 @@ describe('ResetPasswordRecoveryPhone', () => {
   });
 
   it('renders as expected', async () => {
-    renderWithLocalizationProvider(<ResetPasswordRecoveryPhone {...defaultProps} />);
+    renderWithLocalizationProvider(
+      <ResetPasswordRecoveryPhone {...defaultProps} />
+    );
 
     expect(screen.getByRole('button', { name: 'Back' })).toBeInTheDocument();
     expect(
@@ -62,7 +64,9 @@ describe('ResetPasswordRecoveryPhone', () => {
 
   it('has expected glean click events', async () => {
     const user = userEvent.setup();
-    renderWithLocalizationProvider(<ResetPasswordRecoveryPhone {...defaultProps} />);
+    renderWithLocalizationProvider(
+      <ResetPasswordRecoveryPhone {...defaultProps} />
+    );
 
     await waitFor(() => user.type(screen.getByRole('textbox'), '123456'));
 
@@ -86,7 +90,9 @@ describe('ResetPasswordRecoveryPhone', () => {
   });
 
   it('submits with valid code', async () => {
-    renderWithLocalizationProvider(<ResetPasswordRecoveryPhone {...defaultProps} />);
+    renderWithLocalizationProvider(
+      <ResetPasswordRecoveryPhone {...defaultProps} />
+    );
 
     const input = screen.getByRole('textbox');
 
@@ -98,7 +104,9 @@ describe('ResetPasswordRecoveryPhone', () => {
   });
 
   it('handles invalid code', async () => {
-    renderWithLocalizationProvider(<ResetPasswordRecoveryPhone {...propsWithError} />);
+    renderWithLocalizationProvider(
+      <ResetPasswordRecoveryPhone {...propsWithError} />
+    );
 
     const input = screen.getByRole('textbox');
 
@@ -118,7 +126,9 @@ describe('ResetPasswordRecoveryPhone', () => {
   });
 
   it('handles resend code', async () => {
-    renderWithLocalizationProvider(<ResetPasswordRecoveryPhone {...defaultProps} />);
+    renderWithLocalizationProvider(
+      <ResetPasswordRecoveryPhone {...defaultProps} />
+    );
 
     userEvent.click(screen.getByRole('button', { name: 'Resend code' }));
 
@@ -126,7 +136,9 @@ describe('ResetPasswordRecoveryPhone', () => {
   });
 
   it('handles `Are you locked out?` link', async () => {
-    renderWithLocalizationProvider(<ResetPasswordRecoveryPhone {...defaultProps} />);
+    renderWithLocalizationProvider(
+      <ResetPasswordRecoveryPhone {...defaultProps} />
+    );
 
     const link = screen.getByRole('link', { name: /Are you locked out/i });
     expect(link).toHaveAttribute(

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.tsx
@@ -22,6 +22,7 @@ const ResetPasswordRecoveryPhone = ({
   lastFourPhoneDigits,
   verifyCode,
   resendCode,
+  location,
 }: ResetPasswordRecoveryPhoneProps & RouteComponentProps) => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const [errorDescription, setErrorDescription] = React.useState('');
@@ -76,6 +77,7 @@ const ResetPasswordRecoveryPhone = ({
             'Use backup authentication codes instead?'
           ),
           gleanId: 'reset_password_backup_phone_error_use_backup_code_link',
+          ...(location?.state ? { locationState: location.state } : {}),
         });
         return;
       }
@@ -130,6 +132,7 @@ const ResetPasswordRecoveryPhone = ({
               path: errorLink.path,
               localizedText: errorLink.localizedText,
               gleanId: errorLink.gleanId,
+              locationState: errorLink.locationState,
             } as BannerLinkProps,
           })}
         />

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/interfaces.ts
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { HandledError } from '../../../lib/error-utils';
-import { Integration } from '../../../models';
 import { CompleteResetPasswordLocationState } from '../CompleteResetPassword/interfaces';
 
-export type ResetPasswordRecoveryPhoneLocationState = CompleteResetPasswordLocationState & {
-  lastFourPhoneDigits: string;
-};
+export type ResetPasswordRecoveryPhoneLocationState =
+  CompleteResetPasswordLocationState & {
+    lastFourPhoneDigits: string;
+  };
 
 export type ResetPasswordRecoveryPhoneProps = {
   lastFourPhoneDigits: string;

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/mocks.tsx
@@ -23,6 +23,7 @@ export const Subject = ({
           lastFourPhoneDigits,
           verifyCode,
           resendCode,
+          locationState: {} as any,
         }}
       />
     </LocationProvider>


### PR DESCRIPTION
Because:
 - the error banner for failed recovery phone code during password reset has a link to use backup codes, but it doesn't pass the necessary state for the functionality

This commit:
 - updates the link in the error banner so that it has the state with the required token for password reset with backup auth codes
 - adds a functional test
 - fixes minor bugs where clicks in functional tests were not awaited

