### PR TITLE
task: audit yarn resolutions – protobufjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,7 +277,6 @@
     "minimist": "^1.2.6",
     "nest-typed-config/class-validator": "0.14.1",
     "plist": "^3.0.6",
-    "protobufjs:>6.0.0 <7": ">=6.11.4",
     "underscore": ">=1.13.2"
   },
   "packageManager": "yarn@3.3.0",


### PR DESCRIPTION
## Because

- Yarn resolutions should be used as last resort
- pinning old packages prohibits security patches

## This pull request

- removes the resolution for `protobufjs` package

## Issue that this pull request solves

Closes: FXA-11991

## Other information

I confirm that before and after resolution removal, `protobufjs` resolves to `7.5.0` (satisfying the resolution).  This is also why yarn.lock is unchanged.