### PR TITLE
fix(next): support negative amounts at checkout

### DIFF
--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -76,10 +76,10 @@ interface StripeWrapperProps {
   cart: {
     paymentInfo?: {
       type:
-        | Stripe.PaymentMethod.Type
-        | 'google_iap'
-        | 'apple_iap'
-        | 'external_paypal';
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -103,7 +103,7 @@ export function StripeWrapper({
   const options: StripeElementsOptions = {
     mode: 'subscription',
     locale: isStripeElementLocale(locale) ? locale : 'auto',
-    amount,
+    amount: amount >= 0 ? amount : 0,
     currency,
     paymentMethodCreation: 'manual',
     externalPaymentMethodTypes: ['external_paypal'],


### PR DESCRIPTION
## Because

- The Stripe payment element does not support negative amounts.

## This pull request

- If the cart.amount is less than zero, then initialize the Stripe payment element with a zero amount.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).