### PR TITLE
fix(next): fetch canceled subscription in getCart

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -385,6 +385,13 @@ export class CartSubscriptionNotFoundError extends CartError {
   }
 }
 
+export class GetCartSubscriptionIdCartError extends CartSubscriptionNotFoundError {
+  constructor(cartId: string) {
+    super('Get cart missing subscription id', cartId);
+    this.name = 'GetCartSubscriptionIdCartError';
+  }
+}
+
 export class FinalizeWithoutSubscriptionIdCartError extends CartSubscriptionNotFoundError {
   constructor(cartId: string) {
     super('Cart missing subscription id in finalization', cartId);

--- a/libs/payments/cart/src/lib/cart.factories.ts
+++ b/libs/payments/cart/src/lib/cart.factories.ts
@@ -20,6 +20,13 @@ import {
   TaxAmount,
   UpdateCart,
   UpdateCartInput,
+  type BaseCartDTO,
+  type FailCartDTO,
+  type Invoice,
+  type NeedsInputCartDTO,
+  type ProcessingCartDTO,
+  type StartCartDTO,
+  type SuccessCartDTO,
 } from './cart.types';
 import type { SubscriptionAttributionParams } from './checkout.types';
 
@@ -38,6 +45,20 @@ export const CheckoutCustomerDataFactory = (
 ): CheckoutCustomerData => ({
   locale: faker.helpers.arrayElement(['en-US', 'de', 'es', 'fr-FR']),
   displayName: faker.person.fullName(),
+  ...override,
+});
+
+export const InvoiceFactory = (override?: Partial<Invoice>): Invoice => ({
+  currency: faker.finance.currencyCode().toLowerCase(),
+  totalAmount: faker.number.int({ min: 1, max: 10000 }),
+  taxAmounts: [TaxAmountFactory()],
+  discountAmount: null,
+  subtotal: faker.number.int({ min: 1, max: 10000 }),
+  number: null,
+  nextInvoiceDate: faker.date.past().getTime(),
+  amountDue: faker.number.int({ min: 1, max: 10000 }),
+  creditApplied: null,
+  startingBalance: faker.number.int({ min: 1, max: 10000 }),
   ...override,
 });
 
@@ -137,4 +158,63 @@ export const ResultCartFactory = (
   version: faker.number.int(),
   eligibilityStatus: faker.helpers.enumValue(CartEligibilityStatus),
   ...override,
+});
+
+export const BaseCartDTOFactory = (
+  override?: Partial<BaseCartDTO>
+): BaseCartDTO => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { state, ...baseResultCart } = ResultCartFactory(override);
+  return {
+    ...baseResultCart,
+    metricsOptedOut: true,
+    offeringPrice: faker.number.int(),
+    upcomingInvoicePreview: InvoiceFactory(),
+    taxAddress: TaxAddressFactory(),
+    currency: faker.finance.currencyCode().toLowerCase(),
+    ...override,
+  };
+};
+
+export const StartCartDTOFactory = (
+  override?: Partial<StartCartDTO>
+): StartCartDTO => ({
+  ...BaseCartDTOFactory(),
+  hasActiveSubscriptions: false,
+  ...override,
+  state: CartState.START,
+});
+
+export const ProcessingCartDTOFactory = (
+  override?: Partial<ProcessingCartDTO>
+): ProcessingCartDTO => ({
+  ...BaseCartDTOFactory(),
+  ...override,
+  state: CartState.PROCESSING,
+});
+export const SuccessCartDTOFactory = (
+  override?: Partial<SuccessCartDTO>
+): SuccessCartDTO => ({
+  ...BaseCartDTOFactory(),
+  latestInvoicePreview: InvoiceFactory(),
+  paymentInfo: PaymentInfoFactory(),
+  hasActiveSubscriptions: true,
+  ...override,
+  state: CartState.SUCCESS,
+});
+
+export const NeedsInputCartDTOFactory = (
+  override?: Partial<NeedsInputCartDTO>
+): NeedsInputCartDTO => ({
+  ...BaseCartDTOFactory(),
+  ...override,
+  state: CartState.NEEDS_INPUT,
+});
+
+export const FailCartDTOFactory = (
+  override?: Partial<FailCartDTO>
+): FailCartDTO => ({
+  ...BaseCartDTOFactory(),
+  ...override,
+  state: CartState.FAIL,
 });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -62,6 +62,7 @@ import {
   CartSetupInvalidPromoCodeError,
   CartRestartInvalidPromoCodeError,
   CartCouldNotRetrievePriceForCurrencyWhenAttemptingToGetCartCartError,
+  GetCartSubscriptionIdCartError,
   SetupCartCurrencyNotFoundError,
   UpdateCartCurrencyNotFoundError,
   FinalizeWithoutSubscriptionIdCartError,
@@ -904,11 +905,17 @@ export class CartService {
       subscriptions &&
       cart.state !== CartState.FAIL
     ) {
-      const subscription = subscriptions.find(
-        (subscription) => subscription.id === cart.stripeSubscriptionId
-      );
+      const subscription =
+        subscriptions.find(
+          (subscription) => subscription.id === cart.stripeSubscriptionId
+        ) ||
+        (await this.subscriptionManager.retrieve(cart.stripeSubscriptionId));
+
       // fetch latest payment info from subscription
-      assert(subscription?.latest_invoice, 'Subscription not found');
+      assert(
+        subscription?.latest_invoice,
+        new GetCartSubscriptionIdCartError(cartId)
+      );
       latestInvoicePreview = await this.invoiceManager.preview(
         subscription.latest_invoice
       );

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -20,10 +20,7 @@ import {
   ProductConfigError,
   ProductConfigurationManager,
 } from '@fxa/shared/cms';
-import {
-  CartState,
-  type CartErrorReasonId,
-} from '@fxa/shared/db/mysql/account';
+import { CartErrorReasonId, CartState } from '@fxa/shared/db/mysql/account';
 import { SanitizeExceptions } from '@fxa/shared/error';
 import { GeoDBManager } from '@fxa/shared/geodb';
 
@@ -133,9 +130,7 @@ export class NextJSActionsService {
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
   async getCart(args: { cartId: string }) {
-    const cart = await this.cartService.getCart(args.cartId);
-
-    return cart;
+    return this.cartService.getCart(args.cartId);
   }
 
   @SanitizeExceptions({

--- a/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
+++ b/libs/payments/ui/src/lib/utils/buildRedirectUrl.ts
@@ -32,6 +32,7 @@ export function buildRedirectUrl(
   const searchParamsString = optional?.searchParams
     ? `?${new URLSearchParams(optional?.searchParams).toString()}`
     : '';
+  const localeString = optional?.locale ? `${optional.locale}/` : '';
 
-  return `${startUrl}${optional?.locale}/${offeringId}/${interval}/${pageTypeUrl}${endUrl}${searchParamsString}`;
+  return `${startUrl}${localeString}${offeringId}/${interval}/${pageTypeUrl}${endUrl}${searchParamsString}`;
 }


### PR DESCRIPTION
## Because

- AssertionError: Subscription not found errors caused getCart to fail,
  since the subscription was canceled and therefore not fetched as part
  of list subscriptions resulting in the customer being shown the generic
  error fallback page.

## This pull request

- If the subscription on the cart is canceled, getCart will no longer
  throw AssertionError: Subscription not found.
- If the subscription is not part of the list returned for a customer,
  then attempt to fetch the subscription by id directly.

## Issue that this pull request solves

Closes: #PAY-3108

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Steps to reproduce
1. Create a subscription, and keep the success page open
1. Open Stripe and manually immediately delete the Subscription
1. Refresh the success page
1. Should show an error page
