### PR TITLE
feat(payments-next): populate fxa flow id in subplat glean

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/landing/route.ts
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/landing/route.ts
@@ -149,9 +149,9 @@ export async function GET(
   try {
     try {
       const metricsFlow = await getMetricsFlowAction();
-      redirectToUrl.searchParams.set('flowId', metricsFlow.flowId);
+      redirectToUrl.searchParams.set('flow_id', metricsFlow.flowId);
       redirectToUrl.searchParams.set(
-        'flowBeginTime',
+        'flow_begin_time',
         metricsFlow.flowBeginTime.toString()
       );
     } catch (error) {

--- a/libs/shared/metrics/glean/src/lib/metrics.context.ts
+++ b/libs/shared/metrics/glean/src/lib/metrics.context.ts
@@ -31,12 +31,13 @@ export class MetricsContext {
 
   constructor(queryParams?: Record<string, string | undefined>) {
     queryParams = queryParams || {};
-    this.deviceId = queryParams['deviceId'];
+    this.deviceId = queryParams['deviceId'] || queryParams['device_id'];
     this.entrypoint = queryParams['entrypoint'];
-    this.flowId = queryParams['flowId'];
-    this.flowBeginTime = queryParams['flowBeginTime']
-      ? Number(queryParams['flowBeginTime'])
-      : undefined;
+    this.flowId = queryParams['flowId'] || queryParams['flow_id'];
+    this.flowBeginTime =
+      queryParams['flowBeginTime'] || queryParams['flow_begin_time']
+        ? Number(queryParams['flowBeginTime'] || queryParams['flow_begin_time'])
+        : undefined;
     this.utmCampaign =
       queryParams['utmCampaign'] || queryParams['utm_campaign'];
     this.utmContent = queryParams['utmContent'] || queryParams['utm_content'];


### PR DESCRIPTION
Because:

* fxa flow id was not getting pupulated because of a snake_case/camelCase mismatch

This commit:

* fixes the mismatch, preferring snake_case but accepting camelCase

Closes #FXA-11881

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
