### PR TITLE
fix(settings): lang race condition with browser translation service

### DIFF
--- a/libs/shared/l10n/src/index.ts
+++ b/libs/shared/l10n/src/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 export { default as supportedLanguages } from './lib/supported-languages.json';
+export { default as rtlLocales } from './lib/rtl-locales.json';
 export * from './lib/localizer/localizer.base';
 export * from './lib/l10n.formatters';
 export * from './lib/l10n.constants';

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -5,6 +5,10 @@
 const { readFileSync } = require('fs');
 const { join, extname } = require('path');
 const { createProxyMiddleware } = require('http-proxy-middleware');
+const {
+  supportedLanguages,
+  rtlLocales,
+} = require('../../../../dist/libs/shared/l10n/main.js');
 const config = require('./configuration');
 const FLOW_ID_KEY = config.get('flow_id_key');
 const flowMetrics = require('./flow-metrics');
@@ -45,6 +49,8 @@ const settingsConfig = {
   l10n: {
     strict: false,
     baseUrl: config.get('l10n.baseUrl'),
+    supportedLanguages,
+    rtlLocales,
   },
   sentry: {
     dsn: config.get('sentry.dsn'),
@@ -112,7 +118,7 @@ const settingsConfig = {
   nimbusPreview: config.get('nimbusPreview'),
   cms: {
     enabled: config.get('cms.enabled'),
-  }
+  },
 };
 
 // Inject Settings content into the index HTML

--- a/packages/fxa-react/components/Head/index.tsx
+++ b/packages/fxa-react/components/Head/index.tsx
@@ -5,12 +5,6 @@
 import React, { useEffect } from 'react';
 import { useLocalization } from '@fluent/react';
 import { Helmet } from 'react-helmet';
-import { determineLocale, determineDirection } from '@fxa/shared/l10n';
-
-const supportedUserLocale = determineLocale(
-  window.navigator.languages.join(', ')
-);
-const localeDirection = determineDirection(supportedUserLocale);
 
 const Head = ({ title }: { title?: string }) => {
   const { l10n } = useLocalization();
@@ -29,9 +23,7 @@ const Head = ({ title }: { title?: string }) => {
   });
 
   return (
-    <Helmet
-      htmlAttributes={{ lang: supportedUserLocale, dir: localeDirection }}
-    >
+    <Helmet>
       <title>{customTitle}</title>
     </Helmet>
   );

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -20,6 +20,7 @@
 
   <!--iOS App Banner-->
   <meta name="apple-itunes-app" content="app-id=989804926, affiliate-data=ct=smartbanner-fxa" />
+  <script type="module" src="%PUBLIC_URL%/lang-fix.js"></script>
   <script defer src="%PUBLIC_URL%/query-fix.js"></script>
 </head>
 

--- a/packages/fxa-settings/public/lang-fix.js
+++ b/packages/fxa-settings/public/lang-fix.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* This module sets the language and direction on the HTML element ASAP,
+ * before the main application bundle loads. This prevents a race condition
+ * where the browser's translation service might offer to translate the page
+ * based on the initial 'en' language attribute, before client-side rendering
+ * can correct it. (FXA-12013) */
+try {
+  const configTag = document.querySelector('meta[name="fxa-config"]');
+  const serverConfig = JSON.parse(decodeURIComponent(configTag.content));
+  const { supportedLanguages, rtlLocales } = serverConfig.l10n;
+  const supported = new Set(supportedLanguages);
+
+  let lang = 'en';
+
+  for (const requested of navigator.languages || []) {
+    // check for exact match e.g. "en-US"
+    if (supported.has(requested)) {
+      lang = requested;
+      break;
+    }
+    // check for base language match e.g. "en"
+    const baseLang = requested.split('-')[0];
+    if (supported.has(baseLang)) {
+      lang = baseLang;
+      break;
+    }
+  }
+
+  const dir = rtlLocales.includes(lang) ? 'rtl' : 'ltr';
+
+  document.documentElement.lang = lang;
+  document.documentElement.dir = dir;
+} catch (e) {
+  console.error('Error updating HTML lang attribute.', e);
+  document.documentElement.lang = 'en';
+  document.documentElement.dir = 'ltr';
+}


### PR DESCRIPTION
## Because

- the language and direction attributes aren't set until the full bundle loads.  This can take so long that browsers offer to translate the default "en" before it is changed to the actual requested language.

## This pull request

- pulls the language update out of the bundle and loads it first to ensure requested language is set quickly

## Issue that this pull request solves

Closes: FXA-12013

## Other information
I was unable to trigger the unwanted translation prompt using steps to reproduce listed in the ticket.  However, I could clearly see the case where HTML renders first with `en`, then after multi-second delay finally updates to the requested language.  I did this by changing Firefox page language and throttling devtools network to 4G.

I confirmed that with the fix in this PR, the requested language is set immediately, instead of after the significant delay due to bundle load.  

**TO TEST:**

Before (on main branch):
- Firefox Browser Settings > Language > Choose your preferred language for displaying pages: set language to a supported value like Spanish
- Firefox Dev Tools > Network tab: set throttle to 4G or similar
- With Firefox Dev Tools Inspector open, visit http://localhost:3030 keeping an eye on the opening HTML tag `<html dir="ltr" lang="en-US">`.  Notice it takes multiple seconds before the `lang` attribute updates to your language selected above.

After:
- switch to branch `fix-lang-race-condition`
- restart your stack, or at least settings-react and content – I used `yarn pm2 restart settings-react react-tsc content`
- repeat the steps above and notice your selected language immediately reflected in the opening HTML tag.
