### PR TITLE
fix(next): cart updates handle version mismatch

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -66,6 +66,8 @@ import {
   FinalizeWithoutSubscriptionIdCartError,
   FinalizeWithoutSubscriptionCartError,
   InvalidPromoCodeCartError,
+  CartVersionMismatchError,
+  CartInvalidStateForActionError,
 } from './cart.error';
 import { CartManager } from './cart.manager';
 import type {
@@ -650,7 +652,11 @@ export class CartService {
    * Update a cart in the database by ID or with an existing cart reference
    */
   @SanitizeExceptions({
-    allowlist: [PromotionCodeError],
+    allowlist: [
+      PromotionCodeError,
+      CartVersionMismatchError,
+      CartInvalidStateForActionError,
+    ],
   })
   async updateCart(
     cartId: string,
@@ -659,7 +665,13 @@ export class CartService {
   ): Promise<ResultCart> {
     return this.wrapWithCartCatch(
       cartId,
-      { errorAllowList: [PromotionCodeError] },
+      {
+        errorAllowList: [
+          PromotionCodeError,
+          CartVersionMismatchError,
+          CartInvalidStateForActionError,
+        ],
+      },
       async () => {
         const oldCart = await this.cartManager.fetchCartById(cartId);
         const cartDetails: UpdateCart = {
@@ -1024,7 +1036,6 @@ export class CartService {
           intent.id,
           isPaymentIntentId(intent.id) ? 'PaymentIntent' : 'SetupIntent'
         );
-
       } else {
         throw new SubmitNeedsInputFailedError(cartId);
       }

--- a/libs/payments/ui/src/lib/actions/applyCoupon.ts
+++ b/libs/payments/ui/src/lib/actions/applyCoupon.ts
@@ -15,6 +15,8 @@ export const applyCouponAction = async (
 ) => {
   const actionsService = getApp().getActionsService();
 
+  let response = undefined;
+  let revalidate = true;
   try {
     await actionsService.updateCart({
       cartId,
@@ -24,25 +26,36 @@ export const applyCouponAction = async (
       },
     });
   } catch (err) {
+    revalidate = false;
     switch (err.name) {
+      case 'CartVersionMismatchError':
+        response = CouponErrorMessageType.Generic;
+        revalidate = true;
+        break;
       case 'CouponErrorCannotRedeem':
-        return CouponErrorMessageType.CannotRedeem;
+        response = CouponErrorMessageType.CannotRedeem;
+        break;
       case 'CouponErrorExpired':
-        return CouponErrorMessageType.Expired;
+        response = CouponErrorMessageType.Expired;
+        break;
       case 'CouponErrorGeneric':
-        return CouponErrorMessageType.Generic;
+        response = CouponErrorMessageType.Generic;
+        break;
       case 'CouponErrorLimitReached':
-        return CouponErrorMessageType.LimitReached;
+        response = CouponErrorMessageType.LimitReached;
+        break;
       case 'CouponErrorInvalid':
       default:
-        return CouponErrorMessageType.Invalid;
+        response = CouponErrorMessageType.Invalid;
     }
   }
 
-  revalidatePath(
-    `/[locale]/[offeringId]/[interval]/checkout/[cartId]/start`,
-    'page'
-  );
+  if (revalidate) {
+    revalidatePath(
+      `/[locale]/[offeringId]/[interval]/checkout/[cartId]/start`,
+      'page'
+    );
+  }
 
-  return;
+  return response;
 };


### PR DESCRIPTION
## Because

- Version mismatch errors on tax address or coupon changes result in the cart going into fail state.

## This pull request

- Handles version mismatch and invalid cart state errors and returns an appropriate error to the user and revalidates the data on the current page.
- Removes local state from SelectTaxLocation's Expand component.

## Issue that this pull request solves

Closes: #FXA-12047

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Easiest steps to reproduce are listed below.
1. Open the checkout page for any offer
1. Duplicate the tab, so that both tabs use the same cart
1. Change the address in the first tab and save
1. Without refreshing the page, on the 2nd tab change the address, and save.
1. User should be shown an error message, and allowed to try resave the address. (Previously it would move the cart to error state)
