### PR TITLE
fix(functional-tests): Don't pass testAccountTracker

### DIFF
--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -5,7 +5,6 @@
 import { getCode } from 'fxa-settings/src/lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -29,13 +28,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       await settings.totp.addButton.click();
@@ -71,7 +65,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       await settings.goto();
       await settings.totp.addButton.click();
       await totp.fillOutTotpForms();
@@ -167,9 +162,8 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await page.waitForURL(/\//);
   await signin.fillOutEmailFirstForm(credentials.email);
@@ -177,6 +171,4 @@ async function signInAccount(
   await page.waitForURL(/settings/);
   // Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }

--- a/packages/functional-tests/tests/settings/avatar.spec.ts
+++ b/packages/functional-tests/tests/settings/avatar.spec.ts
@@ -5,7 +5,6 @@
 import path from 'path';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -20,12 +19,13 @@ test.describe('severity-1 #smoke', () => {
     pages: { page, settings, signin },
     testAccountTracker,
   }) => {
+    const credentials = await testAccountTracker.signUp();
     const { email } = await signInAccount(
       target,
       page,
       settings,
       signin,
-      testAccountTracker
+      credentials
     );
 
     await expect(settings.avatarDropDownMenu).toBeHidden();
@@ -45,7 +45,8 @@ test.describe('severity-1 #smoke', () => {
     pages: { avatar, page, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -93,9 +94,8 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
+  credentials: Credentials
 ): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { ChangePasswordPage } from '../../pages/settings/changePassword';
 import { SecondaryEmailPage } from '../../pages/settings/secondaryEmail';
@@ -17,13 +16,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const initialEmail = credentials.email;
       const newEmail = testAccountTracker.generateEmail();
 
@@ -57,13 +51,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const initialPassword = credentials.password;
       const newEmail = testAccountTracker.generateEmail();
       const newPassword = testAccountTracker.generatePassword();
@@ -103,13 +92,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const initialEmail = credentials.email;
       const initialPassword = credentials.password;
       const secondEmail = testAccountTracker.generateEmail();
@@ -159,13 +143,8 @@ test.describe('severity-1 #smoke', () => {
       },
       testAccountTracker,
     }) => {
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const newEmail = testAccountTracker.generateEmail();
       const newPassword = testAccountTracker.generatePassword();
 
@@ -200,7 +179,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const newEmail = testAccountTracker.generateEmail();
 
       await settings.goto();
@@ -240,17 +220,14 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }
 
 async function changePrimaryEmail(

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -15,7 +14,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, settings, signin },
       testAccountTracker,
     }) => {
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const newPassword = testAccountTracker.generatePassword();
 
       // Enter incorrect old password and verify the tooltip error
@@ -33,13 +33,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
       const initialPassword = credentials.password;
       const newPassword = testAccountTracker.generatePassword();
 
@@ -66,7 +61,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, settings, signin },
       testAccountTracker,
     }) => {
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       await settings.password.changeButton.click();
@@ -91,7 +87,8 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, resetPassword, settings, signin },
       testAccountTracker,
     }) => {
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
 
@@ -111,15 +108,12 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }

