### PR TITLE
fix(settings): fix text mismatch in SMS code confirm page

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/en.ftl
@@ -6,7 +6,7 @@ flow-setup-phone-confirm-code-heading = Enter verification code
 
 # $phoneNumber is a partially obfuscated phone number with only the last 4 digits showing (e.g., *** *** 1234)
 # span element applies formatting to ensure the number is always displayed left-to-right
-flow-setup-phone-confirm-code-instruction = A 6-digit code was sent to <span>{ $phoneNumber }</span> by text message. This code expires after 5 minutes.
+flow-setup-phone-confirm-code-instruction-v2 = A 6-digit code was sent to <span>{ $phoneNumber }</span> by text message. This code expires after 5 minutes.
 flow-setup-phone-confirm-code-input-label = Enter 6-digit code
 flow-setup-phone-confirm-code-button = Confirm
 # button to resend a code by text message to the user's phone

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
@@ -136,7 +136,7 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
         <h2 className="font-bold text-xl">Enter verification code</h2>
       </FtlMsg>
       <FtlMsg
-        id="flow-setup-phone-confirm-code-instruction"
+        id="flow-setup-phone-confirm-code-instruction-v2"
         elems={{ span: <span dir="ltr" className="font-bold"></span> }}
         vars={{ phoneNumber: nationalFormatPhoneNumber }}
       >


### PR DESCRIPTION
## Because

- "six-digit" should be "6-digit"

## This pull request

- updates the fluent ID so that the string can be updated on stage/prod

## Issue that this pull request solves

Closes: FXA-12053

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
