### PR TITLE
bug(auth): /v1/support/ticket/ failing customs checks

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
@@ -98,7 +98,9 @@ export const supportRoutes = (
 
         const { uid, email } = await getAccountInfo(request);
         const { location } = request.app.geo;
-        await customs.checkAuthenticated(request, uid, email, 'supportRequest');
+
+        // Note, uid maybe null! Don't use checkAuthenticated here.
+        await customs.check(request, email, 'supportRequest');
 
         const {
           productName,

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -233,6 +233,9 @@ describe('support', () => {
           customFieldsOnTicket
         );
         assert.deepEqual(res, { success: true, ticket: 91 });
+
+        assert.callCount(customs.check, 1);
+
         nock.isDone();
         spy.restore();
       });
@@ -319,6 +322,7 @@ describe('support', () => {
           zendeskReq.custom_fields.map((field) => field.value),
           customFieldsOnTicket
         );
+        assert.callCount(customs.check, 1);
         assert.deepEqual(res, { success: true, ticket: 91 });
         nock.isDone();
         spy.restore();


### PR DESCRIPTION
## Because

- We got a report that the customs check was failing.
- When the supportSecret is used for auth, it's possible the account is not located, and the uid/email are null

## This pull request

- Does not assume uid and email exist
- Falls back to check or checkIpOnly depending on whether or not uid / email are undefined.

## Issue that this pull request solves

Closes: FXA-12001

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
