### PR TITLE
bug(settings): Redirect to signin from `/settings` not working as intended

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
@@ -388,5 +388,56 @@ describe('PageSettings', () => {
         screen.queryByTestId('submit_add_recovery_phone')
       ).not.toBeInTheDocument();
     });
+
+    describe('it handles email query param', () => {
+      const originalLocation = window.location;
+
+      afterEach(() => {
+        Object.defineProperty(window, 'location', originalLocation);
+      });
+
+      it('does not redirect on email match', async () => {
+        Object.defineProperty(window, 'location', {
+          writable: true,
+          value: {
+            ...window.location,
+            search: `?email=${coldStartAccount.email}`,
+            replace: jest.fn(),
+          },
+        });
+        renderWithRouter(
+          <AppContext.Provider
+            value={mockAppContext({ account: coldStartAccount })}
+          >
+            <PageSettings integration={mockWebIntegration} />
+          </AppContext.Provider>
+        );
+        expect(window.location.replace).not.toHaveBeenCalledWith(
+          '/signin?email=foo@mozilla.com'
+        );
+      });
+
+      it('redirects to signin on email mismatch', async () => {
+        Object.defineProperty(window, 'location', {
+          writable: true,
+          value: {
+            ...window.location,
+            search: '?email=foo@mozilla.com',
+            replace: jest.fn(),
+          },
+        });
+        renderWithRouter(
+          <AppContext.Provider
+            value={mockAppContext({ account: coldStartAccount })}
+          >
+            <PageSettings integration={mockWebIntegration} />
+          </AppContext.Provider>
+        );
+
+        expect(window.location.replace).toHaveBeenCalledWith(
+          '/signin?email=foo@mozilla.com'
+        );
+      });
+    });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -140,6 +140,23 @@ export const PageSettings = ({
     productPromoGleanEventSent,
   ]);
 
+  useEffect(() => {
+    const targetEmail = (() => {
+      try {
+        const params = new URLSearchParams(window.location.search);
+        return params.get('email');
+      } catch {}
+      return null;
+    })();
+
+    // RPs might want to link to settings and specify a target account. If the
+    // current account email doesn't match the requested email, sign in the user
+    // in with this email.
+    if (targetEmail && targetEmail !== account.email) {
+      window.location.replace(`/signin${window.location.search}`);
+    }
+  }, [account]);
+
   // -- Account feature promotion checks --
 
   // The estimated Sync devices is optionally returned by the auth-server,

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -93,7 +93,11 @@ export const errorHandler: ErrorHandler = ({
         if (window.location && window.location.pathname.includes('settings')) {
           // Redirect to /signin since that page will send the user
           // to correct location
-          return window.location.replace(`/signin?action=email&service=sync`);
+
+          // Note, we relay the search query, so that RP can control the signin flow.
+          // For example an RP could link to https://accounts.firefox.com/settings?email=foo@mozilla.com
+          // in order to force a user to signin as foo@mozilla.com.
+          return window.location.replace(`/signin${window.location.search}`);
         } else {
           // If the user isn't in Settings and they see this message they may hit it due to
           // the initial metrics query - e.g. if they attempt to sign in and see the TOTP page,


### PR DESCRIPTION
## Because

- Some RPs link directly to `/settings`
- If the user is no longer logged in, we'd direct them to signin and say they were a sync user, which might not be the case.

## This pull request

- No longer assumes a user accessing the /settings page is a sync user.
- Adds support for an email query parameter to the settings page.
- Checks if the email query param matches the current account email, if not redirects to sign in.

## Issue that this pull request solves

Closes: FXA-11928

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


https://github.com/user-attachments/assets/1b06363c-962d-4319-a5c6-7b3173a289fc



## Other information (Optional)

To ensure that RPs direct their users to the right settings page, they can now supply the target email in the settings page link, e.g. `https://accounts.firefox.com/settings?email=target@email.com`.
