### PR TITLE
fix(metrics): Tweak 2FA Glean metrics to only emit on a login flow

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -427,6 +427,7 @@ class RecoveryPhoneHandler {
       const { acceptLanguage, geo, ua } = request.app;
 
       this.statsd.increment('account.recoveryPhone.phoneSignin.success');
+
       // this signals the end of the login flow
       await request.emitMetricsEvent('account.confirmed', { uid });
 

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -332,15 +332,12 @@ describe('totp', () => {
         assert.equal('totp-2fa', args[1], 'called with correct method');
 
         // emits correct metrics
-        sinon.assert.calledTwice(request.emitMetricsEvent);
+        sinon.assert.calledOnce(request.emitMetricsEvent);
         sinon.assert.calledWith(
           request.emitMetricsEvent,
           'totpToken.verified',
           { uid: 'uid' }
         );
-        sinon.assert.calledWith(request.emitMetricsEvent, 'account.confirmed', {
-          uid: 'uid',
-        });
 
         // correct emails sent
         assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);


### PR DESCRIPTION
## Because

- The TOTP routes were emitting login and account confirmation events during both setup and login flows, which caused duplicate or misleading metrics.

## This pull request

- Updates the TOTP route to only emit login success and account confirmation events during actual login, not during TOTP setup.
- Updates related tests to match the new event flow.

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11697

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)
