### PR TITLE
feat(payments-next): Ensure redirects do not strip out attribution route parameters.

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -69,7 +69,7 @@ export default async function CheckoutError({
     cart.paymentInfo?.type
   );
 
-  const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config);
+  const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config, searchParams);
 
   return (
     <>

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -67,7 +67,7 @@ export default async function UpgradeError({
     cart.paymentInfo?.type
   );
 
-  const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config);
+  const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config, searchParams);
 
   return (
     <>

--- a/apps/payments/next/app/[locale]/error.tsx
+++ b/apps/payments/next/app/[locale]/error.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react';
 import * as Sentry from '@sentry/nextjs';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, useSearchParams } from 'next/navigation';
 import Image from 'next/image';
 import errorIcon from '@fxa/shared/assets/images/error.svg';
 import { CheckoutParams, LoadingSpinner } from '@fxa/payments/ui';
@@ -32,6 +32,7 @@ export default function Error({
   const [loading, setLoading] = useState(false);
   const { locale, offeringId, interval, cartId } = useParams<ErrorParams>();
   const hasProductData = locale && offeringId && interval;
+  const queryParams = useSearchParams().toString();
 
   const SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://support.mozilla.org';
 
@@ -44,8 +45,8 @@ export default function Error({
         const newCart = await restartCartAction(cartId);
         setLoading(false);
         router.push(
-          `/${locale}/${offeringId}/${interval}/checkout/${newCart.id}/${cart.state}`
-        );
+          `/${locale}/${offeringId}/${interval}/checkout/${newCart.id}/${cart.state}` +
+                                  (queryParams ? `?${queryParams}` : ''));
       } else {
         setLoading(false);
         reset();
@@ -53,7 +54,7 @@ export default function Error({
     } catch (getCartError) {
       Sentry.captureException(getCartError);
       setLoading(false);
-      router.push(`/${locale}/${offeringId}/${interval}/landing`);
+      router.push(`/${locale}/${offeringId}/${interval}/landing` + (queryParams ? `?${queryParams}` : ''));
     }
   }
 
@@ -61,7 +62,7 @@ export default function Error({
     if (cartId) {
       redirectWithCart();
     } else {
-      router.push(`/${locale}/${offeringId}/${interval}/landing`);
+      router.push(`/${locale}/${offeringId}/${interval}/landing` + (queryParams ? `?${queryParams}` : ''));
     }
   }
 

--- a/libs/payments/ui/src/lib/actions/handleStripeError.ts
+++ b/libs/payments/ui/src/lib/actions/handleStripeError.ts
@@ -8,17 +8,21 @@ import { StripeError } from '@stripe/stripe-js';
 import { getApp } from '../nestapp/app';
 import { redirect } from 'next/navigation';
 import { stripeErrorToErrorReasonId } from '@fxa/payments/cart';
+import { URLSearchParams } from 'url';
 
 export const handleStripeErrorAction = async (
   cartId: string,
-  stripeError: StripeError
+  stripeError: StripeError,
+  searchParams?: Record<string, string | string[]>
 ) => {
   const errorReasonId = stripeErrorToErrorReasonId(stripeError);
+  const urlSearchParams = new URLSearchParams(searchParams);
+  const params = searchParams ? `?${urlSearchParams.toString()}` : '';
 
   await getApp().getActionsService().finalizeCartWithError({
     cartId,
     errorReasonId,
   });
 
-  redirect('error');
+  redirect(`error${params}`);
 };

--- a/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
@@ -6,9 +6,15 @@
 
 import { getApp } from '../nestapp/app';
 import { redirect } from 'next/navigation';
+import { URLSearchParams } from 'url';
 
-export const submitNeedsInputAndRedirectAction = async (cartId: string) => {
+export const submitNeedsInputAndRedirectAction = async (
+  cartId: string,
+  searchParams?: Record<string, string | string[]>
+) => {
   let redirectPath: string | undefined;
+  const urlSearchParams = new URLSearchParams(searchParams);
+  const params = searchParams ? `?${urlSearchParams.toString()}` : '';
   try {
     await getApp().getActionsService().submitNeedsInput({ cartId });
     redirectPath = 'success';
@@ -17,5 +23,5 @@ export const submitNeedsInputAndRedirectAction = async (cartId: string) => {
    redirectPath = 'error';
   }
 
-  redirect(redirectPath);
+  redirect(`${redirectPath}${params}`);
 };

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -99,6 +99,10 @@ export function CheckoutForm({
   const stripe = useStripe();
   const params = useParams();
   const searchParams = useSearchParams();
+  const searchParamsRecord: Record<string, string> = {};
+  for (const [key, value] of searchParams.entries()) {
+    searchParamsRecord[key] = value;
+  }
 
   const [formEnabled, setFormEnabled] = useState(false);
   const [showConsentError, setShowConsentError] = useState(false);
@@ -233,7 +237,7 @@ export function CheckoutForm({
       if (confirmationTokenError.type === 'validation_error') {
         return;
       } else {
-        await handleStripeErrorAction(cart.id, confirmationTokenError);
+        await handleStripeErrorAction(cart.id, confirmationTokenError, searchParamsRecord);
         return;
       }
     }

--- a/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
@@ -32,7 +32,7 @@ export function PaymentInputHandler({ cartId }: { cartId: string }) {
             await stripe.handleNextAction({
               clientSecret: inputRequest.data.clientSecret,
             });
-            await submitNeedsInputAndRedirectAction(cartId);
+            await submitNeedsInputAndRedirectAction(cartId, searchParamsRecord);
             break;
           case 'notRequired':
             await validateCartStateAndRedirectAction(

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -4,6 +4,7 @@
 
 import { CartErrorReasonId } from '@fxa/shared/db/mysql/account';
 import { CheckoutParams } from './types';
+import { URLSearchParams } from 'url';
 
 export function getErrorFtlInfo(
   reason: CartErrorReasonId | string | null,
@@ -11,8 +12,13 @@ export function getErrorFtlInfo(
   config: {
     contentServerUrl: string;
     supportUrl: string;
-  }
+  },
+  searchParams?: Record<string, string | string[]>
 ) {
+
+  const urlSearchParams = new URLSearchParams(searchParams);
+  const queryParamString = searchParams ? `?${urlSearchParams.toString()}` : '';
+
   switch (reason) {
     case CartErrorReasonId.CART_ELIGIBILITY_STATUS_DOWNGRADE:
       return {
@@ -35,7 +41,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
-        buttonUrl: `${config.contentServerUrl}/subscriptions`,
+        buttonUrl: `${config.contentServerUrl}/subscriptions${queryParamString}`,
         message: 'You’ve already subscribed to this product.',
         messageFtl: 'checkout-error-already-subscribed',
       };
@@ -43,7 +49,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
-        buttonUrl: `${config.contentServerUrl}/subscriptions`,
+        buttonUrl: `${config.contentServerUrl}/subscriptions${queryParamString}`,
         message:
           'You have a mobile in-app subscription that conflicts with this product — please contact support so we can help you.',
         messageFtl: 'next-iap-blocked-contact-support',
@@ -52,7 +58,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'We were unable to determine the currency for this purchase, please try again.',
         messageFtl: 'cart-error-currency-not-determined',
@@ -61,7 +67,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'An unexpected error has occurred while processing your payment, please try again.',
         messageFtl: 'checkout-processing-general-error',
@@ -70,7 +76,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message: 'The invoice amount has changed. Please try again.',
         messageFtl: 'cart-total-mismatch-error',
       };
@@ -78,7 +84,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'Your transaction could not be processed. Please verify your credit card information and try again.',
         messageFtl: 'intent-card-error',
@@ -87,7 +93,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'It looks like your credit card has expired. Try another card.',
         messageFtl: 'intent-expired-card-error',
@@ -96,7 +102,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'Hmm. There was a problem authorizing your payment. Try again or get in touch with your card issuer.',
         messageFtl: 'intent-payment-error-try-again',
@@ -105,7 +111,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.',
         messageFtl: 'intent-payment-error-get-in-touch',
@@ -114,7 +120,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'An unexpected error has occurred while processing your payment, please try again.',
         messageFtl: 'intent-payment-error-generic',
@@ -123,7 +129,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message:
           'It looks like your card has insufficient funds. Try another card.',
         messageFtl: 'intent-payment-error-insufficient-funds',
@@ -133,7 +139,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-retry-button',
         buttonLabel: 'Try again',
-        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing`,
+        buttonUrl: `/${params.locale}/${params.offeringId}/${params.interval}/landing${queryParamString}`,
         message: 'Something went wrong. Please try again later.',
         messageFtl: 'next-basic-error-message',
       };

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -683,10 +683,14 @@ Router = Router.extend({
       if (
         reactRouteGroups[routeGroup].routes.find((route) => routeName === route)
       ) {
+        const showBackboneOAuthRoute =
+          routeName === 'oauth' &&
+          Url.searchParam('channel_id', this.window.location.search);
         return (
           reactRouteGroups[routeGroup].featureFlagOn &&
           (this.isInReactExperiment() ||
-            reactRouteGroups[routeGroup].fullProdRollout === true)
+            reactRouteGroups[routeGroup].fullProdRollout === true) &&
+          !showBackboneOAuthRoute
         );
       }
     }

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -42,7 +42,7 @@ describe('lib/router', () => {
   const mockReactRouteGroups = {
     alwaysOnRoutes: {
       featureFlagOn: mockShowReactAppConfig.alwaysOnRoutes,
-      routes: ['alwaysOnRoute'],
+      routes: ['alwaysOnRoute', 'oauth'],
       fullProdRollout: true,
     },
     sometimesOnRoutes: {
@@ -563,6 +563,11 @@ describe('lib/router', () => {
           sinon.stub(router, 'isInReactExperiment').callsFake(() => true);
           assert.isTrue(router.showReactApp('sometimesOnRoute'));
         });
+
+        it('when route is oauth but channel_id parameter is not present', () => {
+          windowMock.location.search = '';
+          assert.isTrue(router.showReactApp('oauth'));
+        });
       });
 
       describe('returns false', () => {
@@ -590,8 +595,14 @@ describe('lib/router', () => {
           sinon.stub(router, 'isInReactExperiment').callsFake(() => false);
           assert.isFalse(router.showReactApp('sometimesOnRoute'));
         });
+
+        it('when route is oauth and channel_id parameter is present', () => {
+          windowMock.location.search = '?channel_id=test123';
+          assert.isFalse(router.showReactApp('oauth'));
+        });
       });
     });
+
     describe('createReactOrBackboneViewHandler', () => {
       const viewConstructorOptions = {};
       const additionalParams = {};

--- a/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
@@ -43,6 +43,11 @@ function addAllReactRoutesConditionally(
               } else {
                 return next('route');
               }
+              // Allow '/oauth' to serve the React application, _but_ if the request URL includes
+              // a 'channel_id' query parameter, we know it's Fx Desktop trying to begin the pairing
+              // flow. Show Backbone in this case until the pair flow is converted to React.
+            } else if (req.path === '/oauth' && req.query.channel_id) {
+              return next('route');
             }
             return middleware(req, res, next);
           }

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -29,9 +29,10 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       // first.
       routes: reactRoute.getRoutes([
         'authorization',
-        // We have to temporarily remove the `/oauth` because Fx desktop uses
-        // that path to initiate the pairing flow
-        // 'oauth'
+        // NOTE: 'oauth' is currently a weird case because because Fx desktop uses
+        // it to initiate the pairing flow. We have logic at the Express level to
+        // handle showing React/Backbone for this route until pairing is Reactified.
+        'oauth',
         '/',
       ]),
       fullProdRollout: true,
@@ -117,6 +118,13 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
 
     pairRoutes: {
       featureFlagOn: showReactApp.pairRoutes,
+      // TODO: see comment above about the '/oauth' route in `emailFirstRoutes`. We cannot
+      // check React experiment status at the Express level, so adding pair routes here
+      // without accounting for the 'oauth' conditional would mean Backbone
+      // `/oauth?channel_id=...` would get 100% of traffic while all other pairing gets 15%.
+      // Are we OK with that and then rolling Fx Desktop pairing out at 100%, or, relying on
+      // a feature flag only for the '/pair' flow, meaning at the Express level we could add
+      // a check for this flag to conditionally show '/oauth' React/Backbone?
       routes: [],
       fullProdRollout: false,
     },

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -132,6 +132,10 @@ export class OAuthWebIntegration extends GenericIntegration<
   }
 
   getServiceName() {
+    // TODO: Currently we try to get the `serviceName` in `AuthAndSetupRoutes`. If the
+    // 'scope' param isn't provided and the user lands on /oauth, there's an
+    // `Uncaught OAuthError: Invalid OAuth parameter: scope`, and we should be
+    // showing `<OAuthDataError>`.
     const permissions = this.getPermissions();
     // As a special case for UX purposes, any client requesting access to
     // the user's sync data must have a display name of "Firefox Sync".
@@ -239,7 +243,7 @@ export class OAuthWebIntegration extends GenericIntegration<
 
     if (!permissions.length) {
       throw new OAuthError(OAUTH_ERRORS.INVALID_PARAMETER.errno, {
-        params: 'scope',
+        param: 'scope',
       });
     }
 


### PR DESCRIPTION
## Because

- In some places, query params are lost in route reconstruction.

## This pull request

- Preserves query params from the original request

## Issue that this pull request solves

Closes: #FXA-12002

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
