### PR TITLE
fix(payments-ui): Use whole fluent string IDs

### DIFF
--- a/libs/payments/ui/src/lib/server/components/PriceInterval/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/PriceInterval/index.tsx
@@ -15,8 +15,28 @@ type PriceIntervalProps = {
 
 export async function PriceInterval(props: PriceIntervalProps) {
   const { l10n, amount, currency, interval, locale } = props;
+  let priceIntervalId;
+  switch (interval) {
+    case 'daily':
+      priceIntervalId = 'plan-price-interval-daily';
+      break;
+    case 'weekly':
+      priceIntervalId = 'plan-price-interval-weekly';
+      break;
+    case 'halfyearly':
+      priceIntervalId = 'plan-price-interval-halfyearly';
+      break;
+    case 'yearly':
+      priceIntervalId = 'plan-price-interval-yearly';
+      break;
+    case 'monthly':
+    default:
+      priceIntervalId = 'plan-price-interval-monthly';
+      break;
+  }
+
   return l10n.getString(
-    `plan-price-interval-${interval}`,
+    priceIntervalId,
     {
       amount: l10n.getLocalizedCurrency(amount, currency),
     },

--- a/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/server/components/UpgradePurchaseDetails/index.tsx
@@ -57,6 +57,21 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
   const exclusiveTaxRates = taxAmounts.filter(
     (taxAmount) => !taxAmount.inclusive
   );
+  const getNewPlanLabelFtlId = (interval: string) => {
+    switch (interval) {
+      case 'daily':
+        return 'upgrade-purchase-details-new-plan-daily';
+      case 'weekly':
+        return 'upgrade-purchase-details-new-plan-weekly';
+      case 'monthly':
+      default:
+        return 'upgrade-purchase-details-new-plan-monthly';
+      case 'halfyearly':
+        return 'upgrade-purchase-details-new-plan-halfyearly';
+      case 'yearly':
+        return 'upgrade-purchase-details-new-plan-yearly';
+    }
+  };
   return (
     <section
       aria-labelledby="current-plan new-plan"
@@ -145,7 +160,7 @@ export function UpgradePurchaseDetails(props: UpgradePurchaseDetailsProps) {
         <li className="flex items-center justify-between gap-2 leading-5 text-grey-600">
           <p>
             {l10n.getString(
-              `upgrade-purchase-details-new-plan-${interval}`,
+              getNewPlanLabelFtlId(interval),
               {
                 productName,
               },


### PR DESCRIPTION
## Because

- we want to be able to tell if a string is used or not in the future

## This pull request

- updates fluent ids to be whole strings

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.