### PR TITLE
polish(payments-next): Add libs/profile ts files to payments-next hot reload

### DIFF
--- a/apps/payments/next/Gruntfile.js
+++ b/apps/payments/next/Gruntfile.js
@@ -48,6 +48,7 @@ module.exports = function(grunt) {
           '../../../libs/payments/**/*.ts',
           '../../../libs/shared/**/*.ts',
           '../../../libs/google/**/*.ts',
+          '../../../libs/profile/**/*.ts',
         ],
         tasks: ['http:nestapp'],
         options: {


### PR DESCRIPTION
Because:

* The ProfileClient class is used by nextjs, but changes to it do not cause a hotreload

This commit:

* Adds the libs/profile/**/*.ts files to the payments-next gruntfile

Closes #n/a

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
