### PR TITLE
fix(next): add descriptive error for intent failures

### DIFF
--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -15,6 +15,13 @@ cart-error-currency-not-determined = We were unable to determine the currency fo
 checkout-processing-general-error = An unexpected error has occurred while processing your payment, please try again.
 cart-total-mismatch-error = The invoice amount has changed. Please try again.
 
+## Error pages - Payment method failure messages
+intent-card-error = Your transaction could not be processed. Please verify your credit card information and try again.
+intent-expired-card-error = It looks like your credit card has expired. Try another card.
+intent-payment-error-try-again = Hmm. There was a problem authorizing your payment. Try again or get in touch with your card issuer.
+intent-payment-error-get-in-touch = Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.
+intent-payment-error-generic = An unexpected error has occurred while processing your payment, please try again.
+
 ## Processing page and Needs Input page - /checkout and /upgrade
 ## Common strings used in multiple pages
 next-payment-processing-message = Please wait while we process your payment…

--- a/libs/payments/cart/src/lib/checkout.error.ts
+++ b/libs/payments/cart/src/lib/checkout.error.ts
@@ -91,17 +91,6 @@ export class PaymentMethodUpdateFailedError extends CheckoutError {
   }
 }
 
-export class DetermineCheckoutAmountFromPriceRequiredError extends CheckoutError {
-  constructor(priceId: string, currency: string, taxAddress: TaxAddress) {
-    super('fromPrice not present for upgrade cart', {
-      priceId,
-      currency,
-      taxAddress,
-    });
-    this.name = 'DetermineCheckoutAmountCustomerRequiredError';
-  }
-}
-
 export class DetermineCheckoutAmountCustomerRequiredError extends CheckoutError {
   constructor(priceId: string, currency: string, taxAddress: TaxAddress) {
     super('Customer is required for upgrade', {
@@ -120,5 +109,92 @@ export class DetermineCheckoutAmountSubscriptionRequiredError extends CheckoutEr
       fromPriceId,
     });
     this.name = 'DetermineCheckoutAmountCustomerRequiredError';
+  }
+}
+
+export class IntentFailedGenericError extends CheckoutError {
+  constructor(
+    cartId: string,
+    paymentIntentId: string,
+    paymentIntentState: string,
+    intentType: 'SetupIntent' | 'PaymentIntent'
+  ) {
+    super('Intent payment method failed with general error', {
+      cartId,
+      paymentIntentId,
+      paymentIntentState,
+      intentType,
+    });
+    this.name = 'IntentPaymentFailedGenericError';
+  }
+}
+
+export class IntentFailedHandledError extends CheckoutError {
+  constructor(message: string, info: Record<string, any>) {
+    super(message, info);
+    this.name = 'IntentFailedHandledError';
+  }
+}
+
+export class IntentCardDeclinedError extends IntentFailedHandledError {
+  constructor(
+    cartId: string,
+    paymentIntentId: string,
+    intentType: 'SetupIntent' | 'PaymentIntent'
+  ) {
+    super('Intent payment method card declined', {
+      cartId,
+      paymentIntentId,
+      intentType,
+    });
+    this.name = 'IntentCardDeclinedError';
+  }
+}
+
+export class IntentCardExpiredError extends IntentFailedHandledError {
+  constructor(
+    cartId: string,
+    paymentIntentId: string,
+    intentType: 'SetupIntent' | 'PaymentIntent'
+  ) {
+    super('Intent payment method card expired', {
+      cartId,
+      paymentIntentId,
+      intentType,
+    });
+    this.name = 'IntentCardExpiredError';
+  }
+}
+
+export class IntentTryAgainError extends IntentFailedHandledError {
+  constructor(
+    cartId: string,
+    paymentIntentId: string,
+    intentType: 'SetupIntent' | 'PaymentIntent'
+  ) {
+    super('Intent failed with an error where customers can try again.', {
+      cartId,
+      paymentIntentId,
+      intentType,
+    });
+    this.name = 'IntentTryAgainError';
+  }
+}
+
+export class IntentGetInTouchError extends IntentFailedHandledError {
+  constructor(
+    cartId: string,
+    paymentIntentId: string,
+    intentType: 'SetupIntent' | 'PaymentIntent'
+  ) {
+    super(
+      'Intent failed with an error requiring customers to get in touch with the payment issuer.',
+      {
+        cartId,
+        paymentIntentId,
+        intentType,
+      }
+    );
+    this.name = 'IntentGetInTouchError';
   }
 }

