### PR TITLE
chore(functional-tests): disable maxFailures for functional-tests on nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,9 @@ commands:
     parameters:
       project:
         type: string
+      fail_fast:
+        type: boolean
+        default: true
     steps:
       - run:
           name: Running Playwright tests
@@ -359,6 +362,7 @@ commands:
             ACCOUNTS_API_DOMAIN: << pipeline.parameters.accounts-api-domain >>
             RELIER_DOMAIN: << pipeline.parameters.relier-domain >>
             UNTRUSTED_RELIER_DOMAIN: << pipeline.parameters.untrusted-relier-domain >>
+            PLAYWRIGHT_FAIL_FAST: << parameters.fail_fast >>
 
   store-artifacts:
     steps:
@@ -758,6 +762,9 @@ jobs:
         default: production
       workflow:
         type: string
+      fail_fast:
+        type: boolean
+        default: true
     executor: smoke-test-executor
     parallelism: << parameters.parallelism >>
     steps:
@@ -766,6 +773,7 @@ jobs:
       - provision
       - run-playwright-tests:
           project: << parameters.project >>
+          fail_fast: << parameters.fail_fast >>
       - store-artifacts
       - upload_to_gcs:
           workflow: << parameters.workflow >>
@@ -780,6 +788,9 @@ jobs:
         default: 8 # this should correspond with the resource-class defined in the executor
       workflow:
         type: string
+      fail_fast:
+        type: boolean
+        default: true
     executor: functional-test-executor
     parallelism: << parameters.parallelism >>
     steps:
@@ -800,6 +811,7 @@ jobs:
           no_output_timeout: 20m
       - run-playwright-tests:
           project: local
+          fail_fast: << parameters.fail_fast >>
       - store-artifacts
       - upload_to_gcs:
           workflow: << parameters.workflow >>
@@ -979,6 +991,7 @@ workflows:
               only: /.*/
             tags:
               only: /.*/
+          fail_fast: false
 
   deploy_fxa_image:
     # This workflow can be triggered after a PR lands on main. It requires approval.
@@ -1277,6 +1290,7 @@ workflows:
           workflow: nightly
           requires:
             - Build (nightly)
+          fail_fast: false
       - on-complete:
           name: Tests Complete (nightly)
           stage: Tests (nightly)

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -22,13 +22,15 @@ const JUNIT_OUTPUT_NAME = process.env.CIRCLE_NODE_INDEX
 const DEBUG = !!process.env.DEBUG;
 const SLOWMO = parseInt(process.env.PLAYWRIGHT_SLOWMO || '0');
 const NUM_WORKERS = parseInt(process.env.PLAYWRIGHT_WORKERS || '4');
+const FAIL_FAST = !!process.env.PLAYWRIGHT_FAIL_FAST || true;
 
-let workers = NUM_WORKERS || 2,
-  maxFailures = 0;
+let workers = NUM_WORKERS || 2;
+let maxFailures = 0;
+
 if (CI) {
   // Overall maxFailures is dependent on the number of workers
   workers = 2;
-  maxFailures = workers * 2;
+  maxFailures = FAIL_FAST ? workers * 2 : 0;
 }
 
 export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({

--- a/packages/functional-tests/scripts/start-services.sh
+++ b/packages/functional-tests/scripts/start-services.sh
@@ -12,7 +12,7 @@ mkdir -p artifacts/tests
 chmod +x node_modules/@nestjs/cli/bin/nest.js
 
 # Make sure we have built the latest
-NODE_OPTIONS="--max-old-space-size=7168" CI=false NODE_ENV=test npx nx run-many \
+NODE_OPTIONS="--max-old-space-size=7168" NODE_ENV=test npx nx run-many \
     -t start \
     --parallel=2 \
     --verbose \
@@ -24,6 +24,6 @@ NODE_OPTIONS="--max-old-space-size=7168" CI=false NODE_ENV=test npx nx run-many 
     fxa-payments-server \
     fxa-profile-server \
     fxa-settings \
-    > ~/.pm2/logs/startup.log
+    | tee ~/.pm2/logs/startup.log
 
 npx pm2 ls


### PR DESCRIPTION
## Because

- Playwright can skip tests due to `maxFailures`
- And we want to attempt to run all tests during `nightly`
- And we want to improve build time by utilizing the nx cache

## This pull request

- Adds an environment variable for `PLAYWRIGHT_FAIL_FAST`, defaulted to true
- Passes an override for this environment variable to the workflows to disable it for appropriate builds
- And fixes env var that caused NX to ignore local and remote cache

## Issue that this pull request solves

Closes: FXA-12015

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
