### PR TITLE
fix(content-server): Conditionally serve React/Backbone for 'oauth' route

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -683,10 +683,14 @@ Router = Router.extend({
       if (
         reactRouteGroups[routeGroup].routes.find((route) => routeName === route)
       ) {
+        const showBackboneOAuthRoute =
+          routeName === 'oauth' &&
+          Url.searchParam('channel_id', this.window.location.search);
         return (
           reactRouteGroups[routeGroup].featureFlagOn &&
           (this.isInReactExperiment() ||
-            reactRouteGroups[routeGroup].fullProdRollout === true)
+            reactRouteGroups[routeGroup].fullProdRollout === true) &&
+          !showBackboneOAuthRoute
         );
       }
     }

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -47,7 +47,7 @@ describe('lib/router', () => {
     },
     sometimesOnRoutes: {
       featureFlagOn: mockShowReactAppConfig.sometimesOnRoutes,
-      routes: ['sometimesOnRoute', 'view'],
+      routes: ['sometimesOnRoute', 'view', 'oauth'],
       fullProdRollout: false,
     },
     neverOnRoutes: {
@@ -563,6 +563,20 @@ describe('lib/router', () => {
           sinon.stub(router, 'isInReactExperiment').callsFake(() => true);
           assert.isTrue(router.showReactApp('sometimesOnRoute'));
         });
+
+        it('when route is oauth but channel_id parameter is not present', () => {
+          const testRouteGroups = {
+            ...mockReactRouteGroups,
+            alwaysOnRoutes: {
+              ...mockReactRouteGroups.alwaysOnRoutes,
+              routes: ['alwaysOnRoute', 'oauth'],
+            },
+          };
+          sinon.stub(router, 'getReactRouteGroups').returns(testRouteGroups);
+
+          windowMock.location.search = '';
+          assert.isTrue(router.showReactApp('oauth'));
+        });
       });
 
       describe('returns false', () => {
@@ -590,8 +604,23 @@ describe('lib/router', () => {
           sinon.stub(router, 'isInReactExperiment').callsFake(() => false);
           assert.isFalse(router.showReactApp('sometimesOnRoute'));
         });
+
+        it('when route is oauth and channel_id parameter is present', () => {
+          const testRouteGroups = {
+            ...mockReactRouteGroups,
+            alwaysOnRoutes: {
+              ...mockReactRouteGroups.alwaysOnRoutes,
+              routes: ['alwaysOnRoute', 'oauth'],
+            },
+          };
+          sinon.stub(router, 'getReactRouteGroups').returns(testRouteGroups);
+
+          windowMock.location.search = '?channel_id=test123';
+          assert.isFalse(router.showReactApp('oauth'));
+        });
       });
     });
+
     describe('createReactOrBackboneViewHandler', () => {
       const viewConstructorOptions = {};
       const additionalParams = {};

--- a/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/add-routes.js
@@ -43,6 +43,11 @@ function addAllReactRoutesConditionally(
               } else {
                 return next('route');
               }
+              // Allow '/oauth' to serve the React application, _but_ if the request URL includes
+              // a 'channel_id' query parameter, we know it's Fx Desktop trying to begin the pairing
+              // flow. Show Backbone in this case until the pair flow is converted to React.
+            } else if (req.path === '/oauth' && req.query.channel_id) {
+              return next('route');
             }
             return middleware(req, res, next);
           }

--- a/packages/fxa-content-server/server/lib/routes/react-app/index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/index.js
@@ -29,9 +29,10 @@ const getReactRouteGroups = (showReactApp, reactRoute) => {
       // first.
       routes: reactRoute.getRoutes([
         'authorization',
-        // We have to temporarily remove the `/oauth` because Fx desktop uses
-        // that path to initiate the pairing flow
-        // 'oauth'
+        // Note: 'oauth' is currently a weird case because because Fx desktop uses
+        // it to initiate the pairing flow. We have logic at the Express level to
+        // handle showing React/Backbone for this route until pairing is Reactified.
+        'oauth',
         '/',
       ]),
       fullProdRollout: true,

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -132,6 +132,10 @@ export class OAuthWebIntegration extends GenericIntegration<
   }
 
   getServiceName() {
+    // TODO: Currently we try to get the `serviceName` in `AuthAndSetupRoutes`. If the
+    // 'scope' param isn't provided and the user lands on /oauth, there's an
+    // `Uncaught OAuthError: Invalid OAuth parameter: scope`, and we should be
+    // showing `<OAuthDataError>`.
     const permissions = this.getPermissions();
     // As a special case for UX purposes, any client requesting access to
     // the user's sync data must have a display name of "Firefox Sync".
@@ -239,7 +243,7 @@ export class OAuthWebIntegration extends GenericIntegration<
 
     if (!permissions.length) {
       throw new OAuthError(OAUTH_ERRORS.INVALID_PARAMETER.errno, {
-        params: 'scope',
+        param: 'scope',
       });
     }
 


### PR DESCRIPTION
Because:
* Firefox Desktop begins the pair flow at the '/oauth' route, so we disabled serving the React app for direct '/oauth' hits since the pair flow has not been converted yet. As a consequence users that refresh on our email-first /oauth React page would be shown the Backbone app

This commit:
* Serves the React app at '/oauth' if the channel_id param is not present, else the Backbone app is served

fixes FXA-12090

--

Draft because I need to rebase on #19225 and write some notes + manual testing instructions. I'd also like to think a little more about what a follow up ticket might look like for when we work on the pairing flow - with 'oauth' in the route group we've got it in with `fullProdRollout: true` and us needing to check this at the Express level since it doesn't have access to the user's React experiment status, it's going to be 100% rolled out even if the rest of the pairing flow is at 15%.