### PR TITLE
chore(tests): add global setup for chaiAsPromised

### DIFF
--- a/packages/fxa-auth-server/.mocharc.js
+++ b/packages/fxa-auth-server/.mocharc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extension: ['ts', 'js'], // include extensions
+  require: [
+    'test/setup.js' // setup file to run before any tests
+  ],
 };

--- a/packages/fxa-auth-server/test/local/l10n/index.ts
+++ b/packages/fxa-auth-server/test/local/l10n/index.ts
@@ -4,12 +4,9 @@
 
 import { FluentBundle } from '@fluent/bundle';
 import { Localization } from '@fluent/dom';
-import chai, { assert } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { assert } from 'chai';
 import Localizer from '../../../lib/l10n';
 import { LocalizerBindings } from '../../../lib/l10n/bindings';
-
-chai.use(chaiAsPromised);
 
 describe('Localizer', () => {
   describe('fetches bundles', () => {

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -6,7 +6,6 @@ const { AccountEventsManager } = require('../../../lib/account-events');
 const AppError = require('../../../lib/error');
 
 const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
 const { AccountManager } = require('@fxa/shared/account/account');
 
 const sinon = require('sinon');
@@ -23,7 +22,6 @@ const {
 const { getRoute } = require('../../routes_helpers');
 const { mockRequest } = require('../../mocks');
 const { Container } = require('typedi');
-chai.use(chaiAsPromised);
 
 describe('/recovery_phone', () => {
   const sandbox = sinon.createSandbox();

--- a/packages/fxa-auth-server/test/local/senders/renderer.ts
+++ b/packages/fxa-auth-server/test/local/senders/renderer.ts
@@ -2,15 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import chai, { assert } from 'chai';
-import chaiAsPromised from 'chai-as-promised';
+import { assert } from 'chai';
 import Renderer, {
   flattenNestedObjects,
   splitPlainTextLine,
 } from '../../../lib/senders/renderer';
 import { NodeRendererBindings } from '../../../lib/senders/renderer/bindings-node';
-
-chai.use(chaiAsPromised);
 
 describe('Renderer', () => {
   it('fails with a bad localizer ftl basePath', () => {

--- a/packages/fxa-auth-server/test/remote/password_forgot_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_forgot_tests.js
@@ -4,8 +4,7 @@
 
  'use strict';
 
- const chai = require('chai');
- const chaiAsPromised = require('chai-as-promised');
+ const { assert } = require('chai');
  const url = require('url');
  const Client = require('../client')();
  const TestServer = require('../test_server');
@@ -14,9 +13,6 @@
 
  const config = require('../../config').default.getProperties();
  const mocks = require('../mocks');
-
- chai.use(chaiAsPromised);
- const { assert } = chai;
 
  [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
    describe(`#integration${testOptions.version} - remote password forgot`, function () {

--- a/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_phone_tests.js
@@ -2,8 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const chai = require('chai');
-const chaiAsPromised = require('chai-as-promised');
+const { assert } = require('chai');
 const Client = require('../client')();
 const TestServer = require('../test_server');
 const config = require('../../config').default.getProperties();
@@ -12,8 +11,6 @@ const { setupAccountDatabase } = require('@fxa/shared/db/mysql/account');
 const { RECOVERY_PHONE_REDIS_PREFIX } = require('@fxa/accounts/recovery-phone');
 const otplib = require('otplib');
 const crypto = require('crypto');
-const { assert } = chai;
-chai.use(chaiAsPromised);
 
 const redis = new Redis({
   ...config.redis,

--- a/packages/fxa-auth-server/test/setup.js
+++ b/packages/fxa-auth-server/test/setup.js
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Global setup for chaiAsPromised so test modules don't need
+// to configure it individually.
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);


### PR DESCRIPTION
## Becuase:
 - Test modules that don't configure chaiAsPromised are implicitly coupled to other test modules that do

## This Commit:
 - Uses a global setup for configuring chaiAsPromised

Closes (FXA-12098)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
