### PR TITLE
[wip] chore(ci): lower functional test ci overhead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -798,7 +798,7 @@ jobs:
             CI=false \
             NODE_ENV=test \
               npx nx run-many -t start \
-              --parallel=2 \
+              --parallel=4 \
               --verbose
               --projects \
                 123done \
@@ -806,7 +806,6 @@ jobs:
                 fxa-content-server \
                 fxa-payments-server \
                 fxa-settings \
-                | tee ~/.pm2/logs/startup.log
           environment:
             NODE_ENV: test
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,6 +785,9 @@ jobs:
             sudo cat /etc/hosts
       - wait-for-infrastructure
       - run:
+          name: Ensure directories
+          command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots
+      - run:
           name: Start services for playwright tests
           # command: ./packages/functional-tests/scripts/start-services.sh
           # testing out having this command here instead of in the script

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,7 +786,24 @@ jobs:
       - wait-for-infrastructure
       - run:
           name: Start services for playwright tests
-          command: ./packages/functional-tests/scripts/start-services.sh
+          # command: ./packages/functional-tests/scripts/start-services.sh
+          # testing out having this command here instead of in the script
+          # it appears that having it in a script is preventing NX cache
+          # from working properly
+          command: |
+            NODE_OPTIONS="--max-old-space-size=7168" \
+            CI=false \
+            NODE_ENV=test \
+              npx nx run-many -t start \
+              --parallel=2 \
+              --verbose
+              --projects \
+                123done \
+                fxa-auth-server \
+                fxa-content-server \
+                fxa-payments-server \
+                fxa-settings \
+                | tee ~/.pm2/logs/startup.log
           environment:
             NODE_ENV: test
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,6 +806,7 @@ jobs:
                 fxa-content-server \
                 fxa-payments-server \
                 fxa-settings \
+            && npx pm2 ls
           environment:
             NODE_ENV: test
           no_output_timeout: 20m


### PR DESCRIPTION
## Because

- The vast majority of functional test CI time is spent waiting for services to start

## This pull request

- Is testing to see if NX-caching is broken for these these because of the startup script

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
