### PR TITLE
feat(payments-next): Add subscription management routes

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
+++ b/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { signIn } from 'apps/payments/next/auth';
+import { NextRequest } from 'next/server';
+import { config } from 'apps/payments/next/config';
+import { getMetricsFlowAction } from '@fxa/payments/ui/actions';
+import { ManageParams } from '@fxa/payments/ui';
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-dynamic'; // defaults to auto
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: ManageParams }
+) {
+  const requestSearchParams = request.nextUrl.searchParams;
+  const { locale } = params;
+
+  const redirectToUrl = new URL(
+    `${config.paymentsNextHostedUrl}/${locale}/subscriptions/manage`
+  );
+  redirectToUrl.search = requestSearchParams.toString();
+
+  if (
+    !redirectToUrl.searchParams.has('flow_id') &&
+    !redirectToUrl.searchParams.has('flow_begin_time')
+  ) {
+    try {
+      const metricsFlow = await getMetricsFlowAction();
+      redirectToUrl.searchParams.set('flow_id', metricsFlow.flowId);
+      redirectToUrl.searchParams.set(
+        'flow_begin_time',
+        metricsFlow.flowBeginTime.toString()
+      );
+    } catch (error) {
+      // Prevent error propagation on failed metrics flow fetch
+      console.error(error);
+    }
+  }
+
+  let redirectUrl;
+  try {
+    redirectUrl = await signIn(
+      'fxa',
+      {
+        redirect: false,
+        redirectTo: redirectToUrl.href,
+      },
+      { prompt: 'none', return_on_error: 'false' }
+    );
+  } catch (error) {
+    console.error(error);
+  }
+
+  redirect(redirectUrl ?? redirectToUrl.href);
+}

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ManageParams } from '@fxa/payments/ui';
+import { auth } from 'apps/payments/next/auth';
+import { config } from 'apps/payments/next/config';
+import { redirect } from 'next/navigation';
+import { URLSearchParams } from 'url';
+
+export default async function Manage({
+  params,
+  searchParams,
+}: {
+  params: ManageParams;
+  searchParams: Record<string, string | string[]> | undefined;
+}) {
+  const { locale } = params;
+  const session = await auth();
+  if (!session) {
+    const redirectToUrl = new URL(
+      `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
+    );
+    redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirect(redirectToUrl.href);
+  }
+
+  return <div>Subscription management</div>;
+}

--- a/libs/payments/ui/src/lib/utils/types.ts
+++ b/libs/payments/ui/src/lib/utils/types.ts
@@ -21,14 +21,18 @@ export interface CheckoutParams extends BaseParams {
 }
 
 export type Page =
-    | 'landing'
-    | 'new'
-    | 'start'
-    | 'success'
-    | 'error'
-    | 'location'
-    | 'page-not-found'
-    | 'processing'
-    | 'needs_input';
+  | 'landing'
+  | 'new'
+  | 'start'
+  | 'success'
+  | 'error'
+  | 'location'
+  | 'page-not-found'
+  | 'processing'
+  | 'needs_input';
 
 export type PageType = 'checkout' | 'upgrade';
+
+export interface ManageParams {
+  locale: string;
+}


### PR DESCRIPTION
Because:

* Subscription management needs an auth flow and landing pages

This commit:

* Adds in the {locale}/subscriptions/* route for payments-next
* If no session object, redirects user through the auth flow (no-prompt, then prompted)

Closes #FXA-11227

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
