### PR TITLE
feat(functional-tests): skip flaky sp2 tests

### DIFF
--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponExpired.spec.ts
@@ -10,6 +10,7 @@ test.describe('severity-2 #smoke', () => {
     test('apply an expired coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'test plan not available in prod'

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponForeverDiscount.spec.ts
@@ -13,6 +13,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, signin, subscribe },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
@@ -53,6 +54,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, signin, subscribe },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponInvalid.spec.ts
@@ -11,6 +11,7 @@ test.describe('severity-2 #smoke', () => {
     test('apply an invalid coupon', async ({ pages: { relier, subscribe } }, {
       project,
     }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'test plan not available in prod'
@@ -44,6 +45,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, signin, subscribe },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/couponOneTimeDiscount.spec.ts
@@ -13,6 +13,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, signin, subscribe },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
@@ -54,6 +55,7 @@ test.describe('severity-2 #smoke', () => {
     test('remove a coupon and verify', async ({
       pages: { relier, subscribe },
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'test plan not available in prod'

--- a/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/coupons-ui-tests/resubscription.spec.ts
@@ -15,6 +15,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, subscribe, settings, signin },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'

--- a/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/subscription.spec.ts
@@ -13,6 +13,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, signin, subscribe },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
@@ -44,7 +45,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, signin, subscribe },
       credentials,
     }, { project }) => {
-      test.fixme(true, "Blocking tag while works in dev, has been flaky");
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'
@@ -116,6 +117,7 @@ test.describe('severity-2 #smoke', () => {
     test('subscribe with paypal opens popup', async ({
       pages: { relier, subscribe },
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'

--- a/packages/functional-tests/tests/subscription-tests/support.spec.ts
+++ b/packages/functional-tests/tests/subscription-tests/support.spec.ts
@@ -50,6 +50,7 @@ test.describe('severity-2 #smoke', () => {
       pages: { relier, subscribe, settings, signin },
       credentials,
     }, { project }) => {
+      test.fixme(true, 'To be deprecated as part of PAY-3176');
       test.skip(
         project.name === 'production',
         'no real payment method available in prod'


### PR DESCRIPTION
## Because

- Some SP2 checkout tests are flaky causing unnecessary circle ci delays and issues during releases.
- SP2 checkout functional tests are no longer as important as before as most subscription checkout is now done through SP3 checkout pages.

## This pull request

- Adds fixme to flaky functional tests, and added a reference to a future ticket to remove the functional tests.

## Issue that this pull request solves

Closes: #PAY-3168

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information

List of flaky tests is based on CircleCi Flaky test designation with tests failing more than 2 times. in the last 2 weeks.
