### PR TITLE
fix(settings): Fix navigation from cached signin

### DIFF
--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -78,11 +78,13 @@ const AuthorizationContainer = ({
         relierAccount
       );
 
+      const isOauthPromptNone = true;
       const { data, error } = await cachedSignIn(
         account?.sessionToken!,
         authClient,
         cache,
-        session
+        session,
+        isOauthPromptNone
       );
 
       if (error === AuthUiErrors.SESSION_EXPIRED) {


### PR DESCRIPTION
## Because

* Users with 2FA enabled signing in to a cached session should be directed to signin_totp_code not signin_token_code if their session is unverified

## This pull request

* Update logic in cached signin handler to correctly set verification reason and verification method
## Issue that this pull request solves

Closes: FXA-12079

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This fix is simplified vs the previously proposed PR that included a new API endpoint. New issue filed for proposed endpoint updates: `https://mozilla-hub.atlassian.net/browse/FXA-12182`