--- a/libs/payments/cart/src/lib/util/isPaymentIntent.ts
+++ b/libs/payments/cart/src/lib/util/isPaymentIntent.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import type {
+  StripePaymentIntent,
+  StripeSetupIntent,
+} from '@fxa/payments/stripe';
+
+export function isPaymentIntent(
+  intent: StripePaymentIntent | StripeSetupIntent
+): intent is StripePaymentIntent {
+  return intent.object === 'payment_intent';
+}

--- a/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
+++ b/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
@@ -8,7 +8,14 @@ import {
   CartStateProcessingError,
   CartTotalMismatchError,
 } from '../cart.error';
-import { CheckoutError } from '../checkout.error';
+import {
+  CheckoutError,
+  IntentCardDeclinedError,
+  IntentCardExpiredError,
+  IntentFailedGenericError,
+  IntentGetInTouchError,
+  IntentTryAgainError,
+} from '../checkout.error';
 import { BaseError } from '@fxa/shared/error';
 
 export function resolveErrorInstance(error: Error) {
@@ -25,6 +32,18 @@ export function resolveErrorInstance(error: Error) {
       return CartErrorReasonId.CART_PROCESSING_GENERAL_ERROR;
     case error instanceof CartTotalMismatchError:
       return CartErrorReasonId.CART_TOTAL_MISMATCH;
+
+    // Payment failed errors
+    case error instanceof IntentCardDeclinedError:
+      return CartErrorReasonId.INTENT_FAILED_CARD_DECLINED;
+    case error instanceof IntentCardExpiredError:
+      return CartErrorReasonId.INTENT_FAILED_CARD_EXPIRED;
+    case error instanceof IntentTryAgainError:
+      return CartErrorReasonId.INTENT_FAILED_TRY_AGAIN;
+    case error instanceof IntentGetInTouchError:
+      return CartErrorReasonId.INTENT_FAILED_GET_IN_TOUCH;
+    case error instanceof IntentFailedGenericError:
+      return CartErrorReasonId.INTENT_FAILED_GENERIC;
 
     // Checkout Errors
     case error instanceof CheckoutError:

--- a/libs/payments/cart/src/lib/util/throwIntentFailedError.spec.ts
+++ b/libs/payments/cart/src/lib/util/throwIntentFailedError.spec.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { throwIntentFailedError } from './throwIntentFailedError';
+import {
+  IntentCardDeclinedError,
+  IntentCardExpiredError,
+  IntentFailedGenericError,
+  IntentGetInTouchError,
+  IntentTryAgainError,
+} from '../checkout.error';
+
+const cartId = 'test-cart-id';
+const paymentIntentId = 'test-intent-id';
+const intentType = 'PaymentIntent' as const;
+
+describe('throwIntentFailedError', () => {
+  test.each([
+    ['approve_with_id', IntentTryAgainError],
+    ['issuer_not_available', IntentTryAgainError],
+    ['reenter_transaction', IntentTryAgainError],
+    ['call_issuer', IntentGetInTouchError],
+    ['card_not_supported', IntentGetInTouchError],
+    ['card_velocity_exceeded', IntentGetInTouchError],
+    ['do_not_honor', IntentGetInTouchError],
+    ['fraudulent', IntentGetInTouchError],
+    ['generic_decline', IntentGetInTouchError],
+    ['invalid_account', IntentGetInTouchError],
+    ['lost_card', IntentGetInTouchError],
+    ['merchant_blacklist', IntentGetInTouchError],
+    ['new_account_information_available', IntentGetInTouchError],
+    ['no_action_take', IntentGetInTouchError],
+    ['not_permitted', IntentGetInTouchError],
+    ['pickup_card', IntentGetInTouchError],
+    ['restricted_card', IntentGetInTouchError],
+    ['revocation_of_all_authorizations', IntentGetInTouchError],
+    ['revocation_of_authorization', IntentGetInTouchError],
+    ['security_violation', IntentGetInTouchError],
+    ['service_not_allowed', IntentGetInTouchError],
+    ['stolen_card', IntentGetInTouchError],
+    ['stop_payment_order', IntentGetInTouchError],
+    ['transaction_not_allowed', IntentGetInTouchError],
+    ['unexpected_code', IntentCardDeclinedError],
+  ])(
+    'returns correct error class for card_declined with decline_code=%s',
+    (declineCode, ExpectedError) => {
+      expect(() =>
+        throwIntentFailedError(
+          'card_declined',
+          declineCode,
+          cartId,
+          paymentIntentId,
+          intentType
+        )
+      ).toThrow(ExpectedError);
+    }
+  );
+
+  it('returns IntentCardDeclinedError for incorrect_cvc', () => {
+    expect(() =>
+      throwIntentFailedError(
+        'incorrect_cvc',
+        undefined,
+        cartId,
+        paymentIntentId,
+        intentType
+      )
+    ).toThrow(IntentCardDeclinedError);
+  });
+
+  it('returns IntentCardExpiredError for expired_card', () => {
+    expect(() =>
+      throwIntentFailedError(
+        'expired_card',
+        undefined,
+        cartId,
+        paymentIntentId,
+        intentType
+      )
+    ).toThrow(IntentCardExpiredError);
+  });
+
+  test.each([
+    'payment_intent_authentication_failure',
+    'setup_intent_authentication_failure',
+    'processing_error',
+  ])('returns IntentTryAgainError for %s', (errorCode) => {
+    expect(() =>
+      throwIntentFailedError(
+        errorCode as any,
+        undefined,
+        cartId,
+        paymentIntentId,
+        intentType
+      )
+    ).toThrow(IntentTryAgainError);
+  });
+
+  it('returns IntentFailedGenericError for undefined error code', () => {
+    expect(() =>
+      throwIntentFailedError(
+        undefined,
+        undefined,
+        cartId,
+        paymentIntentId,
+        intentType
+      )
+    ).toThrow(IntentFailedGenericError);
+  });
+
+  it('returns IntentFailedGenericError for unknown error code', () => {
+    expect(() =>
+      throwIntentFailedError(
+        'unknown_code' as any,
+        undefined,
+        cartId,
+        paymentIntentId,
+        intentType
+      )
+    ).toThrow(IntentFailedGenericError);
+  });
+});

--- a/libs/payments/cart/src/lib/util/throwIntentFailedError.ts
+++ b/libs/payments/cart/src/lib/util/throwIntentFailedError.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Stripe } from 'stripe';
+import {
+  IntentCardDeclinedError,
+  IntentCardExpiredError,
+  IntentFailedGenericError,
+  IntentGetInTouchError,
+  IntentTryAgainError,
+} from '../checkout.error';
+
+export function throwIntentFailedError(
+  errorCode:
+    | Stripe.PaymentIntent.LastPaymentError.Code
+    | Stripe.SetupIntent.LastSetupError.Code
+    | undefined,
+  declineCode: string | undefined,
+  cartId: string,
+  paymentIntentId: string,
+  intentType: 'SetupIntent' | 'PaymentIntent'
+) {
+  switch (errorCode) {
+    case 'card_declined': {
+      switch (declineCode) {
+        case 'approve_with_id':
+        case 'issuer_not_available':
+        case 'reenter_transaction':
+          throw new IntentTryAgainError(cartId, paymentIntentId, intentType);
+        case 'call_issuer':
+        case 'card_not_supported':
+        case 'card_velocity_exceeded':
+        case 'do_not_honor':
+        case 'fraudulent':
+        case 'generic_decline':
+        case 'invalid_account':
+        case 'lost_card':
+        case 'merchant_blacklist':
+        case 'new_account_information_available':
+        case 'no_action_take':
+        case 'not_permitted':
+        case 'pickup_card':
+        case 'restricted_card':
+        case 'revocation_of_all_authorizations':
+        case 'revocation_of_authorization':
+        case 'security_violation':
+        case 'service_not_allowed':
+        case 'stolen_card':
+        case 'stop_payment_order':
+        case 'transaction_not_allowed':
+          throw new IntentGetInTouchError(cartId, paymentIntentId, intentType);
+        default:
+          throw new IntentCardDeclinedError(
+            cartId,
+            paymentIntentId,
+            intentType
+          );
+      }
+    }
+    case 'incorrect_cvc':
+      throw new IntentCardDeclinedError(cartId, paymentIntentId, intentType);
+    case 'expired_card':
+      throw new IntentCardExpiredError(cartId, paymentIntentId, intentType);
+    case 'payment_intent_authentication_failure':
+    case 'setup_intent_authentication_failure':
+    case 'processing_error':
+      throw new IntentTryAgainError(cartId, paymentIntentId, intentType);
+    default:
+      throw new IntentFailedGenericError(
+        cartId,
+        paymentIntentId,
+        '',
+        intentType
+      );
+  }
+}

--- a/libs/payments/customer/src/lib/customer.error.ts
+++ b/libs/payments/customer/src/lib/customer.error.ts
@@ -190,28 +190,6 @@ export class StripeNoMinimumChargeAmountAvailableError extends CustomerError {
   }
 }
 
