### PR TITLE
Initial Strapi and accounts integration

### DIFF
--- a/libs/accounts/cms/.eslintrc.json
+++ b/libs/accounts/cms/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/accounts/cms/README.md
+++ b/libs/accounts/cms/README.md
@@ -1,0 +1,19 @@
+# @fxa/account-cms
+
+This library provides a Node.js module for managing and fetching CMS (Content Management System) configurations from a Strapi API, with Redis caching for improved performance. It is designed to integrate with the Mozilla Accounts ecosystem and is built using [Nx](https://nx.dev) for a monorepo setup.
+
+## Overview
+
+The `@fxa/account-cms` library enables applications to fetch configuration data from a Strapi CMS instance, specifically for client-specific and entrypoint-specific settings (e.g., UI configurations like headlines and descriptions for different pages). It includes:
+
+- **StrapiClient**: A client for making authenticated HTTP requests to the Strapi API.
+- **CMSManager**: A manager class that handles fetching configurations, caching them in Redis, and tracking metrics with StatsD.
+- **Error Handling**: Custom error classes for handling Strapi API errors, cache issues, and configuration not found scenarios.
+
+## Building
+
+Run `nx build accounts-cms` to build the library.
+
+## Running unit tests
+
+Run `nx test accounts-cms` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/accounts/cms/jest.config.ts
+++ b/libs/accounts/cms/jest.config.ts
@@ -1,0 +1,20 @@
+export default {
+  displayName: 'accounts-cms',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/accounts/cms',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/lib/accounts/cms',
+        outputName: 'accounts-cms-jest-unit-results.xml',
+      },
+    ],
+  ],
+};

--- a/libs/accounts/cms/package.json
+++ b/libs/accounts/cms/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@fxa/accounts/cms",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/libs/accounts/cms/project.json
+++ b/libs/accounts/cms/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "accounts-cms",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/accounts/cms/src",
+  "projectType": "library",
+  "tags": ["scope:shared:lib"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/accounts/cms",
+        "main": "libs/accounts/cms/src/index.ts",
+        "tsConfig": "libs/accounts/cms/tsconfig.lib.json",
+        "assets": ["libs/accounts/cms/*.md"],
+        "format": ["cjs"],
+        "generatePackageJson": true
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/accounts/cms/jest.config.ts",
+        "testPathPattern": ["^(?!.*\\.in\\.spec\\.ts$).*$"]
+      }
+    },
+    "test-integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/accounts/cms/jest.config.ts",
+        "testPathPattern": ["\\.in\\.spec\\.ts$"]
+      }
+    }
+  }
+}

--- a/libs/accounts/cms/src/index.ts
+++ b/libs/accounts/cms/src/index.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './lib/strapi.client';
+export * from './lib/cms-manager';

