### PR TITLE
chore(admin-server,admin-panel): Move fxa-shared/guards to libs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,6 +350,7 @@ commands:
             cd packages/functional-tests/tests
             TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
             cd ..
+
             echo $TEST_FILES | circleci tests run \
               --command="xargs yarn playwright test --project=<< parameters.project >> $GREP" \
               --verbose \

--- a/libs/shared/guards/.eslintrc.json
+++ b/libs/shared/guards/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/shared/guards/README.md
+++ b/libs/shared/guards/README.md
@@ -1,0 +1,11 @@
+# guards
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build guards` to build the library.
+
+## Running unit tests
+
+Run `nx test guards` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/shared/guards/jest.config.ts
+++ b/libs/shared/guards/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: 'guards',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/shared/guards',
+};

--- a/libs/shared/guards/package.json
+++ b/libs/shared/guards/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fxa/shared/guards",
+  "version": "0.0.1"
+}

--- a/libs/shared/guards/project.json
+++ b/libs/shared/guards/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "shared-guards",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared/guards/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/shared/guards",
+        "main": "libs/shared/guards/src/index.ts",
+        "tsConfig": "libs/shared/guards/tsconfig.lib.json",
+        "assets": ["libs/shared/guards/*.md"],
+        "format": ["cjs"],
+        "generatePackageJson": true
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/shared/guards/jest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/shared/guards/src/index.ts
+++ b/libs/shared/guards/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/admin-panel-guard';
+export * from './lib/guard';

--- a/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
@@ -3,20 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import {
-  AdminPanelEnv,
   AdminPanelFeature,
   AdminPanelGroup,
   AdminPanelGuard,
   getGroupsByEnv,
   PermissionLevel,
-} from '../../guards';
+} from './admin-panel-guard';
 import { expect } from 'chai';
+import { GuardEnv } from './guard';
 
 describe('support agents', () => {
   describe('Admin Panel Guard', () => {
     const guard = new AdminPanelGuard();
-    const stageGuard = new AdminPanelGuard(AdminPanelEnv.Stage);
-    const prodGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+    const stageGuard = new AdminPanelGuard(GuardEnv.Stage);
+    const prodGuard = new AdminPanelGuard(GuardEnv.Prod);
 
     it('allows', () => {
       expect(
@@ -65,25 +65,25 @@ describe('support agents', () => {
         name: 'Admin',
         header: 'vpn_fxa_admin_panel_prod',
         level: PermissionLevel.Admin,
-        env: AdminPanelEnv.Prod,
+        env: GuardEnv.Prod,
       });
       expect(guard.getGroup(AdminPanelGroup.AdminStage)).deep.equal({
         name: 'Admin',
         header: 'vpn_fxa_admin_panel_stage',
         level: PermissionLevel.Admin,
-        env: AdminPanelEnv.Stage,
+        env: GuardEnv.Stage,
       });
       expect(guard.getGroup(AdminPanelGroup.SupportAgentProd)).deep.equal({
         name: 'Support',
         header: 'vpn_fxa_supportagent_prod',
         level: PermissionLevel.Support,
-        env: AdminPanelEnv.Prod,
+        env: GuardEnv.Prod,
       });
       expect(guard.getGroup(AdminPanelGroup.SupportAgentStage)).deep.equal({
         name: 'Support',
         header: 'vpn_fxa_supportagent_stage',
         level: PermissionLevel.Support,
-        env: AdminPanelEnv.Stage,
+        env: GuardEnv.Stage,
       });
     });
 

--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -7,8 +7,8 @@ import {
   Permissions,
   Groups,
   MaxPermissionLevel,
-  AdminPanelEnv,
-} from './Guard';
+  GuardEnv,
+} from './guard';
 
 /** The header key containing the user group. */
 export const USER_GROUP_HEADER = 'remote-groups';
@@ -58,25 +58,25 @@ const adminPanelGroups: Groups = {
     name: 'Admin',
     header: AdminPanelGroup.AdminProd,
     level: PermissionLevel.Admin,
-    env: AdminPanelEnv.Prod,
+    env: GuardEnv.Prod,
   },
   [AdminPanelGroup.AdminStage]: {
     name: 'Admin',
     header: AdminPanelGroup.AdminStage,
     level: PermissionLevel.Admin,
-    env: AdminPanelEnv.Stage,
+    env: GuardEnv.Stage,
   },
   [AdminPanelGroup.SupportAgentProd]: {
     name: 'Support',
     header: AdminPanelGroup.SupportAgentProd,
     level: PermissionLevel.Support,
-    env: AdminPanelEnv.Prod,
+    env: GuardEnv.Prod,
   },
   [AdminPanelGroup.SupportAgentStage]: {
     name: 'Support',
     header: AdminPanelGroup.SupportAgentStage,
     level: PermissionLevel.Support,
-    env: AdminPanelEnv.Stage,
+    env: GuardEnv.Stage,
   },
   [AdminPanelGroup.None]: {
     name: 'Unknown',
@@ -161,7 +161,7 @@ const defaultAdminPanelPermissions: Permissions = {
  * @param env The target environment
  * @returns Set of groups
  */
-export function getGroupsByEnv(env?: AdminPanelEnv) {
+export function getGroupsByEnv(env?: GuardEnv) {
   return Object.values(adminPanelGroups)
     .filter((x) => env == null || x.env == null || x.env === env)
     .reduce((map: Groups, x) => {
@@ -172,11 +172,11 @@ export function getGroupsByEnv(env?: AdminPanelEnv) {
 
 /** Setup configured guard for admin panel */
 export class AdminPanelGuard extends Guard<AdminPanelFeature, AdminPanelGroup> {
-  protected envToNum(env?: AdminPanelEnv): number {
+  protected envToNum(env?: GuardEnv): number {
     return env === 'prod' ? 10 : env === 'stage' ? 20 : 30;
   }
 
-  constructor(env?: AdminPanelEnv) {
+  constructor(env?: GuardEnv) {
     super(defaultAdminPanelPermissions, getGroupsByEnv(env));
   }
 }

--- a/libs/shared/guards/src/lib/guard.spec.ts
+++ b/libs/shared/guards/src/lib/guard.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Guard, Permissions, Groups } from '../../guards';
+import { Guard, Permissions, Groups } from './guard';
 import { expect } from 'chai';
 
 describe('support agents', () => {
@@ -18,7 +18,7 @@ describe('support agents', () => {
 
     let guard: TestGuard;
 
-    before(() => {
+    beforeAll(() => {
       guard = new TestGuard(
         {
           test: {

--- a/libs/shared/guards/src/lib/guard.ts
+++ b/libs/shared/guards/src/lib/guard.ts
@@ -4,7 +4,7 @@
 
 /** Enum for known environment names */
 // TODO: Refactor to be called GuardEnv... This isn't really specific to the admin panel...
-export enum AdminPanelEnv {
+export enum GuardEnv {
   Prod = 'prod',
   Stage = 'stage',
 }
@@ -42,7 +42,7 @@ export interface IGroup {
   level: number;
 
   /** Target environment */
-  env?: AdminPanelEnv;
+  env?: GuardEnv;
 }
 
 export type Permissions = Record<string, IFeature>;

--- a/libs/shared/guards/tsconfig.json
+++ b/libs/shared/guards/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared/guards/tsconfig.lib.json
+++ b/libs/shared/guards/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/shared/guards/tsconfig.spec.json
+++ b/libs/shared/guards/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-environment-node": "^29.7.0",
     "json": "^11.0.0",
+    "jsonc-eslint-parser": "^2.1.0",
     "mocha-junit-reporter": "^2.2.0",
     "mocha-multi": "^1.1.7",
     "nx": "21.1.2",

--- a/packages/fxa-admin-panel/constants/index.ts
+++ b/packages/fxa-admin-panel/constants/index.ts
@@ -2,6 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export { USER_GROUP_HEADER, USER_EMAIL_HEADER } from 'fxa-shared/guards';
+export { USER_GROUP_HEADER, USER_EMAIL_HEADER } from '@fxa/shared/guards';
 export const SERVER_CONFIG_PLACEHOLDER = '__SERVER_CONFIG__';
 export const HIDE_ROW = 'N/A';

--- a/packages/fxa-admin-panel/interfaces/index.ts
+++ b/packages/fxa-admin-panel/interfaces/index.ts
@@ -4,7 +4,7 @@
 
 import { IncomingHttpHeaders } from 'http';
 import { USER_EMAIL_HEADER, USER_GROUP_HEADER } from '../constants';
-import { AdminPanelGuard, IGroup } from 'fxa-shared/guards';
+import { AdminPanelGuard, IGroup } from '@fxa/shared/guards';
 
 export interface IUserInfo {
   group: IGroup;

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -5,7 +5,7 @@
 import convict from 'convict';
 import fs from 'fs';
 import path from 'path';
-import { GuardConfig } from 'fxa-shared/guards';
+import { GuardConfig } from '@fxa/shared/guards';
 import { tracingConfig } from 'fxa-shared/tracing/config';
 
 convict.addFormats(require('convict-format-with-moment'));

--- a/packages/fxa-admin-panel/server/jest.config.js
+++ b/packages/fxa-admin-panel/server/jest.config.js
@@ -2,12 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const { pathsToModuleNameMapper } = require('ts-jest');
+
+const { compilerOptions } = require('../../../tsconfig.base.json');
+
 module.exports = {
   transform: {
     '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
   },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+  roots: ['<rootDir>'],
+  modulePaths: [compilerOptions.baseUrl],
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/../../../',
+  }),
   coveragePathIgnorePatterns: ['<rootDir>'],
-  collectCoverageFrom: ['**/*.js', '!**/jest*js'],
   coverageThreshold: {
     global: {
       branches: 0,

--- a/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.test.ts
@@ -6,12 +6,12 @@ import { ClientConfig } from '.';
 import { SERVER_CONFIG_PLACEHOLDER } from '../../../constants';
 import { JSDOM } from 'jsdom';
 import {
-  AdminPanelEnv,
+  GuardEnv,
   AdminPanelGroup,
   PermissionLevel,
   USER_EMAIL_HEADER,
   USER_GROUP_HEADER,
-} from 'fxa-shared/guards';
+} from '@fxa/shared/guards';
 import { IUserInfo } from '../../../interfaces';
 
 describe('ClientConfig', () => {
@@ -49,7 +49,7 @@ describe('ClientConfig', () => {
         name: 'Admin',
         header: 'vpn_fxa_admin_panel_prod',
         level: PermissionLevel.Admin,
-        env: AdminPanelEnv.Prod,
+        env: GuardEnv.Prod,
       },
     });
   });
@@ -61,7 +61,7 @@ describe('ClientConfig', () => {
         name: 'Support',
         header: 'vpn_fxa_supportagent_prod',
         level: PermissionLevel.Support,
-        env: AdminPanelEnv.Prod,
+        env: GuardEnv.Prod,
       },
     });
   });
@@ -97,7 +97,7 @@ describe('ClientConfig', () => {
         name: 'Support',
         header: AdminPanelGroup.SupportAgentProd,
         level: PermissionLevel.Support,
-        env: AdminPanelEnv.Prod,
+        env: GuardEnv.Prod,
       },
     });
   });
@@ -111,7 +111,7 @@ describe('ClientConfig', () => {
           name: 'Admin',
           header: AdminPanelGroup.AdminProd,
           level: PermissionLevel.Admin,
-          env: AdminPanelEnv.Prod,
+          env: GuardEnv.Prod,
         },
       }
     );

--- a/packages/fxa-admin-panel/server/lib/client-config/index.ts
+++ b/packages/fxa-admin-panel/server/lib/client-config/index.ts
@@ -12,11 +12,11 @@ import {
   USER_GROUP_HEADER,
   SERVER_CONFIG_PLACEHOLDER,
 } from '../../../constants';
-import { AdminPanelEnv, AdminPanelGuard } from 'fxa-shared/guards';
+import { GuardEnv, AdminPanelGuard } from '@fxa/shared/guards';
 import log from '../logging';
 import version from '../version';
 
-const guard = new AdminPanelGuard(config.get('guard.env') as AdminPanelEnv);
+const guard = new AdminPanelGuard(config.get('guard.env') as GuardEnv);
 
 /** Client Config Defaults provided by env */
 const defaultConfig: IClientConfig = {

--- a/packages/fxa-admin-panel/src/App.test.tsx
+++ b/packages/fxa-admin-panel/src/App.test.tsx
@@ -5,16 +5,12 @@
 import React from 'react';
 import App from './App';
 import { mockConfigBuilder } from './lib/config';
-import {
-  AdminPanelEnv,
-  AdminPanelGroup,
-  AdminPanelGuard,
-} from 'fxa-shared/guards';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { MockedProvider } from '@apollo/client/testing';
 
 it('renders without imploding', () => {
-  const guard = new AdminPanelGuard(AdminPanelEnv.Prod);
+  const guard = new AdminPanelGuard(GuardEnv.Prod);
   const config = mockConfigBuilder({
     guard,
     user: {

--- a/packages/fxa-admin-panel/src/App.tsx
+++ b/packages/fxa-admin-panel/src/App.tsx
@@ -10,7 +10,7 @@ import AppLayout from './components/AppLayout';
 import AccountSearch from './components/PageAccountSearch';
 import { PagePermissions } from './components/PagePermissions';
 import { IClientConfig, IUserInfo } from '../interfaces';
-import { AdminPanelFeature, AdminPanelGuard } from 'fxa-shared/guards';
+import { AdminPanelFeature, AdminPanelGuard } from '@fxa/shared/guards';
 import PageRelyingParties from './components/PageRelyingParties';
 import PageAccountDelete from './components/PageAccountDelete';
 

--- a/packages/fxa-admin-panel/src/components/Guard/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/Guard/index.test.tsx
@@ -7,14 +7,14 @@ import { render } from '@testing-library/react';
 import { IClientConfig } from '../../../interfaces';
 import { Guard } from './index';
 import {
-  AdminPanelEnv,
+  GuardEnv,
   AdminPanelFeature,
   AdminPanelGroup,
   AdminPanelGuard,
-} from 'fxa-shared/guards';
+} from '@fxa/shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
 
-const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
 
 export const mockConfig: IClientConfig = mockConfigBuilder({

--- a/packages/fxa-admin-panel/src/components/Guard/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Guard/index.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { useUserContext } from '../../hooks/UserContext';
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import { useGuardContext } from '../../hooks/GuardContext';
 
 export type GuardProps = {

--- a/packages/fxa-admin-panel/src/components/Nav/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Nav/index.tsx
@@ -7,7 +7,7 @@ import { NavLink } from 'react-router-dom';
 import accountIcon from '../../images/icon-account.svg';
 import keyIcon from '../../images/icon-key.svg';
 import logsIcon from '../../images/icon-logs.svg';
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import Guard from '../Guard';
 
 const getNavLinkClassName = (isActive: boolean) =>

--- a/packages/fxa-admin-panel/src/components/PageAccountDelete/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountDelete/index.test.tsx
@@ -7,11 +7,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { PageAccountDelete } from '.';
 import { IClientConfig } from '../../../interfaces';
-import {
-  AdminPanelEnv,
-  AdminPanelGroup,
-  AdminPanelGuard,
-} from '../../../../fxa-shared/guards';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import {
@@ -20,7 +16,7 @@ import {
 } from './mocks';
 
 // Setup the current user hook. Required for Guards.
-const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 const mockConfig: IClientConfig = mockConfigBuilder({
   user: {
     email: 'test@mozilla.com',

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -6,15 +6,11 @@ import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import { Account, AccountProps } from './index';
 import { BounceSubType, BounceType } from 'fxa-admin-server/src/graphql';
-import {
-  AdminPanelEnv,
-  AdminPanelGroup,
-  AdminPanelGuard,
-} from 'fxa-shared/guards';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { IClientConfig } from '../../../../interfaces';
 import { mockConfigBuilder } from '../../../lib/config';
 
-const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
 
 export const mockConfig: IClientConfig = mockConfigBuilder({

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -12,7 +12,7 @@ import {
   BackupCodes as BackupCodesType,
   RecoveryPhone as RecoveryPhoneType,
 } from 'fxa-admin-server/src/graphql';
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import Guard from '../../Guard';
 import Subscription from '../Subscription';
 import { ConnectedServices } from '../ConnectedServices';

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/mocks.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/mocks.tsx
@@ -10,8 +10,8 @@ export const mockUnsubscribe = (success: boolean): MockedResponse => {
     query: UNSUBSCRIBE_FROM_MAILING_LISTS,
   };
 
-  let result = undefined;
-  let error = undefined;
+  let result: { data: { status: boolean } } | undefined;
+  let error: Error | undefined;
   if (success) {
     result = {
       data: {

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.tsx
@@ -5,7 +5,7 @@
 import { useMutation } from '@apollo/client';
 import { Email } from 'fxa-admin-server/src/graphql';
 import { RECORD_ADMIN_SECURITY_EVENT } from '../Account/index.gql';
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import Guard from '../../Guard';
 import { getFormattedDate } from '../../../lib/utils';
 import { ReactElement } from 'react';

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/EmailBounces/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/EmailBounces/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import Guard from '../../Guard';
 import { useMutation } from '@apollo/client';
 import { RECORD_ADMIN_SECURITY_EVENT } from '../Account/index.gql';

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/index.test.tsx
@@ -9,11 +9,7 @@ import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { AccountSearch } from './index';
 import { EDIT_LOCALE, RECORD_ADMIN_SECURITY_EVENT } from './Account/index.gql';
 import { GET_ACCOUNT_BY_EMAIL, GET_EMAILS_LIKE } from './index.gql';
-import {
-  AdminPanelEnv,
-  AdminPanelGroup,
-  AdminPanelGuard,
-} from 'fxa-shared/guards';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { UNSUBSCRIBE_FROM_MAILING_LISTS } from './DangerZone/index.gql';
 import { CLEAR_BOUNCES_BY_EMAIL } from './EmailBounces/index.gql';
 
@@ -26,7 +22,7 @@ let calledAccountSearch = false;
 let calledGetEmailsLike = false;
 
 // Mock AdminPanelGuard
-const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 const mockGroup = mockGuard.getGroup(AdminPanelGroup.AdminProd);
 jest.mock('../../hooks/UserContext.ts', () => {
   return {
@@ -308,7 +304,12 @@ class GetEmailsLike {
     calledGetEmailsLike = true;
     // Return the original testEmail if the search matches its first 6 characters
     // Otherwise return a mock email that matches the search pattern
-    const mockEmail = search === testEmail.substring(0, 6) ? testEmail : (search.includes('@') ? search : `${search}@example.com`);
+    const mockEmail =
+      search === testEmail.substring(0, 6)
+        ? testEmail
+        : search.includes('@')
+          ? search
+          : `${search}@example.com`;
     return {
       data: {
         getEmailsLike: [{ email: mockEmail }],

--- a/packages/fxa-admin-panel/src/components/PagePermissions/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PagePermissions/index.test.tsx
@@ -6,14 +6,10 @@ import React from 'react';
 import { render, RenderResult } from '@testing-library/react';
 import { IClientConfig } from '../../../interfaces';
 import { PagePermissions } from './index';
-import {
-  AdminPanelEnv,
-  AdminPanelGroup,
-  AdminPanelGuard,
-} from 'fxa-shared/guards';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
 
-const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
 
 export const mockConfig: IClientConfig = mockConfigBuilder({

--- a/packages/fxa-admin-panel/src/components/PagePermissions/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PagePermissions/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { IFeatureFlag } from 'fxa-shared/guards';
+import { IFeatureFlag } from '@fxa/shared/guards';
 import { useUserContext } from '../../hooks/UserContext';
 import { useGuardContext } from '../../hooks/GuardContext';
 import { TableRowYHeader, TableYHeaders } from '../TableYHeaders';

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.test.tsx
@@ -14,16 +14,12 @@ import {
   MOCK_RP_FALSY_FIELDS,
 } from './mocks';
 import { IClientConfig } from '../../../interfaces';
-import {
-  AdminPanelEnv,
-  AdminPanelGroup,
-  AdminPanelGuard,
-} from '../../../../fxa-shared/guards';
+import { GuardEnv, AdminPanelGroup, AdminPanelGuard } from '@fxa/shared/guards';
 import { mockConfigBuilder } from '../../lib/config';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 
 // Setup the current user hook. Required for Guards.
-const mockGuard = new AdminPanelGuard(AdminPanelEnv.Prod);
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
 
 const mockConfig: IClientConfig = mockConfigBuilder({
   user: {

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -7,7 +7,7 @@ import { ApolloError, useMutation, useQuery } from '@apollo/client';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { RelyingParty } from 'fxa-admin-server/src/graphql';
 import ErrorAlert from '../ErrorAlert';
-import { AdminPanelFeature } from '../../../../fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import { Guard } from '../Guard';
 import { getFormattedDate } from '../../lib/utils';
 import { TableRowYHeader, TableYHeaders } from '../TableYHeaders';

--- a/packages/fxa-admin-panel/src/hooks/GuardContext.ts
+++ b/packages/fxa-admin-panel/src/hooks/GuardContext.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { createContext, useContext } from 'react';
-import { AdminPanelGuard } from 'fxa-shared/guards';
+import { AdminPanelGuard } from '@fxa/shared/guards';
 
 export interface IGuardContext {
   guard: AdminPanelGuard;

--- a/packages/fxa-admin-panel/src/lib/config.ts
+++ b/packages/fxa-admin-panel/src/lib/config.ts
@@ -9,7 +9,7 @@ import {
   unknownGroup,
   USER_EMAIL_HEADER,
   USER_GROUP_HEADER,
-} from 'fxa-shared/guards';
+} from '@fxa/shared/guards';
 import { SERVER_CONFIG_PLACEHOLDER } from '../../constants';
 import { IClientConfig } from '../../interfaces';
 

--- a/packages/fxa-admin-panel/tsconfig.json
+++ b/packages/fxa-admin-panel/tsconfig.json
@@ -1,18 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": [
-      "jest",
-      "node",
-      "@testing-library/jest-dom"
-    ],
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "noEmit": true,
+    "types": ["jest", "@testing-library/jest-dom"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "isolatedModules": true,
-    "noEmit": true
+    "noImplicitAny": false
   },
   "include": [
     "src"

--- a/packages/fxa-admin-server/src/auth/user-group-header.decorator.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.decorator.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import { SetMetadata } from '@nestjs/common';
 
 export const FEATURE_KEY = 'AdminPanelFeature';

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.spec.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.spec.ts
@@ -12,7 +12,7 @@ import {
   AdminPanelFeature,
   AdminPanelGroup,
   USER_GROUP_HEADER,
-} from 'fxa-shared/guards';
+} from '@fxa/shared/guards';
 import { UserGroupGuard } from './user-group-header.guard';
 
 describe('UserGroupGuard for graphql', () => {

--- a/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
+++ b/packages/fxa-admin-server/src/auth/user-group-header.guard.ts
@@ -3,28 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { MozLoggerService } from '@fxa/shared/mozlog';
-import {
-  CanActivate,
-  ExecutionContext,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import {
-  AdminPanelEnv,
+  GuardEnv,
   AdminPanelFeature,
   AdminPanelGuard,
   USER_GROUP_HEADER,
-} from 'fxa-shared/guards';
+} from '@fxa/shared/guards';
 import config from '../config';
 import { FEATURE_KEY } from './user-group-header.decorator';
 
-const guard = new AdminPanelGuard(config.get('guard.env') as AdminPanelEnv);
+const guard = new AdminPanelGuard(config.get('guard.env') as GuardEnv);
 
 @Injectable()
 export class UserGroupGuard implements CanActivate {
-  constructor(private reflector?: Reflector, private log?: MozLoggerService) {}
+  constructor(
+    private reflector?: Reflector,
+    private log?: MozLoggerService
+  ) {}
 
   canActivate(context: ExecutionContext): boolean {
     // Reflect on the end point to determine if it has been tagged with admin panel feature.

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -5,7 +5,7 @@
 import convict from 'convict';
 import fs from 'fs';
 import { makeMySQLConfig, makeRedisConfig } from 'fxa-shared/db/config';
-import { GuardConfig, USER_EMAIL_HEADER } from 'fxa-shared/guards';
+import { GuardConfig, USER_EMAIL_HEADER } from '@fxa/shared/guards';
 import { tracingConfig } from '@fxa/shared/otel';
 import path from 'path';
 import { CloudTasksConvictConfigFactory } from '@fxa/shared/cloud-tasks';

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -24,7 +24,7 @@ import {
 import { AttachedSession } from 'fxa-shared/connected-services/models/AttachedSession';
 import { Account, getAccountCustomerByUid } from 'fxa-shared/db/models/auth';
 import { SecurityEventNames } from 'fxa-shared/db/models/auth/security-event';
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 import { CurrentUser } from '../../auth/auth-header.decorator';

--- a/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/email-bounce/email-bounce.resolver.ts
@@ -5,7 +5,7 @@ import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import { CurrentUser } from '../../auth/auth-header.decorator';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
 import { Features } from '../../auth/user-group-header.decorator';

--- a/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
@@ -6,7 +6,7 @@ import { UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
 import { uuidTransformer } from '../../database/transformers';
 
-import { AdminPanelFeature } from 'fxa-shared/guards';
+import { AdminPanelFeature } from '@fxa/shared/guards';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
 import { Features } from '../../auth/user-group-header.decorator';
 import { DatabaseService } from '../../database/database.service';

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -25,6 +25,7 @@
       ],
       "@fxa/shared/error": ["libs/shared/error/src/index"],
       "@fxa/shared/geodb": ["libs/shared/geodb/src/index"],
+      "@fxa/shared/guards": ["libs/shared/guards/src/index"],
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index"],
       "@fxa/shared/log": ["libs/shared/log/src/index"],
       "@fxa/shared/metrics/statsd": ["libs/shared/metrics/statsd/src/index"],

--- a/packages/fxa-shared/guards/index.ts
+++ b/packages/fxa-shared/guards/index.ts
@@ -1,6 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-export * from './Guard';
-export * from './AdminPanelGuard';

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -109,14 +109,6 @@
       "import": "./dist/esm/packages/fxa-shared/feature-flags/*.js",
       "require": "./dist/cjs/packages/fxa-shared/feature-flags/*.js"
     },
-    "./guards": {
-      "import": "./dist/esm/packages/fxa-shared/guards/index.js",
-      "require": "./dist/cjs/packages/fxa-shared/guards/index.js"
-    },
-    "./guards/*": {
-      "import": "./dist/esm/packages/fxa-shared/guards/*.js",
-      "require": "./dist/cjs/packages/fxa-shared/guards/*.js"
-    },
     "./lib/*": {
       "import": "./dist/esm/packages/fxa-shared/lib/*.js",
       "require": "./dist/cjs/packages/fxa-shared/lib/*.js"

--- a/packages/fxa-shared/sentry/browser.ts
+++ b/packages/fxa-shared/sentry/browser.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import * as Sentry from '@sentry/browser';
-import { SamplingContext } from '@sentry/core';
+import { Integration } from '@sentry/core';
 import { SentryConfigOpts } from './models/SentryConfigOpts';
 import { ILogger } from '../log';
 import { tagFxaName } from './tag';
@@ -170,9 +170,9 @@ function configure(config: SentryConfigOpts, log?: ILogger) {
   const opts = buildSentryConfig(config, log);
 
   // If tracing is configured, add the integration.
-  const integrations = [];
+  const integrations: Integration[] = [];
   if (opts.tracesSampleRate || opts.tracesSampler) {
-    integrations.push(Sentry.browserTracingIntegration())
+    integrations.push(Sentry.browserTracingIntegration());
   }
 
   try {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -75,6 +75,7 @@
       "@fxa/shared/error/error": ["libs/shared/error/src/lib/error.ts"],
       "@fxa/shared/geodb": ["libs/shared/geodb/src/index.ts"],
       "@fxa/shared/glean": ["libs/shared/metrics/glean/src/index.ts"],
+      "@fxa/shared/guards": ["libs/shared/guards/src/index.ts"],
       "@fxa/shared/l10n": ["libs/shared/l10n/src/index.ts"],
       "@fxa/shared/l10n/client": ["libs/shared/l10n/src/client.ts"],
       "@fxa/shared/l10n/server": ["libs/shared/l10n/src/server.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -33569,6 +33569,7 @@ __metadata:
     jose: "npm:^5.9.6"
     jsdom: "npm:^26.0.0"
     json: "npm:^11.0.0"
+    jsonc-eslint-parser: "npm:^2.1.0"
     knex: "npm:^3.1.0"
     kysely: "npm:^0.27.2"
     lint-staged: "npm:^15.2.0"


### PR DESCRIPTION
## Because

- We are trying to phase out `fxa-shared`

## This pull request

- Ports `fxa-shared/guards` to libs
- Updates references and configs

## Issue that this pull request solves

Closes: FXA-12158

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