-export class PaymentIntentNotFoundError extends CustomerError {
-  constructor(subscriptionId: string) {
-    super('Payment intent not found', { subscriptionId });
-    this.name = 'PaymentIntentNotFoundError';
-  }
-}
-
-export class InvalidPaymentIntentError extends CustomerError {
-  constructor(
-    subscriptionId: string,
-    paymentIntentId: string,
-    paymentIntentErrorMessage?: string
-  ) {
-    super('Invalid payment intent', {
-      subscriptionId,
-      paymentIntentId,
-      paymentIntentErrorMessage,
-    });
-    this.name = 'InvalidPaymentIntentError';
-  }
-}
-
 export class TransactionMissingOnPaidInvoiceError extends CustomerError {
   constructor(invoiceId: string, customerId: string) {
     super('Paid invoice missing transaction id', { invoiceId, customerId });
@@ -254,6 +232,16 @@ export class PayPalPaymentFailedError extends CustomerError {
       status: status ?? 'undefined',
     });
     this.name = 'PayPalPaymentFailedError';
+  }
+}
+
+export class SetupIntentCancelInvalidStatusError extends CustomerError {
+  constructor(setupIntentId: string, setupIntentStatus: string) {
+    super('Setup Intent can not be canceled due to invalid status.', {
+      setupIntentId,
+      setupIntentStatus,
+    });
+    this.name = 'SetupIntentCancelInvalidStatusError';
   }
 }
 

