### PR TITLE
bug(settings): Wrong account being picked

### DIFF
--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -46,6 +46,13 @@ function accounts(accounts?: LocalAccounts) {
   return storage.get('accounts') as LocalAccounts;
 }
 
+export function findAccountByEmail(
+  email: string
+): StoredAccountData | undefined {
+  const all = accounts() || {};
+  return Object.values(all).find((x) => x.email && x.email === email);
+}
+
 export function currentAccount(
   account?: StoredAccountData
 ): StoredAccountData | undefined {

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -213,6 +213,11 @@ function mockModelsModule() {
 // Call this when testing local storage
 function mockCurrentAccount(storedAccount: any) {
   jest.spyOn(CacheModule, 'currentAccount').mockReturnValue(storedAccount);
+  jest
+    .spyOn(CacheModule, 'findAccountByEmail')
+    .mockImplementation((email: string) => {
+      return email === storedAccount.email ? storedAccount : undefined;
+    });
   jest.spyOn(CacheModule, 'discardSessionToken');
 }
 
@@ -1048,7 +1053,7 @@ describe('signin container', () => {
     it('runs handler, calls accountProfile and recoveryEmailStatus', async () => {
       mockAuthClient.accountProfile = jest.fn().mockResolvedValue({
         authenticationMethods: ['pwd', 'email'],
-        authenticatorAssuranceLevel: 1 // email verified session
+        authenticatorAssuranceLevel: 1, // email verified session
       });
       mockAuthClient.recoveryEmailStatus = jest.fn().mockResolvedValue({
         verified: false,
@@ -1088,7 +1093,7 @@ describe('signin container', () => {
     it('does not return a verification reason with verified 2FA session', async () => {
       mockAuthClient.accountProfile = jest.fn().mockResolvedValue({
         authenticationMethods: ['pwd', 'email', 'otp'],
-        authenticatorAssuranceLevel: 2 // 2FA verified session
+        authenticatorAssuranceLevel: 2, // 2FA verified session
       });
       mockAuthClient.recoveryEmailStatus = jest.fn().mockResolvedValue({
         verified: true,
@@ -1103,8 +1108,8 @@ describe('signin container', () => {
         const handlerResult =
           await currentSigninProps?.cachedSigninHandler(MOCK_SESSION_TOKEN);
 
-        expect(handlerResult?.data?.verificationMethod).toBeUndefined()
-        expect(handlerResult?.data?.verificationReason).toBeUndefined()
+        expect(handlerResult?.data?.verificationMethod).toBeUndefined();
+        expect(handlerResult?.data?.verificationReason).toBeUndefined();
         expect(handlerResult?.data?.emailVerified).toEqual(true);
       });
     });
@@ -1112,7 +1117,7 @@ describe('signin container', () => {
     it('throws if mismatch 2FA and assurance level', async () => {
       mockAuthClient.accountProfile = jest.fn().mockResolvedValue({
         authenticationMethods: ['pwd', 'email', 'otp'],
-        authenticatorAssuranceLevel: 1 // Session verified by email
+        authenticatorAssuranceLevel: 1, // Session verified by email
       });
       mockAuthClient.recoveryEmailStatus = jest.fn().mockResolvedValue({
         verified: true,


### PR DESCRIPTION
## Because

- The wrong account was being used

## This pull request

- Adjust the logic for how to select an account during sign in.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is in draft, because I feel like I didn't spend enough time testing it. Considering there's some bugs around this issue, maybe we should just throw it up for QA to look at... 

I'll ultimately leave this up to the reviewer to decide. This is actually a follow up to a previous PR. In that PR, note that during code review we were questioning the basic implementation for `getAccountInfo`. This PR should be seen as re-write of that where the email parameter makes a best effort to find the target account. The PR that this follows is, https://github.com/mozilla/fxa/pull/18988. 
