### PR TITLE
fix(stripe-webhooks): include canceled subscriptions in customer.updated

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
@@ -299,6 +299,7 @@ describe('StripeFirestore', () => {
       assert.calledTwice(stripe.customers.retrieve);
       assert.calledOnceWithExactly(stripe.subscriptions.list, {
         customer: customer.id,
+        status: "all"
       });
       assert.callCount(tx.set, 2); // customer + subscription
       assert.callCount(tx.get, 2); // customer + subscription

--- a/packages/fxa-shared/payments/stripe-firestore.ts
+++ b/packages/fxa-shared/payments/stripe-firestore.ts
@@ -191,6 +191,7 @@ export class StripeFirestore {
         this.stripe.subscriptions
           .list({
             customer: customerId,
+            status: "all"
           })
           .autoPagingToArray({ limit: 100 }),
       ]);


### PR DESCRIPTION
## Because

- We want to reconcile cached Firestore data against Stripe, even for canceled subscriptions.

## This pull request

- Adds the `status: "all"` parameter when fetching customer subscriptions.

## Issue that this pull request solves

Closes PAY-3098