### PR TITLE
fix(auth): disable cms for sub int tests

### DIFF
--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -45,6 +45,7 @@ const PRODUCT_NAME = 'All Done Pro';
         sharedSecret: 'wibble',
         paymentsServer: config.subscriptions.paymentsServer,
       };
+      config.cms.enabled = false;
       Container.set(AppConfig, config);
     });
 


### PR DESCRIPTION
## Because

- Subscription integration tests in auth-server should not have CMS
  enabled

## This pull request

- Manually sets cms.enabled to false

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
