### PR TITLE
fix(next): add delayed subscription update

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -119,6 +119,9 @@ import {
   MockGoogleIapClientConfigProvider,
 } from '@fxa/payments/iap';
 import { Logger } from '@nestjs/common';
+import { delay } from './util/delay';
+
+jest.mock('./util/delay.ts');
 
 describe('CheckoutService', () => {
   let accountCustomerManager: AccountCustomerManager;
@@ -510,6 +513,10 @@ describe('CheckoutService', () => {
       jest.spyOn(profileClient, 'deleteCache').mockResolvedValue('test');
       jest.spyOn(cartManager, 'finishCart').mockResolvedValue();
       jest.spyOn(statsd, 'increment');
+      (delay as jest.Mock).mockReturnValue(undefined);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
     });
 
     it('success', async () => {

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -73,6 +73,7 @@ import {
 import { isPaymentIntentId } from './util/isPaymentIntentId';
 import { isPaymentIntent } from './util/isPaymentIntent';
 import { throwIntentFailedError } from './util/throwIntentFailedError';
+import { delay } from './util/delay';
 
 @Injectable()
 export class CheckoutService {
@@ -287,6 +288,17 @@ export class CheckoutService {
       payment_provider: paymentProvider,
       offering_id: cart.offeringConfigId,
       interval: cart.interval,
+    });
+
+    await delay(30000);
+
+    await this.subscriptionManager.update(subscription.id, {
+      metadata: {
+        ...subscription.metadata,
+        [STRIPE_SUBSCRIPTION_METADATA.LastUpdated]: Math.floor(
+          Date.now() / 1000
+        ),
+      },
     });
   }
 

--- a/libs/payments/cart/src/lib/util/delay.ts
+++ b/libs/payments/cart/src/lib/util/delay.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -23,7 +23,7 @@ export type InvoicePreview = {
 export type InvoicePreviewForUpgrade = InvoicePreview & {
   oneTimeCharge: number;
   oneTimeChargeSubtotal: number;
-}
+};
 
 export interface Interval {
   interval: NonNullable<StripePrice['recurring']>['interval'];
@@ -74,6 +74,7 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   SessionEntrypoint = 'session_entrypoint',
   SessionEntrypointExperiment = 'session_entrypoint_experiment',
   SessionEntrypointVariation = 'session_entrypoint_variation',
+  LastUpdated = 'last_updated',
 }
 
 export enum STRIPE_INVOICE_METADATA {


### PR DESCRIPTION
## Because

- Due to SP3 subscription creation differences compared to SP2, it is possible that when subscription update events are processed by the stripe-webhook handler, that the subscription stored in firestore will have an incorrect status compared to the actual value in Stripe.

## This pull request

- This change helps mitigate the incorrect status, by performing a delayed update to the subscription. This results in a delayed webhook event, which should allow for enough time for the correct Stripe subscription status to be updated in SubPlat firestore

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).