### PR TITLE
fix(next): ignore handled intent errors

### DIFF
--- a/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
@@ -10,7 +10,10 @@ const EXPECTED_ERRORS = new Set([
   'PromotionCodePriceNotValidError',
   'PromotionCodeNotFoundError',
   'CouponErrorInvalidCode',
-  'IntentFailedHandledError',
+  'IntentCardDeclinedError',
+  'IntentCardExpiredError',
+  'IntentTryAgainError',
+  'IntentGetInTouchError',
 ]);
 
 export const beforeSend = function (


### PR DESCRIPTION
## Because

- Instances of IntentFailedHandledError should not be reported to Sentry.

## This pull request

- Manually add errors inheriting from IntentFailedHandledError to sentry ignore list.

## Issue that this pull request solves

Closes:

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
