### PR TITLE
task(admin-panel): Support new user groups and permissions

### DIFF
--- a/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
@@ -58,6 +58,56 @@ describe('support agents', () => {
           AdminPanelGroup.AdminProd
         )
       ).true;
+
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.DeleteAccount,
+          AdminPanelGroup.DsarProd
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.DeleteAccount,
+          AdminPanelGroup.DsarStage
+        )
+      ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.AccountDelete,
+          AdminPanelGroup.DsarProd
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.AccountDelete,
+          AdminPanelGroup.DsarStage
+        )
+      ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.AccountSearch,
+          AdminPanelGroup.DsarProd
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.AccountSearch,
+          AdminPanelGroup.DsarStage
+        )
+      ).true;
+
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.AccountSearch,
+          AdminPanelGroup.ReadOnlyProd
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.AccountSearch,
+          AdminPanelGroup.ReadOnlyStage
+        )
+      ).true;
     });
 
     it('looks up group', () => {
@@ -155,7 +205,7 @@ describe('support agents', () => {
     it('gets feature', () => {
       expect(guard.getFeature(AdminPanelFeature.AccountSearch)).deep.equal({
         name: 'Lookup Account By Email/UID',
-        level: PermissionLevel.Support,
+        level: PermissionLevel.ReadOnly,
       });
     });
 
@@ -165,6 +215,10 @@ describe('support agents', () => {
       expect(groups[AdminPanelGroup.SupportAgentProd]).to.exist;
       expect(groups[AdminPanelGroup.AdminStage]).to.exist;
       expect(groups[AdminPanelGroup.SupportAgentStage]).to.exist;
+      expect(groups[AdminPanelGroup.DsarProd]).to.exist;
+      expect(groups[AdminPanelGroup.DsarStage]).to.exist;
+      expect(groups[AdminPanelGroup.ReadOnlyProd]).to.exist;
+      expect(groups[AdminPanelGroup.ReadOnlyStage]).to.exist;
       expect(groups[AdminPanelGroup.None]).to.exist;
     });
 

--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -20,6 +20,8 @@ export const USER_EMAIL_HEADER = 'oidc-claim-id-token-email';
 export enum PermissionLevel {
   Admin = 0,
   Support = 1,
+  DSAR = 2,
+  ReadOnly = 3,
   None = MaxPermissionLevel,
 }
 
@@ -50,6 +52,10 @@ export enum AdminPanelGroup {
   AdminStage = 'vpn_fxa_admin_panel_stage',
   SupportAgentProd = 'vpn_fxa_supportagent_prod',
   SupportAgentStage = 'vpn_fxa_supportagent_stage',
+  ReadOnlyProd = 'vpn_fxa_admin_ro_prod',
+  ReadOnlyStage = 'vpn_fxa_admin_ro_stage',
+  DsarProd = 'vpn_fxa_admin_dsar_prod',
+  DsarStage = 'vpn_fxa_admin_dsar_stage',
   None = '',
 }
 
@@ -78,6 +84,30 @@ const adminPanelGroups: Groups = {
     level: PermissionLevel.Support,
     env: GuardEnv.Stage,
   },
+  [AdminPanelGroup.DsarProd]: {
+    name: 'DSAR',
+    header: AdminPanelGroup.DsarProd,
+    level: PermissionLevel.DSAR,
+    env: GuardEnv.Prod,
+  },
+  [AdminPanelGroup.DsarStage]: {
+    name: 'DSAR',
+    header: AdminPanelGroup.DsarStage,
+    level: PermissionLevel.DSAR,
+    env: GuardEnv.Stage,
+  },
+  [AdminPanelGroup.ReadOnlyProd]: {
+    name: 'ReadOnly',
+    header: AdminPanelGroup.ReadOnlyProd,
+    level: PermissionLevel.ReadOnly,
+    env: GuardEnv.Prod,
+  },
+  [AdminPanelGroup.ReadOnlyStage]: {
+    name: 'ReadOnly',
+    header: AdminPanelGroup.ReadOnlyStage,
+    level: PermissionLevel.ReadOnly,
+    env: GuardEnv.Stage,
+  },
   [AdminPanelGroup.None]: {
     name: 'Unknown',
     header: AdminPanelGroup.None,
@@ -92,23 +122,23 @@ export const unknownGroup = adminPanelGroups[AdminPanelGroup.None];
 const defaultAdminPanelPermissions: Permissions = {
   [AdminPanelFeature.AccountSearch]: {
     name: 'Lookup Account By Email/UID',
-    level: PermissionLevel.Support,
+    level: PermissionLevel.ReadOnly,
   },
   [AdminPanelFeature.AccountHistory]: {
     name: 'Account History',
-    level: PermissionLevel.Support,
+    level: PermissionLevel.ReadOnly,
   },
   [AdminPanelFeature.AccountDelete]: {
     name: 'Delete Account By Email/UID',
-    level: PermissionLevel.Admin,
+    level: PermissionLevel.DSAR,
   },
   [AdminPanelFeature.ConnectedServices]: {
     name: 'View Active Sessions',
-    level: PermissionLevel.Support,
+    level: PermissionLevel.ReadOnly,
   },
   [AdminPanelFeature.LinkedAccounts]: {
     name: 'View Linked Accounts',
-    level: PermissionLevel.Support,
+    level: PermissionLevel.ReadOnly,
   },
   [AdminPanelFeature.ClearEmailBounces]: {
     name: 'Clear Email Bounces',
@@ -136,7 +166,7 @@ const defaultAdminPanelPermissions: Permissions = {
   },
   [AdminPanelFeature.DeleteAccount]: {
     name: 'DeleteAccount Account',
-    level: PermissionLevel.Admin,
+    level: PermissionLevel.DSAR,
   },
   [AdminPanelFeature.RelyingParties]: {
     name: 'View Relying Parties',


### PR DESCRIPTION
## Because

- We want to add a new group for DSAR users
- We want to add a new group for read only users

## This pull request

- Adds DSAR group, which has a ability to search for and delete accounts
- Adds readonly group, which has a read only view
- Updates configurations accordingly

## Issue that this pull request solves

Closes: FXA-10976

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1199" height="774" alt="image" src="https://github.com/user-attachments/assets/5ebfa2b1-3bf0-4e0d-a40b-df454131c228" />
<img width="1226" height="782" alt="image" src="https://github.com/user-attachments/assets/306d92a5-c458-487c-b7af-caf41c747ca1" />

## Other information (Optional)

Note, this is based on [#19237](https://github.com/mozilla/fxa/pull/19239), which moves fxa-shared/guards into libs. Please review that first!
