### PR TITLE
task(payments-next): update nextauth to use profile client

### DIFF
--- a/libs/payments/ui/src/lib/nestapp/validators/GetUserinfoArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetUserinfoArgs.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class GetUserinfoArgs {
+  @IsString()
+  userinfoUrl!: string;
+
+  @IsString()
+  accessToken!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetUserinfoResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetUserinfoResult.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsOptional, IsString } from 'class-validator';
+
+export class GetUserinfoResult {
+  @IsString()
+  uid!: string;
+
+  @IsString()
+  @IsOptional()
+  displayName?: string;
+
+  @IsString()
+  @IsOptional()
+  email?: string;
+
+  @IsString()
+  @IsOptional()
+  avatar?: string;
+}

--- a/libs/profile/client/src/lib/profile.client.spec.ts
+++ b/libs/profile/client/src/lib/profile.client.spec.ts
@@ -6,6 +6,7 @@ import { Test } from '@nestjs/testing';
 import { ProfileClient } from './profile.client';
 import { MockProfileClientConfigProvider } from './profile.config';
 import { Logger } from '@nestjs/common';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 
 describe('ProfileClient', () => {
   let profileClient: ProfileClient;
@@ -24,6 +25,7 @@ describe('ProfileClient', () => {
           useValue: mockLogger,
         },
         ProfileClient,
+        MockStatsDProvider,
       ],
     }).compile();
 

--- a/libs/profile/client/src/lib/profile.error.ts
+++ b/libs/profile/client/src/lib/profile.error.ts
@@ -36,3 +36,10 @@ export class ProfileClientServiceFailureError extends ProfileError {
     this.name = 'ProfileClientServiceFailureError';
   }
 }
+
+export class MalformedUserinfoError extends ProfileError {
+  constructor(userinfo: Record<string, any>) {
+    super('userinfo is missing required fields', userinfo);
+    this.name = 'MalformedUserinfoError';
+  }
+}

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -274,7 +274,7 @@ async function run(config) {
   );
   Container.set(RecoveryPhoneService, recoveryPhoneService);
 
-  const profile = new ProfileClient(log, {
+  const profile = new ProfileClient(log, statsd, {
     ...config.profileServer,
     serviceName: 'subhub',
   });

--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -47,7 +47,7 @@ export async function setupProcessingTaskObjects(processName: string) {
   // Establish database connection and bind instance to Model using Knex
   setupAuthDatabase(config.database.mysql.auth, log, statsd);
 
-  const profile = new ProfileClient(log, {
+  const profile = new ProfileClient(log, statsd, {
     ...config.profileServer,
     serviceName: 'subhub',
   });

--- a/packages/fxa-auth-server/scripts/delete-account.ts
+++ b/packages/fxa-auth-server/scripts/delete-account.ts
@@ -58,7 +58,7 @@ Container.set(AppConfig, config);
 Container.set(AuthLogger, log);
 const authFirestore = setupFirestore(config);
 Container.set(AuthFirestore, authFirestore);
-const profile = new ProfileClient(log, {
+const profile = new ProfileClient(log, statsd, {
   ...config.profileServer,
   serviceName: 'subhub',
 });


### PR DESCRIPTION
Because:

* the userinfo for next-auth comes from their default handler currently

This commit:

* updates the userinfo provider to be the profile client

Closes #FXA-11964

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
