### PR TITLE
fix(payments-next): Display prorated price if available instead of list price to match invoice

### DIFF
--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -41,6 +41,7 @@ export interface Invoice {
   nextInvoiceDate: number;
   amountDue: number;
   creditApplied: number | null;
+  remainingAmountTotal?: number;
   startingBalance: number;
   unusedAmountTotal?: number;
 }

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -18,6 +18,7 @@ export type InvoicePreview = {
   nextInvoiceDate: number;
   amountDue: number;
   creditApplied: number | null;
+  remainingAmountTotal?: number;
   startingBalance: number;
   unusedAmountTotal?: number;
 };

--- a/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
+++ b/libs/payments/customer/src/lib/util/stripeInvoiceToFirstInvoicePreviewDTO.spec.ts
@@ -40,6 +40,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
         ? mockUpcomingInvoice.starting_balance -
           mockUpcomingInvoice.ending_balance
         : mockUpcomingInvoice.starting_balance,
+      remainingAmountTotal: undefined,
       startingBalance: mockUpcomingInvoice.starting_balance,
       unusedAmountTotal: 0,
       discountEnd: undefined,
@@ -79,6 +80,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
         ? mockUpcomingInvoice.starting_balance -
           mockUpcomingInvoice.ending_balance
         : mockUpcomingInvoice.starting_balance,
+      remainingAmountTotal: undefined,
       startingBalance: mockUpcomingInvoice.starting_balance,
       unusedAmountTotal: 0,
       discountEnd: null,
