### PR TITLE
fix(payments-next): fix navigation workaround for location restrictions

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -28,6 +28,7 @@ import {
 } from '@fxa/payments/ui/actions';
 import { config } from 'apps/payments/next/config';
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -76,6 +77,25 @@ export default async function Checkout({
     cartPromise,
     cmsDataPromise,
   ]);
+
+  // prevent cart and session user mismatch
+  if (cart.uid !== session?.user?.id) {
+    const redirectSearchParams: Record<string, string> = searchParams || {};
+    delete redirectSearchParams.cartId;
+    delete redirectSearchParams.cartVersion;
+    const redirectTo = buildRedirectUrl(
+      params.offeringId,
+      params.interval,
+      'new',
+      'checkout',
+      {
+        baseUrl: config.paymentsNextHostedUrl,
+        locale,
+        searchParams: redirectSearchParams,
+      }
+    );
+    redirect(redirectTo);
+  }
 
   const redirectSearchParams: Record<string, string> = searchParams || {};
   redirectSearchParams.cartId = cart.id;


### PR DESCRIPTION
Because:

* A user can press "back" after being directed to the /location page upon login, which would re-load the original checkout page without the location requirements
* The user would be logged in and the checkout page would show this, but the cart would not have a uid associated with it

This commit:

* If the landing page has a session user id that does not match the cart's uid, the page is refreshed and the user is caught by the /location intercept

Closes #FXA-11958

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
