### PR TITLE
fix(payments-next): Display any saved card in checkout

### DIFF
--- a/libs/payments/customer/src/lib/customerSession.manager.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.ts
@@ -19,7 +19,7 @@ export class CustomerSessionManager {
             payment_method_redisplay: 'enabled',
             payment_method_save: 'disabled',
             payment_method_remove: 'disabled',
-            payment_method_allow_redisplay_filters: ['always', 'unspecified'],
+            payment_method_allow_redisplay_filters: ['always', 'limited', 'unspecified'],
           },
         },
       },


### PR DESCRIPTION
Because:

* Depending on how a card is saved, we may not be displaying the user's default payment method at checkout

This commit:

* Permits 'limited' cards to be displayed in the payment element

Closes #[PAY-3185](https://mozilla-hub.atlassian.net/browse/PAY-3185)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

[PAY-3185]: https://mozilla-hub.atlassian.net/browse/PAY-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