### PR TITLE
fix(storybook): fix broken stories using SettingsLayout

### DIFF
--- a/packages/fxa-react/lib/storybooks.tsx
+++ b/packages/fxa-react/lib/storybooks.tsx
@@ -5,6 +5,11 @@
 import React from 'react';
 import { Decorator } from '@storybook/react';
 import AppLocalizationProvider from './AppLocalizationProvider';
+import {
+  createHistory,
+  createMemorySource,
+  LocationProvider,
+} from '@reach/router';
 
 // This decorator makes the localization bundles available in the stories.
 // If a localized string is available, that will be rendered in the storybook,
@@ -17,3 +22,22 @@ export const withLocalization: Decorator = (Story) => (
     <Story />
   </AppLocalizationProvider>
 );
+
+export const withLocation: (location: string | undefined) => Decorator =
+  (location) => (Story) => {
+    if (location === undefined) {
+      return (
+        <LocationProvider>
+          <Story />
+        </LocationProvider>
+      );
+    }
+    const source = createMemorySource(location);
+    const history = createHistory(source);
+
+    return (
+      <LocationProvider history={history}>
+        <Story />
+      </LocationProvider>
+    );
+  };

--- a/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FormPassword/index.stories.tsx
@@ -7,13 +7,13 @@ import { Subject } from './mocks';
 import { LocationProvider } from '@reach/router';
 import FormPassword from '.';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../Settings/SettingsLayout';
 
 export default {
   title: 'Components/FormPassword',
   component: FormPassword,
-  decorators: [withLocalization],
+  decorators: [withLocalization, withLocation('/settings/password')],
 } as Meta;
 export const WithCurrentPassword = () => (
   <LocationProvider>

--- a/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowRecoveryKeyConfirmPwd/index.stories.tsx
@@ -8,13 +8,13 @@ import { Meta } from '@storybook/react';
 import { Account, AppContext, useFtlMsgResolver } from '../../../models';
 import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 
 export default {
   title: 'Components/Settings/FlowRecoveryKeyConfirmPwd',
   component: FlowRecoveryKeyConfirmPwd,
-  decorators: [withLocalization],
+  decorators: [withLocalization, withLocation('/settings/account_recovery')],
 } as Meta;
 
 const viewName = 'example-view-name';

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import {
   MOCK_2FA_SECRET_KEY_RAW,
   PLACEHOLDER_QR_CODE,
@@ -18,7 +18,10 @@ import { TwoStepSetupMethod } from './types';
 export default {
   title: 'Components/Settings/FlowSetup2faApp',
   component: FlowSetup2faApp,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/two_step_authentication'),
+  ],
 } as Meta;
 
 const verifyCodeSuccess = async (code: string) => {

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupChoice/index.stories.tsx
@@ -4,14 +4,17 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { FlowSetup2faBackupChoice } from '.';
 
 export default {
   title: 'Components/Settings/FlowSetup2faBackupChoice',
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/two_step_authentication'),
+  ],
 } as Meta;
 
 const navigateBackward = async () => {

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeConfirm/index.stories.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { FlowSetup2faBackupCodeConfirm } from '.';
@@ -12,7 +12,10 @@ import { FlowSetup2faBackupCodeConfirm } from '.';
 export default {
   title: 'Components/Settings/FlowSetup2faBackupCodeConfirm',
   component: FlowSetup2faBackupCodeConfirm,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/two_step_authentication'),
+  ],
 } as Meta;
 
 const navigateBackward = async () => {

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faBackupCodeDownload/index.stories.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { FlowSetup2faBackupCodeDownload } from '.';
@@ -13,7 +13,10 @@ import { MOCK_BACKUP_CODES, MOCK_EMAIL } from '../../../pages/mocks';
 export default {
   title: 'Components/Settings/FlowSetup2faBackupCodeDownload',
   component: FlowSetup2faBackupCodeDownload,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/two_step_authentication'),
+  ],
 } as Meta;
 
 const navigateBackward = async () => {

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.stories.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import FlowSetup2faComplete from '.';
 import { action } from '@storybook/addon-actions';
@@ -12,7 +12,10 @@ import { action } from '@storybook/addon-actions';
 export default {
   title: 'Components/Settings/FlowSetup2faComplete',
   component: FlowSetup2faComplete,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/two_step_authentication'),
+  ],
 } as Meta;
 
 const onContinue = () => {

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
@@ -14,7 +14,10 @@ import { MOCK_NATIONAL_FORMAT_PHONE_NUMBER } from '../../../pages/mocks';
 export default {
   title: 'Components/Settings/FlowSetupRecoveryPhoneConfirmCode',
   component: FlowSetupRecoveryPhoneConfirmCode,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/recovery_phone/setup'),
+  ],
 } as Meta;
 
 const localizedPageTitle = 'Add recovery phone';

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.stories.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { action } from '@storybook/addon-actions';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
@@ -14,7 +14,10 @@ import { RecoveryPhoneSetupReason } from '../../../lib/types';
 export default {
   title: 'Components/Settings/FlowSetupRecoveryPhoneSubmitNumber',
   component: FlowSetupRecoveryPhoneSubmitNumber,
-  decorators: [withLocalization],
+  decorators: [
+    withLocalization,
+    withLocation('/settings/recovery_phone/setup'),
+  ],
 } as Meta;
 
 const localizedPageTitle = 'Add recovery phone';

--- a/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ProductPromo/index.stories.tsx
@@ -4,14 +4,14 @@
 
 import React from 'react';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import ProductPromo, { ProductPromoProps } from '.';
 import SettingsLayout from '../SettingsLayout';
 
 export default {
   title: 'Components/Settings/ProductPromo',
   component: ProductPromo,
-  decorators: [withLocalization],
+  decorators: [withLocalization, withLocation('/settings')],
 } as Meta<typeof ProductPromo>;
 
 /**

--- a/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Security/index.stories.tsx
@@ -36,6 +36,15 @@ export const Default = storyWithAccount({
   totp: { exists: false, verified: false },
   hasPassword: true,
   passwordCreated: 1651860173938,
+  backupCodes: {
+    hasBackupCodes: false,
+  },
+  recoveryPhone: {
+    exists: false,
+    phoneNumber: null,
+    nationalFormat: null,
+    available: true,
+  },
 });
 
 export const SecurityFeaturesEnabled = storyWithAccount(
@@ -44,6 +53,16 @@ export const SecurityFeaturesEnabled = storyWithAccount(
     totp: { verified: true, exists: true },
     hasPassword: true,
     passwordCreated: 1651860173938,
+    backupCodes: {
+      hasBackupCodes: true,
+      count: 5,
+    },
+    recoveryPhone: {
+      exists: true,
+      phoneNumber: '+1234567890',
+      nationalFormat: '123-456-7890',
+      available: true,
+    },
   },
   'Account recovery key set and two factor enabled'
 );
@@ -53,6 +72,9 @@ export const NoPassword = storyWithAccount(
     recoveryKey: { exists: false },
     totp: { verified: false, exists: false },
     hasPassword: false,
+    backupCodes: {
+      hasBackupCodes: false,
+    },
   },
   'Third party auth, no password set'
 );

--- a/packages/fxa-settings/src/components/Settings/SettingsLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SettingsLayout/index.stories.tsx
@@ -1,12 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import React from 'react';
 import SettingsLayout from './index';
 import { Meta } from '@storybook/react';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 
 export default {
   title: 'Components/Settings/SettingsLayout',
   component: SettingsLayout,
-  decorators: [withLocalization],
+  decorators: [withLocalization, withLocation('/settings')],
 } as Meta;
 
 export const Basic = () => (


### PR DESCRIPTION
## Because

- A bunch of stories using SettingsLayout are broken. We need to wrap them in LocationProvider.


## This pull request

- wraps broken stories in `LocationProvider` by using a new `withLocation` decorator

## Issue that this pull request solves

Closes: FXA-12150

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
