### PR TITLE
fix(settings): fix “Sync is turned on” page displayed  for a brief period of time

### DIFF
--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.test.tsx
@@ -232,16 +232,15 @@ describe('ConfirmSignupCode page', () => {
   });
 
   it('renders as expected with cms', () => {
-    renderWithSession({ session, integration: createMockOAuthWebIntegration() });
+    renderWithSession({
+      session,
+      integration: createMockOAuthWebIntegration(),
+    });
     // testAllL10n(screen, bundle);
 
     const headingEl = screen.getByRole('heading', { level: 1 });
-    expect(headingEl).toHaveTextContent(
-      'Enter confirmation code'
-    );
-    screen.getByText(
-      'For your Mozilla account'
-    );
+    expect(headingEl).toHaveTextContent('Enter confirmation code');
+    screen.getByText('For your Mozilla account');
     screen.getByLabelText('Enter 6-digit code');
 
     screen.getByRole('button', { name: 'Confirm' });
@@ -371,6 +370,25 @@ describe('ConfirmSignupCode page', () => {
       input.focus();
       await user.paste('123456');
       expect(session.verifySession).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate to the confirmed page if integration is mobile sync', async () => {
+      const integration = createMockOAuthNativeIntegration(true);
+      jest.spyOn(integration, 'isFirefoxMobileClient').mockReturnValue(true);
+
+      renderWithSession({
+        session,
+        integration,
+        finishOAuthFlowHandler: mockFinishOAuthFlowHandler,
+      });
+      submit(MOCK_SIGNUP_CODE, 'Start syncing');
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalled();
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        expect.stringContaining('signup_confirmed_sync')
+      );
     });
   });
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -53,7 +53,7 @@ const ConfirmSignupCode = ({
   keyFetchToken,
   unwrapBKey,
   flowQueryParams,
-  origin
+  origin,
 }: ConfirmSignupCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -221,7 +221,7 @@ const ConfirmSignupCode = ({
             });
             // Mobile sync will close the web view, OAuth Desktop mimics DesktopV3 behavior
             const { to } = getSyncNavigate(location.search, {
-              showSignupConfirmedSync: true,
+              showSignupConfirmedSync: !integration.isFirefoxMobileClient(),
             });
             navigate(to);
             return;
@@ -299,22 +299,24 @@ const ConfirmSignupCode = ({
         'Enter confirmation code'
       )}
     >
-
       {cmsInfo ? (
-          <>
-            {cmsInfo?.shared?.logoUrl && cmsInfo?.shared?.logoAltText && (
-              <img
-                data-testid="cms-logo"
-                src={cmsInfo?.shared.logoUrl}
-                alt={cmsInfo?.shared.logoAltText}
-                className="justify-start mb-4 max-h-[40px]"
-              />)}
-            <h1 className="card-header">{cmsInfo?.SignupConfirmCodePage?.headline}</h1>
-            <p className="mt-1 text-sm">
-              {cmsInfo?.SignupConfirmCodePage?.description}
-            </p>
-          </>
-        ) : (
+        <>
+          {cmsInfo?.shared?.logoUrl && cmsInfo?.shared?.logoAltText && (
+            <img
+              data-testid="cms-logo"
+              src={cmsInfo?.shared.logoUrl}
+              alt={cmsInfo?.shared.logoAltText}
+              className="justify-start mb-4 max-h-[40px]"
+            />
+          )}
+          <h1 className="card-header">
+            {cmsInfo?.SignupConfirmCodePage?.headline}
+          </h1>
+          <p className="mt-1 text-sm">
+            {cmsInfo?.SignupConfirmCodePage?.description}
+          </p>
+        </>
+      ) : (
         <CardHeader
           headingText="Enter confirmation code"
           headingAndSubheadingFtlId="confirm-signup-code-heading-2"
@@ -364,7 +366,7 @@ const ConfirmSignupCode = ({
           cmsButton: {
             text: cmsInfo?.SignupConfirmCodePage?.primaryButtonText,
             color: cmsInfo?.shared?.buttonColor,
-          }
+          },
         }}
       />
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -40,7 +40,13 @@ export interface ConfirmSignupCodeFormData {
 
 export type ConfirmSignupCodeBaseIntegration = Pick<
   Integration,
-  'type' | 'data' | 'getService' | 'getClientId' | 'isDesktopRelay' | 'isSync' | 'getCmsInfo'
+  | 'type'
+  | 'data'
+  | 'getService'
+  | 'getClientId'
+  | 'isDesktopRelay'
+  | 'isSync'
+  | 'getCmsInfo'
 >;
 
 export type ConfirmSignupCodeOAuthIntegration = Pick<
@@ -55,6 +61,7 @@ export type ConfirmSignupCodeOAuthIntegration = Pick<
   | 'getPermissions'
   | 'isDesktopRelay'
   | 'getCmsInfo'
+  | 'isFirefoxMobileClient'
 >;
 
 export type ConfirmSignupCodeIntegration =


### PR DESCRIPTION
## Because

- “Sync is turned on” page is displayed for a brief period of time when signing up for sync on mobile

## This pull request

- fixes this issue and adds a unit test for this scenario.

## Issue that this pull request solves

Closes: FXA-12076

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
