### PR TITLE
feat(2fa): show 2fa recovery choices "inline"

### DIFF
--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -7,6 +7,7 @@ import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
+import { getPhoneNumber } from '../../lib/targets';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('OAuth totp', () => {
@@ -89,7 +90,8 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const config = await configPage.getConfig();
       test.skip(
-        !config.featureFlags?.updatedInlineTotpSetupFlow,
+        !config.featureFlags?.updatedInlineTotpSetupFlow ||
+          config.featureFlags?.updatedInlineRecoverySetupFlow,
         'The updated Inline TOTP setup flow is not enabled'
       );
       const credentials = await testAccountTracker.signUp();
@@ -143,7 +145,8 @@ test.describe('severity-1 #smoke', () => {
     }) => {
       const config = await configPage.getConfig();
       test.skip(
-        config.featureFlags?.updatedInlineTotpSetupFlow,
+        config.featureFlags?.updatedInlineTotpSetupFlow ||
+          config.featureFlags?.updatedInlineRecoverySetupFlow,
         'The updated Inline TOTP setup flow is enabled, skipping old tests'
       );
       const credentials = await testAccountTracker.signUp();
@@ -198,6 +201,263 @@ test.describe('severity-1 #smoke', () => {
         .fill(recoveryCodes[0]);
 
       await signin.page.getByRole('button', { name: 'Confirm' }).click();
+
+      expect(await relier.isLoggedIn()).toBe(true);
+
+      await settings.goto();
+      await settings.disconnectTotp();
+    });
+
+    test('can setup TOTP inline with backup codes choice (old setup)', async ({
+      target,
+      pages: { page, relier, settings, signin, configPage, totp },
+      testAccountTracker,
+    }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.featureFlags?.updatedInlineTotpSetupFlow ||
+          !config.featureFlags?.updatedInlineRecoverySetupFlow,
+        'Skip unless old totp setup with new recovery flow'
+      );
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/inline_totp_setup/);
+
+      await expect(
+        signin.page.getByText('Enable two-step authentication')
+      ).toBeVisible();
+
+      await signin.page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(
+        signin.page.getByText('Scan authentication code')
+      ).toBeVisible();
+
+      await signin.page
+        .getByRole('button', { name: 'Can’t scan code?' })
+        .click();
+
+      await expect(signin.page.getByText('Enter code manually')).toBeVisible();
+
+      const secret = (
+        await signin.page.getByTestId('manual-datablock').innerText()
+      )?.replace(/\s/g, '');
+      const code = await getCode(secret);
+
+      await signin.page
+        .getByRole('textbox', { name: 'Authentication code' })
+        .fill(code);
+
+      await signin.page.getByRole('button', { name: 'Ready' }).click();
+
+      await page.waitForURL(/inline_recovery_setup/);
+
+      await totp.chooseBackupCodesOption();
+      const recoveryCodes = await totp.backupCodesDownloadStep();
+      await totp.confirmBackupCodeStep(recoveryCodes[0]);
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      expect(await relier.isLoggedIn()).toBe(true);
+
+      await settings.goto();
+      await settings.disconnectTotp();
+    });
+
+    test('can setup TOTP inline with recovery phone choice (old setup)', async ({
+      target,
+      pages: {
+        page,
+        relier,
+        settings,
+        signin,
+        configPage,
+        totp,
+        recoveryPhone,
+      },
+      testAccountTracker,
+    }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        config.featureFlags?.updatedInlineTotpSetupFlow ||
+          !config.featureFlags?.updatedInlineRecoverySetupFlow,
+        'Skip unless old totp setup with new recovery flow'
+      );
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/inline_totp_setup/);
+
+      await expect(
+        signin.page.getByText('Enable two-step authentication')
+      ).toBeVisible();
+
+      await signin.page.getByRole('button', { name: 'Continue' }).click();
+
+      await expect(
+        signin.page.getByText('Scan authentication code')
+      ).toBeVisible();
+
+      await signin.page
+        .getByRole('button', { name: 'Can’t scan code?' })
+        .click();
+
+      await expect(signin.page.getByText('Enter code manually')).toBeVisible();
+
+      const secret = (
+        await signin.page.getByTestId('manual-datablock').innerText()
+      )?.replace(/\s/g, '');
+      const code = await getCode(secret);
+
+      await signin.page
+        .getByRole('textbox', { name: 'Authentication code' })
+        .fill(code);
+
+      await signin.page.getByRole('button', { name: 'Ready' }).click();
+
+      await page.waitForURL(/inline_recovery_setup/);
+
+      await totp.chooseRecoveryPhoneOption();
+      await recoveryPhone.enterPhoneNumber(getPhoneNumber(target.name));
+      await recoveryPhone.clickSendCode();
+
+      await expect(recoveryPhone.confirmHeader).toBeVisible();
+
+      const smsCode = await target.smsClient.getCode(
+        getPhoneNumber(target.name),
+        credentials.uid
+      );
+
+      await recoveryPhone.enterCode(smsCode);
+      await recoveryPhone.clickConfirm();
+
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      expect(await relier.isLoggedIn()).toBe(true);
+
+      await settings.goto();
+      await settings.disconnectTotp();
+    });
+
+    test('can setup TOTP inline with backup codes choice (new setup)', async ({
+      target,
+      pages: {
+        page,
+        relier,
+        settings,
+        signin,
+        configPage,
+        totp,
+        inlineTotpSetup,
+      },
+      testAccountTracker,
+    }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        !config.featureFlags?.updatedInlineTotpSetupFlow ||
+          !config.featureFlags?.updatedInlineRecoverySetupFlow,
+        'Skip unless new totp setup with new recovery flow'
+      );
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/inline_totp_setup/);
+
+      await expect(inlineTotpSetup.introHeading).toBeVisible();
+      await inlineTotpSetup.continueButton.click();
+      await expect(totp.setup2faAppHeading).toBeVisible();
+      await totp.step1CantScanCodeLink.click();
+      const secret = (await totp.step1ManualCode.innerText())?.replace(
+        /\s/g,
+        ''
+      );
+      const code = await getCode(secret);
+      await totp.step1AuthenticationCodeTextbox.fill(code);
+      await totp.step1SubmitButton.click();
+
+      await page.waitForURL(/inline_recovery_setup/);
+
+      await totp.chooseBackupCodesOption();
+      const recoveryCodes = await totp.backupCodesDownloadStep();
+      await totp.confirmBackupCodeStep(recoveryCodes[0]);
+      await page.getByRole('button', { name: 'Continue' }).click();
+
+      expect(await relier.isLoggedIn()).toBe(true);
+
+      await settings.goto();
+      await settings.disconnectTotp();
+    });
+
+    test('can setup TOTP inline with recovery phone choice (new setup)', async ({
+      target,
+      pages: {
+        page,
+        relier,
+        settings,
+        signin,
+        configPage,
+        totp,
+        recoveryPhone,
+        inlineTotpSetup,
+      },
+      testAccountTracker,
+    }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        !config.featureFlags?.updatedInlineTotpSetupFlow ||
+          !config.featureFlags?.updatedInlineRecoverySetupFlow,
+        'Skip unless new totp setup with new recovery flow'
+      );
+      const credentials = await testAccountTracker.signUp();
+
+      await relier.goto();
+      await relier.clickRequire2FA();
+      await signin.fillOutEmailFirstForm(credentials.email);
+      await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/inline_totp_setup/);
+
+      await expect(inlineTotpSetup.introHeading).toBeVisible();
+      await inlineTotpSetup.continueButton.click();
+      await expect(totp.setup2faAppHeading).toBeVisible();
+      await totp.step1CantScanCodeLink.click();
+      const secret = (await totp.step1ManualCode.innerText())?.replace(
+        /\s/g,
+        ''
+      );
+      const code = await getCode(secret);
+      await totp.step1AuthenticationCodeTextbox.fill(code);
+      await totp.step1SubmitButton.click();
+
+      await page.waitForURL(/inline_recovery_setup/);
+
+      await totp.chooseRecoveryPhoneOption();
+      await recoveryPhone.enterPhoneNumber(getPhoneNumber(target.name));
+      await recoveryPhone.clickSendCode();
+
+      await expect(recoveryPhone.confirmHeader).toBeVisible();
+
+      const smsCode = await target.smsClient.getCode(
+        getPhoneNumber(target.name),
+        credentials.uid
+      );
+
+      await recoveryPhone.enterCode(smsCode);
+      await recoveryPhone.clickConfirm();
+
+      await page.getByRole('button', { name: 'Continue' }).click();
 
       expect(await relier.isLoggedIn()).toBe(true);
 

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -116,6 +116,10 @@ const settingsConfig = {
     updatedInlineTotpSetupFlow: config.get(
       'featureFlags.updatedInlineTotpSetupFlow'
     ),
+    updated2faSetupFlow: config.get('featureFlags.updated2faSetupFlow'),
+    updatedInlineRecoverySetupFlow: config.get(
+      'featureFlags.updatedInlineRecoverySetupFlow'
+    ),
   },
   nimbusPreview: config.get('nimbusPreview'),
   cms: {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -244,6 +244,18 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_UPDATED_INLINE_TOTP_SETUP_FLOW',
     },
