### PR TITLE
refactor(metrics): Add more logging when server-side OTP confirmation fails

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -1031,7 +1031,7 @@ module.exports = (
         }
 
         const secret = matchedEmail.emailCode;
-        const isValid = otpUtils.verifyOtpCode(
+        const { valid: isValid } = otpUtils.verifyOtpCode(
           code,
           secret,
           otpOptions,

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -400,7 +400,7 @@ module.exports = function (
         const account = await db.account(uid);
         const secret = account.primaryEmail.emailCode;
 
-        const isValidCode = otpUtils.verifyOtpCode(
+        const { valid: isValidCode } = otpUtils.verifyOtpCode(
           code,
           secret,
           otpOptions,
@@ -681,7 +681,7 @@ module.exports = function (
         const account = await db.account(uid);
         const secret = account.primaryEmail.emailCode;
 
-        const isValidCode = otpUtils.verifyOtpCode(
+        const { valid: isValidCode } = otpUtils.verifyOtpCode(
           code,
           secret,
           otpOptions,

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -379,7 +379,7 @@ module.exports = (
             window: config.window,
           };
 
-          const isValidCode = otpUtils.verifyOtpCode(
+          const { valid: isValidCode } = otpUtils.verifyOtpCode(
             code,
             sharedSecret,
             otpOptions,
@@ -556,7 +556,7 @@ module.exports = (
           window: config.window,
         };
 
-        const isValidCode = otpUtils.verifyOtpCode(
+        const { valid: isValidCode, delta } = otpUtils.verifyOtpCode(
           code,
           sharedSecret,
           otpOptions,
@@ -571,6 +571,15 @@ module.exports = (
           // an edgecase where the client may accept a code that the server rejects.
           if (!isValidCode) {
             glean.twoFactorAuth.setupInvalidCodeError(request, { uid });
+            // Lots of data to help determine the cause of FXA-12145
+            log.error('totp.setup.invalidCode', {
+              uid,
+              code,
+              step: config.step,
+              window: config.window,
+              delta,
+            });
+
             throw errors.invalidTokenVerficationCode();
           } else {
             // Once a valid TOTP code has been detected, the token becomes verified

--- a/packages/fxa-auth-server/lib/routes/utils/otp.js
+++ b/packages/fxa-auth-server/lib/routes/utils/otp.js
@@ -55,7 +55,7 @@ module.exports = (log, config, db, statsd) => {
      * @param secret the secret used to verify code
      * @param otpOptions additional options
      * @param type the type of totp code being verified
-     * @returns boolean
+     * @returns {{valid: boolean, delta: number}} object with valid status and delta
      */
     verifyOtpCode(code, secret, otpOptions, type) {
       const authenticator = new otplib.authenticator.Authenticator();
@@ -66,13 +66,13 @@ module.exports = (log, config, db, statsd) => {
         { secret }
       );
       const valid = authenticator.check(code, secret);
+      const delta = authenticator.checkDelta(code, secret);
 
       if (type) {
-        const delta = authenticator.checkDelta(code, secret);
         statsd.histogram(`${type}.totp.delta_histogram`, delta);
       }
-
-      return valid;
+      // Return delta for logging
+      return { valid, delta };
     },
   };
 };


### PR DESCRIPTION
Because:
* We need more data to help us debug why users are running into this error

This commit:
* Logs data to BQ