### PR TITLE
bug(settings): Don't block UI with spinner on setIsSignedIn

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -10,6 +10,7 @@ import {
   useState,
   useLayoutEffect,
   useMemo,
+  startTransition,
 } from 'react';
 
 import { QueryParams } from '../..';
@@ -191,7 +192,9 @@ export const App = ({
 
       // If the local apollo cache says we are signed in, then we can skip the rest.
       if (isSignedInData?.isSignedIn === true) {
-        setIsSignedIn(true);
+        startTransition(() => {
+          setIsSignedIn(true);
+        });
         return;
       }
 
@@ -201,7 +204,9 @@ export const App = ({
         localUser?.sessionToken &&
         (await session.isValid(localUser.sessionToken))
       ) {
-        setIsSignedIn(true);
+        startTransition(() => {
+          setIsSignedIn(true);
+        });
         return;
       }
 
@@ -241,7 +246,9 @@ export const App = ({
         }
       }
 
-      setIsSignedIn(isValidSession);
+      startTransition(() => {
+        setIsSignedIn(isValidSession);
+      });
     };
     initializeSession();
   }, [integration, isSignedInData?.isSignedIn, session]);


### PR DESCRIPTION
## Because

- We don't want to block the UI with a loading spinner while determining the session status

## This pull request

- Wraps calls to `setIsSignedIn(...)` with `startTransition`
- This tells react not to put the UI into a 'suspended' state which might trigger a loading spinner.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I manually tested with different 'network throttling' settings in dev tools, and couldn't see any difference in UX. If this gets the error to go away, I'm all for it though.
