### PR TITLE
polish(rate-limit): Add test validating bans expire

### DIFF
--- a/libs/accounts/rate-limit/README.md
+++ b/libs/accounts/rate-limit/README.md
@@ -14,7 +14,7 @@ Run `nx test rate-limit` to execute the unit tests via [Jest](https://jestjs.io)
 
 This library is driven by a simple grammar for defining rules. The grammar is as follows:
 
-` ${action} : ${blockOn} : ${maxAttempts} : ${window} : ${blockDuration} : ${policy} `
+`${action} : ${blockOn} : ${maxAttempts} : ${window} : ${blockDuration} : ${policy}`
 
 Where a 'section' is separated by ':' and leading and trailing whitespace within a section is trimmed.
 Note that comments can be added by starting a line with '#'.
@@ -26,14 +26,13 @@ Note that comments can be added by starting a line with '#'.
 - blockDuration - this is how long the block (or ban) lasts. Note that while active, attempts are being not counted!
 - policy - This is what should happen when max attempts are exceeded. Options are block or ban.
 
-
 ### BlockOn
 
-- ip        - The user's IP. This is often useful for 'ban' policies, were we want to flag an IP that is making a large number of requests.
-- ip_email  - The user's ip with the user's email appended. This is useful for ensuring one user cannot impact another user's experience.
-- email     - The user's email. This is useful only when the account isn't known and for some reason, we don't want to use ip_email.
-- uid       - The user's account id. This can be useful from stopping a user that has logged in from doing something malicious, like trying to mine data.
-- ip_uid    - The user's IP with the user's uid appended. This is useful for ensuring that one user can be impacted by another user's experience.
+- ip - The user's IP. This is often useful for 'ban' policies, were we want to flag an IP that is making a large number of requests.
+- ip_email - The user's ip with the user's email appended. This is useful for ensuring one user cannot impact another user's experience.
+- email - The user's email. This is useful only when the account isn't known and for some reason, we don't want to use ip_email.
+- uid - The user's account id. This can be useful from stopping a user that has logged in from doing something malicious, like trying to mine data.
+- ip_uid - The user's IP with the user's uid appended. This is useful for ensuring that one user can be impacted by another user's experience.
 
 ### The 'default' Rule
 
@@ -51,15 +50,15 @@ we'd increment the redis count for action foo blocking on ip, but we'd use the d
 
 ### Policy
 
-- ban - Once a rule is violated (i.e. max attempts exceeded) a ban policy indicates that all other actions are also prohibited for the given blockOn property.
+- ban - Once a rule is violated (i.e. max attempts exceeded) a ban policy indicates that all other actions are also prohibited.
 - block - Once a rule is violated (i.e. max attempts exceeded) a block policy indicates that only that action is prohibited for the given blockOn property.
-- report - Once a rule is violated (i.e. max attempts exceeded) a report policy indicates that the action is reported, but not actually blocked.
+- report - Once a rule is violated (i.e. max attempts exceeded) a report policy indicates that the action is reported, but not actually blocked or banned.
 
 It's probably obvious, but bans are serious and need to be used carefully since they effectively lock a user out of the system entirely. It's much better
 to just set sensible block policies when possible. We should only use ban policies when the rule identifies obviously malicious behavior.
 
 The report policy can be very useful when experimenting with new rules. This will not impact the existing behavior, i.e. by adding a report policy, we don't
-change which block would have been selected. These rules only generate metrics, so we can get an idea for the rate at which blocks __would__ occur if the
+change which block would have been selected. These rules only generate metrics, so we can get an idea for the rate at which blocks **would** occur if the
 rule had a policy of ban or block.
 
 ### A quick example:
@@ -81,7 +80,7 @@ These rules would create the following rate limit policy:
 - A user with a given IP+EMAIL combo could try to login 5 times per 5 minute window before getting blocked from trying to login again for 15 minutes.
 - This user could still request a password reset or an unblock code, and these actions would not be blocked.
 - If we detect than an IP fails to login more than 20 times in an hour, we will ban that IP for 24 hours, which means the IP will not be allowed to
-  conduct __any__ other action until the ban expires. For example, the IP cannot send a unblock code or request a password reset, and they certainly
+  conduct **any** other action until the ban expires. For example, the IP cannot send a unblock code or request a password reset, and they certainly
   cannot try logging in again.
 
 ### Testing & Development Considerations
@@ -89,12 +88,14 @@ These rules would create the following rate limit policy:
 When developing new features, running functional test suites locally, or running smoke tests remotely, rate-limiting behavior can be annoying — or even downright disruptive. To work around this, there are a few options:
 
 #### Disable the rules:
-You can simply remove the rate-limiting rules. Our servers typically hold the rules as a string in the environment, e.g., RATE_LIMIT__RULES=['some','rules']. Override this value with an empty string, and rate limiting will effectively be disabled. Want to test a single rate limit? Just specify that one rule. It doesn’t get much simpler than that.
+
+You can simply remove the rate-limiting rules. Our servers typically hold the rules as a string in the environment, e.g., RATE_LIMIT\_\_RULES=['some','rules']. Override this value with an empty string, and rate limiting will effectively be disabled. Want to test a single rate limit? Just specify that one rule. It doesn’t get much simpler than that.
 
 #### Exclude specific attributes like ip, email, or UID
+
 When running smoke tests against a remote server, the first approach may not work — so we also support excluding specific emails, user IDs (UIDs), or IP addresses from being checked by the rate limiter. To do this, define these values in your server's config file and pass them to the rate limiter.
 
- - Email ignore values can use regex filters.
- - IP addresses and UIDs must be exact string matches.
+- Email ignore values can use regex filters.
+- IP addresses and UIDs must be exact string matches.
 
 Ideally, the IP filter should be used. This is the preferred method because all requests contain an IP address, making it the lowest common denominator for rate-limiting attributes. Other advantages of using the IP filter include its consistency and ease of configuration.

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -931,6 +931,7 @@ describe('#integration - AccountResolver', () => {
           wrapKbVersion2: 'wrapKbVersion2',
           authPWVersion2: 'authPWVersion2',
           clientSalt: 'clientSalt',
+          sessionToken: '123456789abcdef',
           keys: true,
         });
 
@@ -940,7 +941,7 @@ describe('#integration - AccountResolver', () => {
           {
             authPW: 'authPW',
             wrapKb: 'wrapKb',
-            sessionToken: undefined,
+            sessionToken: '123456789abcdef',
             wrapKbVersion2: 'wrapKbVersion2',
             authPWVersion2: 'authPWVersion2',
             clientSalt: 'clientSalt',


### PR DESCRIPTION
## Because

- We wanted to validate that bans expire just like blocks.


## This pull request

- Adds tests validating that a ban expires, just like blocks
- Fixes poorly named test case
- Corrects wording in readme

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

In response to a question about whether or not ban's actually expire.
