### PR TITLE
fix(payments-next):Error in getNeedsInput does not cleanup subscription

### DIFF
--- a/libs/payments/ui/src/lib/actions/getNeedsInput.ts
+++ b/libs/payments/ui/src/lib/actions/getNeedsInput.ts
@@ -5,9 +5,22 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import * as Sentry from '@sentry/nextjs';
+import { revalidatePath } from 'next/cache';
 
-export const getNeedsInputAction = async (cartId: string) => {
-  const inputNeeded = getApp().getActionsService().getNeedsInput({ cartId });
+export const getNeedsInputAction = async (
+  cartId: string
+) => {
+  try {
+    const inputNeeded = await getApp().getActionsService().getNeedsInput({ cartId });
+    return inputNeeded;
+  } catch (error) {
+    Sentry.captureException(error);
+    revalidatePath(
+        `/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input`,
+        'page'
+    );
+    return;
+  }
 
-  return inputNeeded;
 };

--- a/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
@@ -26,20 +26,22 @@ export function PaymentInputHandler({ cartId }: { cartId: string }) {
     }
     const handleNextAction = async () => {
       const inputRequest = await getNeedsInputAction(cartId);
-      switch (inputRequest.inputType) {
-        case 'stripeHandleNextAction':
-          await stripe.handleNextAction({
-            clientSecret: inputRequest.data.clientSecret,
-          });
-          await submitNeedsInputAndRedirectAction(cartId);
-          break;
-        case 'notRequired':
-          await validateCartStateAndRedirectAction(
-            cartId,
-            SupportedPages.NEEDS_INPUT,
-            searchParamsRecord
-          );
-          break;
+      if (inputRequest) {
+        switch (inputRequest.inputType) {
+          case 'stripeHandleNextAction':
+            await stripe.handleNextAction({
+              clientSecret: inputRequest.data.clientSecret,
+            });
+            await submitNeedsInputAndRedirectAction(cartId);
+            break;
+          case 'notRequired':
+            await validateCartStateAndRedirectAction(
+              cartId,
+              SupportedPages.NEEDS_INPUT,
+              searchParamsRecord
+            );
+            break;
+        }
       }
     };
     handleNextAction();


### PR DESCRIPTION
## Because

- Error in getNeedsInput does not cleanup subscription.

## This pull request

- Wraps getNeedsInput in wrapWithCartCatch to clean up subscription if error occurs.
- Redirects user to appropriate page (like error) from needs_input.

## Issue that this pull request solves

Closes: #FXA-11864

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
