### PR TITLE
bug(functional): Avoid do while loop with waitForTimeout.

### DIFF
--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -208,6 +208,10 @@ test.describe('severity-2 #smoke', () => {
       },
       testAccountTracker,
     }) => {
+      // Retries and waiting for unblock codes takes time. Without this
+      // test routinely times out in circleci.
+      test.setTimeout(30000);
+
       const config = await configPage.getConfig();
       const credentials = await testAccountTracker.signUpSync({
         lang: 'en',
@@ -252,10 +256,21 @@ test.describe('severity-2 #smoke', () => {
       // Create blocked sign in
       await page.goto(target.contentServerUrl);
       await signin.fillOutEmailFirstForm(credentials.email);
-      do {
-        await signin.fillOutPasswordForm(credentials.password + Date.now());
-        await page.waitForTimeout(300);
-      } while (page.url().indexOf('signin_unblock') === -1);
+
+      await signin.passwordTextbox.fill(credentials.password + 1);
+      await signin.signInButton.click();
+
+      await signin.passwordTextbox.fill(credentials.password + 2);
+      await signin.signInButton.click();
+
+      await signin.passwordTextbox.fill(credentials.password + 3);
+      await signin.signInButton.click();
+
+      await signin.passwordTextbox.fill(credentials.password + 4);
+      await signin.signInButton.click();
+
+      await signin.passwordTextbox.fill(credentials.password + 5);
+      await signin.signInButton.click();
 
       //Verify sign in block header
       await expect(page).toHaveURL(/signin_unblock/);
@@ -264,7 +279,7 @@ test.describe('severity-2 #smoke', () => {
       );
       await signinUnblock.fillOutCodeForm(unblockCode);
 
-      // Enter the unblock code.
+      // Enter the correct password
       await expect(page).toHaveURL(/signin/);
       await signin.fillOutPasswordForm(credentials.password);
 


### PR DESCRIPTION


## Because

-  It appears the loop with waitForTimeout caused a race condition in the CI
- Perhaps the CI is slower and the timeout wasn't sufficient

## This pull request

- Replaces loop with set number of password attempts.
- Fixes misleading comment

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