--- a/packages/functional-tests/tests/settings/changePasswordValidation.spec.ts
+++ b/packages/functional-tests/tests/settings/changePasswordValidation.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -36,7 +35,8 @@ test.describe('severity-1 #smoke', () => {
         pages: { page, changePassword, settings, signin },
         testAccountTracker,
       }) => {
-        await signInAccount(target, page, settings, signin, testAccountTracker);
+        const credentials = await testAccountTracker.signUp();
+        await signInAccount(target, page, settings, signin, credentials);
 
         await settings.goto();
         await settings.password.changeButton.click();
@@ -55,12 +55,13 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, settings, signin },
       testAccountTracker,
     }) => {
-      const { email } = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await settings.goto();
@@ -68,7 +69,7 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(changePassword.changePasswordHeading).toBeVisible();
 
-      await changePassword.newPasswordTextbox.fill(email);
+      await changePassword.newPasswordTextbox.fill(credentials.email);
 
       await expect(changePassword.passwordError).toHaveText(
         'Not your email address'
@@ -82,15 +83,12 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }

--- a/packages/functional-tests/tests/settings/deleteAccount.spec.ts
+++ b/packages/functional-tests/tests/settings/deleteAccount.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -14,7 +13,8 @@ test.describe('severity-1 #smoke', () => {
     pages: { page, signin, settings, deleteAccount },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -33,7 +33,8 @@ test.describe('severity-1 #smoke', () => {
     pages: { page, deleteAccount, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -57,18 +58,19 @@ test.describe('severity-1 #smoke', () => {
     pages: { page, deleteAccount, settings, signin },
     testAccountTracker,
   }) => {
-    const { password } = await signInAccount(
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(
       target,
       page,
       settings,
       signin,
-      testAccountTracker
+      credentials
     );
 
     await settings.goto();
 
     await settings.deleteAccountButton.click();
-    await deleteAccount.deleteAccount(password);
+    await deleteAccount.deleteAccount(credentials.password);
 
     await expect(page.getByText('Account deleted successfully')).toBeVisible();
   });
@@ -78,7 +80,8 @@ test.describe('severity-1 #smoke', () => {
     pages: { page, deleteAccount, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -104,15 +107,12 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }

--- a/packages/functional-tests/tests/settings/displayName.spec.ts
+++ b/packages/functional-tests/tests/settings/displayName.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -14,7 +13,8 @@ test.describe('severity-2 #smoke', () => {
     pages: { page, displayName, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -32,7 +32,8 @@ test.describe('severity-2 #smoke', () => {
     pages: { page, displayName, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -51,7 +52,8 @@ test.describe('severity-2 #smoke', () => {
     pages: { page, displayName, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -75,7 +77,8 @@ test.describe('severity-2 #smoke', () => {
     pages: { page, displayName, settings, signin },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -100,15 +103,12 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }

--- a/packages/functional-tests/tests/settings/misc.spec.ts
+++ b/packages/functional-tests/tests/settings/misc.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -15,7 +14,8 @@ test.describe('severity-1 #smoke', () => {
     pages: { signin, settings },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
     const helpPage = await settings.clickHelp();
@@ -31,7 +31,8 @@ test.describe('severity-2 #smoke', () => {
     pages: { signin, settings },
     testAccountTracker,
   }) => {
-    await signInAccount(target, page, settings, signin, testAccountTracker);
+    const credentials = await testAccountTracker.signUp();
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -52,15 +53,12 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -4,7 +4,6 @@
 
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { TotpCredentials, TotpPage } from '../../pages/settings/totp';
 import { SigninPage } from '../../pages/signin';
@@ -85,7 +84,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       await addTotp(settings, totp);
@@ -114,12 +114,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await settings.goto();
@@ -181,12 +182,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await settings.goto();
@@ -245,12 +247,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await setupRecoveryPhone({
@@ -303,12 +306,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await setupRecoveryPhone({
@@ -370,12 +374,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await setupRecoveryPhone({
@@ -435,12 +440,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await setupRecoveryPhone({
@@ -525,12 +531,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       await setupRecoveryPhone({
@@ -584,12 +591,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       const totpCredentials = await setupRecoveryPhone({
@@ -623,6 +631,7 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await page.waitForURL(/settings/);
+      await expect(await settings.totp.status).toHaveText('Enabled');
 
       // Remove totp so account can be deleted
       await settings.disconnectTotp();
@@ -648,12 +657,13 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(
         target,
         page,
         settings,
         signin,
-        testAccountTracker
+        credentials
       );
 
       const totpCredentials = await setupRecoveryPhone({
@@ -692,6 +702,7 @@ test.describe('severity-1 #smoke', () => {
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       await page.waitForURL(/settings/);
+      await expect(await settings.totp.status).toHaveText('Enabled');
 
       // Remove totp so account can be deleted
       await settings.disconnectTotp();
@@ -704,17 +715,14 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials,
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
 
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }
 
 async function addTotp(

--- a/packages/functional-tests/tests/settings/totp.spec.ts
+++ b/packages/functional-tests/tests/settings/totp.spec.ts
@@ -5,7 +5,6 @@
 import { getCode } from 'fxa-settings/src/lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { TotpCredentials, TotpPage } from '../../pages/settings/totp';
 import { SigninPage } from '../../pages/signin';
@@ -23,13 +22,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       await addTotp(settings, totp);
@@ -51,7 +45,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      await signInAccount(target, page, settings, signin, testAccountTracker);
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
 
@@ -84,13 +79,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       const { secret } = await addTotp(settings, totp);
       await settings.signOut();
@@ -127,13 +117,8 @@ test.describe('severity-1 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       const { secret } = await addTotp(settings, totp);
@@ -162,17 +147,14 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }
 
 async function addTotp(

--- a/packages/functional-tests/tests/signin/signIn.spec.ts
+++ b/packages/functional-tests/tests/signin/signIn.spec.ts
@@ -2,11 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Page, expect, test } from '../../lib/fixtures/standard';
-import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
-import { SettingsPage } from '../../pages/settings';
-import { SigninPage } from '../../pages/signin';
+import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-2 #smoke', () => {
   test.describe('signin', () => {
@@ -81,13 +77,13 @@ test.describe('severity-2 #smoke', () => {
       pages: { settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+      await page.waitForURL(/settings/);
+      //Verify logged in on Settings page
+      await expect(settings.settingsHeading).toBeVisible();
 
       // Sign out
       await settings.signOut();
@@ -168,21 +164,3 @@ test.describe('severity-2 #smoke', () => {
     });
   });
 });
-
-async function signInAccount(
-  target: BaseTarget,
-  page: Page,
-  settings: SettingsPage,
-  signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
-  await page.goto(target.contentServerUrl);
-  await signin.fillOutEmailFirstForm(credentials.email);
-  await signin.fillOutPasswordForm(credentials.password);
-  await page.waitForURL(/settings/);
-  //Verify logged in on Settings page
-  await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
-}

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -18,12 +18,13 @@ test.describe('severity-2 #smoke', () => {
       pages: { deleteAccount, settings, signin, signinUnblock },
       testAccountTracker,
     }) => {
-      const credentials = await signInBlockedAccount(
+      const credentials = await testAccountTracker.signUpBlocked();
+      await signInBlockedAccount(
         target,
         page,
         signin,
         signinUnblock,
-        testAccountTracker
+        credentials
       );
 
       //Unblock the email
@@ -49,12 +50,13 @@ test.describe('severity-2 #smoke', () => {
         true,
         'TODO in FXA-9882, fix fxa-settings or test, should not be prompted enter password and unblock code again after entering a valid unblock code'
       );
-      const credentials = await signInBlockedAccount(
+      const credentials = await testAccountTracker.signUpBlocked();
+      await signInBlockedAccount(
         target,
         page,
         signin,
         signinUnblock,
-        testAccountTracker
+        credentials
       );
 
       await signinUnblock.fillOutCodeForm('invalidd');
@@ -85,12 +87,13 @@ test.describe('severity-2 #smoke', () => {
       pages: { signin, settings, signinUnblock, deleteAccount },
       testAccountTracker,
     }) => {
-      const credentials = await signInBlockedAccount(
+      const credentials = await testAccountTracker.signUpBlocked();
+      await signInBlockedAccount(
         target,
         page,
         signin,
         signinUnblock,
-        testAccountTracker
+        credentials
       );
 
       //Click resend code button
@@ -162,13 +165,8 @@ test.describe('severity-2 #smoke', () => {
       testAccountTracker,
     }) => {
       const blockedEmail = testAccountTracker.generateBlockedEmail();
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
@@ -206,17 +204,14 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }
 
 async function signInBlockedAccount(
@@ -224,9 +219,8 @@ async function signInBlockedAccount(
   page: Page,
   signin: SigninPage,
   signinUnblock: SigninUnblockPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUpBlocked();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
@@ -237,8 +231,6 @@ async function signInBlockedAccount(
   await expect(page).toHaveURL(/signin_unblock/);
   await expect(signinUnblock.heading).toBeVisible();
   await expect(page.getByText(credentials.email)).toBeVisible();
-
-  return credentials;
 }
 
 async function removeAccount(

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -5,7 +5,7 @@
 import { getCode } from 'fxa-settings/src/lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
+
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
 
@@ -167,13 +167,8 @@ test.describe('severity-2 #smoke', () => {
         config.featureFlags.updated2faSetupFlow,
         'TODO in FXA-11935 - add test for new flow'
       );
-      const credentials = await signInAccount(
-        target,
-        page,
-        settings,
-        signin,
-        testAccountTracker
-      );
+      const credentials = await testAccountTracker.signUp();
+      await signInAccount(target, page, settings, signin, credentials);
 
       await settings.goto();
       await settings.totp.addButton.click();
@@ -249,15 +244,12 @@ async function signInAccount(
   page: Page,
   settings: SettingsPage,
   signin: SigninPage,
-  testAccountTracker: TestAccountTracker
-): Promise<Credentials> {
-  const credentials = await testAccountTracker.signUp();
+  credentials: Credentials
+): Promise<void> {
   await page.goto(target.contentServerUrl);
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await page.waitForURL(/settings/);
   //Verify logged in on Settings page
   await expect(settings.settingsHeading).toBeVisible();
-
-  return credentials;
 }


### PR DESCRIPTION
## Because

* we want to keep testAccountTracker calls within tests and pass credentials to functions like signInAccount

## This pull request

* update all tests that passed the testAccountTracker

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
