### PR TITLE
chore(l10n): Fix syntax error in support-message-3

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/support/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/support/en.ftl
@@ -1,6 +1,6 @@
 # Variables:
 #  $supportUrl (String) - Link to https://support.mozilla.org/kb/im-having-problems-my-firefox-account
-support-message-3 = For more info, visit <a data-l10n-name="supportLink">{ -brand-mozilla } Support</a>}.
+support-message-3 = For more info, visit <a data-l10n-name="supportLink">{ -brand-mozilla } Support</a>.
 
 # Variables:
 #  $supportUrl (String) - Link to https://support.mozilla.org/kb/im-having-problems-my-firefox-account


### PR DESCRIPTION
## Because

- support-message-3 contains a syntax error causing issues in Pontoon sync

## This pull request

-  Removes the syntax error

## Issue that this pull request solves

