### PR TITLE
fix(csp): Add temp inline style hash

### DIFF
--- a/packages/fxa-content-server/server/lib/csp/blocking.js
+++ b/packages/fxa-content-server/server/lib/csp/blocking.js
@@ -70,6 +70,11 @@ module.exports = function (config) {
   ];
   const scriptSrc = addCdnRuleIfRequired([SELF]);
   const styleSrc = addCdnRuleIfRequired([SELF]);
+
+  // TODO, FXA-12027.
+  // Only allow inline styles matching this hash. This is temporary while we
+  // check if #19127 leads to any performance improvement.
+  styleSrc.push("'sha256-e8nIS94GUs+9w77KIQr5AYAgVEpvMJydNUsOUqKr1hw='");
   if (config.get('env') === 'development') {
     connectSrc.push(config.get('public_url').replace(/^http/, 'ws'));
     connectSrc.push(WEBPACK_DEV_SERVER);

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -44,6 +44,10 @@
       </symbol>
     </svg>
   </div>
+  <!-- Temporary inline styles while we check if #19127 leads to any performance improvement.
+  Will either be removed or more dynamically inserted as this currently requires a hash
+  matching (without whitespace) to our inline style CSP rule. TBD FXA-12027
+  -->
   <style>
     .spritesheet { display: none; }
     .loading-spinner {


### PR DESCRIPTION
Because:
* Our new inline styles are getting blocked and causing issues on stage

This commit:
* Adds a manually generated temp hash until we either decide it's worth it to generate this dynamically or we remove