### PR TITLE
feat(settings): Update Monitor promo

### DIFF
--- a/libs/shared/l10n/src/lib/branding.ftl
+++ b/libs/shared/l10n/src/lib/branding.ftl
@@ -38,13 +38,16 @@
 -product-firefox-account = Firefox account
 
 -product-mozilla-vpn = Mozilla VPN
+-product-mozilla-vpn-short = VPN
 -product-mozilla-hubs = Mozilla Hubs
 # Mozilla Developer Network
 -product-mdn = MDN
 -product-mdn-plus = MDN Plus
 -product-firefox-cloud = Firefox Cloud
 -product-mozilla-monitor = Mozilla Monitor
+-product-mozilla-monitor-short = Monitor
 -product-firefox-relay = Firefox Relay
+-product-firefox-relay-short = Relay
 -product-pocket = Pocket
 
 -brand-apple = Apple

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
@@ -126,7 +126,7 @@ describe('PageSettings', () => {
         );
         expect(GleanMetrics.accountPref.promoMonitorView).toBeCalledTimes(1);
         expect(GleanMetrics.accountPref.promoMonitorView).toBeCalledWith({
-          event: { reason: 'free' },
+          event: { reason: 'default' },
         });
       });
       it('user has all products and subscriptions', async () => {

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -15,10 +15,7 @@ import { SETTINGS_PATH } from 'fxa-settings/src/constants';
 import { Localized } from '@fluent/react';
 import DataCollection from '../DataCollection';
 import GleanMetrics from '../../../lib/glean';
-import ProductPromo, {
-  getProductPromoData,
-  ProductPromoType,
-} from '../ProductPromo';
+import ProductPromo, { getProductPromoData } from '../ProductPromo';
 import SideBar from '../Sidebar';
 import Head from 'fxa-react/components/Head';
 import { SettingsIntegration } from '../interfaces';
@@ -93,11 +90,11 @@ export const PageSettings = ({
   useEffect(() => {
     // We want this view event to fire whenever the account settings page view
     // event fires, if the user is shown the promo.
-    const { gleanEvent, hasAllPromoProducts } = getProductPromoData(
+    const { gleanEvent, hidePromo } = getProductPromoData(
       attachedClients,
       subscriptions
     );
-    if (!hasAllPromoProducts && !productPromoGleanEventSent) {
+    if (!hidePromo && !productPromoGleanEventSent) {
       GleanMetrics.accountPref.promoMonitorView(gleanEvent);
       // Keep track of this because `attachedClients` can change on disconnect
       setProductPromoGleanEventSent(true);
@@ -171,7 +168,7 @@ export const PageSettings = ({
             </Link>
           </Localized>
         </div>
-        <ProductPromo type={ProductPromoType.Settings} />
+        <ProductPromo type="settings" />
       </div>
     </div>
   );

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/en.ftl
@@ -2,9 +2,12 @@
 
 product-promo-monitor =
  .alt = { -product-mozilla-monitor }
-product-promo-monitor-description = Find where your private info is exposed — and take it back
-product-promo-monitor-plus-description = Privacy Matters: Find where your private info is exposed and take it back
+product-promo-monitor-description-v2 = Find where your private info is exposed and take control
+# this message will only be shown to users eligible for a special promotion, based on their location (initially USA only)
+# $price - formatted for user locale, in the target market's currency (for launch, always USD)
+# /mo is 'per month'
+product-promo-monitor-special-promo-description = For { $price }/mo, save on { -product-mozilla-vpn-short }, { -product-mozilla-monitor-short }’s data-broker protection, and { -product-firefox-relay-short }’s unlimited email masks.
 # Links out to the Monitor site
 product-promo-monitor-cta = Get free scan
 # Links out to the Monitor pricing site
-product-promo-monitor-plus-cta = Get started
+product-promo-monitor-special-promo-cta = Get year-round protection

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
@@ -12,26 +12,37 @@ import { AccountData, useAccount, useConfig } from '../../../models';
 import { constructHrefWithUtm } from '../../../lib/utilities';
 import { LINK } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
+import { parseAcceptLanguage } from '../../../../../../libs/shared/l10n/src';
 
-export enum ProductPromoType {
-  Sidebar = 'sidebar',
-  Settings = 'settings',
-}
-
-// TODO, remove this and logic. This is temporary until we work out the UX for
-// this. This was left configurable via props for tests and storybook.
-const MONITOR_PLUS_ENABLED = false;
+type ProductPromoType = 'sidebar' | 'settings';
 
 export interface ProductPromoProps {
   type?: ProductPromoType;
-  monitorPlusEnabled?: boolean;
+  /**
+   * Temporary prop for Storybook / tests.
+   * Will be removed once we have real user‑location data to decide whether a
+   * user belongs to the *special promo* treatment group (initially - USA users).
+   */
+  specialPromoEligible?: boolean;
 }
 
+/**
+ * Determine which (if any) promo variant to show.
+ *
+ * **Stage 1** (current):
+ *   • Hide promos entirely for **Monitor Plus** (paid) subscribers.
+ *   • Everyone else sees the *generic* free‑scan promo.
+ *
+ * **Stage 2** (in progress):
+ *   • US‑based *Monitor‑free* users will see a *special* bundled
+ *     promo for Monitor Plus + VPN + Relay.
+ *   • All other non‑paid users continue to see the generic promo.
+ *   • Paid subscribers still see nothing.
+ */
 export function getProductPromoData(
   attachedClients: AccountData['attachedClients'],
   subscriptions: AccountData['subscriptions'],
-  // Temporary until we work on MonitorPlus
-  monitorPlusEnabled = MONITOR_PLUS_ENABLED
+  specialPromoEligible = false // Placeholder until location is retrieved in FXA-11920
 ) {
   const hasMonitor = attachedClients.some(
     ({ name }) => name === MozServices.Monitor
@@ -41,79 +52,115 @@ export function getProductPromoData(
     ({ productName }) => productName === MozServices.MonitorPlus
   );
 
-  // Temporary until we work on MonitorPlus
-  const showMonitorPlusPromo =
-    hasMonitor && !hasMonitorPlus && monitorPlusEnabled;
-  const hasAllPromoProducts = hasMonitor && !showMonitorPlusPromo;
+  // Paid users never see a promo at all.
+  if (hasMonitorPlus) {
+    return { hidePromo: true } as const;
+  }
 
-  const gleanEvent = showMonitorPlusPromo
-    ? { event: { reason: 'plus' } }
-    : { event: { reason: 'free' } };
+  // Stage‑2: decide whether to surface the special US‑only promo.
+  const showSpecialPromo = hasMonitor && specialPromoEligible;
 
-  return { showMonitorPlusPromo, hasAllPromoProducts, gleanEvent };
+  const gleanEvent = showSpecialPromo
+    ? { event: { reason: 'special' } }
+    : { event: { reason: 'default' } };
+
+  return { hidePromo: false, showSpecialPromo, gleanEvent };
 }
 
 export const ProductPromo = ({
-  type = ProductPromoType.Sidebar,
-  // Temporary until we work on MonitorPlus
-  monitorPlusEnabled = MONITOR_PLUS_ENABLED,
+  type = 'sidebar',
+  // default: generic global promo, prop for storybook and testing only
+  // TODO(FXA-11920): replace specialPromoEligible prop with real geo location check
+  specialPromoEligible = false,
 }: ProductPromoProps) => {
   const { attachedClients, subscriptions } = useAccount();
-  const { env } = useConfig();
-  const { showMonitorPlusPromo, hasAllPromoProducts, gleanEvent } =
-    getProductPromoData(attachedClients, subscriptions, monitorPlusEnabled);
+  const { sentry } = useConfig();
 
-  if (hasAllPromoProducts) {
-    return <></>;
+  const { hidePromo, showSpecialPromo, gleanEvent } = getProductPromoData(
+    attachedClients,
+    subscriptions,
+    specialPromoEligible
+  );
+
+  // Paid Monitor Plus subscribers never see a promo.
+  if (hidePromo) {
+    return null;
   }
 
-  const monitorPromoLink = constructHrefWithUtm(
-    env === 'stage' ? LINK.MONITOR_STAGE : LINK.MONITOR,
-    'product-partnership',
+  const DEFAULT_PROMO_URL = constructHrefWithUtm(
+    // using sentry.env because it differentiates between 'dev', 'stage' and 'prod'
+    // (vs 'env' which marks all hosted environments as 'production')
+    sentry.env !== 'stage' ? LINK.MONITOR : LINK.MONITOR_STAGE,
+    'referral',
     'moz-account',
-    'sidebar',
-    'monitor-free',
+    type === 'sidebar' ? 'sidebar' : 'settings',
+    'get-free-scan-global',
     'settings-promo'
   );
 
-  const monitorPlusPromoLink = constructHrefWithUtm(
-    env === 'stage' ? LINK.MONITOR_PLUS_STAGE : LINK.MONITOR_PLUS,
-    'product-partnership',
+  const SPECIAL_PROMO_URL = constructHrefWithUtm(
+    sentry.env !== 'stage' ? LINK.MONITOR_PLUS : LINK.MONITOR_PLUS_STAGE,
+    'referral',
     'moz-account',
-    'sidebar',
-    'monitor-plus',
+    type === 'sidebar' ? 'sidebar' : 'settings',
+    'get-year-round-protection-us',
     'settings-promo'
   );
 
-  const promoContent = showMonitorPlusPromo ? (
+  const price = 8.25;
+  const formattedLocalizedPrice = new Intl.NumberFormat(
+    parseAcceptLanguage(navigator.languages.join(', ')),
+    {
+      style: 'currency',
+      currency: 'USD',
+    }
+  ).format(price);
+
+  const promoContent = showSpecialPromo ? (
     <>
-      <p className="my-2">
-        <FtlMsg id="product-promo-monitor-plus-description">
-          Privacy Matters: Find where your private info is exposed and take it
-          back
-        </FtlMsg>
-      </p>
+      <FtlMsg
+        id="product-promo-monitor-special-promo-description"
+        vars={{ price: formattedLocalizedPrice }}
+      >
+        {/* Price in fallback is always in English formatting */}
+        <p className="my-2">
+          For{' '}
+          {new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: 'USD',
+          }).format(price)}
+          /mo, save on VPN, Monitor’s data-broker protection, and Relay’s
+          unlimited email masks.
+        </p>
+      </FtlMsg>
+
       <LinkExternal
-        href={monitorPlusPromoLink}
+        href={SPECIAL_PROMO_URL}
         className="link-blue"
+        gleanDataAttrs={{
+          id: 'account_pref_promo_monitor_submit',
+          type: 'special',
+        }}
         onClick={() => GleanMetrics.accountPref.promoMonitorSubmit(gleanEvent)}
       >
-        <FtlMsg id="product-promo-monitor-plus-cta">Get started</FtlMsg>
+        <FtlMsg id="product-promo-monitor-special-promo-cta">
+          Get year-round protection
+        </FtlMsg>
       </LinkExternal>
     </>
   ) : (
     <>
       <p className="my-2">
-        <FtlMsg id="product-promo-monitor-description">
-          Find where your private info is exposed — and take it back
+        <FtlMsg id="product-promo-monitor-description-v2">
+          Find where your private info is exposed and take control
         </FtlMsg>
       </p>
       <LinkExternal
-        href={monitorPromoLink}
+        href={DEFAULT_PROMO_URL}
         className="link-blue"
         gleanDataAttrs={{
           id: 'account_pref_promo_monitor_submit',
-          type: 'free',
+          type: 'default',
         }}
         onClick={() => GleanMetrics.accountPref.promoMonitorSubmit(gleanEvent)}
       >
@@ -125,15 +172,15 @@ export const ProductPromo = ({
   return (
     <aside
       className={classNames(
-        'bg-white rounded-lg desktop:w-11/12 desktop:max-w-56 desktop:p-4 desktop:pb-6 text-grey-600 text-lg desktop:text-sm text-start',
-        type === ProductPromoType.Sidebar &&
-          'px-6 mt-4 desktop:mt-20 desktop:max-w-80 desktop:w-11/12',
-        type === ProductPromoType.Settings && 'desktop:hidden px-5 py-3 mb-16'
+        'bg-white rounded-lg desktop:w-11/12 desktop:max-w-56 desktop:p-4 desktop:pb-6 text-grey-600 text-md desktop:text-sm text-start',
+        type === 'sidebar' &&
+          'hidden desktop:block px-6 mt-4 desktop:mt-20 desktop:max-w-80 desktop:w-11/12',
+        type === 'settings' && 'desktop:hidden px-5 py-3 mb-16'
       )}
     >
       <div
         className={classNames(
-          type === ProductPromoType.Sidebar &&
+          type === 'sidebar' &&
             'border-2 border-grey-100 desktop:border-0 rounded-lg px-5 py-3 desktop:px-0 desktop:py-0'
         )}
       >

--- a/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Nav, { NavRefProps } from '../Nav';
-import ProductPromo, { ProductPromoType } from '../ProductPromo';
+import ProductPromo from '../ProductPromo';
 
 export const SideBar = ({
   profileRef,
@@ -25,7 +25,7 @@ export const SideBar = ({
           dataCollectionRef,
         }}
       />
-      <ProductPromo type={ProductPromoType.Sidebar} />
+      <ProductPromo type="sidebar" />
     </div>
   );
 };

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 export const SETTINGS_PATH = '/settings';
 
 export const SHOW_BALLOON_TIMEOUT = 500;
@@ -32,9 +31,9 @@ export const LINK = {
   MDN: 'https://developer.mozilla.org/',
   MONITOR: 'https://monitor.mozilla.org/',
   MONITOR_STAGE: 'https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/',
-  MONITOR_PLUS: 'https://monitor.mozilla.org/#pricing',
+  MONITOR_PLUS: 'https://monitor.mozilla.org/subscription-plans',
   MONITOR_PLUS_STAGE:
-    'https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/#pricing',
+    'https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/subscription-plans',
   POCKET: 'https://getpocket.com/',
   RELAY: 'https://relay.firefox.com/',
   VPN: 'https://vpn.mozilla.org/',

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -141,29 +141,44 @@ export function resetOnce() {
  * Constructs a URL with UTM parameters appended to the query string.
  *
  * @param {string} pathname - The base URL path.
- * @param {'mozilla-websites' | 'product-partnership'} utmMedium - The medium through which the link is being shared.
+ * @param {'mozilla-websites' | 'product-partnership' | 'referral'} utmMedium - The medium through which the link is being shared.
  * @param {'moz-account'} utmSource - The source of the traffic.
- * @param {'bento' | 'sidebar'} utmTerm - The search term or keyword associated with the campaign.
- * @param {'fx-desktop' | 'fx-mobile' | 'monitor' | 'monitor-free' | 'monitor-plus' | 'relay' | 'vpn'} utmContent - The specific content or product that the link is associated with.
+ * @param {'bento' | 'sidebar' | 'settings' } utmTerm - The search term or keyword associated with the campaign.
+ * @param {'fx-desktop' | 'fx-mobile' | 'monitor' | 'monitor-free' | 'monitor-plus' | 'relay' | 'vpn' | 'get-free-scan-global' | 'get-year-round-protection-us' } utmContent - The specific content or product that the link is associated with.
  * @param {'permanent' | 'settings-promo' | 'connect-device'} utmCampaign - The name of the marketing campaign.
  * @returns {string} - The constructed URL with UTM parameters.
  */
 export const constructHrefWithUtm = (
   pathname: string,
-  utmMedium: 'mozilla-websites' | 'product-partnership',
-  utmSource: 'moz-account',
-  utmTerm: 'bento' | 'sidebar',
-  utmContent:
+  utmMedium?: 'mozilla-websites' | 'product-partnership' | 'referral',
+  utmSource?: 'moz-account',
+  utmTerm?: 'bento' | 'sidebar' | 'settings',
+  utmContent?:
     | 'fx-desktop'
     | 'fx-mobile'
     | 'monitor'
     | 'monitor-free'
     | 'monitor-plus'
     | 'relay'
-    | 'vpn',
-  utmCampaign: 'permanent' | 'settings-promo' | 'connect-device'
+    | 'vpn'
+    | 'get-free-scan-global'
+    | 'get-year-round-protection-us',
+  utmCampaign?: 'permanent' | 'settings-promo' | 'connect-device'
 ) => {
-  return `${pathname}?utm_source=${utmSource}&utm_medium=${utmMedium}&utm_term=${utmTerm}&utm_content=${utmContent}&utm_campaign=${utmCampaign}`;
+  const pairs: [string, string | undefined | null][] = [
+    ['utm_source', utmSource],
+    ['utm_medium', utmMedium],
+    ['utm_term', utmTerm],
+    ['utm_content', utmContent],
+    ['utm_campaign', utmCampaign],
+  ];
+
+  const query = pairs
+    .filter(([, value]) => value != null)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&');
+
+  return query ? `${pathname}?${query}` : pathname;
 };
 
 /**


### PR DESCRIPTION
## Because

* Monitor promo copy and link updated
* Preparing for US-only special promo with updated message and CTA

## This pull request

* Update promo, stories and tests
* Styling tweaks
* Update display condition to show the default promo to all users except if they have already subscribed to monitor plus

## Issue that this pull request solves

Closes: FXA-11753

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Storybook: https://storage.googleapis.com/mozilla-storybooks-fxa/commits/4441e1b81a80c35ce8d0d3a917c36405d0fcbf03/fxa-settings/index.html?path=/story/components-settings-productpromo--default-desktop

## Other information (Optional)

This PR updates the promo content, link and changes audience conditions. The default promo will now be shown to all users *except* if they are eligible for a special bundle promo (defaults to false currently, will be updated to check for location in `FXA-11920`) OR if they are already have a paid Monitor subscription.

Content for the special promo has been included to get a start on l10n.
