### PR TITLE
fix(metrics): Add more logging to verifySession endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -194,6 +194,36 @@ Lug.prototype.summary = function (request, response) {
     }
   }
 
+
+  // TODO: Remove after debugging email confirmations issues
+  if (line.status === 400 &&
+    line.path === '/v1/session/verify_code' &&
+    // Only log for invalid code and invalid parameter errors
+    (line.errno === 107 || line.errno === 183)
+  ) {
+    (async () => {
+      try {
+        const metricsContext = (await request.app.metricsContext) || {};
+        const requestBody = JSON.stringify(payload);
+        const requestQuery = JSON.stringify(query);
+        const requestMetrics = JSON.stringify(metricsContext);
+        const body = JSON.stringify(responseBody);
+        this.info('request.summary.debug.email', {
+          body,
+          requestBody,
+          requestQuery,
+          requestMetrics,
+          bodySize: body.length,
+        });
+      } catch (error) {
+        this.info('request.summary.debug.email', {
+          bodySize: -1,
+          error,
+        });
+      }
+    })();
+  }
+
   if (line.status >= 500) {
     line.trace = request.app.traced;
     line.stack = response.stack;


### PR DESCRIPTION
## Because

- We want to debug metrics issues in https://mozilla-hub.atlassian.net/browse/FXA-11965

## This pull request

- Add additional logging on the 108 and 183 errors for this endpoint
- Logs the metrics context for these requests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12057

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
