### PR TITLE
fix(oauth): Allow empty string `login_hint` another attempt

### DIFF
--- a/packages/fxa-settings/src/lib/validation/index.ts
+++ b/packages/fxa-settings/src/lib/validation/index.ts
@@ -1,4 +1,5 @@
 import {
+  isEmail,
   isURL,
   ValidationArguments,
   ValidatorConstraint,
@@ -44,5 +45,19 @@ export class IsFxaRedirectUri implements ValidatorConstraintInterface {
 
   defaultMessage(args: ValidationArguments) {
     return '($value) is not a valid FxA redirect uri';
+  }
+}
+
+@ValidatorConstraint({ name: 'isEmailOrEmpty', async: false })
+export class IsEmailOrEmpty implements ValidatorConstraintInterface {
+  validate(value: any, args: ValidationArguments) {
+    if (value === '' || value === undefined) {
+      return true;
+    }
+    return isEmail(value, { require_tld: false });
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return 'loginHint must be a valid email, empty string, or undefined';
   }
 }

--- a/packages/fxa-settings/src/models/integrations/data/data.ts
+++ b/packages/fxa-settings/src/models/integrations/data/data.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  Allow,
   IsBoolean,
   IsEmail,
   IsHexadecimal,
@@ -23,7 +22,7 @@ import {
   KeyTransforms as T,
   ModelDataProvider,
 } from '../../../lib/model-data';
-import { IsFxaRedirectToUrl, IsFxaRedirectUri } from '../../../lib/validation';
+import { IsEmailOrEmpty, IsFxaRedirectToUrl, IsFxaRedirectUri } from '../../../lib/validation';
 
 /**
  * Base integration class. Fields in this class represents data commonly accessed across many pages and is useful for various flows.
@@ -58,8 +57,7 @@ export class IntegrationData extends ModelDataProvider {
   email: string | undefined;
 
   @IsOptional()
-  @IsString()
-  @Allow()
+  @Validate(IsEmailOrEmpty, {})
   @bind(T.snakeCase)
   loginHint: string | undefined;
 

--- a/packages/fxa-settings/src/models/pages/index/query-params.test.ts
+++ b/packages/fxa-settings/src/models/pages/index/query-params.test.ts
@@ -26,5 +26,6 @@ describe('SigninQueryParams checks', function () {
     expect(validate('login_hint=test+test@gmail.com').isValid).toBeFalsy();
     expect(validate('login_hint=test%2Btest%40gmail.com').isValid).toBeTruthy(); // supports uri encoding
     expect(validate('login_hint=test%2Btest-gmail.com').isValid).toBeFalsy(); // missing @
+    expect(validate('login_hint=').isValid).toBeTruthy(); // missing @
   });
 });

--- a/packages/fxa-settings/src/models/pages/index/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/index/query-params.ts
@@ -2,12 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsEmail, IsIn, IsOptional } from 'class-validator';
+import { IsEmail, IsIn, IsOptional, Validate } from 'class-validator';
 import {
   bind,
   KeyTransforms,
   ModelDataProvider,
 } from '../../../lib/model-data';
+import { IsEmailOrEmpty } from '../../../lib/validation';
 
 export class IndexQueryParams extends ModelDataProvider {
   @IsOptional()
@@ -16,7 +17,7 @@ export class IndexQueryParams extends ModelDataProvider {
   email: string | undefined;
 
   @IsOptional()
-  @IsEmail()
+  @Validate(IsEmailOrEmpty, {})
   @bind(KeyTransforms.snakeCase)
   loginHint: string | undefined;
 

--- a/packages/fxa-settings/src/models/pages/signin/oauth-query-params.test.ts
+++ b/packages/fxa-settings/src/models/pages/signin/oauth-query-params.test.ts
@@ -39,6 +39,18 @@ describe('OAuthQueryParams checks', function () {
     ).toBeTruthy();
   });
 
+  it('checks login_hint', () => {
+    expect(
+      validate('client_id=123abc&scope=profile&login_hint=example@mozilla.com').isValid
+    ).toBeTruthy();
+    expect(
+      validate('client_id=123abc&scope=profile&login_hint=').isValid
+    ).toBeTruthy();
+    expect(
+      validate('client_id=123abc&scope=profile&login_hint=123').isValid
+    ).toBeFalsy();
+  });
+
   it('checks prompt', () => {
     expect(
       validate('client_id=123abc&scope=profile&prompt=foo').isValid

--- a/packages/fxa-settings/src/models/pages/signin/oauth-query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signin/oauth-query-params.ts
@@ -5,7 +5,6 @@
 import {
   Matches,
   IsBoolean,
-  IsEmail,
   IsHexadecimal,
   IsIn,
   IsOptional,
@@ -16,14 +15,13 @@ import {
   IsNumber,
   Min,
   Validate,
-  Allow,
 } from 'class-validator';
 import {
   bind,
   ModelDataProvider,
   KeyTransforms as T,
 } from '../../../lib/model-data';
-import { IsFxaRedirectUri } from '../../../lib/validation';
+import { IsFxaRedirectUri, IsEmailOrEmpty } from '../../../lib/validation';
 
 /**
  *  Note: class-validator logic was ported from Vat rules in content-server.
@@ -75,10 +73,9 @@ export class OAuthQueryParams extends ModelDataProvider {
   idTokenHint!: string;
 
   @IsOptional()
-  @IsEmail()
-  @Allow()
+  @Validate(IsEmailOrEmpty, {})
   @bind(T.snakeCase)
-  loginHint!: string;
+  loginHint: string | undefined;
 
   @IsOptional()
   @IsNumber()


### PR DESCRIPTION
## Because

- The fix in https://github.com/mozilla/fxa/pull/19050, was tested against our 123Done client which did not go through same steps as IAM, but failed when in stage

## This pull request

- Adds a new class validator to check if login_hint is an email or empty string

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I'm not really sure how/why the functional test I added in https://github.com/mozilla/fxa/pull/19050 gave me a false positive. 
