### PR TITLE
fix(storybook): fix storybook rendering for Page2faSetup

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.stories.tsx
@@ -3,14 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { LocationProvider } from '@reach/router';
 import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { totpUtils } from '../../../lib/totp-utils';
 import Page2faSetup from '.';
-import SettingsLayout from '../SettingsLayout';
 import { Subject } from './mocks';
 
 // mock check code function to avoid requiring a real totp that changes every 30s
@@ -24,44 +22,36 @@ export default {
 } as Meta;
 
 export const WithRecoveryPhoneOption = () => (
-  <LocationProvider>
-    <SettingsLayout>
-      <Subject
-        account={{
-          recoveryPhone: { available: true },
-          verifyTotp: async () => {
-            action('Verify and enable 2FA')();
-          },
-          addRecoveryPhone: async (phoneNumber: string) => {
-            action('Start phone setup')();
-            return { nationalFormat: phoneNumber };
-          },
-          confirmRecoveryPhone: async () => {
-            action('Confirm SMS code and add phone')();
-          },
-          refresh: async () => {
-            action('Refresh account data for display in settings page')();
-          },
-        }}
-      />
-    </SettingsLayout>
-  </LocationProvider>
+  <Subject
+    account={{
+      recoveryPhone: { available: true },
+      verifyTotp: async () => {
+        action('Verify and enable 2FA')();
+      },
+      addRecoveryPhone: async (phoneNumber: string) => {
+        action('Start phone setup')();
+        return { nationalFormat: phoneNumber };
+      },
+      confirmRecoveryPhone: async () => {
+        action('Confirm SMS code and add phone')();
+      },
+      refresh: async () => {
+        action('Refresh account data for display in settings page')();
+      },
+    }}
+  />
 );
 
 export const WithRecoveryPhoneUnavailable = () => (
-  <LocationProvider>
-    <SettingsLayout>
-      <Subject
-        account={{
-          recoveryPhone: { available: false },
-          verifyTotp: async () => {
-            action('Verify and enable 2FA')();
-          },
-          refresh: async () => {
-            action('Refresh account data for display in settings page')();
-          },
-        }}
-      />
-    </SettingsLayout>
-  </LocationProvider>
+  <Subject
+    account={{
+      recoveryPhone: { available: false },
+      verifyTotp: async () => {
+        action('Verify and enable 2FA')();
+      },
+      refresh: async () => {
+        action('Refresh account data for display in settings page')();
+      },
+    }}
+  />
 );

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/mocks.tsx
@@ -3,27 +3,66 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
+import {
+  MOCK_ACCOUNT,
+  mockAppContext,
+  mockSession,
+} from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
 import Page2faSetup from '.';
-import { LocationProvider } from '@reach/router';
-import { MOCK_2FA_SECRET_KEY_RAW, MOCK_BACKUP_CODES } from '../../../pages/mocks';
+import {
+  LocationProvider,
+  createHistory,
+  createMemorySource,
+  NavigateFn,
+} from '@reach/router';
+import { action } from '@storybook/addon-actions';
+import {
+  MOCK_2FA_SECRET_KEY_RAW,
+  MOCK_BACKUP_CODES,
+  PLACEHOLDER_QR_CODE,
+} from '../../../pages/mocks';
 
 export const MOCK_TOTP_INFO = {
-  qrCodeUrl: 'https://example.com/fake-qr.png',
+  qrCodeUrl: PLACEHOLDER_QR_CODE,
   secret: MOCK_2FA_SECRET_KEY_RAW,
   recoveryCodes: MOCK_BACKUP_CODES,
+};
+
+// Create a safe navigate function for Storybook that matches NavigateFn type
+const createSafeNavigate = (): NavigateFn => {
+  return (to: string | number, options?: any) => {
+    action('Navigate')(`to: ${to}`, options);
+    return Promise.resolve();
+  };
 };
 
 export const Subject = ({ account: accountOverrides = {} }) => {
   const account = {
     ...MOCK_ACCOUNT,
+    createTotp: async () => {
+      action('createTotp called')();
+      return MOCK_TOTP_INFO;
+    },
     ...accountOverrides,
   } as Account;
+
+  const source = createMemorySource('/settings/two_step_authentication');
+  const history = createHistory(source);
+  const historyWithSafeNavigate = {
+    ...history,
+    navigate: createSafeNavigate(),
+  };
+
   return (
-    <LocationProvider>
-      <AppContext.Provider value={{ ...mockAppContext({ account }) }}>
-          <Page2faSetup />
+    <LocationProvider history={historyWithSafeNavigate}>
+      <AppContext.Provider
+        value={{
+          ...mockAppContext({ account }),
+          session: mockSession(true),
+        }}
+      >
+        <Page2faSetup />
       </AppContext.Provider>
     </LocationProvider>
   );


### PR DESCRIPTION
## Because

- Storybook for Page2faSetup was not rendering

## This pull request

- add navigation mock to fix storybook render error
- fix `createTotp` mock to return valid TOTP info including `PLACEHOLDER_QR_CODE`
- removed `SettingsLayout` wrapper - not essential for this story - and `LocationProvider` (duplicated in mocks) from story file 

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
