### PR TITLE
fix(next): early exit subscribe submit handler while loading

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -74,10 +74,10 @@ interface CheckoutFormProps {
     };
     paymentInfo?: {
       type:
-        | Stripe.PaymentMethod.Type
-        | 'google_iap'
-        | 'apple_iap'
-        | 'external_paypal';
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -158,7 +158,7 @@ export function CheckoutForm({
   ) => {
     event.preventDefault();
 
-    if (!stripe || !elements) {
+    if (!stripe || !elements || loading) {
       // Stripe.js hasn't yet loaded.
       // Make sure to disable form submission until Stripe.js has loaded.
       return;
@@ -213,12 +213,12 @@ export function CheckoutForm({
     const confirmationTokenParams: ConfirmationTokenCreateParams | undefined =
       !isSavedPaymentMethod
         ? {
-            payment_method_data: {
-              billing_details: {
-                name: fullName,
-              },
+          payment_method_data: {
+            billing_details: {
+              name: fullName,
             },
-          }
+          },
+        }
         : undefined;
 
     // Create the ConfirmationToken using the details collected by the Payment Element


### PR DESCRIPTION
## Because

- Continuing to press the Subscribe Now button while it is loading results in duplicate action calls.

## This pull request

- Early exists the Subscribe Now button submit handler, while it  is loading so that multiple button presses do not result in duplicate subscription creation calls.

## Issue that this pull request solves

Closes: #FXA-12044

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).