### PR TITLE
feat(cms): Refactor AppLayout, fix customizations in inline flows

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -553,7 +553,7 @@ const AuthAndAccountSetupRoutes = ({
           path="/signin_unblock/*"
           {...{ integration, flowQueryParams }}
         />
-        <InlineRecoveryKeySetupContainer path="/inline_recovery_key_setup/*" />
+        <InlineRecoveryKeySetupContainer path="/inline_recovery_key_setup/*" cmsInfo={integration.getCmsInfo()} />
 
         {/* Signup */}
         <CannotCreateAccount path="/cannot_create_account/*" />

--- a/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
@@ -7,6 +7,7 @@ import AppLayout from './index';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { RelierCmsInfo } from '../../models/integrations';
+import { MOCK_CMS_INFO } from '../../pages/mocks';
 
 export default {
   title: 'Components/AppLayout',
@@ -48,123 +49,92 @@ export const WithWidthClass = () => (
 );
 
 export const WithIntegration = () => {
-  const mockIntegration = {
-    getCmsInfo: () =>
-      ({
-        name: 'Test App',
-        clientId: 'test123',
-        entrypoint: 'test',
-        shared: {
-          buttonColor: '#0078d4',
-          logoUrl: 'https://example.com/logo.png',
-          logoAltText: 'Test App Logo',
-          backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-          pageTitle: 'Test App - Custom Title',
-        },
-      }) as RelierCmsInfo,
-  };
-
   return (
-    <AppLayout integration={mockIntegration}>
+    <AppLayout cmsInfo={MOCK_CMS_INFO}>
       <h1 className="card-header">Header content</h1>
       <p className="mt-2">Paragraph content here</p>
     </AppLayout>
   );
 };
 
-export const WithIntegrationNoBackground = () => {
-  const mockIntegration = {
-    getCmsInfo: () =>
-      ({
-        name: 'Test App',
-        clientId: 'test123',
-        entrypoint: 'test',
-        shared: {
-          buttonColor: '#0078d4',
-          logoUrl: 'https://example.com/logo.png',
-          logoAltText: 'Test App Logo',
-          pageTitle: 'Test App - Custom Title',
-          // No backgroundColor, so no background image should be applied
-        },
-      }) as RelierCmsInfo,
-  };
+export const WithCmsInfoNoBackground = () => {
+  const mockCmsInfo = {
+    name: 'Test App',
+    clientId: 'test123',
+    entrypoint: 'test',
+    shared: {
+      buttonColor: '#0078d4',
+      logoUrl: 'https://example.com/logo.png',
+      logoAltText: 'Test App Logo',
+      pageTitle: 'Test App - Custom Title',
+      // No backgroundColor, so no background image should be applied
+    },
+  } as RelierCmsInfo;
 
   return (
-    <AppLayout integration={mockIntegration}>
+    <AppLayout cmsInfo={mockCmsInfo}>
       <h1 className="card-header">Header content</h1>
       <p className="mt-2">Paragraph content here</p>
     </AppLayout>
   );
 };
 
-export const WithIntegrationInvalidBackground = () => {
-  const mockIntegration = {
-    getCmsInfo: () =>
-      ({
-        name: 'Test App',
-        clientId: 'test123',
-        entrypoint: 'test',
-        shared: {
-          buttonColor: '#0078d4',
-          logoUrl: 'https://example.com/logo.png',
-          logoAltText: 'Test App Logo',
-          backgroundColor: 'invalid-color',
-          pageTitle: 'Test App - Custom Title',
-        },
-      }) as RelierCmsInfo,
-  };
+export const WithCmsInfoInvalidBackground = () => {
+  const mockCmsInfo = {
+    name: 'Test App',
+    clientId: 'test123',
+    entrypoint: 'test',
+    shared: {
+      buttonColor: '#0078d4',
+      logoUrl: 'https://example.com/logo.png',
+      logoAltText: 'Test App Logo',
+      backgroundColor: 'invalid-color',
+      pageTitle: 'Test App - Custom Title',
+    },
+  } as RelierCmsInfo;
 
   return (
-    <AppLayout integration={mockIntegration}>
+    <AppLayout cmsInfo={mockCmsInfo}>
       <h1 className="card-header">Header content</h1>
       <p className="mt-2">Paragraph content here</p>
     </AppLayout>
   );
 };
 
-export const WithIntegrationRadialGradient = () => {
-  const mockIntegration = {
-    getCmsInfo: () =>
-      ({
-        name: 'Test App',
-        clientId: 'test123',
-        entrypoint: 'test',
-        shared: {
-          buttonColor: '#0078d4',
-          logoUrl: 'https://example.com/logo.png',
-          logoAltText: 'Test App Logo',
-          backgroundColor: 'radial-gradient(circle, #ff6b6b, #4ecdc4)',
-          pageTitle: 'Test App - Custom Title',
-        },
-      }) as RelierCmsInfo,
-  };
+export const WithCmsInfoRadialGradient = () => {
+  const mockCmsInfo = {
+    name: 'Test App',
+    clientId: 'test123',
+    entrypoint: 'test',
+    shared: {
+      buttonColor: '#0078d4',
+      logoUrl: 'https://example.com/logo.png',
+      logoAltText: 'Test App Logo',
+      backgroundColor: 'radial-gradient(circle, #ff6b6b, #4ecdc4)',
+      pageTitle: 'Test App - Custom Title',
+    },
+  } as RelierCmsInfo;
 
   return (
-    <AppLayout integration={mockIntegration}>
+    <AppLayout cmsInfo={mockCmsInfo}>
       <h1 className="card-header">Header content</h1>
       <p className="mt-2">Paragraph content here</p>
     </AppLayout>
   );
 };
 
-export const WithIntegrationNoCmsInfo = () => {
-  const mockIntegration = {
-    getCmsInfo: () => undefined,
-  };
-
+export const WithCmsInfoUndefined = () => {
   return (
-    <AppLayout integration={mockIntegration}>
+    <AppLayout cmsInfo={undefined}>
       <h1 className="card-header">Header content</h1>
       <p className="mt-2">Paragraph content here</p>
     </AppLayout>
   );
 };
 
-export const WithIntegrationNoGetCmsInfo = () => {
-  const mockIntegration = {};
-
+export const WithoutCmsInfo = () => {
   return (
-    <AppLayout integration={mockIntegration}>
+    <AppLayout>
       <h1 className="card-header">Header content</h1>
       <p className="mt-2">Paragraph content here</p>
     </AppLayout>

--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -51,26 +51,23 @@ describe('<AppLayout />', () => {
     screen.getByText('Hello, world!');
   });
 
-  it('renders with integration prop and valid background image', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/logo.png',
-            logoAltText: 'Test App Logo',
-            backgroundColor:
-              'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-            pageTitle: 'Test App - Custom Title',
-          },
-        }) as RelierCmsInfo,
-    };
+  it('renders with cmsInfo prop and valid background image', async () => {
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/logo.png',
+        logoAltText: 'Test App Logo',
+        backgroundColor:
+          'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        pageTitle: 'Test App - Custom Title',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -85,25 +82,22 @@ describe('<AppLayout />', () => {
     });
   });
 
-  it('renders with integration prop and radial gradient background', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/logo.png',
-            logoAltText: 'Test App Logo',
-            backgroundColor: 'radial-gradient(circle, #ff6b6b, #4ecdc4)',
-            pageTitle: 'Test App - Custom Title',
-          },
-        }) as RelierCmsInfo,
-    };
+  it('renders with cmsInfo prop and radial gradient background', async () => {
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/logo.png',
+        logoAltText: 'Test App Logo',
+        backgroundColor: 'radial-gradient(circle, #ff6b6b, #4ecdc4)',
+        pageTitle: 'Test App - Custom Title',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -118,25 +112,22 @@ describe('<AppLayout />', () => {
     });
   });
 
-  it('renders with integration prop but no background image when backgroundColor is missing', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/logo.png',
-            logoAltText: 'Test App Logo',
-            pageTitle: 'Test App - Custom Title',
-            // No backgroundColor
-          },
-        }) as RelierCmsInfo,
-    };
+  it('renders with cmsInfo prop but no background image when backgroundColor is missing', async () => {
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/logo.png',
+        logoAltText: 'Test App Logo',
+        pageTitle: 'Test App - Custom Title',
+        // No backgroundColor
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -149,25 +140,22 @@ describe('<AppLayout />', () => {
     expect(appElement).not.toHaveStyle({ '--cms-bg': expect.any(String) });
   });
 
-  it('renders with integration prop but no background image when backgroundColor is invalid', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/logo.png',
-            logoAltText: 'Test App Logo',
-            backgroundColor: 'solid-color-red', // Not a valid background-image value
-            pageTitle: 'Test App - Custom Title',
-          },
-        }) as RelierCmsInfo,
-    };
+  it('renders with cmsInfo prop but no background image when backgroundColor is invalid', async () => {
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/logo.png',
+        logoAltText: 'Test App Logo',
+        backgroundColor: 'solid-color-red', // Not a valid background-image value
+        pageTitle: 'Test App - Custom Title',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -180,13 +168,9 @@ describe('<AppLayout />', () => {
     expect(appElement).not.toHaveStyle({ '--cms-bg': expect.any(String) });
   });
 
-  it('renders with integration prop but no background image when getCmsInfo returns undefined', async () => {
-    const mockIntegration = {
-      getCmsInfo: () => undefined,
-    };
-
+  it('renders with cmsInfo prop but no background image when cmsInfo is undefined', async () => {
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={undefined}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -199,11 +183,9 @@ describe('<AppLayout />', () => {
     expect(appElement).not.toHaveStyle({ '--cms-bg': expect.any(String) });
   });
 
-  it('renders with integration prop but no background image when getCmsInfo is missing', async () => {
-    const mockIntegration = {};
-
+  it('renders with cmsInfo prop but no background image when cmsInfo is missing', async () => {
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -216,24 +198,21 @@ describe('<AppLayout />', () => {
     expect(appElement).not.toHaveStyle({ '--cms-bg': expect.any(String) });
   });
 
-  it('renders with integration prop and uses CMS page title when available', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/logo.png',
-            logoAltText: 'Test App Logo',
-            pageTitle: 'CMS Custom Title',
-          },
-        }) as RelierCmsInfo,
-    };
+  it('renders with cmsInfo prop and uses CMS page title when available', async () => {
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/logo.png',
+        logoAltText: 'Test App Logo',
+        pageTitle: 'CMS Custom Title',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration} title="Default Title">
+      <AppLayout cmsInfo={mockCmsInfo} title="Default Title">
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -242,24 +221,21 @@ describe('<AppLayout />', () => {
     screen.getByText('Hello, world!');
   });
 
-  it('renders with integration prop and falls back to default title when CMS page title is not available', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/logo.png',
-            logoAltText: 'Test App Logo',
-            // No pageTitle
-          },
-        }) as RelierCmsInfo,
-    };
+  it('renders with cmsInfo prop and falls back to default title when CMS page title is not available', async () => {
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/logo.png',
+        logoAltText: 'Test App Logo',
+        // No pageTitle
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration} title="Default Title">
+      <AppLayout cmsInfo={mockCmsInfo} title="Default Title">
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -269,21 +245,18 @@ describe('<AppLayout />', () => {
   });
 
   it('renders CMS header logo when headerLogoUrl is provided', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            headerLogoUrl: 'https://example.com/cms-logo.png',
-            headerLogoAltText: 'CMS Custom Logo',
-          },
-        }) as RelierCmsInfo,
-    };
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        headerLogoUrl: 'https://example.com/cms-logo.png',
+        headerLogoAltText: 'CMS Custom Logo',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -295,21 +268,18 @@ describe('<AppLayout />', () => {
   });
 
   it('renders CMS header logo with default alt text when headerLogoAltText is not provided', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            headerLogoUrl: 'https://example.com/cms-logo.png',
-            // No headerLogoAltText
-          },
-        }) as RelierCmsInfo,
-    };
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        headerLogoUrl: 'https://example.com/cms-logo.png',
+        // No headerLogoAltText
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -320,21 +290,18 @@ describe('<AppLayout />', () => {
   });
 
   it('renders default Mozilla logo when headerLogoUrl is not provided', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            // No headerLogoUrl
-            buttonColor: '#0078d4',
-          },
-        }) as RelierCmsInfo,
-    };
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        // No headerLogoUrl
+        buttonColor: '#0078d4',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -345,7 +312,7 @@ describe('<AppLayout />', () => {
     expect(defaultLogo).toHaveAttribute('src');
   });
 
