### PR TITLE
feat(auth): Add API endpoint to check for feature availability based on location

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -2340,7 +2340,7 @@ export default class AuthClient {
   }
 
   /**
-   * Gets status of the recovery phone on the users account.\
+   * Gets status of the recovery phone on the users account.
    * @param sessionToken The user's current session token
    * @param headers
    * @returns { exists:boolean, phoneNumber: string }
@@ -2365,6 +2365,21 @@ export default class AuthClient {
       null,
       headers
     );
+  }
+
+  /**
+   * Checks if a feature is available based on user location.
+   * @param sessionToken The user's current session token
+   * @param feature The feature that we are checking
+   * @param headers
+   * @returns { eligible:boolean }
+   */
+  async geoEligibilityCheck(
+    sessionToken: string,
+    feature: string,
+    headers?: Headers
+  ): Promise<{ eligible: boolean }> {
+    return this.sessionGet(`/geo/eligibility/${feature}`, sessionToken, headers);
   }
 
   protected async getPayloadV2({

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -159,6 +159,14 @@ const convictConf = convict({
       env: 'GEODB_LOCATION_OVERRIDE',
     },
   },
+  geoEligibility: {
+    rules: {
+      doc: 'Mapping of features to country codes that are allowed to see the feature',
+      format: Object,
+      default: {}, // ex. { "MONITORPLUSPROMO": ["US"] }
+      env: 'GEO_ELIGIBILITY_RULES',
+    },
+  },
   appleAuthConfig: {
     clientId: {
       default: 'com.mozilla.firefox.accounts.auth',

--- a/packages/fxa-auth-server/docs/swagger/misc-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/misc-api.ts
@@ -79,10 +79,23 @@ const OAUTH_ID_TOKEN_VERIFY_POST = {
   ],
 };
 
+const GEO_ELIGIBILITY_GET = {
+  ...TAGS_MISC,
+  description: 'geo/eligibility/{feature}',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Returns eligibility for a given feature based on user's country.
+    `,
+  ],
+};
+
 const API_DOCS = {
   ACCOUNT_GET,
   ACCOUNT_LOCK_POST,
   ACCOUNT_SESSIONS_LOCATIONS_GET,
+  GEO_ELIGIBILITY_GET,
   NEWSLETTERS_POST,
   OAUTH_ID_TOKEN_VERIFY_POST,
   SUPPORT_TICKET_POST,

--- a/packages/fxa-auth-server/lib/routes/geo-location.ts
+++ b/packages/fxa-auth-server/lib/routes/geo-location.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Generic **location‑based eligibility** helper and route.
+
+import isA from 'joi';
+import { ConfigType } from '../../config';
+import { AuthLogger, AuthRequest } from '../types';
+import MISC_DOCS from '../../docs/swagger/misc-api';
+
+export type GeoEligibilityRules = Record<string, string[]>;
+
+export class GeoEligibilityCheckService {
+  private readonly rules: GeoEligibilityRules;
+
+  constructor(rulesFromConfig: GeoEligibilityRules = {}) {
+    // Normalise once: every feature + country stored in UPPER‑CASE.
+    this.rules = Object.entries(rulesFromConfig).reduce<GeoEligibilityRules>(
+      (acc, [feature, countries]) => {
+        acc[feature.toUpperCase()] = (countries ?? []).map((c) =>
+          c.toUpperCase()
+        );
+        return acc;
+      },
+      {}
+    );
+  }
+
+  /** Expose the (already normalised) rule set for diagnostics/logging. */
+  getRules(): GeoEligibilityRules {
+    return this.rules;
+  }
+
+  exists(feature: string): boolean {
+    return feature.toUpperCase() in this.rules;
+  }
+
+  isAllowed(feature: string, country?: string | null): boolean {
+    if (!country) return false;
+    const allow = this.rules[feature.toUpperCase()];
+    return Array.isArray(allow) && allow.includes(country.toUpperCase());
+  }
+}
+
+export class GeoLocationHandler {
+  private readonly geoEligibilityCheckService: GeoEligibilityCheckService;
+
+  constructor(
+    private config: ConfigType,
+    private log: AuthLogger
+  ) {
+    const rulesFromConfig = (config.geoEligibility?.rules ??
+      {}) as GeoEligibilityRules;
+    this.geoEligibilityCheckService = new GeoEligibilityCheckService(rulesFromConfig);
+  }
+
+  geoEligibilityCheck = (request: AuthRequest) => {
+    this.log.begin('geo.eligibility.check', request);
+    const feature = request.params.feature.toUpperCase();
+
+    if (!this.geoEligibilityCheckService.exists(feature)) {
+      this.log.error('geo.eligibility.checkfailure', {
+        feature,
+        uid: (request.auth.credentials as any).uid,
+        rules: this.geoEligibilityCheckService.getRules(),
+      });
+      return { eligible: false };
+    }
+
+    const country = request.app.geo?.location?.countryCode ?? null;
+    const eligible = this.geoEligibilityCheckService.isAllowed(feature, country);
+
+    this.log.info('geo.eligibility.checked', {
+      feature,
+      country,
+      eligible,
+      uid: (request.auth.credentials as any).uid,
+      rules: this.geoEligibilityCheckService.getRules(),
+    });
+
+    return { eligible };
+  };
+}
+
+export const geoRoutes = (config: ConfigType, log: AuthLogger) => {
+  const handler = new GeoLocationHandler(config, log);
+
+  return [
+    {
+      method: 'GET',
+      path: '/geo/eligibility/{feature}',
+      options: {
+        ...MISC_DOCS.GEO_ELIGIBILITY_GET,
+        auth: {
+          strategy: 'sessionToken',
+          mode: 'required',
+        },
+        validate: {
+          params: isA.object({
+            feature: isA.string().max(64).required(),
+          }),
+        },
+        response: {
+          schema: isA.object({
+            eligible: isA.boolean().required(),
+          }),
+        },
+      },
+      handler: (request: AuthRequest) => handler.geoEligibilityCheck(request),
+    },
+  ];
+};
+
+export default geoRoutes;

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -221,17 +221,16 @@ module.exports = function (
   );
 
   const { cmsRoutes } = require('./cms');
-  const cms = cmsRoutes(
-    log,
-    config,
-    statsd
-  );
+  const cms = cmsRoutes(log, config, statsd);
 
   const { cloudTaskRoutes } = require('./cloud-tasks');
   const cloudTasks = cloudTaskRoutes(log, config, statsd);
 
   const { cloudSchedulerRoutes } = require('./cloud-scheduler');
   const cloudScheduler = cloudSchedulerRoutes(log, config, statsd);
+
+  const { geoRoutes } = require('./geo-location');
+  const geo = geoRoutes(config, log);
 
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {
@@ -258,7 +257,8 @@ module.exports = function (
     linkedAccounts,
     cloudTasks,
     cloudScheduler,
-    cms
+    cms,
+    geo
   );
 
   function optionallyIgnoreTrace(fn) {

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1497,6 +1497,17 @@ module.exports = (config) => {
     );
   };
 
+  ClientApi.prototype.geoEligibilityCheck = async function (
+    sessionToken,
+    feature
+  ) {
+    return this.doRequest(
+      'GET',
+      `${this.baseURL}/eligibility/${feature}`,
+      sessionToken
+    );
+  };
+
   ClientApi.heartbeat = function (origin) {
     return new ClientApi(origin).doRequest('GET', `${origin}/__heartbeat__`);
   };

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -880,6 +880,10 @@ module.exports = (config) => {
     return this.api.verifyTotpCode(this.sessionToken, code, options);
   };
 
+  Client.prototype.geoEligibilityCheck = async function (feature) {
+    return this.api.geoEligibilityCheck(this.sessionToken, feature);
+  };
+
   Client.prototype.replaceRecoveryCodes = function (options = {}) {
     return this.api.replaceRecoveryCodes(this.sessionToken, options);
   };

--- a/packages/fxa-auth-server/test/local/routes/geo-location.js
+++ b/packages/fxa-auth-server/test/local/routes/geo-location.js
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const getRoute = require('../../routes_helpers').getRoute;
+const mocks = require('../../mocks');
+
+let log, routes, route, request, response;
+
+/**
+ * Helper that sets up mocks, constructs the request, executes the handler,
+ * and returns the handler’s response.
+ */
+function setup({
+  countryCode, // e.g. 'US' | 'FR'
+  feature = 'TEST_FEATURE',
+  rules = { TEST_FEATURE: ['US', 'CA'] },
+  geoMissing = false,
+} = {}) {
+  log = mocks.mockLog();
+
+  const config = {
+    geoEligibility: { rules },
+  };
+
+  const geoRoutes = require('../../../lib/routes/geo-location').default;
+  routes = geoRoutes(config, log);
+  route = getRoute(routes, '/geo/eligibility/{feature}', 'GET');
+
+  request = mocks.mockRequest({
+    params: { feature },
+    app: {
+      geo: geoMissing ? undefined : { location: { countryCode } },
+    },
+    credentials: { uid: 'uid123' },
+    log,
+  });
+
+  return route.handler(request);
+}
+
+describe('GET /geo/eligibility/{feature}', () => {
+  describe('eligible country', () => {
+    beforeEach(async () => {
+      response = await setup({ countryCode: 'US' });
+    });
+
+    it('returns { eligible: true }', () => {
+      assert.deepEqual(response, { eligible: true });
+    });
+
+    it('called log.begin correctly', () => {
+      assert.equal(log.begin.callCount, 1);
+      const [name, req] = log.begin.args[0];
+      assert.equal(name, 'geo.eligibility.check');
+      assert.equal(req, request);
+    });
+
+    it('logged the eligibility check', () => {
+      assert.equal(log.info.callCount, 1);
+      const [msg, details] = log.info.args[0];
+      assert.equal(msg, 'geo.eligibility.checked');
+      assert.equal(details.feature, 'TEST_FEATURE');
+      assert.equal(details.country, 'US');
+      assert.equal(details.eligible, true);
+    });
+  });
+
+  describe('ineligible country', () => {
+    beforeEach(async () => {
+      response = await setup({ countryCode: 'FR' });
+    });
+
+    it('returns { eligible: false }', () => {
+      assert.deepEqual(response, { eligible: false });
+    });
+  });
+
+  describe('missing geo information', () => {
+    beforeEach(async () => {
+      response = await setup({ geoMissing: true });
+    });
+
+    it('returns { eligible: false } when country is unknown', () => {
+      assert.deepEqual(response, { eligible: false });
+    });
+  });
+
+  describe('unknown feature', () => {
+    beforeEach(async () => {
+      response = await setup({
+        feature: 'UNKNOWN',
+        countryCode: 'US',
+        rules: { TEST_FEATURE: ['US'] },
+      });
+    });
+
+    it('logs error and returns false', () => {
+      assert.equal(log.error.callCount, 1);
+      const [msg, details] = log.error.args[0];
+      assert.equal(msg, 'geo.eligibility.checkfailure');
+      assert.equal(details.feature, 'UNKNOWN');
+      assert.deepEqual(response, { eligible: false });
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -97,6 +97,11 @@ jest.mock('../../lib/glean', () => ({
   },
 }));
 
+const mockUseGeoEligibilityCheck = jest.fn().mockReturnValue({ eligible: false });
+jest.mock('../../lib/hooks/useGeoEligibilityCheck', () => ({
+  useGeoEligibilityCheck: () => mockUseGeoEligibilityCheck(),
+}));
+
 const mockMetricsQueryAccountAmplitude = {
   recoveryKey: true,
   totpActive: true,
@@ -534,7 +539,15 @@ describe('SettingsRoutes', () => {
         history: { navigate },
       } = renderWithRouter(
         <AppContext.Provider
-          value={{ ...mockAppContext(), ...createAppContext() }}
+          value={{
+            ...mockAppContext({
+              account: {
+                ...MOCK_ACCOUNT,
+                getMonitorPlusPromoEligibility: () => Promise.resolve(false),
+              } as unknown as Account,
+            }),
+            ...createAppContext(),
+          }}
         >
           <App flowQueryParams={updatedFlowQueryParams} />
         </AppContext.Provider>,
@@ -563,7 +576,10 @@ describe('SettingsRoutes', () => {
       } = renderWithRouter(
         <AppContext.Provider
           value={mockAppContext({
-            account: MOCK_ACCOUNT as unknown as Account,
+            account: {
+              ...MOCK_ACCOUNT,
+              getMonitorPlusPromoEligibility: () => Promise.resolve(false),
+            } as unknown as Account,
           })}
         >
           <App flowQueryParams={updatedFlowQueryParams} />

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
@@ -9,83 +9,24 @@ import { PageSettings } from '.';
 import { Config } from '../../../lib/config';
 
 import { LocationProvider } from '@reach/router';
-import { isMobileDevice } from '../../../lib/utilities';
-import { mockAppContext, mockEmail, MOCK_ACCOUNT } from '../../../models/mocks';
-import { MOCK_SERVICES } from '../ConnectedServices/mocks';
+import { mockAppContext } from '../../../models/mocks';
 import { AppContext } from 'fxa-settings/src/models';
-import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
-
-const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
+import {
+  accountEligibleForRecoveryKey,
+  accountEligibleForRecoveryPhoneOnly,
+  coldStartAccount,
+  completelyFilledOutAccount,
+  partiallyFilledOutAccount,
+} from './mocks';
 
 export default {
   title: 'Pages/Settings',
   component: PageSettings,
   decorators: [withLocalization],
 } as Meta;
-
-const coldStartAccount = {
-  ...MOCK_ACCOUNT,
-  displayName: null,
-  avatar: { id: null, url: null },
-  recoveryKey: { exists: false },
-  totp: { exists: false, verified: false },
-  attachedClients: [SERVICES_NON_MOBILE[0]],
-} as unknown as Account;
-
-const partiallyFilledOutAccount = {
-  ...MOCK_ACCOUNT,
-  displayName: null,
-  totp: { exists: true, verified: false },
-  attachedClients: SERVICES_NON_MOBILE,
-  linkedAccounts: MOCK_LINKED_ACCOUNTS,
-} as unknown as Account;
-
-const accountWithoutRecoveryKey = {
-  ...MOCK_ACCOUNT,
-  displayName: null,
-  recoveryKey: { exists: false, estimatedSyncDeviceCount: 2 },
-  totp: { exists: false, verified: false },
-  attachedClients: MOCK_SERVICES,
-  linkedAccounts: MOCK_LINKED_ACCOUNTS,
-} as unknown as Account;
-
-const completelyFilledOutAccount = {
-  ...MOCK_ACCOUNT,
-  subscriptions: [{ created: 1, productName: 'x' }],
-  emails: [mockEmail(), mockEmail('johndope2@gmail.com', false)],
-  attachedClients: SERVICES_NON_MOBILE,
-  linkedAccounts: MOCK_LINKED_ACCOUNTS,
-  totp: { exists: true, verified: true },
-  backupCodes: {
-    hasBackupCodes: true,
-    count: 3,
-  },
-  recoveryPhone: {
-    exists: true,
-    phoneNumber: '1234',
-    available: true,
-    nationalFormat: '',
-  },
-};
-
-const accountEligibleForRecoveryPhone = {
-  ...MOCK_ACCOUNT,
-  recoveryKey: { exists: false, estimatedSyncDeviceCount: 2 },
-  totp: { exists: true, verified: true },
-  backupCodes: {
-    hasBackupCodes: true,
-    count: 3,
-  },
-  recoveryPhone: {
-    exists: false,
-    phoneNumber: null,
-    available: true,
-    nationalFormat: null,
-  },
-};
 
 const storyWithContext = (
   account: Partial<Account>,
@@ -122,11 +63,11 @@ export const CompletelyFilledOut = storyWithContext(
 );
 
 export const PartiallyFilledOutWithKeyPromo = storyWithContext(
-  accountWithoutRecoveryKey,
+  accountEligibleForRecoveryKey,
   'with recovery key promo'
 );
 
 export const PartiallyFilledOutWithPhonePromo = storyWithContext(
-  accountEligibleForRecoveryPhone,
+  accountEligibleForRecoveryPhoneOnly,
   'with recovery phone promo'
 );

--- a/packages/fxa-settings/src/components/Settings/PageSettings/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/mocks.tsx
@@ -1,0 +1,84 @@
+import { isMobileDevice } from '../../../lib/utilities';
+import { Account } from '../../../models';
+import { MOCK_ACCOUNT, mockEmail } from '../../../models/mocks';
+import { MOCK_SERVICES } from '../ConnectedServices/mocks';
+import { MOCK_LINKED_ACCOUNTS } from '../LinkedAccounts/mocks';
+
+const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
+
+export const coldStartAccount = {
+  ...MOCK_ACCOUNT,
+  displayName: null,
+  avatar: { id: null, url: null },
+  recoveryKey: { exists: false },
+  totp: { exists: false, verified: false },
+  attachedClients: [SERVICES_NON_MOBILE[0]],
+} as unknown as Account;
+
+export const partiallyFilledOutAccount = {
+  ...MOCK_ACCOUNT,
+  displayName: null,
+  totp: { exists: true, verified: false },
+  attachedClients: SERVICES_NON_MOBILE,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+} as unknown as Account;
+
+export const accountEligibleForRecoveryKey = {
+  ...MOCK_ACCOUNT,
+  displayName: null,
+  recoveryKey: { exists: false, estimatedSyncDeviceCount: 2 },
+  totp: { exists: false, verified: false },
+  attachedClients: MOCK_SERVICES,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+} as unknown as Account;
+
+export const completelyFilledOutAccount = {
+  ...MOCK_ACCOUNT,
+  subscriptions: [{ created: 1, productName: 'x' }],
+  emails: [mockEmail(), mockEmail('johndope2@gmail.com', false)],
+  attachedClients: SERVICES_NON_MOBILE,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+  totp: { exists: true, verified: true },
+  backupCodes: {
+    hasBackupCodes: true,
+    count: 3,
+  },
+  recoveryPhone: {
+    exists: true,
+    phoneNumber: '1234',
+    available: true,
+    nationalFormat: '',
+  },
+} as unknown as Account;
+
+export const accountEligibleForRecoveryPhoneOnly = {
+  ...MOCK_ACCOUNT,
+  recoveryKey: { exists: false, estimatedSyncDeviceCount: 0 },
+  totp: { exists: true, verified: true },
+  backupCodes: {
+    hasBackupCodes: true,
+    count: 3,
+  },
+  recoveryPhone: {
+    exists: false,
+    phoneNumber: null,
+    available: true,
+    nationalFormat: null,
+  },
+} as unknown as Account;
+
+export const accountEligibleForRecoveryPhoneAndKey = {
+  ...MOCK_ACCOUNT,
+  recoveryKey: { exists: false, estimatedSyncDeviceCount: 2 },
+  totp: { exists: true, verified: true },
+  backupCodes: {
+    hasBackupCodes: true,
+    count: 3,
+  },
+  recoveryPhone: {
+    exists: false,
+    phoneNumber: null,
+    available: true,
+    nationalFormat: null,
+  },
+} as unknown as Account;

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
@@ -7,9 +7,6 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import ProductPromo, { ProductPromoProps } from '.';
 import SettingsLayout from '../SettingsLayout';
-import { Account, AppContext } from '../../../models';
-import { mockAppContext } from '../../../models/mocks';
-import { MozServices } from '../../../lib/types';
 
 export default {
   title: 'Components/Settings/ProductPromo',
@@ -20,68 +17,45 @@ export default {
 /**
  * Helper to generate a Storybook story with a mocked AppContext.
  */
-function storyWithProps(
-  props: ProductPromoProps,
-  account: Account,
-  storyName?: string
-) {
+function storyWithProps(props: ProductPromoProps, storyName?: string) {
   return {
     name: storyName,
     render: () => (
-      <AppContext.Provider
-        value={mockAppContext({
-          account,
-        })}
-      >
-        <SettingsLayout>
-          <ProductPromo {...props} />
-        </SettingsLayout>
-      </AppContext.Provider>
+      <SettingsLayout>
+        <ProductPromo {...props} />
+      </SettingsLayout>
     ),
   };
 }
 
-// Convenience account presets
-const noMonitor = {
-  attachedClients: [],
-  subscriptions: [],
-} as unknown as Account;
-const monitorFree = {
-  attachedClients: [{ name: MozServices.Monitor }],
-  subscriptions: [],
-} as unknown as Account;
-const monitorPlus = {
-  attachedClients: [{ name: MozServices.Monitor }],
-  subscriptions: [{ productName: MozServices.MonitorPlus }],
-} as unknown as Account;
-
 // --- Generic promo: user *without* Monitor or **with** Monitor‑free but not in market eligible for special promo ----------------------------------
 export const DefaultMobile = storyWithProps(
-  { type: 'settings' },
-  noMonitor,
+  {
+    type: 'settings',
+    monitorPromo: { hidePromo: false, showMonitorPlusPromo: false },
+  },
   'Default Monitor promo - Banner - mobile'
 );
 export const DefaultDesktop = storyWithProps(
-  { type: 'sidebar' },
-  noMonitor,
+  {
+    type: 'sidebar',
+    monitorPromo: { hidePromo: false, showMonitorPlusPromo: false },
+  },
   'Default Monitor promo - Sidebar - desktop'
 );
 
 // --- Special promo: Monitor‑free + eligible (US) ----------------------------
 export const SpecialPromoMobile = storyWithProps(
-  { type: 'settings', specialPromoEligible: true },
-  monitorFree,
+  {
+    type: 'settings',
+    monitorPromo: { hidePromo: false, showMonitorPlusPromo: true },
+  },
   'Special promo (US) - Banner - mobile'
 );
 export const SpecialPromoDesktop = storyWithProps(
-  { type: 'sidebar', specialPromoEligible: true },
-  monitorFree,
+  {
+    type: 'sidebar',
+    monitorPromo: { hidePromo: false, showMonitorPlusPromo: true },
+  },
   'Special promo (US) - Sidebar - desktop'
-);
-
-// --- Hidden state: Monitor Plus subscribers --------------------------------
-export const NoPromo = storyWithProps(
-  {},
-  monitorPlus,
-  'No Promo | existing Monitor Plus user'
 );

--- a/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Sidebar/index.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Nav, { NavRefProps } from '../Nav';
-import ProductPromo from '../ProductPromo';
+import ProductPromo, { MonitorPromoData } from '../ProductPromo';
 
 export const SideBar = ({
   profileRef,
@@ -12,7 +12,8 @@ export const SideBar = ({
   connectedServicesRef,
   linkedAccountsRef,
   dataCollectionRef,
-}: NavRefProps) => {
+  monitorPromo,
+}: NavRefProps & { monitorPromo?: MonitorPromoData | null }) => {
   // top-[7.69rem] allows the sticky nav header to align exactly with first section heading
   return (
     <div className="fixed desktop:sticky desktop:top-[7.69rem] inset-0 bg-white desktop:bg-transparent w-full mt-19 desktop:mt-0">
@@ -25,7 +26,9 @@ export const SideBar = ({
           dataCollectionRef,
         }}
       />
-      <ProductPromo type="sidebar" />
+      {monitorPromo && !monitorPromo.hidePromo && (
+        <ProductPromo type="sidebar" {...{ monitorPromo }} />
+      )}
     </div>
   );
 };

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -43,11 +43,17 @@ jest.mock('@reach/router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const mockUseGeoEligibilityCheck = jest.fn().mockReturnValue({ eligible: false });
+jest.mock('../../lib/hooks/useGeoEligibilityCheck', () => ({
+  useGeoEligibilityCheck: () => mockUseGeoEligibilityCheck(),
+}));
+
 describe('Settings App', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
     (useInitialSettingsState as jest.Mock).mockReturnValue({ loading: false });
+    mockNavigate.mockReset();
   });
 
   it('renders `LoadingSpinner` component when loading initial state is true', () => {
@@ -290,6 +296,7 @@ describe('Settings App', () => {
       const account = {
         ...MOCK_ACCOUNT,
         hasPassword: false,
+        getMonitorPlusPromoEligibility: () => Promise.resolve(false),
       } as unknown as Account;
 
       const config = {

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -30,10 +30,9 @@ export const LINK = {
   HUBS: 'https://hubs.mozilla.com/',
   MDN: 'https://developer.mozilla.org/',
   MONITOR: 'https://monitor.mozilla.org/',
-  MONITOR_STAGE: 'https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/',
+  MONITOR_STAGE: 'https://monitor-stage.allizom.org/',
   MONITOR_PLUS: 'https://monitor.mozilla.org/subscription-plans',
-  MONITOR_PLUS_STAGE:
-    'https://stage.firefoxmonitor.nonprod.cloudops.mozgcp.net/subscription-plans',
+  MONITOR_PLUS_STAGE: 'https://monitor-stage.allizom.org/subscription-plans',
   POCKET: 'https://getpocket.com/',
   RELAY: 'https://relay.firefox.com/',
   VPN: 'https://vpn.mozilla.org/',

--- a/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
+++ b/packages/fxa-settings/src/lib/gql-key-stretch-upgrade.ts
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { MutationFunction } from '@apollo/client';
 import {
   CredentialStatus,

--- a/packages/fxa-settings/src/lib/hooks/useGeoEligibilityCheck/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useGeoEligibilityCheck/index.tsx
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useState, useEffect, useRef } from 'react';
+import { sessionToken } from '../../cache';
+import { useAuthClient } from '../../../models';
+
+const featureEligibilityCache = new Map<string, boolean>();
+
+export function useGeoEligibilityCheck(feature: string): {
+  eligible: boolean;
+  loading: boolean;
+} {
+  const [eligible, setEligible] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const authClient = useAuthClient();
+  const hasChecked = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (featureEligibilityCache.has(feature)) {
+      setEligible(featureEligibilityCache.get(feature)!);
+      setLoading(false);
+      return;
+    }
+
+    if (hasChecked.current !== feature) {
+      hasChecked.current = feature;
+
+      authClient
+        .geoEligibilityCheck(sessionToken()!, feature)
+        .then(({ eligible }) => {
+          featureEligibilityCache.set(feature, eligible);
+          setEligible(eligible);
+        })
+        .catch((err) => {
+          console.error('geoEligibilityCheck failed', err);
+          setEligible(false);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+  }, [feature, authClient]);
+
+  return { eligible, loading };
+}


### PR DESCRIPTION
## Because

* We want to check if users are located in the US and eligible for MonitorPlus
* Would be nice if we can reuse this checkpoint in the future for other features

## This pull request

* Adds a new auth-server endpoint and adds handlers
* Uses this endpoint to conditionally display monitor promo to US users

## Issue that this pull request solves

Closes: FXA-11920

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Feature availability rules are controlled via config for easier/faster updates (to add or remove rules and/or countries) without requiring a deployment