### PR TITLE
fix(metrics): await 'account.confirmed' event after verifying email-otp

### DIFF
--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -326,9 +326,8 @@ module.exports = function (
           ...newTokenState,
           ...newUAInfo,
         };
-        const newSessionToken = await db.createSessionToken(
-          sessionTokenOptions
-        );
+        const newSessionToken =
+          await db.createSessionToken(sessionTokenOptions);
 
         const response = {
           uid: newSessionToken.uid,
@@ -419,7 +418,7 @@ module.exports = function (
         if (!account.primaryEmail.isVerified) {
           await signupUtils.verifyAccount(request, account, options);
         } else {
-          request.emitMetricsEvent('account.confirmed', { uid });
+          await request.emitMetricsEvent('account.confirmed', { uid });
           glean.login.verifyCodeConfirmed(request, { uid });
           await signinUtils.cleanupReminders({ verified: true }, account);
           await push.notifyAccountUpdated(uid, devices, 'accountConfirm');

--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -47,7 +47,8 @@ const CONFIGS = {
 };
 
 const env = process.env.FXA_ENV || 'local';
-const FXA_DESKTOP_CONTEXT = process.env.FXA_DESKTOP_CONTEXT || 'oauth_webchannel_v1';
+const FXA_DESKTOP_CONTEXT =
+  process.env.FXA_DESKTOP_CONTEXT || 'oauth_webchannel_v1';
 const e10sDisabled = process.env.DISABLE_E10S === 'true';
 let fxaEnv = CONFIGS[env];
 
@@ -120,10 +121,8 @@ const fxaProfile = {
   'identity.fxaccounts.autoconfig.uri': fxaEnv.content,
   // disable password auto-fill; we typically don't need to test this daily.
   'signon.rememberSignons': false,
-  ...(process.env.FXA_DESKTOP_CONTEXT === 'oauth_webchannel_v1' && {
-    'identity.fxaccounts.oauth.enabled': true,
-    'identity.fxaccounts.contextParam': 'oauth_webchannel_v1',
-  }),
+  'identity.fxaccounts.oauth.enabled':
+    FXA_DESKTOP_CONTEXT === 'oauth_webchannel_v1',
 };
 
 // Configuration for local sync development


### PR DESCRIPTION
Because:
 - the FxA auth server might not able to emit the metrics in time on `request.emitMetricsEvent` when the function call is not awaited

This commit:
 - awaits 'account.confirmed' when a user successfully verified their email login code

