### PR TITLE
fix(payments-next):/location page - unexpected placeholders for Country and Postal Code fields

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -93,7 +93,7 @@ export default async function New({
         {
           locale: params.locale,
           baseUrl: config.paymentsNextHostedUrl,
-          searchParams: searchParams,
+          searchParams,
         }
       )
     );
@@ -148,6 +148,8 @@ export default async function New({
 
   redirectToUrl.searchParams.delete('cartId');
   redirectToUrl.searchParams.delete('cartVersion');
+  redirectToUrl.searchParams.delete('countryCode');
+  redirectToUrl.searchParams.delete('postalCode');
 
   redirect(redirectToUrl.href);
 }

--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -38,8 +38,12 @@ function buildSignOutRedirectPath(
   postalCode: string
 ) {
   const { locale, offeringId, interval } = params;
-  const remainingQueryParams = searchParams.toString();
   const basePath = `/${locale}/${offeringId}/${interval}/new?countryCode=${countryCode}&postalCode=${postalCode}`;
+
+  const allRemainingQueryParams = new URLSearchParams(searchParams.toString());
+  allRemainingQueryParams.delete('countryCode');
+  allRemainingQueryParams.delete('postalCode');
+  const remainingQueryParams = allRemainingQueryParams.toString();
 
   if (remainingQueryParams) {
     return `${basePath}&${remainingQueryParams}`;


### PR DESCRIPTION
## Because

- /location page had unexpected placeholders for Country and Postal Code fields.
- Country and Postal codes were being doubled in the URL, creating unexpected behavior (like showing 'Product unavailable' for countries like USA).

## This pull request

- Removes countryCode and postalCode from /new page's searchParams
- Removes countryCode and postalCode from remainingQueryParams, preventing them from getting doubled in the resulting path. 

## Issue that this pull request solves

Closes: #FXA-11889

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
