### PR TITLE
bug(gql): ip_uid and ip_email were not provided to rate-limit check

### DIFF
--- a/libs/shared/nestjs/customs/src/lib/customs.service.spec.ts
+++ b/libs/shared/nestjs/customs/src/lib/customs.service.spec.ts
@@ -98,12 +98,22 @@ describe('Customs Service', () => {
           action: 'test',
           ip: '127.0.0.1',
           email: 'foo@mozilla.com',
+          uid: '123',
           // Important! Trigger and check localized error message state!
           acceptLanguage: 'fr',
         });
       } catch (err) {
         error = err;
       }
+
+      expect(mockRateLimit.check).toHaveBeenCalled();
+      expect(mockRateLimit.check).toHaveBeenCalledWith('test', {
+        ip: '127.0.0.1',
+        email: 'foo@mozilla.com',
+        uid: '123',
+        ip_email: '127.0.0.1_foo@mozilla.com',
+        ip_uid: '127.0.0.1_123',
+      });
 
       expect(error).toBeDefined();
       expect(error?.message).toEqual('Client has sent too many requests');


### PR DESCRIPTION
## Because

- There _could be_ rules in the future in graphql-api that need to look ip_uid or ip_email

## This pull request

- Passes ip_uid into the rate-limit check
- Passes ip_email into the rate limit check

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
