### PR TITLE
add Mozilla Monitor Stage to services and product promo check

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.tsx
@@ -41,7 +41,7 @@ export function getProductPromoData(
   monitorPlusPromoEligible = false
 ) {
   const hasMonitor = attachedClients.some(
-    ({ name }) => name === MozServices.Monitor
+    ({ name }) => name === MozServices.Monitor || name === MozServices.MonitorStage
   );
 
   const hasMonitorPlus = subscriptions.some(
@@ -53,8 +53,7 @@ export function getProductPromoData(
     return { hidePromo: true } as const;
   }
 
-  // Stage‑2: decide whether to surface the special US‑only promo.
-  // TODO re-add the hasMonitor condition
+  // Decide whether to surface the special US‑only promo.
   const showMonitorPlusPromo = hasMonitor && monitorPlusPromoEligible;
 
   const gleanEvent = showMonitorPlusPromo

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -41,6 +41,7 @@ export enum MozServices {
   Relay = 'Mozilla Relay',
   TestService = '123Done',
   MonitorPlus = 'Mozilla Monitor Plus',
+  MonitorStage = 'Mozilla Monitor Stage',
 }
 
 // Information about a device


### PR DESCRIPTION
## Because

- We were only checking for Mozilla Monitor service to display the Monitor Plus promo, but on stage the service is named "Mozilla Monitor Stage"

## This pull request

- Add the "Mozilla Monitor Stage" service to types and check for it in promo conditions

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
