### PR TITLE
fix(payments): fix flakey playwright tests

### DIFF
--- a/packages/functional-tests/pages/products/components/paymentInformation.ts
+++ b/packages/functional-tests/pages/products/components/paymentInformation.ts
@@ -56,7 +56,7 @@ export class PaymentInformationPage {
 
   async clickPayNow() {
     // Start waiting for response before clicking
-    const responsePromise = this.page.waitForResponse(
+    await this.page.waitForResponse(
       // After clicking 'Pay Now' we should either see an API call to
       // billing-and-subscriptions or an error message
       (response) =>
@@ -66,6 +66,5 @@ export class PaymentInformationPage {
         )
     );
     await this.page.getByTestId('submit').click();
-    await responsePromise;
   }
 }


### PR DESCRIPTION
Because:

* Playwright payment tests have been failing at an increasing rate

This commit:

* The failing tests all seem to pertain to one method, `clickPayNow` in paymentinformation.ts, which has flakey behavior described inline, but no tests rely on this flakey behavior
* Updates this function to `await` the page response before clicking 'submit'

Closes #N/A

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
