### PR TITLE
cleanup(settings): Replace deprecated toBeCalled assertion

### DIFF
--- a/packages/fxa-settings/src/components/InputCheckboxBlue/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputCheckboxBlue/index.test.tsx
@@ -39,5 +39,5 @@ it('will call onChange argument', () => {
   const onChange = jest.fn();
   renderWithLocalizationProvider(<InputCheckboxBlue {...{ onChange }} />);
   fireEvent.click(screen.getByRole('checkbox'));
-  expect(onChange).toBeCalled();
+  expect(onChange).toHaveBeenCalled();
 });

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.test.tsx
@@ -66,8 +66,11 @@ describe('RecoveryKeySetupHint', () => {
 
   it('emits the expected metrics when the user lands on this step of the flow', () => {
     renderWithContext(accountWithSuccess);
-    expect(logViewEvent).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'create-hint.view');
+    expect(logViewEvent).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'create-hint.view'
+    );
   });
 
   it('saves the hint on submit if the user has entered a valid hint in the text input', async () => {
@@ -85,14 +88,14 @@ describe('RecoveryKeySetupHint', () => {
     });
     fireEvent.click(submitButton);
     await waitFor(() => {
-      expect(logViewEvent).toBeCalledWith(
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'create-hint.submit'
       );
-      expect(accountWithSuccess.updateRecoveryKeyHint).toBeCalledWith(
+      expect(accountWithSuccess.updateRecoveryKeyHint).toHaveBeenCalledWith(
         hintValue
       );
-      expect(logViewEvent).toBeCalledWith(
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'create-hint.success'
       );
@@ -126,13 +129,15 @@ describe('RecoveryKeySetupHint', () => {
     });
     fireEvent.click(submitButton);
     await waitFor(() => {
-      expect(logViewEvent).toBeCalledWith(
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'create-hint.submit'
       );
-      expect(accountWithError.updateRecoveryKeyHint).toBeCalledWith(hintValue);
+      expect(accountWithError.updateRecoveryKeyHint).toHaveBeenCalledWith(
+        hintValue
+      );
       // logs the error
-      expect(logViewEvent).toBeCalledWith(
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'create-hint.fail',
         gqlUnexpectedError
@@ -148,7 +153,7 @@ describe('RecoveryKeySetupHint', () => {
     const submitButton = screen.getByText('Finish');
     fireEvent.click(submitButton);
     await waitFor(() => {
-      expect(accountWithSuccess.updateRecoveryKeyHint).not.toBeCalled();
+      expect(accountWithSuccess.updateRecoveryKeyHint).not.toHaveBeenCalled();
       expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'create-hint.skip'

--- a/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/BentoMenu/index.test.tsx
@@ -130,7 +130,7 @@ describe('BentoMenu', () => {
         expect(
           screen.getByRole('link', { name: /Firefox Browser for Desktop/ })
         ).toBeVisible();
-        expect(GleanMetrics.accountPref.bentoView).toBeCalledTimes(1);
+        expect(GleanMetrics.accountPref.bentoView).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -147,7 +147,9 @@ describe('BentoMenu', () => {
         screen.getByRole('link', { name: /Firefox Browser for Desktop/ })
       );
       await waitFor(() => {
-        expect(GleanMetrics.accountPref.bentoFirefoxDesktop).toBeCalledTimes(1);
+        expect(
+          GleanMetrics.accountPref.bentoFirefoxDesktop
+        ).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -164,7 +166,9 @@ describe('BentoMenu', () => {
         screen.getByRole('link', { name: /Firefox Browser for Mobile/ })
       );
       await waitFor(() => {
-        expect(GleanMetrics.accountPref.bentoFirefoxMobile).toBeCalledTimes(1);
+        expect(
+          GleanMetrics.accountPref.bentoFirefoxMobile
+        ).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -179,7 +183,7 @@ describe('BentoMenu', () => {
       });
       userEvent.click(screen.getByRole('link', { name: /Mozilla Monitor/ }));
       await waitFor(() => {
-        expect(GleanMetrics.accountPref.bentoMonitor).toBeCalledTimes(1);
+        expect(GleanMetrics.accountPref.bentoMonitor).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -192,7 +196,7 @@ describe('BentoMenu', () => {
       });
       userEvent.click(screen.getByRole('link', { name: /Pocket/ }));
       await waitFor(() => {
-        expect(GleanMetrics.accountPref.bentoPocket).toBeCalledTimes(1);
+        expect(GleanMetrics.accountPref.bentoPocket).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -207,7 +211,7 @@ describe('BentoMenu', () => {
       });
       userEvent.click(screen.getByRole('link', { name: /Firefox Relay/ }));
       await waitFor(() => {
-        expect(GleanMetrics.accountPref.bentoRelay).toBeCalledTimes(1);
+        expect(GleanMetrics.accountPref.bentoRelay).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -220,7 +224,7 @@ describe('BentoMenu', () => {
       });
       userEvent.click(screen.getByRole('link', { name: /Mozilla VPN/ }));
       await waitFor(() => {
-        expect(GleanMetrics.accountPref.bentoVpn).toBeCalledTimes(1);
+        expect(GleanMetrics.accountPref.bentoVpn).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/fxa-settings/src/components/Settings/Checkbox/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Checkbox/index.test.tsx
@@ -39,5 +39,5 @@ it('will call onChange argument', () => {
   const onChange = jest.fn();
   renderWithLocalizationProvider(<Checkbox {...{ onChange }} />);
   fireEvent.click(screen.getByTestId('checkbox-input'));
-  expect(onChange).toBeCalled();
+  expect(onChange).toHaveBeenCalled();
 });

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -431,7 +431,7 @@ describe('Connected Services', () => {
       'submit.no-reason'
     );
 
-    expect(account.disconnectClient).toBeCalledTimes(1);
+    expect(account.disconnectClient).toHaveBeenCalledTimes(1);
   });
 
   it('on disconnect, with more than one empty client name', async () => {
@@ -518,7 +518,7 @@ describe('Connected Services', () => {
       'submit.no-reason'
     );
 
-    expect(account.disconnectClient).toBeCalledTimes(3);
+    expect(account.disconnectClient).toHaveBeenCalledTimes(3);
   });
 
   describe('redirects to /signin when active session is signed out', () => {

--- a/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DataCollection/index.test.tsx
@@ -68,13 +68,13 @@ describe('DataCollection', () => {
     await act(async () => {
       button.click();
     });
-    await waitFor(() => expect(account.metricsOpt).toBeCalledWith('out'));
+    await waitFor(() => expect(account.metricsOpt).toHaveBeenCalledWith('out'));
     //@ts-ignore mock doesn't care that the prop is readonly
     account.metricsEnabled = false;
     await act(async () => {
       button.click();
     });
-    await waitFor(() => expect(account.metricsOpt).toBeCalledWith('in'));
+    await waitFor(() => expect(account.metricsOpt).toHaveBeenCalledWith('in'));
   });
 
   describe('AlertBar', () => {
@@ -96,7 +96,7 @@ describe('DataCollection', () => {
         fireEvent.click(screen.getByTestId('metrics-opt-out'));
       });
 
-      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledTimes(1);
       expect(
         (settingsContext.alertBarInfo?.success as jest.Mock).mock.calls[0][0]
       ).toContain('Opt out successful.');
@@ -122,7 +122,7 @@ describe('DataCollection', () => {
         fireEvent.click(screen.getByTestId('metrics-opt-out'));
       });
 
-      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledTimes(1);
       expect(
         (settingsContext.alertBarInfo?.success as jest.Mock).mock.calls[0][0]
       ).toContain('Thanks! Sharing this data helps us improve');
@@ -148,7 +148,7 @@ describe('DataCollection', () => {
         fireEvent.click(screen.getByTestId('metrics-opt-out'));
       });
 
-      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1);
       expect(
         (settingsContext.alertBarInfo?.error as jest.Mock).mock.calls[0][0]
       ).toContain('Sorry, there was a problem');

--- a/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/DropDownAvatarMenu/index.test.tsx
@@ -162,7 +162,7 @@ describe('DropDownAvatarMenu', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('avatar-menu-sign-out'));
       });
-      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -186,7 +186,7 @@ describe('DropDownAvatarMenu', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('avatar-menu-sign-out'));
       });
-      expect(fxaLogoutSpy).toBeCalledWith({ uid: account.uid });
+      expect(fxaLogoutSpy).toHaveBeenCalledWith({ uid: account.uid });
     });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.test.tsx
@@ -19,5 +19,5 @@ it('calls the given on back button click handler', async () => {
   await act(async () => {
     fireEvent.click(screen.getByTestId('flow-container-back-btn'));
   });
-  expect(cb).toBeCalledTimes(1);
+  expect(cb).toHaveBeenCalledTimes(1);
 });

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.test.tsx
@@ -146,15 +146,15 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       );
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.success'
         );
-        expect(navigateForward).toBeCalledTimes(1);
+        expect(navigateForward).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -175,15 +175,15 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
         screen.getByText(/You’ve tried too many times/);
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.fail'
         );
-        expect(navigateForward).not.toBeCalled();
+        expect(navigateForward).not.toHaveBeenCalled();
       });
     });
 
@@ -206,15 +206,15 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
         screen.getByText('Incorrect password');
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.fail'
         );
-        expect(navigateForward).not.toBeCalled();
+        expect(navigateForward).not.toHaveBeenCalled();
       });
     });
 
@@ -237,23 +237,23 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
         screen.getByText('Unexpected error');
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.fail'
         );
-        expect(navigateForward).not.toBeCalled();
+        expect(navigateForward).not.toHaveBeenCalled();
       });
     });
 
     it('emits the expected metrics when user navigates back', () => {
       renderFlowPage(accountWithKeyCreationSuccess);
       fireEvent.click(screen.getByTestId('flow-container-back-btn'));
-      expect(navigateBackward).toBeCalledTimes(1);
-      expect(logViewEvent).toBeCalledWith(
+      expect(navigateBackward).toHaveBeenCalledTimes(1);
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'create-key.cancel'
       );
@@ -310,15 +310,15 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       );
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.success'
         );
-        expect(navigateForward).toBeCalledTimes(1);
+        expect(navigateForward).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -339,15 +339,15 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
         screen.getByText(/You’ve tried too many times/);
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.fail'
         );
-        expect(navigateForward).not.toBeCalled();
+        expect(navigateForward).not.toHaveBeenCalled();
       });
     });
 
@@ -370,15 +370,15 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
         screen.getByText('Incorrect password');
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.fail'
         );
-        expect(navigateForward).not.toBeCalled();
+        expect(navigateForward).not.toHaveBeenCalled();
       });
     });
 
