### PR TITLE
fix(sign-in): fix "User cannot sign in to Sync with accounts that have 2FA set"

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -144,7 +144,9 @@ export const SigninUnblock = ({
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
         redirectTo,
-        performNavigation: !integration.isFirefoxMobileClient(),
+        performNavigation: !(
+          integration.isFirefoxMobileClient() && data.signIn.verified
+        ),
       };
 
       // If the web redirect is invalid, this shows an "Invalid redirect" message in alertBar

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -985,14 +985,11 @@ describe('Signin component', () => {
           });
         });
 
-        it('does not navigate when integration isFirefoxMobileClient', async () => {
+        it('does not navigate when integration isFirefoxMobileClient and the sign-in is verified', async () => {
           const handleNavigationSpy = jest.spyOn(
             SigninUtils,
             'handleNavigation'
           );
-          const cachedSigninHandler = jest
-            .fn()
-            .mockReturnValueOnce(CACHED_SIGNIN_HANDLER_RESPONSE);
           const finishOAuthFlowHandler = jest
             .fn()
             .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
@@ -1000,7 +997,11 @@ describe('Signin component', () => {
             isMobile: true,
           });
           render({
-            cachedSigninHandler,
+            beginSigninHandler: jest.fn().mockReturnValue(
+              createBeginSigninResponse({
+                verified: true,
+              })
+            ),
             integration,
             finishOAuthFlowHandler,
             sessionToken: MOCK_SESSION_TOKEN,
@@ -1011,6 +1012,39 @@ describe('Signin component', () => {
             expect(handleNavigationSpy).toHaveBeenCalledWith(
               expect.objectContaining({
                 performNavigation: false,
+              })
+            );
+          });
+          handleNavigationSpy.mockRestore();
+        });
+
+        it('still navigates if integration isFirefoxMobileClient and the sign-in is not verified', async () => {
+          const handleNavigationSpy = jest.spyOn(
+            SigninUtils,
+            'handleNavigation'
+          );
+          const finishOAuthFlowHandler = jest
+            .fn()
+            .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+          const integration = createMockSigninOAuthNativeIntegration({
+            isMobile: true,
+          });
+          render({
+            beginSigninHandler: jest.fn().mockReturnValue(
+              createBeginSigninResponse({
+                verified: false,
+              })
+            ),
+            integration,
+            finishOAuthFlowHandler,
+            sessionToken: MOCK_SESSION_TOKEN,
+          });
+
+          enterPasswordAndSubmit();
+          await waitFor(() => {
+            expect(handleNavigationSpy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                performNavigation: true,
               })
             );
           });

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -230,7 +230,9 @@ const Signin = ({
           showInlineRecoveryKeySetup: data.showInlineRecoveryKeySetup,
           handleFxaLogin: true,
           handleFxaOAuthLogin: true,
-          performNavigation: !integration.isFirefoxMobileClient(),
+          performNavigation: !(
+            integration.isFirefoxMobileClient() && data.signIn.verified
+          ),
         };
 
         const { error: navError } = await handleNavigation(navigationOptions);


### PR DESCRIPTION
## Because

- the fix FXA-12076 was problematic and users cannot sign in to Sync with accounts that have 2FA set

## This pull request

- fixes the problem and added more unit tests

## Issue that this pull request solves

Closes: FXA-12159

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
