### PR TITLE
fix(payments-next,ui): Move PayPalScriptProvider to PaymentSection

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -59,6 +59,7 @@ export default async function Checkout({
   const { locale } = params;
 
   const acceptLanguage = headers().get('accept-language');
+  const nonce = headers().get('x-nonce') || undefined;
   const sessionPromise = auth();
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const cmsDataPromise = fetchCMSData(
@@ -80,7 +81,8 @@ export default async function Checkout({
 
   // prevent cart and session user mismatch
   if (cart.uid !== session?.user?.id) {
-    const redirectSearchParams: Record<string, string | string[]> = searchParams || {};
+    const redirectSearchParams: Record<string, string | string[]> =
+      searchParams || {};
     delete redirectSearchParams.cartId;
     delete redirectSearchParams.cartVersion;
     const redirectTo = buildRedirectUrl(
@@ -97,7 +99,8 @@ export default async function Checkout({
     redirect(redirectTo);
   }
 
-  const redirectSearchParams: Record<string, string | string[]> = searchParams || {};
+  const redirectSearchParams: Record<string, string | string[]> =
+    searchParams || {};
   redirectSearchParams.cartId = cart.id;
   redirectSearchParams.cartVersion = cart.version.toString();
 
@@ -279,6 +282,8 @@ export default async function Checkout({
                 },
               }}
               locale={locale}
+              nonce={nonce}
+              paypalClientId={config.paypal.clientId}
               sessionUid={session?.user?.id}
             />
           )}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -49,6 +49,7 @@ export default async function Upgrade({
 }) {
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');
+  const nonce = headers().get('x-nonce') || undefined;
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const session = await auth();
 
@@ -160,6 +161,8 @@ export default async function Upgrade({
               }}
               cart={cart}
               locale={locale}
+              nonce={nonce}
+              paypalClientId={config.paypal.clientId}
               sessionUid={session?.user?.id}
             />
           )}

--- a/apps/payments/next/app/[locale]/layout.tsx
+++ b/apps/payments/next/app/[locale]/layout.tsx
@@ -16,7 +16,6 @@ export default async function RootProviderLayout({
   children: React.ReactNode;
 }) {
   const acceptLanguage = headers().get('accept-language');
-  const nonce = headers().get('x-nonce') || undefined;
   const fetchedMessages = getApp().getFetchedMessages(
     acceptLanguage,
     params.locale
@@ -32,7 +31,6 @@ export default async function RootProviderLayout({
         },
       }}
       fetchedMessages={fetchedMessages}
-      nonce={nonce}
     >
       {children}
     </Providers>

--- a/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
@@ -7,6 +7,18 @@
 import Stripe from 'stripe';
 import { CheckoutForm } from '../CheckoutForm';
 import { StripeWrapper } from '../StripeWrapper';
+import {
+  PayPalScriptProvider,
+  ReactPayPalScriptOptions,
+} from '@paypal/react-paypal-js';
+
+const paypalInitialOptions: ReactPayPalScriptOptions = {
+  clientId: '',
+  vault: true,
+  commit: false,
+  intent: 'capture',
+  disableFunding: ['credit', 'card'],
+};
 
 interface PaymentFormProps {
   cmsCommonContent: {
@@ -41,6 +53,8 @@ interface PaymentFormProps {
     hasActiveSubscriptions: boolean;
   };
   locale: string;
+  nonce?: string;
+  paypalClientId: string;
   sessionUid?: string;
 }
 
@@ -49,21 +63,31 @@ export function PaymentSection({
   paymentsInfo,
   cart,
   locale,
+  nonce,
+  paypalClientId,
   sessionUid,
 }: PaymentFormProps) {
   return (
-    <StripeWrapper
-      amount={paymentsInfo.amount}
-      currency={paymentsInfo.currency}
-      cart={cart}
-      locale={locale}
+    <PayPalScriptProvider
+      options={{
+        ...paypalInitialOptions,
+        clientId: paypalClientId,
+        dataCspNonce: nonce,
+      }}
     >
-      <CheckoutForm
-        cmsCommonContent={cmsCommonContent}
+      <StripeWrapper
+        amount={paymentsInfo.amount}
+        currency={paymentsInfo.currency}
         cart={cart}
         locale={locale}
-        sessionUid={sessionUid}
-      />
-    </StripeWrapper>
+      >
+        <CheckoutForm
+          cmsCommonContent={cmsCommonContent}
+          cart={cart}
+          locale={locale}
+          sessionUid={sessionUid}
+        />
+      </StripeWrapper>
+    </PayPalScriptProvider>
   );
 }

--- a/libs/payments/ui/src/lib/client/providers/Providers.tsx
+++ b/libs/payments/ui/src/lib/client/providers/Providers.tsx
@@ -6,10 +6,6 @@
 
 import { ConfigContextValues, ConfigProvider } from './ConfigProvider';
 import { FluentLocalizationProvider } from './FluentLocalizationProvider';
-import {
-  PayPalScriptProvider,
-  ReactPayPalScriptOptions,
-} from '@paypal/react-paypal-js';
 import { initSentryForNextjsClient } from '@fxa/shared/sentry/client';
 import { getClient as sentryGetClient } from '@sentry/nextjs';
 import { GENERIC_ERROR_MESSAGE } from '@fxa/shared/error/error';
@@ -17,22 +13,12 @@ import { GENERIC_ERROR_MESSAGE } from '@fxa/shared/error/error';
 interface ProvidersProps {
   config: ConfigContextValues;
   fetchedMessages: Record<string, string>;
-  nonce?: string;
   children: React.ReactNode;
 }
-
-const paypalInitialOptions: ReactPayPalScriptOptions = {
-  clientId: '',
-  vault: true,
-  commit: false,
-  intent: 'capture',
-  disableFunding: ['credit', 'card'],
-};
 
 export function Providers({
   config,
   fetchedMessages,
-  nonce,
   children,
 }: ProvidersProps) {
   //Only initialize Sentry if it hasn't been initialized yet
@@ -50,15 +36,7 @@ export function Providers({
   return (
     <ConfigProvider config={config}>
       <FluentLocalizationProvider fetchedMessages={fetchedMessages}>
-        <PayPalScriptProvider
-          options={{
-            ...paypalInitialOptions,
-            clientId: config.paypalClientId,
-            dataCspNonce: nonce,
-          }}
-        >
-          {children}
-        </PayPalScriptProvider>
+        {children}
       </FluentLocalizationProvider>
     </ConfigProvider>
   );


### PR DESCRIPTION
## This pull request

- [x] Updates `<Providers>` component by removing `<PayPalScriptProvider>`
- [x] Moves `<PayPalScriptProvider>` to `<PaymentSection>` component

## Issue that this pull request solves

Closes: FXA-11247

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.