### PR TITLE
fix(next): modify build to update package version

### DIFF
--- a/_dev/docker/mono/build.sh
+++ b/_dev/docker/mono/build.sh
@@ -29,6 +29,10 @@ for d in ./packages/*/ ; do
   (cd "$d" && mkdir -p config && cp ../version.json . && cp ../version.json config && patchVersion)
 done
 
+for d in ./apps/payments/*/ ; do
+  (cd "$d" && mkdir -p config && cp ../../version.json . && cp ../../version.json config && patchVersion)
+done
+
 # `npx yarn` because `npm i -g yarn` needs sudo
 npx yarn install
 npx yarn gql:allowlist

--- a/_scripts/create-version-json.sh
+++ b/_scripts/create-version-json.sh
@@ -9,7 +9,7 @@ if [[ "${CIRCLECI}" == "true" ]]; then
     "${CIRCLE_PROJECT_USERNAME:-mozilla}" \
     "${CIRCLE_PROJECT_REPONAME:-fxa}" \
     "${CIRCLE_BUILD_URL}" \
-    | tee "$DIR/../packages/version.json"
+    | tee "$DIR/../packages/version.json" "$DIR/../apps/version.json"
 elif [[ "${GITHUB_ACTIONS}" == "true" ]]; then
   printf '{"version":{"hash":"%s","version":"%s","source":"https://github.com/%s","build":"%s/%s/actions/runs/%s"}}\n' \
     "${GITHUB_SHA}" \
@@ -18,10 +18,10 @@ elif [[ "${GITHUB_ACTIONS}" == "true" ]]; then
     "${GITHUB_SERVER_URL}" \
     "${GITHUB_REPOSITORY}" \
     "${GITHUB_RUN_ID}" \
-    | tee "$DIR/../packages/version.json"
+    | tee "$DIR/../packages/version.json" "$DIR/../apps/version.json"
 else
   printf '{"version":{"hash":"%s","version":"%s","source":"https://github.com/mozilla/fxa","build":""}}\n' \
     "$(git rev-parse HEAD)" \
     "$(git rev-parse --abbrev-ref HEAD)" \
-    | tee "$DIR/../packages/version.json"
+    | tee "$DIR/../packages/version.json" "$DIR/../apps/version.json"
 fi


### PR DESCRIPTION
## Because

- Currently the `payments-next` package.json version attribute has a static value of 0.0.0, instead of the deployed train tag.

## This pull request

- Updates the mono repo build process to update the patch version of the `payments-next` package.json.

## Issue that this pull request solves

Closes: #FXA-11522

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).