### PR TITLE
feat(settings): create new FlowSetup2faComplete component

### DIFF
--- a/packages/fxa-settings/src/components/Settings/FlowContainer/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowContainer/index.tsx
@@ -7,6 +7,7 @@ import { useFtlMsgResolver } from '../../../models';
 import { RouteComponentProps } from '@reach/router';
 import Head from 'fxa-react/components/Head';
 import ButtonBack from '../../ButtonBack';
+import classNames from 'classnames';
 
 type FlowContainerProps = {
   title?: string;
@@ -50,14 +51,22 @@ export const FlowContainer = ({
             localizedAriaLabel={backButtonTitle}
           />
         )}
-        <h1 className="font-header text-md text-grey-400">{title}</h1>
+        {title && (
+          <h1 className="font-header text-md text-grey-400">{title}</h1>
+        )}
       </div>
       {subtitle && (
         <h2 className="text-xs text-grey-400 font-semibold uppercase mt-1">
           {subtitle}
         </h2>
       )}
-      <div className="w-full flex flex-col mt-2">{children}</div>
+      <div
+        className={classNames('w-full flex flex-col', {
+          'mt-2': title || subtitle,
+        })}
+      >
+        {children}
+      </div>
     </div>
   );
 };

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/en.ftl
@@ -1,0 +1,20 @@
+flow-setup-2fa-inline-complete-success-banner = Two-step authentication enabled
+
+flow-setup-2fa-inline-complete-backup-code = Backup authentication codes
+flow-setup-2fa-inline-complete-backup-phone = Recovery phone
+
+# $count (Number) - an integer representing the number of backup
+# authentication codes remaining
+flow-setup-2fa-inline-complete-backup-code-info = { $count ->
+  [one] { $count } code remaining
+  *[other] { $count } codes remaining
+}
+
+flow-setup-2fa-inline-complete-backup-code-description = This is the safest recovery method if you can’t sign in with your mobile device or authenticator app.
+flow-setup-2fa-inline-complete-backup-phone-description = This is the easiest recovery method if you can’t sign in with your authenticator app.
+
+flow-setup-2fa-inline-complete-learn-more-link = How this protects your account
+
+# $serviceName (String) - the name of the product that the user will be
+# redirected to.
+flow-setup-2fa-inline-complete-continue-button = Continue to { $serviceName }

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.stories.tsx
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import SettingsLayout from '../SettingsLayout';
+import FlowSetup2faComplete from '.';
+import { action } from '@storybook/addon-actions';
+
+export default {
+  title: 'Components/Settings/FlowSetup2faComplete',
+  component: FlowSetup2faComplete,
+  decorators: [withLocalization],
+} as Meta;
+
+const onContinue = () => {
+  action('onContinue')();
+};
+
+export const BackupCode = () => (
+  <SettingsLayout>
+    <FlowSetup2faComplete
+      serviceName="123Done"
+      onContinue={onContinue}
+      backupType="code"
+      numCodesRemaining={8}
+    />
+  </SettingsLayout>
+);
+
+export const RecoveryPhone = () => (
+  <SettingsLayout>
+    <FlowSetup2faComplete
+      serviceName="123Done"
+      onContinue={onContinue}
+      backupType="phone"
+      lastFourPhoneDigits="4567"
+    />
+  </SettingsLayout>
+);

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.test.tsx
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import FlowSetup2faComplete from './index';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import GleanMetrics from '../../../lib/glean';
+
+describe('FlowSetup2faComplete', () => {
+  const serviceName = '123Done';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders backup code version with 3 codes as expected', () => {
+    renderWithLocalizationProvider(
+      <FlowSetup2faComplete
+        backupType="code"
+        numCodesRemaining={3}
+        serviceName={serviceName}
+        onContinue={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Backup authentication codes')).toBeInTheDocument();
+    expect(screen.getByText('3 codes remaining')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This is the safest recovery method if you can’t sign in with your mobile device or authenticator app.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders backup code version with 1 code as expected', () => {
+    renderWithLocalizationProvider(
+      <FlowSetup2faComplete
+        backupType="code"
+        numCodesRemaining={1}
+        serviceName={serviceName}
+        onContinue={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Backup authentication codes')).toBeInTheDocument();
+    expect(screen.getByText('1 code remaining')).toBeInTheDocument();
+  });
+
+  it('renders recovery phone type', () => {
+    renderWithLocalizationProvider(
+      <FlowSetup2faComplete
+        backupType="phone"
+        lastFourPhoneDigits="1234"
+        serviceName={serviceName}
+        onContinue={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Recovery phone')).toBeInTheDocument();
+    expect(screen.getByText('•••••• 1234')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'This is the easiest recovery method if you can’t sign in with your authenticator app.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('emits and sets up Glean metrics correctly', () => {
+    const spy = jest.spyOn(GleanMetrics.accountPref, 'twoStepAuthCompleteView');
+    renderWithLocalizationProvider(
+      <FlowSetup2faComplete
+        backupType="code"
+        numCodesRemaining={3}
+        serviceName={serviceName}
+        onContinue={jest.fn()}
+      />
+    );
+    expect(spy).toHaveBeenCalledWith({
+      event: { reason: 'inline setup' },
+    });
+    const btn = screen.getByRole('button', {
+      name: 'Continue to 123Done',
+    });
+    expect(btn).toHaveAttribute(
+      'data-glean-id',
+      'two_step_auth_complete_continue'
+    );
+    expect(btn).toHaveAttribute('data-glean-type', 'inline setup');
+  });
+
+  it('calls onContinue for on button click', () => {
+    const onContinue = jest.fn();
+    renderWithLocalizationProvider(
+      <FlowSetup2faComplete
+        backupType="code"
+        numCodesRemaining={3}
+        serviceName={serviceName}
+        onContinue={onContinue}
+      />
+    );
+    const btn = screen.getByRole('button', {
+      name: 'Continue to 123Done',
+    });
+    fireEvent.click(btn);
+    expect(onContinue).toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.tsx
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useEffect } from 'react';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import FlowContainer from '../FlowContainer';
+import GleanMetrics from '../../../lib/glean';
+import { useFtlMsgResolver } from '../../../models';
+import Banner from '../../Banner';
+import {
+  BackupCodesIcon,
+  BackupRecoverySmsIcon,
+  CheckmarkGreenIcon,
+} from '../../Icons';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { GleanClickEventType2FA } from '../../../lib/types';
+
+type FlowSetup2faCompleteProps = (
+  | {
+      backupType: 'code';
+      numCodesRemaining: number;
+    }
+  | {
+      backupType: 'phone';
+      lastFourPhoneDigits: string;
+    }
+) & {
+  serviceName: string;
+  onContinue: () => void;
+  reason?: GleanClickEventType2FA;
+};
+
+const BackupCodesDetails = ({
+  numCodesRemaining,
+}: {
+  numCodesRemaining: number;
+}) => {
+  return (
+    <div className="bg-grey-10 rounded-lg flex mt-3 p-6 gap-5 items-center">
+      <BackupCodesIcon className="flex-none" />
+      <div>
+        <FtlMsg id="flow-setup-2fa-inline-complete-backup-code">
+          <p className="font-semibold text-md">Backup authentication codes</p>
+        </FtlMsg>
+        <div className="flex">
+          <CheckmarkGreenIcon mode="enabled" className="flex-none" />
+          <FtlMsg
+            id="flow-setup-2fa-inline-complete-backup-code-info"
+            vars={{ count: numCodesRemaining }}
+          >
+            <p className="text-sm">{`${numCodesRemaining} ${numCodesRemaining === 1 ? 'code' : 'codes'} remaining`}</p>
+          </FtlMsg>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const RecoveryPhoneDetails = ({
+  lastFourPhoneDigits,
+}: {
+  lastFourPhoneDigits: string;
+}) => {
+  return (
+    <div className="bg-grey-10 rounded-lg flex mt-3 p-6 gap-5 items-center">
+      <BackupRecoverySmsIcon className="flex-none" />
+      <div>
+        <FtlMsg id="flow-setup-2fa-inline-complete-backup-phone">
+          <p className="font-semibold text-md">Recovery phone</p>
+        </FtlMsg>
+        <div className="flex">
+          <CheckmarkGreenIcon mode="enabled" className="flex-none" />
+          {/* Phone numbers should always be displayed left-to-right,
+           *including* in rtl languages */}
+          <p dir="ltr" className="text-sm">
+            •••••• {lastFourPhoneDigits}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const FlowSetup2faComplete = (props: FlowSetup2faCompleteProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const {
+    backupType,
+    serviceName,
+    onContinue,
+    reason = GleanClickEventType2FA.inline,
+  } = props;
+
+  useEffect(() => {
+    GleanMetrics.accountPref.twoStepAuthCompleteView({
+      event: { reason },
+    });
+  }, [reason]);
+
+  return (
+    <FlowContainer hideBackButton={true}>
+      <Banner
+        type="success"
+        textAlignClassName="text-center"
+        content={{
+          localizedHeading: ftlMsgResolver.getMsg(
+            'flow-setup-2fa-inline-complete-success-banner',
+            'Two-step authentication enabled'
+          ),
+        }}
+      ></Banner>
+      {backupType === 'code' ? (
+        <BackupCodesDetails numCodesRemaining={props.numCodesRemaining} />
+      ) : (
+        <RecoveryPhoneDetails lastFourPhoneDigits={props.lastFourPhoneDigits} />
+      )}
+      <div className="text-sm px-4 mt-6 mb-16">
+        {backupType === 'code' ? (
+          <FtlMsg id="flow-setup-2fa-inline-complete-backup-code-description">
+            <p className="mb-2">
+              This is the safest recovery method if you can’t sign in with your
+              mobile device or authenticator app.
+            </p>
+          </FtlMsg>
+        ) : (
+          <FtlMsg id="flow-setup-2fa-inline-complete-backup-phone-description">
+            <p className="mb-2">
+              This is the easiest recovery method if you can’t sign in with your
+              authenticator app.
+            </p>
+          </FtlMsg>
+        )}
+        <FtlMsg id="flow-setup-2fa-inline-complete-learn-more-link">
+          <LinkExternal
+            className="link-blue"
+            href="https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication"
+          >
+            How this protects your account
+          </LinkExternal>
+        </FtlMsg>
+      </div>
+      <FtlMsg
+        id="flow-setup-2fa-inline-complete-continue-button"
+        vars={{ serviceName }}
+      >
+        <button
+          className="cta-primary cta-xl w-full"
+          onClick={onContinue}
+          data-glean-id="two_step_auth_complete_continue"
+          data-glean-type={reason}
+        >
+          Continue to {serviceName}
+        </button>
+      </FtlMsg>
+    </FlowContainer>
+  );
+};
+
+export default FlowSetup2faComplete;

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -590,6 +590,11 @@ const recordEventMetric = (
     case 'account_pref_two_step_auth_disable_success_view':
       accountPref.twoStepAuthDisableSuccessView.record();
       break;
+    case 'account_pref_two_step_auth_complete_view':
+      accountPref.twoStepAuthCompleteView.record({
+        reason: gleanPingMetrics?.event?.['reason'] || '',
+      });
+      break;
     case 'delete_account_settings_submit':
       deleteAccount.settingsSubmit.record();
       break;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2514,6 +2514,27 @@ account_pref:
     expires: never
     data_sensitivity:
       - interaction
+  two_step_auth_complete_view:
+    type: event
+    description: |
+      User viewed the setup complete page after successfully setting up two-step authentication inline.
+    send_in_pings:
+      - events
+    notification_emails:
+      - vzare@mozilla.com
+      - fxa-staff@mozilla.com
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/FXA-10244
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
+    expires: never
+    data_sensitivity:
+      - interaction
+    extra_keys:
+      reason:
+        description: Page is viewed to 'setup' (from settings) or 'inline setup' 2FA.
+        type: string
   change_password_submit:
     type: event
     description: |

--- a/packages/fxa-shared/metrics/glean/web/accountPref.ts
+++ b/packages/fxa-shared/metrics/glean/web/accountPref.ts
@@ -423,6 +423,25 @@ export const twoStepAuthCodesView = new EventMetricType<{
 );
 
 /**
+ * User viewed the setup complete page after successfully setting up two-step
+ * authentication inline.
+ *
+ * Generated from `account_pref.two_step_auth_complete_view`.
+ */
+export const twoStepAuthCompleteView = new EventMetricType<{
+  reason?: string;
+}>(
+  {
+    category: 'account_pref',
+    name: 'two_step_auth_complete_view',
+    sendInPings: ['events'],
+    lifetime: 'ping',
+    disabled: false,
+  },
+  ['reason']
+);
+
+/**
  * User viewed the modal to disable two-step authentication on their account.
  *
  * Generated from `account_pref.two_step_auth_disable_modal_view`.

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { firstGoogleOauthStart } from './email';
-import { backupChoiceSubmit } from './login';
-
 export type GleanMetricsConfig = {
   enabled: boolean;
   applicationId: string;
@@ -207,6 +204,7 @@ export const eventsMap = {
       'account_pref_two_step_auth_disable_modal_view',
     twoStepAuthDisableSuccessView:
       'account_pref_two_step_auth_disable_success_view',
+    twoStepAuthCompleteView: 'account_pref_two_step_auth_complete_view',
     changePasswordSubmit: 'account_pref_change_password_submit',
     deviceSignout: 'account_pref_device_signout',
     appleSubmit: 'account_pref_apple_submit',


### PR DESCRIPTION
## Because

- we need a new flow component to communicate success at the end of the inline 2FA flow before redirecting to the relying party.

## This pull request

- create a new FlowSetup2faComplete component, with storybook, unit tests, l10n and metrics

## Issue that this pull request solves

Closes: FXA-10244

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="544" height="522" alt="image" src="https://github.com/user-attachments/assets/3b242c17-b1fa-492c-be85-4688471fb539" />

<img width="549" height="511" alt="image" src="https://github.com/user-attachments/assets/6bd7e74b-f49e-4828-9ae0-f9ce6fe0305b" />

## Other information (Optional)

Any other information that is important to this pull request.
