### PR TITLE
task(rate-limit): Support report only block policy

### DIFF
--- a/libs/accounts/rate-limit/README.md
+++ b/libs/accounts/rate-limit/README.md
@@ -47,14 +47,19 @@ rateLimit.check('foo', { ip:0.0.0.0})
 
 And there was no configuration for foo, but there was a configuration for 'default' and ip. Then
 we'd increment the redis count for action foo blocking on ip, but we'd use the default rule's settings.
+
 ### Policy
 
 - ban - Once a rule is violated (i.e. max attempts exceeded) a ban policy indicates that all other actions are also prohibited for the given blockOn property.
 - block - Once a rule is violated (i.e. max attempts exceeded) a block policy indicates that only that action is prohibited for the given blockOn property.
+- report - Once a rule is violated (i.e. max attempts exceeded) a report policy indicates that the action is reported, but not actually blocked.
 
 It's probably obvious, but bans are serious and need to be used carefully since they effectively lock a user out of the system entirely. It's much better
 to just set sensible block policies when possible. We should only use ban policies when the rule identifies obviously malicious behavior.
-policies.
+
+The report policy can be very useful when experimenting with new rules. This will not impact the existing behavior, i.e. by adding a report policy, we don't
+change which block would have been selected. These rules only generate metrics, so we can get an idea for the rate at which blocks __would__ occur if the
+rule had a policy of ban or block.
 
 ### A quick example:
 

--- a/libs/accounts/rate-limit/src/lib/config.ts
+++ b/libs/accounts/rate-limit/src/lib/config.ts
@@ -119,8 +119,8 @@ export function parseConfigRules(
         line
       );
     }
-    if (!/^block$|^ban$/.test(rule.blockPolicy)) {
-      throw new InvalidRule(`Policy must be block or ban.`, line);
+    if (!/^block$|^ban$|^report$/.test(rule.blockPolicy)) {
+      throw new InvalidRule(`Policy must be block, ban, or report.`, line);
     }
 
     // Add the rule to the map.

--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -18,7 +18,7 @@ export type BlockOnOpts = {
  *  - block - only applies to the current action being checked, and is done in isolation.
  *  - ban - will apply to the current action and all other actions being checked for the given rules ip, email, or uid.
  **/
-export type BlockPolicy = 'block' | 'ban';
+export type BlockPolicy = 'block' | 'ban' | 'report';
 
 /** Constant for the common error message, too-many-attempts. */
 export const TOO_MANY_ATTEMPTS = 'too-many-attempts';

--- a/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.in.spec.ts
@@ -63,6 +63,36 @@ describe('rate-limit', () => {
         'action:testBlock',
       ]);
     });
