### PR TITLE
fix(storybook): PageSettings storybook missing auth client mock

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.stories.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { Account } from '../../../models/Account';
+import AuthClient from 'fxa-auth-client/browser';
 
 import { PageSettings } from '.';
 import { Config } from '../../../lib/config';
@@ -28,24 +29,34 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+const mockAuthClient = {
+  geoEligibilityCheck: async () => ({ eligible: true }),
+} as Partial<AuthClient> as AuthClient;
+
 const storyWithContext = (
   account: Partial<Account>,
   storyName?: string,
   config?: Config
 ) => {
   const context = config
-    ? { account: account as Account, config: config }
-    : { account: account as Account };
+    ? {
+        account: account as Account,
+        config: config,
+        authClient: mockAuthClient,
+      }
+    : { account: account as Account, authClient: mockAuthClient };
 
-  const story = () => (
-    <LocationProvider>
-      <AppContext.Provider value={mockAppContext(context)}>
-        <SettingsLayout>
-          <PageSettings />
-        </SettingsLayout>
-      </AppContext.Provider>
-    </LocationProvider>
-  );
+  const story = () => {
+    return (
+      <LocationProvider>
+        <AppContext.Provider value={mockAppContext(context)}>
+          <SettingsLayout>
+            <PageSettings />
+          </SettingsLayout>
+        </AppContext.Provider>
+      </LocationProvider>
+    );
+  };
   if (storyName) story.storyName = storyName;
   return story;
 };


### PR DESCRIPTION
## Because

- PageSettings storybook was not rendering

## This pull request

- add an authclient mock for the useGeoEligibilityCheck hook, resolving eligibility to true
- this setting shows the global Monitor promo in the "cold start" story with no services, and the special US-only promo in the "completely filled out" story which includes Monitor in the services list

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