--- a/libs/accounts/cms/src/lib/cms-manager.spec.ts
+++ b/libs/accounts/cms/src/lib/cms-manager.spec.ts
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CMSManager, CMSManagerConfig } from './cms-manager';
+import { CMSConfigFetchError, StrapiConfigNotFoundError, StrapiFetchError } from './error';
+import { StrapiClientConfig } from './strapi.client';
+import fetchMock from 'fetch-mock';
+
+interface PartialRedis {
+  get: jest.Mock<Promise<string | null>, [key: string]>;
+  set: jest.Mock<Promise<string | undefined>, [key: string, value: string, mode?: string, duration?: number]>;
+  del: jest.Mock<Promise<number>, [key: string]>;
+}
+
+describe('CMSManager', () => {
+  const apiUrl = 'https://api.example.com';
+  const apiKey = 'valid-token';
+  const clientId = 'test-client';
+  const entrypoint = 'test-entrypoint';
+  const prefix = 'cmsaccounts:';
+  const cacheTTL = 3600;
+  const config: CMSManagerConfig = {
+    enabled: true,
+    cacheTTL,
+    strapiClient: { apiUrl, apiKey },
+  };
+  const apiUrlPattern = new RegExp(
+    `${apiUrl.replace('.', '\\.')}/api/clients\\?populate=\\*|%2A&filters%5BclientId%5D=${clientId}&filters%5Bentrypoint%5D=${entrypoint}`
+  );
+  const cacheKey = `${prefix}${clientId}:${entrypoint}`;
+
+  let redis: PartialRedis;
+  let statsd: { increment: jest.Mock };
+  let cmsManager: CMSManager;
+
+  beforeEach(() => {
+    statsd = { increment: jest.fn() };
+    redis = {
+      get: jest.fn(),
+      set: jest.fn(() => Promise<any>),
+      del: jest.fn(),
+    } as any;
+
+    fetchMock.reset();
+    cmsManager = new CMSManager(config, redis as any, statsd as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fetchMock.restore();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with valid config, redis, and statsd', () => {
+      expect(cmsManager).toBeInstanceOf(CMSManager);
+    });
+  });
+
+  describe('getConfig', () => {
+    const mockConfig: StrapiClientConfig = {
+      id: 1,
+      clientId,
+      entrypoint,
+      EmailFirstPage: { headline: 'Test', description: 'Description' },
+    };
+
+    it('should return undefined if disabled', async () => {
+      const disabledConfig = { ...config, enabled: false };
+      const disabledManager = new CMSManager(disabledConfig, redis as any, statsd as any);
+      const result = await disabledManager.getConfig(clientId, entrypoint);
+      expect(result).toBeUndefined();
+      expect(statsd.increment).not.toHaveBeenCalled();
+      expect(fetchMock.called(apiUrlPattern)).toBe(false);
+    });
+
+    it('should return cached configuration', async () => {
+      redis.get.mockResolvedValueOnce(JSON.stringify(mockConfig));
+
+      const result = await cmsManager.getConfig(clientId, entrypoint);
+
+      expect(result).toEqual(mockConfig);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_hit.${clientId}.${entrypoint}`);
+      expect(statsd.increment).not.toHaveBeenCalledWith(`cms_manager.cache_miss.${clientId}.${entrypoint}`);
+      expect(fetchMock.called(apiUrlPattern)).toBe(false);
+    });
+
+    it('should fetch from Strapi on cache miss and cache result', async () => {
+      fetchMock.get({ url: apiUrlPattern, matchPartialBody: true }, {
+        status: 200,
+        body: { data: [mockConfig] },
+      });
+
+      const result = await cmsManager.getConfig(clientId, entrypoint);
+
+      expect(result).toEqual(mockConfig);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_miss.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.strapi_fetch_success.${clientId}.${entrypoint}`);
+      expect(fetchMock.called(apiUrlPattern)).toBe(true);
+      const requestOptions = fetchMock.lastCall()?.[1];
+      expect(requestOptions?.headers).toBeInstanceOf(Headers);
+      expect((requestOptions?.headers as Headers).get('Authorization')).toBe(`Bearer ${apiKey}`);
+
+      expect(redis.set).toHaveBeenCalledWith('cmsaccounts:test-client:test-entrypoint', JSON.stringify(mockConfig), 'EX', cacheTTL);
+    });
+
+    it('should handle Redis get error and fetch from Strapi', async () => {
+      redis.get.mockRejectedValueOnce(new Error('Redis get error'));
+      fetchMock.get({ url: apiUrlPattern, matchPartialBody: true }, {
+        status: 200,
+        body: { data: [mockConfig] },
+      });
+
+      const result = await cmsManager.getConfig(clientId, entrypoint);
+
+      expect(result).toEqual(mockConfig);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_error.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.strapi_fetch_success.${clientId}.${entrypoint}`);
+      expect(fetchMock.called(apiUrlPattern)).toBe(true);
+    });
+
+    it('should handle Redis set error and return config', async () => {
+      redis.set.mockRejectedValueOnce(new Error('Redis error'));
+      fetchMock.get({ url: apiUrlPattern, matchPartialBody: true }, {
+        status: 200,
+        body: { data: [mockConfig] },
+      });
+
+      const result = await cmsManager.getConfig(clientId, entrypoint);
+
+      expect(result).toEqual(mockConfig);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_miss.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.strapi_fetch_success.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_set_error.${clientId}.${entrypoint}`);
+    });
+
+    it('should re-throw StrapiFetchError', async () => {
+      fetchMock.get({ url: apiUrlPattern, matchPartialBody: true }, {
+        status: 404,
+        body: 'Not Found',
+      });
+
+      await expect(cmsManager.getConfig(clientId, entrypoint)).rejects.toThrow(
+        new StrapiFetchError(clientId, entrypoint)
+      );
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_miss.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.error.${clientId}.${entrypoint}`);
+    });
+
+    it('should re-throw StrapiConfigNotFoundError', async () => {
+      fetchMock.get({ url: apiUrlPattern, matchPartialBody: true }, {
+        status: 200,
+        body: { data: [] },
+      });
+
+      await expect(cmsManager.getConfig(clientId, entrypoint)).rejects.toThrow(
+        new StrapiConfigNotFoundError(clientId, entrypoint)
+      );
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_miss.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.error.${clientId}.${entrypoint}`);
+    });
+
+    it('should wrap non-Strapi errors in CMSConfigFetchError', async () => {
+      fetchMock.get({ url: apiUrlPattern, matchPartialBody: true }, () => {
+        throw new Error('Network error');
+      });
+
+      await expect(cmsManager.getConfig(clientId, entrypoint)).rejects.toThrow(
+        new CMSConfigFetchError(clientId, entrypoint, new Error('Network error'))
+      );
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.cache_miss.${clientId}.${entrypoint}`);
+      expect(statsd.increment).toHaveBeenCalledWith(`cms_manager.error.${clientId}.${entrypoint}`);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('should clear cache for clientId and entrypoint', async () => {
+      await cmsManager.clearCache(clientId, entrypoint);
+      expect(redis.del).toHaveBeenCalledWith(cacheKey);
+    });
+
+    it('should handle Redis error silently', async () => {
+      redis.del.mockRejectedValueOnce(new Error('Redis error'));
+      await expect(cmsManager.clearCache(clientId, entrypoint)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/libs/accounts/cms/src/lib/cms-manager.ts
+++ b/libs/accounts/cms/src/lib/cms-manager.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Redis } from 'ioredis';
+
+import { CMSConfigFetchError, StrapiConfigNotFoundError, StrapiFetchError } from './error';
+import { StrapiClient, StrapiClientConfig } from './strapi.client';
+import { StatsD } from '@fxa/shared/metrics/statsd';
+
+export interface CMSManagerConfig {
+  enabled: boolean;
+  cacheTTL: number;
+  strapiClient: {
+    apiUrl: string; // Base URL for Strapi API
+    apiKey: string; // Bearer token for authentication
+  }
+}
+
+/**
+ * CMSManager class for fetching and caching Strapi configurations using Redis.
+ */
+export class CMSManager {
+  private readonly strapiClient: StrapiClient | undefined;
+  private readonly redis: Redis | undefined;
+  private readonly cacheTTL; // Default cache TTL in seconds
+  private readonly statsd: any;
+  private readonly enabled: boolean;
+  private readonly redisKeyPrefix: string;
+
+  constructor(config: CMSManagerConfig, redis: Redis, statsd: StatsD, redisKeyPrefix = 'cmsaccounts:') {
+    this.enabled = config.enabled;
+    this.redisKeyPrefix = redisKeyPrefix;
+    this.redis = redis;
+    this.cacheTTL = config.cacheTTL;
+    this.statsd = statsd;
+
+    if (!this.enabled) {
+      return;
+    }
+
+    if (!config.strapiClient || !config.strapiClient.apiUrl || !config.strapiClient.apiKey) {
+      throw new Error('Invalid Strapi client configuration');
+    }
+    if (!redis) {
+      throw new Error('Redis client is required for Strapi');
+    }
+
+    this.strapiClient = new StrapiClient(
+      config.strapiClient.apiUrl,
+      config.strapiClient.apiKey
+    );
+  }
+
+  private getCacheKey(clientId: string, entrypoint: string): string {
+    return `${this.redisKeyPrefix}${clientId}:${entrypoint}`;
+  }
+
+  async getConfig(
+    clientId: string,
+    entrypoint: string
+  ): Promise<StrapiClientConfig | undefined> {
+    if (!this.enabled || !this.redis || !this.strapiClient) {
+      return;
+    }
+
+    const cacheKey = this.getCacheKey(clientId, entrypoint);
+
+    try {
+      const cached = await this.redis.get(cacheKey);
+      if (cached) {
+        this.statsd?.increment(
+          `cms_manager.cache_hit.${clientId}.${entrypoint}`
+        );
+        return JSON.parse(cached) as StrapiClientConfig;
+      }
+      this.statsd?.increment(
+        `cms_manager.cache_miss.${clientId}.${entrypoint}`
+      );
+    } catch (err) {
+      this.statsd?.increment(
+        `cms_manager.cache_error.${clientId}.${entrypoint}`
+      );
+    }
+
+    // Cache miss: fetch from Strapi
+    try {
+      const config = await this.strapiClient.fetchConfig(clientId, entrypoint);
+      this.statsd?.increment(
+        `cms_manager.strapi_fetch_success.${clientId}.${entrypoint}`
+      );
+      try {
+        await this.redis.set(
+          cacheKey,
+          JSON.stringify(config),
+          'EX',
+          this.cacheTTL
+        );
+      } catch (err) {
+        this.statsd?.increment(
+          `cms_manager.cache_set_error.${clientId}.${entrypoint}`
+        );
+      }
+
+      return config;
+    } catch (err) {
+      this.statsd?.increment(`cms_manager.error.${clientId}.${entrypoint}`);
+
+      if (
+        err instanceof StrapiFetchError ||
+        err instanceof StrapiConfigNotFoundError
+      ) {
+        throw err;
+      }
+      throw new CMSConfigFetchError(clientId, entrypoint, err as Error);
+    }
+  }
+
+  async clearCache(clientId: string, entrypoint: string): Promise<void> {
+    if (!this.enabled || !this.redis || !this.strapiClient) {
+      return;
+    }
+
+    const cacheKey = this.getCacheKey(clientId, entrypoint);
+    try {
+      await this.redis.del(cacheKey);
+    } catch (err) {}
+  }
+}

--- a/libs/accounts/cms/src/lib/error.ts
+++ b/libs/accounts/cms/src/lib/error.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export class StrapiFetchError extends Error {
+  constructor(
+    public readonly clientId: string,
+    public readonly entrypoint: string
+  ) {
+    super(`Failed to fetch Strapi config for clientId: ${clientId}, entrypoint: ${entrypoint}.`);
+  }
+}
+
+
+export class StrapiConfigNotFoundError extends Error {
+  constructor(
+    public readonly clientId: string,
+    public readonly entrypoint: string
+  ) {
+    super(`No configuration found for clientId: ${clientId}, entrypoint: ${entrypoint}.`);
+  }
+}
+
+export class CMSConfigFetchError extends Error {
+  constructor(
+    public readonly clientId: string,
+    public readonly entrypoint: string,
+    public readonly cause?: Error
+  ) {
+    super(`Failed to fetch CMS config from Redis for clientId: ${clientId}, entrypoint: ${entrypoint}.`);
+    if (cause) {
+      this.message += ` Cause: ${cause.message}`;
+    }
+  }
+}

--- a/libs/accounts/cms/src/lib/strapi.client.spec.ts
+++ b/libs/accounts/cms/src/lib/strapi.client.spec.ts
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import fetchMock from 'fetch-mock';
+import { StrapiConfigNotFoundError, StrapiFetchError } from './error';
+import { StrapiClient, StrapiClientConfig } from './strapi.client';
+
+describe('StrapiClient', () => {
+  const baseUrl = 'https://strapi.com';
+  const token = 'valid-token';
+  const clientId = 'test-client';
+  const entrypoint = 'test-entrypoint';
+  const apiUrl = `${baseUrl}/api/clients?populate=*&filters%5BclientId%5D=${clientId}&filters%5Bentrypoint%5D=${entrypoint}`;
+
+
+  beforeEach(() => {
+    fetchMock.reset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    fetchMock.restore();
+  });
+
+  describe('constructor', () => {
+    it('should initialize with valid URL and token', () => {
+      const client = new StrapiClient(baseUrl, token);
+      expect(client).toBeInstanceOf(StrapiClient);
+    });
+
+    it('should throw error for invalid URL', () => {
+      expect(() => new StrapiClient('invalid-url', token)).toThrow('Invalid Strapi URL provided');
+    });
+
+    it('should throw error for empty token', () => {
+      expect(() => new StrapiClient(baseUrl, '')).toThrow('Invalid or missing token');
+    });
+
+    it('should throw error for non-string token', () => {
+      expect(() => new StrapiClient(baseUrl, null as any)).toThrow('Invalid or missing token');
+    });
+  });
+
+  describe('fetchConfig', () => {
+    let client: StrapiClient;
+
+    beforeEach(() => {
+      client = new StrapiClient(baseUrl, token);
+    });
+
+    it('should fetch and return a single configuration', async () => {
+      const mockConfig: StrapiClientConfig = {
+        id: 1,
+        clientId,
+        entrypoint,
+        EmailFirstPage: { headline: 'Test', description: 'Description' },
+      };
+      fetchMock.get(apiUrl, {
+        status: 200,
+        body: { data: [mockConfig] },
+      });
+
+      const result = await client.fetchConfig(clientId, entrypoint);
+
+      expect(fetchMock.called(apiUrl)).toBe(true);
+
+      const requestOptions = fetchMock.lastCall()?.[1];
+      expect((requestOptions?.headers as Headers).get('Authorization')).toBe(`Bearer ${token}`);
+
+      expect(result).toEqual(mockConfig);
+    });
+
+    it('should return first configuration and if multiple configurations are found', async () => {
+      const mockConfigs: StrapiClientConfig[] = [
+        { id: 1, clientId, entrypoint, EmailFirstPage: { headline: 'Test1' } },
+        { id: 2, clientId, entrypoint, EmailFirstPage: { headline: 'Test2' } },
+      ];
+      fetchMock.get(apiUrl, {
+        status: 200,
+        body: { data: mockConfigs },
+      });
+
+      const result = await client.fetchConfig(clientId, entrypoint);
+
+      expect(result).toEqual(mockConfigs[0]);
+    });
+
+    it('should throw StrapiFetchError on non-OK response', async () => {
+      fetchMock.get(apiUrl, {
+        status: 404,
+        body: 'Not Found',
+      });
+
+      await expect(client.fetchConfig(clientId, entrypoint)).rejects.toThrow(
+        new StrapiFetchError(clientId, entrypoint)
+      );
+    });
+
+    it('should throw StrapiConfigNotFoundError on empty data array', async () => {
+      fetchMock.get(apiUrl, {
+        status: 200,
+        body: { data: [] },
+      });
+
+      await expect(client.fetchConfig(clientId, entrypoint)).rejects.toThrow(
+        new StrapiConfigNotFoundError(clientId, entrypoint)
+      );
+    });
+
+    it('should throw StrapiConfigNotFoundError on missing data property', async () => {
+      fetchMock.get(apiUrl, {
+        status: 200,
+        body: {},
+      });
+
+      await expect(client.fetchConfig(clientId, entrypoint)).rejects.toThrow(
+        new StrapiConfigNotFoundError(clientId, entrypoint)
+      );
+    });
+
+    it('should throw StrapiConfigNotFoundError on non-array data', async () => {
+      fetchMock.get(apiUrl, {
+        status: 200,
+        body: { data: {} },
+      });
+
+      await expect(client.fetchConfig(clientId, entrypoint)).rejects.toThrow(
+        new StrapiConfigNotFoundError(clientId, entrypoint)
+      );
+    });
+
+    it('should handle invalid JSON response', async () => {
+      fetchMock.get(apiUrl, () => {
+        throw new Error('Invalid JSON');
+      });
+
+      await expect(client.fetchConfig(clientId, entrypoint)).rejects.toThrow('Invalid JSON');
+    });
+  });
+});

--- a/libs/accounts/cms/src/lib/strapi.client.ts
+++ b/libs/accounts/cms/src/lib/strapi.client.ts
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { StrapiConfigNotFoundError, StrapiFetchError } from './error';
+
+export interface EmailFirstPage {
+  headline?: string;
+  description?: string;
+}
+
+export interface StrapiClientConfig {
+  id: number;
+  clientId: string;
+  entrypoint: string;
+  EmailFirstPage?: EmailFirstPage;
+}
+
+/**
+ * Client class for fetching configurations from Strapi API.
+ */
+export class StrapiClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(strapiUrl: string, token: string) {
+    try {
+      new URL(strapiUrl);
+    } catch {
+      throw new Error('Invalid Strapi URL provided');
+    }
+    if (!token) {
+      throw new Error('Invalid or missing token');
+    }
+    this.baseUrl = strapiUrl;
+    this.token = token;
+  }
+
+  async fetchConfig(clientId: string, entrypoint: string): Promise<StrapiClientConfig> {
+    const url = new URL(`${this.baseUrl}/api/clients`);
+    const params = new URLSearchParams({
+      'populate': '*',
+      'filters[clientId]': clientId,
+      'filters[entrypoint]': entrypoint,
+    });
+    url.search = params.toString();
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${this.token}`);
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      throw new StrapiFetchError(clientId, entrypoint);
+    }
+    const { data: result } = await response.json() as { data: StrapiClientConfig[] };
+
+    if (!Array.isArray(result)) {
+      throw new StrapiConfigNotFoundError(clientId, entrypoint);
+    }
+
+    if (result.length === 0) {
+      throw new StrapiConfigNotFoundError(clientId, entrypoint);
+    }
+
+    // We shouldn't have more than one config for a clientId and entrypoint
+    // but if we do, we return the first one.
+    return result[0];
+  }
+}

