### PR TITLE
fix(functional-tests): Prevent account deletion failures in tests

### DIFF
--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -20,6 +20,20 @@ type AccountDetails = {
   password: string;
 };
 
+/**
+ * TestAccountTracker manages test account lifecycle with automatic cleanup.
+ *
+ * Features:
+ * - Tracks all created accounts for automatic cleanup
+ * - Automatically disables TOTP before account destruction
+ * - Handles edge cases like blocked accounts and email changes
+ *
+ * Best Practices:
+ * - While tests should still call `settings.disconnectTotp()` for explicit cleanup,
+ *   the automatic cleanup will handle cases where tests fail before reaching cleanup
+ * - Update account credentials if email or password changes during the test
+ * - Blocked accounts may still need manual cleanup in some cases
+ */
 export class TestAccountTracker {
   accounts: (AccountDetails | Credentials)[];
   private target: BaseTarget;
@@ -169,61 +183,109 @@ export class TestAccountTracker {
   }
 
   /**
-   * Destroys all accounts tracked by this TestAccountTracker
+   * Destroys all accounts tracked by this TestAccountTracker.
+   * Fails fast if any account cleanup fails.
    */
   async destroyAllAccounts() {
     while (this.accounts.length > 0) {
       const account = this.accounts.pop();
-      if (!account) {
-        continue;
-      }
+      if (!account) continue;
 
+      // Check if account exists
       const accountStatus = await this.target.authClient.accountStatusByEmail(
         account.email
       );
+      if (!accountStatus.exists) continue;
 
-      if (!accountStatus.exists) {
-        continue;
+      try {
+        // Get session token (existing or new)
+        let sessionToken: string;
+        if ('sessionToken' in account && account.sessionToken) {
+          sessionToken = account.sessionToken;
+        } else {
+          const credentials = await this.target.authClient.signIn(
+            account.email,
+            account.password
+          );
+          sessionToken = credentials.sessionToken;
+        }
+
+        // Helper function to verify session if needed
+        const verifySessionIfNeeded = async () => {
+          try {
+            await this.target.authClient.sessionResendVerifyCode(sessionToken);
+            const code = await this.target.emailClient.getVerifyLoginCode(
+              account.email
+            );
+            await this.target.authClient.sessionVerifyCode(sessionToken, code);
+          } catch {
+            // Ignore verification errors - session might already be verified
+          }
+        };
+
+        // Helper function to get fresh session if current one is invalid
+        const getFreshSessionIfNeeded = async (error: any) => {
+          if (
+            error.message.includes('Invalid authentication token') ||
+            error.message.includes('Missing authentication')
+          ) {
+            const credentials = await this.target.authClient.signIn(
+              account.email,
+              account.password
+            );
+            sessionToken = credentials.sessionToken;
+            await verifySessionIfNeeded();
+            return true;
+          }
+          return false;
+        };
+
+        // Try to disable TOTP if it exists
+        try {
+          await this.target.authClient.deleteTotpToken(sessionToken);
+        } catch (totpError) {
+          if (totpError.message.includes('Unconfirmed session')) {
+            await verifySessionIfNeeded();
+            await this.target.authClient.deleteTotpToken(sessionToken);
+          } else if (await getFreshSessionIfNeeded(totpError)) {
+            await this.target.authClient.deleteTotpToken(sessionToken);
+          }
+          // Otherwise ignore TOTP errors - account might not have TOTP
+        }
+
+        // Try to destroy the account
+        try {
+          await this.target.authClient.accountDestroy(
+            account.email,
+            account.password,
+            {},
+            sessionToken
+          );
+        } catch (destroyError) {
+          if (destroyError.message.includes('Unconfirmed session')) {
+            await verifySessionIfNeeded();
+            await this.target.authClient.accountDestroy(
+              account.email,
+              account.password,
+              {},
+              sessionToken
+            );
+          } else if (await getFreshSessionIfNeeded(destroyError)) {
+            await this.target.authClient.accountDestroy(
+              account.email,
+              account.password,
+              {},
+              sessionToken
+            );
+          } else {
+            throw destroyError;
+          }
+        }
+      } catch (error) {
+        throw new Error(
+          `Failed to cleanup account ${account.email}: ${error.message}`
+        );
       }
-
-      /**
-       * Troubleshooting if accounts fail to destroy:
-       *
-       * Error Message: 'Sign in with this email type is not currently supported'
-       * The primary email was most likely changed, the test case must
-       * update the account with the new email
-       *
-       * Error Message: 'The request was blocked for security reasons'
-       * Some accounts are always prompted to unblock, ie emails starting
-       * with `blocked.`. These accounts need to be destroyed in the test
-       * case
-       *
-       * Error Message: 'Unconfirmed session'
-       * The account is most likely using TOTP. Disable TOTP or remove the
-       * account in the test
-       */
-      const credentials = await this.target.authClient.signIn(
-        account.email,
-        account.password
-      );
-
-      await this.target.authClient.sessionResendVerifyCode(
-        credentials.sessionToken
-      );
-      const code = await this.target.emailClient.getVerifyLoginCode(
-        account.email
-      );
-      await this.target.authClient.sessionVerifyCode(
-        credentials.sessionToken,
-        code
-      );
-
-      await this.target.authClient.accountDestroy(
-        account.email,
-        account.password,
-        {},
-        credentials.sessionToken
-      );
     }
   }
 }


### PR DESCRIPTION
## Because

* Account cleanup could fail silently
* This was noticed when tests reached the max number of accounts tied to the same phone number (all tests use same phone number)

## This pull request

* Keep totp disabling in tests, but add removal in test account tracker as additional fallback
* Throw error if account deletion fails, we don't want failed cleanup to pollute database

## Issue that this pull request solves

Closes: FXA-12034

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
