### PR TITLE
bug(ci): Test artifacts were not declared in nx.json config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -87,6 +87,7 @@
       "inputs": ["production", "^production"],
       "dependsOn": ["test-unit", "test-integration", "test-e2e"],
       "outputs": [
+        "{workspaceRoot}/artifacts/tests",
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
         "{projectRoot}/test-results.xml"
@@ -97,6 +98,7 @@
       "dependsOn": ["build"],
       "inputs": ["production", "^production"],
       "outputs": [
+        "{workspaceRoot}/artifacts/tests",
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
         "{projectRoot}/test-results.xml"
@@ -106,6 +108,7 @@
       "dependsOn": ["build", "gen-keys"],
       "inputs": ["test", "^test"],
       "outputs": [
+        "{workspaceRoot}/artifacts/tests",
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
         "{projectRoot}/test-results.xml",
@@ -117,6 +120,7 @@
       "dependsOn": ["build", "gen-keys"],
       "inputs": ["test", "^test"],
       "outputs": [
+        "{workspaceRoot}/artifacts/tests",
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
         "{projectRoot}/test-results.xml",
@@ -128,6 +132,7 @@
       "dependsOn": ["build", "gen-keys"],
       "inputs": ["test", "^test"],
       "outputs": [
+        "{workspaceRoot}/artifacts/tests",
         "{projectRoot}/coverage",
         "{projectRoot}/.nyc_output",
         "{projectRoot}/test-results.xml"
@@ -145,7 +150,8 @@
           "ci": true,
           "codeCoverage": true
         }
-      }
+      },
+      "outputs": ["{workspaceRoot}/artifacts/tests"]
     },
     "@nx/js:tsc": {
       "cache": true,


### PR DESCRIPTION
## Because

- We want to be able to use the nx cache

## This pull request

- Makes sure test artifacts are cached as part of the test output

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