--- a/libs/accounts/cms/tsconfig.json
+++ b/libs/accounts/cms/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/accounts/cms/tsconfig.lib.json
+++ b/libs/accounts/cms/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/accounts/cms/tsconfig.spec.json
+++ b/libs/accounts/cms/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -52,6 +52,7 @@ const {
   TwilioFactory,
 } = require('@fxa/accounts/recovery-phone');
 const { parseConfigRules, RateLimit } = require('@fxa/accounts/rate-limit');
+const { CMSManager } = require('@fxa/accounts/cms');
 const { AccountManager } = require('@fxa/shared/account/account');
 const { setupAccountDatabase } = require('@fxa/shared/db/mysql/account');
 const { EmailCloudTaskManager } = require('../lib/email-cloud-tasks');
@@ -238,6 +239,14 @@ async function run(config) {
     statsd
   );
   Container.set(RateLimit, rateLimit);
+
+  // Setup the auth server cms manager
+  const cmsRedis = new Redis({
+    ...config.redis,
+    ...config.redis.cmsAccounts,
+  });
+  const cmsAccounts = new CMSManager(config.cmsAccounts, cmsRedis, statsd, config.redis.cmsAccounts.prefix);
+  Container.set(CMSManager, cmsAccounts);
 
   // Create Recovery Phone Service
   const twilio = TwilioFactory.useFactory(config.twilio);

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2163,6 +2163,34 @@ const convictConf = convict({
       },
     },
   },
