### PR TITLE
fix(settings): fix error message displayed at the beginning of the 2FA setup flow

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/en.ftl
@@ -1,6 +1,9 @@
 ## FlowSetup2faApp
 
 flow-setup-2fa-qr-heading = Connect to your authenticator app
+# DEV NOTE: "2a" in the id should be "2fa". This typo is kept intentionally to
+# avoid losing existing translations; fix it when creating a new version of
+# this string.
 flow-setup-2a-qr-instruction = <strong>Step 1:</strong> Scan this QR code using any authenticator app, like Duo or Google Authenticator.
 
 # Alt text for the QR-code image shown during two-step authentication setup.

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.tsx
@@ -76,11 +76,11 @@ export const FlowSetup2faApp = ({
   const localizedHeading =
     setupMethod === TwoStepSetupMethod.QrCode
       ? ftlMsgResolver.getMsg(
-          'flow-setup-2a-qr-heading',
+          'flow-setup-2fa-qr-heading',
           'Connect to your authenticator app'
         )
       : ftlMsgResolver.getMsg(
-          'flow-setup-2a-manual-key-heading',
+          'flow-setup-2fa-manual-key-heading',
           'Enter code manually'
         );
 
@@ -116,7 +116,7 @@ export const FlowSetup2faApp = ({
       )}
 
       <FtlMsg
-        id="flow-setup-2a-step-2-instruction"
+        id="flow-setup-2fa-step-2-instruction"
         elems={{ strong: <strong></strong> }}
       >
         <p className="text-sm mt-4">
@@ -257,7 +257,7 @@ const ManualCodeStep = ({
   return (
     <div>
       <FtlMsg
-        id="flow-setup-2a-manual-key-instruction"
+        id="flow-setup-2fa-manual-key-instruction"
         elems={{ strong: <strong></strong> }}
       >
         <p className="text-sm">

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.tsx
@@ -115,18 +115,19 @@ const Page2faSetup = (_: RouteComponentProps) => {
     }
   }, [backupMethod, currentStep, flowHasPhoneChoice, createRecoveryCodes]);
 
-  /* ───── early return states ───── */
-  if (totpInfoLoading) return <LoadingSpinner fullScreen />;
   // if there is an issue retrieving totp info, 2FA cannot be set up
   // --> return to main settings page with alert bar message
+  useEffect(() => {
+    if (!totpInfoLoading && (totpInfoError || !totpInfo)) {
+      showGenericError();
+      goHome();
+    }
+  }, [totpInfoLoading, totpInfoError, totpInfo, showGenericError, goHome]);
+
+  /* ───── early return states ───── */
+  if (totpInfoLoading) return <LoadingSpinner fullScreen />;
+
   if (totpInfoError || !totpInfo) {
-    alertBar.error(
-      ftlMsgResolver.getMsg(
-        'flow-setup-2fa-totpinfo-error',
-        'There was an error setting up two-step authentication. Try again later.'
-      )
-    );
-    goHome();
     return <></>;
   }
 

--- a/packages/fxa-settings/src/lib/hooks/useTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useTotpSetup/index.tsx
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
- 
+
 import { useEffect, useState } from 'react';
 import { useAccount, useSession } from '../../../models';
 import { TotpInfo } from '../../types';
@@ -11,7 +11,7 @@ export const useTotpSetup = () => {
   const session = useSession();
 
   const [totpInfo, setTotpInfo] = useState<TotpInfo | undefined>();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
@@ -19,7 +19,6 @@ export const useTotpSetup = () => {
 
     let cancelled = false;
     const fetchTotp = async () => {
-      setLoading(true);
       setError(null);
       try {
         const result = await account.createTotp(true);


### PR DESCRIPTION
## Because

- An error message is displayed at the beginning of the 2FA set-up flow

## This pull request

- Removes this error message by fixing typos in ftl ids and wrapping state updates in useEffect

## Issue that this pull request solves

Closes: FXA-12030

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
