### PR TITLE
fix(events): Add more metrics for tracking third party auth security events

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/third-party-events.ts
@@ -5,8 +5,10 @@
 import axios from 'axios';
 import { Provider, PROVIDER } from 'fxa-shared/db/models/auth/linked-account';
 import jwt from 'jsonwebtoken';
+import * as Sentry from '@sentry/node';
 
 import { jwk2pem } from '@fxa/shared/pem-jwk';
+import { StatsD } from 'hot-shots';
 
 const RISC_CONFIG_URI =
   'https://accounts.google.com/.well-known/risc-configuration';
@@ -55,15 +57,20 @@ async function getAccountFromSub(
   sub: string,
   db: any,
   provider: Provider,
-  log: any
+  log: any,
+  statsd: StatsD
 ) {
   try {
-    return db.getLinkedAccount(sub, provider);
+    return await db.getLinkedAccount(sub, provider);
   } catch (err) {
     // If the account doesn't exist, we can ignore the event.
     // This might happen if the user has already deleted their account before we got the
     // security event.
-    log.debug(`Unknown account for sub: ${sub} and provider: ${provider}`);
+    log.debug(`Unknown account for sub: ${sub} and provider: ${provider}`, {
+      error: err.message,
+      stack: err.stack,
+    });
+    statsd.increment('getAccountFromSub.error');
     return null;
   }
 }