+  cmsAccounts: {
+    enabled: {
+      default: false,
+      doc: 'Whether to use CMS',
+      env: 'CMS_ENABLED',
+      format: Boolean,
+    },
+    cacheTTL: {
+      default: 60 * 15, // 15 minutes
+      doc: 'CMS config cache TTL in seconds.',
+      env: 'CMS_CACHE_TTL',
+      format: Number,
+    },
+    strapiClient: {
+      apiUrl: {
+        default: 'http://localhost:1337',
+        doc: 'Base URL for Strapi API',
+        env: 'CMS_STRAPI_API_URL',
+        format: String,
+      },
+      apiKey: {
+        default: '',
+        doc: 'API key for Strapi to fetch RP-provided content',
+        env: 'CMS_STRAPI_API_KEY',
+        format: String,
+      }
+    }
+  },
   rateLimit: {
     ignoreIPs: {
       default: undefined,

--- a/packages/fxa-auth-server/lib/routes/cms.ts
+++ b/packages/fxa-auth-server/lib/routes/cms.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ConfigType } from '../../config';
+import { AuthLogger, AuthRequest } from '../types';
+import { CMSManager } from '@fxa/accounts/cms';
+import { Container } from 'typedi';
+import AppError from '../error';
+import isA from 'joi';
+import validators from './validators';
+import { StatsD } from 'hot-shots';
+
+export class CMSHandler {
+  private readonly cmsManager: CMSManager | null;
+  private config: ConfigType;
+  private statsd: StatsD;
+
+  constructor(
+    private log: AuthLogger,
+    config: ConfigType,
+    statsD: StatsD
+  ) {
+    this.cmsManager = Container.has(CMSManager)
+      ? Container.get(CMSManager)
+      : null;
+    this.config = config;
+    this.statsd = statsD;
+  }
+
+  async getConfig(request: AuthRequest) {
+    this.log.begin('cms.getConfig', request);
+
+    if (!this.config.cmsAccounts.enabled || !this.cmsManager) {
+      throw AppError.featureNotEnabled();
+    }
+
+    const clientId = request.query.clientId;
+    const entrypoint = request.query.entrypoint;
+
+    try {
+      return await this.cmsManager.getConfig(clientId, entrypoint);
+    } catch (error) {
+      // We don't want failures to fetch a config to bubble up to the user.
+      this.statsd.increment(`cms.getConfig.error.${clientId}.${entrypoint}`);
+      return {};
+    }
+  }
+}
+
+export const cmsRoutes = (
+  log: AuthLogger,
+  config: ConfigType,
+  statsD: StatsD
+) => {
+  const cmsHandler = new CMSHandler(log, config, statsD);
+  return [
+    {
+      method: 'GET',
+      path: '/cms/config',
+      options: {
+        validate: {
+          query: isA.object({
+            clientId: validators.clientId.required(),
+            entrypoint: validators.entrypoint,
+          }),
+        },
+      },
+      handler: (request: AuthRequest) => cmsHandler.getConfig(request),
+    },
+  ];
+};
+
+export default cmsRoutes;

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -220,6 +220,13 @@ module.exports = function (
     glean
   );
 
+  const { cmsRoutes } = require('./cms');
+  const cms = cmsRoutes(
+    log,
+    config,
+    statsd
+  );
+
   const { cloudTaskRoutes } = require('./cloud-tasks');
   const cloudTasks = cloudTaskRoutes(log, config, statsd);
 
@@ -250,7 +257,8 @@ module.exports = function (
     newsletters,
     linkedAccounts,
     cloudTasks,
-    cloudScheduler
+    cloudScheduler,
+    cms
   );
 
   function optionallyIgnoreTrace(fn) {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -892,3 +892,7 @@ module.exports.thirdPartyProvider = isA
 
 module.exports.thirdPartyIdToken = module.exports.jwt.optional();
 module.exports.thirdPartyOAuthCode = isA.string().optional();
+
+module.exports.entrypoint = isA.string()
+  .regex(/^[a-zA-Z0-9_-]+$/) // Only allow letters, digits, underscores, and dashes
+  .required();

--- a/packages/fxa-shared/db/config.ts
+++ b/packages/fxa-shared/db/config.ts
@@ -340,6 +340,38 @@ export function makeRedisConfig() {
       },
     },
 
+    cmsAccounts: {
+      enabled: {
+        default: true,
+        doc: 'Enable Redis for Strapi caching',
+        format: Boolean,
+        env: 'CMS_ACCOUNTS_REDIS_ENABLED',
+      },
+      host: {
+        default: 'localhost',
+        env: 'CMS_ACCOUNTS_REDIS_HOST',
+        format: String,
+      },
+      port: {
+        default: 6379,
+        env: 'CMS_ACCOUNTS_REDIS_PORT',
+        format: 'port',
+      },
+      password: {
+        default: '',
+        env: 'CMS_ACCOUNTS_REDISS_PASSWORD',
+        format: String,
+        sensitive: true,
+        doc: `Password for connecting to redis`,
+      },
+      prefix: {
+        default: 'cmsaccounts:',
+        env: 'CMS_ACCOUNTS_REDISS_KEY_PREFIX',
+        format: String,
+        doc: 'Key prefix for strapi server records in Redis',
+      },
+    },
+
     metrics: {
       enabled: {
         default: true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
         "libs/accounts/recovery-phone/src/index.ts"
       ],
       "@fxa/accounts/two-factor": ["libs/accounts/two-factor/src/index.ts"],
+      "@fxa/accounts/cms": ["libs/accounts/cms/src/index.ts"],
       "@fxa/google": ["libs/google/src/index.ts"],
       "@fxa/payments/capability": ["libs/payments/capability/src/index.ts"],
       "@fxa/payments/cart": ["libs/payments/cart/src/index.ts"],


### PR DESCRIPTION
ON HOLD DONT REVIEW

## Because

- Add the backend API and configuration for Strapi to manage CMS
- We want to be able to cache Strapi configs for improving performance

## This pull request

- Adds the `@fxa/accounts-cms` NX library, which includes:
  - A `StrapiClient` class for making authenticated HTTP requests to the Strapi API
  - A `CMSManager` class for fetching and caching CMS configurations in Redis, with StatsD metrics tracking
- Integrates the CMS functionality into the `fxa-auth-server`:
  - Adds CMS configuration options in `config/index.ts` (e.g., `cmsAccounts.enabled`, `strapiClient.apiUrl`, `strapiClient.apiKey`)
  - Introduces a new `/cms/config` GET endpoint in `lib/routes/cms.ts` to fetch CMS configurations based on `clientId` and `entrypoint`
  - Sets up Redis for CMS caching

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11895

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)