### PR TITLE
task: WAF-related friendly url updates

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -24,7 +24,7 @@ $(document).ready(function () {
   const sp3URL = {
     local: 'http://localhost:3035/',
     dev: '',
-    stage: 'https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net/',
+    stage: 'https://payments-next.allizom.org/',
     prod: '',
   };
 
@@ -37,7 +37,7 @@ $(document).ready(function () {
 
   const pwdlessPaymentURL = {
     local: 'http://localhost:3031/checkout/',
-    stage: 'https://payments-stage.fxa.nonprod.cloudops.mozgcp.net/checkout/',
+    stage: 'https://payments-server.allizom.org/checkout/',
   };
 
   const subscriptionConfig = {
@@ -134,17 +134,17 @@ $(document).ready(function () {
   if (paymentConfig.env === 'prod') {
     $('.btn-subscribe').hide();
   } else {
-    $('.btn-subscribe, .btn-subscribe-rp-provided-flow-metrics').each(function (
-      index
-    ) {
-      const { env, plans, product, sp3Url, sp3links } = paymentConfig;
-      const currency = $(this).attr('data-currency');
-      const sp3 = $(this).attr('data-sp3');
-      const currencyMappedURL = sp3
-        ? `${sp3Url}${sp3links[sp3]}`
-        : `${env}${product}?plan=${plans[currency]}`;
-      $(this).attr('href', currencyMappedURL);
-    });
+    $('.btn-subscribe, .btn-subscribe-rp-provided-flow-metrics').each(
+      function (index) {
+        const { env, plans, product, sp3Url, sp3links } = paymentConfig;
+        const currency = $(this).attr('data-currency');
+        const sp3 = $(this).attr('data-sp3');
+        const currencyMappedURL = sp3
+          ? `${sp3Url}${sp3links[sp3]}`
+          : `${env}${product}?plan=${plans[currency]}`;
+        $(this).attr('href', currencyMappedURL);
+      }
+    );
   }
 
   function isSubscribed() {

--- a/packages/fxa-payments-server/backstage.yaml
+++ b/packages/fxa-payments-server/backstage.yaml
@@ -15,7 +15,7 @@ metadata:
     - url: https://subscriptions.firefox.com/
       title: Production Subscription Platform
       type: website
-    - url: https://payments-stage.fxa.nonprod.cloudops.mozgcp.net/
+    - url: https://payments-server.allizom.org/
       title: Stage Subscription Platform
       type: website
 spec:


### PR DESCRIPTION
## Because

- We're implementing the Fastly WAF
- Some of our domains needed friendly URLs to accommodate this

## This pull request

- Adds/updates friendly urls for event-broker, payments-server, and payments-next

## Issue that this pull request solves

Closes: FXA-12157

## Other information (Optional)

This PR should be merged in coordination with DNS cutover.

See also https://github.com/mozilla/webservices-infra/blob/main/fxa/tf/stage/waf.tf which sets up the friendly domains (under `subscription_domains`)
