### PR TITLE
feat(login): add error banner for locked account

### DIFF
--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -561,6 +561,16 @@ describe('lib/glean', () => {
           'login_recovery_phone_success_view'
         );
       });
+
+      it('submits a ping with the login_locked_account_banner_view event name', async () => {
+        GleanMetrics.login.lockedAccountBannerView();
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(setEventNameStub);
+        sinon.assert.calledWith(
+          setEventNameStub,
+          'login_locked_account_banner_view'
+        );
+      });
     });
 
     describe('loginTotpBackup', () => {

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -322,6 +322,9 @@ const recordEventMetric = (
     case 'login_engage':
       login.engage.record();
       break;
+    case 'login_locked_account_banner_view':
+      login.lockedAccountBannerView.record();
+      break;
     case 'cached_login_forgot_pwd_submit':
       cachedLogin.forgotPwdSubmit.record();
       break;

--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -22,3 +22,10 @@ signin-password-button-label = Password
 signin-desktop-relay = { -brand-firefox } will try sending you back to use an email mask after you sign in.
 
 signin-code-expired-error = Code expired. Please sign in again.
+
+signin-account-locked-banner-heading = Reset your password
+signin-account-locked-banner-description = We locked your account to keep it safe from suspicious activity.
+# This link points to https://accounts.firefox.com/reset_password
+signin-account-locked-banner-link = Reset your password to sign in
+
+##

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -14,6 +14,8 @@ import {
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { SigninProps } from './interfaces';
 import { MOCK_SERVICE, MOCK_SESSION_TOKEN } from '../mocks';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { BeginSigninError } from '../../lib/error-utils';
 
 export default {
   title: 'Pages/Signin',
@@ -29,6 +31,14 @@ const storyWithProps = ({
 };
 
 export const SignInToSettingsWithPassword = storyWithProps();
+export const SignInToSettingsWithPasswordAccountLockedError = storyWithProps({
+  beginSigninHandler: () => {
+    return Promise.resolve({
+      error: AuthUiErrors.ACCOUNT_RESET as BeginSigninError,
+    });
+  },
+});
+
 export const SignInToRelyingPartyWithPassword = storyWithProps({
   serviceName: MOCK_SERVICE,
 });

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -710,6 +710,24 @@ login:
     expires: never
     data_sensitivity:
       - interaction
+  locked_account_banner_view:
+    type: event
+    description: |
+      The user is shown a banner on the login page indicating that their account
+      is locked with a link to the password reset page.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-7265
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
   email_confirmation_success_view:
     type: event
     description: |

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -92,6 +92,7 @@ export const eventsMap = {
     backupChoiceView: 'login_backup_choice_view',
     backupChoiceSubmit: 'login_backup_choice_submit',
     recoveryPhoneSuccessView: 'login_recovery_phone_success_view',
+    lockedAccountBannerView: 'login_locked_account_banner_view',
   },
 
   cachedLogin: {

--- a/packages/fxa-shared/metrics/glean/web/login.ts
+++ b/packages/fxa-shared/metrics/glean/web/login.ts
@@ -201,6 +201,23 @@ export const forgotPwdSubmit = new EventMetricType(
 );
 
 /**
+ * The user is shown a banner on the login page indicating that their account
+ * is locked with a link to the password reset page.
+ *
+ * Generated from `login.locked_account_banner_view`.
+ */
+export const lockedAccountBannerView = new EventMetricType(
+  {
+    category: 'login',
+    name: 'locked_account_banner_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  []
+);
+
+/**
  * Event that indicates the user successfully authenticated via recovery phone.
  *
  * Generated from `login.recovery_phone_success_view`.


### PR DESCRIPTION
## Because

- our current error tooltip for account reset is not informative.

## This pull request

- In addition to the tooltip, shows a banner with a more detailed message and a link to the password reset page.

## Issue that this pull request solves

Closes: FXA-11388

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="402" alt="image" src="https://github.com/user-attachments/assets/c2c12159-c531-48d3-a490-0394f7c5f01c" />

## Other information (Optional)

Any other information that is important to this pull request.
