### PR TITLE
feat(settings): Create new FlowSetup2faPrompt component

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/en.ftl
@@ -1,0 +1,10 @@
+flow-setup-2fa-prompt-heading = Set up two-step authentication
+
+# Variable { $serviceName } is the name of the product (e.g. Firefox Add-ons)
+# that requests two-step authentication setup.
+flow-setup-2fa-prompt-description = { $serviceName } requires you to set up two-step authentication to keep your account safe.
+
+# "these authenticator apps" links to https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication
+flow-setup-2fa-prompt-use-authenticator-apps = You can use any of <authenticationAppsLink>these authenticator apps</authenticationAppsLink> to proceed.
+
+flow-setup-2fa-prompt-continue-button = Continue

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.stories.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import { action } from '@storybook/addon-actions';
+import { FlowSetup2faPrompt } from '.';
+
+export default {
+  title: 'Components/Settings/FlowSetup2faPrompt',
+  component: FlowSetup2faPrompt,
+  decorators: [withLocalization],
+} as Meta;
+
+const handleContinueClick = action('continue-clicked');
+const handleCancelClick = action('cancel-clicked');
+
+export const Default = () => (
+  <FlowSetup2faPrompt
+    localizedPageTitle="Two-step authentication"
+    serviceName="123Done"
+    onContinue={handleContinueClick}
+    onBackButtonClick={handleCancelClick}
+  />
+);
+
+export const WithError = () => (
+  <FlowSetup2faPrompt
+    localizedPageTitle="Two-step authentication"
+    serviceName="123Done"
+    onContinue={handleContinueClick}
+    onBackButtonClick={handleCancelClick}
+    localizedErrorMessage="An error occurred while setting up two-step authentication."
+  />
+);

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.test.tsx
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { FlowSetup2faPrompt, FlowSetup2faPromptProps } from '.';
+import { GleanClickEventType2FA } from '../../../lib/types';
+
+const renderFlowSetup2faPrompt = (
+  props: Partial<FlowSetup2faPromptProps> = {}
+) => {
+  const onContinue = jest.fn();
+  const onBackButtonClick = jest.fn();
+  const defaultProps = {
+    localizedPageTitle: 'Two-step authentication',
+    serviceName: '123Done',
+    onContinue,
+    onBackButtonClick,
+    ...props,
+  };
+
+  return {
+    ...renderWithLocalizationProvider(<FlowSetup2faPrompt {...defaultProps} />),
+    onContinue,
+    onBackButtonClick,
+  };
+};
+
+describe('FlowSetup2faPrompt', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders as expected', () => {
+    renderFlowSetup2faPrompt();
+
+    expect(screen.getByText('Two-step authentication')).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toBeInTheDocument();
+    expect(
+      screen.getByText('Set up two-step authentication')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '123Done requires you to set up two-step authentication to keep your account safe.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/You can use any of/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Continue' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the error banner message when provided', () => {
+    const localizedErrorMessage =
+      'An error occurred while setting up two-step authentication.';
+    renderFlowSetup2faPrompt({ localizedErrorMessage });
+
+    expect(screen.getByText(localizedErrorMessage)).toBeInTheDocument();
+  });
+
+  it('renders the authentication apps link with correct attributes', () => {
+    renderFlowSetup2faPrompt();
+
+    const authAppsLink = screen.getByRole('link', {
+      name: /these authenticator apps/,
+    });
+    expect(authAppsLink).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication'
+    );
+    expect(authAppsLink).toHaveAttribute(
+      'data-glean-id',
+      'two_step_auth_inline_prompt_app_link'
+    );
+    expect(authAppsLink).toHaveAttribute(
+      'data-glean-type',
+      GleanClickEventType2FA.inline
+    );
+  });
+
+  it('calls onContinue when continue button is clicked', async () => {
+    const { onContinue } = renderFlowSetup2faPrompt();
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+    await userEvent.click(continueButton);
+
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onBackButtonClick when back button is clicked', async () => {
+    const { onBackButtonClick } = renderFlowSetup2faPrompt();
+
+    const backButton = screen.getByRole('button', { name: 'Back' });
+    await userEvent.click(backButton);
+
+    expect(onBackButtonClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { BackupRecoveryPhoneCodeImage } from '../../images';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import FlowContainer from '../FlowContainer';
+import { GleanClickEventType2FA } from '../../../lib/types';
+import Banner from '../../Banner';
+
+export type FlowSetup2faPromptProps = {
+  localizedPageTitle: string;
+  onContinue: () => void;
+  onBackButtonClick: () => void;
+  serviceName: string;
+  localizedErrorMessage?: string;
+};
+
+export const FlowSetup2faPrompt = ({
+  localizedPageTitle,
+  onContinue,
+  onBackButtonClick,
+  serviceName,
+  localizedErrorMessage,
+}: FlowSetup2faPromptProps) => {
+  return (
+    <FlowContainer
+      onBackButtonClick={onBackButtonClick}
+      title={localizedPageTitle}
+    >
+      {localizedErrorMessage && (
+        <Banner
+          type="error"
+          content={{ localizedHeading: localizedErrorMessage }}
+        />
+      )}
+      <BackupRecoveryPhoneCodeImage ariaHidden />
+      <FtlMsg id="flow-setup-2fa-prompt-heading">
+        <h2 className="font-bold text-xl my-2">
+          Set up two-step authentication
+        </h2>
+      </FtlMsg>
+      <FtlMsg id="flow-setup-2fa-prompt-description" vars={{ serviceName }}>
+        <p className="text-base mb-4">
+          {serviceName} requires you to set up two-step authentication to keep
+          your account safe.
+        </p>
+      </FtlMsg>
+      <FtlMsg
+        id="flow-setup-2fa-prompt-use-authenticator-apps"
+        elems={{
+          authenticationAppsLink: (
+            <LinkExternal
+              className="link-blue text-base"
+              href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+              gleanDataAttrs={{
+                id: 'two_step_auth_inline_prompt_app_link',
+                type: GleanClickEventType2FA.inline,
+              }}
+            >
+              these authenticator apps
+            </LinkExternal>
+          ),
+        }}
+      >
+        <p className="text-base mb-8">
+          You can use any of{' '}
+          <LinkExternal
+            className="link-blue text-base"
+            href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+            gleanDataAttrs={{
+              id: 'two_step_auth_inline_prompt_app_link',
+              type: GleanClickEventType2FA.inline,
+            }}
+          >
+            these authenticator apps
+          </LinkExternal>{' '}
+          to proceed.
+        </p>
+      </FtlMsg>
+      <FtlMsg id="flow-setup-2fa-prompt-continue-button">
+        <button
+          type="submit"
+          className="cta-primary cta-xl w-full"
+          onClick={onContinue}
+        >
+          Continue
+        </button>
+      </FtlMsg>
+    </FlowContainer>
+  );
+};
+
+export default FlowSetup2faPrompt;


### PR DESCRIPTION
## Because

- The first screen of the inline flow is unique and was not included in the previous epic.

## This pull request

- extracts the first page of the inline setup flow into FlowSetup2faPrompt and updates it to match the latest design


## Issue that this pull request solves

Closes: FXA-10208

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="625" height="573" alt="image" src="https://github.com/user-attachments/assets/e2e5492a-3b91-4d6d-b63a-db38a10ebab4" />

## Other information (Optional)

Any other information that is important to this pull request.
