### PR TITLE
fix(perf): Change email-first LoadingSpinner fallback to LoadingSpinnerSprite

### DIFF
--- a/packages/fxa-settings/config/webpackDevServer.config.js
+++ b/packages/fxa-settings/config/webpackDevServer.config.js
@@ -44,7 +44,7 @@ module.exports = function (proxy, allowedHost) {
       'Access-Control-Allow-Headers': '*',
     },
     // Enable gzip compression of generated files.
-    compress: true,
+    compress: false,
     static: {
       // By default WebpackDevServer serves physical files from current directory
       // in addition to all the virtual build products that it serves from memory.

--- a/packages/fxa-settings/config/webpackDevServer.config.js
+++ b/packages/fxa-settings/config/webpackDevServer.config.js
@@ -9,6 +9,7 @@ const ignoredFiles = require('react-dev-utils/ignoredFiles');
 const redirectServedPath = require('react-dev-utils/redirectServedPathMiddleware');
 const paths = require('./paths');
 const getHttpsConfig = require('./getHttpsConfig');
+const compression = require('compression');
 
 const host = process.env.HOST || '0.0.0.0';
 const sockHost = process.env.WDS_SOCKET_HOST;
@@ -43,7 +44,9 @@ module.exports = function (proxy, allowedHost) {
       'Access-Control-Allow-Methods': '*',
       'Access-Control-Allow-Headers': '*',
     },
-    // Enable gzip compression of generated files.
+    // This is the default webpack gzip compression option for generated files
+    // but we need to use the compression middleware directly to avoid a content-
+    // encoding problems when modifying the public HTML file. See #19012 / #19127
     compress: false,
     static: {
       // By default WebpackDevServer serves physical files from current directory
@@ -125,6 +128,11 @@ module.exports = function (proxy, allowedHost) {
       // it used the same host and port.
       // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
       devServer.app.use(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
+    },
+    // Enable gzip compression of generated files with our own middleware
+    setupMiddlewares: (middlewares, devServer) => {
+      middlewares.unshift(compression({ threshold: '4kb' }));
+      return middlewares;
     },
   };
 };

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -24,6 +24,52 @@
 </head>
 
 <body data-flow-id="__FLOW_ID__" data-flow-begin-time="__FLOW_BEGIN_TIME__">
+  <div class="spritesheet">
+    <svg xmlns="http://www.w3.org/2000/svg">
+      <symbol id="loading-spinner" viewBox="0 0 73 73">
+        <linearGradient id="a" x1="93.09281%" x2="68.51334%" y1="52.773438%" y2="119.326007%">
+          <stop offset="0" stop-color="#0a84ff" stop-opacity="0"/>
+          <stop offset=".693698182" stop-color="#0a84ff"/>
+          <stop offset="1" stop-color="#0a84ff"/>
+          <stop offset="1" stop-color="#2484c6" stop-opacity=".004778"/>
+          <stop offset="1" stop-color="#2484c6" stop-opacity="0"/>
+        </linearGradient>
+        <mask id="b" fill="#fff">
+          <path d="m0 0h48v60h-48z" fill="#fff" fill-rule="evenodd"/>
+        </mask>
+        <g fill="none" fill-rule="evenodd" transform="translate(-5 -1)">
+          <path d="m41.8 73.8c-19.9 0-36-16.1-36-36 0-19.7 15.8-35.6 35.3-36h.3.4c2.8.4 5 2.7 5 5.5s-2.2 5.2-5 5.4c-13.8.1-25 11.3-25 25.1s11.2 25 25 25 25-11.2 25-25h11c0 19.9-16.1 36-36 36z" fill="url(#a)"/>
+          <path d="m41.8 73.8c-19.9 0-36-16.1-36-36 0-19.7 15.8-35.6 35.3-36h.3.4c2.8.4 5 2.7 5 5.5s-2.2 5.2-5 5.4c-13.8.1-25 11.3-25 25.1s11.2 25 25 25 25-11.2 25-25h11c0 19.9-16.1 36-36 36z" fill="#0a84ff" mask="url(#b)"/>
+        </g>
+      </symbol>
+    </svg>
+  </div>
+  <style>
+    .spritesheet { display: none; }
+    .loading-spinner {
+      width: 2.5rem;
+      height: 2.5rem;
+      display: inline-block;
+      animation: rotate 0.8s linear infinite;
+    }
+    @keyframes rotate {
+      100% { transform: rotate(360deg); }
+    }
+    .loading-spinner-fullscreen {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: #FAFAFB; /* bg-grey-10 */
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+      user-select: none;
+    }
+  </style>
+
   <noscript>Mozilla accounts requires JavaScript.</noscript>
   <div id="root"></div>
 </body>

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -40,10 +40,10 @@ import { hardNavigate } from 'fxa-react/lib/utils';
 import sentryMetrics from 'fxa-shared/sentry/browser';
 
 // Components
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { ScrollToTop } from '../Settings/ScrollToTop';
 import SignupConfirmedSync from '../../pages/Signup/SignupConfirmedSync';
 import useSyncEngines from '../../lib/hooks/useSyncEngines';
+import LoadingSpinnerSprite from '../LoadingSpinnerSprite';
 
 // Pages
 const IndexContainer = lazy(() => import('../../pages/Index/container'));
@@ -344,7 +344,7 @@ export const App = ({
     isSignedIn === undefined ||
     metricsEnabled === undefined
   ) {
-    return <LoadingSpinner fullScreen />;
+    return <LoadingSpinnerSprite />;
   }
 
   return (
@@ -385,14 +385,14 @@ const SettingsRoutes = ({
       hardNavigate(`/?${params.toString()}`);
     }
 
-    return <LoadingSpinner fullScreen />;
+    return <LoadingSpinnerSprite />;
   }
 
   const settingsContext = initializeSettingsContext();
   return (
     <SettingsContext.Provider value={settingsContext}>
       <ScrollToTop default>
-        <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <Suspense fallback={<LoadingSpinnerSprite />}>
           <Settings path="/settings/*" {...{ integration }} />
         </Suspense>
       </ScrollToTop>
@@ -422,7 +422,7 @@ const AuthAndAccountSetupRoutes = ({
   const useSyncEnginesResult = useSyncEngines(integration);
 
   return (
-    <Suspense fallback={<LoadingSpinner fullScreen />}>
+    <Suspense fallback={<LoadingSpinnerSprite />}>
       <Router>
         {/* Index */}
         <IndexContainer

--- a/packages/fxa-settings/src/components/LoadingSpinnerSprite/index.tsx
+++ b/packages/fxa-settings/src/components/LoadingSpinnerSprite/index.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+
+import { memo } from 'react';
+import { useFtlMsgResolver } from '../../models';
+
+ // This component uses CSS and the XML we set in public/index.html that is
+ // be available before the first app render completes.
+const LoadingSpinnerSprite = () => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const loadingAriaLabel = ftlMsgResolver.getMsg(
+    'app-loading-spinner-aria-label-loading',
+    'Loading…'
+  );
+
+  return (
+    <div className="loading-spinner-fullscreen">
+      <svg className="loading-spinner" role="img" aria-label={loadingAriaLabel}>
+        <use xlinkHref="#loading-spinner" />
+      </svg>
+    </div>
+  );
+}
+
+export default memo(LoadingSpinnerSprite);

--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -61,7 +61,7 @@ jest.mock('../../lib/email-domain-validator', () => ({
   checkEmailDomain: jest.fn(),
 }));
 
-jest.mock('fxa-react/components/LoadingSpinner', () => () => (
+jest.mock('../../components/LoadingSpinnerSprite', () => () => (
   <div>LoadingSpinner</div>
 ));
 

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -30,7 +30,7 @@ import { getLocalizedEmailValidationErrorMessage } from './errorMessageMapper';
 import { IndexContainerProps, LocationState } from './interfaces';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import { hardNavigate } from 'fxa-react/lib/utils';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import LoadingSpinnerSprite from '../../components/LoadingSpinnerSprite';
 
 const IndexContainer = ({
   integration,
@@ -266,7 +266,7 @@ const IndexContainer = ({
   const deeplink = queryParamModel.deeplink;
 
   return isLoading ? (
-    <LoadingSpinner fullScreen />
+    <LoadingSpinnerSprite />
   ) : (
     <Index
       {...{


### PR DESCRIPTION
Because:
* React Profiler shows our LoadingSpinner is heavy

This commit:
* Adds a spritesheet to our public HTML file and updates references to our LoadingSpinner on App/Index to an svg use instead, to load less XML on renders

fixes FXA-11880

---

The spritesheet approach gave me slightly better results in the Profiler than using `<img src=` and referencing it as a background image. However, the Profiler seems to be giving me slightly inconsistent results now compared to before - I was getting around 4.9ms in [this branch](https://github.com/mozilla/fxa/compare/main...LZoog:remove-loading-spinner-email-first?expand=1) with it swapped to an empty string, but when I do that off `main` now, I seem to get around ~7ms? I'm unsure if this is because locally I changed `compress: false` in webpack dev server to be able to make changes to the public file ([see Slack note here](https://mozilla.slack.com/archives/CLV3KMZ8B/p1751385961279919?thread_ts=1751056116.880179&cid=CLV3KMZ8B)) but I think this is worth a shot regardless.

Note, I consistently saw better results if we don't localize the alt text of the loading spinner. I didn't do testing before of keeping the loading spinner but removing the alt text, and I'm wondering now what that result would be. I will double check with a11y folks and file a follow up but I don't think this is going to qualify as decorative because users on very slow connection might end up having "Loading..." read.

<details>
<summary>With that said here's some local Profiler results that maybe aren't as cool as I wish they were</summary>

On `main`, I ran this a few times and this was about average:
![image](https://github.com/user-attachments/assets/4c477a87-f342-464b-8b0e-b829e06370b8)
![image](https://github.com/user-attachments/assets/98fc447b-37a8-459d-aabd-7906a357b7e6)

On this branch (ran this a few times and saw about a ~1ms difference so eh, ~12% improvement?):
![image](https://github.com/user-attachments/assets/4ff34f6c-298b-4a27-a6bd-1fdc455d26d0)
![image](https://github.com/user-attachments/assets/edc1254b-f7b4-4c1e-9cde-cf99e65fc349)
</details>

When we get results for this I'll file an issue to either use this in place of our other `LoadingSpinner`s or consider reverting the public HTML changes if there's no difference.