### PR TITLE
fix(next): on auth profile info fetch redirect to error page

### DIFF
--- a/apps/payments/next/auth.ts
+++ b/apps/payments/next/auth.ts
@@ -41,6 +41,16 @@ export const {
       clientSecret: config.auth.clientSecret,
       token: config.auth.tokenUrl,
       profile: (profile) => {
+        // A successful profile fetch should always return a uid
+        // This is a temporary fix and a permanent solution should be
+        // implemented as part of FXA-11964
+        if (!profile.uid) {
+          console.log('AuthProfileFetchError', { profile });
+          throw new AuthError(
+            'Error while fetching user profile',
+            { info: profile }
+          );
+        }
         return {
           id: profile.uid,
           name: profile.displayName,


### PR DESCRIPTION
## Because

- Currently an error that might occur during profile fetch will redirect the customer to the SP3 checkout page in a half logged in, half logged out state, preventing the customer from completing a subscription, but also not showing any useful error information.

## This pull request

- Throws an error during auth when the profile can not be fetched, and redirects customers to an error page informing them that an error ocurred.

## Issue that this pull request solves

Closes: 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before
![image](https://github.com/user-attachments/assets/d617b630-c9bb-4c93-af89-96e185e8f717)

After
![image](https://github.com/user-attachments/assets/fef8cbec-8ea8-47b5-9915-d0e676f4d678)
