### PR TITLE
fix(bug): Fix issue where some cms customized emails are missing logo

### DIFF
--- a/libs/shared/metrics/glean/src/lib/metrics.context.ts
+++ b/libs/shared/metrics/glean/src/lib/metrics.context.ts
@@ -28,6 +28,7 @@ export class MetricsContext {
   utmMedium?: string;
   utmSource?: string;
   utmTerm?: string;
+  clientId?: string;
 
   constructor(queryParams?: Record<string, string | undefined>) {
     queryParams = queryParams || {};
@@ -38,6 +39,7 @@ export class MetricsContext {
       queryParams['flowBeginTime'] || queryParams['flow_begin_time']
         ? Number(queryParams['flowBeginTime'] || queryParams['flow_begin_time'])
         : undefined;
+    this.clientId = queryParams['clientId'] || queryParams['client_id'];
     this.utmCampaign =
       queryParams['utmCampaign'] || queryParams['utm_campaign'];
     this.utmContent = queryParams['utmContent'] || queryParams['utm_content'];

--- a/packages/fxa-auth-server/lib/metrics/context.js
+++ b/packages/fxa-auth-server/lib/metrics/context.js
@@ -45,6 +45,7 @@ const SCHEMA = isA
     utmTerm: UTM_SCHEMA.optional(),
     productId: isA.string().max(128).optional(),
     planId: isA.string().max(128).optional(),
+    clientId: isA.string().length(16).regex(HEX_STRING).optional(),
   })
   .unknown(false)
   .and('flowId', 'flowBeginTime');
@@ -162,6 +163,7 @@ module.exports = function (log, config) {
       data.flowBeginTime = metadata.flowBeginTime;
       data.flowCompleteSignal = metadata.flowCompleteSignal;
       data.flowType = metadata.flowType;
+      data.clientId = metadata.clientId;
 
       if (metadata.service) {
         data.service = metadata.service;

--- a/packages/fxa-auth-server/test/local/metrics/context.js
+++ b/packages/fxa-auth-server/test/local/metrics/context.js
@@ -428,6 +428,74 @@ describe('metricsContext', () => {
               entrypointVariation: 'mock entrypoint experiment variation',
               migration: 'mock migration',
               service: 'mock service',
+              clientId: 'mock client id',
+              utmCampaign: 'mock utm_campaign',
+              utmContent: 'mock utm_content',
+              utmMedium: 'mock utm_medium',
+              utmSource: 'mock utm_source',
+              utmTerm: 'mock utm_term',
+              ignore: 'mock ignorable property',
+              productId: 'productId',
+              planId: 'planId',
+            }),
+          },
+        },
+        {}
+      )
+      .then((result) => {
+        assert.isObject(result);
+        assert.lengthOf(Object.keys(result), 19);
+        assert.isAbove(result.time, time);
+        assert.equal(result.device_id, 'mock device id');
+        assert.equal(result.entrypoint, 'mock entry point');
+        assert.equal(
+          result.entrypoint_experiment,
+          'mock entrypoint experiment'
+        );
+        assert.equal(
+          result.entrypoint_variation,
+          'mock entrypoint experiment variation'
+        );
+        assert.equal(result.flow_id, 'mock flow id');
+        assert.isAbove(result.flow_time, 0);
+        assert.isBelow(result.flow_time, time);
+        assert.equal(result.flowBeginTime, time);
+        assert.equal(result.flowCompleteSignal, 'mock flow complete signal');
+        assert.equal(result.flowType, 'mock flow type');
+        assert.equal(result.service, 'mock service');
+        assert.equal(result.clientId, 'mock client id');
+        assert.equal(result.utm_campaign, 'mock utm_campaign');
+        assert.equal(result.utm_content, 'mock utm_content');
+        assert.equal(result.utm_medium, 'mock utm_medium');
+        assert.equal(result.utm_source, 'mock utm_source');
+        assert.equal(result.utm_term, 'mock utm_term');
+
+        assert.equal(cache.get.callCount, 0);
+      });
+  });
+
+  it('metricsContext.gather with clientId only', () => {
+    results.get = Promise.resolve({
+      flowId: 'not this flow id',
+      flowBeginTime: 0,
+    });
+    const time = Date.now() - 1;
+    return metricsContext.gather
+      .call(
+        {
+          app: {
+            metricsContext: Promise.resolve({
+              deviceId: 'mock device id',
+              flowId: 'mock flow id',
+              flowBeginTime: time,
+              flowCompleteSignal: 'mock flow complete signal',
+              flowType: 'mock flow type',
+              context: 'mock context',
+              entrypoint: 'mock entry point',
+              entrypointExperiment: 'mock entrypoint experiment',
+              entrypointVariation: 'mock entrypoint experiment variation',
+              migration: 'mock migration',
+              clientId: 'mock client id',
               utmCampaign: 'mock utm_campaign',
               utmContent: 'mock utm_content',
               utmMedium: 'mock utm_medium',
@@ -461,7 +529,7 @@ describe('metricsContext', () => {
         assert.equal(result.flowBeginTime, time);
         assert.equal(result.flowCompleteSignal, 'mock flow complete signal');
         assert.equal(result.flowType, 'mock flow type');
-        assert.equal(result.service, 'mock service');
+        assert.equal(result.clientId, 'mock client id');
         assert.equal(result.utm_campaign, 'mock utm_campaign');
         assert.equal(result.utm_content, 'mock utm_content');
         assert.equal(result.utm_medium, 'mock utm_medium');
@@ -504,7 +572,7 @@ describe('metricsContext', () => {
         {}
       )
       .then((result) => {
-        assert.lengthOf(Object.keys(result), 8);
+        assert.lengthOf(Object.keys(result), 9);
         assert.isUndefined(result.entrypoint);
         assert.isUndefined(result.entrypoint_experiment);
         assert.isUndefined(result.entrypoint_variation);

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -1423,6 +1423,7 @@ describe('/account/create', () => {
         metricsContext: {
           ...defaults.payload.metricsContext,
           service: '00f00f',
+          clientId: '00f00f',
           entrypoint: 'testo',
         },
         verificationMethod: 'email-otp',
@@ -2243,6 +2244,7 @@ describe('/account/login', () => {
         flowId:
           'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
         service: '00f00f',
+        clientId: '00f00f',
         entrypoint: 'testo',
       },
     },

--- a/packages/fxa-auth-server/test/local/routes/utils/signin.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signin.js
@@ -759,6 +759,7 @@ describe('sendSigninNotifications', () => {
         flowBeginTime: Date.now(),
         flowId:
           'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
+        clientId: '00f00f',
         utmCampaign: 'utm campaign',
         utmContent: 'utm content',
         utmMedium: 'utm medium',

--- a/packages/fxa-graphql-api/src/gql/dto/input/metrics-context.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/metrics-context.ts
@@ -34,6 +34,9 @@ export class MetricsContext {
   public planId?: string;
 
   @Field({ nullable: true })
+  public clientId?: string;
+
+  @Field({ nullable: true })
   public utmCampaign?: string;
 
   @Field({ nullable: true })


### PR DESCRIPTION
## Because

- Sync emails were not getting customizations loaded correctly
- Typically the `metricsContext.service` is the clientId, however for sync it is "sync". Changing that value could risk breaking our metrics so I opted to pass the clientId directly into the account create and login routes

## This pull request

- Updates graphql to pass the clientId in metricsContext
- Updates auth-server to stash the clientId in metricsContext
- Updates the auth-server to fetch customizations on the clientId instead of service value

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12121
Closes: https://mozilla-hub.atlassian.net/browse/FXA-12123

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="396" height="701" alt="Screenshot 2025-07-24 at 1 00 57 PM" src="https://github.com/user-attachments/assets/5816ae12-b279-437d-b491-88bf8088abdc" />
<img width="349" height="595" alt="Screenshot 2025-07-24 at 1 01 02 PM" src="https://github.com/user-attachments/assets/590a40f2-fa4c-46ca-95f1-cbdcaefd02b6" />


## Other information (Optional)

Any other information that is important to this pull request.
