### PR TITLE
feat(payments-next): Add content to Subscription Management page

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -68,118 +68,121 @@ export default async function CheckoutLayout({
         }}
         cart={cart}
       />
-      {session?.user?.email && (
-        <section
-          aria-labelledby="signedin-heading"
-          className="mb-12 tablet:hidden"
-        >
-          <SignedIn email={session.user.email} />
-        </section>
-      )}
-      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-        <SubscriptionTitle cart={cart} l10n={l10n} />
+      <div className="flex justify-center">
+        {session?.user?.email && (
+          <section
+            aria-labelledby="signedin-heading"
+            className="mb-12 tablet:hidden"
+          >
+            <SignedIn email={session.user.email} />
+          </section>
+        )}
+        <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
+          <SubscriptionTitle cart={cart} l10n={l10n} />
 
-        <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
-          <PurchaseDetails
-            invoice={cart.latestInvoicePreview ?? cart.upcomingInvoicePreview}
-            offeringPrice={cart.offeringPrice}
-            purchaseDetails={purchaseDetails}
-            priceInterval={
-              <PriceInterval
-                l10n={l10n}
-                amount={cart.offeringPrice}
-                currency={cart.upcomingInvoicePreview.currency}
-                interval={cart.interval}
-                locale={locale}
-              />
-            }
-            totalPrice={
-              <PriceInterval
-                l10n={l10n}
-                amount={
-                  cart.latestInvoicePreview?.amountDue ??
-                  cart.upcomingInvoicePreview.amountDue
-                }
-                currency={cart.upcomingInvoicePreview.currency}
-                interval={cart.interval}
-                locale={locale}
-              />
-            }
-            locale={locale}
-            showPrices={
-              cart.state === CartState.START || cart.state === CartState.SUCCESS
-            }
-          />
-          {cart.state === CartState.START && (
-            <section
-              aria-labelledby="location-heading"
-              className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8"
-            >
-              <h2
-                id="location-heading"
-                className="m-0 mb-4 font-semibold text-grey-600"
-              >
-                {l10n.getString('select-tax-location-title', 'Location')}
-              </h2>
-              <SelectTaxLocation
-                saveAction={async (countryCode, postalCode) => {
-                  'use server';
-                  const result = await updateTaxAddressAction(
-                    cart.id,
-                    cart.version,
-                    params.offeringId,
-                    {
-                      countryCode,
-                      postalCode,
-                    },
-                    session?.user?.id
-                  );
-
-                  if (result.ok) {
-                    return {
-                      ok: true,
-                      data: result.taxAddress,
-                    };
-                  } else {
-                    return {
-                      ok: false,
-                      error: result.error,
-                    };
+          <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
+            <PurchaseDetails
+              invoice={cart.latestInvoicePreview ?? cart.upcomingInvoicePreview}
+              offeringPrice={cart.offeringPrice}
+              purchaseDetails={purchaseDetails}
+              priceInterval={
+                <PriceInterval
+                  l10n={l10n}
+                  amount={cart.offeringPrice}
+                  currency={cart.upcomingInvoicePreview.currency}
+                  interval={cart.interval}
+                  locale={locale}
+                />
+              }
+              totalPrice={
+                <PriceInterval
+                  l10n={l10n}
+                  amount={
+                    cart.latestInvoicePreview?.amountDue ??
+                    cart.upcomingInvoicePreview.amountDue
                   }
-                }}
-                cmsCountries={cms.countries}
-                locale={locale.substring(0, 2)}
-                productName={purchaseDetails.productName}
-                unsupportedLocations={
-                  config.location.subscriptionsUnsupportedLocations
-                }
-                countryCode={cart.taxAddress?.countryCode}
-                postalCode={cart.taxAddress?.postalCode}
-                currentCurrency={cart.currency}
-                showNewTaxRateInfoMessage={cart.hasActiveSubscriptions}
-              />
-            </section>
-          )}
-          {cart.state !== CartState.FAIL && (
-            <CouponForm
-              cartId={cart.id}
-              cartVersion={cart.version}
-              promoCode={cart.couponCode}
-              readOnly={cart.state === CartState.START ? false : true}
+                  currency={cart.upcomingInvoicePreview.currency}
+                  interval={cart.interval}
+                  locale={locale}
+                />
+              }
+              locale={locale}
+              showPrices={
+                cart.state === CartState.START ||
+                cart.state === CartState.SUCCESS
+              }
             />
-          )}
-        </div>
+            {cart.state === CartState.START && (
+              <section
+                aria-labelledby="location-heading"
+                className="bg-white rounded-b-lg shadow-sm shadow-grey-300 mt-6 p-4 rounded-t-lg text-base tablet:my-8"
+              >
+                <h2
+                  id="location-heading"
+                  className="m-0 mb-4 font-semibold text-grey-600"
+                >
+                  {l10n.getString('select-tax-location-title', 'Location')}
+                </h2>
+                <SelectTaxLocation
+                  saveAction={async (countryCode, postalCode) => {
+                    'use server';
+                    const result = await updateTaxAddressAction(
+                      cart.id,
+                      cart.version,
+                      params.offeringId,
+                      {
+                        countryCode,
+                        postalCode,
+                      },
+                      session?.user?.id
+                    );
 
-        <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
-          {children}
-          <TermsAndPrivacy
-            l10n={l10n}
-            {...cart}
-            {...purchaseDetails}
-            {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
-            contentServerUrl={config.contentServerUrl}
-            showFXALinks={true}
-          />
+                    if (result.ok) {
+                      return {
+                        ok: true,
+                        data: result.taxAddress,
+                      };
+                    } else {
+                      return {
+                        ok: false,
+                        error: result.error,
+                      };
+                    }
+                  }}
+                  cmsCountries={cms.countries}
+                  locale={locale.substring(0, 2)}
+                  productName={purchaseDetails.productName}
+                  unsupportedLocations={
+                    config.location.subscriptionsUnsupportedLocations
+                  }
+                  countryCode={cart.taxAddress?.countryCode}
+                  postalCode={cart.taxAddress?.postalCode}
+                  currentCurrency={cart.currency}
+                  showNewTaxRateInfoMessage={cart.hasActiveSubscriptions}
+                />
+              </section>
+            )}
+            {cart.state !== CartState.FAIL && (
+              <CouponForm
+                cartId={cart.id}
+                cartVersion={cart.version}
+                promoCode={cart.couponCode}
+                readOnly={cart.state === CartState.START ? false : true}
+              />
+            )}
+          </div>
+
+          <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
+            {children}
+            <TermsAndPrivacy
+              l10n={l10n}
+              {...cart}
+              {...purchaseDetails}
+              {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
+              contentServerUrl={config.contentServerUrl}
+              showFXALinks={true}
+            />
+          </div>
         </div>
       </div>
     </MetricsWrapper>

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -204,7 +204,7 @@ export default async function Checkout({
             </form>
           </div>
 
-          <hr className="mx-auto w-full border-grey-200" />
+          <hr className="mx-auto w-full border-grey-200" aria-hidden="true" />
         </section>
       )}
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -149,13 +149,20 @@ export default async function CheckoutSuccess({
             locale
           )}
           {cart.paymentInfo.type === 'external_paypal' ? (
-            <Image src={getCardIcon('paypal')} alt="paypal" />
+            <Image
+              src={getCardIcon('paypal', l10n).img}
+              alt={l10n.getString('paypal-logo-alt-text', 'PayPal logo')}
+              width={91}
+              height={24}
+            />
           ) : (
             <span className="flex items-center gap-2">
               {cart.paymentInfo.brand && (
                 <Image
-                  src={getCardIcon(cart.paymentInfo.brand)}
-                  alt={cart.paymentInfo.brand}
+                  src={getCardIcon(cart.paymentInfo.brand, l10n).img}
+                  alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
+                  width={40}
+                  height={24}
                 />
               )}
               {l10n.getString(

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -85,7 +85,7 @@ export default async function UpgradeError({
 
         {errorReason.buttonUrl && (
           <Link
-            className="flex items-center justify-center bg-blue-500 hover:bg-blue-700 font-semibold h-12 my-8 rounded-md text-white w-full"
+            className="min-w-[300px] flex items-center justify-center bg-blue-500 hover:bg-blue-700 font-semibold h-12 my-8 rounded-md text-white"
             href={errorReason.buttonUrl}
           >
             {l10n.getString(errorReason.buttonFtl, errorReason.buttonLabel)}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
@@ -50,58 +50,61 @@ export default async function UpgradeSuccessLayout({
         }}
         cart={cart}
       />
-      {session?.user?.email && (
-        <section
-          aria-labelledby="signedin-heading"
-          className="mb-12 tablet:hidden"
-        >
-          <SignedIn email={session.user.email} />
-        </section>
-      )}
-      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-        <SubscriptionTitle cart={cart} l10n={l10n} />
-        <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
-          <PurchaseDetails
-            invoice={cart.latestInvoicePreview ?? cart.upcomingInvoicePreview}
-            offeringPrice={cart.offeringPrice}
-            purchaseDetails={purchaseDetails}
-            priceInterval={
-              <PriceInterval
-                l10n={l10n}
-                amount={cart.offeringPrice}
-                currency={cart.upcomingInvoicePreview.currency}
-                interval={cart.interval}
-                locale={locale}
-              />
-            }
-            totalPrice={
-              <PriceInterval
-                l10n={l10n}
-                amount={
-                  cart.latestInvoicePreview?.amountDue ??
-                  cart.upcomingInvoicePreview.amountDue
-                }
-                currency={cart.upcomingInvoicePreview.currency}
-                interval={cart.interval}
-                locale={locale}
-              />
-            }
-            locale={locale}
-            showPrices={
-              cart.state === CartState.START || cart.state === CartState.SUCCESS
-            }
-          />
-        </div>
-        <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
-          {children}
-          <TermsAndPrivacy
-            l10n={l10n}
-            {...cart}
-            {...purchaseDetails}
-            {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
-            contentServerUrl={config.contentServerUrl}
-            showFXALinks={true}
-          />
+      <div className="flex justify-center">
+        {session?.user?.email && (
+          <section
+            aria-labelledby="signedin-heading"
+            className="mb-12 tablet:hidden"
+          >
+            <SignedIn email={session.user.email} />
+          </section>
+        )}
+        <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
+          <SubscriptionTitle cart={cart} l10n={l10n} />
+          <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
+            <PurchaseDetails
+              invoice={cart.latestInvoicePreview ?? cart.upcomingInvoicePreview}
+              offeringPrice={cart.offeringPrice}
+              purchaseDetails={purchaseDetails}
+              priceInterval={
+                <PriceInterval
+                  l10n={l10n}
+                  amount={cart.offeringPrice}
+                  currency={cart.upcomingInvoicePreview.currency}
+                  interval={cart.interval}
+                  locale={locale}
+                />
+              }
+              totalPrice={
+                <PriceInterval
+                  l10n={l10n}
+                  amount={
+                    cart.latestInvoicePreview?.amountDue ??
+                    cart.upcomingInvoicePreview.amountDue
+                  }
+                  currency={cart.upcomingInvoicePreview.currency}
+                  interval={cart.interval}
+                  locale={locale}
+                />
+              }
+              locale={locale}
+              showPrices={
+                cart.state === CartState.START ||
+                cart.state === CartState.SUCCESS
+              }
+            />
+          </div>
+          <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
+            {children}
+            <TermsAndPrivacy
+              l10n={l10n}
+              {...cart}
+              {...purchaseDetails}
+              {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
+              contentServerUrl={config.contentServerUrl}
+              showFXALinks={true}
+            />
+          </div>
         </div>
       </div>
     </MetricsWrapper>

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
@@ -150,13 +150,20 @@ export default async function UpgradeSuccess({
               locale
             )}
             {cart.paymentInfo.type === 'external_paypal' ? (
-              <Image src={getCardIcon('paypal')} alt="paypal" />
+              <Image
+                src={getCardIcon('paypal', l10n).img}
+                alt={l10n.getString('paypal-logo-alt-text', 'PayPal logo')}
+                width={91}
+                height={24}
+              />
             ) : (
               <span className="flex items-center gap-2">
                 {cart.paymentInfo.brand && (
                   <Image
-                    src={getCardIcon(cart.paymentInfo.brand)}
-                    alt={cart.paymentInfo.brand}
+                    src={getCardIcon(cart.paymentInfo.brand, l10n).img}
+                    alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
+                    width={40}
+                    height={24}
                   />
                 )}
                 {l10n.getString(

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -60,40 +60,42 @@ export default async function UpgradeLayout({
         }}
         cart={cart}
       />
-      {session?.user?.email && (
-        <section
-          aria-labelledby="signedin-heading"
-          className="mb-12 tablet:hidden"
-        >
-          <SignedIn email={session.user.email} />
-        </section>
-      )}
-      <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
-        <SubscriptionTitle cart={cart} l10n={l10n} />
+      <div className="flex justify-center">
+        {session?.user?.email && (
+          <section
+            aria-labelledby="signedin-heading"
+            className="mb-12 tablet:hidden"
+          >
+            <SignedIn email={session.user.email} />
+          </section>
+        )}
+        <div className="mx-7 tablet:grid tablet:grid-cols-[minmax(min-content,500px)_minmax(20rem,1fr)] tablet:grid-rows-[min-content] tablet:gap-x-8 tablet:mb-auto desktop:grid-cols-[600px_1fr]">
+          <SubscriptionTitle cart={cart} l10n={l10n} />
 
-        <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
-          <UpgradePurchaseDetails
-            l10n={l10n}
-            interval={cart.interval}
-            invoice={cart.upcomingInvoicePreview}
-            fromPrice={cart.fromPrice}
-            fromPurchaseDetails={currentPurchaseDetails}
-            offeringPrice={cart.offeringPrice}
-            purchaseDetails={purchaseDetails}
-            locale={locale}
-          />
-        </div>
+          <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
+            <UpgradePurchaseDetails
+              l10n={l10n}
+              interval={cart.interval}
+              invoice={cart.upcomingInvoicePreview}
+              fromPrice={cart.fromPrice}
+              fromPurchaseDetails={currentPurchaseDetails}
+              offeringPrice={cart.offeringPrice}
+              purchaseDetails={purchaseDetails}
+              locale={locale}
+            />
+          </div>
 
-        <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
-          {children}
-          <TermsAndPrivacy
-            l10n={l10n}
-            {...cart}
-            {...purchaseDetails}
-            {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
-            contentServerUrl={config.contentServerUrl}
-            showFXALinks={true}
-          />
+          <div className="bg-white rounded-b-lg shadow-sm shadow-grey-300 border-t-0 mb-6 pt-4 px-4 pb-14 rounded-t-lg text-grey-600 tablet:clip-shadow tablet:rounded-t-none desktop:px-12 desktop:pb-12">
+            {children}
+            <TermsAndPrivacy
+              l10n={l10n}
+              {...cart}
+              {...purchaseDetails}
+              {...(cms.commonContent.localizations.at(0) || cms.commonContent)}
+              contentServerUrl={config.contentServerUrl}
+              showFXALinks={true}
+            />
+          </div>
         </div>
       </div>
     </MetricsWrapper>

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -91,13 +91,20 @@ export default async function Upgrade({
         {cart.paymentInfo && (
           <div className="flex items-center justify-between mt-4 text-sm">
             {cart.paymentInfo.type === 'external_paypal' ? (
-              <Image src={getCardIcon('paypal')} alt="paypal" />
+              <Image
+                src={getCardIcon('paypal', l10n).img}
+                alt={l10n.getString('paypal-logo-alt-text', 'PayPal logo')}
+                width={91}
+                height={24}
+              />
             ) : (
               <span className="flex items-center gap-2">
                 {cart.paymentInfo.brand && (
                   <Image
-                    src={getCardIcon(cart.paymentInfo.brand)}
-                    alt={cart.paymentInfo.brand}
+                    src={getCardIcon(cart.paymentInfo.brand, l10n).img}
+                    alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
+                    width={40}
+                    height={24}
                   />
                 )}
                 {l10n.getString(
@@ -132,8 +139,8 @@ export default async function Upgrade({
             `Your plan will change immediately, and you’ll be charged a prorated
           amount today for the rest of this billing cycle. Starting
           ${l10n.getLocalizedDateString(
-              cart.upcomingInvoicePreview.nextInvoiceDate
-            )}
+            cart.upcomingInvoicePreview.nextInvoiceDate
+          )}
           you’ll be charged the full amount.`
           )}
         </p>

--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -1,5 +1,15 @@
 checkout-error-boundary-retry-button = Try again
 checkout-error-boundary-basic-error-message = Something went wrong. Please try again or <contactSupportLink>contact support.</contactSupportLink>
+amex-logo-alt-text = { -brand-amex } logo
+diners-logo-alt-text = { -brand-diner } logo
+discover-logo-alt-text = { -brand-discover } logo
+jcb-logo-alt-text = { -brand-jcb } logo
+mastercard-logo-alt-text = { -brand-mastercard } logo
+paypal-logo-alt-text = { -brand-paypal } logo
+unionpay-logo-alt-text = { -brand-unionpay } logo
+visa-logo-alt-text = { -brand-visa } logo
+# Alt text for generic payment card logo
+unbranded-logo-alt-text = Unbranded logo
 
 ## Error pages - /checkout and /upgrade
 ## Common strings used in multiple pages

--- a/apps/payments/next/app/[locale]/error.tsx
+++ b/apps/payments/next/app/[locale]/error.tsx
@@ -99,7 +99,7 @@ export default function Error({
 
       {hasProductData && (
         <button
-          className="flex items-center justify-center bg-blue-500 hover:bg-blue-700 font-semibold h-12 my-8 rounded-md text-white w-full"
+          className="min-w-[300px] flex items-center justify-center bg-blue-500 hover:bg-blue-700 font-semibold h-12 my-8 rounded-md text-white"
           disabled={loading}
           onClick={handleProductRetry}
         >

--- a/apps/payments/next/app/[locale]/subscriptions/en.ftl
+++ b/apps/payments/next/app/[locale]/subscriptions/en.ftl
@@ -1,0 +1,5 @@
+## Layout - Subscription Management
+
+subscription-management-breadcrumb-account-home = Account Home
+subscription-management-breadcrumb-subscriptions = Subscriptions
+subscription-management-account-profile-picture = Account profile picture

--- a/apps/payments/next/app/[locale]/subscriptions/layout.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/layout.tsx
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { headers } from 'next/headers';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { Header } from '@fxa/payments/ui';
+import { getApp } from '@fxa/payments/ui/server';
+import defaultAvatarIcon from '@fxa/shared/assets/images/avatar-default.svg';
+import { auth, signOut } from 'apps/payments/next/auth';
+import { config } from 'apps/payments/next/config';
+
+export default async function SubscriptionsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: {
+    locale: string;
+  };
+}) {
+  const { locale } = params;
+  const acceptLanguage = headers().get('accept-language');
+  const l10n = getApp().getL10n(acceptLanguage, locale);
+  const session = await auth();
+  const breadcrumbs = [
+    {
+      label: l10n.getString(
+        'subscription-management-breadcrumb-subscriptions',
+        'Subscriptions'
+      ),
+      href: '/subscriptions/manage',
+    },
+  ];
+
+  return (
+    <>
+      <Header
+        auth={{
+          user: session?.user,
+          signOut: async () => {
+            'use server';
+            await signOut({ redirect: false });
+          },
+        }}
+        redirectPath={`${config.contentServerUrl}/settings`}
+      />
+
+      <nav className="p-4 tablet:p-6" aria-label="Breadcrumb">
+        <ol className="flex items-center">
+          <li>
+            <Link
+              href={`${config.contentServerUrl}/settings`}
+              className="font-semibold text-blue-600 hover:underline"
+            >
+              {l10n.getString(
+                'subscription-management-breadcrumb-account-home',
+                'Account Home'
+              )}
+            </Link>
+          </li>
+
+          {breadcrumbs.map((crumb, i) => {
+            const isLast = i === breadcrumbs.length - 1;
+            return (
+              <li key={crumb.href} className="flex items-center">
+                <span className="px-3">{' > '}</span>
+                {isLast ? (
+                  <span className="font-semibold" aria-current="page">
+                    {crumb.label}
+                  </span>
+                ) : (
+                  <Link
+                    href={crumb.href}
+                    className="font-semibold text-blue-600 hover:underline"
+                  >
+                    {crumb.label}
+                  </Link>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <div className="flex justify-center">
+        <div className="w-full py-6 text-grey-600 tablet:bg-white tablet:w-[640px] tablet:rounded-2xl tablet:shadow-sm tablet:shadow-grey-300 tablet:border-t-0 tablet:clip-shadow">
+          <section
+            aria-labelledby="profile-heading"
+            className="flex items-center gap-4 px-4 tablet:px-8"
+          >
+            <Image
+              unoptimized={true}
+              src={session?.user?.image ?? defaultAvatarIcon}
+              alt={l10n.getString(
+                'subscription-management-account-profile-picture',
+                'Account profile picture'
+              )}
+              width="48"
+              height="48"
+              className="w-12 h-12 tablet:w-16 tablet:h-16"
+            />
+            <h1
+              id="profile-heading"
+              className="leading-6 overflow-hidden font-semibold text-ellipsis text-start text-nowrap tablet:text-xl"
+            >
+              <div>{session?.user?.name || session?.user?.email}</div>
+              {session?.user?.name && (
+                <div className="font-normal leading-6 text-base text-grey-400 mb-0">
+                  {session?.user?.email}
+                </div>
+              )}
+            </h1>
+          </section>
+          <hr className="border-b border-grey-50 my-6" aria-hidden="true" />
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/payments/next/app/[locale]/subscriptions/manage/en.ftl
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/en.ftl
@@ -1,0 +1,27 @@
+## Page - Subscription Management
+
+subscription-management-payment-information-heading = Payment Information
+subscription-management-button-add-payment-method-aria = Add payment method
+subscription-management-button-add-payment-method = Add
+subscription-management-button-change-payment-method-aria = Change payment method
+subscription-management-button-change-payment-method = Change
+# $last4 (String) - Last four numbers of credit card
+subscription-management-card-ending-in = Card ending in { $last4 }
+# $expirationDate (Date) - Payment card's expiration date
+subscription-management-card-expires-date = Expires { $expirationDate }
+subscription-management-subscriptions-heading = Subscriptions
+subscription-management-your-subscriptions-aria = Your subscriptions
+subscription-management-no-subscriptions = You don’t have any subscriptions yet
+subscription-management-button-cancel-subscription-aria = Cancel subscription
+subscription-management-button-cancel-subscription = Cancel
+subscription-management-your-apple-iap-subscriptions-aria = Your { -brand-apple } In-App Subscriptions
+subscription-management-apple-in-app-purchase = { -brand-apple }: In-App purchase
+subscription-management-your-google-iap-subscriptions-aria = Your { -brand-google } In-App Subscriptions
+subscription-management-google-in-app-purchase = { -brand-google }: In-App purchase
+# $date (String) - Date of next bill
+subscription-management-iap-sub-next-bill = Next billed on { $date }
+# $date (String) - Date of In-App purchase expires
+subscription-management-iap-sub-expires-on = Expires on { $date }
+# $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscription-management-button-manage-subscription-aria = Manage subscription for { $productName }
+subscription-management-button-manage-subscription = Manage

--- a/apps/payments/next/app/styles/global.css
+++ b/apps/payments/next/app/styles/global.css
@@ -4,9 +4,8 @@
 
 @import '../../../../../libs/shared/assets/src/styles/index.css';
 
-/* layout */
 body {
-  @apply grid min-h-[100vh] tablet:justify-center text-base font-body bg-grey-10 text-grey-900 leading-[1.15];
+  @apply bg-grey-10 leading-[1.15];
 }
 
 @layer utilities {

--- a/libs/payments/customer/src/lib/paymentMethod.manager.spec.ts
+++ b/libs/payments/customer/src/lib/paymentMethod.manager.spec.ts
@@ -2,33 +2,54 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { faker } from '@faker-js/faker';
 import { Test } from '@nestjs/testing';
-
 import { PaymentMethodManager } from './paymentMethod.manager';
+import { determinePaymentMethodType } from './util/determinePaymentMethodType';
+import {
+  MockPaypalClientConfigProvider,
+  PaypalBillingAgreementManager,
+  PayPalClient,
+  PaypalCustomerManager,
+} from '@fxa/payments/paypal';
 import {
   StripeClient,
   MockStripeConfigProvider,
   StripeResponseFactory,
   StripeCustomerFactory,
   StripePaymentMethodFactory,
+  StripeSubscriptionFactory,
 } from '@fxa/payments/stripe';
+import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
+
+jest.mock('./util/determinePaymentMethodType');
+const mockDeterminePaymentMethodType = jest.mocked(determinePaymentMethodType);
 
 describe('PaymentMethodManager', () => {
   let paymentMethodManager: PaymentMethodManager;
+  let paypalBillingAgreementManager: PaypalBillingAgreementManager;
   let stripeClient: StripeClient;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [
+        MockAccountDatabaseNestFactory,
+        MockPaypalClientConfigProvider,
         MockStripeConfigProvider,
         PaymentMethodManager,
+        PaypalBillingAgreementManager,
+        PayPalClient,
+        PaypalCustomerManager,
         StripeClient,
         MockStatsDProvider,
       ],
     }).compile();
 
     paymentMethodManager = moduleRef.get(PaymentMethodManager);
+    paypalBillingAgreementManager = moduleRef.get(
+      PaypalBillingAgreementManager
+    );
     stripeClient = moduleRef.get(StripeClient);
   });
 
@@ -53,6 +74,77 @@ describe('PaymentMethodManager', () => {
         }
       );
       expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('retrieve', () => {
+    it('should retrieve a payment method', async () => {
+      const mockPaymentMethod = StripePaymentMethodFactory();
+      const mockResponse = StripeResponseFactory(mockPaymentMethod);
+
+      jest
+        .spyOn(stripeClient, 'paymentMethodRetrieve')
+        .mockResolvedValue(mockResponse);
+
+      const result = await paymentMethodManager.retrieve(mockPaymentMethod.id);
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getDefaultPaymentMethod', () => {
+    it('returns payment method information - card', async () => {
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory({})
+      );
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockSubscriptions = [StripeSubscriptionFactory()];
+      const mockUid = faker.string.uuid();
+
+      mockDeterminePaymentMethodType.mockReturnValue({
+        type: 'stripe',
+        paymentMethodId: 'pm_id',
+      });
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+
+      const result = await paymentMethodManager.getDefaultPaymentMethod(
+        mockStripeCustomer,
+        mockSubscriptions,
+        mockUid
+      );
+      expect(result).toEqual({
+        type: mockPaymentMethod.type,
+        brand: mockPaymentMethod.card?.brand,
+        last4: mockPaymentMethod.card?.last4,
+        expMonth: mockPaymentMethod.card?.exp_month,
+        expYear: mockPaymentMethod.card?.exp_year,
+      });
+    });
+
+    it('returns payment method information - paypal', async () => {
+      const mockPaypalBillingAgreementId = faker.string.sample();
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockSubscriptions = [StripeSubscriptionFactory()];
+      const mockUid = faker.string.uuid();
+
+      mockDeterminePaymentMethodType.mockReturnValue({
+        type: 'external_paypal',
+      });
+      jest
+        .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
+        .mockResolvedValue(mockPaypalBillingAgreementId);
+
+      const result = await paymentMethodManager.getDefaultPaymentMethod(
+        mockStripeCustomer,
+        mockSubscriptions,
+        mockUid
+      );
+      expect(result).toEqual({
+        type: 'external_paypal',
+        brand: 'paypal',
+        billingAgreementId: mockPaypalBillingAgreementId,
+      });
     });
   });
 });

--- a/libs/payments/customer/src/lib/paymentMethod.manager.ts
+++ b/libs/payments/customer/src/lib/paymentMethod.manager.ts
@@ -4,11 +4,21 @@
 
 import { Injectable } from '@nestjs/common';
 import { Stripe } from 'stripe';
-import { StripeClient } from '@fxa/payments/stripe';
+import { PaypalBillingAgreementManager } from '@fxa/payments/paypal';
+import {
+  StripeClient,
+  StripeCustomer,
+  StripeSubscription,
+} from '@fxa/payments/stripe';
+import { DefaultPaymentMethod } from './types';
+import { determinePaymentMethodType } from './util/determinePaymentMethodType';
 
 @Injectable()
 export class PaymentMethodManager {
-  constructor(private stripeClient: StripeClient) {}
+  constructor(
+    private stripeClient: StripeClient,
+    private paypalBillingAgreementManager: PaypalBillingAgreementManager
+  ) {}
 
   async attach(
     paymentMethodId: string,
@@ -19,5 +29,38 @@ export class PaymentMethodManager {
 
   async retrieve(paymentMethodId: string) {
     return this.stripeClient.paymentMethodRetrieve(paymentMethodId);
+  }
+
+  async getDefaultPaymentMethod(
+    customer: StripeCustomer,
+    subscriptions: StripeSubscription[],
+    uid: string
+  ) {
+    let defaultPaymentMethod: DefaultPaymentMethod | undefined;
+    const paymentMethodType = determinePaymentMethodType(
+      customer,
+      subscriptions
+    );
+    if (paymentMethodType?.type === 'stripe') {
+      const paymentMethod = await this.retrieve(
+        paymentMethodType.paymentMethodId
+      );
+      defaultPaymentMethod = {
+        type: paymentMethod.type,
+        brand: paymentMethod.card?.brand,
+        last4: paymentMethod.card?.last4,
+        expMonth: paymentMethod.card?.exp_month,
+        expYear: paymentMethod.card?.exp_year,
+      };
+    } else if (paymentMethodType?.type === 'external_paypal') {
+      const billingAgreementId =
+        await this.paypalBillingAgreementManager.retrieveActiveId(uid);
+      defaultPaymentMethod = {
+        type: 'external_paypal',
+        brand: 'paypal',
+        billingAgreementId,
+      };
+    }
+    return defaultPaymentMethod;
   }
 }

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -27,6 +27,21 @@ export interface Interval {
   intervalCount: number;
 }
 
+export type PaymentProvidersType =
+  | Stripe.PaymentMethod.Type
+  | 'google_iap'
+  | 'apple_iap'
+  | 'external_paypal';
+
+export interface DefaultPaymentMethod {
+  type: PaymentProvidersType;
+  brand?: string;
+  last4?: string;
+  expMonth?: number;
+  expYear?: number;
+  billingAgreementId?: string;
+}
+
 export interface PricingForCurrency {
   price: StripePrice;
   unitAmountForCurrency: number | null;

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -2,9 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Test } from '@nestjs/testing';
-import { SubscriptionManagementService } from '@fxa/payments/management';
 import { Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+
+import {
+  determinePaymentMethodType,
+  CustomerManager,
+  PaymentMethodManager,
+  SubscriptionManager,
+} from '@fxa/payments/customer';
+import { SubscriptionManagementService } from '@fxa/payments/management';
+import {
+  AccountCustomerManager,
+  ResultAccountCustomerFactory,
+  StripeClient,
+  StripeConfig,
+  StripeCustomerFactory,
+  StripePaymentMethodFactory,
+  StripeResponseFactory,
+  StripeSubscriptionFactory,
+} from '@fxa/payments/stripe';
+import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
+
+jest.mock('@fxa/payments/customer');
+const mockDeterminePaymentMethodType = jest.mocked(determinePaymentMethodType);
 
 jest.mock('@fxa/shared/error', () => ({
   ...jest.requireActual('@fxa/shared/error'),
@@ -20,23 +43,120 @@ jest.mock('@fxa/shared/error', () => ({
 }));
 
 describe('SubscriptionManagementService', () => {
+  let accountCustomerManager: AccountCustomerManager;
+  let customerManager: CustomerManager;
+  let paymentMethodManager: PaymentMethodManager;
+  let subscriptionManager: SubscriptionManager;
   let subscriptionManagementService: SubscriptionManagementService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      providers: [Logger, SubscriptionManagementService],
+      providers: [
+        Logger,
+        AccountCustomerManager,
+        CustomerManager,
+        MockAccountDatabaseNestFactory,
+        MockStatsDProvider,
+        PaymentMethodManager,
+        StripeClient,
+        StripeConfig,
+        SubscriptionManager,
+        SubscriptionManagementService,
+      ],
     }).compile();
 
+    accountCustomerManager = moduleRef.get(AccountCustomerManager);
+    customerManager = moduleRef.get(CustomerManager);
+    paymentMethodManager = moduleRef.get(PaymentMethodManager);
+    subscriptionManager = moduleRef.get(SubscriptionManager);
     subscriptionManagementService = moduleRef.get(
       SubscriptionManagementService
     );
   });
 
-  describe('checkInitialization', () => {
-    it('is initialized', () => {
-      const initialization =
-        subscriptionManagementService.checkInitialization();
-      expect(initialization.initialized).toBeTruthy();
+  describe('getPageContent', () => {
+    it('returns page content', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory();
+      const mockStripeCustomer = StripeResponseFactory(StripeCustomerFactory());
+      const mockSubscriptions = StripeSubscriptionFactory();
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory({})
+      );
+      const mockPaymentMethodInformation = {
+        type: mockPaymentMethod.type,
+        brand: mockPaymentMethod.card?.brand,
+        last4: mockPaymentMethod.card?.last4,
+        expMonth: mockPaymentMethod.card?.exp_month,
+        expYear: mockPaymentMethod.card?.exp_year,
+      };
+
+      mockDeterminePaymentMethodType.mockReturnValue({
+        type: 'stripe',
+        paymentMethodId: 'pm_id',
+      });
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest
+        .spyOn(subscriptionManager, 'listForCustomer')
+        .mockResolvedValue([mockSubscriptions]);
+      jest
+        .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
+        .mockResolvedValueOnce(mockPaymentMethodInformation);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      expect(result).toEqual({
+        defaultPaymentMethod: mockPaymentMethodInformation,
+      });
+    });
+
+    it('returns no page information - Stripe customer does not exist', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory();
+
+      mockDeterminePaymentMethodType.mockReturnValue(null);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(subscriptionManager, 'listForCustomer').mockResolvedValue([]);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      expect(result).toEqual({
+        defaultPaymentMethod: undefined,
+      });
+    });
+
+    it('returns page information - Stripe customer but no payment information nor subscriptions', async () => {
+      const mockUid = faker.string.uuid();
+      const mockAccountCustomer = ResultAccountCustomerFactory();
+      const mockStripeCustomer = StripeResponseFactory(StripeCustomerFactory());
+
+      mockDeterminePaymentMethodType.mockReturnValue(null);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockStripeCustomer);
+      jest.spyOn(subscriptionManager, 'listForCustomer').mockResolvedValue([]);
+      jest
+        .spyOn(paymentMethodManager, 'getDefaultPaymentMethod')
+        .mockResolvedValueOnce(undefined);
+
+      const result =
+        await subscriptionManagementService.getPageContent(mockUid);
+
+      expect(result).toEqual({
+        defaultPaymentMethod: undefined,
+      });
     });
   });
 });

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -3,17 +3,57 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Inject, Injectable, Logger, type LoggerService } from '@nestjs/common';
+import {
+  CustomerManager,
+  DefaultPaymentMethod,
+  PaymentMethodManager,
+  SubscriptionManager,
+} from '@fxa/payments/customer';
+import {
+  AccountCustomerManager,
+  AccountCustomerNotFoundError,
+} from '@fxa/payments/stripe';
 import { SanitizeExceptions } from '@fxa/shared/error';
 
 @Injectable()
 export class SubscriptionManagementService {
-  constructor(@Inject(Logger) private log: LoggerService) {}
+  constructor(
+    @Inject(Logger) private log: LoggerService,
+    private accountCustomerManager: AccountCustomerManager,
+    private customerManager: CustomerManager,
+    private paymentMethodManager: PaymentMethodManager,
+    private subscriptionManager: SubscriptionManager
+  ) {}
 
-  // TODO: Remove when developing this class, along with the associated tests.
-  // This method is for testing purposes only
   @SanitizeExceptions()
-  checkInitialization() {
-    this.log.log('SubscriptionManagementService is initialized');
-    return { initialized: true };
+  async getPageContent(uid: string) {
+    let defaultPaymentMethod: DefaultPaymentMethod | undefined;
+    const accountCustomer = await this.accountCustomerManager
+      .getAccountCustomerByUid(uid)
+      .catch((error) => {
+        if (!(error instanceof AccountCustomerNotFoundError)) {
+          throw error;
+        }
+      });
+
+    if (accountCustomer && accountCustomer.stripeCustomerId) {
+      const [subs, customer] = await Promise.all([
+        this.subscriptionManager.listForCustomer(
+          accountCustomer.stripeCustomerId
+        ),
+        this.customerManager.retrieve(accountCustomer.stripeCustomerId),
+      ]);
+
+      defaultPaymentMethod =
+        await this.paymentMethodManager.getDefaultPaymentMethod(
+          customer,
+          subs,
+          uid
+        );
+    }
+
+    return {
+      defaultPaymentMethod,
+    };
   }
 }

--- a/libs/payments/ui/src/lib/actions/getSubManPageContent.ts
+++ b/libs/payments/ui/src/lib/actions/getSubManPageContent.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const getSubManPageContentAction = async (uid: string) => {
+  const result = await getApp()
+    .getActionsService()
+    .getSubManPageContent({ uid });
+
+  return result;
+};

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -11,6 +11,7 @@ export { getCartAction } from './getCart';
 export { getCartOrRedirectAction } from './getCartOrRedirect';
 export { getMetricsFlowAction } from './getMetricsFlow';
 export { getPayPalCheckoutToken } from './getPayPalCheckoutToken';
+export { getSubManPageContentAction } from './getSubManPageContent';
 export { getTaxAddressAction } from './getTaxAddress';
 export { handleStripeErrorAction } from './handleStripeError';
 export { recordEmitterEventAction } from './recordEmitterEvent';

--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -57,25 +57,29 @@ type HeaderProps = {
     user: User | undefined;
     signOut: () => Promise<void>;
   };
-  cart: {
+  cart?: {
     taxAddress: {
       countryCode: string;
       postalCode: string;
     };
   };
+  redirectPath?: string;
 };
 
-export const Header = ({ auth, cart }: HeaderProps) => {
+export const Header = ({ auth, cart, redirectPath }: HeaderProps) => {
   const router = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
 
-  const signOutRedirectPath = buildSignOutRedirectPath(
-    params,
-    searchParams,
-    cart.taxAddress.countryCode,
-    cart.taxAddress.postalCode
-  );
+  const signOutRedirectPath =
+    cart?.taxAddress.countryCode && cart.taxAddress.postalCode
+      ? buildSignOutRedirectPath(
+          params,
+          searchParams,
+          cart.taxAddress.countryCode,
+          cart.taxAddress.postalCode
+        )
+      : redirectPath || '/';
 
   const signedIn = auth && auth.user;
 
@@ -141,7 +145,7 @@ export const Header = ({ auth, cart }: HeaderProps) => {
       'bento',
       'vpn',
       'permanent'
-    )
+    ),
   };
 
   const iconClassNames = 'inline-block w-5 -mb-1 me-1';
@@ -384,11 +388,8 @@ export const Header = ({ auth, cart }: HeaderProps) => {
                     <div className="px-4 py-5">
                       <button
                         onClick={async () => {
-                          // As of this commit, both router.push and direct location.href overwriting are necessary to ensure
-                          // the browser is in the correct state without any contentless flashes
                           await auth.signOut();
-                          router.push(signOutRedirectPath);
-                          window.location.href = signOutRedirectPath;
+                          router.replace(signOutRedirectPath);
                         }}
                         className="pl-3 group"
                       >

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -68,6 +68,7 @@ import {
   GoogleIapClient,
   GoogleIapPurchaseManager,
 } from '@fxa/payments/iap';
+import { SubscriptionManagementService } from '@fxa/payments/management';
 
 @Module({
   imports: [
@@ -141,7 +142,8 @@ import {
     StripeEventManager,
     SubscriptionEventsService,
     StripeWebhookService,
+    SubscriptionManagementService,
     { provide: LOGGER_PROVIDER, useValue: logger },
   ],
 })
-export class AppModule { }
+export class AppModule {}

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -14,6 +14,7 @@ import {
 } from '@fxa/payments/cart';
 import { ContentServerManager } from '@fxa/payments/content-server';
 import { CurrencyManager } from '@fxa/payments/currency';
+import { SubscriptionManagementService } from '@fxa/payments/management';
 import { CheckoutTokenManager } from '@fxa/payments/paypal';
 import {
   ProductConfigError,
@@ -32,6 +33,8 @@ import { FetchCMSDataActionArgs } from './validators/FetchCMSDataActionArgs';
 import { FinalizeCartWithErrorArgs } from './validators/FinalizeCartWithErrorArgs';
 import { GetCartActionArgs } from './validators/GetCartActionArgs';
 import { GetPayPalCheckoutTokenArgs } from './validators/GetPayPalCheckoutTokenArgs';
+import { GetSubManPageContentActionArgs } from './validators/GetSubManPageContentActionArgs';
+import { GetSubManPageContentActionResult } from './validators/GetSubManPageContentActionResult';
 import { RestartCartActionArgs } from './validators/RestartCartActionArgs';
 import { SetupCartActionArgs } from './validators/SetupCartActionArgs';
 import { UpdateCartActionArgs } from './validators/UpdateCartActionArgs';
@@ -110,6 +113,7 @@ export class NextJSActionsService {
     private eligibilityService: EligibilityService,
     private productConfigurationManager: ProductConfigurationManager,
     private profileClient: ProfileClient,
+    private subscriptionManagementService: SubscriptionManagementService,
     @Inject(StatsDService) public statsd: StatsD,
     @Inject(Logger) private log: LoggerService
   ) {}
@@ -331,6 +335,21 @@ export class NextJSActionsService {
     );
 
     return offering;
+  }
+
+  @SanitizeExceptions()
+  @NextIOValidator(
+    GetSubManPageContentActionArgs,
+    GetSubManPageContentActionResult
+  )
+  @WithTypeCachableAsyncLocalStorage()
+  @CaptureTimingWithStatsD()
+  async getSubManPageContent(args: { uid: string }) {
+    const result = await this.subscriptionManagementService.getPageContent(
+      args.uid
+    );
+
+    return result;
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/GetSubManPageContentActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetSubManPageContentActionArgs.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class GetSubManPageContentActionArgs {
+  @IsString()
+  uid!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetSubManPageContentActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetSubManPageContentActionResult.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Type } from 'class-transformer';
+import {
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import type { PaymentProvidersType } from '@fxa/payments/customer';
+
+class DefaultPaymentMethod {
+  @IsString()
+  type!: PaymentProvidersType;
+
+  @IsOptional()
+  @IsString()
+  brand?: string;
+
+  @IsOptional()
+  @IsString()
+  last4?: string;
+
+  @IsOptional()
+  @IsNumber()
+  expMonth?: number;
+
+  @IsOptional()
+  @IsNumber()
+  expYear?: number;
+
+  @IsOptional()
+  @IsString()
+  billingAgreementId?: string;
+}
+
+export class GetSubManPageContentActionResult {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => DefaultPaymentMethod)
+  defaultPaymentMethod?: DefaultPaymentMethod;
+}

--- a/libs/payments/ui/src/lib/utils/getCardIcon.ts
+++ b/libs/payments/ui/src/lib/utils/getCardIcon.ts
@@ -11,26 +11,54 @@ import Paypal from '@fxa/shared/assets/images/payment-methods/paypal.svg';
 import Unbranded from '@fxa/shared/assets/images/payment-methods/unbranded.svg';
 import UnionPay from '@fxa/shared/assets/images/payment-methods/unionpay.svg';
 import Visa from '@fxa/shared/assets/images/payment-methods/visa.svg';
+import { LocalizerRsc } from '@fxa/shared/l10n/server';
 
-export function getCardIcon(cardBrand: string) {
+export function getCardIcon(cardBrand: string, l10n: LocalizerRsc) {
   switch (cardBrand) {
     case 'amex':
-      return Amex;
+      return {
+        img: Amex,
+        altText: l10n.getString('amex-logo-alt-text', 'American Express logo'),
+      };
     case 'diners':
-      return Diners;
+      return {
+        img: Diners,
+        altText: l10n.getString('diners-logo-alt-text', 'Diners logo'),
+      };
     case 'discover':
-      return Discover;
+      return {
+        img: Discover,
+        altText: l10n.getString('discover-logo-alt-text', 'Discover logo'),
+      };
     case 'jcb':
-      return Jcb;
+      return {
+        img: Jcb,
+        altText: l10n.getString('jcb-logo-alt-text', 'JCB logo'),
+      };
     case 'mastercard':
-      return Mastercard;
+      return {
+        img: Mastercard,
+        altText: l10n.getString('mastercard-logo-alt-text', 'Mastercard logo'),
+      };
     case 'paypal':
-      return Paypal;
+      return {
+        img: Paypal,
+        altText: l10n.getString('paypal-logo-alt-text', 'PayPal logo'),
+      };
     case 'unionpay':
-      return UnionPay;
+      return {
+        img: UnionPay,
+        altText: l10n.getString('unionpay-logo-alt-text', 'Union Pay logo'),
+      };
     case 'visa':
-      return Visa;
+      return {
+        img: Visa,
+        altText: l10n.getString('visa-logo-alt-text', 'Visa logo'),
+      };
     default:
-      return Unbranded;
+      return {
+        img: Unbranded,
+        altText: l10n.getString('unbranded-logo-alt-text', 'Unbranded logo'),
+      };
   }
 }

--- a/libs/shared/l10n/src/lib/branding.ftl
+++ b/libs/shared/l10n/src/lib/branding.ftl
@@ -54,6 +54,13 @@
 -brand-google = Google
 -brand-paypal = PayPal
 -brand-name-stripe = Stripe
+-brand-amex = American Express
+-brand-diners = Diners Club
+-brand-discover = Discover
+-brand-jcb = JCB
+-brand-mastercard = Mastercard
+-brand-unionpay = UnionPay
+-brand-visa = Visa
 
 -app-store = App Store
 -google-play = Google Play

--- a/libs/shared/l10n/src/lib/l10n.formatters.spec.ts
+++ b/libs/shared/l10n/src/lib/l10n.formatters.spec.ts
@@ -6,6 +6,7 @@ import {
   getLocalizedCurrencyString,
   getLocalizedDate,
   getLocalizedDateString,
+  getLocalizedMonthYearString,
 } from './l10n.formatters';
 
 describe('format.ts', () => {
@@ -89,6 +90,35 @@ describe('format.ts', () => {
           const actual = getLocalizedDateString(unixSeconds, true);
           expect(actual).toMatch(pattern);
         });
+      });
+    });
+
+    describe('getLocalizedMonthYearString', () => {
+      it('returns formatted month year date - en', () => {
+        const month = 4;
+        const year = 2024;
+        const locale = 'en';
+        const pattern = /April 2024/;
+        const actual = getLocalizedMonthYearString(month, year, locale);
+        expect(actual).toMatch(pattern);
+      });
+
+      it('returns formatted month year date - fr', () => {
+        const month = 4;
+        const year = 2024;
+        const locale = 'fr';
+        const pattern = /avril 2024/;
+        const actual = getLocalizedMonthYearString(month, year, locale);
+        expect(actual).toMatch(pattern);
+      });
+
+      it('returns formatted month year date - jp', () => {
+        const month = 4;
+        const year = 2024;
+        const locale = 'ja';
+        const pattern = /2024年4月/;
+        const actual = getLocalizedMonthYearString(month, year, locale);
+        expect(actual).toMatch(pattern);
       });
     });
   });

--- a/libs/shared/l10n/src/lib/l10n.formatters.ts
+++ b/libs/shared/l10n/src/lib/l10n.formatters.ts
@@ -111,3 +111,15 @@ export function getLocalizedDateString(
 
   return new Intl.DateTimeFormat('en', options).format(date);
 }
+
+export function getLocalizedMonthYearString(
+  month: number,
+  year: number,
+  locale: string
+): string {
+  const date = new Date(year, month - 1);
+  return new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    year: 'numeric',
+  }).format(date);
+}

--- a/libs/shared/l10n/src/lib/localizer/localizer.rsc.spec.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.rsc.spec.ts
@@ -43,22 +43,22 @@ describe('LocalizerRsc', () => {
     it('should call getElement with createElement fragment', () => {
       mockReactLocalization.getBundle = jest.fn().mockReturnValue(true);
       localizerRsc.getFragmentWithSource('id', {}, {} as any);
-      expect(mockReactLocalization.getElement).toBeCalled();
-      expect(spyCreateFragment).toBeCalledTimes(1);
+      expect(mockReactLocalization.getElement).toHaveBeenCalled();
+      expect(spyCreateFragment).toHaveBeenCalledTimes(1);
     });
 
     it('should call getElement with fallback', () => {
       mockReactLocalization.getBundle = jest.fn().mockReturnValue(false);
       localizerRsc.getFragmentWithSource('id', {}, {} as any);
-      expect(mockReactLocalization.getElement).toBeCalled();
-      expect(spyCreateFragment).not.toBeCalled();
+      expect(mockReactLocalization.getElement).toHaveBeenCalled();
+      expect(spyCreateFragment).not.toHaveBeenCalled();
     });
   });
 
   describe('getFragment', () => {
     it('should call getElement', () => {
       localizerRsc.getFragment('id', {});
-      expect(mockReactLocalization.getElement).toBeCalled();
+      expect(mockReactLocalization.getElement).toHaveBeenCalled();
     });
   });
 
@@ -67,7 +67,7 @@ describe('LocalizerRsc', () => {
     const fallback = 'fallback text';
     it('should call getString with no vars', () => {
       localizerRsc.getString(id, fallback);
-      expect(mockReactLocalization.getString).toBeCalledWith(
+      expect(mockReactLocalization.getString).toHaveBeenCalledWith(
         id,
         undefined,
         fallback
@@ -77,7 +77,7 @@ describe('LocalizerRsc', () => {
     it('should call getString with vars', () => {
       const vars = { test: 'var' };
       localizerRsc.getString(id, vars, fallback);
-      expect(mockReactLocalization.getString).toBeCalledWith(
+      expect(mockReactLocalization.getString).toHaveBeenCalledWith(
         id,
         vars,
         fallback
@@ -93,25 +93,33 @@ describe('LocalizerRsc', () => {
     it('should call getLocalizedCurrency', () => {
       const spy = jest.spyOn(formatters, 'getLocalizedCurrency');
       localizerRsc.getLocalizedCurrency(amountInCents, currency);
-      expect(spy).toBeCalledWith(amountInCents, currency);
+      expect(spy).toHaveBeenCalledWith(amountInCents, currency);
     });
 
     it('should call getLocalizedCurrencyString', () => {
       const spy = jest.spyOn(formatters, 'getLocalizedCurrencyString');
       localizerRsc.getLocalizedCurrencyString(amountInCents, currency, locale);
-      expect(spy).toBeCalledWith(amountInCents, currency, locale);
+      expect(spy).toHaveBeenCalledWith(amountInCents, currency, locale);
     });
 
     it('should call getLocalizedDate', () => {
       const spy = jest.spyOn(formatters, 'getLocalizedDate');
       localizerRsc.getLocalizedDate(unixSeconds);
-      expect(spy).toBeCalledWith(unixSeconds, false);
+      expect(spy).toHaveBeenCalledWith(unixSeconds, false);
     });
 
     it('should call getLocalizedDateString', () => {
       const spy = jest.spyOn(formatters, 'getLocalizedDateString');
       localizerRsc.getLocalizedDateString(unixSeconds);
-      expect(spy).toBeCalledWith(unixSeconds, false);
+      expect(spy).toHaveBeenCalledWith(unixSeconds, false);
+    });
+
+    it('should call getLocalizedMonthYearString', () => {
+      const month = 4;
+      const year = 2024;
+      const spy = jest.spyOn(formatters, 'getLocalizedMonthYearString');
+      localizerRsc.getLocalizedMonthYearString(month, year, locale);
+      expect(spy).toHaveBeenCalledWith(month, year, locale);
     });
   });
 });

--- a/libs/shared/l10n/src/lib/localizer/localizer.rsc.ts
+++ b/libs/shared/l10n/src/lib/localizer/localizer.rsc.ts
@@ -22,6 +22,7 @@ import {
   getLocalizedCurrencyString,
   getLocalizedDate,
   getLocalizedDateString,
+  getLocalizedMonthYearString,
 } from '../l10n.formatters';
 
 /**
@@ -106,7 +107,11 @@ export class LocalizerRsc {
     return getLocalizedCurrency(amountInCents, currency);
   }
 
-  getLocalizedCurrencyString(amountInCents: number | null, currency: string, locale: string) {
+  getLocalizedCurrencyString(
+    amountInCents: number | null,
+    currency: string,
+    locale: string
+  ) {
     return getLocalizedCurrencyString(amountInCents, currency, locale);
   }
 
@@ -116,5 +121,13 @@ export class LocalizerRsc {
 
   getLocalizedDateString(unixSeconds: number, numericDate = false): string {
     return getLocalizedDateString(unixSeconds, numericDate);
+  }
+
+  getLocalizedMonthYearString(
+    month: number,
+    year: number,
+    locale: string
+  ): string {
+    return getLocalizedMonthYearString(month, year, locale);
   }
 }


### PR DESCRIPTION
## This pull request

- [x] updates Checkout/Upgrade page layout for payments-next
- [x] adds layout for Subscription Management page
   - [x] adds Header to layout
   - [x] handle Sign Out
- [x] adds following content sections to Subscription Management page:
  - Payment Information
    - [x] Adds "Add" button to add payment method (functionality to be added later)
    - [x] Adds "Change" button to change payment method (functionality to be handed in FXA-11246)
    - [x] Displays default payment method 
    - [x] Includes functionality to change PayPal payment method
  - Subscriptions
    - [x] Displays "You don't have subscriptions yet" when customer has no subscriptions
    - [x] Displays placeholder for subscriptions (content to be added in FXA-11919)
    - [x] Displays placeholder for IAP subscriptions (content to be added in FXA-12089)
    - [x] Adds "Change" button functionality to be handled in FXA-11242 and FXA-11243)
- [x] Updates SubscriptionManagement Service to get page content for Subscription Management page
- [x] Adds `getSubManPageContentAction`

## Issue that this pull request solves

Closes: FXA-11241

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
Mobile
<img width="402" height="834" alt="Screenshot 2025-07-14 at 2 51 52 PM" src="https://github.com/user-attachments/assets/ec0bf45d-628b-4b64-a5d1-272f442d4400" />

Tablet
<img width="845" height="1106" alt="Screenshot 2025-07-14 at 2 52 09 PM" src="https://github.com/user-attachments/assets/04786adf-3919-4e32-a398-ab042ca2d2a5" />

Desktop
<img width="1042" height="1090" alt="Screenshot 2025-07-14 at 2 52 21 PM" src="https://github.com/user-attachments/assets/93f868cd-b09e-47db-82c0-30c130b75b70" />
