### PR TITLE
feat(next): error on changing upgrade amount

### DIFF
--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -13,6 +13,7 @@ checkout-error-already-subscribed = You’re already subscribed to this product.
 checkout-error-contact-support = Please contact support so we can help you.
 cart-error-currency-not-determined = We were unable to determine the currency for this purchase, please try again.
 checkout-processing-general-error = An unexpected error has occurred while processing your payment, please try again.
+cart-total-mismatch-error = The invoice amount has changed. Please try again.
 
 ## Processing page and Needs Input page - /checkout and /upgrade
 ## Common strings used in multiple pages

--- a/libs/payments/cart/src/lib/checkout.error.ts
+++ b/libs/payments/cart/src/lib/checkout.error.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { TaxAddress } from '@fxa/payments/customer';
 import { BaseError } from '@fxa/shared/error';
 
 /**
@@ -39,7 +40,7 @@ export class InvalidIntentStateError extends CheckoutError {
         cartId,
         paymentIntentId,
         paymentIntentState,
-        intentType
+        intentType,
       }
     );
     this.name = 'InvalidPaymentIntentStateError';
@@ -87,5 +88,37 @@ export class PaymentMethodUpdateFailedError extends CheckoutError {
       customerId,
     });
     this.name = 'PaymentMethodUpdateFailedError';
+  }
+}
+
+export class DetermineCheckoutAmountFromPriceRequiredError extends CheckoutError {
+  constructor(priceId: string, currency: string, taxAddress: TaxAddress) {
+    super('fromPrice not present for upgrade cart', {
+      priceId,
+      currency,
+      taxAddress,
+    });
+    this.name = 'DetermineCheckoutAmountCustomerRequiredError';
+  }
+}
+
+export class DetermineCheckoutAmountCustomerRequiredError extends CheckoutError {
+  constructor(priceId: string, currency: string, taxAddress: TaxAddress) {
+    super('Customer is required for upgrade', {
+      priceId,
+      currency,
+      taxAddress,
+    });
+    this.name = 'DetermineCheckoutAmountCustomerRequiredError';
+  }
+}
+
+export class DetermineCheckoutAmountSubscriptionRequiredError extends CheckoutError {
+  constructor(customerId: string, fromPriceId: string) {
+    super('Subscription required', {
+      customerId,
+      fromPriceId,
+    });
+    this.name = 'DetermineCheckoutAmountCustomerRequiredError';
   }
 }

--- a/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
+++ b/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
@@ -6,6 +6,7 @@ import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
 import {
   CartCurrencyNotFoundError,
   CartStateProcessingError,
+  CartTotalMismatchError,
 } from '../cart.error';
 import { CheckoutError } from '../checkout.error';
 import { BaseError } from '@fxa/shared/error';
@@ -22,6 +23,8 @@ export function resolveErrorInstance(error: Error) {
       return CartErrorReasonId.CART_CURRENCY_NOT_DETERMINED;
     case error instanceof CartStateProcessingError:
       return CartErrorReasonId.CART_PROCESSING_GENERAL_ERROR;
+    case error instanceof CartTotalMismatchError:
+      return CartErrorReasonId.CART_TOTAL_MISMATCH;
 
     // Checkout Errors
     case error instanceof CheckoutError:

--- a/libs/payments/customer/src/lib/invoice.factories.ts
+++ b/libs/payments/customer/src/lib/invoice.factories.ts
@@ -3,23 +3,32 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { faker } from '@faker-js/faker';
-import { InvoicePreview } from './types';
+import { InvoicePreview, type InvoicePreviewForUpgrade } from './types';
 
 export const InvoicePreviewFactory = (
   override?: Partial<InvoicePreview>
 ): InvoicePreview => ({
   currency: faker.finance.currencyCode(),
-  listAmount: faker.number.int({ max: 1000 }),
-  totalAmount: faker.number.int({ max: 1000 }),
+  listAmount: faker.number.int({ min: 1, max: 1000 }),
+  totalAmount: faker.number.int({ min: 1, max: 1000 }),
   taxAmounts: [],
   discountAmount: null,
-  subtotal: faker.number.int({ max: 1000 }),
+  subtotal: faker.number.int({ min: 1, max: 1000 }),
   discountEnd: null,
   discountType: faker.helpers.arrayElement(['forever', 'once', 'repeating']),
   number:
     faker.string.alphanumeric({ length: 8 }).toLocaleUpperCase() +
     '-' +
     faker.string.numeric({ length: 4, allowLeadingZeros: true }),
-  ...override,
   nextInvoiceDate: faker.date.future().getDate(),
+  ...override,
+});
+
+export const InvoicePreviewForUpgradeFactory = (
+  override?: Partial<InvoicePreviewForUpgrade>
+): InvoicePreviewForUpgrade => ({
+  ...InvoicePreviewFactory(override),
+  oneTimeCharge: faker.number.int({ min: 1, max: 1000 }),
+  oneTimeChargeSubtotal: faker.number.int({ min: 1, max: 1000 }),
+  ...override,
 });

--- a/libs/payments/customer/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.spec.ts
@@ -282,6 +282,7 @@ describe('InvoiceManager', () => {
       expect(result).toEqual({
         ...mockPreviewSubsequentInvoice,
         oneTimeCharge: mockPreviewUpcomingUpgradeInvoice.totalAmount,
+        oneTimeChargeSubtotal: mockPreviewUpcomingUpgradeInvoice.subtotal,
       });
     });
 

--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -24,6 +24,7 @@ import {
   STRIPE_CUSTOMER_METADATA,
   STRIPE_INVOICE_METADATA,
   TaxAddress,
+  type InvoicePreviewForUpgrade,
 } from './types';
 import { isCustomerTaxEligible } from './util/isCustomerTaxEligible';
 import { stripeInvoiceToInvoicePreviewDTO } from './util/stripeInvoiceToFirstInvoicePreviewDTO';
@@ -164,7 +165,7 @@ export class InvoiceManager {
     priceId: string;
     customer: StripeCustomer;
     fromSubscriptionItem: StripeSubscriptionItem;
-  }): Promise<InvoicePreview> {
+  }): Promise<InvoicePreviewForUpgrade> {
     if (!customer.currency) {
       throw new UpgradeCustomerMissingCurrencyInvoiceError(customer.id);
     }
@@ -186,6 +187,7 @@ export class InvoiceManager {
     return {
       ...previewSubsequentInvoice,
       oneTimeCharge: previewUpcomingInvoiceOfUpgrade.totalAmount,
+      oneTimeChargeSubtotal: previewUpcomingInvoiceOfUpgrade.subtotal,
     };
   }
 

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -16,9 +16,14 @@ export type InvoicePreview = {
   discountType?: string;
   number: string | null; // customer-facing invoice identifier
   paypalTransactionId?: string;
-  oneTimeCharge?: number;
   nextInvoiceDate: number;
+  oneTimeCharge?: number;
 };
+
+export type InvoicePreviewForUpgrade = InvoicePreview & {
+  oneTimeCharge: number;
+  oneTimeChargeSubtotal: number;
+}
 
 export interface Interval {
   interval: NonNullable<StripePrice['recurring']>['interval'];

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -66,6 +66,14 @@ export function getErrorFtlInfo(
           'An unexpected error has occurred while processing your payment, please try again.',
         messageFtl: 'checkout-processing-general-error',
       };
+    case CartErrorReasonId.CART_TOTAL_MISMATCH:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message: 'The invoice amount has changed. Please try again.',
+        messageFtl: 'cart-total-mismatch-error',
+      };
 
     case CartErrorReasonId.BASIC_ERROR:
     default:

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -40,6 +40,7 @@ export enum CartErrorReasonId {
   CART_ELIGIBILITY_STATUS_INVALID = 'cart_eligibility_status_invalid',
   CART_CURRENCY_NOT_DETERMINED = 'cart_currency_not_determined',
   CART_PROCESSING_GENERAL_ERROR = 'cart_processing_general_error',
+  CART_TOTAL_MISMATCH = 'cart_total_mismatch',
   UNKNOWN = 'unknown',
 }
 

--- a/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
+++ b/libs/shared/error/src/lib/sanitizeExceptionsDecorator.ts
@@ -69,7 +69,7 @@ export function SanitizeExceptions(
   };
 }
 
-function handleException(args: {
+export function handleException(args: {
   error: unknown;
   className: string;
   methodName: string;


### PR DESCRIPTION
## Because

- It is possible for the one time charge on an upgrade to change while the customer is checking out, resulting in a mismatch between the value shown to the customer and what they are charged.

## This pull request

- Updates the cart.amount for upgrades to use the one time charge subtotal.
- On checkout, for upgrades, compare the cart.amount with the one time charge subtotal and error if the amounts don't match.
- Add new error message to be displayed on the error page when the cart totals do not match.
- Handle errors thrown during checkout

## Issue that this pull request solves

Closes: #FXA-11840

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
