### PR TITLE
fix(sign-in): Properly redirect users without verified sessions (+ reverted revert of #19086)

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -135,6 +135,13 @@ export const Settings = ({
     return <AppErrorDialog data-testid="error-dialog" />;
   }
 
+  // If the session hasn't been verified, kick back to root
+  if (session.verified === false) {
+    console.warn('Session.verified false on /settings access!');
+    navigateWithQuery('/');
+    return <LoadingSpinner fullScreen />;
+  }
+
   return (
     <SettingsLayout>
       <Head />

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -112,9 +112,11 @@ export class Session implements SessionData {
     });
   }
 
-  async sendVerificationCode() {
+  async sendVerificationCode(sessionTokenArg?: hexstring) {
     await this.withLoadingStatus(
-      this.authClient.sessionResendVerifyCode(sessionToken()!)
+      this.authClient.sessionResendVerifyCode(
+        sessionTokenArg || sessionToken()!
+      )
     );
   }
 

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -26,6 +26,7 @@ import {
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
+import { NavigationOptions } from '../Signin/interfaces';
 
 const convertToRelierAccount = (
   account: ReturnType<typeof currentAccount>,
@@ -98,7 +99,7 @@ const AuthorizationContainer = ({
       }
 
       if (data) {
-        const navigationOptions = {
+        const navigationOptions: NavigationOptions = {
           email: account?.email!,
           signinData: {
             verified: data.verified,
@@ -107,6 +108,7 @@ const AuthorizationContainer = ({
             uid: data.uid,
             sessionToken: account?.sessionToken!,
           },
+          sessionVerified: data.sessionVerified,
           integration,
           redirectTo: integration.data.redirectTo,
           finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -108,6 +108,7 @@ const SetPasswordContainer = ({
               verified: true,
               keyFetchToken,
             },
+            sessionVerified: true,
             unwrapBKey,
             integration,
             finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -25,6 +25,7 @@ import { handleNavigation } from '../utils';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import Banner, { ResendCodeSuccessBanner } from '../../../components/Banner';
+import { NavigationOptions } from '../interfaces';
 
 export const viewName = 'signin-token-code';
 
@@ -144,7 +145,7 @@ const SigninTokenCode = ({
         // in another. You reach the "Sorry. We've locked your account" screen
         GleanMetrics.loginConfirmation.success();
 
-        const navigationOptions = {
+        const navigationOptions: NavigationOptions = {
           email,
           signinData: {
             uid,
@@ -153,6 +154,7 @@ const SigninTokenCode = ({
             verified: true,
             keyFetchToken,
           },
+          sessionVerified: true,
           unwrapBKey,
           integration,
           finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -50,6 +50,7 @@ import {
   GetAccountKeysResponse,
   PasswordChangeFinishResponse,
   CredentialStatusResponse,
+  RecoveryEmailStatusResponse,
 } from './interfaces';
 import { getCredentials } from 'fxa-auth-client/lib/crypto';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
@@ -377,6 +378,15 @@ const SigninContainer = ({
         }
       );
 
+      // Check session verified status after successful sign in call
+      let sessionVerified = false;
+      if ('data' in result && result.data) {
+        const status: RecoveryEmailStatusResponse =
+          await authClient.recoveryEmailStatus(
+            result.data?.signIn.sessionToken
+          );
+        sessionVerified = status.sessionVerified;
+      }
       // Check recovery key status if signin was successful, user is on sync Desktop
       // and they didn't click "Do it later"; this affects navigation.
       if (
@@ -419,7 +429,11 @@ const SigninContainer = ({
         credentials.credentialStatus?.upgradeNeeded === true &&
         credentials.v2Credentials
       ) {
-        if ('data' in result && result.data?.signIn.verified === true) {
+        if (
+          'data' in result &&
+          result.data?.signIn.verified === true &&
+          sessionVerified === true
+        ) {
           const sessionToken = result.data?.signIn.sessionToken;
           await upgradeClient.upgrade(
             email,
@@ -436,9 +450,29 @@ const SigninContainer = ({
         }
       }
 
+      // Send totp token email if session is not verified at this point since users will
+      // be redirected to /signin_token_code
+      if (!sessionVerified && 'data' in result) {
+        await session.sendVerificationCode(result.data?.signIn.sessionToken);
+      }
+
+      // If the result is a successful sign-in then include sessionVerified
+      if ('data' in result && result.data) {
+        return {
+          ...result,
+          data: {
+            ...result.data,
+            signIn: {
+              ...result.data.signIn,
+              sessionVerified,
+            },
+          },
+        };
+      }
       return result;
     },
     [
+      session,
       beginSignin,
       config,
       credentialStatus,

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -31,7 +31,7 @@ import {
   isClientPocket,
   isClientRelay,
 } from '../../models/integrations/client-matching';
-import { SigninFormData, SigninProps } from './interfaces';
+import { NavigationOptions, SigninFormData, SigninProps } from './interfaces';
 import { handleNavigation } from './utils';
 import { useWebRedirect } from '../../lib/hooks/useWebRedirect';
 import { getLocalizedErrorMessage } from '../../lib/error-utils';
@@ -146,7 +146,7 @@ const Signin = ({
       if (data) {
         GleanMetrics.cachedLogin.success();
 
-        const navigationOptions = {
+        const navigationOptions: NavigationOptions = {
           email,
           signinData: {
             verified: data.verified,
@@ -155,6 +155,7 @@ const Signin = ({
             uid: data.uid,
             sessionToken,
           },
+          sessionVerified: data.sessionVerified,
           integration,
           redirectTo:
             isWebIntegration(integration) && webRedirectCheck?.isValid

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -119,6 +119,7 @@ export interface BeginSigninResponse {
   unwrapBKey?: hexstring;
   authPW?: hexstring;
   showInlineRecoveryKeySetup?: boolean;
+  sessionVerified?: boolean;
 }
 
 export type CachedSigninHandler = (
@@ -201,6 +202,8 @@ export interface NavigationOptions {
     // This (and unwrapBKey) will never exist for the cached signin (prompt=none)
     keyFetchToken?: hexstring;
   };
+  // TODO, make required?
+  sessionVerified?: boolean;
   // unwrapBKey is included if integration.wantsKeys()
   unwrapBKey?: hexstring;
   integration: SigninIntegration;

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -157,7 +157,7 @@ export const cachedSignIn = async (
         verified,
         // Because the cached signin was a success, we know 'uid' exists
         uid: storedLocalAccount!.uid,
-        sessionVerified, // might not need
+        sessionVerified,
         emailVerified, // might not need
       },
     };
@@ -189,7 +189,10 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
   const isWebChannelIntegration =
     integration.isSync() || integration.isDesktopRelay();
 
-  if (!navigationOptions.signinData.verified) {
+  if (
+    !navigationOptions.signinData.verified ||
+    navigationOptions.sessionVerified === false
+  ) {
     const { to, locationState } =
       getUnverifiedNavigationTarget(navigationOptions);
     if (


### PR DESCRIPTION
Because:
* Non-new accounts have issues signing in, where /settings takes them back to sign-in in an endless loop

This commit:
* Adds a check for sessionVerified and redirects accordingly

fixes FXA-12035

---

Opening as a draft for now because I need to check on tests.

Currently not sure how to test this locally very well but I'm sure there's a way. Late last week I created a couple of accounts locally before signing off, and then could repro on those accounts this morning and used those to test and fix for cached signin + signin with PW. Setting `SIGNIN_CONFIRMATION_FORCE_GLOBALLY` doesn't seem to give me what I want.

I think we've been directing users with an unverified session to settings a lot more than we realized. We could revert #19086, but this is an attempt at fixing the underlying bug instead.