### PR TITLE
fix(oauth): Allow empty string `login_hint`

### DIFF
--- a/packages/functional-tests/tests/oauth/loginHint.spec.ts
+++ b/packages/functional-tests/tests/oauth/loginHint.spec.ts
@@ -17,6 +17,17 @@ test.describe('severity-2 #smoke', () => {
       await expect(page.getByText('Valid email required')).toBeVisible();
     });
 
+    test('allows empty login_hint', async ({
+                                                        pages: { page, relier, signup }, target
+                                                      }) => {
+      await relier.goto(`login_hint=`);
+      await relier.clickEmailFirst();
+
+      // Email first page does not prefill an email
+      await expect(signup.emailFormHeading).toBeVisible();
+      await expect(signup.emailTextbox).toHaveValue('');
+    });
+
     test('login_hint specified by relier, not registered', async ({
       page,
       pages: { signup, relier },

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -38,7 +38,7 @@ const SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA = {
   ),
   keys_jwk: Vat.keysJwk().renameTo('keysJwk'),
   id_token_hint: Vat.idToken().renameTo('idTokenHint'),
-  login_hint: Vat.email().renameTo('loginHint'),
+  login_hint: Vat.email().allow('').renameTo('loginHint'),
   max_age: Vat.number().min(0).renameTo('maxAge'),
   prompt: Vat.prompt(),
   redirect_uri: Vat.url()

--- a/packages/fxa-settings/src/models/integrations/data/data.ts
+++ b/packages/fxa-settings/src/models/integrations/data/data.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
+  Allow,
   IsBoolean,
   IsEmail,
   IsHexadecimal,
@@ -58,6 +59,7 @@ export class IntegrationData extends ModelDataProvider {
 
   @IsOptional()
   @IsString()
+  @Allow()
   @bind(T.snakeCase)
   loginHint: string | undefined;
 

--- a/packages/fxa-settings/src/models/pages/signin/oauth-query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signin/oauth-query-params.ts
@@ -16,6 +16,7 @@ import {
   IsNumber,
   Min,
   Validate,
+  Allow,
 } from 'class-validator';
 import {
   bind,
@@ -75,6 +76,7 @@ export class OAuthQueryParams extends ModelDataProvider {
 
   @IsOptional()
   @IsEmail()
+  @Allow()
   @bind(T.snakeCase)
   loginHint!: string;
 


### PR DESCRIPTION
## Because

- Some RPs send over an empty string for the login_hint

## This pull request

- Ignores empty string values for login_hint, ie `login_hint=` if they are sent
- Allows this value in React and Backbone app

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11916

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The OpenID spec says this value is optional, but depends on the server if they want to reject (strict) or allow (lenient) the value if it is empty

> login_hint
    OPTIONAL. Hint to the Authorization Server about the login identifier the End-User might use to log in (if necessary). This hint can be used by an RP if it first asks the End-User for their e-mail address (or other identifier) and then wants to pass that value as a hint to the discovered authorization service. It is RECOMMENDED that the hint value match the value used for discovery. This value MAY also be a phone number in the format specified for the phone_number Claim. The use of this parameter is left to the OP's discretion. 
