### PR TITLE
fix l10n id for data trio

### DIFF
--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -207,7 +207,7 @@ export const GetDataTrio = ({
        *   for triggering the print screen.
        **/}
       <FtlMsg
-        id="get-data-trio-download-2"
+        id="get-data-trio-print-2"
         attrs={{ title: true, 'aria-label': true }}
       >
         <button


### PR DESCRIPTION
## Because

- Wrong localization shown for title on the button

## This pull request

- correct l10n id

## Issue that this pull request solves

Closes: FXA-12039

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