--- a/libs/payments/customer/src/lib/subscription.manager.spec.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.spec.ts
@@ -10,8 +10,6 @@ import {
   StripeApiListFactory,
   StripeResponseFactory,
   StripeCustomerFactory,
-  StripeInvoiceFactory,
-  StripePaymentIntentFactory,
   StripeSubscriptionFactory,
   MockStripeConfigProvider,
 } from '@fxa/payments/stripe';
@@ -311,63 +309,6 @@ describe('SubscriptionManager', () => {
 
       const result = subscriptionManager.getPaymentProvider(mockSubscription);
       expect(result).toEqual('paypal');
-    });
-  });
-
-  describe('getLatestPaymentIntent', () => {
-    it('fetches the latest payment intent for the subscription', async () => {
-      const mockSubscription = StripeResponseFactory(
-        StripeSubscriptionFactory()
-      );
-      const mockInvoice = StripeResponseFactory(StripeInvoiceFactory());
-      const mockPaymentIntent = StripeResponseFactory(
-        StripePaymentIntentFactory()
-      );
-
-      jest
-        .spyOn(stripeClient, 'invoicesRetrieve')
-        .mockResolvedValue(mockInvoice);
-
-      jest
-        .spyOn(stripeClient, 'paymentIntentRetrieve')
-        .mockResolvedValue(mockPaymentIntent);
-
-      const result = await subscriptionManager.getLatestPaymentIntent(
-        mockSubscription
-      );
-
-      expect(result).toEqual(mockPaymentIntent);
-    });
-
-    it('returns undefined if no invoice on subscription', async () => {
-      const mockSubscription = StripeSubscriptionFactory({
-        latest_invoice: null,
-      });
-
-      const result = await subscriptionManager.getLatestPaymentIntent(
-        mockSubscription
-      );
-
-      expect(result).toEqual(undefined);
-    });
-
-    it('returns undefined if the invoice has no payment intent', async () => {
-      const mockSubscription = StripeSubscriptionFactory();
-      const mockInvoice = StripeResponseFactory(
-        StripeInvoiceFactory({
-          payment_intent: null,
-        })
-      );
-
-      jest
-        .spyOn(stripeClient, 'invoicesRetrieve')
-        .mockResolvedValue(mockInvoice);
-
-      const result = await subscriptionManager.getLatestPaymentIntent(
-        mockSubscription
-      );
-
-      expect(result).toEqual(undefined);
     });
   });
 });

--- a/libs/payments/stripe/src/lib/stripe.client.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.ts
@@ -422,13 +422,23 @@ export class StripeClient {
   }
 
   @CaptureTimingWithStatsD()
-  async setupIntentCreate(
-    params?: Stripe.SetupIntentCreateParams,
+  async setupIntentCancel(
+    setupIntentId: string,
+    params?: Stripe.SetupIntentCancelParams
   ) {
+    const result = await this.stripe.setupIntents.cancel(setupIntentId, {
+      ...params,
+      expand: undefined,
+    });
+    return result as StripeResponse<StripeSetupIntent>;
+  }
+
+  @CaptureTimingWithStatsD()
+  async setupIntentCreate(params?: Stripe.SetupIntentCreateParams) {
     const result = await this.stripe.setupIntents.create({
       ...params,
       expand: undefined,
-    })
+    });
     return result as StripeResponse<StripeSetupIntent>;
   }
 

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -74,6 +74,51 @@ export function getErrorFtlInfo(
         message: 'The invoice amount has changed. Please try again.',
         messageFtl: 'cart-total-mismatch-error',
       };
