### PR TITLE
fix(bug): Remove `email` from query param when clicking `Change email`

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -1098,7 +1098,7 @@ describe('Signin component', () => {
           1
         );
       });
-      expect(mockNavigate).toHaveBeenCalledWith('/', {
+      expect(mockNavigate).toHaveBeenCalledWith('/?', {
         state: { prefillEmail: MOCK_EMAIL },
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -505,9 +505,14 @@ const Signin = ({
               e.preventDefault();
               GleanMetrics.login.diffAccountLinkClick();
 
-              navigateWithQuery('/', {
+              // Some RPs may specify an email address in the query params which
+              // we prioritize. Users attempting to change their email address is a signal
+              // that the email in query params is not correct.
+              const searchParams = new URLSearchParams(window.location.search);
+              searchParams.delete('email');
+              navigateWithQuery(`/?${searchParams.toString()}`, {
                 state: {
-                  prefillEmail: email,
+                  prefillEmail: email
                 },
               });
             }}

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -288,7 +288,7 @@ describe('Signup page', () => {
       });
       await waitFor(() => {
         expect(GleanMetrics.registration.changeEmail).toBeCalledTimes(1);
-        expect(mockNavigate).toHaveBeenCalledWith('/', {
+        expect(mockNavigate).toHaveBeenCalledWith('/?', {
           state: { prefillEmail: MOCK_EMAIL },
         });
       });

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -368,9 +368,12 @@ export const Signup = ({
             onClick={async (e) => {
               e.preventDefault();
               GleanMetrics.registration.changeEmail();
-              navigateWithQuery('/', {
+
+              const searchParams = new URLSearchParams(window.location.search);
+              searchParams.delete('email');
+              navigateWithQuery(`/?${searchParams.toString()}`, {
                 state: {
-                  prefillEmail: email,
+                  prefillEmail: email
                 },
               });
             }}


### PR DESCRIPTION
## Because

- When users change their email address during sign-in or sign-up, the application should clear any prefilled email from the query parameters to avoid confusion and ensure the correct email is used.

## This pull request

- Updates the sign-in and sign-up flows to remove the `email` query parameter from the URL when users choose to change their email address.
- Ensures that the navigation back to the entry page (`/`) includes any remaining query parameters except for `email`.
- Updates related tests to expect the new navigation behavior.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
