### PR TITLE
fix(settings): Fix email confirmation navigation

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -27,6 +27,7 @@ import VerificationReasons from '../../../constants/verification-reasons';
 import { currentAccount } from '../../../lib/cache';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import { NavigationOptions } from '../../Signin/interfaces';
 
 type LinkedAccountData = {
   uid: hexstring;
@@ -78,7 +79,7 @@ const ThirdPartyAuthCallback = ({
    */
   const performNavigation = useCallback(
     async (linkedAccount: LinkedAccountData, needsVerification = false) => {
-      const navigationOptions = {
+      const navigationOptions: NavigationOptions = {
         email: linkedAccount.email,
         signinData: {
           uid: linkedAccount.uid,
@@ -137,7 +138,10 @@ const ThirdPartyAuthCallback = ({
       // Extract relayed fxa parameters
       const params = new URLSearchParams(fxaParams || '');
       const flowId = params.get('flowId') || params.get('flow_id') || undefined;
-      const flowBeginTime = params.get('flowBeginTime') || params.get('flow_begin_time') || undefined;
+      const flowBeginTime =
+        params.get('flowBeginTime') ||
+        params.get('flow_begin_time') ||
+        undefined;
       const originalService =
         params.get('service') || params.get('client_id') || undefined;
       const linkedAccount: LinkedAccountData =

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -6,7 +6,7 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import SigninPushCode from '.';
 import { MozServices } from '../../../lib/types';
 import { getSigninState, handleNavigation } from '../utils';
-import { SigninLocationState } from '../interfaces';
+import { NavigationOptions, SigninLocationState } from '../interfaces';
 import {
   Integration,
   isWebIntegration,
@@ -86,7 +86,7 @@ export const SigninPushCodeContainer = ({
   }
 
   const onCodeVerified = async () => {
-    const navigationOptions = {
+    const navigationOptions : NavigationOptions = {
       email: signinState.email,
       signinData: { ...signinState, verified: true },
       unwrapBKey,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -30,6 +30,7 @@ import { HeadingPrimary } from '../../../components/HeadingPrimary';
 import ButtonBack from '../../../components/ButtonBack';
 import classNames from 'classnames';
 import { GET_LOCAL_SIGNED_IN_STATUS } from '../../../components/App/gql';
+import { NavigationOptions } from '../interfaces';
 
 export const viewName = 'signin-recovery-code';
 
@@ -86,7 +87,7 @@ const SigninRecoveryCode = ({
   };
 
   const onSuccessNavigate = useCallback(async () => {
-    const navigationOptions = {
+    const navigationOptions : NavigationOptions = {
       email,
       signinData: {
         uid,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -5,7 +5,7 @@
 import React, { useContext, useEffect } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import SigninRecoveryPhone from '.';
-import { SigninLocationState } from '../interfaces';
+import { NavigationOptions, SigninLocationState } from '../interfaces';
 import { getSigninState, handleNavigation } from '../utils';
 import {
   AppContext,
@@ -104,7 +104,7 @@ const SigninRecoveryPhoneContainer = ({
       });
       await new Promise((resolve) => setTimeout(resolve, 100));
 
-      const navigationOptions = {
+      const navigationOptions : NavigationOptions = {
         email: signinState.email,
         signinData: {
           uid: signinState.uid,

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -10,7 +10,7 @@ import { logViewEvent } from '../../../lib/metrics';
 import { MozServices } from '../../../lib/types';
 import AppLayout from '../../../components/AppLayout';
 import GleanMetrics from '../../../lib/glean';
-import { SigninIntegration, SigninLocationState } from '../interfaces';
+import { NavigationOptions, SigninIntegration, SigninLocationState } from '../interfaces';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { handleNavigation } from '../utils';
 import { FinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
@@ -90,7 +90,7 @@ export const SigninTotpCode = ({
         verified: true,
       });
 
-      const navigationOptions = {
+      const navigationOptions: NavigationOptions = {
         email,
         signinData: {
           uid,

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -33,6 +33,7 @@ import { ResendStatus } from '../../../lib/types';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import Banner, { ResendCodeSuccessBanner } from '../../../components/Banner';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
+import { NavigationOptions } from '../interfaces';
 
 export const viewName = 'signin-unblock';
 
@@ -134,7 +135,7 @@ export const SigninUnblock = ({
 
       storeAccountData(accountData);
 
-      const navigationOptions = {
+      const navigationOptions: NavigationOptions = {
         email,
         signinData: data.signIn,
         unwrapBKey: data.unwrapBKey,

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -215,11 +215,12 @@ const Signin = ({
 
         storeAccountData(accountData);
 
-        const navigationOptions = {
+        const navigationOptions: NavigationOptions = {
           email,
           signinData: data.signIn,
           unwrapBKey: data.unwrapBKey,
-          verified: data.signIn.verified,
+
+          sessionVerified: data.sessionVerified,
           integration,
           finishOAuthFlowHandler,
           redirectTo:
@@ -404,7 +405,7 @@ const Signin = ({
             clientId,
             serviceName,
             cmsLogoUrl: cmsInfo?.shared?.logoUrl,
-            cmsLogoAltText: cmsInfo?.shared?.logoAltText
+            cmsLogoAltText: cmsInfo?.shared?.logoAltText,
           }}
         />
       )}
@@ -528,7 +529,7 @@ const Signin = ({
               searchParams.delete('email');
               navigateWithQuery(`/?${searchParams.toString()}`, {
                 state: {
-                  prefillEmail: email
+                  prefillEmail: email,
                 },
               });
             }}


### PR DESCRIPTION
## Because

* Sign in with password was not navigating to signin_token_code when session verification required, then getting bumped back from settings

## This pull request

* Pass missing `sessionVerified` value to navigation handler

## Issue that this pull request solves

Closes: FXA-12096

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
