### PR TITLE
chore(fxa-settings): clean up React act() unit test warnings

### DIFF
--- a/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPasswordWithBalloons/index.test.tsx
@@ -67,7 +67,7 @@ describe('FormPasswordWithBalloons component', () => {
       it('disallows space-only passwords', async () => {
         renderWithLocalizationProvider(<Subject />);
         const passwordField = screen.getByLabelText('Password');
-        user.type(passwordField, '        ');
+        await user.type(passwordField, '        ');
 
         await waitFor(() => screen.getByText('Password requirements'));
         expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
@@ -83,7 +83,7 @@ describe('FormPasswordWithBalloons component', () => {
       it('disallows common passwords', async () => {
         renderWithLocalizationProvider(<Subject />);
         const passwordField = screen.getByLabelText('Password');
-        user.type(passwordField, 'mozilla accounts');
+        await user.type(passwordField, 'mozilla accounts');
         await waitFor(() => screen.getByText('Password requirements'));
         expect(screen.queryAllByText('icon-check-blue-50.svg')).toHaveLength(2);
 

--- a/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FormPhoneNumber from '.';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
@@ -11,13 +11,14 @@ import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localiz
 const mockSubmit = jest.fn();
 
 describe('FormPhoneNumber', () => {
-  function render() {
-    renderWithLocalizationProvider(
-      <FormPhoneNumber
-        localizedCTAText="Send code"
-        submitPhoneNumber={mockSubmit}
-      />
-    );
+  async function render() {
+      await act(() => {renderWithLocalizationProvider(
+        <FormPhoneNumber
+          localizedCTAText="Send code"
+          submitPhoneNumber={mockSubmit}
+        />
+      )
+    });
   }
 
   function renderWithInfoBannerProps() {
@@ -49,7 +50,7 @@ describe('FormPhoneNumber', () => {
   }
 
   it('renders the component as expected', async () => {
-    render();
+    await render();
     await waitFor(() => {
       expect(screen.getByRole('combobox')).toBeInTheDocument();
       expect(getPhoneInput()).toBeInTheDocument();
@@ -75,7 +76,7 @@ describe('FormPhoneNumber', () => {
   });
 
   it('submit button is disabled by default', async () => {
-    render();
+    await render();
     await waitFor(() => {
       expect(getSubmitButton()).toBeDisabled();
     });
@@ -84,7 +85,7 @@ describe('FormPhoneNumber', () => {
   describe('form validity and submission', () => {
     it('submit button is enabled for valid North American number, 1231231234, and is formatted as expected', async () => {
       const user = userEvent.setup();
-      render();
+      await render();
       await waitFor(() => user.type(getPhoneInput(), '1231231234'));
       expect(getSubmitButton()).toBeEnabled();
       user.click(getSubmitButton());
@@ -95,7 +96,7 @@ describe('FormPhoneNumber', () => {
 
     it('submit button is enabled for valid North American number, (123) 123-1234, and is formatted as expected', async () => {
       const user = userEvent.setup();
-      render();
+      await render();
       await waitFor(
         async () => await user.type(getPhoneInput(), '(123) 123-1234')
       );
@@ -106,7 +107,7 @@ describe('FormPhoneNumber', () => {
 
     it('input value is restricted to 10 digits', async () => {
       const user = userEvent.setup();
-      render();
+      await render();
       await waitFor(
         async () => await user.type(getPhoneInput(), '12312312345')
       );
@@ -116,7 +117,7 @@ describe('FormPhoneNumber', () => {
 
     it('submit button is disabled for invalid number with letters phoneValidationNorthAmerica, abc12312345', async () => {
       const user = userEvent.setup();
-      render();
+      await render();
       await waitFor(
         async () => await user.type(getPhoneInput(), 'abc12312345')
       );

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { UserEvent, userEvent } from '@testing-library/user-event';
 import { logViewEvent } from '../../../lib/metrics';
 import FlowRecoveryKeyDownload from './';
 import { renderWithRouter } from '../../../models/mocks';
@@ -30,10 +31,11 @@ jest.mock('@react-pdf/renderer', () => {
   };
 });
 
-const renderFlowPage = () => {
+const renderFlowPage = async () => {
   window.URL.createObjectURL = jest.fn();
-  renderWithRouter(
-    <FlowRecoveryKeyDownload
+  await act(() => {
+    renderWithRouter(
+      <FlowRecoveryKeyDownload
       {...{
         localizedBackButtonTitle,
         localizedPageTitle,
@@ -43,17 +45,19 @@ const renderFlowPage = () => {
       }}
       email={MOCK_EMAIL}
       recoveryKeyValue={MOCK_RECOVERY_KEY_VALUE}
-    />
-  );
+      />
+    );
+  });
 };
 
 describe('FlowRecoveryKeyDownload', () => {
+
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('renders as expected', async () => {
-    renderFlowPage();
+    await renderFlowPage();
 
     screen.getByRole('heading', {
       level: 2,
@@ -71,7 +75,7 @@ describe('FlowRecoveryKeyDownload', () => {
   });
 
   it('emits the expected metrics when user copies the recovery key', async () => {
-    renderFlowPage();
+    await renderFlowPage();
     const copyButton = screen.getByRole('button', { name: 'Copy' });
     fireEvent.click(copyButton);
     await waitFor(() =>
@@ -83,7 +87,7 @@ describe('FlowRecoveryKeyDownload', () => {
   });
 
   it('emits the expected metrics when user downloads the recovery key', async () => {
-    renderFlowPage();
+    await renderFlowPage();
     const downloadButton = screen.getByText('Download and continue');
     fireEvent.click(downloadButton);
     await waitFor(() => {
@@ -94,8 +98,8 @@ describe('FlowRecoveryKeyDownload', () => {
     });
   });
 
-  it('emits the expected metrics when user navigates forward', () => {
-    renderFlowPage();
+  it('emits the expected metrics when user navigates forward', async () => {
+    await renderFlowPage();
     const nextPageLink = screen.getByRole('button', {
       name: 'Continue without downloading',
     });
@@ -107,8 +111,8 @@ describe('FlowRecoveryKeyDownload', () => {
     expect(navigateForward).toHaveBeenCalledTimes(1);
   });
 
-  it('emits the expected metrics when user clicks the back arrow', () => {
-    renderFlowPage();
+  it('emits the expected metrics when user clicks the back arrow', async () => {
+    await renderFlowPage();
     const backLink = screen.getByRole('button', { name: 'Back to settings' });
     fireEvent.click(backLink);
     expect(navigateBackward).toHaveBeenCalledTimes(1);

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import FlowSetupRecoveryPhoneSubmitNumber from '.';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
@@ -35,10 +35,21 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
     jest.clearAllMocks();
   });
 
+  /**
+   * Renders the {@link FlowSetupRecoveryPhoneSubmitNumber} component with the provided props.
+   * Uses defaultProps if none are provided.
+   * @param props
+   */
+  async function renderWith(props = defaultProps) {
+    await act(() => {
+      renderWithLocalizationProvider(
+        <FlowSetupRecoveryPhoneSubmitNumber {...props} />
+      );
+    });
+  }
+
   test('renders component as expected', async () => {
-    renderWithLocalizationProvider(
-      <FlowSetupRecoveryPhoneSubmitNumber {...defaultProps} />
-    );
+    await renderWith();
 
     await waitFor(() =>
       expect(
@@ -66,9 +77,7 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
 
   test('handles successful number verification', async () => {
     const user = userEvent.setup();
-    renderWithLocalizationProvider(
-      <FlowSetupRecoveryPhoneSubmitNumber {...defaultProps} />
-    );
+    await renderWith();
 
     await waitFor(() =>
       user.type(
@@ -81,13 +90,10 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
     await waitFor(() => expect(mockVerifyPhoneNumber).toHaveBeenCalledTimes(1));
     expect(mockNavigateForward).toHaveBeenCalledTimes(1);
   });
-
-  test('handles error during number verification', async () => {
+   test('handles error during number verification', async () => {
     mockVerifyPhoneNumber.mockRejectedValueOnce(new Error('error'));
     const user = userEvent.setup();
-    renderWithLocalizationProvider(
-      <FlowSetupRecoveryPhoneSubmitNumber {...defaultProps} />
-    );
+    await renderWith();
 
     await waitFor(() =>
       user.type(
@@ -106,9 +112,7 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
 
   test('navigates backward when back button is clicked', async () => {
     const user = userEvent.setup();
-    renderWithLocalizationProvider(
-      <FlowSetupRecoveryPhoneSubmitNumber {...defaultProps} />
-    );
+    await renderWith();
 
     user.click(screen.getByRole('button', { name: /Back/i }));
 

--- a/packages/fxa-settings/src/components/Settings/SettingsLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SettingsLayout/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { renderWithRouter } from '../../../models/mocks';
 import { SETTINGS_PATH } from '../../../constants';
 import SettingsLayout from '.';
@@ -16,7 +16,11 @@ it('renders the app with children', async () => {
       <p data-testid="test-child">Hello, world!</p>
     </SettingsLayout>
   );
-  await navigate(SETTINGS_PATH);
+
+  await waitFor(() => {
+    navigate(SETTINGS_PATH);
+  });
+
   expect(screen.getByTestId('app')).toBeInTheDocument();
   expect(screen.getByTestId('content-skip')).toBeInTheDocument();
   expect(screen.getByTestId('header')).toBeInTheDocument();

--- a/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
@@ -4,7 +4,7 @@
 
 import 'mutationobserver-shim';
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, act } from '@testing-library/react';
 import {
   mockAppContext,
   mockSession,
@@ -21,14 +21,17 @@ it('renders the content when verified', async () => {
   } as unknown as Account;
   const onDismiss = jest.fn();
   const onError = jest.fn();
-  renderWithRouter(
-    <AppContext.Provider
-      value={mockAppContext({ account, session: mockSession(true, false) })}
-    >
-      <VerifiedSessionGuard {...{ onDismiss, onError }}>
-        <div data-testid="children">Content</div>
-      </VerifiedSessionGuard>
-    </AppContext.Provider>
+
+  await act(async () =>
+      await renderWithRouter(
+        <AppContext.Provider
+        value={mockAppContext({ account, session: mockSession(true, false) })}
+        >
+        <VerifiedSessionGuard {...{ onDismiss, onError }}>
+          <div data-testid="children">Content</div>
+        </VerifiedSessionGuard>
+      </AppContext.Provider>
+    )
   );
 
   expect(screen.getByTestId('children')).toBeInTheDocument();
@@ -42,15 +45,15 @@ it('renders the guard when unverified', async () => {
       email: 'smcarthur@mozilla.com',
     },
   } as unknown as Account;
-  renderWithRouter(
-    <AppContext.Provider
-      value={mockAppContext({ account, session: mockSession(false) })}
-    >
-      <VerifiedSessionGuard {...{ onDismiss, onError }}>
-        <div>Content</div>
-      </VerifiedSessionGuard>
-    </AppContext.Provider>
-  );
+
+  await act(async () => await renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account, session: mockSession(false) })}>
+        <VerifiedSessionGuard {...{ onDismiss, onError }}>
+          <div>Content</div>
+        </VerifiedSessionGuard>
+      </AppContext.Provider>
+      )
+    );
 
   expect(screen.getByTestId('modal-verify-session')).toBeInTheDocument();
 });

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -57,6 +57,10 @@ function renderWith(props?: any) {
 }
 
 const mockFormSubmit = jest.fn();
+// This prevents console errors when the deepLink logic is tested.
+// However, for some reason we cannot mock `requestSubmit` and we'll
+// still see errors logged for that.
+HTMLFormElement.prototype.submit = mockFormSubmit;
 
 describe('ThirdPartyAuthComponent', () => {
   // Form submission not supported in jest test. Instead, prevent the submission

--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -519,6 +519,11 @@ describe('IndexContainer', () => {
           }),
         });
 
+        const gleanSubmitSuccessSpy = jest.spyOn(
+          GleanMetrics.emailFirst,
+          'submitSuccess'
+        );
+
         render(
           <IndexContainer
             {...{ integration, serviceName: MozServices.Default }}
@@ -543,10 +548,6 @@ describe('IndexContainer', () => {
           },
         });
 
-        const gleanSubmitSuccessSpy = jest.spyOn(
-          GleanMetrics.emailFirst,
-          'submitSuccess'
-        );
         expect(gleanSubmitSuccessSpy).toHaveBeenCalledTimes(1);
         expect(gleanSubmitSuccessSpy).toHaveBeenCalledWith({
           event: { reason: 'registration' },
@@ -613,10 +614,10 @@ describe('IndexContainer', () => {
           />
         );
 
-        await waitFor(() => {
+        await waitFor(async () => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
+          await currentIndexProps?.processEmailSubmission('invalid-email');
         });
-        await currentIndexProps?.processEmailSubmission('invalid-email');
         await waitFor(() => {
           expect(currentIndexProps?.tooltipErrorMessage).toBeDefined();
           expect(currentIndexProps?.tooltipErrorMessage).toEqual(
@@ -645,12 +646,12 @@ describe('IndexContainer', () => {
           />
         );
 
-        await waitFor(() => {
+        await waitFor(async () => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
+          await currentIndexProps?.processEmailSubmission(
+            'test@relay.firefox.com'
+          );
         });
-        await currentIndexProps?.processEmailSubmission(
-          'test@relay.firefox.com'
-        );
         await waitFor(() => {
           expect(currentIndexProps?.tooltipErrorMessage).toBeDefined();
           expect(currentIndexProps?.tooltipErrorMessage).toEqual(
@@ -682,10 +683,10 @@ describe('IndexContainer', () => {
           />
         );
 
-        await waitFor(() => {
+        await waitFor(async () => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
+          await currentIndexProps?.processEmailSubmission('test@firefox.com');
         });
-        await currentIndexProps?.processEmailSubmission('test@firefox.com');
         await waitFor(() => {
           expect(currentIndexProps?.tooltipErrorMessage).toBeDefined();
           expect(currentIndexProps?.tooltipErrorMessage).toEqual(
@@ -722,12 +723,12 @@ describe('IndexContainer', () => {
           />
         );
 
-        await waitFor(() => {
+        await waitFor(async () => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
+          await currentIndexProps?.processEmailSubmission(
+            'mockinvaliddomain@invalid.invalid'
+          );
         });
-        await currentIndexProps?.processEmailSubmission(
-          'mockinvaliddomain@invalid.invalid'
-        );
         await waitFor(() => {
           expect(currentIndexProps?.tooltipErrorMessage).toBeDefined();
           expect(currentIndexProps?.tooltipErrorMessage).toEqual(

--- a/packages/fxa-settings/src/pages/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.test.tsx
@@ -122,12 +122,14 @@ describe('Index page', () => {
         integration={createMockIndexOAuthNativeIntegration({
           isSync: false,
           isDesktopRelay: true,
-          cmsInfo: MOCK_CMS_INFO
+          cmsInfo: MOCK_CMS_INFO,
         })}
       />
     );
 
-    screen.getByRole('heading', { name: 'Sign up or sign in to your Mozilla account' });
+    screen.getByRole('heading', {
+      name: 'Sign up or sign in to your Mozilla account',
+    });
     screen.getByText(
       'Stay protected with continuous data monitoring and automatic data removal.'
     );
@@ -143,17 +145,27 @@ describe('Index page', () => {
     );
   });
 
-  it('does not render when deeplinking third party auth', () => {
-    renderWithLocalizationProvider(
-      <Subject
-        integration={createMockIndexOAuthIntegration({
-          clientId: POCKET_CLIENTIDS[0],
-        })}
-        deeplink="appleLogin"
-      />
-    );
+  // This is wrapped so that the HTMLFormElement.submit can be mocked
+  // without affecting other tests.
+  describe('deep linking', () => {
+    beforeEach(() => {
+      HTMLFormElement.prototype.submit = jest.fn();
+    });
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+    it('does not render when deeplinking third party auth', () => {
+      renderWithLocalizationProvider(
+        <Subject
+          integration={createMockIndexOAuthIntegration({
+            clientId: POCKET_CLIENTIDS[0],
+          })}
+          deeplink="appleLogin"
+        />
+      );
 
-    thirdPartyAuthNotRendered();
+      thirdPartyAuthNotRendered();
+    });
   });
 
   it('renders as expected when client is Pocket', () => {

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.test.tsx
@@ -26,8 +26,10 @@ describe('InlineRecoveryKeySetup', () => {
       name: 'Got a minute to protect your data?',
     });
   });
-  it('renders as expected, step 2', () => {
-    renderWithLocalizationProvider(<Subject currentStep={2} />);
+  it('renders as expected, step 2', async () => {
+    await act(() => {
+      renderWithLocalizationProvider(<Subject currentStep={2} />);
+    });
 
     screen.getByText('Account recovery key created', { exact: false });
 

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { act, screen, waitFor, within } from '@testing-library/react';
-import userEvent, { UserEvent } from '@testing-library/user-event';
+import { userEvent, UserEvent } from '@testing-library/user-event';
 import InlineRecoverySetup from '.';
 import { MozServices } from '../../lib/types';
 import { renderWithRouter } from '../../models/mocks';
@@ -83,10 +83,7 @@ describe('InlineRecoverySetup', () => {
   it('renders "showConfirmation" content as expected', async () => {
     renderWithRouter(<InlineRecoverySetup email={MOCK_EMAIL} {...props} />);
 
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
 
     screen.getByRole('heading', {
       name: `Confirm backup authentication code to continue to ${MozServices.Default}`,
@@ -109,10 +106,9 @@ describe('InlineRecoverySetup', () => {
         {...props}
       />
     );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
     screen.getByRole('heading', {
       name: `Confirm backup authentication code to continue to ${MozServices.MozillaVPN}`,
     });
@@ -126,21 +122,14 @@ describe('InlineRecoverySetup', () => {
         {...props}
       />
     );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
-    await act(
-      async () =>
-        await user.type(
-          screen.getByLabelText('Backup authentication code'),
-          'chargingelephant'
-        )
-    );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Confirm' }))
-    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+
+    await user.type(
+      screen.getByLabelText('Backup authentication code'),
+      'chargingelephant'
+    )
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
     await screen.findByText('Incorrect backup authentication code');
   });
 
@@ -152,10 +141,8 @@ describe('InlineRecoverySetup', () => {
         oAuthError={new OAuthError('TRY_AGAIN')}
       />
     );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
     await waitFor(() => {
       screen.getByText(OAUTH_ERRORS.TRY_AGAIN.message);
     });
@@ -172,21 +159,11 @@ describe('InlineRecoverySetup', () => {
         {...{ verifyTotpHandler, successfulSetupHandler }}
       />
     );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
-    await act(
-      async () =>
-        await user.type(
-          screen.getByLabelText('Backup authentication code'),
-          MOCK_BACKUP_CODES[0]
-        )
-    );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Confirm' }))
-    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.type(
+      screen.getByLabelText('Backup authentication code'),
+      MOCK_BACKUP_CODES[0]);
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => {
       expect(verifyTotpHandler).toHaveBeenCalled();
@@ -205,21 +182,12 @@ describe('InlineRecoverySetup', () => {
         {...{ verifyTotpHandler, successfulSetupHandler }}
       />
     );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.type(
+      screen.getByLabelText('Backup authentication code'),
+      MOCK_BACKUP_CODES[0]
     );
-    await act(
-      async () =>
-        await user.type(
-          screen.getByLabelText('Backup authentication code'),
-          MOCK_BACKUP_CODES[0]
-        )
-    );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Confirm' }))
-    );
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
     expect(verifyTotpHandler).toHaveBeenCalled();
     expect(successfulSetupHandler).not.toHaveBeenCalled();
     await screen.findByText(

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -75,10 +75,7 @@ describe('InlineTotpSetup', () => {
 
   it('renders QR code by default when a user clicks "Continue"', async () => {
     renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
     await screen.findByAltText(
       `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
@@ -86,10 +83,8 @@ describe('InlineTotpSetup', () => {
 
   it('toggles from QR code to manual secret code view when user clicks "Can\'t scan code"', async () => {
     renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
     await screen.findByAltText(
       `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
@@ -97,31 +92,29 @@ describe('InlineTotpSetup', () => {
     const changeToManualModeButton = screen.getByRole('button', {
       name: 'Can’t scan code?',
     });
-    await act(async () => await user.click(changeToManualModeButton));
+
+    await user.click(changeToManualModeButton);
+
     screen.getByText(formatSecret(MOCK_TOTP_TOKEN.secret));
     await screen.findByRole('button', { name: 'Scan QR code instead?' });
   });
 
   it('toggles from secret code to QR code view when user clicks "Scan QR code instead?', async () => {
     renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
     await screen.findByAltText(
       `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
+
     const changeToManualModeButton = screen.getByRole('button', {
       name: 'Can’t scan code?',
     });
-    await act(async () => await user.click(changeToManualModeButton));
+    await user.click(changeToManualModeButton);
     await screen.findByRole('button', { name: 'Scan QR code instead?' });
-    await act(
-      async () =>
-        await user.click(
-          screen.getByRole('button', { name: 'Scan QR code instead?' })
-        )
-    );
+    await user.click(
+      screen.getByRole('button', { name: 'Scan QR code instead?' })
+    )
     await screen.findByAltText(
       `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
     );
@@ -139,18 +132,10 @@ describe('InlineTotpSetup', () => {
         }}
       />
     );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Continue' }))
-    );
-    await act(
-      async () =>
-        await user.type(screen.getByLabelText('Authentication code'), '000000')
-    );
-    await act(
-      async () =>
-        await user.click(screen.getByRole('button', { name: 'Ready' }))
-    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }))
+    await user.type(screen.getByLabelText('Authentication code'), '000000')
+    await user.click(screen.getByRole('button', { name: 'Ready' }))
     await screen.findByText('Invalid two-step authentication code');
     expect(verifyCodeHandler).toHaveBeenCalledWith('000000');
   });

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.test.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { act } from '@testing-library/react'
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';
 import { screen } from '@testing-library/react';
@@ -9,7 +10,9 @@ import { MOCK_EMAIL } from '../../mocks';
 
 describe('SetPassword page', () => {
   it('renders as expected', async () => {
-    renderWithLocalizationProvider(<Subject />);
+    await act(() => {
+      renderWithLocalizationProvider(<Subject />);
+    });
 
     expect(
       screen.getByRole('heading', { name: 'Create password to sync' })


### PR DESCRIPTION
## Because

- There are a number of `act(...)` warnings from fxa-settings React unit-tests

## This pull request

- Updates tests to prevent any `act(...)` tests. This forces tests to complete flushing events and render components as they would appear to the user - more accurate tests

## Issue that this pull request solves

Closes: (FXA-12097)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There are a few buckets that the React `act(...)` warnings could fall under and best ways to resolve them.

- If tests use `waitFor` or `userEvent.click()` or other `@testing-library` tools, actions are automatically wrapped in `act()`. 
  - Using `fireEvent` can cause the `act()` warning because a click can change the state of the component, and in places where we were still relying on `fireEvent` we can then update to `userEvent` so we don't have to manually wrap those commands in `act()`.
- If a component changes due to an async event, like fetching data at render, then the above don't do us any good, we'll still get the warning because the initial render is fine, but then state changes later on. This is where we can wrap the _render_ step in `act()`. 
  - > To the above, it might be worth looking at wrapping `renderWithLocalizationProvider()` in act() regardless as it doesn't do any harm to have that.

- Additionally, if there is something that happens on an async delay (setTimeout), it's a good idea to pass an async callback to `act()` so it knows to double wait basically. IDE's may complain that the render is not awaitable, but it will solve for those delayed actions.
- Another warning you may see crop up is that the test environment isn't configured for `act()`. This happens if you double wrap one of the `testing-library` functions like this: `await act(() => waitFor(() => {...}));`. This can just be unwrapped and just call `waitFor` or whatever other function.
- If you wrap something in `act()` while trying to resolve the warning, but the test times out - try `waitFor()`! _kind of a "duh", but easy to get tripped up on._
