### PR TITLE
feat(2fa): new InlineTotpSetup using new flow components

### DIFF
--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/* eslint-disable playwright/no-conditional-in-test */
+
 import { getCode } from 'fxa-settings/src/lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
@@ -92,9 +94,10 @@ test.describe('severity-1 #smoke', () => {
 
     test('can setup TOTP inline and login', async ({
       target,
-      pages: { page, relier, settings, signin, totp },
+      pages: { page, relier, settings, signin, totp, configPage },
       testAccountTracker,
     }) => {
+      const config = await configPage.getConfig();
       const credentials = await testAccountTracker.signUp();
 
       await relier.goto();
@@ -104,32 +107,62 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/inline_totp_setup/);
 
-      await expect(
-        signin.page.getByText('Enable two-step authentication')
-      ).toBeVisible();
+      // TODO: Remove conditions after the old flow is cleaned up
+      if (config.featureFlags.updatedInlineTotpSetupFlow) {
+        await expect(
+          signin.page.getByRole('heading', {
+            name: 'Set up two-step authentication',
+          })
+        ).toBeVisible();
 
-      await signin.page.getByRole('button', { name: 'Continue' }).click();
+        await signin.page.getByRole('button', { name: 'Continue' }).click();
 
-      await expect(
-        signin.page.getByText('Scan authentication code')
-      ).toBeVisible();
+        await expect(signin.page.getByText(/Scan this QR code/)).toBeVisible();
 
-      await signin.page
-        .getByRole('button', { name: 'Can’t scan code?' })
-        .click();
+        await signin.page
+          .getByRole('button', { name: 'Can’t scan QR code?' })
+          .click();
 
-      await expect(signin.page.getByText('Enter code manually')).toBeVisible();
+        const secret = (
+          await signin.page.getByTestId('manual-datablock').innerText()
+        )?.replace(/\s/g, '');
+        const code = await getCode(secret);
 
-      const secret = (
-        await signin.page.getByTestId('manual-datablock').innerText()
-      )?.replace(/\s/g, '');
-      const code = await getCode(secret);
+        await signin.page
+          .getByRole('textbox', { name: 'Enter 6-digit code' })
+          .fill(code);
 
-      await signin.page
-        .getByRole('textbox', { name: 'Authentication code' })
-        .fill(code);
+        await signin.page.getByRole('button', { name: 'Continue' }).click();
+      } else {
+        await expect(
+          signin.page.getByText('Enable two-step authentication')
+        ).toBeVisible();
 
-      await signin.page.getByRole('button', { name: 'Ready' }).click();
+        await signin.page.getByRole('button', { name: 'Continue' }).click();
+
+        await expect(
+          signin.page.getByText('Scan authentication code')
+        ).toBeVisible();
+
+        await signin.page
+          .getByRole('button', { name: 'Can’t scan code?' })
+          .click();
+
+        await expect(
+          signin.page.getByText('Enter code manually')
+        ).toBeVisible();
+
+        const secret = (
+          await signin.page.getByTestId('manual-datablock').innerText()
+        )?.replace(/\s/g, '');
+        const code = await getCode(secret);
+
+        await signin.page
+          .getByRole('textbox', { name: 'Authentication code' })
+          .fill(code);
+
+        await signin.page.getByRole('button', { name: 'Ready' }).click();
+      }
 
       await page.waitForURL(/inline_recovery_setup/);
 

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -114,6 +114,9 @@ const settingsConfig = {
       'featureFlags.recoveryPhonePasswordReset2fa'
     ),
     updated2faSetupFlow: config.get('featureFlags.updated2faSetupFlow'),
+    updatedInlineTotpSetupFlow: config.get(
+      'featureFlags.updatedInlineTotpSetupFlow'
+    ),
   },
   nimbusPreview: config.get('nimbusPreview'),
   cms: {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -244,6 +244,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW',
     },
+    updatedInlineTotpSetupFlow: {
+      default: false,
+      doc: 'Enables a redesign of the inline TOTP setup',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_UPDATED_INLINE_TOTP_SETUP_FLOW',
+    },
   },
   cms: {
     enabled: {
@@ -251,7 +257,7 @@ const conf = (module.exports = convict({
       doc: 'Enables the CMS (Strapi) for frontend. Users are also required to be in a english locale to see the CMS content.',
       env: 'CMS_ENABLED',
       format: Boolean,
-    }
+    },
   },
   showReactApp: {
     emailFirstRoutes: {

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.test.tsx
@@ -91,7 +91,9 @@ describe('FlowSetup2faPrompt', () => {
   });
 
   it('calls onBackButtonClick when back button is clicked', async () => {
-    const { onBackButtonClick } = renderFlowSetup2faPrompt();
+    const { onBackButtonClick } = renderFlowSetup2faPrompt({
+      hideBackButton: false,
+    });
 
     const backButton = screen.getByRole('button', { name: 'Back' });
     await userEvent.click(backButton);

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
@@ -13,7 +13,8 @@ import Banner from '../../Banner';
 export type FlowSetup2faPromptProps = {
   localizedPageTitle: string;
   onContinue: () => void;
-  onBackButtonClick: () => void;
+  onBackButtonClick?: () => void;
+  hideBackButton?: boolean;
   serviceName: string;
   localizedErrorMessage?: string;
 };
@@ -21,6 +22,7 @@ export type FlowSetup2faPromptProps = {
 export const FlowSetup2faPrompt = ({
   localizedPageTitle,
   onContinue,
+  hideBackButton = true,
   onBackButtonClick,
   serviceName,
   localizedErrorMessage,
@@ -28,6 +30,7 @@ export const FlowSetup2faPrompt = ({
   return (
     <FlowContainer
       onBackButtonClick={onBackButtonClick}
+      hideBackButton={hideBackButton}
       title={localizedPageTitle}
     >
       {localizedErrorMessage && (

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -94,6 +94,7 @@ export interface Config {
     recoveryCodeSetupOnSyncSignIn?: boolean;
     recoveryPhonePasswordReset2fa?: boolean;
     updated2faSetupFlow?: boolean;
+    updatedInlineTotpSetupFlow?: boolean;
   };
   nimbusPreview: boolean;
   cms: {
@@ -177,6 +178,7 @@ export function getDefault() {
       recoveryCodeSetupOnSyncSignIn: false,
       recoveryPhonePasswordReset2fa: false,
       updated2faSetupFlow: false,
+      updatedInlineTotpSetupFlow: false,
     },
     cms: {
       // Note: Even if this flag is true, the user must be an `en` language

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -42,6 +42,7 @@ export enum MozServices {
   TestService = '123Done',
   MonitorPlus = 'Mozilla Monitor Plus',
   MonitorStage = 'Mozilla Monitor Stage',
+  Addons = 'Add-ons',
 }
 
 // Information about a device

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as ApolloClientModule from '@apollo/client';
-import * as InlineTotpSetupModule from './index';
+import * as InlineTotpSetupModule from './old';
 import * as utils from 'fxa-react/lib/utils';
 import { mockWindowLocation } from 'fxa-react/lib/test-utils/mockWindowLocation';
 
@@ -18,7 +18,6 @@ import {
   MOCK_TOTP_TOKEN,
   MOCK_QUERY_PARAMS,
   MOCK_SIGNIN_LOCATION_STATE,
-  MOCK_EMAIL,
   MOCK_SIGNIN_RECOVERY_LOCATION_STATE,
 } from './mocks';
 import { screen, waitFor } from '@testing-library/react';
@@ -239,7 +238,6 @@ describe('InlineTotpSetupContainer', () => {
         const args = (InlineTotpSetupModule.default as jest.Mock).mock
           .calls[0][0];
         expect(args.totp).toBe(MOCK_TOTP_TOKEN);
-        expect(args.email).toBe(MOCK_EMAIL);
         expect(args.serviceName).toBe(MozServices.Default);
       });
     });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -6,7 +6,8 @@ import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState, useRef } from 'react';
-import InlineTotpSetup from '.';
+import InlineTotpSetupOld from './old';
+import InlineTotpSetupNew from '.';
 import { MozServices } from '../../lib/types';
 import { Integration, isOAuthIntegration, useSession } from '../../models';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
@@ -22,6 +23,7 @@ import { hardNavigate } from 'fxa-react/lib/utils';
 import { QueryParams } from '../..';
 import { queryParamsToMetricsContext } from '../../lib/metrics';
 import GleanMetrics from '../../lib/glean';
+import config from '../../lib/config';
 
 export const InlineTotpSetupContainer = ({
   isSignedIn,
@@ -178,10 +180,16 @@ export const InlineTotpSetupContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  const isUpdatedInlineTotpSetupFlow =
+    config.featureFlags?.updatedInlineTotpSetupFlow || false;
+
+  const InlineTotpSetup = isUpdatedInlineTotpSetupFlow
+    ? InlineTotpSetupNew
+    : InlineTotpSetupOld;
+
   return (
     <InlineTotpSetup
       {...{ totp, serviceName, cancelSetupHandler, verifyCodeHandler }}
-      email={signinState.email}
     />
   );
 };

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/en.ftl
@@ -43,3 +43,5 @@ inline-totp-setup-security-code-placeholder = Authentication code
 # The "authentication code" here refers to the code provided by an authentication app.
 inline-totp-setup-code-required-error = Authentication code required
 tfa-qr-code-alt = Use the code { $code } to set up two-step authentication in supported applications.
+
+inline-totp-setup-page-title = Two-step authentication

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.test.tsx
@@ -2,26 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { act, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { UserEvent, userEvent } from '@testing-library/user-event';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import InlineTotpSetup from '.';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { MOCK_TOTP_TOKEN } from './mocks';
 import { MozServices } from '../../lib/types';
-import { MOCK_EMAIL, MOCK_TOTP_TOKEN } from './mocks';
-import { formatSecret } from '../../lib/utilities';
 
 const cancelSetupHandler = jest.fn();
 const verifyCodeHandler = jest.fn();
 const mockProps = {
   totp: MOCK_TOTP_TOKEN,
-  email: MOCK_EMAIL,
+  serviceName: MozServices.Addons,
   cancelSetupHandler,
   verifyCodeHandler,
 };
 
 describe('InlineTotpSetup', () => {
   let user: UserEvent;
+
+  const clickContinue = async () => {
+    await user.click(await screen.findByRole('button', { name: 'Continue' }));
+  };
 
   beforeAll(async () => {
     global.URL.createObjectURL = jest.fn();
@@ -31,93 +34,57 @@ describe('InlineTotpSetup', () => {
     user = userEvent.setup();
   });
 
-  it('renders default as expected', () => {
+  it('renders the intro as expected', () => {
     renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+
     screen.getByRole('heading', {
-      name: `Enable two-step authentication to continue to ${MozServices.Default}`,
+      name: 'Two-step authentication',
     });
     expect(
-      screen.getByLabelText('A device with a hidden 6-digit code.', {
-        selector: 'svg',
-      })
+      screen.getByText('Set up two-step authentication')
     ).toBeInTheDocument();
-
+    expect(
+      screen.getByText(
+        'Add-ons requires you to set up two-step authentication to keep your account safe.'
+      )
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Continue' })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Cancel setup' })
-    ).toBeInTheDocument();
   });
 
-  it('renders intro view as expected with custom service name', () => {
-    renderWithLocalizationProvider(
-      <InlineTotpSetup
-        {...{ ...mockProps, serviceName: MozServices.Monitor }}
-      />
-    );
-    screen.getByRole('heading', {
-      name: `Enable two-step authentication to continue to ${MozServices.Monitor}`,
-    });
+  it('renders step 1 with as expected, showing the QR code by default', async () => {
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+    await clickContinue();
     expect(
-      screen.getByLabelText('A device with a hidden 6-digit code.', {
-        selector: 'svg',
+      await screen.findByRole('progressbar', {
+        name: 'Step 1 of 4.',
       })
     ).toBeInTheDocument();
+    expect(await screen.findByText(/Scan this QR code/)).toBeInTheDocument();
+  });
 
+  it('can go back to intro from step 1', async () => {
+    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
+    await clickContinue();
     expect(
-      screen.getByRole('button', { name: 'Continue' })
+      await screen.findByText('Connect to your authenticator app')
     ).toBeInTheDocument();
+    user.click(screen.getByRole('button', { name: 'Back' }));
     expect(
-      screen.getByRole('button', { name: 'Cancel setup' })
+      await screen.findByText('Set up two-step authentication')
     ).toBeInTheDocument();
   });
 
-  it('renders QR code by default when a user clicks "Continue"', async () => {
+  it('calls verifyCodeHandler on code submission', async () => {
     renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-    await user.click(screen.getByRole('button', { name: 'Continue' }))
-    await screen.findByAltText(
-      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
+    await clickContinue();
+    await user.type(
+      await screen.findByLabelText('Enter 6-digit code'),
+      '123456'
     );
-  });
-
-  it('toggles from QR code to manual secret code view when user clicks "Can\'t scan code"', async () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-
-    await user.click(screen.getByRole('button', { name: 'Continue' }))
-    await screen.findByAltText(
-      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
-    );
-
-    const changeToManualModeButton = screen.getByRole('button', {
-      name: 'Can’t scan code?',
-    });
-
-    await user.click(changeToManualModeButton);
-
-    screen.getByText(formatSecret(MOCK_TOTP_TOKEN.secret));
-    await screen.findByRole('button', { name: 'Scan QR code instead?' });
-  });
-
-  it('toggles from secret code to QR code view when user clicks "Scan QR code instead?', async () => {
-    renderWithLocalizationProvider(<InlineTotpSetup {...mockProps} />);
-
-    await user.click(screen.getByRole('button', { name: 'Continue' }))
-    await screen.findByAltText(
-      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
-    );
-
-    const changeToManualModeButton = screen.getByRole('button', {
-      name: 'Can’t scan code?',
-    });
-    await user.click(changeToManualModeButton);
-    await screen.findByRole('button', { name: 'Scan QR code instead?' });
-    await user.click(
-      screen.getByRole('button', { name: 'Scan QR code instead?' })
-    )
-    await screen.findByAltText(
-      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
-    );
+    await clickContinue();
+    expect(verifyCodeHandler).toHaveBeenCalledWith('123456');
   });
 
   it('shows error on incorrect totp submission', async () => {
@@ -133,10 +100,15 @@ describe('InlineTotpSetup', () => {
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'Continue' }))
-    await user.type(screen.getByLabelText('Authentication code'), '000000')
-    await user.click(screen.getByRole('button', { name: 'Ready' }))
-    await screen.findByText('Invalid two-step authentication code');
+    await clickContinue();
+    await user.type(
+      await screen.findByLabelText('Enter 6-digit code'),
+      '000000'
+    );
+    await clickContinue();
     expect(verifyCodeHandler).toHaveBeenCalledWith('000000');
+    expect(
+      await screen.findByText(/Invalid or expired code/)
+    ).toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -2,294 +2,63 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState, useCallback, useEffect } from 'react';
-import classNames from 'classnames';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import React, { useState } from 'react';
 import { useFtlMsgResolver } from '../../models';
-import { TwoFactorAuthImage } from '../../components/images';
-import CardHeader from '../../components/CardHeader';
-import LinkExternal from 'fxa-react/components/LinkExternal';
-import FormVerifyCode from '../../components/FormVerifyCode';
 import AppLayout from '../../components/AppLayout';
 import { InlineTotpSetupProps } from './interfaces';
-import { GleanClickEventType2FA } from '../../lib/types';
-import Banner from '../../components/Banner';
-import GleanMetrics from '../../lib/glean';
-import DataBlockInline from '../../components/DataBlockInline';
-import { formatSecret } from '../../lib/utilities';
+import FlowSetup2faPrompt from '../../components/Settings/FlowSetup2faPrompt';
+import FlowSetup2faApp from '../../components/Settings/FlowSetup2faApp';
+
+// Total number of steps in the TOTP setup flow, including the recovery method setup.
+const numberOfSteps = 4;
 
 export const InlineTotpSetup = ({
   totp,
   serviceName,
-  cancelSetupHandler,
   verifyCodeHandler,
 }: InlineTotpSetupProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
-  const localizedQRCodeAltText = ftlMsgResolver.getMsg(
-    'tfa-qr-code-alt',
-    `Use the code ${totp.secret} to set up two-step authentication in supported applications.`,
-    { code: totp.secret }
-  );
-  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
-    'inline-totp-setup-code-required-error',
-    'Authentication code required'
-  );
-  const [showIntro, setShowIntro] = useState(true);
-  const [showQR, setShowQR] = useState(true);
-  const [totpErrorMessage, setTotpErrorMessage] = useState('');
-  const [localizedBannerMessage, setLocalizedBannerMessage] =
-    useState<string>('');
-
-  useEffect(() => {
-    if (!showIntro) {
-      showQR
-        ? GleanMetrics.accountPref.twoStepAuthQrView({
-            event: { reason: GleanClickEventType2FA.inline },
-          })
-        : GleanMetrics.accountPref.twoStepAuthManualCodeView({
-            event: { reason: GleanClickEventType2FA.inline },
-          });
-    }
-  }, [showIntro, showQR]);
-
-  const onCancel = useCallback(() => {
-    try {
-      cancelSetupHandler();
-    } catch (error) {
-      setLocalizedBannerMessage(
-        ftlMsgResolver.getMsg(error.ftlId, error.message)
-      );
-    }
-  }, [cancelSetupHandler, ftlMsgResolver]);
+  const [currentStep, setCurrentStep] = useState<number>(0);
 
   const onSubmit = async (code: string) => {
     try {
-      setTotpErrorMessage('');
       await verifyCodeHandler(code);
-    } catch (error) {
-      setTotpErrorMessage(ftlMsgResolver.getMsg(error.ftlId, error.message));
+    } catch (err) {
+      return { error: true };
+    }
+    return { error: false };
+  };
+
+  const navigateBackward = () => {
+    if (currentStep > 0) {
+      setCurrentStep(currentStep - 1);
     }
   };
 
+  const localizedPageTitle = ftlMsgResolver.getMsg(
+    'inline-totp-setup-page-title',
+    'Two-step authentication'
+  );
+
   return (
     <AppLayout>
-      {showIntro && (
-        <>
-          <CardHeader
-            headingText="Enable two-step authentication"
-            headingWithCustomServiceFtlId="inline-totp-setup-enable-two-step-authentication-custom-header-2"
-            headingWithDefaultServiceFtlId="inline-totp-setup-enable-two-step-authentication-default-header-2"
-            {...{ serviceName }}
-          />
-          {localizedBannerMessage && (
-            <Banner
-              type="error"
-              content={{ localizedHeading: localizedBannerMessage }}
-            />
-          )}
-          <section className="flex flex-col items-center">
-            <TwoFactorAuthImage />
-            <FtlMsg
-              id="inline-totp-setup-add-security-link"
-              elems={{
-                authenticationAppsLink: (
-                  <LinkExternal
-                    className="link-blue text-sm"
-                    href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
-                    gleanDataAttrs={{
-                      id: 'two_step_auth_app_link',
-                      type: GleanClickEventType2FA.inline,
-                    }}
-                  >
-                    these authentication apps
-                  </LinkExternal>
-                ),
-              }}
-            >
-              <p className="text-sm">
-                Add a layer of security to your account by requiring
-                authentication codes from one of{' '}
-                <LinkExternal
-                  className="link-blue text-sm"
-                  href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
-                  gleanDataAttrs={{
-                    id: 'two_step_auth_app_link',
-                    type: GleanClickEventType2FA.inline,
-                  }}
-                >
-                  these authentication apps
-                </LinkExternal>
-                .
-              </p>
-            </FtlMsg>
-            <button
-              type="submit"
-              className="cta-primary cta-xl w-full my-6"
-              onClick={() => {
-                setShowIntro(false);
-                setLocalizedBannerMessage('');
-              }}
-            >
-              <FtlMsg id="inline-totp-setup-continue-button">Continue</FtlMsg>
-            </button>
-            <button
-              type="button"
-              className="link-blue text-sm"
-              onClick={onCancel}
-            >
-              <FtlMsg id="inline-totp-setup-cancel-setup-button">
-                Cancel setup
-              </FtlMsg>
-            </button>
-          </section>
-        </>
+      {currentStep === 0 && (
+        <FlowSetup2faPrompt
+          onContinue={() => setCurrentStep(currentStep + 1)}
+          localizedPageTitle={localizedPageTitle}
+          serviceName={serviceName || ''}
+        />
       )}
-      {!showIntro && (
-        <>
-          {showQR ? (
-            <CardHeader
-              headingText="Scan authentication code"
-              headingWithCustomServiceFtlId="inline-totp-setup-show-qr-custom-service-header-2"
-              headingWithDefaultServiceFtlId="inline-totp-setup-show-qr-default-service-header-2"
-              {...{ serviceName }}
-            />
-          ) : (
-            <CardHeader
-              headingText="Enter code manually"
-              headingWithCustomServiceFtlId="inline-totp-setup-no-qr-custom-service-header-2"
-              headingWithDefaultServiceFtlId="inline-totp-setup-no-qr-default-service-header-2"
-              {...{ serviceName }}
-            />
-          )}
-          {localizedBannerMessage && (
-            <Banner
-              type="error"
-              content={{ localizedHeading: localizedBannerMessage }}
-            />
-          )}
-          <section>
-            <div id="totp" className="totp-details">
-              {showQR ? (
-                <>
-                  <FtlMsg
-                    id="inline-totp-setup-use-qr-or-enter-key-instructions"
-                    elems={{
-                      toggleToManualModeButton: (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setShowQR(false);
-                          }}
-                          className="link-blue inline"
-                        >
-                          Can’t scan code?
-                        </button>
-                      ),
-                    }}
-                  >
-                    <p className="text-sm my-4">
-                      Scan the QR code in your authentication app and then enter
-                      the authentication code it provides.{' '}
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setShowQR(false);
-                        }}
-                        className="link-blue inline"
-                      >
-                        Can’t scan code?
-                      </button>
-                    </p>
-                  </FtlMsg>
-                  <div>
-                    <img
-                      className={classNames(
-                        {
-                          hidden: !totp.qrCodeUrl,
-                        },
-                        'mx-auto w-48 h-48 rounded-xl border-8 border-green-800/10'
-                      )}
-                      alt={localizedQRCodeAltText}
-                      src={totp.qrCodeUrl}
-                    />
-                  </div>
-                  <FtlMsg id="inline-totp-setup-on-completion-description">
-                    <p className="text-sm my-4">
-                      Once complete, it will begin generating authentication
-                      codes for you to enter.
-                    </p>
-                  </FtlMsg>
-                </>
-              ) : (
-                <>
-                  <FtlMsg
-                    id="inline-totp-setup-enter-key-or-use-qr-instructions"
-                    elems={{
-                      toggleToQRButton: (
-                        <button
-                          onClick={() => {
-                            setShowQR(true);
-                          }}
-                          className="link-blue inline"
-                        >
-                          Scan QR code instead?
-                        </button>
-                      ),
-                    }}
-                  >
-                    <p className="text-sm mt-4 mb-1">
-                      Type this secret key into your authentication app.{' '}
-                      <button
-                        onClick={() => {
-                          setShowQR(true);
-                        }}
-                        className="link-blue inline"
-                      >
-                        Scan QR code instead?
-                      </button>
-                    </p>
-                  </FtlMsg>
-                  <DataBlockInline
-                    value={formatSecret(totp.secret)}
-                    prefixDataTestId="manual"
-                  />
-                  <FtlMsg id="inline-totp-setup-on-completion-description">
-                    <p className="text-sm mb-4">
-                      Once complete, it will begin generating authentication
-                      codes for you to enter.
-                    </p>
-                  </FtlMsg>
-                </>
-              )}
-              <FormVerifyCode
-                viewName="inline_totp_setup"
-                verifyCode={onSubmit}
-                formAttributes={{
-                  inputLabelText: 'Authentication code',
-                  inputFtlId: 'inline-totp-setup-security-code-placeholder',
-                  pattern: 'd{6}',
-                  maxLength: 6,
-                  submitButtonText: 'Ready',
-                  submitButtonFtlId: 'inline-totp-setup-ready-button',
-                }}
-                codeErrorMessage={totpErrorMessage}
-                setCodeErrorMessage={setTotpErrorMessage}
-                {...{ localizedCustomCodeRequiredMessage }}
-                gleanDataAttrs={{
-                  id: showQR
-                    ? 'two_step_auth_qr_submit'
-                    : 'two_step_auth_manual_code_submit',
-                  type: GleanClickEventType2FA.inline,
-                }}
-              />
-              <button className="link-blue text-sm mt-4" onClick={onCancel}>
-                <FtlMsg id="inline-totp-setup-cancel-setup-button">
-                  Cancel setup
-                </FtlMsg>
-              </button>
-            </div>
-          </section>
-        </>
+      {currentStep === 1 && (
+        <FlowSetup2faApp
+          localizedPageTitle={localizedPageTitle}
+          showProgressBar
+          currentStep={currentStep}
+          numberOfSteps={numberOfSteps}
+          totpInfo={totp}
+          verifyCode={onSubmit}
+          onBackButtonClick={navigateBackward}
+        />
       )}
     </AppLayout>
   );

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
@@ -7,8 +7,7 @@ import { TotpToken } from '../Signin/interfaces';
 
 export interface InlineTotpSetupProps {
   totp: TotpToken;
-  email: string;
   serviceName?: MozServices;
   cancelSetupHandler: () => void;
-  verifyCodeHandler: (code: string) => void;
+  verifyCodeHandler: (code: string) => Promise<void>;
 }

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/mocks.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { MOCK_SESSION_TOKEN, MOCK_UID } from '../mocks';
+import { MOCK_SESSION_TOKEN, MOCK_UID, PLACEHOLDER_QR_CODE } from '../mocks';
 
 export const MOCK_TOTP_TOKEN = {
   secret: 'I5KTS23HJBUDOUTMHBCDCTDZGJSFGTCB',
-  qrCodeUrl: 'data:image/png;base64,pewpewpew',
+  qrCodeUrl: PLACEHOLDER_QR_CODE,
   recoveryCodes: ['recoveryCode1', 'recoveryCode2'],
 };
 export const MOCK_QUERY_PARAMS = {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.stories.tsx
@@ -3,42 +3,38 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import InlineTotpSetup from '.';
+import InlineTotpSetupOld from './old';
 import { Meta } from '@storybook/react';
 import { MozServices } from '../../lib/types';
 import { MOCK_TOTP_TOKEN } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { action } from '@storybook/addon-actions';
-import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 
 export default {
-  title: 'Pages/InlineTotpSetup',
-  component: InlineTotpSetup,
+  title: 'Pages/InlineTotpSetupOld',
+  component: InlineTotpSetupOld,
   decorators: [withLocalization],
 } as Meta;
 
+const cancelSetupHandler = () => {};
 const verifyCodeHandler = (code: string) => {
   action('verifyCodeHandler')(code);
   return Promise.resolve();
 };
 
 export const Default = () => (
-  <InlineTotpSetup
+  <InlineTotpSetupOld
     totp={MOCK_TOTP_TOKEN}
-    serviceName={MozServices.Addons}
+    cancelSetupHandler={cancelSetupHandler}
     verifyCodeHandler={verifyCodeHandler}
-    cancelSetupHandler={() => {}} // not actually used in the new component
   />
 );
 
-export const onError = () => (
-  <InlineTotpSetup
+export const WithCustomService = () => (
+  <InlineTotpSetupOld
     totp={MOCK_TOTP_TOKEN}
-    serviceName={MozServices.Addons}
-    verifyCodeHandler={(code) => {
-      action('verifyCodeHandler')(code);
-      return Promise.reject(AuthUiErrors.INVALID_TOTP_CODE);
-    }}
-    cancelSetupHandler={() => {}} // not actually used in the new component
+    serviceName={MozServices.Monitor}
+    cancelSetupHandler={cancelSetupHandler}
+    verifyCodeHandler={verifyCodeHandler}
   />
 );

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.test.tsx
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen } from '@testing-library/react';
+import { UserEvent, userEvent } from '@testing-library/user-event';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import InlineTotpSetupOld from './old';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { MozServices } from '../../lib/types';
+import { MOCK_EMAIL, MOCK_TOTP_TOKEN } from './mocks';
+import { formatSecret } from '../../lib/utilities';
+
+const cancelSetupHandler = jest.fn();
+const verifyCodeHandler = jest.fn();
+const mockProps = {
+  totp: MOCK_TOTP_TOKEN,
+  email: MOCK_EMAIL,
+  cancelSetupHandler,
+  verifyCodeHandler,
+};
+
+describe('InlineTotpSetup', () => {
+  let user: UserEvent;
+
+  beforeAll(async () => {
+    global.URL.createObjectURL = jest.fn();
+  });
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  it('renders default as expected', () => {
+    renderWithLocalizationProvider(<InlineTotpSetupOld {...mockProps} />);
+    screen.getByRole('heading', {
+      name: `Enable two-step authentication to continue to ${MozServices.Default}`,
+    });
+    expect(
+      screen.getByLabelText('A device with a hidden 6-digit code.', {
+        selector: 'svg',
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Continue' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel setup' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders intro view as expected with custom service name', () => {
+    renderWithLocalizationProvider(
+      <InlineTotpSetupOld
+        {...{ ...mockProps, serviceName: MozServices.Monitor }}
+      />
+    );
+    screen.getByRole('heading', {
+      name: `Enable two-step authentication to continue to ${MozServices.Monitor}`,
+    });
+    expect(
+      screen.getByLabelText('A device with a hidden 6-digit code.', {
+        selector: 'svg',
+      })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: 'Continue' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Cancel setup' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders QR code by default when a user clicks "Continue"', async () => {
+    renderWithLocalizationProvider(<InlineTotpSetupOld {...mockProps} />);
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByAltText(
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
+    );
+  });
+
+  it('toggles from QR code to manual secret code view when user clicks "Can\'t scan code"', async () => {
+    renderWithLocalizationProvider(<InlineTotpSetupOld {...mockProps} />);
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByAltText(
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
+    );
+
+    const changeToManualModeButton = screen.getByRole('button', {
+      name: 'Can’t scan code?',
+    });
+
+    await user.click(changeToManualModeButton);
+
+    screen.getByText(formatSecret(MOCK_TOTP_TOKEN.secret));
+    await screen.findByRole('button', { name: 'Scan QR code instead?' });
+  });
+
+  it('toggles from secret code to QR code view when user clicks "Scan QR code instead?', async () => {
+    renderWithLocalizationProvider(<InlineTotpSetupOld {...mockProps} />);
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await screen.findByAltText(
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
+    );
+
+    const changeToManualModeButton = screen.getByRole('button', {
+      name: 'Can’t scan code?',
+    });
+    await user.click(changeToManualModeButton);
+    await screen.findByRole('button', { name: 'Scan QR code instead?' });
+    await user.click(
+      screen.getByRole('button', { name: 'Scan QR code instead?' })
+    );
+    await screen.findByAltText(
+      `Use the code ${MOCK_TOTP_TOKEN.secret} to set up two-step authentication in supported applications.`
+    );
+  });
+
+  it('shows error on incorrect totp submission', async () => {
+    const verifyCodeHandler = jest
+      .fn()
+      .mockRejectedValue(AuthUiErrors.INVALID_TOTP_CODE);
+    renderWithLocalizationProvider(
+      <InlineTotpSetupOld
+        {...{
+          ...mockProps,
+          verifyCodeHandler,
+        }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    await user.type(screen.getByLabelText('Authentication code'), '000000');
+    await user.click(screen.getByRole('button', { name: 'Ready' }));
+    await screen.findByText('Invalid two-step authentication code');
+    expect(verifyCodeHandler).toHaveBeenCalledWith('000000');
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
@@ -1,0 +1,298 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState, useCallback, useEffect } from 'react';
+import classNames from 'classnames';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { useFtlMsgResolver } from '../../models';
+import { TwoFactorAuthImage } from '../../components/images';
+import CardHeader from '../../components/CardHeader';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import FormVerifyCode from '../../components/FormVerifyCode';
+import AppLayout from '../../components/AppLayout';
+import { InlineTotpSetupProps } from './interfaces';
+import { GleanClickEventType2FA } from '../../lib/types';
+import Banner from '../../components/Banner';
+import GleanMetrics from '../../lib/glean';
+import DataBlockInline from '../../components/DataBlockInline';
+import { formatSecret } from '../../lib/utilities';
+
+export const InlineTotpSetupOld = ({
+  totp,
+  serviceName,
+  cancelSetupHandler,
+  verifyCodeHandler,
+}: InlineTotpSetupProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedQRCodeAltText = ftlMsgResolver.getMsg(
+    'tfa-qr-code-alt',
+    `Use the code ${totp.secret} to set up two-step authentication in supported applications.`,
+    { code: totp.secret }
+  );
+  const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
+    'inline-totp-setup-code-required-error',
+    'Authentication code required'
+  );
+  const [showIntro, setShowIntro] = useState(true);
+  const [showQR, setShowQR] = useState(true);
+  const [totpErrorMessage, setTotpErrorMessage] = useState('');
+  const [localizedBannerMessage, setLocalizedBannerMessage] =
+    useState<string>('');
+
+  useEffect(() => {
+    if (!showIntro) {
+      showQR
+        ? GleanMetrics.accountPref.twoStepAuthQrView({
+            event: { reason: GleanClickEventType2FA.inline },
+          })
+        : GleanMetrics.accountPref.twoStepAuthManualCodeView({
+            event: { reason: GleanClickEventType2FA.inline },
+          });
+    }
+  }, [showIntro, showQR]);
+
+  const onCancel = useCallback(() => {
+    try {
+      cancelSetupHandler();
+    } catch (error) {
+      setLocalizedBannerMessage(
+        ftlMsgResolver.getMsg(error.ftlId, error.message)
+      );
+    }
+  }, [cancelSetupHandler, ftlMsgResolver]);
+
+  const onSubmit = async (code: string) => {
+    try {
+      setTotpErrorMessage('');
+      await verifyCodeHandler(code);
+    } catch (error) {
+      setTotpErrorMessage(ftlMsgResolver.getMsg(error.ftlId, error.message));
+    }
+  };
+
+  return (
+    <AppLayout>
+      {showIntro && (
+        <>
+          <CardHeader
+            headingText="Enable two-step authentication"
+            headingWithCustomServiceFtlId="inline-totp-setup-enable-two-step-authentication-custom-header-2"
+            headingWithDefaultServiceFtlId="inline-totp-setup-enable-two-step-authentication-default-header-2"
+            {...{ serviceName }}
+          />
+          {localizedBannerMessage && (
+            <Banner
+              type="error"
+              content={{ localizedHeading: localizedBannerMessage }}
+            />
+          )}
+          <section className="flex flex-col items-center">
+            <TwoFactorAuthImage />
+            <FtlMsg
+              id="inline-totp-setup-add-security-link"
+              elems={{
+                authenticationAppsLink: (
+                  <LinkExternal
+                    className="link-blue text-sm"
+                    href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                    gleanDataAttrs={{
+                      id: 'two_step_auth_app_link',
+                      type: GleanClickEventType2FA.inline,
+                    }}
+                  >
+                    these authentication apps
+                  </LinkExternal>
+                ),
+              }}
+            >
+              <p className="text-sm">
+                Add a layer of security to your account by requiring
+                authentication codes from one of{' '}
+                <LinkExternal
+                  className="link-blue text-sm"
+                  href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
+                  gleanDataAttrs={{
+                    id: 'two_step_auth_app_link',
+                    type: GleanClickEventType2FA.inline,
+                  }}
+                >
+                  these authentication apps
+                </LinkExternal>
+                .
+              </p>
+            </FtlMsg>
+            <button
+              type="submit"
+              className="cta-primary cta-xl w-full my-6"
+              onClick={() => {
+                setShowIntro(false);
+                setLocalizedBannerMessage('');
+              }}
+            >
+              <FtlMsg id="inline-totp-setup-continue-button">Continue</FtlMsg>
+            </button>
+            <button
+              type="button"
+              className="link-blue text-sm"
+              onClick={onCancel}
+            >
+              <FtlMsg id="inline-totp-setup-cancel-setup-button">
+                Cancel setup
+              </FtlMsg>
+            </button>
+          </section>
+        </>
+      )}
+      {!showIntro && (
+        <>
+          {showQR ? (
+            <CardHeader
+              headingText="Scan authentication code"
+              headingWithCustomServiceFtlId="inline-totp-setup-show-qr-custom-service-header-2"
+              headingWithDefaultServiceFtlId="inline-totp-setup-show-qr-default-service-header-2"
+              {...{ serviceName }}
+            />
+          ) : (
+            <CardHeader
+              headingText="Enter code manually"
+              headingWithCustomServiceFtlId="inline-totp-setup-no-qr-custom-service-header-2"
+              headingWithDefaultServiceFtlId="inline-totp-setup-no-qr-default-service-header-2"
+              {...{ serviceName }}
+            />
+          )}
+          {localizedBannerMessage && (
+            <Banner
+              type="error"
+              content={{ localizedHeading: localizedBannerMessage }}
+            />
+          )}
+          <section>
+            <div id="totp" className="totp-details">
+              {showQR ? (
+                <>
+                  <FtlMsg
+                    id="inline-totp-setup-use-qr-or-enter-key-instructions"
+                    elems={{
+                      toggleToManualModeButton: (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setShowQR(false);
+                          }}
+                          className="link-blue inline"
+                        >
+                          Can’t scan code?
+                        </button>
+                      ),
+                    }}
+                  >
+                    <p className="text-sm my-4">
+                      Scan the QR code in your authentication app and then enter
+                      the authentication code it provides.{' '}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setShowQR(false);
+                        }}
+                        className="link-blue inline"
+                      >
+                        Can’t scan code?
+                      </button>
+                    </p>
+                  </FtlMsg>
+                  <div>
+                    <img
+                      className={classNames(
+                        {
+                          hidden: !totp.qrCodeUrl,
+                        },
+                        'mx-auto w-48 h-48 rounded-xl border-8 border-green-800/10'
+                      )}
+                      alt={localizedQRCodeAltText}
+                      src={totp.qrCodeUrl}
+                    />
+                  </div>
+                  <FtlMsg id="inline-totp-setup-on-completion-description">
+                    <p className="text-sm my-4">
+                      Once complete, it will begin generating authentication
+                      codes for you to enter.
+                    </p>
+                  </FtlMsg>
+                </>
+              ) : (
+                <>
+                  <FtlMsg
+                    id="inline-totp-setup-enter-key-or-use-qr-instructions"
+                    elems={{
+                      toggleToQRButton: (
+                        <button
+                          onClick={() => {
+                            setShowQR(true);
+                          }}
+                          className="link-blue inline"
+                        >
+                          Scan QR code instead?
+                        </button>
+                      ),
+                    }}
+                  >
+                    <p className="text-sm mt-4 mb-1">
+                      Type this secret key into your authentication app.{' '}
+                      <button
+                        onClick={() => {
+                          setShowQR(true);
+                        }}
+                        className="link-blue inline"
+                      >
+                        Scan QR code instead?
+                      </button>
+                    </p>
+                  </FtlMsg>
+                  <DataBlockInline
+                    value={formatSecret(totp.secret)}
+                    prefixDataTestId="manual"
+                  />
+                  <FtlMsg id="inline-totp-setup-on-completion-description">
+                    <p className="text-sm mb-4">
+                      Once complete, it will begin generating authentication
+                      codes for you to enter.
+                    </p>
+                  </FtlMsg>
+                </>
+              )}
+              <FormVerifyCode
+                viewName="inline_totp_setup"
+                verifyCode={onSubmit}
+                formAttributes={{
+                  inputLabelText: 'Authentication code',
+                  inputFtlId: 'inline-totp-setup-security-code-placeholder',
+                  pattern: 'd{6}',
+                  maxLength: 6,
+                  submitButtonText: 'Ready',
+                  submitButtonFtlId: 'inline-totp-setup-ready-button',
+                }}
+                codeErrorMessage={totpErrorMessage}
+                setCodeErrorMessage={setTotpErrorMessage}
+                {...{ localizedCustomCodeRequiredMessage }}
+                gleanDataAttrs={{
+                  id: showQR
+                    ? 'two_step_auth_qr_submit'
+                    : 'two_step_auth_manual_code_submit',
+                  type: GleanClickEventType2FA.inline,
+                }}
+              />
+              <button className="link-blue text-sm mt-4" onClick={onCancel}>
+                <FtlMsg id="inline-totp-setup-cancel-setup-button">
+                  Cancel setup
+                </FtlMsg>
+              </button>
+            </div>
+          </section>
+        </>
+      )}
+    </AppLayout>
+  );
+};
+
+export default InlineTotpSetupOld;


### PR DESCRIPTION
## Because

- we need to assemble newly created components into InlineTotpSetup

## This pull request

- replaces the existing implementation with a step controller pattern, creates storybooks states and unit tests.
- feature-flags the new design for easy roll back, and updates the functional tests to handle both versions.

## Issue that this pull request solves

Closes: FXA-11720

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
