### PR TITLE
fix(next): allow upgrade for missing payment method

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import assert from 'assert';
 import { headers } from 'next/headers';
 import Image from 'next/image';
 import { getCardIcon, PaymentSection } from '@fxa/payments/ui';
@@ -64,7 +63,6 @@ export default async function Upgrade({
     locale
   );
   const [cart, cms] = await Promise.all([cartDataPromise, cmsDataPromise]);
-  assert(cart.paymentInfo, 'paymentInfo is missing in cart');
 
   return (
     <>
@@ -90,27 +88,29 @@ export default async function Upgrade({
           )}
         </h2>
 
-        <div className="flex items-center justify-between mt-4 text-sm">
-          {cart.paymentInfo.type === 'external_paypal' ? (
-            <Image src={getCardIcon('paypal')} alt="paypal" />
-          ) : (
-            <span className="flex items-center gap-2">
-              {cart.paymentInfo.brand && (
-                <Image
-                  src={getCardIcon(cart.paymentInfo.brand)}
-                  alt={cart.paymentInfo.brand}
-                />
-              )}
-              {l10n.getString(
-                'next-payment-confirmation-cc-card-ending-in',
-                {
-                  last4: cart.paymentInfo.last4 ?? '',
-                },
-                `Card ending in ${cart.paymentInfo.last4}`
-              )}
-            </span>
-          )}
-        </div>
+        {cart.paymentInfo && (
+          <div className="flex items-center justify-between mt-4 text-sm">
+            {cart.paymentInfo.type === 'external_paypal' ? (
+              <Image src={getCardIcon('paypal')} alt="paypal" />
+            ) : (
+              <span className="flex items-center gap-2">
+                {cart.paymentInfo.brand && (
+                  <Image
+                    src={getCardIcon(cart.paymentInfo.brand)}
+                    alt={cart.paymentInfo.brand}
+                  />
+                )}
+                {l10n.getString(
+                  'next-payment-confirmation-cc-card-ending-in',
+                  {
+                    last4: cart.paymentInfo.last4 ?? '',
+                  },
+                  `Card ending in ${cart.paymentInfo.last4}`
+                )}
+              </span>
+            )}
+          </div>
+        )}
 
         <div
           className="border-b border-grey-200 my-6"
@@ -132,8 +132,8 @@ export default async function Upgrade({
             `Your plan will change immediately, and you’ll be charged a prorated
           amount today for the rest of this billing cycle. Starting
           ${l10n.getLocalizedDateString(
-            cart.upcomingInvoicePreview.nextInvoiceDate
-          )}
+              cart.upcomingInvoicePreview.nextInvoiceDate
+            )}
           you’ll be charged the full amount.`
           )}
         </p>


### PR DESCRIPTION
## Because

- In instances where a customer does not have a default payment method, these customers should not be blocked from upgrading the subscription.

## This pull request

- Hides payment information section on upgrade page if not available and lets customers checkout with a new payment method.

## Issue that this pull request solves

Closes: #PAY-3131

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).