### PR TITLE
task(payments-next): Add SubscriptionManagementService

### DIFF
--- a/libs/payments/management/.eslintrc.json
+++ b/libs/payments/management/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/payments/management/.swcrc
+++ b/libs/payments/management/.swcrc
@@ -1,0 +1,14 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}

--- a/libs/payments/management/README.md
+++ b/libs/payments/management/README.md
@@ -1,0 +1,15 @@
+# payments-management
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build payments-management` to build the library.
+
+## Running unit tests
+
+Run `nx test-unit payments-management` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running integration tests
+
+Run `nx test-integration payments-management` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/payments/management/jest.config.ts
+++ b/libs/payments/management/jest.config.ts
@@ -1,0 +1,43 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+import { Config } from 'jest';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
+const config: Config = {
+  displayName: 'payments-management',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
+  coverageDirectory: '../../../coverage/libs/payments/management',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-management',
+        outputName: 'payments-management-jest-unit-results.xml',
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/libs/payments/management/package.json
+++ b/libs/payments/management/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fxa/payments/management",
+  "version": "0.0.1"
+}

--- a/libs/payments/management/project.json
+++ b/libs/payments/management/project.json
@@ -1,0 +1,60 @@
+{
+  "name": "payments-management",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/payments/management/src",
+  "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "main": "libs/payments/management/src/index.ts",
+        "outputPath": "dist/libs/payments/management",
+        "outputFileName": "main.js",
+        "tsConfig": "libs/payments/management/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "libs/payments/management/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ],
+        "platform": "node",
+        "declaration" : true
+      },
+      "configurations": {
+        "development": {
+          "minify": false
+        },
+        "production": {
+          "minify": true
+        }
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/payments/management/**/*.ts"]
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/management/jest.config.ts",
+        "testPathPattern": ["^(?!.*\\.in\\.spec\\.ts$).*$"]
+      }
+    },
+    "test-integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/management/jest.config.ts",
+        "testPathPattern": ["\\.in\\.spec\\.ts$"]
+      }
+    }
+  }
+}

--- a/libs/payments/management/src/index.ts
+++ b/libs/payments/management/src/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './lib/subscriptionManagement.service';

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Test } from '@nestjs/testing';
+import { SubscriptionManagementService } from '@fxa/payments/management';
+import { Logger } from '@nestjs/common';
+
+jest.mock('@fxa/shared/error', () => ({
+  ...jest.requireActual('@fxa/shared/error'),
+  SanitizeExceptions: jest.fn(({ allowlist = [] } = {}) => {
+    return function (
+      target: any,
+      propertyKey: string,
+      descriptor: PropertyDescriptor
+    ) {
+      return descriptor;
+    };
+  }),
+}));
+
+describe('SubscriptionManagementService', () => {
+  let subscriptionManagementService: SubscriptionManagementService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [Logger, SubscriptionManagementService],
+    }).compile();
+
+    subscriptionManagementService = moduleRef.get(
+      SubscriptionManagementService
+    );
+  });
+
+  describe('checkInitialization', () => {
+    it('is initialized', () => {
+      const initialization =
+        subscriptionManagementService.checkInitialization();
+      expect(initialization.initialized).toBeTruthy();
+    });
+  });
+});

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Inject, Injectable, Logger, type LoggerService } from '@nestjs/common';
+import { SanitizeExceptions } from '@fxa/shared/error';
+
+@Injectable()
+export class SubscriptionManagementService {
+  constructor(@Inject(Logger) private log: LoggerService) {}
+
+  // TODO: Remove when developing this class, along with the associated tests.
+  // This method is for testing purposes only
+  @SanitizeExceptions()
+  checkInitialization() {
+    this.log.log('SubscriptionManagementService is initialized');
+    return { initialized: true };
+  }
+}

--- a/libs/payments/management/tsconfig.json
+++ b/libs/payments/management/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/payments/management/tsconfig.lib.json
+++ b/libs/payments/management/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/payments/management/tsconfig.spec.json
+++ b/libs/payments/management/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -41,6 +41,7 @@
       "@fxa/payments/events": ["libs/payments/events/src/index.ts"],
       "@fxa/payments/iap": ["libs/payments/iap/src/index.ts"],
       "@fxa/payments/legacy": ["libs/payments/legacy/src/index.ts"],
+      "@fxa/payments/management": ["libs/payments/management/src/index.ts"],
       "@fxa/payments/metrics": ["libs/payments/metrics/src/index.ts"],
       "@fxa/payments/metrics/provider": [
         "libs/payments/metrics/src/provider.ts"


### PR DESCRIPTION
Because:

* payments-next is going to own the subscription management page, and as such needs a service to wrap the logic

This commit:

* Adds in a new nx project, payments-management
* Adds in a SubscriptionManagementService, along with a standin function for testing purposes Closes #FXA-11240

Closes: #FXA-11240

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
