### PR TITLE
fix(auth): fix deleteAccount procedure potentially failing in edge cases

### DIFF
--- a/packages/db-migrations/databases/fxa/patches/patch-173-174.sql
+++ b/packages/db-migrations/databases/fxa/patches/patch-173-174.sql
@@ -39,7 +39,7 @@ BEGIN
   DELETE FROM sentEmails WHERE uid = uidArg;
   DELETE FROM linkedAccounts WHERE uid = uidArg;
 
-  INSERT INTO deletedAccounts (uid, deletedAt) VALUES (uidArg, (UNIX_TIMESTAMP(NOW(3)) * 1000));
+  INSERT IGNORE INTO deletedAccounts (uid, deletedAt) VALUES (uidArg, (UNIX_TIMESTAMP(NOW(3)) * 1000));
 
   COMMIT;
 END;


### PR DESCRIPTION
## Because

- deleteAccount will fail if called twice on the same uid.

## This pull request

- fixes the problem by using INSERT IGNORE INTO instead of INSERT INTO

## Issue that this pull request solves

Closes: FXA-11655

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
