### PR TITLE
fix(payments-next): PayPalActiveSubscriptionsMissingAgreementError: PayPal customer has active subscriptions but no billing agreement

### DIFF
--- a/apps/payments/next/app/[locale]/en.ftl
+++ b/apps/payments/next/app/[locale]/en.ftl
@@ -33,6 +33,7 @@ intent-payment-error-get-in-touch = Hmm. There was a problem authorizing your pa
 intent-payment-error-generic = An unexpected error has occurred while processing your payment, please try again.
 intent-payment-error-insufficient-funds = It looks like your card has insufficient funds. Try another card.
 general-paypal-error = An unexpected error has occurred while processing your payment, please try again.
+paypal-active-subscription-no-billing-agreement-error = It looks like there was a problem billing your { -brand-paypal } account. Please re-enable automatic payments for your subscription.
 
 ## Processing page and Needs Input page - /checkout and /upgrade
 ## Common strings used in multiple pages

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -16,6 +16,7 @@ import {
 import {
   PaypalBillingAgreementManager,
   PaypalCustomerManager,
+  PayPalActiveSubscriptionsMissingAgreementError
 } from '@fxa/payments/paypal';
 import {
   CustomerManager,
@@ -505,7 +506,8 @@ export class CheckoutService {
       await this.subscriptionManager.getCustomerPayPalSubscriptions(
         customer.id
       );
-
+    console.log('about to throw PayPalActiveSubscriptionsMissingAgreementError');
+    throw new PayPalActiveSubscriptionsMissingAgreementError(uid);
     const billingAgreementId =
       await this.paypalBillingAgreementManager.retrieveOrCreateId(
         uid,

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -16,7 +16,6 @@ import {
 import {
   PaypalBillingAgreementManager,
   PaypalCustomerManager,
-  PayPalActiveSubscriptionsMissingAgreementError
 } from '@fxa/payments/paypal';
 import {
   CustomerManager,
@@ -506,8 +505,7 @@ export class CheckoutService {
       await this.subscriptionManager.getCustomerPayPalSubscriptions(
         customer.id
       );
-    console.log('about to throw PayPalActiveSubscriptionsMissingAgreementError');
-    throw new PayPalActiveSubscriptionsMissingAgreementError(uid);
+
     const billingAgreementId =
       await this.paypalBillingAgreementManager.retrieveOrCreateId(
         uid,

--- a/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
+++ b/libs/payments/cart/src/lib/util/resolveErrorInstance.ts
@@ -18,7 +18,10 @@ import {
   IntentInsufficientFundsError,
 } from '../checkout.error';
 import { BaseError } from '@fxa/shared/error';
-import { PayPalError } from '@fxa/payments/paypal';
+import {
+  PayPalError,
+  PayPalActiveSubscriptionsMissingAgreementError,
+} from '@fxa/payments/paypal';
 
 export function resolveErrorInstance(error: Error) {
   /**
@@ -48,6 +51,8 @@ export function resolveErrorInstance(error: Error) {
       return CartErrorReasonId.INTENT_FAILED_GENERIC;
     case error instanceof IntentInsufficientFundsError:
       return CartErrorReasonId.INTENT_FAILED_INSUFFICIENT_FUNDS;
+    case error instanceof PayPalActiveSubscriptionsMissingAgreementError:
+      return CartErrorReasonId.PAYPAL_ACTIVE_SUBSCRIPTION_NO_BILLING_AGREEMENT;
     case error instanceof PayPalError:
       return CartErrorReasonId.GENERAL_PAYPAL_ERROR;
 

--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -134,6 +134,15 @@ export function getErrorFtlInfo(
           'It looks like your card has insufficient funds. Try another card.',
         messageFtl: 'intent-payment-error-insufficient-funds',
       };
+    case CartErrorReasonId.PAYPAL_ACTIVE_SUBSCRIPTION_NO_BILLING_AGREEMENT:
+      return {
+        buttonFtl: 'next-payment-error-manage-subscription-button',
+        buttonLabel: 'Manage my subscription',
+        buttonUrl: `${config.contentServerUrl}/subscriptions${queryParamString}`,
+        message:
+          'It looks like there was a problem billing your PayPal account. Please re-enable automatic payments for your subscription.',
+        messageFtl: 'paypal-active-subscription-no-billing-agreement-error',
+      };
     case CartErrorReasonId.GENERAL_PAYPAL_ERROR:
       return {
         buttonFtl: 'next-payment-error-retry-button',

--- a/libs/shared/db/mysql/account/src/lib/kysely-types.ts
+++ b/libs/shared/db/mysql/account/src/lib/kysely-types.ts
@@ -47,6 +47,7 @@ export enum CartErrorReasonId {
   INTENT_FAILED_TRY_AGAIN = 'intent_failed_try_again',
   INTENT_FAILED_GET_IN_TOUCH = 'intent_failed_get_in_touch',
   INTENT_FAILED_INSUFFICIENT_FUNDS = 'intent-payment-error-insufficient-funds',
+  PAYPAL_ACTIVE_SUBSCRIPTION_NO_BILLING_AGREEMENT = 'paypal-active-subscription-no-billing-agreement-error',
   GENERAL_PAYPAL_ERROR = 'general-paypal-error',
   UNKNOWN = 'unknown',
 }

--- a/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
+++ b/libs/shared/sentry/src/lib/utils/beforeSend.server.ts
@@ -18,6 +18,7 @@ const EXPECTED_ERRORS = new Set([
   'IntentInsufficientFundsError',
   'PayPalPaymentMethodError',
   'PayPalServiceUnavailableError',
+  'PayPalActiveSubscriptionsMissingAgreementError'
 ]);
 
 export const beforeSend = function (


### PR DESCRIPTION
## Because

- PayPal customer has active subscriptions but no billing agreement

## This pull request

- Does not report to Sentry
- Provides better error messaging to the client

## Issue that this pull request solves

Closes: #[PAY-3139](https://mozilla-hub.atlassian.net/browse/PAY-3139)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3139]: https://mozilla-hub.atlassian.net/browse/PAY-3139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