+    case CartErrorReasonId.INTENT_FAILED_CARD_DECLINED:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'Your transaction could not be processed. Please verify your credit card information and try again.',
+        messageFtl: 'intent-card-error',
+      };
+    case CartErrorReasonId.INTENT_FAILED_CARD_EXPIRED:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'It looks like your credit card has expired. Try another card.',
+        messageFtl: 'intent-expired-card-error',
+      };
+    case CartErrorReasonId.INTENT_FAILED_TRY_AGAIN:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'Hmm. There was a problem authorizing your payment. Try again or get in touch with your card issuer.',
+        messageFtl: 'intent-payment-error-try-again',
+      };
+    case CartErrorReasonId.INTENT_FAILED_GET_IN_TOUCH:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.',
+        messageFtl: 'intent-payment-error-get-in-touch',
+      };
+    case CartErrorReasonId.INTENT_FAILED_GENERIC:
+      return {
+        buttonFtl: 'next-payment-error-retry-button',
+        buttonLabel: 'Try again',
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        message:
+          'An unexpected error has occurred while processing your payment, please try again.',
+        messageFtl: 'intent-payment-error-generic',
+      };
 
     case CartErrorReasonId.BASIC_ERROR:
     default:

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -8,8 +8,8 @@ import type { ColumnType, JSONColumnType } from 'kysely';
 
 export type Generated<T> =
   T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 
 export type Json = ColumnType<JsonValue, string, string>;
 
@@ -41,6 +41,11 @@ export enum CartErrorReasonId {
   CART_CURRENCY_NOT_DETERMINED = 'cart_currency_not_determined',
   CART_PROCESSING_GENERAL_ERROR = 'cart_processing_general_error',
   CART_TOTAL_MISMATCH = 'cart_total_mismatch',
+  INTENT_FAILED_GENERIC = 'intent_failed_generic',
+  INTENT_FAILED_CARD_DECLINED = 'intent_failed_card_declined',
+  INTENT_FAILED_CARD_EXPIRED = 'intent_failed_card_expired',
+  INTENT_FAILED_TRY_AGAIN = 'intent_failed_try_again',
+  INTENT_FAILED_GET_IN_TOUCH = 'intent_failed_get_in_touch',
   UNKNOWN = 'unknown',
 }
 

--- a/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
@@ -9,11 +9,15 @@ import { ErrorEvent } from '@sentry/core';
 const EXPECTED_ERRORS = new Set([
   'PromotionCodePriceNotValidError',
   'PromotionCodeNotFoundError',
-  'CouponErrorInvalidCode'
+  'CouponErrorInvalidCode',
+  'IntentFailedHandledError',
 ]);
 
-export const beforeSend = function (event: ErrorEvent, hint: any, config: InitSentryOpts) {
-
+export const beforeSend = function (
+  event: ErrorEvent,
+  hint: any,
+  config: InitSentryOpts
+) {
   if (event.exception?.values) {
     for (const value of event.exception.values) {
       if (value.type && EXPECTED_ERRORS.has(value.type)) {


### PR DESCRIPTION
## Because

- Currently a failed payment or setup intent results in Sentry errors and only shows the customer a generic error message.

## This pull request

- Reduces the number of errors thrown in the wrapWithCartCatch.
- Adds handling of Setup Intents to wrapWithCartCatch
- Updates error handling of Payment Intents in wrapWithCartCatch
- Adds new errors for various types of intent failures
- Copies existing error messages from SP2 to be used in SP3 for various types of intent failures.

## Issue that this pull request solves

Closes: #FXA-11981

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Additional Information

To test with a setup intent, ensure that zero dollar invoice is generated. Easiest way to do this is to use 123DonePro - monthly and the EVERYTHING coupon

## Screenshots

Get in touch error - With Contact Support
![image](https://github.com/user-attachments/assets/92b17d61-f02c-4a2b-a7f7-7047dc86edb1)

Get in touch error - With Try Again
![image](https://github.com/user-attachments/assets/5ad1bbca-7700-4b07-bfe9-ba1ac16bce91)

Card Decline - Insufficient funds decline
![image](https://github.com/user-attachments/assets/ffb0da5d-8d32-491d-b10c-87dfa61e2c48)

Card expired
![image](https://github.com/user-attachments/assets/f1edb698-4c33-4c89-b52f-e0048e62d7bb)

Try again error
![image](https://github.com/user-attachments/assets/c3a135f6-3ecb-4c96-878d-8d3a28556454)