@@ -72,20 +79,31 @@ async function revokeThirdPartySessions(
   uid: string,
   provider: Provider,
   log: any,
-  db: any
+  db: any,
+  statsd: StatsD
 ) {
-  const sessions = await db.sessions(uid);
+  try {
+    const sessions = await db.sessions(uid);
 
-  // Revoke all sessions created from third party logins
-  let deletedCount = 0;
-  for (const session of sessions) {
-    if (session.providerId === PROVIDER[provider]) {
-      await db.deleteSessionToken(session);
-      deletedCount++;
+    // Revoke all sessions created from third party logins
+    let deletedCount = 0;
+    for (const session of sessions) {
+      if (session.providerId === PROVIDER[provider]) {
+        try {
+          await db.deleteSessionToken(session);
+          deletedCount++;
+        } catch (deleteError) {
+            statsd.increment('revokeThirdPartySessions.deleteSessionToken.error');
+          // Continue with other sessions instead of failing completely
+        }
+      }
     }
-  }
 
-  log.debug(`Revoked ${deletedCount} third party sessions for user ${uid}`);
+    log.debug(`Revoked ${deletedCount} third party sessions for user ${uid}`);
+  } catch (error) {
+    statsd.increment('revokeThirdPartySessions.error');
+    throw error;
+  }
 }
 
 // See events at https://developers.google.com/identity/protocols/risc#supported_event_types
@@ -132,21 +150,29 @@ export const appleEventHandlers = {
  * @param eventDetails
  * @param log
  * @param db
+ * @param statsd
  * @returns Promise<void>)
  */
 async function handleAppleConsentRevokedEvent(
   eventDetails: AppleSETEvent,
   log: any,
-  db: any
+  db: any,
+  statsd: StatsD
 ) {
-  const sub = eventDetails.sub;
-  const account = await getAccountFromSub(sub, db, 'apple', log);
+  try {
+    const sub = eventDetails.sub;
+    const account = await getAccountFromSub(sub, db, 'apple', log, statsd);
 
-  // We have a guard that account exists because it is possible that it was
-  // removed in another security event
-  if (account) {
-    await revokeThirdPartySessions(account.uid, 'apple', log, db);
-    await db.deleteLinkedAccount(account.uid, 'apple');
+    // We have a guard that account exists because it is possible that it was
+    // removed in another event
+    if (account) {
+      await revokeThirdPartySessions(account.uid, 'apple', log, db, statsd);
+      await db.deleteLinkedAccount(account.uid, 'apple');
+    }
+  } catch (error) {
+    statsd.increment('handleAppleConsentRevokedEvent.error');
+    Sentry.captureException(error);
+    // Don't rethrow - log and continue to prevent unhandled promise rejection
   }
 }
 
@@ -157,18 +183,25 @@ async function handleAppleConsentRevokedEvent(
  * @param eventDetails
  * @param log
  * @param db
+ * @param statsd
  */
 async function handleAppleAccountDeleteEvent(
   eventDetails: AppleSETEvent,
   log: any,
-  db: any
+  db: any,
+  statsd: StatsD
 ) {
-  const sub = eventDetails.sub;
-  const account = await getAccountFromSub(sub, db, 'apple', log);
+  try {
+    const sub = eventDetails.sub;
+    const account = await getAccountFromSub(sub, db, 'apple', log, statsd);
 
-  if (account) {
-    await revokeThirdPartySessions(account.uid, 'apple', log, db);
-    await db.deleteLinkedAccount(account.uid, 'apple');
+    if (account) {
+      await revokeThirdPartySessions(account.uid, 'apple', log, db, statsd);
+      await db.deleteLinkedAccount(account.uid, 'apple');
+    }
+  } catch (error) {
+    statsd.increment('handleAppleAccountDeleteEvent.error');
+    // Don't rethrow - log and continue to prevent unhandled promise rejection
   }
 }
 
@@ -185,20 +218,27 @@ function handleGoogleTestEvent(eventDetails: GoogleSETEvent, log: any) {
  * @param eventDetails
  * @param log
  * @param db
+ * @param statsd
  */
 async function handleGoogleSessionsRevokedEvent(
   eventDetails: GoogleSETEvent,
   log: any,
-  db: any
+  db: any,
+  statsd: StatsD
 ) {
-  if (!eventDetails.subject) {
-    return;
-  }
-  const { sub } = eventDetails.subject;
-  const account = await getAccountFromSub(sub, db, 'google', log);
+  try {
+    if (!eventDetails.subject) {
+      return;
+    }
+    const { sub } = eventDetails.subject;
+    const account = await getAccountFromSub(sub, db, 'google', log, statsd);
 
-  if (account) {
-    await revokeThirdPartySessions(account.uid, 'google', log, db);
+    if (account) {
+      await revokeThirdPartySessions(account.uid, 'google', log, db, statsd);
+    }
+  } catch (error) {
+      statsd.increment('handleGoogleSessionsRevokedEvent.error');
+    // Don't rethrow - log and continue to prevent unhandled promise rejection
   }
 }
 
@@ -209,19 +249,26 @@ async function handleGoogleSessionsRevokedEvent(
  * @param eventDetails
  * @param log
  * @param db
+ * @param statsd
  */
 async function handleGoogleAccountDisabledEvent(
   eventDetails: GoogleSETEvent,
   log: any,
-  db: any
+  db: any,
+  statsd: StatsD
 ) {
-  const { sub } = eventDetails.subject;
+  try {
+    const { sub } = eventDetails.subject;
 
-  const account = await getAccountFromSub(sub, db, 'google', log);
+    const account = await getAccountFromSub(sub, db, 'google', log, statsd);
 
-  if (account) {
-    await revokeThirdPartySessions(account.uid, 'google', log, db);
-    await db.deleteLinkedAccount(account.uid, 'google');
+    if (account) {
+      await revokeThirdPartySessions(account.uid, 'google', log, db, statsd);
+      await db.deleteLinkedAccount(account.uid, 'google');
+    }
+  } catch (error) {
+    statsd.increment('handleGoogleAccountDisabledEvent.error');
+    // Don't rethrow - log and continue to prevent unhandled promise rejection
   }
 }
 
@@ -234,64 +281,104 @@ export function handleGoogleOtherEventType(eventType: string, log: any) {
   log.debug(`Received unknown event: ${eventType}`);
 }
 
+export function normalizeGoogleSETEventType(eventType: string): string {
+  // Map of known event types to clear, concise names
+  const eventTypeMap: { [key: string]: string } = {
+    'https://schemas.openid.net/secevent/risc/event-type/verification': 'verification',
+    'https://schemas.openid.net/secevent/risc/event-type/sessions-revoked': 'sessions_revoked',
+    'https://schemas.openid.net/secevent/risc/event-type/account-disabled': 'account_disabled',
+    'https://schemas.openid.net/secevent/risc/event-type/account-enabled': 'account_enabled',
+    'https://schemas.openid.net/secevent/risc/event-type/account-purged': 'account_purged',
+    'https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required': 'credential_change_required',
+    'https://schemas.openid.net/secevent/oauth/event-type/tokens-revoked': 'tokens_revoked',
+    'https://schemas.openid.net/secevent/oauth/event-type/token-revoked': 'token_revoked',
+    'https://schemas.openid.net/secevent/risc/event-type/unknown': 'unknown',
+  };
+
+  // Return mapped name if available, otherwise fall back to URL normalization
+  if (eventTypeMap[eventType]) {
+    return eventTypeMap[eventType];
+  }
+
+  // Fallback: normalize unknown event types by replacing special characters
+  return eventType
+    .replace(/[^a-zA-Z0-9]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
 /**
  *  Get Apple's public key from their public key endpoint.
  *
  *  Ref: https://developer.apple.com/documentation/sign_in_with_apple/fetch_apple_s_public_key_for_verifying_token_signature
  *
  * @param token
+ * @param statsd
  */
-export async function getApplePublicKey(token: string) {
-  const appleCerts = await axios.get(APPLE_PUBLIC_KEYS);
-  const jwtHeader = jwt.decode(token, { complete: true })?.header;
-  const keyId = jwtHeader?.kid;
-  if (!keyId) {
-    throw new Error('No valid keyId found.');
+export async function getApplePublicKey(token: string, statsd: StatsD) {
+  try {
+    const appleCerts = await axios.get(APPLE_PUBLIC_KEYS);
+    const jwtHeader = jwt.decode(token, { complete: true })?.header;
+    const keyId = jwtHeader?.kid;
+    if (!keyId) {
+      throw new Error('No valid keyId found.');
+    }
+
+    const publicKey = appleCerts.data.keys.find(
+      (key: { kid: string }) => key.kid === keyId
+    );
+
+    if (!publicKey) {
+      throw new Error('Public key certificate not found.');
+    }
+
+    return {
+      pem: jwk2pem(publicKey),
+    };
+  } catch (error) {
+    statsd.increment('getApplePublicKey.error');
+    throw new Error(`Failed to get Apple public key: ${error.message}`);
   }
-
-  const publicKey = appleCerts.data.keys.find(
-    (key: { kid: string }) => key.kid === keyId
-  );
-
-  if (!publicKey) {
-    throw new Error('Public key certificate not found.');
-  }
-
-  return {
-    pem: jwk2pem(publicKey),
-  };
 }
+
 /**
  * Get Google's public key from their RISC configuration.
  *
  * @param token
+ * @param statsd
  * @returns {Promise<{pem: string, issuer: string}>}
  */
 export async function getGooglePublicKey(
-  token: string
+  token: string,
+  statsd: StatsD
 ): Promise<{ pem: string; issuer: string }> {
-  const riscConfig = await axios.get(RISC_CONFIG_URI);
-  const { jwks_uri: jwksUri, issuer } = riscConfig.data;
+  try {
+    const riscConfig = await axios.get(RISC_CONFIG_URI);
+    const { jwks_uri: jwksUri, issuer } = riscConfig.data;
 
-  const googleCerts = await axios.get(jwksUri);
-  const jwtHeader = jwt.decode(token, { complete: true })?.header;
-  const keyId = jwtHeader.kid;
-  if (!keyId) {
-    throw new Error('No valid keyId found.');
+    const googleCerts = await axios.get(jwksUri);
+    const jwtHeader = jwt.decode(token, { complete: true })?.header;
+    const keyId = jwtHeader.kid;
+    if (!keyId) {
+      throw new Error('No valid keyId found.');
+    }
+
+    const publicKey = googleCerts.data.keys.find(
+      (key: { kid: string }) => key.kid === keyId
+    );
+
+    if (!publicKey) {
+      throw new Error('Public key certificate not found.');
+    }
+
+    return {
+      pem: jwk2pem(publicKey),
+      issuer,
+    };
+  } catch (error) {
+    statsd.increment('getGooglePublicKey.error');
+    throw new Error(`Failed to get Google public key: ${error.message}`);
   }
-
-  const publicKey = googleCerts.data.keys.find(
-    (key: { kid: string }) => key.kid === keyId
-  );
-
-  if (!publicKey) {
-    throw new Error('Public key certificate not found.');
-  }
-
-  return {
-    pem: jwk2pem(publicKey),
-    issuer,
-  };
 }
 
 /**
@@ -301,20 +388,26 @@ export async function getGooglePublicKey(
  * @param clientIds
  * @param publicKeyPem
  * @param issuer
+ * @param statsd
  * @returns {Promise}
  */
 export async function validateSecurityToken(
   token: string,
   clientIds: [string],
   publicKeyPem: any,
-  issuer: string
+  issuer: string,
+  statsd: StatsD
 ) {
-  // Decode the token, validating its signature, audience, and issuer
-  return jwt.verify(token, publicKeyPem, {
-    algorithms: ['RS256'],
-    audience: clientIds,
-    issuer: issuer,
-  });
+  try {
+    return jwt.verify(token, publicKeyPem, {
+      algorithms: ['RS256'],
+      issuer,
+      audience: clientIds,
+    });
+  } catch (error) {
+    statsd.increment('validateSecurityToken.error');
+    return undefined; // Return undefined if verification fails
+  }
 }
 
 /**
@@ -325,8 +418,14 @@ export async function validateSecurityToken(
  * @param clientId
  */
 export function isValidClientId(token: string, clientId: string) {
-  const decoded = jwt.decode(token, { complete: true }) as {
-    payload: GoogleJWTSETPayload;
-  };
-  return decoded && decoded.payload.aud.includes(clientId);
+  try {
+    const decoded = jwt.decode(token, { complete: true });
+    if (!decoded || typeof decoded === 'string') {
+      return false;
+    }
+    return decoded.payload.aud === clientId;
+  } catch (error) {
+    // If we can't decode the token, it's not valid
+    return false;
+  }
 }


### PR DESCRIPTION
## Because

- We have elevated failures for third party auth security events

## This pull request

- Adds a try catch around db calls to help pinpoint where/why these failures are happening
- Adds more statsd logging

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11681

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