@@ -123,6 +125,7 @@ describe('stripeInvoiceToFirstInvoicePreviewDTO', () => {
         ? mockUpcomingInvoice.starting_balance -
           mockUpcomingInvoice.ending_balance
         : mockUpcomingInvoice.starting_balance,
+      remainingAmountTotal: undefined,
       startingBalance: mockUpcomingInvoice.starting_balance,
       unusedAmountTotal: 0,
       discountEnd: undefined,

--- a/libs/payments/ui/src/lib/client/components/PurchaseDetails/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/PurchaseDetails/en.ftl
@@ -2,6 +2,8 @@
 
 next-plan-details-header = Product details
 next-plan-details-list-price = List Price
+# $productName (String) - The name of the product, e.g. Mozilla VPN
+plan-details-product-prorated-price = Prorated price for { $productName }
 next-plan-details-tax = Taxes and Fees
 next-plan-details-total-label = Total
 # "Unused time" refers to the remaining value of the current subscription that hasn't been used yet

--- a/libs/payments/ui/src/lib/client/components/PurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PurchaseDetails/index.tsx
@@ -48,6 +48,7 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
     discountAmount,
     discountEnd,
     discountType,
+    remainingAmountTotal,
     startingBalance,
     subtotal,
     taxAmounts,
@@ -123,11 +124,25 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
 
             <ul className="border-b border-grey-200 py-6">
               <li className="flex items-center justify-between gap-2 leading-5 text-grey-600 text-sm">
-                <Localized id="next-plan-details-list-price">
-                  <p>List Price</p>
-                </Localized>
+                {remainingAmountTotal &&
+                offeringPrice !== remainingAmountTotal ? (
+                  <Localized
+                    id="plan-details-product-prorated-price"
+                    vars={{ productName }}
+                  >
+                    <p>Prorated price for {productName}</p>
+                  </Localized>
+                ) : (
+                  <Localized id="next-plan-details-list-price">
+                    <p>List Price</p>
+                  </Localized>
+                )}
                 <p>
-                  {getLocalizedCurrencyString(offeringPrice, currency, locale)}
+                  {getLocalizedCurrencyString(
+                    remainingAmountTotal ?? offeringPrice,
+                    currency,
+                    locale
+                  )}
                 </p>
               </li>
 
@@ -216,7 +231,7 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
                 </Localized>
                 <p
                   className="overflow-hidden text-ellipsis whitespace-nowrap"
-                  data-testid="total-price"
+                  data-testid="total-before-credits-price"
                 >
                   {getLocalizedCurrencyString(totalAmount, currency, locale)}
                 </p>

--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/en.ftl
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/en.ftl
@@ -7,7 +7,6 @@ upgrade-purchase-details-tax-label = Taxes and Fees
 # "Credit issued to account" refers to credit that will be added to the account balance that will be used toward future invoices
 upgrade-purchase-details-credit-to-account = Credit issued to account
 upgrade-purchase-details-credit-will-be-applied = Credit will be applied to your account and used towards future invoices.
-
 ## $productName (String) - Name of the upgraded product (e.g. Mozilla VPN)
 ## Daily/Weekly/Monthly/Yearly refers to the subscription interval/amount of time between billing occurrences
 upgrade-purchase-details-new-plan-daily = { $productName } (Daily)

--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
@@ -48,6 +48,7 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
     creditApplied,
     currency,
     discountAmount,
+    remainingAmountTotal,
     startingBalance,
     subtotal,
     taxAmounts,
@@ -143,18 +144,35 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
 
       <ul className="py-6 text-sm">
         <li className="flex items-center justify-between gap-2 leading-5 text-grey-600">
-          <p>
-            {l10n.getString(
-              `upgrade-purchase-details-new-plan-${interval}`,
-              {
-                productName,
-              },
+          {remainingAmountTotal && offeringPrice !== remainingAmountTotal ? (
+            <p>
+              {l10n.getString(
+                'plan-details-product-prorated-price',
+                {
+                  productName,
+                },
 
-              `${productName} (${formatPlanInterval(interval)})`
-            )}
-          </p>
+                `Prorated price for ${productName}`
+              )}
+            </p>
+          ) : (
+            <p>
+              {l10n.getString(
+                `upgrade-purchase-details-new-plan-${interval}`,
+                {
+                  productName,
+                },
+
+                `${productName} (${formatPlanInterval(interval)})`
+              )}
+            </p>
+          )}
           <p>
-            {l10n.getLocalizedCurrencyString(offeringPrice, currency, locale)}
+            {l10n.getLocalizedCurrencyString(
+              remainingAmountTotal ?? offeringPrice,
+              currency,
+              locale
+            )}
           </p>
         </li>
 


### PR DESCRIPTION
## Because

- the invoice may display the amount for the remaining time (prorated price) of the upgraded plan, not the price of the product (see invoice [1] -  $3.74 (Remaining time on MDN Plus 10M) - $1.87 (Unused time on MDN Plus 5M) = $1.87 total due)
- the confirmation page is showing the list price of the product, so the math is off (see screenshot [2] - $10.00 - $1.87 = $1.87)

## This pull request

- adds remainingAmountTotal to DTO, if amount for remaining time is available
- if remainingAmountTotal is available, display instead of the list price of the product with "Prorated product ({productName})" label
  - if list price and remaining amount are the same, display "List Price" label

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
<img width="347" height="617" alt="Screenshot 2025-07-21 at 10 10 27 AM" src="https://github.com/user-attachments/assets/e9882fb9-30d1-4d55-b280-d9ace465e737" />


[1] 
<img width="489" height="317" alt="Screenshot 2025-07-18 at 11 13 56 AM" src="https://github.com/user-attachments/assets/f2cc2b47-9cfd-4f4f-a8fb-04eed6a53f72" />

[2] 
<img width="424" height="610" alt="Screenshot 2025-07-18 at 11 13 26 AM" src="https://github.com/user-attachments/assets/c2924a97-c8ab-495a-bf93-f4e07087980f" />

### Upgrade Page
[3] Amount for remaining time exists
<img width="341" height="610" alt="Screenshot 2025-07-18 at 1 56 16 PM" src="https://github.com/user-attachments/assets/4e3f4f90-4697-422e-8ea8-b0802df14955" />

[4] No amount for remaining time exists
<img width="325" height="517" alt="Screenshot 2025-07-18 at 1 51 40 PM" src="https://github.com/user-attachments/assets/78524eb0-d24b-456b-9ef8-ac9ee6d775d7" />


### Success Page
[5] Amount for remaining time exists
<img width="338" alt="Screenshot 2025-07-18 at 2 02 54 PM" src="https://github.com/user-attachments/assets/fc53f7a1-bd62-4376-9b0a-45263f042c1c" />

[6] No amount for remaining time exists
<img width="338" height="553" alt="Screenshot 2025-07-18 at 1 52 15 PM" src="https://github.com/user-attachments/assets/8cc8bdbf-4a6f-45a2-ae64-93cce8ecbdd9" />

