### PR TITLE
feat(cms): Fix cms playwright tests for stage, fix entrypoint regex, fix background styling

### DIFF
--- a/packages/functional-tests/tests/cms/cms.spec.ts
+++ b/packages/functional-tests/tests/cms/cms.spec.ts
@@ -12,413 +12,438 @@ const ENTRYPOINT_SYNC = 'firefox-cms';
 const CLIENTID_SYNC = '5882386c6d801776';
 
 test.describe('severity-1 #smoke', () => {
-
-test.describe('CMS customization', () => {
-  async function assertCmsCustomization(
-    page: Page,
-    {
-      headline,
-      description,
-      logoUrl,
-      logoAlt = '123Done logo',
-      buttonColor,
-      buttonText,
-    }: {
-      headline: string;
-      description: string;
-      logoUrl?: string;
-      logoAlt?: string;
-      buttonColor: string;
-      buttonText: string;
-    }
-  ) {
-
-    await expect(page.getByRole('heading', { name: headline })).toBeVisible();
-    await expect(page.getByText(description)).toBeVisible();
-
-    if (description) {
+  test.describe('CMS customization', () => {
+    async function assertCmsCustomization(
+      page: Page,
+      {
+        headline,
+        description,
+        logoUrl,
+        logoAlt = '123Done logo',
+        buttonColor,
+        buttonText,
+      }: {
+        headline: string;
+        description: string;
+        logoUrl?: string;
+        logoAlt?: string;
+        buttonColor: string;
+        buttonText: string;
+      }
+    ) {
+      await expect(page.getByRole('heading', { name: headline })).toBeVisible();
       await expect(page.getByText(description)).toBeVisible();
-    }
 
-    if (logoUrl) {
-      const logo = page.getByRole('img', { name: logoAlt, exact: true });
-      await expect(logo).toBeVisible();
-      await expect(logo).toHaveAttribute('src', logoUrl);
-    }
+      if (description) {
+        await expect(page.getByText(description)).toBeVisible();
+      }
 
-    const button = page.getByRole('button', { name: buttonText, exact: true });
-    await expect(button).toBeVisible();
-    await expect(button).toHaveClass(/cta-primary-cms/);
-    await expect(button).toHaveClass(/cta-xl/);
-    await expect(button).toHaveClass(/cta-primary/);
-    await expect(button).toHaveCSS('--cta-bg', buttonColor);
-    await expect(button).toHaveCSS('--cta-border', buttonColor);
-    await expect(button).toHaveCSS('--cta-active', buttonColor);
-    await expect(button).toHaveCSS('--cta-disabled', `${buttonColor}60`);
-  }
-  test.beforeAll(async ({ target}) => {
-    // These tests require customizations for 123Done and Sync. Please contact
-    // account developer to get access to Strapi dev instance.
-    const relierConfig = await target.authClient.getCmsConfig(CLIENTID_123Done, ENTRYPOINT_123Done);
-    const syncConfig = await target.authClient.getCmsConfig(CLIENTID_SYNC, ENTRYPOINT_SYNC);
+      if (logoUrl) {
+        const logo = page.getByRole('img', { name: logoAlt, exact: true });
+        await expect(logo).toBeVisible();
+        await expect(logo).toHaveAttribute('src', logoUrl);
+      }
 
-    // Check if configs are empty or null/undefined
-    const isConfigEmpty = (config:any ):boolean => {
-      return (
-        !config ||
-        typeof config !== 'object' ||
-        Object.keys(config).length === 0
-      );
-    };
-
-    test.skip(isConfigEmpty(relierConfig) || isConfigEmpty(syncConfig), 'CMS customization is not set up for 123Done or Sync');
-  });
-
-  test.beforeEach(async ({ pages: { configPage } }) => {
-    // Ensure that cms customization is enabled
-    const config = await configPage.getConfig();
-    test.skip(config.cms.enabled !== true, 'CMS customization is not enabled');
-  });
-
-  test.describe('Relying Party customization', () => {
-    test('default experience with invalid entrypoint', async ({
-      target,
-      page,
-      pages: { relier },
-      testAccountTracker,
-    }) => {
-      await testAccountTracker.generateAccountDetails();
-
-      await relier.goto('entrypoint=invalid');
-      await relier.clickEmailFirst();
-
-      await expect(
-        page.getByRole('heading', { name: 'Enter your email' })
-      ).toBeVisible();
-      await expect(page.getByText(/Continue to .*123Done/)).toBeVisible();
       const button = page.getByRole('button', {
-        name: 'Sign up or sign in',
+        name: buttonText,
         exact: true,
       });
-      await expect(button).not.toHaveClass(/cta-primary-cms/);
+      await expect(button).toBeVisible();
+      await expect(button).toHaveClass(/cta-primary-cms/);
+      await expect(button).toHaveClass(/cta-xl/);
+      await expect(button).toHaveClass(/cta-primary/);
+      await expect(button).toHaveCSS('--cta-bg', buttonColor);
+      await expect(button).toHaveCSS('--cta-border', buttonColor);
+      await expect(button).toHaveCSS('--cta-active', buttonColor);
+      await expect(button).toHaveCSS('--cta-disabled', `${buttonColor}60`);
+    }
 
-      // Assert no logo is shown
-      const logo = page.getByRole('img', { name: '123Done logo' });
-      await expect(logo).not.toBeVisible();
-    });
-
-    test('signup', async ({
-      target,
-      page,
-      pages: { signin, relier },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.generateAccountDetails();
-
-      // Navigate to the CMS entrypoint
-      await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
-      await relier.clickEmailFirst();
-
-      await assertCmsCustomization(page, {
-        headline: 'Make Space for What Matters',
-        description:
-          'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Create My List',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Create My List',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Create Your Password',
-        description:
-          'Keep your account private and secure. Set a password for your Mozilla account and get started with 123Done.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Continue',
-      });
-      await signin.passwordTextbox.fill(credentials.password);
-      submitButton = page.getByRole('button', {
-        name: 'Continue',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Almost There',
-        description:
-          'Just one quick step. Enter the code from your email to activate your Mozilla account and unlock 123Done.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Finish Setup',
-      });
-      const code = await target.emailClient.getVerifyShortCode(
-        credentials.email
+    test.beforeAll(async ({ target }) => {
+      // These tests require customizations for 123Done and Sync. Please contact
+      // account developer to get access to Strapi dev instance.
+      const relierConfig = await target.authClient.getCmsConfig(
+        CLIENTID_123Done,
+        ENTRYPOINT_123Done
       );
-      await page.getByLabel('Enter 6-digit code').fill(code);
-      submitButton = page.getByRole('button', {
-        name: 'Finish Setup',
-        exact: true,
-      });
-      await submitButton.click();
-
-      // Verify successful login
-      expect(await relier.isLoggedIn()).toBe(true);
-    });
-
-    test('signin', async ({
-      target,
-      page,
-      pages: { signin, relier },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-
-      // Navigate to the CMS entrypoint
-      await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
-      await relier.clickEmailFirst();
-
-      await assertCmsCustomization(page, {
-        headline: 'Make Space for What Matters',
-        description:
-          'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Create My List',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Create My List',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter your password',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
-        buttonColor: '#4845D2',
-        buttonText: 'Sign in',
-      });
-      await signin.passwordTextbox.fill(credentials.password);
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
-
-      // Verify successful login
-      expect(await relier.isLoggedIn()).toBe(true);
-    });
-
-    test('signup with Sync', async ({
-      target,
-      syncOAuthBrowserPages: { page, signup },
-      testAccountTracker,
-    }) => {
-      const credentials = testAccountTracker.generateAccountDetails();
-
-      syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-      await signup.goto('/authorization', syncDesktopOAuthQueryParams);
-
-      await assertCmsCustomization(page, {
-        headline: 'Continue to your Mozilla account',
-        description:
-          'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign up or sign in',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Sign up or sign in',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Create a password',
-        description:
-          'Sync your passwords, payment methods, bookmarks, and more everywhere you use Firefox.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Create account',
-      });
-      await page
-        .getByTestId('new-password-input-field')
-        .fill(credentials.password);
-      await page
-        .getByTestId('verify-password-input-field')
-        .fill(credentials.password);
-      submitButton = page.getByRole('button', {
-        name: 'Create account',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter confirmation code',
-        description:
-          'Just one quick step. Enter the code from your email to activate your Mozilla account.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Start syncing',
-      });
-      const code = await target.emailClient.getVerifyShortCode(
-        credentials.email
+      const syncConfig = await target.authClient.getCmsConfig(
+        CLIENTID_SYNC,
+        ENTRYPOINT_SYNC
       );
-      await page.getByLabel('Enter 6-digit code').fill(code);
-      submitButton = page.getByRole('button', {
-        name: 'Start syncing',
-        exact: true,
-      });
-      await submitButton.click();
 
-      await assertCmsCustomization(page, {
-        headline: 'Sync is turned on',
-        description:
-          'Your passwords, payment methods, addresses, bookmarks, history, and more can sync everywhere you use Firefox.',
-        buttonColor: '#FF630B',
-        buttonText: 'Add another device',
-      });
-    });
+      // Check if configs are empty or null/undefined
+      const isConfigEmpty = (config: any): boolean => {
+        return (
+          !config ||
+          typeof config !== 'object' ||
+          Object.keys(config).length === 0
+        );
+      };
 
-    test('signin with Sync', async ({
-      syncOAuthBrowserPages: { page, signin },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-
-      // Navigate to the CMS entrypoint
-      syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-
-      await assertCmsCustomization(page, {
-        headline: 'Continue to your Mozilla account',
-        description:
-          'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign up or sign in',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Sign up or sign in',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter your password',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign in',
-      });
-      await page.getByTestId('input-field').fill(credentials.password);
-
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
-
-      await page.getByRole('link', { name: 'Not now', exact: true }).click();
-    });
-
-    test('signin login confirmation with Sync', async ({
-      target,
-      syncOAuthBrowserPages: { page, signin, relier },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUpSync();
-
-      // Navigate to the CMS entrypoint
-      syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
-      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
-
-      await assertCmsCustomization(page, {
-        headline: 'Continue to your Mozilla account',
-        description:
-          'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign up or sign in',
-      });
-
-      await page
-        .getByRole('textbox', { name: 'Email' })
-        .fill(credentials.email);
-      let submitButton = page.getByRole('button', {
-        name: 'Sign up or sign in',
-        exact: true,
-      });
-      await submitButton.click();
-
-      await page.waitForURL(/signin/);
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter your password',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Sign in',
-      });
-      await page.getByTestId('input-field').fill(credentials.password);
-
-      submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
-      await submitButton.click();
-
-      await page.waitForURL(/signin_token_code/);
-
-      await assertCmsCustomization(page, {
-        headline: 'Enter confirmation code',
-        description: 'for your Mozilla account',
-        logoUrl:
-          'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
-        logoAlt: 'Firefox logo',
-        buttonColor: '#FF630B',
-        buttonText: 'Confirm',
-      });
-      const code = await target.emailClient.getVerifyLoginCode(
-        credentials.email
+      test.skip(
+        isConfigEmpty(relierConfig) || isConfigEmpty(syncConfig),
+        'CMS customization is not set up for 123Done or Sync'
       );
-      await page.getByLabel('Enter 6-digit code').fill(code);
-      submitButton = page.getByRole('button', { name: 'Confirm', exact: true });
-      await submitButton.click();
+    });
 
-      await page.getByRole('link', { name: 'Not now', exact: true }).click();
+    test.beforeEach(async ({ pages: { configPage } }) => {
+      // Ensure that cms customization is enabled
+      const config = await configPage.getConfig();
+      test.skip(
+        config.cms.enabled !== true,
+        'CMS customization is not enabled'
+      );
+    });
+
+    test.describe('Relying Party customization', () => {
+      test('default experience with invalid entrypoint', async ({
+        target,
+        page,
+        pages: { relier },
+        testAccountTracker,
+      }) => {
+        await testAccountTracker.generateAccountDetails();
+
+        await relier.goto('entrypoint=invalid');
+        await relier.clickEmailFirst();
+
+        await expect(
+          page.getByRole('heading', { name: 'Enter your email' })
+        ).toBeVisible();
+        const button = page.getByRole('button', {
+          name: 'Sign up or sign in',
+          exact: true,
+        });
+        await expect(button).not.toHaveClass(/cta-primary-cms/);
+
+        // Assert no logo is shown
+        const logo = page.getByRole('img', { name: '123Done logo' });
+        await expect(logo).not.toBeVisible();
+      });
+
+      test('signup', async ({
+        target,
+        page,
+        pages: { signin, relier },
+        testAccountTracker,
+      }) => {
+        const credentials = await testAccountTracker.generateAccountDetails();
+
+        // Navigate to the CMS entrypoint
+        await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
+        await relier.clickEmailFirst();
+
+        await assertCmsCustomization(page, {
+          headline: 'Make Space for What Matters',
+          description:
+            'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+          buttonColor: '#4845D2',
+          buttonText: 'Create My List',
+        });
+
+        await page
+          .getByRole('textbox', { name: 'Email' })
+          .fill(credentials.email);
+        let submitButton = page.getByRole('button', {
+          name: 'Create My List',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Create Your Password',
+          description:
+            'Keep your account private and secure. Set a password for your Mozilla account and get started with 123Done.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+          buttonColor: '#4845D2',
+          buttonText: 'Continue',
+        });
+        await signin.passwordTextbox.fill(credentials.password);
+        submitButton = page.getByRole('button', {
+          name: 'Continue',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Almost There',
+          description:
+            'Just one quick step. Enter the code from your email to activate your Mozilla account and unlock 123Done.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+          buttonColor: '#4845D2',
+          buttonText: 'Finish Setup',
+        });
+        const code = await target.emailClient.getVerifyShortCode(
+          credentials.email
+        );
+        await page.getByLabel('Enter 6-digit code').fill(code);
+        submitButton = page.getByRole('button', {
+          name: 'Finish Setup',
+          exact: true,
+        });
+        await submitButton.click();
+
+        // Verify successful login
+        expect(await relier.isLoggedIn()).toBe(true);
+      });
+
+      test('signin', async ({
+        target,
+        page,
+        pages: { signin, relier },
+        testAccountTracker,
+      }) => {
+        const credentials = await testAccountTracker.signUp();
+
+        // Navigate to the CMS entrypoint
+        await relier.goto(`entrypoint=${ENTRYPOINT_123Done}`);
+        await relier.clickEmailFirst();
+
+        await assertCmsCustomization(page, {
+          headline: 'Make Space for What Matters',
+          description:
+            'Start your clutter-free to-do list with 123Done. Sign up with your email to create a Mozilla account and get started today.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+          buttonColor: '#4845D2',
+          buttonText: 'Create My List',
+        });
+
+        await page
+          .getByRole('textbox', { name: 'Email' })
+          .fill(credentials.email);
+        let submitButton = page.getByRole('button', {
+          name: 'Create My List',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Enter your password',
+          description: 'for your Mozilla account',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/123Done-blue-logo.svg',
+          buttonColor: '#4845D2',
+          buttonText: 'Sign in',
+        });
+        await signin.passwordTextbox.fill(credentials.password);
+        submitButton = page.getByRole('button', {
+          name: 'Sign in',
+          exact: true,
+        });
+        await submitButton.click();
+
+        // Verify successful login
+        expect(await relier.isLoggedIn()).toBe(true);
+      });
+
+      test('signup with Sync', async ({
+        target,
+        syncOAuthBrowserPages: { page, signup },
+        testAccountTracker,
+      }) => {
+        const credentials = testAccountTracker.generateAccountDetails();
+
+        syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
+        await signup.goto('/authorization', syncDesktopOAuthQueryParams);
+
+        await assertCmsCustomization(page, {
+          headline: 'Continue to your Mozilla account',
+          description:
+            'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Sign up or sign in',
+        });
+
+        await page
+          .getByRole('textbox', { name: 'Email' })
+          .fill(credentials.email);
+        let submitButton = page.getByRole('button', {
+          name: 'Sign up or sign in',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Create a password',
+          description:
+            'Sync your passwords, payment methods, bookmarks, and more everywhere you use Firefox.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Create account',
+        });
+        await page
+          .getByTestId('new-password-input-field')
+          .fill(credentials.password);
+        await page
+          .getByTestId('verify-password-input-field')
+          .fill(credentials.password);
+        submitButton = page.getByRole('button', {
+          name: 'Create account',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Enter confirmation code',
+          description:
+            'Just one quick step. Enter the code from your email to activate your Mozilla account.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Start syncing',
+        });
+        const code = await target.emailClient.getVerifyShortCode(
+          credentials.email
+        );
+        await page.getByLabel('Enter 6-digit code').fill(code);
+        submitButton = page.getByRole('button', {
+          name: 'Start syncing',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Sync is turned on',
+          description:
+            'Your passwords, payment methods, addresses, bookmarks, history, and more can sync everywhere you use Firefox.',
+          buttonColor: '#FF630B',
+          buttonText: 'Add another device',
+        });
+      });
+
+      test('signin with Sync', async ({
+        syncOAuthBrowserPages: { page, signin },
+        testAccountTracker,
+      }) => {
+        const credentials = await testAccountTracker.signUp();
+
+        // Navigate to the CMS entrypoint
+        syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
+        await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+
+        await assertCmsCustomization(page, {
+          headline: 'Continue to your Mozilla account',
+          description:
+            'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Sign up or sign in',
+        });
+
+        await page
+          .getByRole('textbox', { name: 'Email' })
+          .fill(credentials.email);
+        let submitButton = page.getByRole('button', {
+          name: 'Sign up or sign in',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await assertCmsCustomization(page, {
+          headline: 'Enter your password',
+          description: 'for your Mozilla account',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Sign in',
+        });
+        await page.getByTestId('input-field').fill(credentials.password);
+
+        submitButton = page.getByRole('button', {
+          name: 'Sign in',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await page.getByRole('link', { name: 'Not now', exact: true }).click();
+      });
+
+      test('signin login confirmation with Sync', async ({
+        target,
+        syncOAuthBrowserPages: { page, signin, relier },
+        testAccountTracker,
+      }) => {
+        const credentials = await testAccountTracker.signUpSync();
+
+        // Navigate to the CMS entrypoint
+        syncDesktopOAuthQueryParams.set('entrypoint', ENTRYPOINT_SYNC);
+        await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+
+        await assertCmsCustomization(page, {
+          headline: 'Continue to your Mozilla account',
+          description:
+            'Sync your passwords, tabs, and bookmarks everywhere you use Firefox.',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Sign up or sign in',
+        });
+
+        await page
+          .getByRole('textbox', { name: 'Email' })
+          .fill(credentials.email);
+        let submitButton = page.getByRole('button', {
+          name: 'Sign up or sign in',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await page.waitForURL(/signin/);
+
+        await assertCmsCustomization(page, {
+          headline: 'Enter your password',
+          description: 'for your Mozilla account',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Sign in',
+        });
+        await page.getByTestId('input-field').fill(credentials.password);
+
+        submitButton = page.getByRole('button', {
+          name: 'Sign in',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await page.waitForURL(/signin_token_code/);
+
+        await assertCmsCustomization(page, {
+          headline: 'Enter confirmation code',
+          description: 'for your Mozilla account',
+          logoUrl:
+            'https://accounts-cdn.stage.mozaws.net/other/firefox-browser-logo.svg',
+          logoAlt: 'Firefox logo',
+          buttonColor: '#FF630B',
+          buttonText: 'Confirm',
+        });
+        const code = await target.emailClient.getVerifyLoginCode(
+          credentials.email
+        );
+        await page.getByLabel('Enter 6-digit code').fill(code);
+        submitButton = page.getByRole('button', {
+          name: 'Confirm',
+          exact: true,
+        });
+        await submitButton.click();
+
+        await page.getByRole('link', { name: 'Not now', exact: true }).click();
+      });
     });
   });
-});
 });

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -894,5 +894,6 @@ module.exports.thirdPartyIdToken = module.exports.jwt.optional();
 module.exports.thirdPartyOAuthCode = isA.string().optional();
 
 module.exports.entrypoint = isA.string()
-  .regex(/^[a-zA-Z0-9_-]+$/) // Only allow letters, digits, underscores, and dashes
+  .regex(/^[a-zA-Z0-9_.-]+$/) // Only allow letters, digits, underscores, dots, and dashes
+  .max(256)
   .required();

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -32,7 +32,6 @@ export const AppLayout = ({
   wrapInCard = true,
 }: AppLayoutProps) => {
   const { l10n } = useLocalization();
-
   const cmsInfo = integration?.getCmsInfo?.();
   const cmsBackgroundColor = cmsInfo?.shared?.backgroundColor;
   const cmsPageTitle = cmsInfo?.shared?.pageTitle;

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -162,6 +162,7 @@ export const InlineRecoverySetupContainer = ({
         verifyTotpHandler,
         successfulSetupHandler,
         email: signinRecoveryLocationState.email,
+        integration,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -37,6 +37,7 @@ const InlineRecoverySetup = ({
   verifyTotpHandler,
   successfulSetupHandler,
   email,
+  integration,
 }: InlineRecoverySetupProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const navigateWithQuery = useNavigateWithQuery();
@@ -195,7 +196,7 @@ const InlineRecoverySetup = ({
   }, [showConfirmation]);
 
   return (
-    <AppLayout>
+    <AppLayout integration={integration}>
       {showConfirmation ? (
         <>
           <CardHeader

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/interfaces.ts
@@ -5,6 +5,7 @@
 import { FinishOAuthFlowHandlerResult } from '../../lib/oauth/hooks';
 import { MozServices } from '../../lib/types';
 import { SigninLocationState, TotpToken } from './../Signin/interfaces';
+import { Integration } from '../../models';
 
 export type SigninRecoveryLocationState = SigninLocationState & {
   totp: TotpToken;
@@ -18,4 +19,5 @@ export interface InlineRecoverySetupProps {
   verifyTotpHandler: () => Promise<boolean>;
   successfulSetupHandler: () => void;
   email: string;
+  integration?: Integration;
 }

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -184,10 +184,10 @@ export const InlineTotpSetupContainer = ({
     config.featureFlags?.updatedInlineTotpSetupFlow || false;
 
   return isUpdatedInlineTotpSetupFlow ? (
-    <InlineTotpSetupNew {...{ totp, serviceName, verifyCodeHandler }} />
+    <InlineTotpSetupNew {...{ totp, serviceName, verifyCodeHandler, integration }} />
   ) : (
     <InlineTotpSetupOld
-      {...{ totp, serviceName, cancelSetupHandler, verifyCodeHandler }}
+      {...{ totp, serviceName, cancelSetupHandler, verifyCodeHandler, integration }}
     />
   );
 };

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -16,6 +16,7 @@ export const InlineTotpSetup = ({
   totp,
   serviceName,
   verifyCodeHandler,
+  integration,
 }: InlineTotpSetupProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const [currentStep, setCurrentStep] = useState<number>(0);
@@ -41,7 +42,7 @@ export const InlineTotpSetup = ({
   );
 
   return (
-    <AppLayout wrapInCard={false}>
+    <AppLayout wrapInCard={false} integration={integration}>
       {currentStep === 0 && (
         <FlowSetup2faPrompt
           onContinue={() => setCurrentStep(currentStep + 1)}

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/interfaces.ts
@@ -4,11 +4,13 @@
 
 import { MozServices } from '../../lib/types';
 import { TotpToken } from '../Signin/interfaces';
+import { Integration } from '../../models';
 
 export interface InlineTotpSetupProps {
   totp: TotpToken;
   serviceName: MozServices;
   verifyCodeHandler: (code: string) => void;
+  integration?: Integration;
 }
 
 export interface InlineTotpSetupPropsOld {
@@ -16,4 +18,5 @@ export interface InlineTotpSetupPropsOld {
   serviceName?: MozServices;
   cancelSetupHandler: () => void;
   verifyCodeHandler: (code: string) => void;
+  integration?: Integration;
 }

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
@@ -23,6 +23,7 @@ export const InlineTotpSetupOld = ({
   serviceName,
   cancelSetupHandler,
   verifyCodeHandler,
+  integration,
 }: InlineTotpSetupProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedQRCodeAltText = ftlMsgResolver.getMsg(
@@ -72,7 +73,7 @@ export const InlineTotpSetupOld = ({
   };
 
   return (
-    <AppLayout>
+    <AppLayout integration={integration}>
       {showIntro && (
         <>
           <CardHeader

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -166,6 +166,7 @@ const SetPasswordContainer = ({
         email,
         createPasswordHandler,
         offeredSyncEngineConfigs,
+        integration,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
@@ -17,6 +17,7 @@ export const SetPassword = ({
   email,
   createPasswordHandler,
   offeredSyncEngineConfigs,
+  integration,
 }: SetPasswordProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const [createPasswordLoading, setCreatePasswordLoading] =
@@ -56,7 +57,7 @@ export const SetPassword = ({
     });
 
   return (
-    <AppLayout>
+    <AppLayout integration={integration}>
       <FtlMsg id="set-password-heading-v2">
         <h1 className="card-header">Create password to sync</h1>
       </FtlMsg>

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/interfaces.ts
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/interfaces.ts
@@ -4,6 +4,7 @@
 
 import { syncEngineConfigs } from '../../../lib/sync-engines';
 import { HandledError } from '../../../lib/error-utils';
+import { Integration } from '../../../models';
 
 export interface SetPasswordFormData {
   email: string;
@@ -23,4 +24,5 @@ export interface SetPasswordProps {
   email: string;
   createPasswordHandler: CreatePasswordHandler;
   offeredSyncEngineConfigs?: typeof syncEngineConfigs;
+  integration?: Integration;
 }

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -208,7 +208,7 @@ const SigninTokenCode = ({
   const cmsInfo = integration?.getCmsInfo();
 
   return (
-    <AppLayout>
+    <AppLayout integration={integration}>
 
       <CardHeader
         headingText="Enter confirmation code"

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -102,6 +102,7 @@ export const MOCK_CMS_INFO = {
     logoUrl:
       'https://gist.githubusercontent.com/vbudhram/c53b07efd1656acfff7d2c7e9d6825fe/raw/030df98ee27f609333606d36c7bf3af45af53f39/123Done_red.svg',
     logoAltText: 'logo',
+    backgroundColor: 'linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%)',
   },
   EmailFirstPage: {
     headline: 'Sign up or sign in to your Mozilla account',


### PR DESCRIPTION
## Because

- Playwright cms tests were broken in stage
- RPs also use "." in entrypoint names
- Some components dont get customized styles

## This pull request

- Fixes cms tests
- Allows "." in entrypoint for enabling cms, Monitor uses these

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We will also need to add some Strapi validation on inputs. While we shouldnt change the values for the CI RPs, it is possible to copy paste strings (ex Figma), and they would contain special uicode characters. The correct fix is to add validation to all inputs to not allow this.
