### PR TITLE
fix(settings): Navigate directly to inline_totp_setup

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -69,7 +69,8 @@
     "sendFxAStatusOnSettings": true,
     "recoveryCodeSetupOnSyncSignIn": true,
     "recoveryPhonePasswordReset2fa": true,
-    "updatedInlineTotpSetupFlow": true
+    "updatedInlineTotpSetupFlow": true,
+    "updatedInlineRecoverySetupFlow": true
   },
   "rolloutRates": {
     "keyStretchV2": 1,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -185,17 +185,23 @@ const ConfirmSignupCode = ({
         });
         navigate(to);
       } else if (isOAuthIntegration(integration)) {
-        // Check to see if the relier wants TOTP.
-        // Newly created accounts wouldn't have this so lets redirect them to signin.
-        // Certain reliers may require users to set up 2FA / TOTP
+        // Check to see if the relier wants TOTP
+        // Certain reliers (currently AMO only) may require users to set up 2FA / TOTP
         // before they can be redirected back to the RP.
-        // Notes in content-server indicate that a message should be displayed on the signin page
-        // to explain why totp setup is required, but this does not currently
-        // appear to be implemented.
+        // Newly created accounts wouldn't have this so let's redirect them to inline_totp_setup.
 
-        // Params are included to eventually allow for redirect to RP after 2FA setup
         if (integration.wantsTwoStepAuthentication()) {
-          navigateWithQuery('oauth/signin');
+          navigateWithQuery('/inline_totp_setup', {
+            state: {
+              email,
+              uid,
+              sessionToken,
+              keyFetchToken,
+              unwrapBKey,
+              verificationReason: 'signup',
+              verified: true,
+            },
+          });
           return;
         } else {
           const { redirect, code, state, error } = await finishOAuthFlowHandler(


### PR DESCRIPTION
## Because

* When RP requires 2FA, confirm signup code was navigating to cache signin instead of directly to inline totp setup

## This pull request

* Fix navigation and include state

## Issue that this pull request solves

Closes: FXA-11573

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Enabled the new inline recovery setup by default in local env
