### PR TITLE
feat(payments-management): Add 3D Secure payment method support

### DIFF
--- a/libs/payments/management/src/lib/subscriptionManagement.error.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.error.ts
@@ -29,6 +29,13 @@ export class UpdateAccountCustomerMissingStripeId extends SubscriptionManagement
   }
 }
 
+export class SetDefaultPaymentAccountCustomerMissingStripeId extends SubscriptionManagementError {
+  constructor(uid: string) {
+    super('AccountCustomer for updating default payment method is missing a Stripe customer id', { uid });
+    this.name = 'SetDefaultPaymentAccountCustomerMissingStripeId';
+  }
+}
+
 export class SetupIntentInvalidStatusError extends SubscriptionManagementError {
   constructor(setupIntentId?: string, status?: string) {
     super('ConfirmationToken failed to create successful SetupIntent', {

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -29,3 +29,4 @@ export { getCouponAction } from './getCoupon';
 export { serverLogAction } from './serverLog';
 export { getStripeClientSession } from './getStripeClientSession';
 export { updateStripePaymentDetails } from './updateStripePaymentDetails';
+export { setDefaultStripePaymentDetails } from './setDefaultStripePaymentDetails';

--- a/libs/payments/ui/src/lib/actions/setDefaultStripePaymentDetails.ts
+++ b/libs/payments/ui/src/lib/actions/setDefaultStripePaymentDetails.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const setDefaultStripePaymentDetails = async (
+  uid: string,
+  paymentMethodId: string,
+  fullName: string
+) => {
+  const actionsService = getApp().getActionsService();
+
+  return await actionsService.setDefaultStripePaymentDetails({
+    uid,
+    paymentMethodId,
+    fullName,
+  });
+};

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -95,6 +95,7 @@ import { GetStripePaymentManagementDetailsArgs } from './validators/GetStripeCli
 import { GetStripePaymentManagementDetailsResult } from './validators/GetStripePaymentManagementDetailsResult';
 import { UpdateStripePaymentDetailsArgs } from './validators/UpdateStripePaymentDetailsActionArgs';
 import { UpdateStripePaymentDetailsResult } from './validators/UpdateStripePaymentDetailsActionResult';
+import { SetDefaultStripePaymentDetailsActionArgs } from './validators/SetDefaultStripePaymentDetailsActionArgs';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -596,6 +597,21 @@ export class NextJSActionsService {
     return await this.subscriptionManagementService.updateStripePaymentDetails(
       args.uid,
       args.confirmationTokenId
+    );
+  }
+
+  @SanitizeExceptions()
+  @NextIOValidator(SetDefaultStripePaymentDetailsActionArgs, undefined)
+  @CaptureTimingWithStatsD()
+  async setDefaultStripePaymentDetails(args: {
+    uid: string;
+    paymentMethodId: string;
+    fullName: string;
+  }) {
+    return await this.subscriptionManagementService.setDefaultStripePaymentDetails(
+      args.uid,
+      args.paymentMethodId,
+      args.fullName
     );
   }
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/SetDefaultStripePaymentDetailsActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/SetDefaultStripePaymentDetailsActionArgs.ts
@@ -2,16 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsOptional, IsString } from 'class-validator';
+import { IsString } from 'class-validator';
 
-export class UpdateStripePaymentDetailsResult {
+export class SetDefaultStripePaymentDetailsActionArgs {
   @IsString()
-  id!: string;
-
-  @IsString()
-  status!: string;
+  uid!: string;
 
   @IsString()
-  @IsOptional()
-  clientSecret?: string;
+  paymentMethodId!: string;
+
+  @IsString()
+  fullName!: string;
 }


### PR DESCRIPTION
Because:

* Customers need the ability to save 3D Secure cards to their account

This commit:

* Adds in a handler for setupIntents with the 'requires_action' status
* Adds a simplified server action for updating which default payment method is used with the account
* Sets the newly-added payment method as the account's default, as with other payment methods

Closes #PAY-3174

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1677" height="1038" alt="Screenshot 2025-07-30 at 6 45 17 PM" src="https://github.com/user-attachments/assets/02e2260b-f9a9-44ae-998a-cbd974d950fe" />
<img width="426" height="928" alt="Screenshot 2025-07-30 at 6 45 40 PM" src="https://github.com/user-attachments/assets/f5c21de7-d7e9-4273-8720-863aa9989137" />

