### PR TITLE
fix(settings): Dont show backup codes link if no codes available

### DIFF
--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/container.tsx
@@ -138,6 +138,7 @@ export const ResetPasswordRecoveryChoiceContainer = (
       state: {
         ...locationState.state,
         lastFourPhoneDigits: phoneData.lastFourPhoneDigits,
+        numBackupCodes,
       },
       // ensure back button on signin_recovery_code page skips choice page and
       // returns to confirm_totp_reset_password

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.test.tsx
@@ -126,6 +126,7 @@ describe('ResetPasswordRecoveryChoice', () => {
         state: {
           ...fakeState,
           lastFourPhoneDigits: '1234',
+          numBackupCodes: 4,
         },
       });
     });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.tsx
@@ -98,7 +98,7 @@ const ResetPasswordRecoveryChoice = ({
 
         // /reset_password_recovery_phone to be implemented in FXA-11510
         navigateWithQuery('/reset_password_recovery_phone', {
-          state: { ...completeResetPasswordLocationState, lastFourPhoneDigits },
+          state: { ...completeResetPasswordLocationState, lastFourPhoneDigits, numBackupCodes },
         });
         break;
       case CHOICES.code:

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.tsx
@@ -19,6 +19,7 @@ const ResetPasswordRecoveryPhoneContainer = (_: RouteComponentProps) => {
   };
 
   const lastFourPhoneDigits = locationState.state.lastFourPhoneDigits || '';
+  const numBackupCodes = locationState.state.numBackupCodes;
 
   const handleSuccess = async () => {
     try {
@@ -65,6 +66,7 @@ const ResetPasswordRecoveryPhoneContainer = (_: RouteComponentProps) => {
         verifyCode,
         resendCode,
         location: locationState,
+        numBackupCodes,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.stories.tsx
@@ -35,6 +35,16 @@ export const WithCodeErrorOnSubmit = () => (
   />
 );
 
+export const WithCodeErrorOnSubmitNoBackupCodes = () => (
+  <Subject
+    verifyCode={(code: string) =>
+      Promise.resolve(AuthUiErrors.INVALID_EXPIRED_OTP_CODE as HandledError)
+    }
+    resendCode={() => Promise.resolve()}
+    numBackupCodes={0}
+  />
+);
+
 export const WithGeneralErrorMessages = () => (
   <Subject
     verifyCode={(code: string) =>

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/index.tsx
@@ -23,6 +23,7 @@ const ResetPasswordRecoveryPhone = ({
   verifyCode,
   resendCode,
   location,
+  numBackupCodes,
 }: ResetPasswordRecoveryPhoneProps & RouteComponentProps) => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const [errorDescription, setErrorDescription] = React.useState('');
@@ -70,15 +71,17 @@ const ResetPasswordRecoveryPhone = ({
             'The code is invalid or expired.'
           )
         );
-        setErrorLink({
-          path: '/confirm_backup_code_reset_password',
-          localizedText: ftlMsgResolver.getMsg(
-            'reset-password-recovery-phone-invalid-code-error-link',
-            'Use backup authentication codes instead?'
-          ),
-          gleanId: 'reset_password_backup_phone_error_use_backup_code_link',
-          ...(location?.state ? { locationState: location.state } : {}),
-        });
+        if (numBackupCodes && numBackupCodes > 0) {
+          setErrorLink({
+            path: '/confirm_backup_code_reset_password',
+            localizedText: ftlMsgResolver.getMsg(
+              'reset-password-recovery-phone-invalid-code-error-link',
+              'Use backup authentication codes instead?'
+            ),
+            gleanId: 'reset_password_backup_phone_error_use_backup_code_link',
+            ...(location?.state ? { locationState: location.state } : {}),
+          });
+        }
         return;
       }
       setErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, error));

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/interfaces.ts
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/interfaces.ts
@@ -8,10 +8,12 @@ import { CompleteResetPasswordLocationState } from '../CompleteResetPassword/int
 export type ResetPasswordRecoveryPhoneLocationState =
   CompleteResetPasswordLocationState & {
     lastFourPhoneDigits: string;
+    numBackupCodes?: number;
   };
 
 export type ResetPasswordRecoveryPhoneProps = {
   lastFourPhoneDigits: string;
   verifyCode: (code: string) => Promise<HandledError | void>;
   resendCode: () => Promise<HandledError | void>;
+  numBackupCodes?: number;
 };

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/mocks.tsx
@@ -13,6 +13,7 @@ const mockResendCodeSuccess = () => Promise.resolve();
 export const Subject = ({
   verifyCode = mockVerifyCodeSuccess,
   resendCode = mockResendCodeSuccess,
+  numBackupCodes = 4,
 }: Partial<ResetPasswordRecoveryPhoneProps>) => {
   const lastFourPhoneDigits = '1234';
 
@@ -24,6 +25,7 @@ export const Subject = ({
           verifyCode,
           resendCode,
           locationState: {} as any,
+          numBackupCodes,
         }}
       />
     </LocationProvider>

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.tsx
@@ -129,6 +129,7 @@ export const SigninRecoveryChoiceContainer = (_: RouteComponentProps) => {
       state: {
         signinState,
         lastFourPhoneDigits: phoneData.lastFourPhoneDigits,
+        numBackupCodes,
       },
       // ensure back button on signin_recovery_code page skips choice page and returns to signin_totp_code
       replace: true,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
@@ -118,6 +118,7 @@ describe('SigninRecoveryChoice', () => {
         state: {
           signinState: MOCK_SIGNIN_LOCATION_STATE,
           lastFourPhoneDigits: '1234',
+          numBackupCodes: 4,
         },
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -92,7 +92,7 @@ const SigninRecoveryChoice = ({
           return;
         }
         navigateWithQuery('/signin_recovery_phone', {
-          state: { signinState, lastFourPhoneDigits },
+          state: { signinState, lastFourPhoneDigits, numBackupCodes },
         });
         break;
       case CHOICES.code:

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -47,6 +47,7 @@ const SigninRecoveryPhoneContainer = ({
     location.state?.signinState as SigninLocationState
   );
   const lastFourPhoneDigits = location.state?.lastFourPhoneDigits;
+  const numBackupCodes = location.state?.numBackupCodes;
   const navigateWithQuery = useNavigateWithQuery();
 
   useEffect(() => {
@@ -190,6 +191,7 @@ const SigninRecoveryPhoneContainer = ({
         lastFourPhoneDigits,
         verifyCode,
         resendCode,
+        numBackupCodes,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.stories.tsx
@@ -35,6 +35,16 @@ export const WithCodeErrorOnSubmit = () => (
   />
 );
 
+export const WithCodeErrorOnSubmitNoBackupCodes = () => (
+  <Subject
+    verifyCode={(code: string) =>
+      Promise.resolve(AuthUiErrors.INVALID_EXPIRED_OTP_CODE as HandledError)
+    }
+    resendCode={() => Promise.resolve()}
+    numBackupCodes={0}
+  />
+);
+
 export const WithGeneralErrorMessages = () => (
   <Subject
     verifyCode={(code: string) =>

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -22,6 +22,7 @@ const SigninRecoveryPhone = ({
   lastFourPhoneDigits,
   verifyCode,
   resendCode,
+  numBackupCodes,
 }: SigninRecoveryPhoneProps & RouteComponentProps) => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const [errorDescription, setErrorDescription] = React.useState('');
@@ -69,14 +70,16 @@ const SigninRecoveryPhone = ({
             'The code is invalid or expired.'
           )
         );
-        setErrorLink({
-          path: '/signin_recovery_code',
-          localizedText: ftlMsgResolver.getMsg(
-            'signin-recovery-phone-invalid-code-error-link',
-            'Use backup authentication codes instead?'
-          ),
-          gleanId: 'login_backup_phone_error_use_backup_code_link',
-        });
+        if (numBackupCodes && numBackupCodes > 0) {
+          setErrorLink({
+            path: '/signin_recovery_code',
+            localizedText: ftlMsgResolver.getMsg(
+              'signin-recovery-phone-invalid-code-error-link',
+              'Use backup authentication codes instead?'
+            ),
+            gleanId: 'login_backup_phone_error_use_backup_code_link',
+          });
+        }
         return;
       }
       setErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, error));

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/interfaces.ts
@@ -13,10 +13,12 @@ export interface SigninRecoveryPhoneContainerProps {
 export interface SigninRecoveryPhoneLocationState extends SigninLocationState {
   signinState: SigninLocationState;
   lastFourPhoneDigits: string;
+  numBackupCodes?: number;
 }
 
 export type SigninRecoveryPhoneProps = {
   lastFourPhoneDigits: string;
   verifyCode: (code: string) => Promise<HandledError | void>;
   resendCode: () => Promise<HandledError | void>;
+  numBackupCodes?: number;
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/mocks.tsx
@@ -13,6 +13,7 @@ const mockResendCodeSuccess = () => Promise.resolve();
 export const Subject = ({
   verifyCode = mockVerifyCodeSuccess,
   resendCode = mockResendCodeSuccess,
+  numBackupCodes = 4,
 }: Partial<SigninRecoveryPhoneProps>) => {
   const lastFourPhoneDigits = '1234';
 
@@ -23,6 +24,7 @@ export const Subject = ({
           lastFourPhoneDigits,
           verifyCode,
           resendCode,
+          numBackupCodes,
         }}
       />
     </LocationProvider>


### PR DESCRIPTION
## Because

* When entering an incorrect (sms) recovery code when signing in or resetting password, error message contained a message to use backup codes instead - this suggestion should not be shown if the user does not have backup authentication codes

## This pull request

* Check num of codes when constructing error message

## Issue that this pull request solves

Closes: FXA-12031

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![image](https://github.com/user-attachments/assets/a51b7edd-0334-4310-a6e5-689c20dbe44d)

![image](https://github.com/user-attachments/assets/01123c60-c099-4d85-afb4-1a0402e5241b)

## Other information (Optional)

Any other information that is important to this pull request.
