### PR TITLE
fix(settings) - Redirect away from /settings if account unverified

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -48,6 +48,12 @@ jest.mock('../../lib/hooks/useGeoEligibilityCheck', () => ({
   useGeoEligibilityCheck: () => mockUseGeoEligibilityCheck(),
 }));
 
+const mockNavigateWithQuery = jest.fn();
+jest.mock('../../lib/hooks/useNavigateWithQuery', () => ({
+  useNavigateWithQuery: () => mockNavigateWithQuery,
+}));
+
+
 describe('Settings App', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -82,6 +88,31 @@ describe('Settings App', () => {
     expect(getByRole('heading', { level: 2 })).toHaveTextContent(
       'General application error'
     );
+  });
+
+  it('redirects to root if account is not verified', async () => {
+    const unverifiedAccount = {
+      ...MOCK_ACCOUNT,
+      primaryEmail: {
+        ...MOCK_ACCOUNT.primaryEmail,
+        verified: false,
+      },
+      emails: MOCK_ACCOUNT.emails.map((email) =>
+        email.isPrimary ? { ...email, verified: false } : email
+      ),
+    } as unknown as Account;
+
+    renderWithRouter(
+      <AppContext.Provider
+        value={mockAppContext({ account: unverifiedAccount })}
+      >
+        <Subject />
+      </AppContext.Provider>,
+      { route: SETTINGS_PATH }
+    );
+
+    await Promise.resolve();
+    expect(mockNavigateWithQuery).toHaveBeenCalledWith('/');
   });
 
   it('routes to PageSettings', async () => {

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -135,6 +135,17 @@ export const Settings = ({
     return <AppErrorDialog data-testid="error-dialog" />;
   }
 
+  // If the account email isn't verified, kick back to root to prompt for verification.
+  // This should only happen if the user tries to access /settings directly
+  // without entering a confirmation code on confirm_signup_code page.
+  // Session verification requirement and redirect is handled on initial app load
+  // (look for isUnverifiedSessionError in lib/gql.ts for that handling)
+  if (account.primaryEmail.verified === false) {
+    console.warn('Account verification is require to access /settings!');
+    navigateWithQuery('/');
+    return <LoadingSpinner fullScreen />;
+  }
+
   return (
     <SettingsLayout>
       <Head />

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -152,7 +152,7 @@ export class Session implements SessionData {
   }
 
   async isValid(sessionToken: string) {
-    // If the current session token is valid, the folloiwng query will succeed.
+    // If the current session token is valid, the following query will succeed.
     // If current session is not valid an 'Invalid Token' error will be thrown.
     const query = GET_SESSION_IS_VALID;
     const { data } = await this.apolloClient.query({


### PR DESCRIPTION
## Because

* It was possible to bypass confirm_signup_code and go directly to /settings
* Note: this gave very limited access to the account info, majority of settings changes are guarded + sync not accessible until account is confirmed

## This pull request

* Reverts PR-19086 and PR-19144 which modified redirection based on session verification status
* Add a redirect from settings if account email unverified

## Closes 
[FXA-12096](https://mozilla-hub.atlassian.net/browse/FXA-12096)

[FXA-12096]: https://mozilla-hub.atlassian.net/browse/FXA-12096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