+
+    it('should report on ' + blockOn, async () => {
+      rateLimit = new RateLimit(
+        { rules: parseConfigRules([`testReport:${blockOn}:1:1s:1s:report`]) },
+        redis,
+        statsd
+      );
+
+      const check1 = await rateLimit.check('testReport', {
+        ip_email: '127.0.0.1_foo@mozilla.com',
+        ip: '127.0.0.1',
+        email: 'foo@mozilla.com',
+        uid: '123',
+      });
+      const check2 = await rateLimit.check('testReport', {
+        ip_email: '127.0.0.1_foo@mozilla.com',
+        ip: '127.0.0.1',
+        email: 'foo@mozilla.com',
+        uid: '123',
+      });
+
+      expect(check1).toBeNull();
+      expect(check2).toBeNull();
+
+      expect(mockIncrement).toBeCalledTimes(1);
+      expect(mockIncrement).toBeCalledWith('rate_limit.report', [
+        `on:${blockOn}`,
+        'action:testReport',
+      ]);
+    });
   }
 
   it(`should not block after window clears`, async () => {
@@ -194,30 +224,64 @@ describe('rate-limit', () => {
   it('can unblock', async () => {
     rateLimit = new RateLimit(
       {
-        rules: parseConfigRules(['testBlock:ip:1:1s:1s:block']),
+        rules: parseConfigRules([
+          'testBlock:ip:1:1s:1s:block',
+          'testReport:ip:1:1s:1s:report',
+        ]),
       },
       redis,
       statsd
     );
 
+    // Check block
     const check1 = await rateLimit.check('testBlock', { ip: '127.0.0.1' });
+    const checkReportOnly1 = await rateLimit.check('testReport', {
+      ip: '127.0.0.1',
+    });
+
     const check2 = await rateLimit.check('testBlock', { ip: '127.0.0.1' });
+    const checkReportOnly2 = await rateLimit.check('testReport', {
+      ip: '127.0.0.1',
+    });
+
     await rateLimit.unblock({ ip: '127.0.0.1' });
     const check3 = await rateLimit.check('testBlock', { ip: '127.0.0.1' });
+    const checkReportOnly3 = await rateLimit.check('testReport', {
+      ip: '127.0.0.1',
+    });
 
     expect(check1).toBeNull();
+
+    expect(check2).not.toBeNull();
     expect(check2?.reason).toEqual('too-many-attempts');
     expect(check2?.retryAfter).toEqual(1000);
     expect(check3).toBeNull();
 
-    expect(statsd.increment).toBeCalledTimes(2);
+    expect(check2).not.toBeNull();
+    expect(check2?.reason).toEqual('too-many-attempts');
+    expect(check2?.retryAfter).toEqual(1000);
+    expect(check3).toBeNull();
+
+    // Report only never returns an actual block!
+    expect(checkReportOnly1).toBeNull();
+    expect(checkReportOnly2).toBeNull();
+    expect(checkReportOnly3).toBeNull();
+
+    expect(statsd.increment).toBeCalledTimes(5);
+    // For unblock calls
+    expect(statsd.increment).toBeCalledWith('rate_limit.unblock', [
+      'on:ip',
+      'action:testBlock',
+    ]);
+    // For two blocked calls
     expect(statsd.increment).toBeCalledWith('rate_limit.block', [
       'on:ip',
       'action:testBlock',
     ]);
-    expect(statsd.increment).toBeCalledWith('rate_limit.unblock', [
+    // For two report only calls
+    expect(statsd.increment).toBeCalledWith('rate_limit.report', [
       'on:ip',
-      'action:testBlock',
+      'action:testReport',
     ]);
   });
 

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -190,6 +190,7 @@ describe('rate-limit', () => {
         test        : uid                :  1           : 30 seconds            : 1 day          : block
         test        : ip_email           :  100         : 10 seconds            : 1 Month        : block
         testBan     : ip                 :  100         : 10 seconds            : 1 Month        : ban
+        testReport  : ip                 :  10          : 10 seconds            : 1 Month        : report
       `);
       let rules = ruleSet['test'];
 
@@ -229,6 +230,13 @@ describe('rate-limit', () => {
       expect(rules[0].windowDurationInSeconds).toEqual(10);
       expect(rules[0].blockDurationInSeconds).toEqual(2592000);
       expect(rules[0].blockPolicy).toEqual('ban');
+
+      rules = ruleSet['testReport'];
+      expect(rules[0].maxAttempts).toEqual(10);
+      expect(rules[0].blockingOn).toEqual('ip');
+      expect(rules[0].windowDurationInSeconds).toEqual(10);
+      expect(rules[0].blockDurationInSeconds).toEqual(2592000);
+      expect(rules[0].blockPolicy).toEqual('report');
     });
 
     it('throws on duplicate rule in rule set', () => {

--- a/libs/accounts/rate-limit/src/lib/util.ts
+++ b/libs/accounts/rate-limit/src/lib/util.ts
@@ -19,7 +19,7 @@ export function getBanKey(blockingOn: BlockOn, blockedValue: string) {
  * Generates a redis key
  */
 export function getKey(
-  type: 'attempts' | 'block' | 'ban',
+  type: 'attempts' | 'block' | 'ban' | 'report',
   action: string,
   rule: Rule,
   blockedValue: string


### PR DESCRIPTION
## Because

- We'd like to able to 'test' out rules before applying them
- We'd like to see metrics about how these 'test' rules perform

## This pull request

- Introduces an new policy 'report'
- Report will only emit metrics concerning potential blocks, but not actually issue a block

## Issue that this pull request solves

Closes: FXA-11924

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
