### PR TITLE
fix(settings): Google play store badge not rendered correctly

### DIFF
--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -471,6 +471,8 @@ background-image: inline('/path-to-image.svg');
 
 To do this with Tailwind, you'll need to add a class to the `backgroundImage` object in the Tailwind config file. Check config files for examples.
 
+**NOTE:** While inlining SVGs is generally preferred, there are cases where non-inlined SVGs (see below) are more appropriate. This applies particularly to conditionally loaded SVGs, such as those requiring localization with multiple language variants. Inlining all SVGs in such scenarios would require importing every variant as JSX into the component, leading to a significant increase in bundle size. For example, inlining localized SVGs for [mobile App store badges](src/components/Settings/ConnectAnotherDevicePromo/storeImageLoader.tsx) would result in a 300KB+ bundle size increase. To optimize performance, non-inlined SVGs are preferred in these cases, since only SVGs of one locale will be loaded at a time.
+
 #### Non-inlined SVGs
 
 Sometimes it makes sense to let a network request fetch SVGs that are heavy/large and are used across multiple pages for faster rendering after the initial request. While our builds bust our asset caches, if an SVG persists from page to page, it can be more performant to download the image once and let the browser cache it for use across multiple pages, at least until the next release. The Mozilla and Firefox logo are good examples of this.
