### PR TITLE
task: audit yarn resolutions – parse-asn1

### DIFF
--- a/package.json
+++ b/package.json
@@ -276,7 +276,6 @@
     "koa": "^2.16.1",
     "minimist": "^1.2.6",
     "nest-typed-config/class-validator": "0.14.1",
-    "parse-asn1": ">=5.1.7",
     "plist": "^3.0.6",
     "protobufjs:>6.0.0 <7": ">=6.11.4",
     "typescript": "5.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -45219,7 +45219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse-asn1@npm:>=5.1.7":
+"parse-asn1@npm:^5.0.0, parse-asn1@npm:^5.1.7":
   version: 5.1.7
   resolution: "parse-asn1@npm:5.1.7"
   dependencies:


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches

## This pull request

- removes the resolution for `parse-asn1` package

## Issue that this pull request solves

Closes: FXA-11988

## Other information

After removing, I confirm that `parse-asn1` still resolves to `5.1.7`, the minimum version set by original resolution.