@@ -401,23 +401,23 @@ describe('FlowRecoveryKeyConfirmPwd', () => {
       fireEvent.click(createRecoveryKeyButton);
       await waitFor(() => {
         screen.getByText('Unexpected error');
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.submit'
         );
-        expect(logViewEvent).toBeCalledWith(
+        expect(logViewEvent).toHaveBeenCalledWith(
           `flow.${viewName}`,
           'confirm-password.fail'
         );
-        expect(navigateForward).not.toBeCalled();
+        expect(navigateForward).not.toHaveBeenCalled();
       });
     });
 
     it('emits the expected metrics when user navigates back', () => {
       renderFlowPage(accountWithKeyChangeSuccess);
       fireEvent.click(screen.getByTestId('flow-container-back-btn'));
-      expect(navigateBackward).toBeCalledTimes(1);
-      expect(logViewEvent).toBeCalledWith(
+      expect(navigateBackward).toHaveBeenCalledTimes(1);
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'change-key.cancel'
       );

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -75,7 +75,7 @@ describe('FlowRecoveryKeyDownload', () => {
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
     await waitFor(() =>
-      expect(logViewEvent).toBeCalledWith(
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'recovery-key.copy-option'
       )
@@ -87,7 +87,7 @@ describe('FlowRecoveryKeyDownload', () => {
     const downloadButton = screen.getByText('Download and continue');
     fireEvent.click(downloadButton);
     await waitFor(() => {
-      expect(logViewEvent).toBeCalledWith(
+      expect(logViewEvent).toHaveBeenCalledWith(
         `flow.${viewName}`,
         'recovery-key.download-option'
       );
@@ -100,19 +100,19 @@ describe('FlowRecoveryKeyDownload', () => {
       name: 'Continue without downloading',
     });
     fireEvent.click(nextPageLink);
-    expect(logViewEvent).toBeCalledWith(
+    expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
       'recovery-key.skip-download'
     );
-    expect(navigateForward).toBeCalledTimes(1);
+    expect(navigateForward).toHaveBeenCalledTimes(1);
   });
 
   it('emits the expected metrics when user clicks the back arrow', () => {
     renderFlowPage();
     const backLink = screen.getByRole('button', { name: 'Back to settings' });
     fireEvent.click(backLink);
-    expect(navigateBackward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
       'recovery-key.skip-download'
     );

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyHint/index.test.tsx
@@ -68,7 +68,7 @@ describe('FlowRecoveryKeyHint', () => {
   it('emits the expected metrics when user navigates back', () => {
     renderWithContext(accountWithSuccess);
     fireEvent.click(screen.getByTitle('Back to settings'));
-    expect(navigateBackward).toBeCalledTimes(1);
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
     expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
       'create-hint.skip'

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyInfo/index.test.tsx
@@ -52,8 +52,11 @@ describe('FlowRecoveryKeyInfo for key creation', () => {
 
   it('emits the expected metrics on render', () => {
     renderFlowPage(RecoveryKeyAction.Create);
-    expect(logViewEvent).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'create-key.info');
+    expect(logViewEvent).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'create-key.info'
+    );
   });
 
   it('emits the expected metrics when user navigates forward', () => {
@@ -63,16 +66,22 @@ describe('FlowRecoveryKeyInfo for key creation', () => {
         name: 'Get started',
       })
     );
-    expect(navigateForward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'create-key.info');
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'create-key.start');
+    expect(navigateForward).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'create-key.info'
+    );
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'create-key.start'
+    );
   });
 
   it('emits the expected metrics when user navigates back', () => {
     renderFlowPage(RecoveryKeyAction.Create);
     fireEvent.click(screen.getByTestId('flow-container-back-btn'));
-    expect(navigateBackward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
       'create-key.cancel'
     );
@@ -95,8 +104,11 @@ describe('FlowRecoveryKeyInfo for key replacement', () => {
 
   it('emits the expected metrics on render', () => {
     renderFlowPage(RecoveryKeyAction.Change);
-    expect(logViewEvent).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'change-key.info');
+    expect(logViewEvent).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'change-key.info'
+    );
   });
 
   it('emits the expected metrics when user navigates forward', () => {
@@ -106,16 +118,22 @@ describe('FlowRecoveryKeyInfo for key replacement', () => {
         name: 'Get started',
       })
     );
-    expect(navigateForward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'change-key.info');
-    expect(logViewEvent).toBeCalledWith(`flow.${viewName}`, 'change-key.start');
+    expect(navigateForward).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'change-key.info'
+    );
+    expect(logViewEvent).toHaveBeenCalledWith(
+      `flow.${viewName}`,
+      'change-key.start'
+    );
   });
 
   it('emits the expected metrics when user navigates back', () => {
     renderFlowPage(RecoveryKeyAction.Change);
     fireEvent.click(screen.getByTestId('flow-container-back-btn'));
-    expect(navigateBackward).toBeCalledTimes(1);
-    expect(logViewEvent).toBeCalledWith(
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+    expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
       'change-key.cancel'
     );
@@ -124,7 +142,7 @@ describe('FlowRecoveryKeyInfo for key replacement', () => {
   it('emits the expected metrics when key change is cancelled', () => {
     renderFlowPage(RecoveryKeyAction.Change);
     fireEvent.click(screen.getByRole('link', { name: 'Cancel' }));
-    expect(logViewEvent).toBeCalledWith(
+    expect(logViewEvent).toHaveBeenCalledWith(
       `flow.${viewName}`,
       'change-key.cancel'
     );

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.test.tsx
@@ -59,7 +59,7 @@ describe('FlowSetup2faBackupCodeDownload', () => {
       'twoStepAuthEnterCodeView'
     );
     renderFlowSetup2faBackupCodeConfirm();
-    expect(gleanSpy).toBeCalled();
+    expect(gleanSpy).toHaveBeenCalled();
 
     const finishButton = screen.getByRole('button', { name: 'Finish' });
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.test.tsx
@@ -63,7 +63,7 @@ describe('FlowSetup2faBackupCodeDownload', () => {
       'twoStepAuthCodesView'
     );
     renderFlowSetup2faBackupCodeDownload();
-    expect(gleanSpy).toBeCalled();
+    expect(gleanSpy).toHaveBeenCalled();
 
     const downloadButton = screen.getByRole('link', { name: 'Download' });
     const copyButton = screen.getByRole('button', { name: 'Copy' });

--- a/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalVerifySession/index.test.tsx
@@ -103,6 +103,6 @@ describe('ModalVerifySession', () => {
       fireEvent.click(screen.getByTestId('modal-verify-session-submit'));
     });
 
-    expect(onError).toBeCalledWith(error);
+    expect(onError).toHaveBeenCalledWith(error);
   });
 });

--- a/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faReplaceRecoveryCodes/index.test.tsx
@@ -89,7 +89,7 @@ describe('Page2faReplaceRecoveryCodes', () => {
       'download',
       expect.stringContaining('Backup authentication codes')
     );
-    expect(settingsContext.alertBarInfo?.error).not.toBeCalled();
+    expect(settingsContext.alertBarInfo?.error).not.toHaveBeenCalled();
   });
 
   it('displays an error when fails to fetch new backup authentication codes', async () => {

--- a/packages/fxa-settings/src/components/Settings/PageAvatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageAvatar/index.test.tsx
@@ -94,7 +94,7 @@ it('PageAddAvatar | renders ConfirmBtns and calls onsave correctly', async () =>
   await act(async () => {
     fireEvent.click(saveBtn);
   });
-  expect(onSave).toBeCalled();
+  expect(onSave).toHaveBeenCalled();
 });
 
 it('PageAddAvatar | renders ConfirmBtns with save button disabled when "enabled" option is false', async () => {
@@ -126,7 +126,7 @@ it('PageAddAvatar | renders TakePhotoBtn and calls onclick correctly', async () 
   await act(async () => {
     fireEvent.click(takePhotoBtn);
   });
-  expect(onClick).toBeCalled();
+  expect(onClick).toHaveBeenCalled();
 });
 
 it('PageAddAvatar | renders TakePhotoBtn and renders correctly when passed "capturing" option', async () => {
@@ -161,13 +161,13 @@ it('PageAddAvatar | renders ZoomBtns and calls onclick correctly', async () => {
   await act(async () => {
     fireEvent.click(zoomOutBtn);
   });
-  expect(zoomOut).toBeCalled();
+  expect(zoomOut).toHaveBeenCalled();
 
   const zoomInBtn = screen.getByTestId('zoom-in-btn');
   await act(async () => {
     fireEvent.click(zoomInBtn);
   });
-  expect(zoomIn).toBeCalled();
+  expect(zoomIn).toHaveBeenCalled();
 });
 
 it('PageAddAvatar | renders rotateBtn and calls onclick correctly', async () => {
@@ -184,5 +184,5 @@ it('PageAddAvatar | renders rotateBtn and calls onclick correctly', async () => 
   await act(async () => {
     fireEvent.click(rotateBtn);
   });
-  expect(onClick).toBeCalled();
+  expect(onClick).toHaveBeenCalled();
 });

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
@@ -135,7 +135,7 @@ describe('PageChangePassword', () => {
     await render(mockAccount);
     await changePassword();
     await waitFor(() =>
-      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1)
+      expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1)
     );
     expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledWith(
       'Unexpected error'
@@ -146,7 +146,7 @@ describe('PageChangePassword', () => {
     await render();
     await changePassword();
     await waitFor(() =>
-      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1)
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledTimes(1)
     );
     expect(mockNavigate).toHaveBeenCalledWith(SETTINGS_PATH + '#password', {
       replace: true,

--- a/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDisplayName/index.test.tsx
@@ -112,5 +112,5 @@ it('displays a general error in the alert bar', async () => {
   );
 
   await submitDisplayName('John Nope');
-  expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
+  expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1);
 });

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.test.tsx
@@ -32,7 +32,7 @@ describe('Recent Account Activity', () => {
     expect(screen.getByTestId('flow-container')).toBeInTheDocument();
     expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
 
-    expect(account.getSecurityEvents).toBeCalled();
+    expect(account.getSecurityEvents).toHaveBeenCalled();
 
     expect(
       screen.getByRole('heading', {

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneRemove/index.test.tsx
@@ -112,7 +112,7 @@ describe('PageRecoveryPhoneRemove', () => {
       );
     });
 
-    expect(account.removeRecoveryPhone).toBeCalled();
+    expect(account.removeRecoveryPhone).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('/settings#security', {
       replace: true,
     });

--- a/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageTwoStepAuthentication/index.test.tsx
@@ -192,7 +192,7 @@ describe('step 2', () => {
       'download',
       expect.stringContaining('Backup authentication codes')
     );
-    expect(GleanMetrics.accountPref.twoStepAuthCodesView).toBeCalled();
+    expect(GleanMetrics.accountPref.twoStepAuthCodesView).toHaveBeenCalled();
   });
 
   it('shows an error when an invalid auth code is entered', async () => {
@@ -230,7 +230,9 @@ describe('step 3', () => {
   it('renders the backup authentication code form', async () => {
     await getRecoveryCodes();
     expect(screen.getByTestId('recovery-code-input-field')).toBeInTheDocument();
-    expect(GleanMetrics.accountPref.twoStepAuthEnterCodeView).toBeCalled();
+    expect(
+      GleanMetrics.accountPref.twoStepAuthEnterCodeView
+    ).toHaveBeenCalled();
   });
 
   it('shows an error when an incorrect backup authentication code is entered', async () => {
@@ -330,7 +332,7 @@ describe('step 3', () => {
     await act(async () => {
       await fireEvent.click(screen.getByTestId('submit-recovery-code'));
     });
-    expect(getCode).toBeCalledTimes(1);
+    expect(getCode).toHaveBeenCalledTimes(1);
     expect(
       GleanMetrics.accountPref.twoStepAuthQrCodeSuccess
     ).toHaveBeenCalled();
@@ -400,19 +402,19 @@ describe('metrics', () => {
       await fireEvent.click(screen.getByTestId('submit-recovery-code'));
     });
 
-    expect(mockLogPageViewEvent).toBeCalledTimes(2);
+    expect(mockLogPageViewEvent).toHaveBeenCalledTimes(2);
     expect(mockLogPageViewEvent).toHaveBeenCalledWith(metricsPreInPostFix);
     expect(mockLogPageViewEvent).toHaveBeenCalledWith(
       `${metricsPreInPostFix}.recovery-codes`
     );
 
-    expect(mockLogViewEvent).toBeCalledTimes(1);
+    expect(mockLogViewEvent).toHaveBeenCalledTimes(1);
     expect(mockLogViewEvent).toHaveBeenCalledWith(
       metricsPreInPostFix,
       'submit'
     );
 
-    expect(logViewEventSpy).toBeCalledTimes(3);
+    expect(logViewEventSpy).toHaveBeenCalledTimes(3);
     expect(logViewEventSpy).toHaveBeenCalledWith(
       `flow.${metricsPreInPostFix}.recovery-codes`,
       `print-option`

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
@@ -121,7 +121,7 @@ describe('UnitRowSecondaryEmail', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('secondary-email-refresh'));
       });
-      expect(account.refresh).toBeCalledWith('account');
+      expect(account.refresh).toHaveBeenCalledWith('account');
     });
   });
 
@@ -248,7 +248,7 @@ describe('UnitRowSecondaryEmail', () => {
           screen.getByTestId('secondary-email-resend-code-button')
         );
       });
-      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -275,8 +275,8 @@ describe('UnitRowSecondaryEmail', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('secondary-email-make-primary'));
       });
-      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1);
-      expect(settingsContext.alertBarInfo?.success).toBeCalledWith(
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledWith(
         'johndope2@example.com is now your primary email'
       );
     });
@@ -303,7 +303,7 @@ describe('UnitRowSecondaryEmail', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('secondary-email-make-primary'));
       });
-      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -332,8 +332,8 @@ describe('UnitRowSecondaryEmail', () => {
         fireEvent.click(screen.getByTestId('secondary-email-delete'));
       });
 
-      expect(settingsContext.alertBarInfo?.success).toBeCalledTimes(1);
-      expect(settingsContext.alertBarInfo?.success).toBeCalledWith(
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.success).toHaveBeenCalledWith(
         'johndope2@example.com successfully deleted'
       );
     });
@@ -360,7 +360,7 @@ describe('UnitRowSecondaryEmail', () => {
       await act(async () => {
         fireEvent.click(screen.getByTestId('secondary-email-delete'));
       });
-      expect(settingsContext.alertBarInfo?.error).toBeCalledTimes(1);
+      expect(settingsContext.alertBarInfo?.error).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -76,13 +76,13 @@ describe('ThirdPartyAuthComponent', () => {
     renderWith({
       enabled: true,
       flowQueryParams: {
-        flowId: '123'
-      }
+        flowId: '123',
+      },
     });
 
     await screen.findByText('Continue with Google');
     await screen.findByText('Continue with Apple');
-    expect(mockFormSubmit).not.toBeCalled();
+    expect(mockFormSubmit).not.toHaveBeenCalled();
 
     expect(
       (await screen.findByTestId('google-signin-form-state')).getAttribute(
@@ -114,8 +114,8 @@ describe('ThirdPartyAuthComponent', () => {
         'value'
       )
     ).not.toEqual('');
-    expect(onContinueWithApple).toBeCalled();
-    expect(onContinueWithGoogle).not.toBeCalled();
+    expect(onContinueWithApple).toHaveBeenCalled();
+    expect(onContinueWithGoogle).not.toHaveBeenCalled();
   });
 
   it('submits google form', async () => {
@@ -135,8 +135,8 @@ describe('ThirdPartyAuthComponent', () => {
         'value'
       )
     ).not.toEqual('');
-    expect(onContinueWithGoogle).toBeCalled();
-    expect(onContinueWithApple).not.toBeCalled();
+    expect(onContinueWithGoogle).toHaveBeenCalled();
+    expect(onContinueWithApple).not.toHaveBeenCalled();
   });
 
   it('should deeplink directly to google auth, if deeplink=`googleLogin`', async () => {
@@ -144,7 +144,7 @@ describe('ThirdPartyAuthComponent', () => {
       enabled: true,
       showSeparator: false,
       deeplink: 'googleLogin',
-      view: 'index'
+      view: 'index',
     });
 
     expect(
@@ -152,14 +152,14 @@ describe('ThirdPartyAuthComponent', () => {
         'value'
       )
     ).not.toEqual('');
-  })
+  });
 
   it('should deeplink directly to apple auth, if deeplink=`appleLogin`', async () => {
     renderWith({
       enabled: true,
       showSeparator: false,
       deeplink: 'appleLogin',
-      view: 'index'
+      view: 'index',
     });
 
     expect(
@@ -167,7 +167,7 @@ describe('ThirdPartyAuthComponent', () => {
         'value'
       )
     ).not.toEqual('');
-  })
+  });
 
   it('hides separator', async () => {
     renderWith({
@@ -178,7 +178,7 @@ describe('ThirdPartyAuthComponent', () => {
     });
 
     expect(screen.queryByText('Or')).toBeNull();
-    expect(mockViewWithNoPasswordSet).toBeCalled();
+    expect(mockViewWithNoPasswordSet).toHaveBeenCalled();
   });
 
   it('shows separator', async () => {
@@ -190,7 +190,7 @@ describe('ThirdPartyAuthComponent', () => {
     });
 
     expect(screen.queryByText('Or')).toBeDefined();
-    expect(mockViewWithNoPasswordSet).not.toBeCalled();
+    expect(mockViewWithNoPasswordSet).not.toHaveBeenCalled();
   });
 
   describe('emits metrics', () => {
@@ -201,7 +201,7 @@ describe('ThirdPartyAuthComponent', () => {
         onContinueWithApple,
         onContinueWithGoogle,
       });
-      expect(mockViewWithNoPasswordSet).toBeCalled();
+      expect(mockViewWithNoPasswordSet).toHaveBeenCalled();
     });
 
     it('emits glean metrics startGoogleAuthFromIndex', async () => {
@@ -214,8 +214,8 @@ describe('ThirdPartyAuthComponent', () => {
       });
       const button = await screen.findByText('Continue with Google');
       button.click();
-      expect(mockStartGoogleAuthFromIndex).toBeCalled();
-      expect(mockGleanIsDone).toBeCalled();
+      expect(mockStartGoogleAuthFromIndex).toHaveBeenCalled();
+      expect(mockGleanIsDone).toHaveBeenCalled();
     });
 
     it('emits glean metrics startAppleAuthFromIndex', async () => {
@@ -228,7 +228,7 @@ describe('ThirdPartyAuthComponent', () => {
       });
       const button = await screen.findByText('Continue with Apple');
       button.click();
-      expect(mockStartAppleAuthFromIndex).toBeCalled();
+      expect(mockStartAppleAuthFromIndex).toHaveBeenCalled();
     });
 
     it('emits glean metrics startGoogleAuthFromLogin', async () => {
@@ -241,8 +241,8 @@ describe('ThirdPartyAuthComponent', () => {
       });
       const button = await screen.findByText('Continue with Google');
       button.click();
-      expect(mockStartGoogleAuthFromLogin).toBeCalled();
-      expect(mockGleanIsDone).toBeCalled();
+      expect(mockStartGoogleAuthFromLogin).toHaveBeenCalled();
+      expect(mockGleanIsDone).toHaveBeenCalled();
     });
 
     it('emits glean metrics startAppleAuthFromLogin', async () => {
@@ -255,7 +255,7 @@ describe('ThirdPartyAuthComponent', () => {
       });
       const button = await screen.findByText('Continue with Apple');
       button.click();
-      expect(mockStartAppleAuthFromLogin).toBeCalled();
+      expect(mockStartAppleAuthFromLogin).toHaveBeenCalled();
     });
 
     it('emits glean metrics startGoogleAuthFromReg', async () => {
@@ -268,8 +268,8 @@ describe('ThirdPartyAuthComponent', () => {
       });
       const button = await screen.findByText('Continue with Google');
       button.click();
-      expect(mockStartGoogleAuthFromReg).toBeCalled();
-      expect(mockGleanIsDone).toBeCalled();
+      expect(mockStartGoogleAuthFromReg).toHaveBeenCalled();
+      expect(mockGleanIsDone).toHaveBeenCalled();
     });
 
     it('emits glean metrics startAppleAuthFromReg', async () => {
@@ -282,8 +282,8 @@ describe('ThirdPartyAuthComponent', () => {
       });
       const button = await screen.findByText('Continue with Apple');
       button.click();
-      expect(mockStartAppleAuthFromReg).toBeCalled();
-      expect(mockGleanIsDone).toBeCalled();
+      expect(mockStartAppleAuthFromReg).toHaveBeenCalled();
+      expect(mockGleanIsDone).toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/CannotCreateAccount/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CannotCreateAccount/index.test.tsx
@@ -45,6 +45,6 @@ describe('CannotCreateAccount', () => {
       'href',
       'https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy'
     );
-    expect(GleanMetrics.registration.ageInvalid).toBeCalledTimes(1);
+    expect(GleanMetrics.registration.ageInvalid).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
+++ b/packages/fxa-settings/src/pages/CookiesDisabled/index.test.tsx
@@ -131,13 +131,13 @@ describe('CookiesDisabled', () => {
 
         renderWithLocalizationProvider(<CookiesDisabled />);
         fireEvent.click(getTryAgainButton());
-        expect(mockHistoryGo).toBeCalledWith(-2);
+        expect(mockHistoryGo).toHaveBeenCalledWith(-2);
       });
 
       it('when hit directly', () => {
         renderWithLocalizationProvider(<CookiesDisabled />);
         fireEvent.click(getTryAgainButton());
-        expect(mockHistoryBack).toBeCalled();
+        expect(mockHistoryBack).toHaveBeenCalled();
       });
     });
 

--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -191,7 +191,10 @@ describe('IndexContainer', () => {
       </LocationProvider>
     );
     expect(container).toBeDefined();
-    expect(mockUseValidatedQueryParams).toBeCalledWith(IndexQueryParams, false);
+    expect(mockUseValidatedQueryParams).toHaveBeenCalledWith(
+      IndexQueryParams,
+      false
+    );
   });
 
   it('should render the Index component when no redirection is required', async () => {
@@ -203,7 +206,7 @@ describe('IndexContainer', () => {
       </LocationProvider>
     );
     expect(container).toBeDefined();
-    expect(IndexModule.default).toBeCalled();
+    expect(IndexModule.default).toHaveBeenCalled();
     await waitFor(() => {
       expect(currentIndexProps?.prefillEmail).toBe(undefined);
     });
@@ -219,7 +222,7 @@ describe('IndexContainer', () => {
       </LocationProvider>
     );
     expect(container).toBeDefined();
-    expect(IndexModule.default).toBeCalled();
+    expect(IndexModule.default).toHaveBeenCalled();
     await waitFor(() => {
       expect(currentIndexProps?.prefillEmail).toBe(MOCK_EMAIL);
     });
@@ -234,13 +237,16 @@ describe('IndexContainer', () => {
     });
 
     // simulate rejecting from auth client after a delay
-    const rejectingMock = jest.fn(() => new Promise((_, reject) => {
-      setTimeout(() => reject('mock delayed error'), 50);
-    }));
+    const rejectingMock = jest.fn(
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject('mock delayed error'), 50);
+        })
+    );
 
     mockUseAuthClient.mockReturnValue({
       accountStatusByEmail: rejectingMock,
-    })
+    });
 
     const { getByText, queryByText } = renderWithLocalizationProvider(
       <LocationProvider>
@@ -279,7 +285,7 @@ describe('IndexContainer', () => {
         </LocationProvider>
       );
       expect(container).toBeDefined();
-      expect(IndexModule.default).toBeCalled();
+      expect(IndexModule.default).toHaveBeenCalled();
       await waitFor(() => {
         expect(currentIndexProps?.prefillEmail).not.toBe('test@example.com');
         expect(currentIndexProps?.prefillEmail).toBe(MOCK_EMAIL);

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.test.tsx
@@ -117,7 +117,7 @@ describe('InlineRecoveryKeySetupContainer', () => {
     expect(hardNavigateSpy).toHaveBeenCalledWith(
       '/pair?showSuccessMessage=true'
     );
-    expect(InlineRecoveryKeySetupModule.default).not.toBeCalled();
+    expect(InlineRecoveryKeySetupModule.default).not.toHaveBeenCalled();
   });
 
   it('gets data from sensitive data client, renders component', async () => {
@@ -129,7 +129,7 @@ describe('InlineRecoveryKeySetupContainer', () => {
     expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
       SensitiveData.Key.Auth
     );
-    expect(InlineRecoveryKeySetupModule.default).toBeCalled();
+    expect(InlineRecoveryKeySetupModule.default).toHaveBeenCalled();
   });
 
   it('createRecoveryKey calls expected authClient methods', async () => {

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.test.tsx
@@ -320,7 +320,7 @@ describe('InlineRecoverySetupContainer', () => {
           const successfulSetupHandler = args.successfulSetupHandler;
           await successfulSetupHandler();
 
-          expect(hardNavigateSpy).toBeCalledWith(
+          expect(hardNavigateSpy).toHaveBeenCalledWith(
             MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect
           );
         });

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
@@ -63,7 +63,7 @@ describe('InlineRecoverySetup', () => {
       screen.getByRole('button', { name: 'Continue' })
     ).toBeInTheDocument();
 
-    expect(GleanMetrics.accountPref.twoStepAuthCodesView).toBeCalled();
+    expect(GleanMetrics.accountPref.twoStepAuthCodesView).toHaveBeenCalled();
   });
 
   it('renders as expected with a custom service name', () => {
@@ -95,7 +95,9 @@ describe('InlineRecoverySetup', () => {
     screen.getByRole('button', { name: 'Confirm' });
     screen.getByRole('button', { name: 'Back' });
     screen.getByRole('button', { name: 'Cancel setup' });
-    expect(GleanMetrics.accountPref.twoStepAuthEnterCodeView).toBeCalled();
+    expect(
+      GleanMetrics.accountPref.twoStepAuthEnterCodeView
+    ).toHaveBeenCalled();
   });
 
   it('renders "showConfirmation" content as expected with a custom service name', async () => {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -226,10 +226,10 @@ describe('InlineTotpSetupContainer', () => {
 
       render();
       await waitFor(() => {
-        expect(mockTotpStatusQuery).toBeCalled();
+        expect(mockTotpStatusQuery).toHaveBeenCalled();
       });
       screen.getByLabelText('Loading…');
-      expect(InlineTotpSetupModule.default).not.toBeCalled();
+      expect(InlineTotpSetupModule.default).not.toHaveBeenCalled();
     });
 
     it('invokes InlineTotpSetup with the correct props', async () => {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -152,6 +152,6 @@ describe('InlineTotpSetup', () => {
         await user.click(screen.getByRole('button', { name: 'Ready' }))
     );
     await screen.findByText('Invalid two-step authentication code');
-    expect(verifyCodeHandler).toBeCalledWith('000000');
+    expect(verifyCodeHandler).toHaveBeenCalledWith('000000');
   });
 });

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.test.tsx
@@ -175,7 +175,7 @@ describe('ThirdPartyAuthCallback component', () => {
       );
     });
 
-    expect(hardNavigateSpy).toBeCalledWith(
+    expect(hardNavigateSpy).toHaveBeenCalledWith(
       '/post_verify/third_party_auth/callback?flowId=aaaa&flowBeginTime=1734112296000&utm_campaign=testo'
     );
   });
@@ -195,7 +195,7 @@ describe('ThirdPartyAuthCallback component', () => {
 
     renderWith({ integration });
 
-    expect(hardNavigateSpy).toBeCalledWith(
+    expect(hardNavigateSpy).toHaveBeenCalledWith(
       '/?flowId=aaaa&flowBeginTime=1734112296000&utm_campaign=testo'
     );
   });
@@ -212,7 +212,7 @@ describe('ThirdPartyAuthCallback component', () => {
     renderWith({ integration });
 
     await waitFor(() => {
-      expect(handleNavigation).toBeCalledWith({
+      expect(handleNavigation).toHaveBeenCalledWith({
         email: 'johndope@example.com',
         finishOAuthFlowHandler: mockFinishOAuthFlowHandler,
         handleFxaLogin: false,

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.test.tsx
@@ -61,7 +61,7 @@ describe('ResetPassword', () => {
 
       await waitFor(() => user.click(screen.getByRole('button')));
 
-      expect(mockRequestResetPasswordCode).toBeCalledWith(MOCK_EMAIL);
+      expect(mockRequestResetPasswordCode).toHaveBeenCalledWith(MOCK_EMAIL);
 
       expect(GleanMetrics.passwordReset.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.passwordReset.submit).toHaveBeenCalledTimes(1);
@@ -81,7 +81,7 @@ describe('ResetPassword', () => {
 
       await waitFor(() => user.click(screen.getByRole('button')));
 
-      expect(mockRequestResetPasswordCode).toBeCalledWith(MOCK_EMAIL);
+      expect(mockRequestResetPasswordCode).toHaveBeenCalledWith(MOCK_EMAIL);
       expect(GleanMetrics.passwordReset.view).toHaveBeenCalledTimes(1);
       expect(GleanMetrics.passwordReset.submit).toHaveBeenCalledTimes(1);
     });
@@ -97,7 +97,7 @@ describe('ResetPassword', () => {
         await waitFor(() => user.click(screen.getByRole('button')));
 
         expect(screen.getByText('Valid email required')).toBeVisible();
-        expect(mockRequestResetPasswordCode).not.toBeCalled();
+        expect(mockRequestResetPasswordCode).not.toHaveBeenCalled();
         expect(GleanMetrics.passwordReset.view).toHaveBeenCalledTimes(1);
         expect(GleanMetrics.passwordReset.submit).not.toHaveBeenCalled();
       });
@@ -114,7 +114,7 @@ describe('ResetPassword', () => {
         await waitFor(() => user.click(screen.getByRole('button')));
 
         expect(screen.getByText('Valid email required')).toBeVisible();
-        expect(mockRequestResetPasswordCode).not.toBeCalled();
+        expect(mockRequestResetPasswordCode).not.toHaveBeenCalled();
         expect(GleanMetrics.passwordReset.view).toHaveBeenCalledTimes(1);
         expect(GleanMetrics.passwordReset.submit).not.toHaveBeenCalled();
       });

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/container.test.tsx
@@ -97,8 +97,8 @@ describe('ResetPasswordRecoveryChoice container', () => {
     it('redirects if page is reached without location state', async () => {
       mockReachRouter('reset_password_totp_recovery_choice');
       render();
-      expect(ResetPasswordRecoveryChoiceModule.default).not.toBeCalled();
-      expect(mockNavigate).toBeCalledWith('/reset_password');
+      expect(ResetPasswordRecoveryChoiceModule.default).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/reset_password');
     });
   });
 
@@ -112,14 +112,14 @@ describe('ResetPasswordRecoveryChoice container', () => {
         expect(
           mockAuthClient.recoveryPhoneGetWithPasswordForgotToken
         ).toHaveBeenCalled();
-        expect(ResetPasswordRecoveryChoiceModule.default).toBeCalled();
+        expect(ResetPasswordRecoveryChoiceModule.default).toHaveBeenCalled();
       });
     });
 
     it('passes the correct props to the child component', async () => {
       render();
       await waitFor(() => {
-        expect(ResetPasswordRecoveryChoiceModule.default).toBeCalledWith(
+        expect(ResetPasswordRecoveryChoiceModule.default).toHaveBeenCalledWith(
           expect.objectContaining({
             lastFourPhoneDigits: '1234',
             numBackupCodes: 3,
@@ -142,8 +142,10 @@ describe('ResetPasswordRecoveryChoice container', () => {
         expect(
           mockAuthClient.recoveryPhoneGetWithPasswordForgotToken
         ).toHaveBeenCalled();
-        expect(ResetPasswordRecoveryChoiceModule.default).not.toBeCalled();
-        expect(mockNavigate).toBeCalledWith(
+        expect(
+          ResetPasswordRecoveryChoiceModule.default
+        ).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith(
           '/confirm_backup_code_reset_password',
           {
             replace: true,

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/index.test.tsx
@@ -122,13 +122,16 @@ describe('ResetPasswordRecoveryChoice', () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toBeCalledWith('/reset_password_recovery_phone', {
-        state: {
-          ...fakeState,
-          lastFourPhoneDigits: '1234',
-          numBackupCodes: 4,
-        },
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/reset_password_recovery_phone',
+        {
+          state: {
+            ...fakeState,
+            lastFourPhoneDigits: '1234',
+            numBackupCodes: 4,
+          },
+        }
+      );
     });
   });
 
@@ -150,7 +153,7 @@ describe('ResetPasswordRecoveryChoice', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(
         'There was a problem sending a code to your recovery phone'
       );
-      expect(mockNavigate).not.toBeCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 
@@ -164,7 +167,7 @@ describe('ResetPasswordRecoveryChoice', () => {
     user.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
-      expect(mockNavigate).toBeCalledWith(
+      expect(mockNavigate).toHaveBeenCalledWith(
         '/confirm_backup_code_reset_password',
         {
           state: fakeState,
@@ -184,7 +187,9 @@ describe('ResetPasswordRecoveryChoice', () => {
           level: 2,
         })
       ).toBeInTheDocument();
-      expect(GleanMetrics.passwordReset.backupChoiceView).toBeCalledTimes(1);
+      expect(GleanMetrics.passwordReset.backupChoiceView).toHaveBeenCalledTimes(
+        1
+      );
     });
 
     it('sends the correct metric when Recovery phone option is selected', async () => {
@@ -197,7 +202,9 @@ describe('ResetPasswordRecoveryChoice', () => {
       user.click(screen.getByRole('button', { name: 'Continue' }));
 
       await waitFor(() =>
-        expect(GleanMetrics.passwordReset.backupChoiceSubmit).toBeCalledWith({
+        expect(
+          GleanMetrics.passwordReset.backupChoiceSubmit
+        ).toHaveBeenCalledWith({
           event: { reason: 'phone' },
         })
       );
@@ -213,7 +220,9 @@ describe('ResetPasswordRecoveryChoice', () => {
       user.click(screen.getByRole('button', { name: 'Continue' }));
 
       await waitFor(() =>
-        expect(GleanMetrics.passwordReset.backupChoiceSubmit).toBeCalledWith({
+        expect(
+          GleanMetrics.passwordReset.backupChoiceSubmit
+        ).toHaveBeenCalledWith({
           event: { reason: 'code' },
         })
       );

--- a/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/ReportSignin/container.test.tsx
@@ -102,7 +102,7 @@ describe('ReportSigninContainer', () => {
   describe('default state', () => {
     it('renders component', async () => {
       await render();
-      expect(ReportSigninModule.ReportSignin).toBeCalled();
+      expect(ReportSigninModule.ReportSignin).toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.test.tsx
@@ -98,7 +98,7 @@ function mockSigninPushCodeModule() {
 }
 
 function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => { });
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
 // Set this when testing local storage
@@ -140,40 +140,40 @@ describe('SigninPushCode container', () => {
         mockLocationState = createMockSigninLocationState();
         render();
         await waitFor(() => {
-          expect(CacheModule.currentAccount).not.toBeCalled();
+          expect(CacheModule.currentAccount).not.toHaveBeenCalled();
         });
         expect(currentSigninPushCodeProps?.signinState.email).toBe(MOCK_EMAIL);
-        expect(SigninPushCodeModule.default).toBeCalled();
+        expect(SigninPushCodeModule.default).toHaveBeenCalled();
       });
       it('router state takes precedence over local storage', async () => {
         mockLocationState = createMockSigninLocationState();
         render();
-        expect(CacheModule.currentAccount).not.toBeCalled();
+        expect(CacheModule.currentAccount).not.toHaveBeenCalled();
         await waitFor(() => {
           expect(currentSigninPushCodeProps?.signinState.email).toBe(
             MOCK_EMAIL
           );
         });
-        expect(SigninPushCodeModule.default).toBeCalled();
+        expect(SigninPushCodeModule.default).toHaveBeenCalled();
       });
       it('is read from localStorage if email is not provided via router state', async () => {
         mockLocationState = {};
         mockCurrentAccount(MOCK_STORED_ACCOUNT);
         render();
-        expect(CacheModule.currentAccount).toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
         await waitFor(() => {
           expect(currentSigninPushCodeProps?.signinState.email).toBe(
             MOCK_STORED_ACCOUNT.email
           );
         });
-        expect(SigninPushCodeModule.default).toBeCalled();
+        expect(SigninPushCodeModule.default).toHaveBeenCalled();
       });
       it('is handled if not provided in location state or local storage', async () => {
         mockLocationState = {};
         render();
-        expect(CacheModule.currentAccount).toBeCalled();
-        expect(mockNavigate).toBeCalledWith('/');
-        expect(SigninPushCodeModule.default).not.toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+        expect(SigninPushCodeModule.default).not.toHaveBeenCalled();
       });
     });
 
@@ -187,7 +187,7 @@ describe('SigninPushCode container', () => {
         render();
 
         await waitFor(() => {
-          expect(mockNavigate).toBeCalledWith('/signin_totp_code', {
+          expect(mockNavigate).toHaveBeenCalledWith('/signin_totp_code', {
             state: mockLocationState,
           });
         });
@@ -198,7 +198,7 @@ describe('SigninPushCode container', () => {
         render();
 
         await waitFor(() => {
-          expect(mockNavigate).not.toBeCalled();
+          expect(mockNavigate).not.toHaveBeenCalled();
         });
       });
     });
@@ -214,7 +214,7 @@ describe('SigninPushCode container', () => {
       mockLocationState = createMockSigninLocationState();
       render();
 
-      await waitFor(() => expect(mockSendLoginPushRequest).toBeCalled());
+      await waitFor(() => expect(mockSendLoginPushRequest).toHaveBeenCalled());
     });
 
     it('navigates when session verified', async () => {
@@ -223,7 +223,7 @@ describe('SigninPushCode container', () => {
       render();
 
       await waitFor(() =>
-        expect(ReactUtils.hardNavigate).toBeCalledWith(
+        expect(ReactUtils.hardNavigate).toHaveBeenCalledWith(
           '/pair?showSuccessMessage=true',
           undefined,
           undefined,

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCodeConfirm/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCodeConfirm/container.test.tsx
@@ -74,7 +74,7 @@ describe('SigninPushCodeConfirm container', () => {
     render();
     fireEvent.click(screen.getByText('Confirm login'));
     await waitFor(() => {
-      expect(mockVerifyLoginPushRequest).toBeCalledWith(
+      expect(mockVerifyLoginPushRequest).toHaveBeenCalledWith(
         null,
         MOCK_HEXSTRING_32,
         '123456'

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.test.tsx
@@ -102,7 +102,7 @@ function applyDefaultMocks() {
 function render() {
   renderWithLocalizationProvider(
     <LocationProvider>
-      <SigninRecoveryChoiceContainer {...{integration}}/>
+      <SigninRecoveryChoiceContainer {...{ integration }} />
     </LocationProvider>
   );
 }
@@ -117,24 +117,24 @@ describe('SigninRecoveryChoice container', () => {
       mockReachRouter('signin_recovery_choice');
       mockCache({}, true);
       await render();
-      expect(SigninRecoveryChoiceModule.default).not.toBeCalled();
-      expect(mockNavigate).toBeCalledWith('/signin');
+      expect(SigninRecoveryChoiceModule.default).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/signin');
     });
 
     it('redirects if there is no sessionToken', async () => {
       mockReachRouter('signin_recovery_choice');
       mockCache({ sessionToken: '' });
       await render();
-      expect(SigninRecoveryChoiceModule.default).not.toBeCalled();
-      expect(mockNavigate).toBeCalledWith('/signin');
+      expect(SigninRecoveryChoiceModule.default).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/signin');
     });
 
     it('retrieves the session token from local storage if no location state', async () => {
       mockReachRouter('signin_recovery_choice', {});
       mockCache(MOCK_STORED_ACCOUNT);
       await waitFor(() => render());
-      expect(mockNavigate).not.toBeCalled();
-      expect(SigninRecoveryChoiceModule.default).toBeCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(SigninRecoveryChoiceModule.default).toHaveBeenCalled();
     });
   });
 
@@ -144,14 +144,14 @@ describe('SigninRecoveryChoice container', () => {
       await waitFor(() => {
         expect(mockAuthClient.getRecoveryCodesExist).toHaveBeenCalled();
         expect(mockAuthClient.recoveryPhoneGet).toHaveBeenCalled();
-        expect(SigninRecoveryChoiceModule.default).toBeCalled();
+        expect(SigninRecoveryChoiceModule.default).toHaveBeenCalled();
       });
     });
 
     it('passes the correct props to the child component', async () => {
       render();
       await waitFor(() => {
-        expect(SigninRecoveryChoiceModule.default).toBeCalledWith(
+        expect(SigninRecoveryChoiceModule.default).toHaveBeenCalledWith(
           expect.objectContaining({
             lastFourPhoneDigits: '1234',
             numBackupCodes: 3,
@@ -170,8 +170,8 @@ describe('SigninRecoveryChoice container', () => {
       await waitFor(() => {
         expect(mockAuthClient.getRecoveryCodesExist).toHaveBeenCalled();
         expect(mockAuthClient.recoveryPhoneGet).toHaveBeenCalled();
-        expect(SigninRecoveryChoiceModule.default).not.toBeCalled();
-        expect(mockNavigate).toBeCalledWith('/signin_recovery_code', {
+        expect(SigninRecoveryChoiceModule.default).not.toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('/signin_recovery_code', {
           replace: true,
           state: { signinState: mockSigninLocationState },
         });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.test.tsx
@@ -114,7 +114,7 @@ describe('SigninRecoveryChoice', () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toBeCalledWith('/signin_recovery_phone', {
+      expect(mockNavigate).toHaveBeenCalledWith('/signin_recovery_phone', {
         state: {
           signinState: MOCK_SIGNIN_LOCATION_STATE,
           lastFourPhoneDigits: '1234',
@@ -140,7 +140,7 @@ describe('SigninRecoveryChoice', () => {
       expect(screen.getByRole('alert')).toHaveTextContent(
         'There was a problem sending a code to your recovery phone'
       );
-      expect(mockNavigate).not.toBeCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 
@@ -154,7 +154,7 @@ describe('SigninRecoveryChoice', () => {
     user.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
-      expect(mockNavigate).toBeCalledWith('/signin_recovery_code', {
+      expect(mockNavigate).toHaveBeenCalledWith('/signin_recovery_code', {
         state: {
           signinState: MOCK_SIGNIN_LOCATION_STATE,
           lastFourPhoneDigits: '1234',
@@ -174,7 +174,7 @@ describe('SigninRecoveryChoice', () => {
           level: 2,
         })
       ).toBeInTheDocument();
-      expect(GleanMetrics.login.backupChoiceView).toBeCalledTimes(1);
+      expect(GleanMetrics.login.backupChoiceView).toHaveBeenCalledTimes(1);
     });
 
     it('sends the correct metric when Recovery phone option is selected', async () => {
@@ -187,7 +187,7 @@ describe('SigninRecoveryChoice', () => {
       user.click(screen.getByRole('button', { name: 'Continue' }));
 
       await waitFor(() =>
-        expect(GleanMetrics.login.backupChoiceSubmit).toBeCalledWith({
+        expect(GleanMetrics.login.backupChoiceSubmit).toHaveBeenCalledWith({
           event: { reason: 'phone' },
         })
       );
@@ -203,7 +203,7 @@ describe('SigninRecoveryChoice', () => {
       user.click(screen.getByRole('button', { name: 'Continue' }));
 
       await waitFor(() =>
-        expect(GleanMetrics.login.backupChoiceSubmit).toBeCalledWith({
+        expect(GleanMetrics.login.backupChoiceSubmit).toHaveBeenCalledWith({
           event: { reason: 'code' },
         })
       );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.test.tsx
@@ -142,21 +142,21 @@ describe('SigninRecoveryCode container', () => {
       mockReachRouter('signin_recovery_code');
       mockCache({}, true);
       await render([]);
-      expect(mockNavigate).toBeCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
 
     it('redirects if there is no sessionToken', async () => {
       mockReachRouter('signin_recovery_code');
       mockCache({ sessionToken: '' });
       await render([]);
-      expect(mockNavigate).toBeCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
 
     it('retrieves the session token from local storage if no location state', async () => {
       mockReachRouter('signin_recovery_code', {});
       mockCache(MOCK_STORED_ACCOUNT);
       await render([]);
-      expect(mockNavigate).not.toBeCalledWith('/');
+      expect(mockNavigate).not.toHaveBeenCalledWith('/');
     });
 
     it('reads data from sensitive data client', () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.test.tsx
@@ -152,7 +152,7 @@ describe('PageSigninRecoveryCode', () => {
           />
         </LocationProvider>
       );
-      expect(GleanMetrics.loginBackupCode.view).toBeCalledTimes(1);
+      expect(GleanMetrics.loginBackupCode.view).toHaveBeenCalledTimes(1);
     });
 
     it('emits metrics events on submit and success', async () => {
@@ -181,8 +181,8 @@ describe('PageSigninRecoveryCode', () => {
 
       await waitFor(() => {
         expect(mockSubmitRecoveryCode).toHaveBeenCalled();
-        expect(GleanMetrics.loginBackupCode.submit).toBeCalledTimes(1);
-        expect(GleanMetrics.loginBackupCode.success).toBeCalledTimes(1);
+        expect(GleanMetrics.loginBackupCode.submit).toHaveBeenCalledTimes(1);
+        expect(GleanMetrics.loginBackupCode.success).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.test.tsx
@@ -134,41 +134,41 @@ describe('SigninTokenCode container', () => {
           expect(screen.getByText('signin token code mock')).toBeInTheDocument()
         );
         await waitFor(() => {
-          expect(CacheModule.currentAccount).not.toBeCalled();
+          expect(CacheModule.currentAccount).not.toHaveBeenCalled();
         });
         expect(currentSigninTokenCodeProps?.signinState.email).toBe(MOCK_EMAIL);
         expect(currentSigninTokenCodeProps?.integration).toBe(integration);
-        expect(SigninTokenCodeModule.default).toBeCalled();
+        expect(SigninTokenCodeModule.default).toHaveBeenCalled();
       });
       it('router state takes precedence over local storage', async () => {
         mockLocationState = createMockSigninLocationState();
         render([]);
-        expect(CacheModule.currentAccount).not.toBeCalled();
+        expect(CacheModule.currentAccount).not.toHaveBeenCalled();
         await waitFor(() => {
           expect(currentSigninTokenCodeProps?.signinState.email).toBe(
             MOCK_EMAIL
           );
         });
-        expect(SigninTokenCodeModule.default).toBeCalled();
+        expect(SigninTokenCodeModule.default).toHaveBeenCalled();
       });
       it('is read from localStorage if email is not provided via router state', async () => {
         mockLocationState = {};
         mockCurrentAccount(MOCK_STORED_ACCOUNT);
         render([]);
-        expect(CacheModule.currentAccount).toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
         await waitFor(() => {
           expect(currentSigninTokenCodeProps?.signinState.email).toBe(
             MOCK_STORED_ACCOUNT.email
           );
         });
-        expect(SigninTokenCodeModule.default).toBeCalled();
+        expect(SigninTokenCodeModule.default).toHaveBeenCalled();
       });
       it('is handled if not provided in location state or local storage', async () => {
         mockLocationState = {};
         render([]);
-        expect(CacheModule.currentAccount).toBeCalled();
-        expect(mockNavigate).toBeCalledWith('/');
-        expect(SigninTokenCodeModule.default).not.toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+        expect(SigninTokenCodeModule.default).not.toHaveBeenCalled();
       });
     });
 
@@ -182,7 +182,7 @@ describe('SigninTokenCode container', () => {
         render([]);
 
         await waitFor(() => {
-          expect(mockNavigate).toBeCalledWith('/signin_totp_code', {
+          expect(mockNavigate).toHaveBeenCalledWith('/signin_totp_code', {
             state: mockLocationState,
           });
         });
@@ -193,7 +193,7 @@ describe('SigninTokenCode container', () => {
         render([]);
 
         await waitFor(() => {
-          expect(mockNavigate).not.toBeCalled();
+          expect(mockNavigate).not.toHaveBeenCalled();
         });
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.test.tsx
@@ -18,7 +18,10 @@ import { createOAuthNativeIntegration, Subject } from './mocks';
 import { MOCK_SIGNUP_CODE } from '../../Signup/ConfirmSignupCode/mocks';
 import { MOCK_EMAIL, MOCK_OAUTH_FLOW_HANDLER_RESPONSE } from '../../mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { createMockSigninOAuthIntegration, createMockSigninWebIntegration } from '../mocks';
+import {
+  createMockSigninOAuthIntegration,
+  createMockSigninWebIntegration,
+} from '../mocks';
 import VerificationReasons from '../../../constants/verification-reasons';
 import { navigate } from '@reach/router';
 import { SigninOAuthIntegration } from '../interfaces';
@@ -52,7 +55,7 @@ jest.mock('@reach/router', () => {
     __esModule: true,
     ...jest.requireActual('@reach/router'),
     navigate: jest.fn(),
-    useLocation: () => () => { },
+    useLocation: () => () => {},
   };
 });
 
@@ -63,7 +66,8 @@ function render(
   } = {}
 ) {
   if (!props.integration) {
-    props.integration = createMockSigninWebIntegration() as SigninOAuthIntegration;
+    props.integration =
+      createMockSigninWebIntegration() as SigninOAuthIntegration;
   }
   renderWithLocalizationProvider(
     <AppContext.Provider value={mockAppContext({ session })}>
@@ -73,7 +77,7 @@ function render(
 }
 
 function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => { });
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
 const serviceRelayText =
@@ -111,7 +115,7 @@ describe('SigninTokenCode page', () => {
       (_, element) =>
         element?.tagName === 'P' &&
         element?.textContent ===
-        `Enter the code that was sent to ${MOCK_EMAIL} within 5 minutes.`
+          `Enter the code that was sent to ${MOCK_EMAIL} within 5 minutes.`
     );
     screen.getByLabelText('Enter 6-digit code');
     screen.getByRole('button', { name: 'Confirm' });
@@ -130,7 +134,7 @@ describe('SigninTokenCode page', () => {
   it('emits a metrics event on render', () => {
     render();
     expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
-    expect(GleanMetrics.loginConfirmation.view).toBeCalledTimes(1);
+    expect(GleanMetrics.loginConfirmation.view).toHaveBeenCalledTimes(1);
   });
 
   describe('handleResendCode submission', () => {
@@ -187,7 +191,7 @@ describe('SigninTokenCode page', () => {
           expect(screen.getByTestId('tooltip')).toHaveTextContent(
             'Confirmation code required'
           );
-          expect(GleanMetrics.loginConfirmation.submit).not.toBeCalled();
+          expect(GleanMetrics.loginConfirmation.submit).not.toHaveBeenCalled();
         });
       }
       it('if no input', async () => {
@@ -218,8 +222,8 @@ describe('SigninTokenCode page', () => {
       await screen.findByText(
         'You’ve tried too many times. Please try again later.'
       );
-      expect(GleanMetrics.loginConfirmation.submit).toBeCalledTimes(1);
-      expect(GleanMetrics.loginConfirmation.success).not.toBeCalled();
+      expect(GleanMetrics.loginConfirmation.submit).toHaveBeenCalledTimes(1);
+      expect(GleanMetrics.loginConfirmation.success).not.toHaveBeenCalled();
     });
     it('on other error, renders expected default error message in tooltip', async () => {
       session = {
@@ -232,8 +236,8 @@ describe('SigninTokenCode page', () => {
       expect(await screen.findByTestId('tooltip')).toHaveTextContent(
         'Invalid or expired confirmation code'
       );
-      expect(GleanMetrics.loginConfirmation.submit).toBeCalledTimes(1);
-      expect(GleanMetrics.loginConfirmation.success).not.toBeCalled();
+      expect(GleanMetrics.loginConfirmation.submit).toHaveBeenCalledTimes(1);
+      expect(GleanMetrics.loginConfirmation.success).not.toHaveBeenCalled();
     });
 
     describe('on success', () => {
@@ -241,7 +245,7 @@ describe('SigninTokenCode page', () => {
       beforeEach(() => {
         hardNavigateSpy = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementation(() => { });
+          .mockImplementation(() => {});
       });
       afterEach(() => {
         hardNavigateSpy.mockRestore();
@@ -249,10 +253,12 @@ describe('SigninTokenCode page', () => {
 
       async function expectSuccessGleanEvents() {
         await waitFor(() => {
-          expect(GleanMetrics.loginConfirmation.submit).toBeCalledTimes(1);
+          expect(GleanMetrics.loginConfirmation.submit).toHaveBeenCalledTimes(
+            1
+          );
         });
-        expect(GleanMetrics.loginConfirmation.success).toBeCalledTimes(1);
-        expect(GleanMetrics.isDone).toBeCalledTimes(1);
+        expect(GleanMetrics.loginConfirmation.success).toHaveBeenCalledTimes(1);
+        expect(GleanMetrics.isDone).toHaveBeenCalledTimes(1);
       }
       it('default behavior', async () => {
         const mockOnSessionVerified = jest.fn().mockResolvedValue(true);
@@ -290,13 +296,18 @@ describe('SigninTokenCode page', () => {
         const integration = createMockSigninOAuthIntegration();
         const hardNavigate = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementation(() => { });
+          .mockImplementation(() => {});
 
         render({ finishOAuthFlowHandler, integration });
         submitCode();
         await expectSuccessGleanEvents();
         await waitFor(() => {
-          expect(hardNavigate).toHaveBeenCalledWith('someUri', undefined, undefined, true);
+          expect(hardNavigate).toHaveBeenCalledWith(
+            'someUri',
+            undefined,
+            undefined,
+            true
+          );
         });
       });
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.test.tsx
@@ -185,7 +185,7 @@ describe('signin totp code container', () => {
 
   it('returns true when code valid', async () => {
     await render();
-    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+    expect(SigninTotpCodeModule.SigninTotpCode).toHaveBeenCalled();
     const result = await currentPageProps?.submitTotpCode('123456');
 
     expect(result?.error).toBeUndefined();
@@ -205,18 +205,18 @@ describe('signin totp code container', () => {
       },
     };
     await render();
-    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+    expect(SigninTotpCodeModule.SigninTotpCode).toHaveBeenCalled();
     const result = await currentPageProps?.submitTotpCode('123456');
 
     expect(result?.error).toBeUndefined();
-    expect(tryFinalizeUpgrade).toBeCalled();
+    expect(tryFinalizeUpgrade).toHaveBeenCalled();
   });
 
   it('returns false when code not valid', async () => {
     mockVerifyTotp(false);
 
     await render();
-    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+    expect(SigninTotpCodeModule.SigninTotpCode).toHaveBeenCalled();
 
     const result = await currentPageProps?.submitTotpCode('123456');
     expect(result?.error).toEqual(AuthUiErrors.INVALID_TOTP_CODE);
@@ -226,7 +226,7 @@ describe('signin totp code container', () => {
     mockVerifyTotp(true, true);
     await render();
 
-    expect(SigninTotpCodeModule.SigninTotpCode).toBeCalled();
+    expect(SigninTotpCodeModule.SigninTotpCode).toHaveBeenCalled();
 
     const result = await currentPageProps?.submitTotpCode('123456');
     expect(result?.error).toEqual(AuthUiErrors.UNEXPECTED_ERROR);
@@ -236,19 +236,19 @@ describe('signin totp code container', () => {
     mockReachRouter();
     mockCache({}, true);
     await render(false);
-    expect(mockNavigate).toBeCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
   it('redirects if there is no sessionToken', async () => {
     mockReachRouter();
     mockCache({ sessionToken: '' });
     await render(false);
-    expect(mockNavigate).toBeCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
   it('redirects if verification method is not totp', async () => {
     mockReachRouter(MOCK_NON_TOTP_LOCATION_STATE);
     await render(false);
-    expect(mockNavigate).toBeCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.test.tsx
@@ -143,7 +143,9 @@ describe('Sign in with TOTP code page', () => {
         target: { value: '123456' },
       });
       screen.getByRole('button', { name: 'Confirm' }).click();
-      await waitFor(() => expect(submitTotpCode).toBeCalledWith('123456'));
+      await waitFor(() =>
+        expect(submitTotpCode).toHaveBeenCalledWith('123456')
+      );
 
       return { submitTotpCode };
     }
@@ -164,7 +166,7 @@ describe('Sign in with TOTP code page', () => {
         fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
         hardNavigateSpy = jest
           .spyOn(utils, 'hardNavigate')
-          .mockImplementation(() => { });
+          .mockImplementation(() => {});
       });
       it('is sent if Sync integration and navigates to pair', async () => {
         const integration = createMockSigninOAuthNativeSyncIntegration();
@@ -182,7 +184,7 @@ describe('Sign in with TOTP code page', () => {
       it('is not sent otherwise', async () => {
         await renderAndSubmitTotpCode({});
         expect(fxaLoginSpy).not.toHaveBeenCalled();
-        expect(hardNavigateSpy).not.toBeCalled();
+        expect(hardNavigateSpy).not.toHaveBeenCalled();
       });
     });
 
@@ -218,7 +220,7 @@ describe('Sign in with TOTP code page', () => {
           .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
         const hardNavigate = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementationOnce(() => { });
+          .mockImplementationOnce(() => {});
 
         await waitFor(() =>
           renderAndSubmitTotpCode({}, finishOAuthFlowHandler, integration)
@@ -227,7 +229,12 @@ describe('Sign in with TOTP code page', () => {
         expect(GleanMetrics.totpForm.submit).toHaveBeenCalledTimes(1);
         expect(GleanMetrics.totpForm.success).toHaveBeenCalledTimes(1);
         await waitFor(() =>
-          expect(hardNavigate).toHaveBeenCalledWith('someUri', undefined, undefined, true)
+          expect(hardNavigate).toHaveBeenCalledWith(
+            'someUri',
+            undefined,
+            undefined,
+            true
+          )
         );
       });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
@@ -154,7 +154,7 @@ describe('signin unblock container', () => {
     );
 
     await screen.findByText('signin unblock mock');
-    expect(SigninUnblockModule.default).toBeCalled();
+    expect(SigninUnblockModule.default).toHaveBeenCalled();
   }
 
   it('handles signin with correct code', async () => {
@@ -225,7 +225,7 @@ describe('signin unblock container', () => {
     expect(result?.data?.signIn?.verified).toBeDefined();
     expect(result?.data?.signIn?.metricsEnabled).toBeDefined();
 
-    expect(tryFinalizeUpgrade).toBeCalledTimes(1);
+    expect(tryFinalizeUpgrade).toHaveBeenCalledTimes(1);
   });
 
   it('handles signin with correct code and failure when looking up credential status', async () => {
@@ -255,7 +255,9 @@ describe('signin unblock container', () => {
     expect(result?.data?.signIn?.verified).toBeDefined();
     expect(result?.data?.signIn?.metricsEnabled).toBeDefined();
     // console warning during test execution is also expected here
-    expect(console.warn).toBeCalledWith('Could not get credential status!');
+    expect(console.warn).toHaveBeenCalledWith(
+      'Could not get credential status!'
+    );
   });
 
   it('handles incorrect unblock code', async () => {

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -362,7 +362,7 @@ describe('signin container', () => {
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
         });
-        expect(SigninModule.default).toBeCalled();
+        expect(SigninModule.default).toHaveBeenCalled();
       });
       it('router state takes precedence over query param state', async () => {
         mockUseValidateModule();
@@ -371,7 +371,7 @@ describe('signin container', () => {
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_ROUTER_STATE_EMAIL);
         });
-        expect(SigninModule.default).toBeCalled();
+        expect(SigninModule.default).toHaveBeenCalled();
       });
       it('can be set from router state', async () => {
         mockLocationState = MOCK_LOCATION_STATE_COMPLETE;
@@ -379,7 +379,7 @@ describe('signin container', () => {
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_ROUTER_STATE_EMAIL);
         });
-        expect(SigninModule.default).toBeCalled();
+        expect(SigninModule.default).toHaveBeenCalled();
       });
       it('if it matches email in local storage, session token in local storage is used', async () => {
         const storedAccount = {
@@ -398,22 +398,22 @@ describe('signin container', () => {
             storedAccount.sessionToken
           );
         });
-        expect(SigninModule.default).toBeCalled();
+        expect(SigninModule.default).toHaveBeenCalled();
       });
       it('is handled if not provided in query params or location state', async () => {
         render([mockGqlAvatarUseQuery()]);
-        expect(CacheModule.currentAccount).toBeCalled();
-        expect(mockNavigate).toBeCalledWith('/');
-        expect(SigninModule.default).not.toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+        expect(SigninModule.default).not.toHaveBeenCalled();
       });
       it('uses local storage value if email is not provided via query param or router state', async () => {
         mockCurrentAccount(MOCK_STORED_ACCOUNT);
         render([mockGqlAvatarUseQuery()]);
-        expect(CacheModule.currentAccount).toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(MOCK_STORED_ACCOUNT.email);
         });
-        expect(SigninModule.default).toBeCalled();
+        expect(SigninModule.default).toHaveBeenCalled();
       });
       it('falls back to last logged in account in local storage if current local storage account does not exist', async () => {
         const LAST_STORED_ACCOUNT = {
@@ -425,12 +425,12 @@ describe('signin container', () => {
           .mockReturnValue(LAST_STORED_ACCOUNT);
         mockCurrentAccount(undefined);
         render([mockGqlAvatarUseQuery()]);
-        expect(CacheModule.currentAccount).toBeCalled();
-        expect(CacheModule.lastStoredAccount).toBeCalled();
+        expect(CacheModule.currentAccount).toHaveBeenCalled();
+        expect(CacheModule.lastStoredAccount).toHaveBeenCalled();
         await waitFor(() => {
           expect(currentSigninProps?.email).toBe(LAST_STORED_ACCOUNT.email);
         });
-        expect(SigninModule.default).toBeCalled();
+        expect(SigninModule.default).toHaveBeenCalled();
       });
     });
     describe('loading spinner', () => {
@@ -446,7 +446,7 @@ describe('signin container', () => {
         render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
           screen.getByLabelText('Loading…');
-          expect(SigninModule.default).not.toBeCalled();
+          expect(SigninModule.default).not.toHaveBeenCalled();
         });
       });
       it('renders if hasPassword is undefined', async () => {
@@ -458,7 +458,7 @@ describe('signin container', () => {
         render([mockGqlAvatarUseQuery()]);
         await waitFor(() => {
           screen.getByLabelText('Loading…');
-          expect(SigninModule.default).not.toBeCalled();
+          expect(SigninModule.default).not.toHaveBeenCalled();
         });
       });
     });
@@ -475,7 +475,7 @@ describe('signin container', () => {
       });
       render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
-        expect(mockAuthClient.accountStatusByEmail).toBeCalledWith(
+        expect(mockAuthClient.accountStatusByEmail).toHaveBeenCalledWith(
           MOCK_QUERY_PARAM_EMAIL,
           { thirdPartyAuthStatus: true }
         );
@@ -488,7 +488,7 @@ describe('signin container', () => {
       };
       render([mockGqlAvatarUseQuery()]);
       await waitFor(() => {
-        expect(mockAuthClient.accountStatusByEmail).toBeCalledWith(
+        expect(mockAuthClient.accountStatusByEmail).toHaveBeenCalledWith(
           MOCK_ROUTER_STATE_EMAIL,
           { thirdPartyAuthStatus: true }
         );
@@ -590,7 +590,7 @@ describe('signin container', () => {
           );
         });
 
-        expect(mockSensitiveDataClient.setDataType).toBeCalledWith(
+        expect(mockSensitiveDataClient.setDataType).toHaveBeenCalledWith(
           SensitiveData.Key.Auth,
           {
             authPW: MOCK_AUTH_PW,
@@ -599,7 +599,7 @@ describe('signin container', () => {
             keyFetchToken: MOCK_KEY_FETCH_TOKEN,
           }
         );
-        expect(mockAuthClient.recoveryKeyExists).toBeCalledWith(
+        expect(mockAuthClient.recoveryKeyExists).toHaveBeenCalledWith(
           handlerResult?.data?.signIn.sessionToken,
           MOCK_EMAIL
         );
@@ -620,7 +620,7 @@ describe('signin container', () => {
           );
         });
 
-        expect(mockAuthClient.recoveryKeyExists).not.toBeCalled();
+        expect(mockAuthClient.recoveryKeyExists).not.toHaveBeenCalled();
         expect(handlerResult?.data?.showInlineRecoveryKeySetup).toEqual(
           undefined
         );
@@ -637,7 +637,7 @@ describe('signin container', () => {
             MOCK_PASSWORD
           );
         });
-        expect(mockAuthClient.recoveryKeyExists).toBeCalledWith(
+        expect(mockAuthClient.recoveryKeyExists).toHaveBeenCalledWith(
           handlerResult?.data?.signIn.sessionToken,
           MOCK_EMAIL
         );
@@ -878,12 +878,15 @@ describe('signin container', () => {
           expect(handlerResult?.data?.signIn?.sessionToken).toEqual(
             MOCK_SESSION_TOKEN
           );
-          expect(mockGetCredentials).toBeCalledWith(MOCK_EMAIL, MOCK_PASSWORD);
-          expect(mockGetCredentialsV2).toBeCalledWith({
+          expect(mockGetCredentials).toHaveBeenCalledWith(
+            MOCK_EMAIL,
+            MOCK_PASSWORD
+          );
+          expect(mockGetCredentialsV2).toHaveBeenCalledWith({
             password: MOCK_PASSWORD,
             clientSalt: MOCK_CLIENT_SALT,
           });
-          expect(mockGetKeysV2).toBeCalledWith({
+          expect(mockGetKeysV2).toHaveBeenCalledWith({
             kB: await CryptoModule.unwrapKB(MOCK_WRAP_KB, MOCK_UNWRAP_BKEY),
             v1: {
               authPW: MOCK_AUTH_PW,
@@ -895,7 +898,10 @@ describe('signin container', () => {
               clientSalt: MOCK_CLIENT_SALT,
             },
           });
-          expect(mockUnwrapKB).toBeCalledWith(MOCK_WRAP_KB, MOCK_UNWRAP_BKEY);
+          expect(mockUnwrapKB).toHaveBeenCalledWith(
+            MOCK_WRAP_KB,
+            MOCK_UNWRAP_BKEY
+          );
         });
       });
 
@@ -917,7 +923,7 @@ describe('signin container', () => {
 
           expect(handlerResult?.error).toBeUndefined();
           expect(handlerResult?.data?.signIn).toBeDefined();
-          expect(mockSentryCaptureMessage).toBeCalledWith(
+          expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
             'Failure to finish v2 key-stretching upgrade. Could not get credential status during signin',
             { tags: { errno: 999 } }
           );
@@ -946,7 +952,7 @@ describe('signin container', () => {
           );
           expect(handlerResult?.error).toBeUndefined();
           expect(handlerResult?.data?.signIn).toBeDefined();
-          expect(mockSentryCaptureMessage).toBeCalledWith(
+          expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
             'Failure to finish v2 key-stretching upgrade. Could not start password change during signin',
             { tags: { errno: 999 } }
           );
@@ -976,8 +982,8 @@ describe('signin container', () => {
           );
           expect(handlerResult?.error?.message).toBeUndefined();
           expect(handlerResult?.data?.signIn).toBeDefined();
-          expect(mockSentryCaptureMessage).toBeCalledTimes(1);
-          expect(mockSentryCaptureMessage).toBeCalledWith(
+          expect(mockSentryCaptureMessage).toHaveBeenCalledTimes(1);
+          expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
             'Failure to finish v2 key-stretching upgrade. Could not get wrapped keys during signin',
             { tags: { errno: 999 } }
           );
@@ -1008,8 +1014,8 @@ describe('signin container', () => {
           );
           expect(handlerResult?.error?.message).toBeUndefined();
           expect(handlerResult?.data?.signIn).toBeDefined();
-          expect(mockSentryCaptureMessage).toBeCalledTimes(1);
-          expect(mockSentryCaptureMessage).toBeCalledWith(
+          expect(mockSentryCaptureMessage).toHaveBeenCalledTimes(1);
+          expect(mockSentryCaptureMessage).toHaveBeenCalledWith(
             'Failure to finish v2 key-stretching upgrade. Could not finish password change during signin',
             { tags: { errno: 999 } }
           );
@@ -1036,7 +1042,7 @@ describe('signin container', () => {
             MOCK_PASSWORD
           );
           expect(handlerResult?.error).toBeUndefined();
-          expect(mockSentryCaptureMessage).toBeCalledTimes(0);
+          expect(mockSentryCaptureMessage).toHaveBeenCalledTimes(0);
           expect(handlerResult?.data?.signIn?.sessionToken).toEqual(
             MOCK_SESSION_TOKEN
           );
@@ -1072,10 +1078,10 @@ describe('signin container', () => {
         const handlerResult =
           await currentSigninProps?.cachedSigninHandler(MOCK_SESSION_TOKEN);
 
-        expect(mockAuthClient.accountProfile).toBeCalledWith(
+        expect(mockAuthClient.accountProfile).toHaveBeenCalledWith(
           MOCK_SESSION_TOKEN
         );
-        expect(mockAuthClient.recoveryEmailStatus).toBeCalledWith(
+        expect(mockAuthClient.recoveryEmailStatus).toHaveBeenCalledWith(
           MOCK_SESSION_TOKEN
         );
         expect(handlerResult?.data?.verificationMethod).toEqual(
@@ -1194,16 +1200,16 @@ describe('signin container', () => {
       mockWebIntegration();
       const container = render([mockGqlAvatarUseQuery()]);
       expect(container).toBeDefined();
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         SigninQueryParams,
         true
       );
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         OAuthQueryParams,
         true,
         true
       );
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         OAuthNativeSyncQueryParameters,
         true,
         true
@@ -1214,16 +1220,16 @@ describe('signin container', () => {
       mockOAuthWebIntegration();
       const container = render([mockGqlAvatarUseQuery()]);
       expect(container).toBeDefined();
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         SigninQueryParams,
         true
       );
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         OAuthQueryParams,
         true,
         false
       );
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         OAuthNativeSyncQueryParameters,
         true,
         true
@@ -1234,16 +1240,16 @@ describe('signin container', () => {
       mockOAuthNativeIntegration();
       const container = render([mockGqlAvatarUseQuery()]);
       expect(container).toBeDefined();
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         SigninQueryParams,
         true
       );
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         OAuthQueryParams,
         true,
         false
       );
-      expect(useValidatedQueryParamsSpy).toBeCalledWith(
+      expect(useValidatedQueryParamsSpy).toHaveBeenCalledWith(
         OAuthNativeSyncQueryParameters,
         true,
         false

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -235,7 +235,7 @@ describe('Signin component', () => {
         render();
         fireEvent.click(screen.getByText('Forgot password?'));
         await waitFor(() => {
-          expect(GleanMetrics.login.forgotPassword).toBeCalledTimes(1);
+          expect(GleanMetrics.login.forgotPassword).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -256,7 +256,7 @@ describe('Signin component', () => {
 
         await waitFor(() => {
           // Make sure event didn't double fire.
-          expect(GleanMetrics.login.engage).toBeCalledTimes(1);
+          expect(GleanMetrics.login.engage).toHaveBeenCalledTimes(1);
         });
       });
 
@@ -514,7 +514,7 @@ describe('Signin component', () => {
               render();
               enterPasswordAndSubmit();
               expect(fxaLoginSpy).not.toHaveBeenCalled();
-              expect(hardNavigateSpy).not.toBeCalled();
+              expect(hardNavigateSpy).not.toHaveBeenCalled();
             });
           });
 
@@ -879,7 +879,9 @@ describe('Signin component', () => {
 
       fireEvent.click(screen.getByText('Forgot password?'));
       await waitFor(() => {
-        expect(GleanMetrics.cachedLogin.forgotPassword).toBeCalledTimes(1);
+        expect(GleanMetrics.cachedLogin.forgotPassword).toHaveBeenCalledTimes(
+          1
+        );
       });
     });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -54,7 +54,7 @@ jest.mock('../../../lib/glean', () => ({
       view: jest.fn(),
       submit: jest.fn(),
       error: jest.fn(),
-    }
+    },
   },
 }));
 
@@ -234,8 +234,8 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(screen.getByText('confirm signup code mock')).toBeInTheDocument()
       );
-      expect(mockEmailBounceStatusQuery).toBeCalled();
-      expect(mockNavigate).toBeCalledWith('/', {
+      expect(mockEmailBounceStatusQuery).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/', {
         state: { hasBounced: true, prefillEmail: MOCK_EMAIL },
       });
     });
@@ -247,8 +247,8 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(screen.getByText('confirm signup code mock')).toBeInTheDocument()
       );
-      expect(mockEmailBounceStatusQuery).toBeCalled();
-      expect(mockNavigate).toBeCalledWith('/signin_bounced');
+      expect(mockEmailBounceStatusQuery).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith('/signin_bounced');
     });
   });
 
@@ -263,7 +263,7 @@ describe('confirm-signup-container', () => {
       await waitFor(() =>
         expect(screen.getByText('loading spinner mock')).toBeInTheDocument()
       );
-      expect(mockNavigate).toBeCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
   });
 
@@ -284,7 +284,12 @@ describe('confirm-signup-container', () => {
                   };
                 }
               ),
-            oAuthDataError: { message: 'Something went wrong. Please close this tab and try again.', errno: 1, version: 1 },
+            oAuthDataError: {
+              message:
+                'Something went wrong. Please close this tab and try again.',
+              errno: 1,
+              version: 1,
+            },
           };
         });
       render();
@@ -293,8 +298,8 @@ describe('confirm-signup-container', () => {
       );
       expect(screen.getByText('Unexpected error')).toBeInTheDocument();
       expect(GleanMetrics.signupConfirmation.error).toHaveBeenCalledWith({
-        event: { reason: "1" }
-      })
+        event: { reason: '1' },
+      });
     });
   });
   describe('useOAuthKeysCheck', () => {
@@ -308,7 +313,7 @@ describe('confirm-signup-container', () => {
         unwrapBKey: undefined,
       });
       render();
-      expect(mockNavigate).toBeCalledWith('/signin', {
+      expect(mockNavigate).toHaveBeenCalledWith('/signin', {
         state: { localizedErrorMessage: 'Code expired. Please sign in again.' },
       });
     });

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -239,7 +239,7 @@ describe('sign-up-container', () => {
     it('renders', async () => {
       await render();
       expect(screen.queryByText('loading spinner mock')).toBeNull();
-      expect(SignupModule.Signup).toBeCalled();
+      expect(SignupModule.Signup).toHaveBeenCalled();
     });
   });
 
@@ -261,7 +261,7 @@ describe('sign-up-container', () => {
       await render('loading spinner mock');
 
       // TODO: Determine if email is valid: https://github.com/mozilla/fxa/pull/16131#discussion_r1418122670
-      expect(mockNavigate).toBeCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
 
     it('handles empty email', async () => {
@@ -281,7 +281,7 @@ describe('sign-up-container', () => {
       await render('loading spinner mock');
 
       // TODO: Show that email is invalid: https://github.com/mozilla/fxa/pull/16131#discussion_r1418122670
-      expect(mockNavigate).toBeCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
     });
   });
 
@@ -300,7 +300,7 @@ describe('sign-up-container', () => {
         'test123'
       );
 
-      expect(mockBeginSignupMutation).toBeCalledWith({
+      expect(mockBeginSignupMutation).toHaveBeenCalledWith({
         variables: {
           input: {
             email: 'foo@mozilla.com',

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -26,7 +26,10 @@ import { MOCK_CMS_INFO, MOCK_EMAIL, MOCK_PASSWORD } from '../mocks';
 import firefox from '../../lib/channels/firefox';
 import GleanMetrics from '../../lib/glean';
 import * as utils from 'fxa-react/lib/utils';
-import { MONITOR_CLIENTIDS, POCKET_CLIENTIDS } from '../../models/integrations/client-matching';
+import {
+  MONITOR_CLIENTIDS,
+  POCKET_CLIENTIDS,
+} from '../../models/integrations/client-matching';
 import { getSyncEngineIds, syncEngineConfigs } from '../../lib/sync-engines';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { SensitiveData } from '../../lib/sensitive-data-client';
@@ -244,7 +247,11 @@ describe('Signup page', () => {
   it('renders as expected when cms enabled', async () => {
     renderWithLocalizationProvider(
       <Subject
-        integration={createMockSignupOAuthWebIntegration(MONITOR_CLIENTIDS[0], undefined, MOCK_CMS_INFO)}
+        integration={createMockSignupOAuthWebIntegration(
+          MONITOR_CLIENTIDS[0],
+          undefined,
+          MOCK_CMS_INFO
+        )}
       />
     );
 
@@ -259,9 +266,7 @@ describe('Signup page', () => {
     ).toBeInTheDocument();
 
     screen.getByRole('heading', { name: 'Create a password' });
-    screen.getByText(
-      'to continue'
-    );
+    screen.getByText('to continue');
   });
 
   describe('email change', () => {
@@ -287,7 +292,7 @@ describe('Signup page', () => {
         );
       });
       await waitFor(() => {
-        expect(GleanMetrics.registration.changeEmail).toBeCalledTimes(1);
+        expect(GleanMetrics.registration.changeEmail).toHaveBeenCalledTimes(1);
         expect(mockNavigate).toHaveBeenCalledWith('/?', {
           state: { prefillEmail: MOCK_EMAIL },
         });
@@ -300,7 +305,7 @@ describe('Signup page', () => {
 
     await waitFor(() => {
       expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
-      expect(GleanMetrics.registration.view).toBeCalledTimes(1);
+      expect(GleanMetrics.registration.view).toHaveBeenCalledTimes(1);
     });
 
     await act(async () => {
@@ -308,8 +313,8 @@ describe('Signup page', () => {
     });
 
     await waitFor(() => {
-      expect(GleanMetrics.registration.engage).toBeCalledTimes(1);
-      expect(GleanMetrics.registration.engage).toBeCalledWith({
+      expect(GleanMetrics.registration.engage).toHaveBeenCalledTimes(1);
+      expect(GleanMetrics.registration.engage).toHaveBeenCalledWith({
         event: { reason: 'password' },
       });
     });
@@ -358,7 +363,7 @@ describe('Signup page', () => {
     submit();
 
     await waitFor(() => {
-      expect(GleanMetrics.registration.submit).toBeCalledTimes(1);
+      expect(GleanMetrics.registration.submit).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -387,7 +392,7 @@ describe('Signup page', () => {
         );
       });
 
-      expect(fxaLoginSpy).not.toBeCalled();
+      expect(fxaLoginSpy).not.toHaveBeenCalled();
       expect(GleanMetrics.registration.success).toHaveBeenCalledTimes(1);
 
       expect(mockNavigate).toHaveBeenCalledWith(`/confirm_signup_code`, {
@@ -430,7 +435,7 @@ describe('Signup page', () => {
             );
           });
 
-          expect(fxaLoginSpy).toBeCalledWith({
+          expect(fxaLoginSpy).toHaveBeenCalledWith({
             ...commonFxaLoginOptions,
             services: {
               sync: {
@@ -541,7 +546,7 @@ describe('Signup page', () => {
       await fillOutForm(false);
       submit();
 
-      expect(fxaLoginSpy).not.toBeCalled();
+      expect(fxaLoginSpy).not.toHaveBeenCalled();
 
       await waitFor(() => {
         expect(mockBeginSignupHandler).toHaveBeenCalledWith(


### PR DESCRIPTION
## Because

* toBeCalled, toBeCalledWith, toBeCalledTimes are deprecated

## This pull request

* Replace with toHaveBeenCalled, toHaveBeenCalledWith, toHaveBeenCalledTimes

## Issue that this pull request solves

Closes: FXA-12087

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
