### PR TITLE
Revert "fix(sign-in): Properly redirect users without verified sessions (+ reverted revert of #19086)"

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -4,24 +4,17 @@
 
 import React, { ReactNode } from 'react';
 import { History } from '@reach/router';
-import {
-  Account,
-  AppContext,
-  Session,
-  useInitialSettingsState,
-} from '../../models';
+import { Account, AppContext, useInitialSettingsState } from '../../models';
 import {
   mockAppContext,
   MOCK_ACCOUNT,
   renderWithRouter,
   mockSession,
-  MOCK_SESSION,
 } from '../../models/mocks';
 import { Config } from '../../lib/config';
 import { SETTINGS_PATH } from '../../constants';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import { Subject } from './mocks';
-import { useGeoEligibilityCheck } from '../../lib/hooks/useGeoEligibilityCheck';
 
 jest.mock('../../models', () => ({
   ...jest.requireActual('../../models'),
@@ -50,23 +43,15 @@ jest.mock('@reach/router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-const mockUseGeoEligibilityCheck = jest
-  .fn()
-  .mockReturnValue({ eligible: false });
+const mockUseGeoEligibilityCheck = jest.fn().mockReturnValue({ eligible: false });
 jest.mock('../../lib/hooks/useGeoEligibilityCheck', () => ({
   useGeoEligibilityCheck: () => mockUseGeoEligibilityCheck(),
-}));
-
-const mockNavigateWithQuery = jest.fn();
-jest.mock('../../lib/hooks/useNavigateWithQuery', () => ({
-  useNavigateWithQuery: () => mockNavigateWithQuery,
 }));
 
 describe('Settings App', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    jest.spyOn(console, 'warn').mockImplementation(() => {});
     (useInitialSettingsState as jest.Mock).mockReturnValue({ loading: false });
     mockNavigate.mockReset();
   });
@@ -352,50 +337,6 @@ describe('Settings App', () => {
     it('redirects ChangePassword', async () => {
       await history.navigate(SETTINGS_PATH + '/change_password');
       expect(history.location.pathname).toBe('/settings/create_password');
-    });
-  });
-
-  describe('prevents access if session is not verified', () => {
-    let history: History;
-
-    beforeEach(() => {
-      const account = {
-        ...MOCK_ACCOUNT,
-        hasPassword: false,
-      } as unknown as Account;
-
-      const session = {
-        ...MOCK_SESSION,
-        verified: false,
-      } as unknown as Session;
-
-      const config = {
-        l10n: { strict: true },
-        metrics: { navTiming: { enabled: true, endpoint: '/foobar' } },
-      } as Config;
-
-      ({ history } = renderWithRouter(
-        <AppContext.Provider
-          value={mockAppContext({ account, session, config })}
-        >
-          <AppLocalizationProvider
-            messages={{ en: ['testo: lol'] }}
-            reportError={() => {}}
-          >
-            <Subject />
-          </AppLocalizationProvider>
-        </AppContext.Provider>,
-        { route: SETTINGS_PATH }
-      ));
-    });
-
-    it('redirects to root', async () => {
-      await history.navigate(SETTINGS_PATH);
-      expect(mockNavigateWithQuery).toHaveBeenCalledTimes(2); // Why does it called twice \o/
-      expect(mockNavigateWithQuery).toHaveBeenCalledWith('/');
-      expect(console.warn).toHaveBeenCalledWith(
-        'Session.verified false on /settings access!'
-      );
     });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -135,13 +135,6 @@ export const Settings = ({
     return <AppErrorDialog data-testid="error-dialog" />;
   }
 
-  // If the session hasn't been verified, kick back to root
-  if (session.verified === false) {
-    console.warn('Session.verified false on /settings access!');
-    navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
-  }
-
   return (
     <SettingsLayout>
       <Head />

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -112,11 +112,9 @@ export class Session implements SessionData {
     });
   }
 
-  async sendVerificationCode(sessionTokenArg?: hexstring) {
+  async sendVerificationCode() {
     await this.withLoadingStatus(
-      this.authClient.sessionResendVerifyCode(
-        sessionTokenArg || sessionToken()!
-      )
+      this.authClient.sessionResendVerifyCode(sessionToken()!)
     );
   }
 

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -26,7 +26,6 @@ import {
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
-import { NavigationOptions } from '../Signin/interfaces';
 
 const convertToRelierAccount = (
   account: ReturnType<typeof currentAccount>,
@@ -99,7 +98,7 @@ const AuthorizationContainer = ({
       }
 
       if (data) {
-        const navigationOptions: NavigationOptions = {
+        const navigationOptions = {
           email: account?.email!,
           signinData: {
             verified: data.verified,
@@ -108,7 +107,6 @@ const AuthorizationContainer = ({
             uid: data.uid,
             sessionToken: account?.sessionToken!,
           },
-          sessionVerified: data.sessionVerified,
           integration,
           redirectTo: integration.data.redirectTo,
           finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -108,7 +108,6 @@ const SetPasswordContainer = ({
               verified: true,
               keyFetchToken,
             },
-            sessionVerified: true,
             unwrapBKey,
             integration,
             finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -25,7 +25,6 @@ import { handleNavigation } from '../utils';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import Banner, { ResendCodeSuccessBanner } from '../../../components/Banner';
-import { NavigationOptions } from '../interfaces';
 
 export const viewName = 'signin-token-code';
 
@@ -145,7 +144,7 @@ const SigninTokenCode = ({
         // in another. You reach the "Sorry. We've locked your account" screen
         GleanMetrics.loginConfirmation.success();
 
-        const navigationOptions: NavigationOptions = {
+        const navigationOptions = {
           email,
           signinData: {
             uid,
@@ -154,7 +153,6 @@ const SigninTokenCode = ({
             verified: true,
             keyFetchToken,
           },
-          sessionVerified: true,
           unwrapBKey,
           integration,
           finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -31,7 +31,7 @@ import {
   isClientPocket,
   isClientRelay,
 } from '../../models/integrations/client-matching';
-import { NavigationOptions, SigninFormData, SigninProps } from './interfaces';
+import { SigninFormData, SigninProps } from './interfaces';
 import { handleNavigation } from './utils';
 import { useWebRedirect } from '../../lib/hooks/useWebRedirect';
 import { getLocalizedErrorMessage } from '../../lib/error-utils';
@@ -146,7 +146,7 @@ const Signin = ({
       if (data) {
         GleanMetrics.cachedLogin.success();
 
-        const navigationOptions: NavigationOptions = {
+        const navigationOptions = {
           email,
           signinData: {
             verified: data.verified,
@@ -155,7 +155,6 @@ const Signin = ({
             uid: data.uid,
             sessionToken,
           },
-          sessionVerified: data.sessionVerified,
           integration,
           redirectTo:
             isWebIntegration(integration) && webRedirectCheck?.isValid

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -119,7 +119,6 @@ export interface BeginSigninResponse {
   unwrapBKey?: hexstring;
   authPW?: hexstring;
   showInlineRecoveryKeySetup?: boolean;
-  sessionVerified?: boolean;
 }
 
 export type CachedSigninHandler = (
@@ -202,8 +201,6 @@ export interface NavigationOptions {
     // This (and unwrapBKey) will never exist for the cached signin (prompt=none)
     keyFetchToken?: hexstring;
   };
-  // TODO, make required?
-  sessionVerified?: boolean;
   // unwrapBKey is included if integration.wantsKeys()
   unwrapBKey?: hexstring;
   integration: SigninIntegration;

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -157,7 +157,7 @@ export const cachedSignIn = async (
         verified,
         // Because the cached signin was a success, we know 'uid' exists
         uid: storedLocalAccount!.uid,
-        sessionVerified,
+        sessionVerified, // might not need
         emailVerified, // might not need
       },
     };
@@ -189,10 +189,7 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
   const isWebChannelIntegration =
     integration.isSync() || integration.isDesktopRelay();
 
-  if (
-    !navigationOptions.signinData.verified ||
-    navigationOptions.sessionVerified === false
-  ) {
+  if (!navigationOptions.signinData.verified) {
     const { to, locationState } =
       getUnverifiedNavigationTarget(navigationOptions);
     if (


### PR DESCRIPTION
Reverts mozilla/fxa#19144

These changes caused `FXA-12096` bug - reverting before the prod deployment. 

https://github.com/mozilla/fxa/pull/19208 will propose an alternative for `FXA-11927`, and an additional issue will be filed about inconsistencies in session verification.