### PR TITLE
fix(payments-next): Payment element does not load when charge amount is less than minimum charge amount

### DIFF
--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -12,6 +12,7 @@ import {
 } from '@stripe/stripe-js';
 import { useContext, useState } from 'react';
 import { ConfigContext } from '../providers/ConfigProvider';
+import { STRIPE_MINIMUM_CHARGE_AMOUNTS } from '../../../../../stripe/src/lib/stripe.constants';
 
 const stripeElementLocales = [
   'auto',
@@ -100,10 +101,14 @@ export function StripeWrapper({
   const config = useContext(ConfigContext);
   const [stripePromise] = useState(() => loadStripe(config.stripePublicApiKey));
 
+  const normalizedCurrency = currency.toLowerCase();
+  const minCharge = STRIPE_MINIMUM_CHARGE_AMOUNTS[normalizedCurrency];
+  const isBelowMin = amount < minCharge;
+
   const options: StripeElementsOptions = {
-    mode: 'subscription',
+    mode: isBelowMin ? 'setup' : 'subscription',
     locale: isStripeElementLocale(locale) ? locale : 'auto',
-    amount: amount >= 0 ? amount : 0,
+    amount: isBelowMin ? undefined : amount,
     currency: currency.toLowerCase(),
     paymentMethodCreation: 'manual',
     externalPaymentMethodTypes: ['external_paypal'],


### PR DESCRIPTION
## Because

- When the charge amount is less than min charge amount, payment element fails to load and instead has an error in the browser console.

## This pull request

- Changes StripeElementsOptions mode to 'setup' instead of 'subscription' when prorated change is less than Stripe min charge amount.
- Uses SetupIntent in such cases, saving user's payment method without immediate charging them.

## Issue that this pull request solves

Closes: #FXA-12072

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