@@ -514,6 +516,8 @@ Since SVGs contain unique vector paths/shapes with inconsistent widths/heights, 
 Use [SVGO](https://github.com/svg/svgo) to minify SVGs. Always double check SVGs after minifying them because occasionally, something is removed or modified that changes the appearance of the SVG.
 
 Recently, we've been keeping original SVGs and appending a `.min` to those SVGs that have been ran through SVGO to make it obvious which SVGs have been minified. This can also make tweaking animations on SVGs easier as well or any other reason we may want to refer to the original graphic.
+
+In some cases, IDs defined in the `<defs>` section of different SVGs on the same page can conflict, causing rendering issues when these SVGs are inlined. This happens because inlined SVGs share the same DOM scope, unlike non-inlined SVGs, which are sandboxed. To resolve these conflicts, you can either manually update the conflicting IDs or use non-inlined SVGs. While SVGO offers a plugin to automatically prefix IDs, we do not enable it in our config for now because SVGO can sometimes alter the appearance of SVGs.
 
 ### Metrics
 

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/en.ftl
@@ -5,9 +5,9 @@ connect-another-find-fx-mobile-2 = Find { -brand-firefox } in the { -google-play
 
 # Alt text for Google Play and Apple App store images that will be shown if the image can't be loaded.
 # These images are used to encourage users to download Firefox on their mobile devices.
-connect-another-play-store-image =
-    .title = Download { -brand-firefox } on { -google-play }
-connect-another-app-store-image-2 =
-    .title = Download { -brand-firefox } on the { -app-store }
+connect-another-play-store-image-2 =
+    .alt = Download { -brand-firefox } on { -google-play }
+connect-another-app-store-image-3 =
+    .alt = Download { -brand-firefox } on the { -app-store }
 
 ##

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.test.tsx
@@ -7,6 +7,7 @@ import { screen } from '@testing-library/react';
 import ConnectAnotherDevicePromo from '.';
 import { renderWithRouter } from '../../../models/mocks';
 import { getStoreImageByLanguages, StoreType } from './storeImageLoader';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 
 describe('Connect another device Promo', () => {
   it('renders "fresh load" <ConnectAnotherDevicePromo/> with correct content', async () => {
@@ -26,62 +27,54 @@ describe('Connect another device Promo', () => {
 });
 
 describe('getStoreImageByLanguages', () => {
-  it('should return default image, if no locale is provided', () => {
-    const expected = 'SvgEn';
-    const {
-      render: { name: actual },
-    }: any = getStoreImageByLanguages(StoreType.apple);
-
-    expect(actual).toEqual(expected);
+  it('should return default image, if no locale is provided', async () => {
+    renderWithLocalizationProvider(getStoreImageByLanguages(StoreType.apple));
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', expect.stringContaining('en.svg'));
   });
 
-  it('should return default image, if invalid locale is provided', () => {
+  it('should return default image, if invalid locale is provided', async () => {
     const languages = ['invalidLanguage'];
-    const expected = 'SvgEn';
-    const {
-      render: { name: actual },
-    }: any = getStoreImageByLanguages(StoreType.apple, languages);
-
-    expect(actual).toEqual(expected);
+    renderWithLocalizationProvider(
+      getStoreImageByLanguages(StoreType.apple, languages)
+    );
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', expect.stringContaining('en.svg'));
   });
 
-  it('should return image for valid language', () => {
+  it('should return image for valid language', async () => {
     const languages = ['en', 'de'];
-    const expected = 'SvgEn';
-    const {
-      render: { name: actual },
-    }: any = getStoreImageByLanguages(StoreType.apple, languages);
-
-    expect(actual).toEqual(expected);
+    renderWithLocalizationProvider(
+      getStoreImageByLanguages(StoreType.apple, languages)
+    );
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', expect.stringContaining('en.svg'));
   });
 
-  it('should return valid image if multiple languages are provided and 1st language is not valid', () => {
+  it('should return valid image if multiple languages are provided and 1st language is not valid', async () => {
     const languages = ['invalidLanguage', 'en'];
-    const expected = 'SvgEn';
-    const {
-      render: { name: actual },
-    }: any = getStoreImageByLanguages(StoreType.apple, languages);
-
-    expect(actual).toEqual(expected);
+    renderWithLocalizationProvider(
+      getStoreImageByLanguages(StoreType.apple, languages)
+    );
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', expect.stringContaining('en.svg'));
   });
 
-  it('should return image with region code', () => {
+  it('should return image with region code', async () => {
     const languages = ['pt-BR', 'pt'];
-    const expected = 'SvgPtBr';
-    const {
-      render: { name: actual },
-    }: any = getStoreImageByLanguages(StoreType.apple, languages);
-
-    expect(actual).toEqual(expected);
+    renderWithLocalizationProvider(
+      getStoreImageByLanguages(StoreType.apple, languages)
+    );
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', expect.stringContaining('pt-BR.svg'));
   });
 
-  it('should return language image if region is not available', () => {
+  it('should return language image if region is not available', async () => {
     const languages = ['pt-ZA', 'pt'];
-    const expected = 'SvgPt';
-    const {
-      render: { name: actual },
-    }: any = getStoreImageByLanguages(StoreType.apple, languages);
-
-    expect(actual).toEqual(expected);
+    renderWithLocalizationProvider(
+      getStoreImageByLanguages(StoreType.apple, languages)
+    );
+    const image = await screen.findByRole('img');
+    expect(image).toHaveAttribute('src', expect.stringContaining('pt.svg'));
   });
 });

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/index.tsx
@@ -4,10 +4,10 @@
 
 import React, { useContext } from 'react';
 import { LinkExternal } from 'fxa-react/components/LinkExternal';
-import { Localized } from '@fluent/react';
 import { getStoreImageByLanguages, StoreType } from './storeImageLoader';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import GleanMetrics from '../../../lib/glean';
+import { FtlMsg } from 'fxa-react/lib/utils';
 
 export function ConnectAnotherDevicePromo() {
   const { navigatorLanguages } = useContext(SettingsContext);
@@ -26,14 +26,14 @@ export function ConnectAnotherDevicePromo() {
       data-testid="connect-another-device-promo"
     >
       <div className="flex flex-col flex-1 text-center mobileLandscape:text-start">
-        <Localized id="connect-another-fx-mobile">
+        <FtlMsg id="connect-another-fx-mobile">
           <p className="text-sm">Get Firefox on mobile or tablet</p>
-        </Localized>
-        <Localized id="connect-another-find-fx-mobile-2">
+        </FtlMsg>
+        <FtlMsg id="connect-another-find-fx-mobile-2">
           <p className="text-grey-400 text-xs">
             Find Firefox in the Google Play and App Store.
           </p>
-        </Localized>
+        </FtlMsg>
       </div>
       <div className="flex flex-2 justify-center mt-5 mobileLandscape:mt-0 mobileLandscape:justify-end mobileLandscape:rtl:justify-start">
         <LinkExternal
@@ -42,15 +42,7 @@ export function ConnectAnotherDevicePromo() {
           href="https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox"
           onClick={() => GleanMetrics.accountPref.googlePlaySubmit()}
         >
-          <Localized
-            id="connect-another-play-store-image"
-            attrs={{ title: true }}
-          >
-            <GooglePlayBadge
-              role="img"
-              title="Download Firefox on Google Play"
-            />
-          </Localized>
+          {GooglePlayBadge}
         </LinkExternal>
         <LinkExternal
           className="self-center m-2 rounded focus-visible-default outline-offset-2"
@@ -58,15 +50,7 @@ export function ConnectAnotherDevicePromo() {
           href="https://app.adjust.com/2uo1qc?redirect=https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926"
           onClick={() => GleanMetrics.accountPref.appleSubmit()}
         >
-          <Localized
-            id="connect-another-app-store-image-2"
-            attrs={{ title: true }}
-          >
-            <AppStoreBadge
-              role="img"
-              title="Download Firefox on the App Store"
-            />
-          </Localized>
+          {AppStoreBadge}
         </LinkExternal>
       </div>
     </div>

--- a/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/storeImageLoader.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectAnotherDevicePromo/storeImageLoader.tsx
@@ -1,57 +1,63 @@
-import { FunctionComponent, SVGProps } from 'react';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { ReactComponent as daApple } from './apple-app-store-button/da.svg';
-import { ReactComponent as deApple } from './apple-app-store-button/de.svg';
-import { ReactComponent as enApple } from './apple-app-store-button/en.svg';
-import { ReactComponent as esApple } from './apple-app-store-button/es.svg';
-import { ReactComponent as etApple } from './apple-app-store-button/et.svg';
-import { ReactComponent as frApple } from './apple-app-store-button/fr.svg';
-import { ReactComponent as heApple } from './apple-app-store-button/he.svg';
-import { ReactComponent as huApple } from './apple-app-store-button/hu.svg';
-import { ReactComponent as idApple } from './apple-app-store-button/id.svg';
-import { ReactComponent as itApple } from './apple-app-store-button/it.svg';
-import { ReactComponent as jaApple } from './apple-app-store-button/ja.svg';
-import { ReactComponent as koApple } from './apple-app-store-button/ko.svg';
-import { ReactComponent as ltApple } from './apple-app-store-button/lt.svg';
-import { ReactComponent as nbNOApple } from './apple-app-store-button/nb-NO.svg';
-import { ReactComponent as nlApple } from './apple-app-store-button/nl.svg';
-import { ReactComponent as plApple } from './apple-app-store-button/pl.svg';
-import { ReactComponent as ptBRApple } from './apple-app-store-button/pt-BR.svg';
-import { ReactComponent as ptApple } from './apple-app-store-button/pt.svg';
-import { ReactComponent as ruApple } from './apple-app-store-button/ru.svg';
-import { ReactComponent as skApple } from './apple-app-store-button/sk.svg';
-import { ReactComponent as slApple } from './apple-app-store-button/sl.svg';
-import { ReactComponent as svSEApple } from './apple-app-store-button/sv-SE.svg';
-import { ReactComponent as trApple } from './apple-app-store-button/tr.svg';
-import { ReactComponent as zhCNApple } from './apple-app-store-button/zh-CN.svg';
-import { ReactComponent as zhTWApple } from './apple-app-store-button/zh-TW.svg';
-import { ReactComponent as caGoogle } from './google-play-store-button/ca.svg';
-import { ReactComponent as csGoogle } from './google-play-store-button/cs.svg';
-import { ReactComponent as daGoogle } from './google-play-store-button/da.svg';
-import { ReactComponent as deGoogle } from './google-play-store-button/de.svg';
-import { ReactComponent as enGoogle } from './google-play-store-button/en.svg';
-import { ReactComponent as esGoogle } from './google-play-store-button/es.svg';
-import { ReactComponent as etGoogle } from './google-play-store-button/et.svg';
-import { ReactComponent as frGoogle } from './google-play-store-button/fr.svg';
-import { ReactComponent as huGoogle } from './google-play-store-button/hu.svg';
-import { ReactComponent as idGoogle } from './google-play-store-button/id.svg';
-import { ReactComponent as itGoogle } from './google-play-store-button/it.svg';
-import { ReactComponent as jaGoogle } from './google-play-store-button/ja.svg';
-import { ReactComponent as koGoogle } from './google-play-store-button/ko.svg';
-import { ReactComponent as ltGoogle } from './google-play-store-button/lt.svg';
-import { ReactComponent as nbNOGoogle } from './google-play-store-button/nb-NO.svg';
-import { ReactComponent as nlGoogle } from './google-play-store-button/nl.svg';
-import { ReactComponent as plGoogle } from './google-play-store-button/pl.svg';
-import { ReactComponent as ptBRGoogle } from './google-play-store-button/pt-BR.svg';
-import { ReactComponent as ptGoogle } from './google-play-store-button/pt.svg';
-import { ReactComponent as ruGoogle } from './google-play-store-button/ru.svg';
-import { ReactComponent as skGoogle } from './google-play-store-button/sk.svg';
-import { ReactComponent as slGoogle } from './google-play-store-button/sl.svg';
-import { ReactComponent as svGoogle } from './google-play-store-button/sv.svg';
-import { ReactComponent as trGoogle } from './google-play-store-button/tr.svg';
-import { ReactComponent as ukGoogle } from './google-play-store-button/uk.svg';
-import { ReactComponent as zhCNGoogle } from './google-play-store-button/zh-CN.svg';
-import { ReactComponent as zhTWGoogle } from './google-play-store-button/zh-TW.svg';
+import React from 'react';
+
+import daApple from './apple-app-store-button/da.svg';
+import deApple from './apple-app-store-button/de.svg';
+import enApple from './apple-app-store-button/en.svg';
+import esApple from './apple-app-store-button/es.svg';
+import etApple from './apple-app-store-button/et.svg';
+import frApple from './apple-app-store-button/fr.svg';
+import heApple from './apple-app-store-button/he.svg';
+import huApple from './apple-app-store-button/hu.svg';
+import idApple from './apple-app-store-button/id.svg';
+import itApple from './apple-app-store-button/it.svg';
+import jaApple from './apple-app-store-button/ja.svg';
+import koApple from './apple-app-store-button/ko.svg';
+import ltApple from './apple-app-store-button/lt.svg';
+import nbNOApple from './apple-app-store-button/nb-NO.svg';
+import nlApple from './apple-app-store-button/nl.svg';
+import plApple from './apple-app-store-button/pl.svg';
+import ptBRApple from './apple-app-store-button/pt-BR.svg';
+import ptApple from './apple-app-store-button/pt.svg';
+import ruApple from './apple-app-store-button/ru.svg';
+import skApple from './apple-app-store-button/sk.svg';
+import slApple from './apple-app-store-button/sl.svg';
+import svSEApple from './apple-app-store-button/sv-SE.svg';
+import trApple from './apple-app-store-button/tr.svg';
+import zhCNApple from './apple-app-store-button/zh-CN.svg';
+import zhTWApple from './apple-app-store-button/zh-TW.svg';
+
+import caGoogle from './google-play-store-button/ca.svg';
+import csGoogle from './google-play-store-button/cs.svg';
+import daGoogle from './google-play-store-button/da.svg';
+import deGoogle from './google-play-store-button/de.svg';
+import enGoogle from './google-play-store-button/en.svg';
+import esGoogle from './google-play-store-button/es.svg';
+import etGoogle from './google-play-store-button/et.svg';
+import frGoogle from './google-play-store-button/fr.svg';
+import huGoogle from './google-play-store-button/hu.svg';
+import idGoogle from './google-play-store-button/id.svg';
+import itGoogle from './google-play-store-button/it.svg';
+import jaGoogle from './google-play-store-button/ja.svg';
+import koGoogle from './google-play-store-button/ko.svg';
+import ltGoogle from './google-play-store-button/lt.svg';
+import nbNOGoogle from './google-play-store-button/nb-NO.svg';
+import nlGoogle from './google-play-store-button/nl.svg';
+import plGoogle from './google-play-store-button/pl.svg';
+import ptBRGoogle from './google-play-store-button/pt-BR.svg';
+import ptGoogle from './google-play-store-button/pt.svg';
+import ruGoogle from './google-play-store-button/ru.svg';
+import skGoogle from './google-play-store-button/sk.svg';
+import slGoogle from './google-play-store-button/sl.svg';
+import svGoogle from './google-play-store-button/sv.svg';
+import trGoogle from './google-play-store-button/tr.svg';
+import ukGoogle from './google-play-store-button/uk.svg';
+import zhCNGoogle from './google-play-store-button/zh-CN.svg';
+import zhTWGoogle from './google-play-store-button/zh-TW.svg';
+import { FtlMsg } from 'fxa-react/lib/utils';
 
 export enum StoreType {
   apple,
@@ -127,11 +133,8 @@ function hasKey<O>(obj: O, key: PropertyKey): key is keyof O {
 export function getStoreImageByLanguages(
   store: StoreType,
   userLanguages: readonly string[] = ['en']
-): FunctionComponent<
-  SVGProps<SVGSVGElement> & {
-    title?: string | undefined;
-  }
-> {
+) {
+  let src = storeImages[store].en; // Fallback to English
   // Iterate through available languages until logo is found, otherwise default to 'en'
   for (let i = 0; i < userLanguages.length; i += 1) {
     // If language string includes region, eg. zh-TW, check if an image is available.
@@ -142,11 +145,22 @@ export function getStoreImageByLanguages(
         : userLanguages[i].slice(0, dashLocation);
 
     if (hasKey(storeImages[store], language)) {
-      // TS issue - If we don't assign to const here, then !== undefined doesn't work.
-      const storeImage = storeImages[store][language];
-      if (storeImage !== undefined) return storeImage;
+      const imgSrc = storeImages[store][language];
+      if (imgSrc !== undefined) {
+        src = imgSrc;
+        break;
+      }
     }
   }
-
-  return storeImages[store].en;
+  return store === StoreType.google ? (
+    <FtlMsg id="connect-another-play-store-image-2" attrs={{ alt: true }}>
+      <img src={src} alt="Download Firefox on Google Play" />
+    </FtlMsg>
+  ) : (
+    <FtlMsg id="connect-another-app-store-image-3" attrs={{ alt: true }}>
+      <img src={src} alt="Download Firefox on the App Store" />
+    </FtlMsg>
+  );
 }
+
+export default getStoreImageByLanguages;


### PR DESCRIPTION
## Because

- the Google Play Store badge is not rendered correctly

## This pull request

- fixes this issue by switching from using inline SVG to using <img> elements, incidentally cutting down bundle size by 380 KB.

## Issue that this pull request solves

Closes: FXA-12063

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
