### PR TITLE
fix(payments-next): Fix string|string[] mismatch in metrics collection code

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -49,7 +49,7 @@ export default async function CheckoutError({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -40,7 +40,7 @@ export default async function NeedsInputPage({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -39,7 +39,7 @@ export default async function ProcessingPage({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -54,7 +54,7 @@ export default async function Checkout({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const { locale } = params;
 
@@ -80,7 +80,7 @@ export default async function Checkout({
 
   // prevent cart and session user mismatch
   if (cart.uid !== session?.user?.id) {
-    const redirectSearchParams: Record<string, string> = searchParams || {};
+    const redirectSearchParams: Record<string, string | string[]> = searchParams || {};
     delete redirectSearchParams.cartId;
     delete redirectSearchParams.cartVersion;
     const redirectTo = buildRedirectUrl(
@@ -97,7 +97,7 @@ export default async function Checkout({
     redirect(redirectTo);
   }
 
-  const redirectSearchParams: Record<string, string> = searchParams || {};
+  const redirectSearchParams: Record<string, string | string[]> = searchParams || {};
   redirectSearchParams.cartId = cart.id;
   redirectSearchParams.cartVersion = cart.version.toString();
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -44,7 +44,7 @@ export default async function CheckoutSuccess({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
@@ -29,7 +29,7 @@ export default async function Location({
   searchParams,
 }: {
   params: BaseParams;
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const acceptLanguage = headers().get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, params.locale);
@@ -40,8 +40,12 @@ export default async function Location({
   const taxAddress =
     providedCountryCode && providedPostalCode
       ? {
-          countryCode: providedCountryCode,
-          postalCode: providedPostalCode,
+          countryCode: Array.isArray(providedCountryCode)
+            ? providedCountryCode[0]
+            : providedCountryCode,
+          postalCode: Array.isArray(providedPostalCode)
+            ? providedPostalCode[0]
+            : providedPostalCode,
         }
       : undefined;
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -20,7 +20,7 @@ import { getIpAddress } from '@fxa/payments/ui/server';
 function getRedirectToUrl(
   cart: ResultCart,
   params: BaseParams,
-  searchParams: Record<string, string>
+  searchParams: Record<string, string | string[]>
 ) {
   const { id, state, eligibilityStatus } = cart;
   const { offeringId, interval, locale } = params;
@@ -52,16 +52,22 @@ export default async function New({
   searchParams,
 }: {
   params: BaseParams;
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const { offeringId, interval } = params;
   const ipAddress = getIpAddress();
   const session = await auth();
 
   const fxaUid = session?.user?.id;
-  const searchParamsCoupon = searchParams.coupon || undefined;
-  const countryCode = searchParams.countryCode;
-  const postalCode = searchParams.postalCode;
+  const searchParamsCoupon = Array.isArray(searchParams.coupon)
+    ? searchParams.coupon[0]
+    : searchParams.coupon || undefined;
+  const countryCode = Array.isArray(searchParams.countryCode)
+    ? searchParams.countryCode[0]
+    : searchParams.countryCode || undefined;
+  const postalCode = Array.isArray(searchParams.postalCode)
+    ? searchParams.postalCode[0]
+    : searchParams.postalCode || undefined;
 
   const taxAddress =
     countryCode && postalCode
@@ -106,7 +112,9 @@ export default async function New({
 
   if (searchParams.cartId && searchParams.cartVersion) {
     const { couponCode: fetchedCoupon } = await getCouponAction(
-      searchParams.cartId,
+      Array.isArray(searchParams.cartId)
+        ? searchParams.cartId[0]
+        : searchParams.cartId,
       Number(searchParams.cartVersion)
     );
     cartCoupon = fetchedCoupon;

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -47,7 +47,7 @@ export default async function UpgradeError({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -40,7 +40,7 @@ export default async function NeedsInputPage({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -39,7 +39,7 @@ export default async function ProcessingPage({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
@@ -27,7 +27,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -44,7 +44,7 @@ export default async function UpgradeSuccess({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }): Promise<Metadata> {
   return buildPageMetadata({
     params,
@@ -45,7 +45,7 @@ export default async function Upgrade({
   searchParams,
 }: {
   params: CheckoutParams;
-  searchParams: Record<string, string> | undefined;
+  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');

--- a/apps/payments/next/app/[locale]/auth/error/page.tsx
+++ b/apps/payments/next/app/[locale]/auth/error/page.tsx
@@ -14,7 +14,7 @@ import { getApp } from '@fxa/payments/ui/server';
 export default function AuthErrorPage({
   searchParams,
 }: {
-  searchParams: Record<string, string>;
+  searchParams: Record<string, string | string[]>;
 }) {
   const cookieStore = cookies();
   const redirectUrl =
@@ -22,9 +22,12 @@ export default function AuthErrorPage({
     cookieStore.get('authjs.callback-url')?.value;
   const supportUrl = config.supportUrl;
   const l10n = getApp().getL10n();
+  const errorMessage = Array.isArray(searchParams?.error)
+    ? searchParams.error[0]
+    : searchParams?.error;
   getApp()
     .getEmitterService()
-    .emit('auth', { type: 'error', errorMessage: searchParams?.error });
+    .emit('auth', { type: 'error', errorMessage });
 
   return (
     <>

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -8,6 +8,7 @@ import { redirect } from 'next/navigation';
 import { getApp } from '../nestapp/app';
 import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
+import { URLSearchParams } from 'url';
 import {
   StartCartDTO,
   ProcessingCartDTO,
@@ -25,33 +26,32 @@ import {
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.START,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<StartCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.PROCESSING,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<ProcessingCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.NEEDS_INPUT,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<NeedsInputCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.ERROR,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<FailCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.SUCCESS,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<SuccessCartDTO>;
-
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<CartDTO> {
   const urlSearchParams = new URLSearchParams(searchParams);
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
@@ -4,6 +4,7 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import { flattenRouteParams } from '../utils/flatParam';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
 import { PaymentProvidersType } from '@fxa/payments/cart';
 import { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
@@ -11,34 +12,33 @@ import { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
 async function recordEmitterEventAction(
   eventName: PaymentsEmitterEventsKeysType,
   params: Record<string, string | string[]>,
-  searchParams: Record<string, string>
+  searchParams: Record<string, string | string[]>
 ): Promise<void>;
 
 async function recordEmitterEventAction(
   eventName: 'checkoutFail',
   params: Record<string, string | string[]>,
-  searchParams: Record<string, string>,
+  searchParams: Record<string, string | string[]>,
   paymentProvider?: PaymentProvidersType
 ): Promise<void>;
 
 async function recordEmitterEventAction(
   eventName: 'checkoutSubmit' | 'checkoutSuccess',
   params: Record<string, string | string[]>,
-  searchParams: Record<string, string>,
+  searchParams: Record<string, string | string[]>,
   paymentProvider: PaymentProvidersType
 ): Promise<void>;
 
 async function recordEmitterEventAction(
   eventName: PaymentsEmitterEventsKeysType,
   params: Record<string, string | string[]>,
-  searchParams: Record<string, string>,
+  searchParams: Record<string, string | string[]>,
   paymentProvider?: PaymentProvidersType
 ) {
   const requestArgs = {
     ...getAdditionalRequestArgs(),
-    // TODO: This type mismatch appears to be an actual bug -- FXA-11214
-    params: params as Record<string, string>,
-    searchParams,
+    params: flattenRouteParams(params),
+    searchParams: flattenRouteParams(searchParams),
   };
 
   return getApp().getActionsService().recordEmitterEvent({

--- a/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
@@ -8,6 +8,7 @@ import { redirect } from 'next/navigation';
 import { getApp } from '../nestapp/app';
 import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
+import { URLSearchParams } from 'url';
 
 /**
  * Redirect if cart state does not match supported page
@@ -17,7 +18,7 @@ import { SupportedPages } from '../utils/types';
 async function validateCartStateAndRedirectAction(
   cartId: string,
   page: SupportedPages,
-  searchParams?: Record<string, string>
+  searchParams?: Record<string, string | string[]>
 ): Promise<void> {
   const urlSearchParams = new URLSearchParams(searchParams);
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';

--- a/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
+++ b/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import type { Page, PageType } from './types';
+import { URLSearchParams } from 'url';
 
 interface Optional {
   baseUrl?: string;
   locale?: string;
   cartId?: string;
-  searchParams?: Record<string, string>;
+  searchParams?: Record<string, string | string[]>;
 }
 
 export function buildRedirectUrl(

--- a/libs/payments/ui/src/lib/utils/flatParam.ts
+++ b/libs/payments/ui/src/lib/utils/flatParam.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * @param params NextJS URL path or query parameters
+ * @returns A flattened Record<string, string> object, with array values of
+ * the original param object marged into a comma-separated value string
+ */
+export const flattenRouteParams = (
+  params: Record<string, string | string[]>
+): Record<string, string> => {
+  const flatParams: Record<string, string> = {};
+  for (const key in params) {
+    if (Array.isArray(params[key])) {
+      flatParams[key] = params[key].join(',');
+    } else {
+      flatParams[key] = params[key];
+    }
+  }
+  return flatParams;
+};

--- a/libs/payments/ui/src/lib/utils/pageMetadata.ts
+++ b/libs/payments/ui/src/lib/utils/pageMetadata.ts
@@ -15,7 +15,7 @@ export async function buildPageMetadata(args: {
   pageType: PageType,
   acceptLanguage: string | null,
   baseUrl: string,
-  searchParams?: Record<string, string> | undefined,
+  searchParams?: Record<string, string | string[]> | undefined,
 }): Promise<Metadata> {
   const {
     params,


### PR DESCRIPTION
Because:

* Query params in NextJS can be of type string or string[], but we're only parsing them as strings

This commit:

* updates typing across the app for clarity
* parses array params into csv strings

Closes #FXA-11214

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
