### PR TITLE
fix(payments-next):FinishErrorCartFailedError: Finish error cart failed

### DIFF
--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -21,6 +21,7 @@ intent-expired-card-error = It looks like your credit card has expired. Try anot
 intent-payment-error-try-again = Hmm. There was a problem authorizing your payment. Try again or get in touch with your card issuer.
 intent-payment-error-get-in-touch = Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.
 intent-payment-error-generic = An unexpected error has occurred while processing your payment, please try again.
+intent-payment-error-insufficient-funds = It looks like your card has insufficient funds. Try another card.
 
 ## Processing page and Needs Input page - /checkout and /upgrade
 ## Common strings used in multiple pages

--- a/libs/payments/cart/src/lib/checkout.error.ts
+++ b/libs/payments/cart/src/lib/checkout.error.ts
@@ -198,3 +198,21 @@ export class IntentGetInTouchError extends IntentFailedHandledError {
     this.name = 'IntentGetInTouchError';
   }
 }
+
+export class IntentInsufficientFundsError extends IntentFailedHandledError {
+  constructor(
+    cartId: string,
+    paymentIntentId: string,
+    intentType: 'SetupIntent' | 'PaymentIntent'
+  ) {
+    super(
+      'Intent payment method card has insufficient funds',
+      {
+        cartId,
+        paymentIntentId,
+        intentType,
+      }
+    );
+    this.name = 'IntentInsufficientFundsError';
+  }
+}

--- a/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
+++ b/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
@@ -15,6 +15,7 @@ import {
   IntentFailedGenericError,
   IntentGetInTouchError,
   IntentTryAgainError,
+  IntentInsufficientFundsError,
 } from '../checkout.error';
 import { BaseError } from '@fxa/shared/error';
 
@@ -44,6 +45,8 @@ export function resolveErrorInstance(error: Error) {
       return CartErrorReasonId.INTENT_FAILED_GET_IN_TOUCH;
     case error instanceof IntentFailedGenericError:
       return CartErrorReasonId.INTENT_FAILED_GENERIC;
+    case error instanceof IntentInsufficientFundsError:
+      return CartErrorReasonId.INTENT_FAILED_INSUFFICIENT_FUNDS;
 
     // Checkout Errors
     case error instanceof CheckoutError:

--- a/libs/payments/cart/src/lib/util/throwIntentFailedError.ts
+++ b/libs/payments/cart/src/lib/util/throwIntentFailedError.ts
@@ -9,6 +9,7 @@ import {
   IntentFailedGenericError,
   IntentGetInTouchError,
   IntentTryAgainError,
+  IntentInsufficientFundsError,
 } from '../checkout.error';
 
 export function throwIntentFailedError(
@@ -28,6 +29,8 @@ export function throwIntentFailedError(
         case 'issuer_not_available':
         case 'reenter_transaction':
           throw new IntentTryAgainError(cartId, paymentIntentId, intentType);
+        case 'insufficient_funds':
+          throw new IntentInsufficientFundsError(cartId, paymentIntentId, intentType);
         case 'call_issuer':
         case 'card_not_supported':
         case 'card_velocity_exceeded':

--- a/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
@@ -6,7 +6,6 @@
 
 import { getApp } from '../nestapp/app';
 import { redirect } from 'next/navigation';
-import { SubmitNeedsInputFailedError } from '@fxa/payments/cart';
 
 export const submitNeedsInputAndRedirectAction = async (cartId: string) => {
   let redirectPath: string | undefined;
@@ -15,11 +14,7 @@ export const submitNeedsInputAndRedirectAction = async (cartId: string) => {
     redirectPath = 'success';
   } catch (error) {
     console.error('Error submitting needs input', error);
-    if (error instanceof SubmitNeedsInputFailedError) {
-      redirectPath = 'error';
-    } else {
-      throw error;
-    }
+   redirectPath = 'error';
   }
 
   redirect(redirectPath);

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -8,7 +8,6 @@ import { GoogleManager } from '@fxa/google';
 import {
   CartInvalidStateForActionError,
   CartService,
-  SubmitNeedsInputFailedError,
   SuccessCartDTO,
   TaxChangeAllowedStatus,
   TaxService,
@@ -373,9 +372,7 @@ export class NextJSActionsService {
     return await this.cartService.getNeedsInput(args.cartId);
   }
 
-  @SanitizeExceptions({
-    allowlist: [SubmitNeedsInputFailedError],
-  })
+  @SanitizeExceptions()
   @NextIOValidator(SubmitNeedsInputActionArgs, undefined)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -119,7 +119,15 @@ export function getErrorFtlInfo(
           'An unexpected error has occurred while processing your payment, please try again.',
         messageFtl: 'intent-payment-error-generic',
       };
-
+    case CartErrorReasonId.INTENT_FAILED_INSUFFICIENT_FUNDS:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'It looks like your card has insufficient funds. Try another card.',
+        messageFtl: 'intent-payment-error-insufficient-funds',
+      };
     case CartErrorReasonId.BASIC_ERROR:
     default:
       return {

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -46,6 +46,7 @@ export enum CartErrorReasonId {
   INTENT_FAILED_CARD_EXPIRED = 'intent_failed_card_expired',
   INTENT_FAILED_TRY_AGAIN = 'intent_failed_try_again',
   INTENT_FAILED_GET_IN_TOUCH = 'intent_failed_get_in_touch',
+  INTENT_FAILED_INSUFFICIENT_FUNDS = 'intent-payment-error-insufficient-funds',
   UNKNOWN = 'unknown',
 }
 

--- a/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
@@ -10,10 +10,12 @@ const EXPECTED_ERRORS = new Set([
   'PromotionCodePriceNotValidError',
   'PromotionCodeNotFoundError',
   'CouponErrorInvalidCode',
+  'FinishErrorCartFailedError',
   'IntentCardDeclinedError',
   'IntentCardExpiredError',
   'IntentTryAgainError',
   'IntentGetInTouchError',
+  'IntentInsufficientFundsError',
 ]);
 
 export const beforeSend = function (

--- a/packages/fxa-auth-server/lib/senders/emails/partials/support/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/support/en.ftl
@@ -1,6 +1,6 @@
 # Variables:
 #  $supportUrl (String) - Link to https://support.mozilla.org/kb/im-having-problems-my-firefox-account
-support-message-3 = For more info, visit <a data-l10n-name="supportLink">{ -brand-mozilla } Support</a>}.
+support-message-3 = For more info, visit <a data-l10n-name="supportLink">{ -brand-mozilla } Support</a>.
 
 # Variables:
 #  $supportUrl (String) - Link to https://support.mozilla.org/kb/im-having-problems-my-firefox-account


### PR DESCRIPTION
## Because

- User is stuck on “Action Required” tab with page showing “Confirming subscription…” and a FinishErrorCartFailedError appears in Sentry.

## This pull request

- Gracefully handles failed payments after a successful 3D secure.
- Handles case when Decline code is insufficient funds, reusing SP2 error message.
- Does not report FinishErrorCartFailedError and IntentInsufficientFundsError to Sentry.

## Issue that this pull request solves

Closes: #FXA-11980

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