-  it('renders default Mozilla logo when integration is not provided', async () => {
+  it('renders default Mozilla logo when cmsInfo is not provided', async () => {
     renderWithLocalizationProvider(
       <AppLayout>
         <p>Hello, world!</p>
@@ -357,13 +324,9 @@ describe('<AppLayout />', () => {
     expect(defaultLogo).toHaveAttribute('src');
   });
 
-  it('renders default Mozilla logo when getCmsInfo returns undefined', async () => {
-    const mockIntegration = {
-      getCmsInfo: () => undefined,
-    };
-
+  it('renders default Mozilla logo when cmsInfo is undefined', async () => {
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={undefined}>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -373,11 +336,9 @@ describe('<AppLayout />', () => {
     expect(defaultLogo).toHaveAttribute('src');
   });
 
-  it('renders default Mozilla logo when getCmsInfo is missing', async () => {
-    const mockIntegration = {};
-
+  it('renders default Mozilla logo when cmsInfo is missing', async () => {
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout>
         <p>Hello, world!</p>
       </AppLayout>
     );
@@ -388,26 +349,23 @@ describe('<AppLayout />', () => {
   });
 
   it('renders CMS header logo when both headerLogoUrl and other CMS properties are provided', async () => {
-    const mockIntegration = {
-      getCmsInfo: () =>
-        ({
-          name: 'Test App',
-          clientId: 'test123',
-          entrypoint: 'test',
-          shared: {
-            headerLogoUrl: 'https://example.com/cms-logo.png',
-            headerLogoAltText: 'CMS Custom Logo',
-            buttonColor: '#0078d4',
-            logoUrl: 'https://example.com/other-logo.png',
-            logoAltText: 'Other Logo',
-            backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-            pageTitle: 'Test App - Custom Title',
-          },
-        }) as RelierCmsInfo,
-    };
+    const mockCmsInfo = {
+      name: 'Test App',
+      clientId: 'test123',
+      entrypoint: 'test',
+      shared: {
+        headerLogoUrl: 'https://example.com/cms-logo.png',
+        headerLogoAltText: 'CMS Custom Logo',
+        buttonColor: '#0078d4',
+        logoUrl: 'https://example.com/other-logo.png',
+        logoAltText: 'Other Logo',
+        backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        pageTitle: 'Test App - Custom Title',
+      },
+    } as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <AppLayout integration={mockIntegration}>
+      <AppLayout cmsInfo={mockCmsInfo}>
         <p>Hello, world!</p>
       </AppLayout>
     );

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -16,7 +16,7 @@ type AppLayoutProps = {
   title?: string;
   children: React.ReactNode;
   widthClass?: string;
-  integration?: { getCmsInfo?: () => RelierCmsInfo | undefined };
+  cmsInfo?: RelierCmsInfo;
   /** Whether the content is wrapped in a card.
    * Set to `false` for content that already provides a card, like
    * `FlowContainer`.
@@ -28,11 +28,10 @@ export const AppLayout = ({
   title,
   children,
   widthClass,
-  integration,
+  cmsInfo,
   wrapInCard = true,
 }: AppLayoutProps) => {
   const { l10n } = useLocalization();
-  const cmsInfo = integration?.getCmsInfo?.();
   const cmsBackgroundColor = cmsInfo?.shared?.backgroundColor;
   const cmsPageTitle = cmsInfo?.shared?.pageTitle;
   const cmsHeaderLogoUrl = cmsInfo?.shared?.headerLogoUrl;

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { useAlertBar, useFtlMsgResolver } from '../../models';
+import { RelierCmsInfo, useAlertBar, useFtlMsgResolver } from '../../models';
 import { pdf } from '@react-pdf/renderer';
 import { saveAs } from 'file-saver';
 import { RecoveryKeyPDF } from '../ButtonDownloadRecoveryKeyPDF/RecoveryKeyPDF';
@@ -15,6 +15,7 @@ import {
 import { logViewEvent } from '../../lib/metrics';
 import { FontData, getRequiredFont } from './requiredFont';
 import { determineLocale } from '@fxa/shared/l10n';
+import CmsButtonWithFallback from '../CmsButtonWithFallback';
 
 export interface LocalizedRecoveryKeyPdfContent {
   heading: string;
@@ -34,6 +35,7 @@ interface ButtonDownloadRecoveryKeyPDFProps {
   recoveryKeyValue: string;
   viewName: string;
   email: string;
+  cmsInfo?: RelierCmsInfo;
 }
 
 export const getFilename = (email: string) => {
@@ -51,6 +53,7 @@ export const ButtonDownloadRecoveryKeyPDF = ({
   recoveryKeyValue,
   viewName,
   email,
+  cmsInfo,
 }: ButtonDownloadRecoveryKeyPDFProps) => {
   const keyCreated = Date.now();
   const currentLanguage = determineLocale(
@@ -144,16 +147,17 @@ export const ButtonDownloadRecoveryKeyPDF = ({
   return (
     <>
       <FtlMsg id="recovery-key-download-button-v3">
-        <button
+        <CmsButtonWithFallback
           className="cta-primary cta-xl w-full mt-4"
           onClick={async () => {
             logViewEvent(`flow.${viewName}`, `recovery-key.download-option`);
             await downloadFile();
             navigateForward && navigateForward();
           }}
+          buttonColor={cmsInfo?.shared?.buttonColor}
         >
           Download and continue
-        </button>
+        </CmsButtonWithFallback>
       </FtlMsg>
     </>
   );

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
@@ -7,15 +7,18 @@ import { RecoveryKeyImage } from '../images';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { CreateRecoveryKeyHandler } from '../../pages/InlineRecoveryKeySetup/interfaces';
 import Banner from '../Banner';
-import { useFtlMsgResolver } from '../../models';
+import { RelierCmsInfo, useFtlMsgResolver } from '../../models';
 import { HeadingPrimary } from '../HeadingPrimary';
+import CmsButtonWithFallback from '../CmsButtonWithFallback';
 
 export const InlineRecoveryKeySetupCreate = ({
   createRecoveryKeyHandler,
   doLaterHandler,
+  cmsInfo
 }: {
   createRecoveryKeyHandler: () => Promise<CreateRecoveryKeyHandler>;
   doLaterHandler: () => void;
+  cmsInfo?: RelierCmsInfo
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [localizedErrorBannerMessage, setLocalizedErrorBannerMessage] =
@@ -71,17 +74,18 @@ export const InlineRecoveryKeySetupCreate = ({
       </p>
 
       <div className="flex mb-7">
-        <button
+        <CmsButtonWithFallback
           className="flex justify-center items-center cta-primary cta-xl"
           type="submit"
           onClick={createRecoveryKey}
           disabled={isLoading}
           data-glean-id="inline_recovery_key_cta_submit"
+          buttonColor={cmsInfo?.shared?.buttonColor}
         >
           <FtlMsg id="inline-recovery-key-setup-start-button">
             Create account recovery key
           </FtlMsg>
-        </button>
+        </CmsButtonWithFallback>
       </div>
 
       <button

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.tsx
@@ -13,12 +13,14 @@ import { FtlMsg } from 'fxa-react/lib/utils';
 import { logViewEvent } from '../../lib/metrics';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import DataBlockInline from '../DataBlockInline';
+import { RelierCmsInfo } from '../../models';
 
 interface RecoveryKeySetupDownloadProps {
   navigateForward: () => void;
   recoveryKeyValue: string;
   viewName: string;
   email: string;
+  cmsInfo?: RelierCmsInfo;
 }
 
 const spinner = (
@@ -34,6 +36,7 @@ export const InlineRecoveryKeySetupDownload = ({
   email,
   navigateForward,
   viewName,
+  cmsInfo,
 }: RecoveryKeySetupDownloadProps) => {
   return (
     <>
@@ -80,7 +83,7 @@ export const InlineRecoveryKeySetupDownload = ({
 
       <Suspense fallback={spinner}>
         <ButtonDownloadRecoveryKeyPDF
-          {...{ navigateForward, recoveryKeyValue, viewName, email }}
+          {...{ navigateForward, recoveryKeyValue, viewName, email, cmsInfo }}
         />
       </Suspense>
 

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
@@ -6,18 +6,20 @@ import React, { useEffect, useState } from 'react';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { Control, useForm, useWatch } from 'react-hook-form';
 import InputText from '../InputText';
-import { useFtlMsgResolver } from '../../models';
+import { RelierCmsInfo, useFtlMsgResolver } from '../../models';
 import { logViewEvent } from '../../lib/metrics';
 import { LightbulbImage } from '../images';
 import { DISPLAY_SAFE_UNICODE } from '../../constants';
 import classNames from 'classnames';
 import { getLocalizedErrorMessage } from '../../lib/error-utils';
 import Banner from '../Banner';
+import CmsButtonWithFallback from '../CmsButtonWithFallback';
 
 export type RecoveryKeySetupHintProps = {
   updateRecoveryKeyHint: (hint: string) => Promise<void>;
   navigateForward: () => void;
   viewName: string;
+  cmsInfo?: RelierCmsInfo;
 };
 
 type FormData = { hint: string };
@@ -28,6 +30,7 @@ export const RecoveryKeySetupHint = ({
   updateRecoveryKeyHint,
   navigateForward,
   viewName,
+  cmsInfo,
 }: RecoveryKeySetupHintProps) => {
   const [localizedErrorMessage, setLocalizedErrorMessage] = useState<string>();
   const [hintError, setHintError] = useState<string>();
@@ -153,13 +156,14 @@ export const RecoveryKeySetupHint = ({
           />
         </FtlMsg>
         <FtlMsg id="flow-recovery-key-hint-cta-text">
-          <button
+          <CmsButtonWithFallback
             className="cta-primary cta-xl w-full mt-4 mb-4"
             type="submit"
             disabled={isSubmitDisabled}
+            buttonColor={cmsInfo?.shared?.buttonColor}
           >
             Finish
-          </button>
+          </CmsButtonWithFallback>
         </FtlMsg>
       </form>
     </>

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.tsx
@@ -12,7 +12,7 @@ import GleanMetrics from '../../../lib/glean';
 import { GleanClickEventType2FA, TotpInfo } from '../../../lib/types';
 import { formatSecret } from '../../../lib/utilities';
 
-import { useFtlMsgResolver } from '../../../models';
+import { RelierCmsInfo, useFtlMsgResolver } from '../../../models';
 
 import Banner from '../../Banner';
 import DataBlockInline from '../../DataBlockInline';
@@ -36,6 +36,7 @@ export type FlowSetup2faAppProps = {
   ) => void;
   reason?: GleanClickEventType2FA;
   showProgressBar?: boolean;
+  cmsInfo?: RelierCmsInfo
 };
 
 export const FlowSetup2faApp = ({
@@ -49,6 +50,7 @@ export const FlowSetup2faApp = ({
   onBackButtonClick,
   reason = GleanClickEventType2FA.setup,
   showProgressBar = true,
+  cmsInfo,
 }: FlowSetup2faAppProps) => {
   const [errorMessage, setErrorMessage] = useState('');
   const [setupMethod, setSetupMethod] =
@@ -145,6 +147,7 @@ export const FlowSetup2faApp = ({
           'Continue'
         )}
         verifyCode={handleCode}
+        cmsButton={{color: cmsInfo?.shared?.buttonColor}}
       />
     </FlowContainer>
   );

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
@@ -9,6 +9,8 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import FlowContainer from '../FlowContainer';
 import { GleanClickEventType2FA } from '../../../lib/types';
 import Banner from '../../Banner';
+import { RelierCmsInfo } from '../../../models';
+import CmsButtonWithFallback from '../../CmsButtonWithFallback';
 
 export type FlowSetup2faPromptProps = {
   localizedPageTitle: string;
@@ -17,6 +19,7 @@ export type FlowSetup2faPromptProps = {
   hideBackButton?: boolean;
   serviceName: string;
   localizedErrorMessage?: string;
+  cmsInfo?: RelierCmsInfo;
 };
 
 export const FlowSetup2faPrompt = ({
@@ -26,6 +29,7 @@ export const FlowSetup2faPrompt = ({
   onBackButtonClick,
   serviceName,
   localizedErrorMessage,
+  cmsInfo,
 }: FlowSetup2faPromptProps) => {
   return (
     <FlowContainer
@@ -84,13 +88,14 @@ export const FlowSetup2faPrompt = ({
         </p>
       </FtlMsg>
       <FtlMsg id="flow-setup-2fa-prompt-continue-button">
-        <button
+        <CmsButtonWithFallback
           type="submit"
           className="cta-primary cta-xl w-full"
           onClick={onContinue}
+          buttonColor={cmsInfo?.shared?.buttonColor}
         >
           Continue
-        </button>
+        </CmsButtonWithFallback>
       </FtlMsg>
     </FlowContainer>
   );

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -100,7 +100,7 @@ export const Index = ({
   const cmsInfo = integration.getCmsInfo();
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {cmsInfo ? (
         <>
           {cmsInfo?.shared?.logoUrl && cmsInfo?.shared?.logoAltText && (

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/container.tsx
@@ -4,6 +4,7 @@
 
 import React, { useCallback, useState } from 'react';
 import {
+  RelierCmsInfo,
   useAuthClient,
   useFtlMsgResolver,
   useSensitiveDataClient,
@@ -18,7 +19,9 @@ import { getSyncNavigate } from '../Signin/utils';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { formatRecoveryKey } from '../../lib/utilities';
 
-export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
+const InlineRecoveryKeySetupContainer = ({
+  cmsInfo,
+}: { cmsInfo?: RelierCmsInfo } & RouteComponentProps) => {
   const [currentStep, setCurrentStep] = useState<number>(1);
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>('');
   const ftlMsgResolver = useFtlMsgResolver();
@@ -140,6 +143,7 @@ export const InlineRecoveryKeySetupContainer = (_: RouteComponentProps) => {
         email,
         formattedRecoveryKey,
         navigateForward,
+        cmsInfo
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.stories.tsx
@@ -17,3 +17,7 @@ export default {
 export const StepOne = () => <Subject />;
 export const StepTwo = () => <Subject currentStep={2} />;
 export const StepThree = () => <Subject currentStep={3} />;
+
+export const StepOneWithCms = () => <Subject cms={true}/>;
+export const StepTwoWithCms = () => <Subject currentStep={2} cms={true}/>;
+export const StepThreeWithCms = () => <Subject currentStep={3} cms={true}/>;

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/index.tsx
@@ -25,6 +25,7 @@ export const InlineRecoveryKeySetup = ({
   email,
   formattedRecoveryKey,
   navigateForward,
+  cmsInfo,
 }: InlineRecoveryKeySetupProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const doLaterHandler = () => {
@@ -48,7 +49,7 @@ export const InlineRecoveryKeySetup = ({
               <HeadingPrimary>Security recommendation</HeadingPrimary>
             </FtlMsg>
             <RecoveryKeySetupHint
-              {...{ viewName }}
+              {...{ viewName, cmsInfo }}
               navigateForward={() => {
                 hardNavigate('/pair', {}, true);
               }}
@@ -87,7 +88,7 @@ export const InlineRecoveryKeySetup = ({
             <div className="w-full flex flex-col gap-4">
               <RecoveryKeySetupDownload
                 recoveryKeyValue={formattedRecoveryKey}
-                {...{ email, navigateForward, viewName }}
+                {...{ email, navigateForward, viewName, cmsInfo }}
               />
             </div>
           </>
@@ -95,13 +96,13 @@ export const InlineRecoveryKeySetup = ({
       default:
         return (
           <InlineRecoveryKeySetupCreate
-            {...{ createRecoveryKeyHandler, doLaterHandler }}
+            {...{ createRecoveryKeyHandler, doLaterHandler, cmsInfo }}
           />
         );
     }
   };
 
-  return <AppLayout>{renderStepComponent()}</AppLayout>;
+  return <AppLayout cmsInfo={cmsInfo}>{renderStepComponent()}</AppLayout>;
 };
 
 export default InlineRecoveryKeySetup;

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/interfaces.ts
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { RelierCmsInfo } from '../../models';
+
 export interface CreateRecoveryKeyHandler {
   localizedErrorMessage?: string;
   data?: {
@@ -16,4 +18,5 @@ export interface InlineRecoveryKeySetupProps {
   email: string;
   formattedRecoveryKey: string;
   navigateForward: () => void;
+  cmsInfo?: RelierCmsInfo;
 }

--- a/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/mocks.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoveryKeySetup/mocks.tsx
@@ -4,9 +4,9 @@
 
 import React from 'react';
 import InlineRecoveryKeySetup from '.';
-import { MOCK_EMAIL, MOCK_RECOVERY_KEY_WITH_SPACES } from '../mocks';
+import { MOCK_CMS_INFO, MOCK_EMAIL, MOCK_RECOVERY_KEY_WITH_SPACES } from '../mocks';
 
-export const Subject = ({ currentStep = 1 }: { currentStep?: number }) => (
+export const Subject = ({ currentStep = 1, cms = false }: { currentStep?: number, cms?: boolean }) => (
   <InlineRecoveryKeySetup
     {...{ currentStep }}
     createRecoveryKeyHandler={() =>
@@ -20,5 +20,6 @@ export const Subject = ({ currentStep = 1 }: { currentStep?: number }) => (
     email={MOCK_EMAIL}
     formattedRecoveryKey={MOCK_RECOVERY_KEY_WITH_SPACES}
     navigateForward={() => {}}
+    cmsInfo={cms ? MOCK_CMS_INFO : undefined}
   />
 );

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.stories.tsx
@@ -8,7 +8,7 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { InlineRecoverySetupProps } from './interfaces';
-import { MOCK_BACKUP_CODES, MOCK_EMAIL } from '../mocks';
+import { MOCK_BACKUP_CODES, MOCK_EMAIL, createMockIntegrationWithCms } from '../mocks';
 import { MozServices } from '../../lib/types';
 
 export default {
@@ -46,4 +46,15 @@ export const Default = () => (
 
 export const WithServiceName = () => (
   <ComponentWithRouter {...props} email={MOCK_EMAIL} />
+);
+
+export const WithCms = () => (
+  <ComponentWithRouter
+    recoveryCodes={MOCK_BACKUP_CODES}
+    cancelSetupHandler={cancelSetupHandler}
+    verifyTotpHandler={verifyTotpHandler}
+    successfulSetupHandler={successfulSetupHandler}
+    email={MOCK_EMAIL}
+    integration={createMockIntegrationWithCms()}
+  />
 );

--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/index.tsx
@@ -195,8 +195,10 @@ const InlineRecoverySetup = ({
       });
   }, [showConfirmation]);
 
+  const cmsInfo = integration?.getCmsInfo?.();
+
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {showConfirmation ? (
         <>
           <CardHeader

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.stories.tsx
@@ -10,6 +10,7 @@ import { MOCK_TOTP_TOKEN } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { action } from '@storybook/addon-actions';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+import { createMockIntegrationWithCms } from '../mocks';
 
 export default {
   title: 'Pages/InlineTotpSetup',
@@ -38,5 +39,14 @@ export const onError = () => (
       action('verifyCodeHandler')(code);
       return Promise.reject(AuthUiErrors.INVALID_TOTP_CODE);
     }}
+  />
+);
+
+export const WithCms = () => (
+  <InlineTotpSetup
+    totp={MOCK_TOTP_TOKEN}
+    serviceName={MozServices.Addons}
+    verifyCodeHandler={verifyCodeHandler}
+    integration={createMockIntegrationWithCms()}
   />
 );

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/index.tsx
@@ -41,13 +41,16 @@ export const InlineTotpSetup = ({
     'Two-step authentication'
   );
 
+  const cmsInfo = integration?.getCmsInfo?.();
+
   return (
-    <AppLayout wrapInCard={false} integration={integration}>
+    <AppLayout wrapInCard={false} cmsInfo={cmsInfo}>
       {currentStep === 0 && (
         <FlowSetup2faPrompt
           onContinue={() => setCurrentStep(currentStep + 1)}
           localizedPageTitle={localizedPageTitle}
           serviceName={serviceName}
+          cmsInfo={cmsInfo}
         />
       )}
       {currentStep === 1 && (
@@ -59,6 +62,7 @@ export const InlineTotpSetup = ({
           totpInfo={totp}
           verifyCode={onSubmit}
           onBackButtonClick={navigateBackward}
+          cmsInfo={cmsInfo}
         />
       )}
     </AppLayout>

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.stories.tsx
@@ -9,6 +9,7 @@ import { MozServices } from '../../lib/types';
 import { MOCK_TOTP_TOKEN } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { action } from '@storybook/addon-actions';
+import { createMockIntegrationWithCms } from '../mocks';
 
 export default {
   title: 'Pages/InlineTotpSetupOld',
@@ -36,5 +37,15 @@ export const WithCustomService = () => (
     serviceName={MozServices.Monitor}
     cancelSetupHandler={cancelSetupHandler}
     verifyCodeHandler={verifyCodeHandler}
+  />
+);
+
+export const WithCms = () => (
+  <InlineTotpSetupOld
+    totp={MOCK_TOTP_TOKEN}
+    serviceName={MozServices.Monitor}
+    cancelSetupHandler={cancelSetupHandler}
+    verifyCodeHandler={verifyCodeHandler}
+    integration={createMockIntegrationWithCms()}
   />
 );

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
@@ -72,8 +72,10 @@ export const InlineTotpSetupOld = ({
     }
   };
 
+  const cmsInfo = integration?.getCmsInfo?.();
+
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {showIntro && (
         <>
           <CardHeader

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.stories.tsx
@@ -8,6 +8,7 @@ import SetPassword from '.';
 import { Meta } from '@storybook/react';
 import { SetPasswordProps } from './interfaces';
 import { Subject } from './mocks';
+import { createMockIntegrationWithCms } from '../../mocks';
 
 export default {
   title: 'Pages/PostVerify/SetPassword',
@@ -23,3 +24,7 @@ const storyWithProps = ({
 };
 
 export const Default = storyWithProps();
+
+export const WithCms = storyWithProps({
+  integration: createMockIntegrationWithCms(),
+});

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/index.tsx
@@ -56,8 +56,10 @@ export const SetPassword = ({
       },
     });
 
+  const cmsInfo = integration?.getCmsInfo?.();
+
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       <FtlMsg id="set-password-heading-v2">
         <h1 className="card-header">Create password to sync</h1>
       </FtlMsg>

--- a/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninConfirmed/index.tsx
@@ -23,10 +23,14 @@ const SigninConfirmed = ({
   isSignedIn,
   serviceName,
   integration
-}: SigninConfirmedProps & RouteComponentProps) => (
-  <AppLayout integration={integration}>
-    <Ready {...{ continueHandler, isSignedIn, viewName, serviceName, integration }} />
-  </AppLayout>
-);
+}: SigninConfirmedProps & RouteComponentProps) => {
+  const cmsInfo = integration?.getCmsInfo?.();
+
+  return (
+    <AppLayout cmsInfo={cmsInfo}>
+      <Ready {...{ continueHandler, isSignedIn, viewName, serviceName, integration }} />
+    </AppLayout>
+  );
+};
 
 export default SigninConfirmed;

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -140,7 +140,7 @@ const SigninRecoveryChoice = ({
   }
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       <div className="relative flex items-center mb-5">
         <ButtonBack />
         {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -210,7 +210,7 @@ const SigninRecoveryCode = ({
   const cmsInfo = integration.getCmsInfo();
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       <div className="relative flex items-center mb-5">
         <ButtonBack />
         {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -161,7 +161,7 @@ const SigninRecoveryPhone = ({
   const cmsInfo = integration?.getCmsInfo();
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
 
       <div className="relative flex items-center">
         <ButtonBack />

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -208,7 +208,7 @@ const SigninTokenCode = ({
   const cmsInfo = integration?.getCmsInfo();
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
 
       <CardHeader
         headingText="Enter confirmation code"

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -120,7 +120,7 @@ export const SigninTotpCode = ({
 
   const cmsInfo = integration.getCmsInfo();
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {cmsInfo ? (
         <>
           {cmsInfo.shared?.logoUrl && cmsInfo.shared?.logoAltText && (

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -206,7 +206,7 @@ export const SigninUnblock = ({
   const cmsInfo = integration.getCmsInfo();
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       <CardHeader
         headingText="Authorize this sign-in"
         headingTextFtlId="signin-unblock-header"

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -373,7 +373,7 @@ const Signin = ({
   const cmsInfo = integration.getCmsInfo();
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {(localizedSuccessBannerHeading || localizedSuccessBannerDescription) && (
         <Banner
           type="success"

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
@@ -6,10 +6,11 @@ import React from 'react';
 import ConfirmSignupCode from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { createMockOAuthNativeIntegration, createMockOAuthWebIntegration, Subject } from './mocks';
+import { createMockOAuthNativeIntegration, Subject } from './mocks';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
+import { createMockIntegrationWithCms } from '../../mocks';
 
 export default {
   title: 'Pages/Signup/ConfirmSignupCode',
@@ -52,6 +53,6 @@ export const OAuthDesktopServiceRelay = () => (
 
 export const WithSuccessCms = () => (
   <AppContext.Provider value={mockAppContext({ account: accountWithSuccess })}>
-    <Subject integration={createMockOAuthWebIntegration()} />
+    <Subject integration={createMockIntegrationWithCms()} />
   </AppContext.Provider>
 );

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -300,7 +300,7 @@ const ConfirmSignupCode = ({
 
   return (
     <AppLayout
-      integration={integration}
+      cmsInfo={cmsInfo}
       title={ftlMsgResolver.getMsg(
         'confirm-signup-code-page-title',
         'Enter confirmation code'

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.stories.tsx
@@ -8,7 +8,7 @@ import { Meta } from '@storybook/react';
 import { MOCK_SERVICE } from './mocks';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { MozServices } from '../../../lib/types';
-import { createMockOAuthWebIntegration } from '../ConfirmSignupCode/mocks';
+import { createMockIntegrationWithCms } from '../../mocks';
 
 export default {
   title: 'Pages/Signup/PrimaryEmailVerified',
@@ -42,5 +42,5 @@ export const BasicIsSync = storyWithProps({
 export const BasicIsSyncCms = storyWithProps({
   isSignedIn: true,
   serviceName: MozServices.FirefoxSync,
-  integration: createMockOAuthWebIntegration(),
+  integration: createMockIntegrationWithCms(),
 });

--- a/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/PrimaryEmailVerified/index.tsx
@@ -22,8 +22,10 @@ const PrimaryEmailVerified = ({
   isSignedIn,
   integration
 }: PrimaryEmailVerifiedProps & RouteComponentProps) => {
+  const cmsInfo = integration?.getCmsInfo?.();
+
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       <Ready {...{ viewName, serviceName, isSignedIn, integration }} />
     </AppLayout>
   );

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.stories.tsx
@@ -8,7 +8,7 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { MozServices } from '../../../lib/types';
-import { createMockOAuthWebIntegration } from '../ConfirmSignupCode/mocks';
+import { createMockIntegrationWithCms } from '../../mocks';
 
 export default {
   title: 'Pages/Signup/SignupConfirmed',
@@ -38,7 +38,7 @@ export const IsSyncWithCms = () => (
   <LocationProvider>
     <SignupConfirmed isSignedIn={false}
                      serviceName={MozServices.FirefoxSync}
-                     integration={createMockOAuthWebIntegration()}
+                     integration={createMockIntegrationWithCms()}
     />
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmed/index.tsx
@@ -22,10 +22,14 @@ const SignupConfirmed = ({
   isSignedIn,
   serviceName,
   integration,
-}: SignupConfirmedProps & RouteComponentProps) => (
-  <AppLayout integration={integration}>
-    <Ready {...{ continueHandler, isSignedIn, viewName, serviceName, integration }} />
-  </AppLayout>
-);
+}: SignupConfirmedProps & RouteComponentProps) => {
+  const cmsInfo = integration?.getCmsInfo?.();
+
+  return (
+    <AppLayout cmsInfo={cmsInfo}>
+      <Ready {...{ continueHandler, isSignedIn, viewName, serviceName, integration }} />
+    </AppLayout>
+  );
+};
 
 export default SignupConfirmed;

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
@@ -42,7 +42,7 @@ const SignupConfirmedSync = ({
   const cmsHideCTA = !!cmsInfo?.shared?.featureFlags?.syncConfirmedPageHideCTA;
 
   return (
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {originPostVerifySetPassword ? (
         <Banner
           type="success"

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -280,7 +280,7 @@ export const Signup = ({
   return (
     // TODO: FXA-8268, if force_auth && AuthErrors.is(error, 'DELETED_ACCOUNT'):
     //       - forceMessage('Account no longer exists. Recreate it?')
-    <AppLayout integration={integration}>
+    <AppLayout cmsInfo={cmsInfo}>
       {cmsInfo ? (
         <>
           {cmsInfo?.shared?.logoUrl && cmsInfo?.shared?.logoAltText && (

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -6,6 +6,7 @@ import * as LoadingSpinnerModule from 'fxa-react/components/LoadingSpinner';
 
 import { MozServices } from '../lib/types';
 import { MOCK_ACCOUNT } from '../models/mocks';
+import { Integration, IntegrationType, OAuthNativeIntegration, RelierCmsInfo } from '../models';
 
 export const MOCK_EMAIL = MOCK_ACCOUNT.primaryEmail.email;
 export const MOCK_UID = 'abcd1234abcd1234abcd1234abcd1234';
@@ -143,3 +144,16 @@ export const MOCK_CMS_INFO = {
     primaryButtonText: 'Continue',
   },
 };
+
+export const createMockIntegrationWithCms = () =>
+  ({
+    type: IntegrationType.OAuthWeb,
+    getService: () => MozServices.TestService,
+    isSync: () => false,
+    wantsKeys: () => false,
+    isDesktopRelay: () => false,
+    getCmsInfo: () => MOCK_CMS_INFO,
+    data: {
+      validate: () => {},
+    },
+  }) as Integration;


### PR DESCRIPTION
## Because

- We pass an `integration` object into AppLayout, it only needs to know about the actual cmsInfo values
- Several inline flows were not updated to use any cms customizations

## This pull request

- Refactors AppLayout
- Updates the InlineRecoverySetup, InlineTotpSetup, others

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12162
Closes: https://mozilla-hub.atlassian.net/browse/FXA-12172

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
