### PR TITLE
fix(settings): make Mozilla logo link to /settings instead of the top of the page

### DIFF
--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/en.ftl
@@ -4,5 +4,7 @@ header-menu-open = Close menu
 header-menu-closed = Site navigation menu
 header-back-to-top-link =
   .title = Back to top
+header-back-to-settings-link =
+  .title = Back to { -product-mozilla-account } settings
 header-title-2 = { -product-mozilla-account }
 header-help = Help

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.stories.tsx
@@ -8,6 +8,11 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import { HeaderLockup } from '.';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext, MOCK_ACCOUNT } from 'fxa-settings/src/models/mocks';
+import {
+  LocationProvider,
+  createHistory,
+  createMemorySource,
+} from '@reach/router';
 
 export default {
   title: 'Components/Settings/HeaderLockup',
@@ -25,17 +30,30 @@ const accountWithoutAvatar = {
   },
 } as unknown as Account;
 
-const storyWithContext = (account: Partial<Account>) => {
+const storyWithContext = (
+  account: Partial<Account>,
+  route: string = '/settings/emails'
+) => {
   const context = { account: account as Account };
+  const source = createMemorySource(route);
+  const history = createHistory(source);
 
   const story = () => (
-    <AppContext.Provider value={mockAppContext(context)}>
-      <HeaderLockup />
-    </AppContext.Provider>
+    <LocationProvider {...{ history }}>
+      <AppContext.Provider value={mockAppContext(context)}>
+        <HeaderLockup />
+      </AppContext.Provider>
+    </LocationProvider>
   );
   return story;
 };
 
-export const WithDefaultAvatar = storyWithContext(accountWithoutAvatar);
-
-export const WithCustomAvatar = () => <HeaderLockup />;
+export const OnSettingsPage = storyWithContext(
+  accountWithoutAvatar,
+  '/settings'
+);
+export const OnOtherPage = storyWithContext(
+  accountWithoutAvatar,
+  '/settings/emails'
+);
+export const WithCustomAvatar = storyWithContext(MOCK_ACCOUNT, '/settings');

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.test.tsx
@@ -4,10 +4,11 @@
 
 import React from 'react';
 import { screen } from '@testing-library/react';
-import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import HeaderLockup from '.';
 import { userEvent } from '@testing-library/user-event';
 import GleanMetrics from '../../../lib/glean';
+import { renderWithRouter } from '../../../models/mocks';
+import { createHistory, createMemorySource } from '@reach/router';
 
 jest.mock('../../../lib/glean', () => ({
   __esModule: true,
@@ -19,8 +20,12 @@ jest.mock('../../../lib/glean', () => ({
 }));
 
 describe('HeaderLockup', () => {
-  it('renders as expected', () => {
-    renderWithLocalizationProvider(<HeaderLockup />);
+  it('renders as expected on other settings pages', () => {
+    renderWithRouter(<HeaderLockup />, {
+      route: '/settings/emails',
+      history: createHistory(createMemorySource('/settings/emails')),
+    });
+
     const headerMenu = screen.getByTestId('header-menu');
 
     expect(
@@ -37,14 +42,24 @@ describe('HeaderLockup', () => {
       'href',
       'https://support.mozilla.org/products/mozilla-account'
     );
-    expect(screen.getByTestId('back-to-top')).toHaveAttribute(
-      'title',
-      'Back to top'
-    );
+    const logo = screen.getByTestId('back-to-settings');
+    expect(logo).toHaveAttribute('title', 'Back to Mozilla account settings');
+    expect(logo).toHaveAttribute('href', '/settings');
+  });
+
+  it('shows the correct tooltip when at the top-level /settings route', () => {
+    renderWithRouter(<HeaderLockup />, {
+      route: '/settings',
+      history: createHistory(createMemorySource('/settings')),
+    });
+
+    const logo = screen.getByTestId('back-to-settings');
+    expect(logo).toHaveAttribute('title', 'Back to top');
+    expect(logo).toHaveAttribute('href', '/settings');
   });
 
   it('emits Glean event on help link click', async () => {
-    renderWithLocalizationProvider(<HeaderLockup />);
+    renderWithRouter(<HeaderLockup />);
     await userEvent.click(
       screen.getByRole('link', { name: 'Help Opens in new window' })
     );

--- a/packages/fxa-settings/src/components/Settings/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/HeaderLockup/index.tsx
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Localized, useLocalization } from '@fluent/react';
 import React, { useState } from 'react';
 import LogoLockup from 'fxa-react/components/LogoLockup';
 import Header from 'fxa-react/components/Header';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { useFtlMsgResolver } from '../../../models';
 import BentoMenu from '../BentoMenu';
 import DropDownAvatarMenu from '../DropDownAvatarMenu';
 import { ReactComponent as Help } from './help.svg';
@@ -14,14 +15,22 @@ import { ReactComponent as Menu } from './menu.svg';
 import { ReactComponent as Close } from './close.svg';
 import Sidebar from '../Sidebar';
 import GleanMetrics from '../../../lib/glean';
+import { Link, useLocation } from '@reach/router';
 
 export const HeaderLockup = () => {
   const [sidebarRevealedState, setNavState] = useState(false);
-  const { l10n } = useLocalization();
-  const localizedHelpText = l10n.getString('header-help', null, 'Help');
+  const ftlMsgResolver = useFtlMsgResolver();
+  const location = useLocation();
+  const localizedHelpText = ftlMsgResolver.getMsg('header-help', 'Help');
   const localizedMenuText = sidebarRevealedState
-    ? l10n.getString('header-menu-open', null, 'Close menu')
-    : l10n.getString('header-menu-closed', null, 'Site navigation menu');
+    ? ftlMsgResolver.getMsg('header-menu-open', 'Close menu')
+    : ftlMsgResolver.getMsg('header-menu-closed', 'Site navigation menu');
+
+  const isAtSettings =
+    location?.pathname === '/settings' || location?.pathname === '/settings/';
+  const logoTitleId = isAtSettings
+    ? 'header-back-to-top-link'
+    : 'header-back-to-settings-link';
 
   const handleHelpLinkClick = () => {
     GleanMetrics.accountPref.help();
@@ -45,25 +54,26 @@ export const HeaderLockup = () => {
         )}
         {sidebarRevealedState && <Sidebar />}
       </button>
-      <Localized id="header-back-to-top-link" attrs={{ title: true }}>
-        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-        <a
-          href="#"
-          title="Back to top"
+      <FtlMsg id={logoTitleId} attrs={{ title: true }}>
+        <Link
+          to="/settings"
+          title={
+            isAtSettings ? 'Back to top' : 'Back to Mozilla account settings'
+          }
           // use gap instead of margin to make the focus outline look right
           // when the header title is invisible
           className="flex gap-4 rounded-sm focus-visible:outline focus-visible:outline-blue-500 focus:outline-2 outline-offset-4"
-          data-testid="back-to-top"
+          data-testid="back-to-settings"
         >
           <LogoLockup>
             <>
-              <Localized id="header-title-2">
+              <FtlMsg id="header-title-2">
                 <span className="font-bold">Mozilla account</span>
-              </Localized>
+              </FtlMsg>
             </>
           </LogoLockup>
-        </a>
-      </Localized>
+        </Link>
+      </FtlMsg>
     </>
   );
   const right = (


### PR DESCRIPTION
## Because

- Mozilla logo links to the top of the current page instead of /settings

## This pull request

- makes Mozilla logo link to /settings instead of the top of the page

## Issue that this pull request solves

Closes: FXA-11857

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
