### PR TITLE
fix(mozlog): resolve nestjs dependencies errors

### DIFF
--- a/libs/shared/mozlog/project.json
+++ b/libs/shared/mozlog/project.json
@@ -15,6 +15,11 @@
         "outputFileName": "main.js",
         "tsConfig": "libs/shared/mozlog/tsconfig.lib.json",
         "declaration": true,
+        "external": [
+          "@nestjs/websockets/socket-module",
+          "@nestjs/microservices/microservices-module",
+          "@nestjs/microservices"
+        ],
         "assets": [
           {
             "glob": "libs/shared/mozlog/README.md",

--- a/libs/shared/nestjs/customs/project.json
+++ b/libs/shared/nestjs/customs/project.json
@@ -12,6 +12,11 @@
         "outputPath": "dist/libs/shared/nestjs/customs",
         "main": "libs/shared/nestjs/customs/src/index.ts",
         "tsConfig": "libs/shared/nestjs/customs/tsconfig.lib.json",
+        "external": [
+          "@nestjs/websockets/socket-module",
+          "@nestjs/microservices/microservices-module",
+          "@nestjs/microservices"
+        ],
         "assets": ["libs/shared/nestjs/customs/*.md"],
         "format": ["cjs"],
         "generatePackageJson": true

--- a/libs/shared/notifier/project.json
+++ b/libs/shared/notifier/project.json
@@ -15,6 +15,11 @@
         "outputFileName": "main.js",
         "tsConfig": "libs/shared/notifier/tsconfig.lib.json",
         "declaration": true,
+        "external": [
+          "@nestjs/websockets/socket-module",
+          "@nestjs/microservices/microservices-module",
+          "@nestjs/microservices"
+        ],
         "assets": [
           {
             "glob": "libs/shared/notifier/README.md",


### PR DESCRIPTION
## Because

- shared-mozlog was failing to build due to nestjs dependency errors

## This pull request

- Mark missing dependencies as external

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).