+    updated2faSetupFlow: {
+      default: false,
+      doc: 'Enables a redesign of the 2fa setup flow from settings with recovery phone option',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW',
+    },
+    updatedInlineRecoverySetupFlow: {
+      default: false,
+      doc: 'Enables a redesign of the 2fa setup flow from settings with recovery phone option',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW',
+    },
   },
   cms: {
     enabled: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -58,6 +58,12 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA = config.get(
     'featureFlags.recoveryPhonePasswordReset2fa'
   );
+  const FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW = config.get(
+    'featureFlags.updated2faSetupFlow'
+  );
+  const FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW = config.get(
+    'featureFlags.updatedInlineRecoverySetupFlow'
+  );
   const NIMBUS_PREVIEW = config.get('nimbusPreview');
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
@@ -122,9 +128,12 @@ function getIndexRouteDefinition(config) {
         FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
       recoveryPhonePasswordReset2fa:
         FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA,
+      updated2faSetupFlow: FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW,
+      updatedInlineRecoverySetupFlow:
+        FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW,
     },
     cms: {
-      enabled: CMS_ENABLED
+      enabled: CMS_ENABLED,
     },
     nimbusPreview: NIMBUS_PREVIEW,
     glean: {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -44,6 +44,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { ScrollToTop } from '../Settings/ScrollToTop';
 import SignupConfirmedSync from '../../pages/Signup/SignupConfirmedSync';
 import useSyncEngines from '../../lib/hooks/useSyncEngines';
+import { InlineRecoverySetupFlowContainer } from '../../pages/InlineRecoverySetupFlow/container';
 
 // Pages
 const IndexContainer = lazy(() => import('../../pages/Index/container'));
@@ -409,6 +410,7 @@ const AuthAndAccountSetupRoutes = ({
   integration: Integration;
   flowQueryParams: QueryParams;
 } & RouteComponentProps) => {
+  const config = useConfig();
   const localAccount = currentAccount();
   // TODO: MozServices / string discrepancy, FXA-6802
   const serviceName = integration.getServiceName() as MozServices;
@@ -517,8 +519,9 @@ const AuthAndAccountSetupRoutes = ({
           path="/signin_confirmed/*"
           {...{ isSignedIn, serviceName, integration }}
         />
-        <SigninRecoveryChoiceContainer path="/signin_recovery_choice/*"
-                                       {...{ integration }}
+        <SigninRecoveryChoiceContainer
+          path="/signin_recovery_choice/*"
+          {...{ integration }}
         />
         <SigninRecoveryPhoneContainer
           path="/signin_recovery_phone/*"
@@ -602,11 +605,19 @@ const AuthAndAccountSetupRoutes = ({
           {...{ isSignedIn, serviceName, flowQueryParams }}
         />
 
-        <InlineRecoverySetupContainer
-          path="/inline_recovery_setup/*"
-          integration={integration}
-          {...{ isSignedIn, serviceName }}
-        />
+        {config.featureFlags?.updatedInlineRecoverySetupFlow ? (
+          <InlineRecoverySetupFlowContainer
+            path="/inline_recovery_setup/*"
+            integration={integration}
+            {...{ isSignedIn, serviceName }}
+          />
+        ) : (
+          <InlineRecoverySetupContainer
+            path="/inline_recovery_setup/*"
+            integration={integration}
+            {...{ isSignedIn, serviceName }}
+          />
+        )}
       </Router>
     </Suspense>
   );

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.tsx
@@ -15,15 +15,18 @@ import {
 } from '../../Icons';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { GleanClickEventType2FA } from '../../../lib/types';
+import { CHOICES } from '../../FormChoice';
 
 type FlowSetup2faCompleteProps = (
   | {
-      backupType: 'code';
+      backupType: typeof CHOICES.code;
       numCodesRemaining: number;
+      lastFourPhoneDigits?: never;
     }
   | {
-      backupType: 'phone';
+      backupType: typeof CHOICES.phone;
       lastFourPhoneDigits: string;
+      numCodesRemaining?: never;
     }
 ) & {
   serviceName: string;

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -94,6 +94,8 @@ export interface Config {
     recoveryCodeSetupOnSyncSignIn?: boolean;
     recoveryPhonePasswordReset2fa?: boolean;
     updatedInlineTotpSetupFlow?: boolean;
+    updated2faSetupFlow?: boolean;
+    updatedInlineRecoverySetupFlow?: boolean;
   };
   nimbusPreview: boolean;
   cms: {
@@ -177,6 +179,8 @@ export function getDefault() {
       recoveryCodeSetupOnSyncSignIn: false,
       recoveryPhonePasswordReset2fa: false,
       updatedInlineTotpSetupFlow: false,
+      updated2faSetupFlow: false,
+      updatedInlineRecoverySetupFlow: false,
     },
     cms: {
       // Note: Even if this flag is true, the user must be an `en` language

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -1,0 +1,387 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as ApolloClientModule from '@apollo/client';
+import * as InlineRecoverySetupFlowModule from '.';
+import * as utils from 'fxa-react/lib/utils';
+
+import { ApolloClient } from '@apollo/client';
+import { LocationProvider } from '@reach/router';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { AuthUiError } from '../../lib/auth-errors/auth-errors';
+import { MozServices } from '../../lib/types';
+import {
+  IntegrationType,
+  OAuthIntegration,
+  useSensitiveDataClient,
+} from '../../models';
+import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../models/mocks';
+import {
+  MOCK_QUERY_PARAMS,
+  MOCK_SIGNIN_LOCATION_STATE,
+  MOCK_SIGNIN_RECOVERY_LOCATION_STATE,
+} from '../InlineTotpSetup/mocks';
+import InlineRecoverySetupFlowContainer from './container';
+import AuthClient from 'fxa-auth-client/browser';
+import { waitFor } from '@testing-library/react';
+import {
+  MOCK_CLIENT_ID,
+  MOCK_NO_TOTP,
+  MOCK_OAUTH_FLOW_HANDLER_RESPONSE,
+  MOCK_TOTP_STATUS_VERIFIED,
+} from '../Signin/mocks';
+import {
+  useFinishOAuthFlowHandler,
+  useOAuthKeysCheck,
+} from '../../lib/oauth/hooks';
+import { SensitiveData } from '../../lib/sensitive-data-client';
+import { mockWindowLocation } from 'fxa-react/lib/test-utils/mockWindowLocation';
+
+let mockLocationState = {};
+const search = '?' + new URLSearchParams(MOCK_QUERY_PARAMS);
+
+mockWindowLocation({
+  pathname: '/inline_recovery_setup',
+  search,
+});
+
+const mockLocationHook = () => {
+  return {
+    pathname: '/inline_recovery_setup',
+    search,
+    state: mockLocationState,
+  };
+};
+
+const mockNavigateHook = jest.fn();
+jest.mock('@reach/router', () => {
+  return {
+    __esModule: true,
+    ...jest.requireActual('@reach/router'),
+    useNavigate: () => mockNavigateHook,
+    useLocation: () => mockLocationHook(),
+  };
+});
+
+jest.mock('../../lib/oauth/hooks.tsx', () => {
+  return {
+    __esModule: true,
+    useFinishOAuthFlowHandler: jest.fn(),
+    useOAuthKeysCheck: jest.fn(),
+  };
+});
+
+const mockSensitiveDataClient = createMockSensitiveDataClient();
+mockSensitiveDataClient.getDataType = jest.fn();
+const mockAuthClient = new AuthClient('http://localhost:9000', {
+  keyStretchVersion: 1,
+});
+let mockSessionHook: () => any = () => ({ token: 'ABBA' });
+let accountRefreshFn = jest.fn();
+let recoveryPhoneFn = jest
+  .fn()
+  .mockImplementationOnce(() => {
+    throw Error('no');
+  })
+  .mockImplementation(() => ({ available: true }));
+let addRecoveryPhoneFn = jest
+  .fn()
+  .mockResolvedValue({ nationalFormat: '+12345678900' });
+let confirmRecoveryPhoneFn = jest.fn();
+let setRecoveryCodesFn = jest.fn();
+let mockAccount = new (class {
+  get recoveryPhone() {
+    return recoveryPhoneFn();
+  }
+  async refresh(x: string) {
+    return accountRefreshFn(x);
+  }
+  async addRecoveryPhone(x: string) {
+    return addRecoveryPhoneFn(x);
+  }
+  async confirmRecoveryPhone(...args: any[]) {
+    return confirmRecoveryPhoneFn(...args);
+  }
+  async setRecoveryCodes(codes: string[]) {
+    return setRecoveryCodesFn(codes);
+  }
+})();
+jest.mock('../../models', () => {
+  return {
+    ...jest.requireActual('../../models'),
+    useSession: jest.fn(() => mockSessionHook()),
+    useAuthClient: jest.fn(() => mockAuthClient),
+    useSensitiveDataClient: jest.fn(),
+    useAccount: jest.fn(() => mockAccount),
+    useConfig: jest.fn(() => ({ recoveryCodes: { count: 8, length: 10 } })),
+  };
+});
+
+let mockGetCode = jest.fn().mockReturnValue('215364');
+jest.mock('../../lib/totp', () => {
+  return {
+    ...jest.requireActual('../../lib/totp'),
+    getCode: jest.fn((...args) => mockGetCode(...args)),
+  };
+});
+let mockGenerateCodes = jest.fn((...args) => ['wibble', 'quux']);
+jest.mock('../../lib/totp-utils', () => {
+  return {
+    totpUtils: {
+      ...jest.requireActual('../../lib/totp-utils').totpUtils,
+      generateRecoveryCodes: (...args: any) => mockGenerateCodes(...args),
+    },
+  };
+});
+
+jest.mock('./index', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(),
+  };
+});
+
+let mockVerifyTotpMutation = jest
+  .fn()
+  .mockResolvedValue({ data: { verifyTotp: { success: true } } });
+
+let mockTotpStatusQuery = jest.fn();
+function setMocks() {
+  mockLocationState = {};
+  mockSessionHook = () => ({ token: 'ABBA' });
+
+  jest.spyOn(ApolloClientModule, 'useMutation').mockReturnValue([
+    async (...args: any[]) => {
+      return mockVerifyTotpMutation(...args);
+    },
+    {
+      loading: false,
+      called: true,
+      client: {} as ApolloClient<any>,
+      reset: () => {},
+    },
+  ]);
+  mockTotpStatusQuery.mockImplementation(() => {
+    return {
+      data: MOCK_NO_TOTP,
+      loading: false,
+    };
+  });
+  jest
+    .spyOn(ApolloClientModule, 'useQuery')
+    .mockReturnValue(mockTotpStatusQuery());
+  (InlineRecoverySetupFlowModule.default as jest.Mock).mockReset();
+  mockNavigateHook.mockReset();
+  (useFinishOAuthFlowHandler as jest.Mock).mockImplementation(() => ({
+    finishOAuthFlowHandler: jest
+      .fn()
+      .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE),
+    oAuthDataError: null,
+  }));
+  (useSensitiveDataClient as jest.Mock).mockImplementation(
+    () => mockSensitiveDataClient
+  );
+  (useOAuthKeysCheck as jest.Mock).mockImplementation(() => ({
+    oAuthKeysCheckError: null,
+  }));
+  recoveryPhoneFn.mockClear();
+}
+
+const defaultProps = {
+  isSignedIn: true,
+  integration: {
+    type: IntegrationType.OAuthWeb,
+    returnOnError: () => true,
+    getService: () => undefined,
+    getClientId: () => MOCK_CLIENT_ID,
+    getRedirectWithErrorUrl: (error: AuthUiError) =>
+      `https://localhost:8080/?error=${error.errno}`,
+  } as OAuthIntegration,
+  serviceName: MozServices.Default,
+};
+
+function render(props = {}) {
+  renderWithLocalizationProvider(
+    <LocationProvider>
+      <InlineRecoverySetupFlowContainer {...{ ...defaultProps, ...props }} />
+    </LocationProvider>
+  );
+}
+
+describe('InlineRecoverySetupFlowContainer', () => {
+  beforeEach(() => {
+    setMocks();
+  });
+
+  describe('redirects away', () => {
+    it('redirects when user is not signed in', async () => {
+      mockLocationState = MOCK_SIGNIN_RECOVERY_LOCATION_STATE;
+      render({ isSignedIn: false });
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+      });
+    });
+
+    it('redirects when there is no signin state', () => {
+      render();
+      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+    });
+
+    it('redirects when there is no totp token', () => {
+      mockLocationState = MOCK_SIGNIN_LOCATION_STATE;
+      render();
+      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+    });
+
+    it('redirects when totp is already active', async () => {
+      mockSessionHook = () => ({ isSessionVerified: async () => true });
+      mockTotpStatusQuery.mockImplementation(() => {
+        return {
+          data: MOCK_TOTP_STATUS_VERIFIED,
+          loading: false,
+        };
+      });
+      jest
+        .spyOn(ApolloClientModule, 'useQuery')
+        .mockReturnValue(mockTotpStatusQuery());
+      mockLocationState = MOCK_SIGNIN_RECOVERY_LOCATION_STATE;
+
+      render();
+      expect(mockNavigateHook).toHaveBeenCalledWith(
+        `/signin_totp_code${search}`,
+        {
+          state: MOCK_SIGNIN_LOCATION_STATE,
+        }
+      );
+    });
+  });
+
+  describe('renders', () => {
+    beforeEach(() => {
+      mockLocationState = {
+        ...MOCK_SIGNIN_RECOVERY_LOCATION_STATE,
+        totp: {
+          ...MOCK_SIGNIN_RECOVERY_LOCATION_STATE.totp,
+          recoveryCodes: [],
+        },
+      };
+    });
+
+    it('invokes InlineRecoverySetupFlow with the correct props', async () => {
+      render();
+      await waitFor(() => {
+        expect(InlineRecoverySetupFlowModule.default).toHaveBeenCalled();
+        const args = (InlineRecoverySetupFlowModule.default as jest.Mock).mock
+          .calls[0][0];
+        expect(args.backupCodes).toEqual([]);
+        expect(args.serviceName).toBe(defaultProps.serviceName);
+        expect(args.email).toBe(MOCK_SIGNIN_RECOVERY_LOCATION_STATE.email);
+        expect(args.currentStep).toBe(1);
+        expect(args.backupMethod).toBe(null);
+      });
+    });
+
+    it('loads the account', async () => {
+      render();
+      await waitFor(() => {
+        expect(accountRefreshFn).toHaveBeenCalledWith('account');
+      });
+    });
+
+    it('reads data from sensitive data client', async () => {
+      render();
+      expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
+        SensitiveData.Key.Auth
+      );
+    });
+
+    describe('callbacks', () => {
+      let args: any;
+
+      beforeEach(async () => {
+        render();
+        await waitFor(() => {
+          expect(InlineRecoverySetupFlowModule.default).toHaveBeenCalled();
+        });
+        args = (InlineRecoverySetupFlowModule.default as jest.Mock).mock
+          .calls[0][0];
+      });
+
+      describe('backupChoiceCb', () => {
+        it('creates recovery codes when code is selected', async () => {
+          await waitFor(async () => {
+            await args.backupChoiceCb('code');
+          });
+          expect(mockGenerateCodes).toHaveBeenCalledWith(8, 10);
+        });
+      });
+
+      describe('verifyPhoneNumber, sendSmsCode, and verifySmsCode', () => {
+        it('adds phone number and enables totp', async () => {
+          await waitFor(async () => {
+            await args.verifyPhoneNumber('12345678900');
+          });
+          args = (InlineRecoverySetupFlowModule.default as jest.Mock).mock
+            .calls[1][0];
+          await waitFor(async () => {
+            await args.sendSmsCode();
+          });
+          expect(addRecoveryPhoneFn).toHaveBeenCalledTimes(2);
+          expect(addRecoveryPhoneFn).toHaveBeenNthCalledWith(1, '12345678900');
+          expect(addRecoveryPhoneFn).toHaveBeenNthCalledWith(2, '12345678900');
+
+          await waitFor(async () => {
+            await args.verifySmsCode('010431');
+          });
+          expect(confirmRecoveryPhoneFn).toHaveBeenCalledWith(
+            '010431',
+            '12345678900',
+            true
+          );
+          expect(mockGetCode).toHaveBeenCalled();
+          expect(mockVerifyTotpMutation).toHaveBeenCalled();
+          expect(
+            mockVerifyTotpMutation.mock.calls[0][0].variables.input.code
+          ).toBe('215364');
+        });
+      });
+
+      describe('completeBackupCodeSetup', () => {
+        it('sets recovery codes and enables totp', async () => {
+          await waitFor(async () => {
+            await args.backupChoiceCb('code');
+          });
+          args = (InlineRecoverySetupFlowModule.default as jest.Mock).mock
+            .calls[1][0];
+          await waitFor(async () => {
+            await args.completeBackupCodeSetup('wibble');
+          });
+          expect(setRecoveryCodesFn).toHaveBeenCalledWith(['wibble', 'quux']);
+          expect(mockGetCode).toHaveBeenCalled();
+          expect(mockVerifyTotpMutation).toHaveBeenCalled();
+          expect(
+            mockVerifyTotpMutation.mock.calls[0][0].variables.input.code
+          ).toBe('215364');
+        });
+      });
+
+      describe('successfulSetupHandler', () => {
+        it('calls finishOAuthFlowHandler and navigates to RP', async () => {
+          const hardNavigateSpy = jest
+            .spyOn(utils, 'hardNavigate')
+            .mockImplementation(() => {});
+
+          const successfulSetupHandler = args.successfulSetupHandler;
+          await waitFor(async () => {
+            await successfulSetupHandler();
+          });
+
+          expect(hardNavigateSpy).toHaveBeenCalledWith(
+            MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -1,0 +1,301 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useMutation, useQuery } from '@apollo/client';
+import { RouteComponentProps, useLocation } from '@reach/router';
+import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  useFinishOAuthFlowHandler,
+  useOAuthKeysCheck,
+} from '../../lib/oauth/hooks';
+import { getCode } from '../../lib/totp';
+import { MozServices } from '../../lib/types';
+import {
+  Integration,
+  useAccount,
+  useAuthClient,
+  useConfig,
+  useFtlMsgResolver,
+  useSensitiveDataClient,
+} from '../../models';
+import { VERIFY_TOTP_MUTATION } from './gql';
+import InlineRecoverySetupFlow from './index';
+import { hardNavigate } from 'fxa-react/lib/utils';
+import { SigninRecoveryLocationState } from './interfaces';
+import { TotpStatusResponse } from '../Signin/SigninTokenCode/interfaces';
+import { GET_TOTP_STATUS } from '../../components/App/gql';
+import OAuthDataError from '../../components/OAuthDataError';
+import { isFirefoxService } from '../../models/integrations/utils';
+import { SensitiveData } from '../../lib/sensitive-data-client';
+import { Choice, CHOICES } from '../../components/FormChoice';
+import { totpUtils } from '../../lib/totp-utils';
+import { getErrorFtlId, getHandledError } from '../../lib/error-utils';
+import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+
+export const InlineRecoverySetupFlowContainer = ({
+  isSignedIn,
+  integration,
+  serviceName,
+}: {
+  isSignedIn: boolean;
+  integration: Integration;
+  serviceName: MozServices;
+} & RouteComponentProps) => {
+  const config = useConfig();
+  const account = useAccount();
+  const [loadingAccount, setLoadingAccount] = useState<boolean>(true);
+
+  useEffect(() => {
+    async function acctRefresh() {
+      try {
+        // can't just put an expression here so a function call it is
+        (() => account.recoveryPhone)();
+      } catch {
+        await account.refresh('account');
+      } finally {
+        setLoadingAccount(false);
+      }
+    }
+    acctRefresh();
+  }, [account]);
+
+  const navigateWithQuery = useNavigateWithQuery();
+
+  const authClient = useAuthClient();
+  const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
+    authClient,
+    integration
+  );
+
+  const location = useLocation() as ReturnType<typeof useLocation> & {
+    state?: SigninRecoveryLocationState;
+  };
+
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedIncorrectBackupCodeError = ftlMsgResolver.getMsg(
+    'tfa-incorrect-recovery-code-1',
+    'Incorrect backup authentication code'
+  );
+
+  const [currentStep, setCurrentStep] = useState<number>(1);
+  const navigateForward = useCallback(() => {
+    setCurrentStep(currentStep + 1);
+  }, [currentStep]);
+  const navigateBackward = useCallback(() => {
+    setCurrentStep(currentStep - 1);
+  }, [currentStep]);
+
+  const signinRecoveryLocationState = location.state;
+  const { totp, ...signinLocationState } = signinRecoveryLocationState || {};
+  const sensitiveDataClient = useSensitiveDataClient();
+  const { keyFetchToken, unwrapBKey } =
+    sensitiveDataClient.getDataType(SensitiveData.Key.Auth) || {};
+
+  const { oAuthKeysCheckError } = useOAuthKeysCheck(
+    integration,
+    keyFetchToken,
+    unwrapBKey
+  );
+
+  const [backupMethod, setBackupMethod] = useState<Choice | null>(null);
+  const [backupCodes, setBackupCodes] = useState<string[]>([]);
+  const [generatingCodes, setGeneratingCodes] = useState(false);
+  const [backupCodeError, setBackupCodeError] = useState<string>('');
+
+  const createRecoveryCodes = useCallback(async () => {
+    if (backupCodes.length || generatingCodes) return;
+    setGeneratingCodes(true);
+    const codes: string[] = await totpUtils.generateRecoveryCodes(
+      config.recoveryCodes.count,
+      config.recoveryCodes.length
+    );
+    setBackupCodes(codes);
+    setGeneratingCodes(false);
+  }, [backupCodes, config.recoveryCodes, generatingCodes]);
+  const backupChoiceCb = useCallback(
+    async (choice: Choice) => {
+      if (choice === CHOICES.code) {
+        await createRecoveryCodes();
+      }
+      setBackupMethod(choice);
+      navigateForward();
+    },
+    [createRecoveryCodes, navigateForward]
+  );
+
+  const [verifyTotp] = useMutation<{ verifyTotp: { success: boolean } }>(
+    VERIFY_TOTP_MUTATION
+  );
+  const verifyTotpHandler = useCallback(async () => {
+    const code = await getCode(totp!.secret);
+    const service = integration.getService();
+    const clientId = integration.getClientId();
+
+    const result = await verifyTotp({
+      variables: {
+        input: {
+          code,
+          ...(isFirefoxService(service) ? { service } : { service: clientId }),
+        },
+      },
+    });
+    return result.data!.verifyTotp.success;
+  }, [integration, totp, verifyTotp]);
+
+  const [phoneData, setPhoneData] = useState<{
+    phoneNumber: string;
+    nationalFormat: string | undefined;
+  }>({ phoneNumber: '', nationalFormat: '' });
+  const verifyPhoneNumber = useCallback(
+    async (phoneNumberInput: string) => {
+      const { nationalFormat } =
+        await account.addRecoveryPhone(phoneNumberInput);
+      setPhoneData({
+        phoneNumber: phoneNumberInput,
+        nationalFormat,
+      });
+    },
+    [account]
+  );
+  const sendSmsCode = useCallback(async () => {
+    await account.addRecoveryPhone(phoneData.phoneNumber);
+    return;
+  }, [account, phoneData.phoneNumber]);
+
+  const verifySmsCode = useCallback(
+    async (code: string) => {
+      await account.confirmRecoveryPhone(code, phoneData.phoneNumber, true);
+      await verifyTotpHandler();
+    },
+    [account, phoneData.phoneNumber, verifyTotpHandler]
+  );
+
+  const completeBackupCodeSetup = useCallback(
+    async (code: string) => {
+      if (!backupCodes.includes(code.trim())) {
+        setBackupCodeError(localizedIncorrectBackupCodeError);
+        return;
+      }
+
+      try {
+        await account.setRecoveryCodes(backupCodes);
+        const success = await verifyTotpHandler();
+
+        if (success) {
+          setBackupCodeError('');
+          navigateForward();
+        } else {
+          // Some server side error occurred. Generic error message in catch
+          // block.
+          throw new Error('cannot enable TOTP');
+        }
+      } catch (err) {
+        const { error } = getHandledError(err);
+        if (error.errno === AuthUiErrors.TOTP_TOKEN_NOT_FOUND.errno) {
+          setBackupCodeError(
+            ftlMsgResolver.getMsg(
+              getErrorFtlId(error),
+              AuthUiErrors.TOTP_TOKEN_NOT_FOUND.message
+            )
+          );
+        } else if (error.errno === AuthUiErrors.INVALID_OTP_CODE.errno) {
+        } else {
+          setBackupCodeError(
+            ftlMsgResolver.getMsg(
+              'tfa-cannot-verify-code-4',
+              'There was a problem confirming your backup authentication code'
+            )
+          );
+        }
+      }
+    },
+    [
+      backupCodes,
+      localizedIncorrectBackupCodeError,
+      account,
+      verifyTotpHandler,
+      navigateForward,
+      ftlMsgResolver,
+    ]
+  );
+
+  const { data: totpStatus, loading: totpStatusLoading } =
+    useQuery<TotpStatusResponse>(GET_TOTP_STATUS);
+
+  const successfulSetupHandler = useCallback(async () => {
+    // When this is called, we know signinRecoveryLocationState exists.
+    const { redirect } = await finishOAuthFlowHandler(
+      signinRecoveryLocationState!.uid,
+      signinRecoveryLocationState!.sessionToken,
+      keyFetchToken,
+      unwrapBKey
+    );
+    hardNavigate(redirect!);
+  }, [
+    signinRecoveryLocationState,
+    finishOAuthFlowHandler,
+    keyFetchToken,
+    unwrapBKey,
+  ]);
+
+  if (currentStep === 0) {
+    navigateWithQuery('/inline_totp_setup', { state: signinLocationState });
+    return;
+  }
+
+  // Some basic sanity checks
+  if (!isSignedIn || !signinRecoveryLocationState?.email || !totp) {
+    navigateWithQuery('/signup');
+    return <LoadingSpinner fullScreen />;
+  }
+
+  if (totpStatus?.account?.totp.verified) {
+    navigateWithQuery('/signin_totp_code', {
+      state: signinLocationState,
+    });
+    return <LoadingSpinner fullScreen />;
+  }
+
+  // !recoveryCodes check should happen after checking !totp
+  if (totpStatusLoading || loadingAccount) {
+    return <LoadingSpinner fullScreen />;
+  }
+
+  if (oAuthDataError) {
+    return <OAuthDataError error={oAuthDataError} />;
+  }
+  // Note that we don't currently need this check on this page right now since AMO is the only
+  // RP requiring 2FA and it doesn't require keys. However it's here for consistency.
+  if (oAuthKeysCheckError) {
+    return <OAuthDataError error={oAuthKeysCheckError} />;
+  }
+
+  return (
+    <InlineRecoverySetupFlow
+      {...{
+        flowHasPhoneChoice: account.recoveryPhone.available,
+        serviceName,
+        email: signinRecoveryLocationState.email,
+        currentStep,
+        backupMethod,
+        backupCodes,
+        phoneData,
+        navigateForward,
+        navigateBackward,
+        backupChoiceCb,
+        backupCodeError,
+        setBackupCodeError,
+        sendSmsCode,
+        verifyPhoneNumber,
+        verifySmsCode,
+        completeBackupCodeSetup,
+        successfulSetupHandler,
+      }}
+    />
+  );
+};
+
+export default InlineRecoverySetupFlowContainer;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/gql.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/gql.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const VERIFY_TOTP_MUTATION = gql`
+  mutation verifyTotp($input: VerifyTotpInput!) {
+    verifyTotp(input: $input) {
+      success
+    }
+  }
+`;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.stories.tsx
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import InlineRecoverySetupFlow from '.';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import { InlineRecoverySetupFlowProps } from './interfaces';
+import { MOCK_BACKUP_CODES, MOCK_EMAIL } from '../mocks';
+import { MozServices } from '../../lib/types';
+
+export default {
+  title: 'Pages/InlineRecoverySetupFlow',
+  component: InlineRecoverySetupFlow,
+  decorators: [withLocalization],
+} as Meta;
+
+const flowHasPhoneChoice = true;
+const serviceName = MozServices.Default;
+const email = MOCK_EMAIL;
+const navigateForward = () => {};
+const navigateBackward = () => {};
+const backupChoiceCb = async (x: string) => {};
+const backupCodeError = '';
+const setBackupCodeError = () => {};
+const sendSmsCode = async () => {};
+const verifyPhoneNumber = async () => {};
+const verifySmsCode = async () => {};
+const completeBackupCodeSetup = async () => {};
+const successfulSetupHandler = () => {};
+
+const ComponentWithRouter = (props: InlineRecoverySetupFlowProps) => (
+  <LocationProvider>
+    <InlineRecoverySetupFlow {...props} />
+  </LocationProvider>
+);
+
+export const ChoiceScreen = () => (
+  <ComponentWithRouter
+    currentStep={1}
+    backupMethod={null}
+    backupCodes={[]}
+    phoneData={{ phoneNumber: '', nationalFormat: '' }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);
+
+export const BackupCodesCopyAndDownload = () => (
+  <ComponentWithRouter
+    currentStep={2}
+    backupMethod={'code'}
+    backupCodes={MOCK_BACKUP_CODES}
+    phoneData={{ phoneNumber: '', nationalFormat: '' }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);
+
+export const BackupCodesConfirmation = () => (
+  <ComponentWithRouter
+    currentStep={3}
+    backupMethod={'code'}
+    backupCodes={MOCK_BACKUP_CODES}
+    phoneData={{ phoneNumber: '', nationalFormat: '' }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);
+
+export const BackupCodesChoiceComplete = () => (
+  <ComponentWithRouter
+    currentStep={4}
+    backupMethod={'code'}
+    backupCodes={MOCK_BACKUP_CODES}
+    phoneData={{ phoneNumber: '', nationalFormat: '' }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);
+
+export const RecoveryPhoneNumber = () => (
+  <ComponentWithRouter
+    currentStep={2}
+    backupMethod={'phone'}
+    backupCodes={[]}
+    phoneData={{ phoneNumber: '', nationalFormat: '' }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);
+
+export const RecoveryPhoneConfirmation = () => (
+  <ComponentWithRouter
+    currentStep={3}
+    backupMethod={'phone'}
+    backupCodes={[]}
+    phoneData={{
+      phoneNumber: '12345678900',
+      nationalFormat: '+1 234-567-8900',
+    }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);
+
+export const RecoveryPhoneChoiceComplete = () => (
+  <ComponentWithRouter
+    currentStep={4}
+    backupMethod={'phone'}
+    backupCodes={[]}
+    phoneData={{
+      phoneNumber: '12345678900',
+      nationalFormat: '+1 234-567-8900',
+    }}
+    {...{
+      flowHasPhoneChoice,
+      serviceName,
+      email,
+      navigateForward,
+      navigateBackward,
+      backupChoiceCb,
+      backupCodeError,
+      setBackupCodeError,
+      sendSmsCode,
+      verifyPhoneNumber,
+      verifySmsCode,
+      completeBackupCodeSetup,
+      successfulSetupHandler,
+    }}
+  />
+);

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.test.tsx
@@ -1,0 +1,243 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { screen, waitFor } from '@testing-library/react';
+import { userEvent, UserEvent } from '@testing-library/user-event';
+import InlineRecoverySetupFlow from '.';
+import { GleanClickEventType2FA, MozServices } from '../../lib/types';
+import { renderWithRouter } from '../../models/mocks';
+import { MOCK_BACKUP_CODES, MOCK_EMAIL } from '../mocks';
+import GleanMetrics from '../../lib/glean';
+
+const setRecoveryCodesFn = jest.fn();
+const addRecoveryPhoneFn = jest.fn().mockResolvedValue('');
+const confirmRecoveryPhoneFn = jest.fn();
+const refreshFn = jest.fn();
+const mockAccount = {
+  addRecoveryPhone: addRecoveryPhoneFn,
+  setRecoveryCodes: setRecoveryCodesFn,
+  confirmRecoveryPhone: confirmRecoveryPhoneFn,
+  refresh: refreshFn,
+};
+jest.mock('../../models', () => ({
+  ...jest.requireActual('../../models'),
+  useAccount: () => mockAccount,
+}));
+jest.mock('../../lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+  usePageViewEvent: jest.fn(),
+}));
+jest.mock('../../lib/glean', () => ({
+  __esModule: true,
+  default: {
+    accountPref: {
+      twoStepAuthBackupChoiceView: jest.fn(),
+      twoStepAuthCodesView: jest.fn(),
+      twoStepAuthEnterCodeView: jest.fn(),
+      twoStepAuthPhoneSubmitView: jest.fn(),
+      twoStepAuthPhoneVerifyView: jest.fn(),
+      twoStepAuthCompleteView: jest.fn(),
+    },
+  },
+}));
+const verifyTotpHandler = jest.fn();
+const successSetupHandler = jest.fn();
+const navigateForward = jest.fn();
+const navigateBackward = jest.fn();
+const backupChoiceCb = jest.fn();
+const setBackupCodeError = jest.fn();
+const sendSmsCode = jest.fn();
+const verifyPhoneNumber = jest.fn();
+const verifySmsCode = jest.fn();
+const completeBackupCodeSetup = jest.fn();
+const props = {
+  flowHasPhoneChoice: true,
+  serviceName: MozServices.Default,
+  email: MOCK_EMAIL,
+  backupCodes: [],
+  phoneData: { phoneNumber: '', nationalFormat: '' },
+  verifyTotpHandler,
+  currentStep: 1,
+  navigateForward,
+  navigateBackward,
+  backupMethod: null,
+  backupChoiceCb,
+  backupCodeError: '',
+  setBackupCodeError,
+  sendSmsCode,
+  verifyPhoneNumber,
+  verifySmsCode,
+  completeBackupCodeSetup,
+  successfulSetupHandler: successSetupHandler,
+};
+
+describe('InlineRecoverySetupFlow', () => {
+  let user: UserEvent;
+
+  beforeAll(async () => {
+    global.URL.createObjectURL = jest.fn();
+  });
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    navigateForward.mockClear();
+    navigateBackward.mockClear();
+    verifyTotpHandler.mockClear();
+    successSetupHandler.mockClear();
+  });
+
+  it('renders the choice screen', () => {
+    renderWithRouter(<InlineRecoverySetupFlow {...props} />);
+    screen.getByRole('heading', {
+      name: 'Two-step authentication',
+    });
+    screen.getByRole('heading', {
+      name: 'Choose a recovery method',
+    });
+    screen.getByText('Recovery phone');
+    screen.getByText('Backup authentication codes');
+    expect(
+      GleanMetrics.accountPref.twoStepAuthBackupChoiceView
+    ).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+  });
+
+  it('does not render the choice screen when recovery phone option is N/A', async () => {
+    // also the test for backup codes copy/download screen
+    renderWithRouter(
+      <InlineRecoverySetupFlow
+        {...{
+          ...props,
+          flowHasPhoneChoice: false,
+          backupCodes: MOCK_BACKUP_CODES,
+        }}
+      />
+    );
+    screen.getByRole('heading', {
+      name: 'Two-step authentication',
+    });
+    screen.getByRole('heading', { name: 'Save backup authentication codes' });
+    MOCK_BACKUP_CODES.forEach((x) => screen.getByText(x));
+    expect(GleanMetrics.accountPref.twoStepAuthCodesView).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+    await user.click(screen.getByRole('button', { name: 'Continue' }));
+    expect(navigateForward).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the backup code confirmation screen', async () => {
+    verifyTotpHandler.mockResolvedValueOnce(true);
+    renderWithRouter(
+      <InlineRecoverySetupFlow
+        {...{
+          ...props,
+          flowHasPhoneChoice: false,
+          backupCodes: MOCK_BACKUP_CODES,
+          currentStep: 2,
+        }}
+      />
+    );
+    expect(
+      GleanMetrics.accountPref.twoStepAuthEnterCodeView
+    ).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+    screen.getByRole('heading', { name: 'Enter backup authentication code' });
+    await waitFor(async () => {
+      await user.type(
+        screen.getByLabelText('Enter 10-character code'),
+        MOCK_BACKUP_CODES[0]
+      );
+      await user.click(screen.getByRole('button', { name: 'Finish' }));
+    });
+    expect(completeBackupCodeSetup).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the recovery phone number screen', async () => {
+    renderWithRouter(
+      <InlineRecoverySetupFlow
+        {...{ ...props, currentStep: 2, backupMethod: 'phone' }}
+      />
+    );
+    expect(
+      GleanMetrics.accountPref.twoStepAuthPhoneSubmitView
+    ).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+    screen.getByRole('heading', { name: 'Verify your phone number' });
+    await user.type(screen.getByLabelText('Enter phone number'), '2345678900');
+    await user.click(screen.getByRole('button', { name: 'Send code' }));
+    expect(verifyPhoneNumber).toHaveBeenCalledWith('+12345678900');
+    expect(navigateForward).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the recovery phone confirmation screen', async () => {
+    renderWithRouter(
+      <InlineRecoverySetupFlow
+        {...{ ...props, currentStep: 3, backupMethod: 'phone' }}
+      />
+    );
+    expect(
+      GleanMetrics.accountPref.twoStepAuthPhoneVerifyView
+    ).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+    screen.getByRole('heading', { name: 'Enter verification code' });
+    await user.type(screen.getByLabelText('Enter 6-digit code'), '246509');
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(navigateForward).toHaveBeenCalledTimes(1);
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+    expect(navigateBackward).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the flow complete screen for backup codes', async () => {
+    renderWithRouter(
+      <InlineRecoverySetupFlow
+        {...{
+          ...props,
+          currentStep: 4,
+          backupMethod: 'code',
+          backupCodes: MOCK_BACKUP_CODES,
+        }}
+      />
+    );
+    expect(
+      GleanMetrics.accountPref.twoStepAuthCompleteView
+    ).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+    screen.getByText('Two-step authentication enabled');
+    screen.getByText('8 codes remaining');
+    await user.click(
+      screen.getByRole('button', { name: `Continue to ${MozServices.Default}` })
+    );
+    expect(successSetupHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the flow complete screen for recovery phone', async () => {
+    renderWithRouter(
+      <InlineRecoverySetupFlow
+        {...{ ...props, currentStep: 4, backupMethod: 'phone' }}
+      />
+    );
+    expect(
+      GleanMetrics.accountPref.twoStepAuthCompleteView
+    ).toHaveBeenCalledWith({
+      event: { reason: GleanClickEventType2FA.inline },
+    });
+    screen.getByText('Two-step authentication enabled');
+    screen.getByText('Recovery phone');
+    await user.click(
+      screen.getByRole('button', { name: `Continue to ${MozServices.Default}` })
+    );
+    expect(successSetupHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useMemo } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { useFtlMsgResolver } from '../../models';
+import AppLayout from '../../components/AppLayout';
+import { InlineRecoverySetupFlowProps } from './interfaces';
+import {
+  GleanClickEventType2FA,
+  RecoveryPhoneSetupReason,
+} from '../../lib/types';
+import FlowSetup2faBackupChoice from '../../components/Settings/FlowSetup2faBackupChoice';
+import FlowSetup2faBackupCodeDownload from '../../components/Settings/FlowSetup2faBackupCodeDownload';
+import FlowSetup2faBackupCodeConfirm from '../../components/Settings/FlowSetup2faBackupCodeConfirm';
+import FlowSetupRecoveryPhoneSubmitNumber from '../../components/Settings/FlowSetupRecoveryPhoneSubmitNumber';
+import FlowSetupRecoveryPhoneConfirmCode from '../../components/Settings/FlowSetupRecoveryPhoneConfirmCode';
+import FlowSetup2faComplete from '../../components/Settings/FlowSetup2faComplete';
+import { CHOICES } from '../../components/FormChoice';
+
+const InlineRecoverySetupFlow = ({
+  flowHasPhoneChoice,
+  serviceName,
+  email,
+  currentStep,
+  backupMethod,
+  backupCodes,
+  phoneData,
+  navigateForward,
+  navigateBackward,
+  backupChoiceCb,
+  backupCodeError,
+  setBackupCodeError,
+  sendSmsCode,
+  verifyPhoneNumber,
+  verifySmsCode,
+  completeBackupCodeSetup,
+  successfulSetupHandler,
+}: InlineRecoverySetupFlowProps & RouteComponentProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const localizedPageTitle = ftlMsgResolver.getMsg(
+    'page-2fa-setup-title',
+    'Two-step authentication'
+  );
+
+  const BackupChoice = useCallback(
+    () => (
+      <FlowSetup2faBackupChoice
+        onSubmitCb={backupChoiceCb}
+        onBackButtonClick={navigateBackward}
+        reason={GleanClickEventType2FA.inline}
+        {...{ currentStep, localizedPageTitle }}
+      />
+    ),
+    [backupChoiceCb, currentStep, localizedPageTitle, navigateBackward]
+  );
+
+  const CodeDownload = useCallback(
+    () => (
+      <FlowSetup2faBackupCodeDownload
+        {...{
+          backupCodes,
+          currentStep,
+          reason: GleanClickEventType2FA.inline,
+          email,
+          onContinue: navigateForward,
+          onBackButtonClick: navigateBackward,
+          localizedPageTitle,
+        }}
+      />
+    ),
+    [
+      backupCodes,
+      currentStep,
+      email,
+      localizedPageTitle,
+      navigateBackward,
+      navigateForward,
+    ]
+  );
+  const CodeConfirm = useCallback(
+    () => (
+      <FlowSetup2faBackupCodeConfirm
+        verifyCode={completeBackupCodeSetup}
+        {...{
+          currentStep,
+          reason: GleanClickEventType2FA.inline,
+          onBackButtonClick: navigateBackward,
+          errorMessage: backupCodeError,
+          setErrorMessage: setBackupCodeError,
+          localizedPageTitle,
+        }}
+      />
+    ),
+    [
+      backupCodeError,
+      completeBackupCodeSetup,
+      currentStep,
+      localizedPageTitle,
+      navigateBackward,
+      setBackupCodeError,
+    ]
+  );
+
+  const RecoveryPhoneSubmit = useCallback(
+    () => (
+      <FlowSetupRecoveryPhoneSubmitNumber
+        {...{
+          navigateForward,
+          navigateBackward,
+          verifyPhoneNumber,
+          localizedPageTitle,
+          reason: RecoveryPhoneSetupReason.inline,
+        }}
+      />
+    ),
+    [localizedPageTitle, navigateBackward, navigateForward, verifyPhoneNumber]
+  );
+
+  const RecoveryPhoneConfirm = useCallback(
+    () => (
+      <FlowSetupRecoveryPhoneConfirmCode
+        {...{
+          currentStep,
+          reason: RecoveryPhoneSetupReason.inline,
+          nationalFormatPhoneNumber: phoneData.nationalFormat as string,
+          navigateForward,
+          navigateBackward,
+          sendCode: sendSmsCode,
+          verifyRecoveryCode: verifySmsCode,
+          localizedPageTitle,
+        }}
+      />
+    ),
+    [
+      currentStep,
+      localizedPageTitle,
+      navigateBackward,
+      navigateForward,
+      phoneData.nationalFormat,
+      sendSmsCode,
+      verifySmsCode,
+    ]
+  );
+
+  const Complete = useCallback(
+    () =>
+      backupMethod === CHOICES.code ? (
+        <FlowSetup2faComplete
+          {...{
+            serviceName,
+            backupType: backupMethod as typeof CHOICES.code,
+            numCodesRemaining: backupCodes.length,
+            reason: GleanClickEventType2FA.inline,
+            onContinue: () => {
+              successfulSetupHandler();
+            },
+          }}
+        />
+      ) : (
+        <FlowSetup2faComplete
+          {...{
+            serviceName,
+            backupType: backupMethod as typeof CHOICES.phone,
+            lastFourPhoneDigits: phoneData.phoneNumber,
+            reason: GleanClickEventType2FA.inline,
+            onContinue: () => {
+              successfulSetupHandler();
+            },
+          }}
+        />
+      ),
+    [
+      backupCodes.length,
+      backupMethod,
+      phoneData.phoneNumber,
+      serviceName,
+      successfulSetupHandler,
+    ]
+  );
+
+  const steps = useMemo(() => {
+    if (flowHasPhoneChoice) {
+      switch (backupMethod) {
+        case CHOICES.phone:
+          return [
+            BackupChoice,
+            RecoveryPhoneSubmit,
+            RecoveryPhoneConfirm,
+            Complete,
+          ];
+        case CHOICES.code:
+        default:
+          return [BackupChoice, CodeDownload, CodeConfirm, Complete];
+      }
+    }
+
+    return [CodeDownload, CodeConfirm, Complete];
+  }, [
+    BackupChoice,
+    CodeConfirm,
+    CodeDownload,
+    Complete,
+    RecoveryPhoneConfirm,
+    RecoveryPhoneSubmit,
+    backupMethod,
+    flowHasPhoneChoice,
+  ]);
+
+  return <AppLayout wrapInCard={false}>{steps[currentStep - 1]()}</AppLayout>;
+};
+
+export default InlineRecoverySetupFlow;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/interfaces.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Dispatch, SetStateAction } from 'react';
+import { Choice } from '../../components/FormChoice';
+import { MozServices } from '../../lib/types';
+import { SigninLocationState, TotpToken } from './../Signin/interfaces';
+
+export type SigninRecoveryLocationState = SigninLocationState & {
+  totp: TotpToken;
+};
+
+export interface InlineRecoverySetupFlowProps {
+  flowHasPhoneChoice: boolean;
+  serviceName: MozServices;
+  email: string;
+  currentStep: number;
+  backupMethod: Choice | null;
+  backupCodes: string[];
+  phoneData: {
+    phoneNumber: string;
+    nationalFormat: string | undefined;
+  };
+  navigateForward: () => void;
+  navigateBackward: () => void;
+  backupChoiceCb: (c: Choice) => Promise<void>;
+
+  backupCodeError: string;
+  setBackupCodeError: Dispatch<SetStateAction<string>>;
+  sendSmsCode: () => Promise<void>;
+  verifyPhoneNumber: (n: string) => Promise<void>;
+  verifySmsCode: (c: string) => Promise<void>;
+  completeBackupCodeSetup: (c: string) => Promise<void>;
+  successfulSetupHandler: () => void;
+}


### PR DESCRIPTION
Because:
 - we want to offer the recovery phone 2fa recovery option during inline
   2fa

This commit:
 - implements 2fa recovery choices with new flow components from
   Settings' 2FA setup
