### PR TITLE
fix(payments): Fix failing subscription deletion email send hook

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -1059,12 +1059,13 @@ export class StripeWebhookHandler extends StripeHandler {
       subscription.latest_invoice,
       INVOICES_RESOURCE
     );
-    const invoiceDetails =
-      await this.stripeHelper.extractInvoiceDetailsForEmail(invoice);
+
     if (subscription.metadata?.cancelled_for_customer_at) {
       // Subscription already cancelled, should have triggered an email earlier
-      return invoiceDetails;
+      return;
     }
+    const invoiceDetails =
+      await this.stripeHelper.extractInvoiceDetailsForEmail(invoice);
     const { uid, email, invoiceStatus } = invoiceDetails;
 
     let account;
@@ -1117,8 +1118,6 @@ export class StripeWebhookHandler extends StripeHandler {
         );
       }
     }
-
-    return invoiceDetails;
   }
 
   async getSubscriptionEndedEventDetails(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -2397,13 +2397,12 @@ describe('StripeWebhookHandler', () => {
           subscription
         );
 
-        assert.calledWith(
-          StripeWebhookHandlerInstance.stripeHelper
-            .extractInvoiceDetailsForEmail,
-          { id: subscription.latest_invoice }
-        );
-
         if (shouldSendSubscriptionFailedPaymentsCancellationEmail()) {
+          assert.calledWith(
+            StripeWebhookHandlerInstance.stripeHelper
+              .extractInvoiceDetailsForEmail,
+            { id: subscription.latest_invoice }
+          );
           assert.calledWith(
             StripeWebhookHandlerInstance.mailer
               .sendSubscriptionFailedPaymentsCancellationEmail,


### PR DESCRIPTION
Because:

* A hook within the stripe-helpers was failing for users who cancelled a subscription while they had a positive account balance (such as after a significantly cheaper bundle purchase)
* In each case, a cusomer had manually cancelled the subscription before this error occurred

This commit:

* Moves the logic to exit early from the subscription-deletion email send function, preventing the unnecessary, failing, Stripe call.
* This method had previously exited early without sending an email, so no functionality is altered
* Removes the unused `return` value for the `sendSubscriptionDeletedEmail` function

Closes #FXA-11934

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
This is a somewhat shallow fix, as customers who did not voluntarily cancel their subscriptions *and* had a positive account balance could still encounter this issue. This is in SP2/stripe-helper though, and so is likely to be deprecated before this becomes a significant issue
