### PR TITLE
bug(settings): Don't allow access to /settings if session isn't verified.

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -135,6 +135,13 @@ export const Settings = ({
     return <AppErrorDialog data-testid="error-dialog" />;
   }
 
+  // If the session hasn't been verified, kick back to root
+  if (session.verified === false) {
+    console.warn('Session.verified false on /settings access!');
+    navigateWithQuery('/');
+    return <LoadingSpinner fullScreen />;
+  }
+
   return (
     <SettingsLayout>
       <Head />


### PR DESCRIPTION
## Because

- User's can direct navigate to /settings from the confirmation code page.

## This pull request

- Makes `session.verified` required to render `/settings` route

## Issue that this pull request solves

Closes: FXA-11927

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Although it might seem strange, it's not actually a big deal if someone access `/settings` with unverified session. The `session.verified` flag is mostly just an artifact that `auth-server` uses to gate access to certain actions. That said, there's really no reason to render the `/settings` route in this case, since the majority of actions would be blocked anyways.
