### PR TITLE
task(content-server): update miniCssExtractPlugin configuration

### DIFF
--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -205,7 +205,7 @@ const webpackConfig = {
 
   plugins: [
     new MiniCssExtractPlugin({
-      filename: '../../app/styles/[name].css',
+      filename: '../../app/styles/main.css',
     }),
     // dynamically loaded routes cause the .md file to be read and a
     // warning to be displayed on the console. Just ignore them.


### PR DESCRIPTION
## Because

- An unexpected appDependencies.css was generated by the recently added MiniCssExtractPlugin.

- `[name].css` was used as the output filename as before, which was expected to resolve to `main.css`.

- The SCSS is imported from a non-entry module, and Webpack assigns a fallback chunk name, "appDependencies".

## This pull request

- sets the plugin’s filename explicitly to `main.css`, restoring original behavior and preventing unintended file generation.

## Issue that this pull request solves

Closes: FXA-11922

## Other information
Misconfiguration introduced via https://github.com/mozilla/fxa/pull/18996
