### PR TITLE
 bug(auth,settings): Fix issue with consuming signin unblock code 

### DIFF
--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { getCode } from 'fxa-settings/src/lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
-import { TestAccountTracker } from '../../lib/testAccountTracker';
 import { SettingsPage } from '../../pages/settings';
 import { DeleteAccountPage } from '../../pages/settings/deleteAccount';
 import { SigninPage } from '../../pages/signin';
@@ -46,10 +46,6 @@ test.describe('severity-2 #smoke', () => {
       pages: { signin, signinUnblock, settings, deleteAccount },
       testAccountTracker,
     }) => {
-      test.fixme(
-        true,
-        'TODO in FXA-9882, fix fxa-settings or test, should not be prompted enter password and unblock code again after entering a valid unblock code'
-      );
       const credentials = await testAccountTracker.signUpBlocked();
       await signInBlockedAccount(
         target,
@@ -189,6 +185,93 @@ test.describe('severity-2 #smoke', () => {
       //Unblock the email
       const unblockCode = await target.emailClient.getUnblockCode(blockedEmail);
       await signinUnblock.fillOutCodeForm(unblockCode);
+
+      //Verify logged in on Settings page
+      await expect(settings.settingsHeading).toBeVisible();
+
+      // Delete blocked account, the fixture teardown doesn't work in this case
+      await removeAccount(settings, deleteAccount, page, credentials.password);
+    });
+
+    test('sync with 2fa', async ({
+      target,
+      page,
+      pages: {
+        deleteAccount,
+        settings,
+        signin,
+        signinUnblock,
+        signinTotpCode,
+        totp,
+        confirmSignupCode,
+        configPage,
+      },
+      testAccountTracker,
+    }) => {
+      const config = await configPage.getConfig();
+      const credentials = await testAccountTracker.signUpSync({
+        lang: 'en',
+        preVerified: 'false',
+      });
+
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      //Verify confirm code header
+      await expect(page).toHaveURL(/confirm_signup_code/);
+
+      const confirmationCode = await target.emailClient.getVerifyLoginCode(
+        credentials.email
+      );
+      await confirmSignupCode.fillOutCodeForm(confirmationCode);
+
+      //Verify logged in on Settings page
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settings.totp.addButton.click();
+
+      // TODO in FXA-11941 - remove condition
+      const { secret } = config.featureFlags.updated2faSetupFlow
+        ? await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice()
+        : await totp.setUpTwoStepAuthWithQrCodeNoRecoveryChoice();
+
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText(
+        'Two-step authentication has been enabled'
+      );
+
+      await page.waitForURL(/settings/);
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.alertBar).toHaveText(
+        'Two-step authentication has been enabled'
+      );
+      await expect(settings.totp.status).toHaveText('Enabled');
+      await settings.signOut();
+
+      // Create blocked sign in
+      await page.goto(target.contentServerUrl);
+      await signin.fillOutEmailFirstForm(credentials.email);
+      do {
+        await signin.fillOutPasswordForm(credentials.password + Date.now());
+        await page.waitForTimeout(300);
+      } while (page.url().indexOf('signin_unblock') === -1);
+
+      //Verify sign in block header
+      await expect(page).toHaveURL(/signin_unblock/);
+      const unblockCode = await target.emailClient.getUnblockCode(
+        credentials.email
+      );
+      await signinUnblock.fillOutCodeForm(unblockCode);
+
+      // Enter the unblock code.
+      await expect(page).toHaveURL(/signin/);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      // Now should go to totp code
+      await expect(page).toHaveURL(/signin_totp_code/);
+      const code = await getCode(secret);
+      await signinTotpCode.fillOutCodeForm(code);
 
       //Verify logged in on Settings page
       await expect(settings.settingsHeading).toBeVisible();

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -175,19 +175,27 @@ module.exports = (
           }
           await request.emitMetricsEvent('account.login.blocked');
 
-          // If this customs error cannot be bypassed with email confirmation,
-          // throw it straight back to the caller.
-          const verificationMethod = e.output.payload.verificationMethod;
-          if (
-            verificationMethod !== 'email-captcha' ||
-            !request.payload.unblockCode
-          ) {
+          // When a rate limiting errors allows unblocking, the error's payload will contain
+          // a verificationMethod field. See AppError.requestBlocked for implementation.
+          //
+          // The following is just a round about way of checking the error state to determine
+          // if an unblock is supported. When this field is missing, it indicates that we've
+          // decided to prevent unblocking, probably because the user has tried unblocking too
+          // many times.
+          if (e.output.payload.verificationMethod == null) {
             throw e;
           }
 
           // Check for a valid unblockCode, to allow the request to proceed.
+          // If no unblock code exists, simply relay the rate-limiting error.
+          // In this state, the user isn't attempting to unblock, so there is
+          // no reason to proceed.
+          const unblockCode = request.payload.unblockCode?.toUpperCase();
+          if (!unblockCode) {
+            throw e;
+          }
+
           // This requires that we load the accountRecord to learn the uid.
-          const unblockCode = request.payload.unblockCode.toUpperCase();
           accountRecord = await db.accountRecord(email);
           try {
             const code = await db.consumeUnblockCode(
@@ -201,6 +209,12 @@ module.exports = (
               throw error.invalidUnblockCode();
             }
             didSigninUnblock = true;
+
+            // The user has provided a valid unblock code. Reset their active blocks.
+            if (customs.v2Enabled()) {
+              await customs.resetV2(request, email);
+            }
+
             await request.emitMetricsEvent(
               'account.login.confirmedUnblockCode'
             );

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2247,6 +2247,7 @@ describe('/account/login', () => {
     check: () => Promise.resolve(),
     checkAuthenticated: () => Promise.resolve(),
     flag: () => Promise.resolve(),
+    resetV2: () => Promise.resolve(),
   };
   const mockCadReminders = mocks.mockCadReminders();
   const accountRoutes = makeRoutes({

--- a/packages/fxa-auth-server/test/local/routes/utils/signin.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signin.js
@@ -269,6 +269,7 @@ describe('checkCustomsAndLoadAccount', () => {
       v2Enabled: sinon.spy(() => true),
       check: sinon.spy(() => Promise.resolve()),
       flag: sinon.spy(() => Promise.resolve({})),
+      resetV2: sinon.spy(() => Promise.resolve()),
     };
     config = {
       signinUnblock: {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -358,6 +358,7 @@ function mockCustoms(errors) {
     checkAuthenticated: optionallyThrow(errors, 'checkAuthenticated'),
     checkIpOnly: optionallyThrow(errors, 'checkIpOnly'),
     v2Enabled: sinon.spy(() => true),
+    resetV2: sinon.spy(() => Promise.resolve()),
   });
 }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -191,8 +191,6 @@ export const SigninUnblockContainer = ({
       }
 
       return result;
-    } finally {
-      sensitiveDataClient.setDataType(SensitiveData.Key.Auth, undefined);
     }
   };
 


### PR DESCRIPTION
## Because

- Even after entering an unblock code the user was still being prompted to enter an unblock code on the next login.
- This was previously done inside the customs server, so there was no analogue for v2 customs.

## This pull request

- Fixes a bug where 'email-otp' verification type wasn't honored
- Fixes a bug where providing an unblock code wasn't clearing all active user blocks, rather it was just allowing the login block to be bypassed.
- Fixes bug where sensitive data client was being cleared out prematurely.

## Issue that this pull request solves

Closes: FXA-12067, FXA-9882

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
