### PR TITLE
enable husky pre-commit and eslint ts files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-lint-staged
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -145,9 +145,7 @@
       "eslint"
     ],
     "*.{ts,tsx}": [
-      "prettier --config _dev/.prettierrc --write"
-    ],
-    "packages/fxa-auth-server/**/*.{ts,tsx}": [
+      "prettier --config _dev/.prettierrc --write",
       "eslint"
     ],
     "*.css": [

--- a/packages/fxa-settings/.eslintignore
+++ b/packages/fxa-settings/.eslintignore
@@ -1,1 +1,7 @@
 storybook-static
+.storybook/*.js
+config/
+public/
+scripts/
+*.config.js
+Gruntfile.js

--- a/packages/fxa-settings/.eslintrc.json
+++ b/packages/fxa-settings/.eslintrc.json
@@ -1,9 +1,6 @@
 {
   "root": true,
-  "extends": [
-    "react-app",
-    "react-app/jest"
-  ],
+  "extends": ["react-app", "react-app/jest"],
   "rules": {
     "import/export": "error",
     "import/named": "off",
@@ -23,5 +20,14 @@
     "testing-library/no-unnecessary-act": "off",
     "testing-library/no-container": "off"
   },
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": "error"
+      }
+    }
+  ],
   "ignorePatterns": ["build/", "scripts/build.js"]
 }

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyDownload/index.test.tsx
@@ -35,22 +35,21 @@ const renderFlowPage = async () => {
   await act(() => {
     renderWithRouter(
       <FlowRecoveryKeyDownload
-      {...{
-        localizedBackButtonTitle,
-        localizedPageTitle,
-        navigateForward,
-        navigateBackward,
-        viewName,
-      }}
-      email={MOCK_EMAIL}
-      recoveryKeyValue={MOCK_RECOVERY_KEY_VALUE}
+        {...{
+          localizedBackButtonTitle,
+          localizedPageTitle,
+          navigateForward,
+          navigateBackward,
+          viewName,
+        }}
+        email={MOCK_EMAIL}
+        recoveryKeyValue={MOCK_RECOVERY_KEY_VALUE}
       />
     );
   });
 };
 
 describe('FlowRecoveryKeyDownload', () => {
-
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/packages/fxa-settings/src/models/experiments/key-stretch-experiment.test.ts
+++ b/packages/fxa-settings/src/models/experiments/key-stretch-experiment.test.ts
@@ -20,6 +20,7 @@ describe('Key Stretch Experiment Model', function () {
   };
 
   const window = new ReachRouterWindow();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let model: KeyStretchExperiment;
   beforeEach(function () {
     model = new KeyStretchExperiment(new GenericData({}));

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -6,7 +6,7 @@ import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
 
 import { MozServices } from '../lib/types';
 import { MOCK_ACCOUNT } from '../models/mocks';
-import { Integration, IntegrationType, OAuthNativeIntegration, RelierCmsInfo } from '../models';
+import { Integration, IntegrationType } from '../models';
 
 export const MOCK_EMAIL = MOCK_ACCOUNT.primaryEmail.email;
 export const MOCK_UID = 'abcd1234abcd1234abcd1234abcd1234';
@@ -103,7 +103,8 @@ export const MOCK_CMS_INFO = {
     logoUrl:
       'https://gist.githubusercontent.com/vbudhram/c53b07efd1656acfff7d2c7e9d6825fe/raw/030df98ee27f609333606d36c7bf3af45af53f39/123Done_red.svg',
     logoAltText: 'logo',
-    backgroundColor: 'linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%)',
+    backgroundColor:
+      'linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%)',
   },
   EmailFirstPage: {
     headline: 'Sign up or sign in to your Mozilla account',


### PR DESCRIPTION
## Because

- pre-commit with linting was not running (at least for fxa-settings), leading to missed lint errors that cause build failures on CI

## This pull request

- enable eslint for all ts files (not just auth-server)
- fix husky pre-commit command
- add rule to lint TS files fur unused vars (which was causing CI failures)
- testing pre-commit on one file lead to some linting fixes

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
