### PR TITLE
fix(settings): Fix missing name attribute warnings for confirmPassword field

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.tsx
@@ -93,7 +93,7 @@ export const FormPasswordWithBalloons = ({
   disableButtonUntilValid = false,
   submitButtonGleanId,
   requirePasswordConfirmation = true,
-  cmsButton
+  cmsButton,
 }: FormPasswordWithBalloonsProps) => {
   const passwordValidator = new PasswordValidator(email);
   const [passwordMatchErrorText, setPasswordMatchErrorText] =
@@ -228,6 +228,7 @@ export const FormPasswordWithBalloons = ({
       }
     }
     if (
+      requirePasswordConfirmation &&
       hasBlurredConfirmPwd &&
       !errors.newPassword &&
       getValues('confirmPassword') !== '' &&
@@ -236,7 +237,7 @@ export const FormPasswordWithBalloons = ({
       setPasswordMatchErrorText(localizedPasswordMatchError);
     }
 
-    if (!formState.isValid) {
+    if (!formState.isValid && requirePasswordConfirmation) {
       trigger('confirmPassword');
     }
   };
@@ -286,7 +287,9 @@ export const FormPasswordWithBalloons = ({
 
   const onChangePassword = (inputName: string) => {
     const newPassword = getValues('newPassword');
-    const confirmPassword = getValues('confirmPassword');
+    const confirmPassword = requirePasswordConfirmation
+      ? getValues('confirmPassword')
+      : '';
     if (inputName === 'newPassword') {
       !hasUserTakenAction && setHasUserTakenAction(true);
       trigger('newPassword');
@@ -296,7 +299,7 @@ export const FormPasswordWithBalloons = ({
       setSROnlyPwdFeedbackMessage('');
     }
 
-    if (!hasBlurredConfirmPwd) {
+    if (!hasBlurredConfirmPwd || !requirePasswordConfirmation) {
       return;
     }
 

--- a/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithInlineCriteria/index.tsx
@@ -150,6 +150,7 @@ export const FormPasswordWithInlineCriteria = ({
       }
     }
     if (
+      showConfirmPasswordInput &&
       !errors.newPassword &&
       getValues('confirmPassword') !== '' &&
       getValues('confirmPassword') !== getValues('newPassword')
@@ -157,7 +158,7 @@ export const FormPasswordWithInlineCriteria = ({
       setPasswordMatchErrorText(localizedPasswordMatchError);
     }
 
-    if (!formState.isValid) {
+    if (!formState.isValid && showConfirmPasswordInput) {
       trigger('confirmPassword');
     }
   };
@@ -193,13 +194,19 @@ export const FormPasswordWithInlineCriteria = ({
 
   const onChangePassword = (inputName: string) => {
     const newPassword = getValues('newPassword');
-    const confirmPassword = getValues('confirmPassword');
+    const confirmPassword = showConfirmPasswordInput
+      ? getValues('confirmPassword')
+      : '';
     if (inputName === 'newPassword') {
       trigger('newPassword');
     }
 
     if (!errors.newPassword) {
       setSROnlyPwdFeedbackMessage('');
+    }
+
+    if (!showConfirmPasswordInput) {
+      return;
     }
 
     if (confirmPassword !== newPassword && confirmPassword !== '') {


### PR DESCRIPTION
## Because

* React Hook Form was attempting to trigger validation on confirmPassword field even when the field didn't exist in the DOM
* This occurred in signup flows where password confirmation is not required, causing "Field is missing with name attribute: confirmPassword" warnings
* The warnings were appearing in FormPasswordWithBalloons and FormPasswordWithInlineCriteria components

## This pull request

* Adds conditional checks around trigger('confirmPassword') calls to only execute when requirePasswordConfirmation/showConfirmPasswordInput is true
* Updates FormPasswordWithBalloons to guard confirmPassword validation with requirePasswordConfirmation prop
* Updates FormPasswordWithInlineCriteria to guard confirmPassword validation with showConfirmPasswordInput prop
* Prevents getValues('confirmPassword') calls when the field doesn't exist
* Eliminates console warnings during signup form tests

## Issue that this pull request solves

Closes: FXA-11954

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
