### PR TITLE
task(auth,settings,gql): Reduce occurrence of orphaned password change tokens

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -98,7 +98,7 @@ export type SignedInAccountData = {
 export type PasswordChangePayload = {
   authPW: string;
   wrapKb: string;
-  sessionToken?: string;
+  sessionToken: string;
   wrapKbVersion2?: string;
   authPWVersion2?: string;
   clientSalt?: string;
@@ -1234,14 +1234,15 @@ export default class AuthClient {
     );
 
     const wrapKb = crypto.unwrapKB(keys.kB, newCredentials.unwrapBKey);
-    const sessionTokenHex = sessionToken
-      ? (await hawk.deriveHawkCredentials(sessionToken, 'sessionToken')).id
-      : undefined;
+    const { id: sessionTokenId } = await hawk.deriveHawkCredentials(
+      sessionToken,
+      'sessionToken'
+    );
 
     let payload: PasswordChangePayload = {
       authPW: newCredentials.authPW,
       wrapKb,
-      sessionToken: sessionTokenHex,
+      sessionToken: sessionTokenId,
     };
 
     let unwrapBKeyVersion2: string | undefined;
@@ -2379,7 +2380,11 @@ export default class AuthClient {
     feature: string,
     headers?: Headers
   ): Promise<{ eligible: boolean }> {
-    return this.sessionGet(`/geo/eligibility/${feature}`, sessionToken, headers);
+    return this.sessionGet(
+      `/geo/eligibility/${feature}`,
+      sessionToken,
+      headers
+    );
   }
 
   /**
@@ -2388,7 +2393,7 @@ export default class AuthClient {
    * @param clientId
    * @param entrypoint
    */
-  async getCmsConfig(clientId:string, entrypoint:string) {
+  async getCmsConfig(clientId: string, entrypoint: string) {
     return this.request(
       'GET',
       `/cms/config?clientId=${clientId}&entrypoint=${entrypoint}`,

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -737,10 +737,12 @@ describe('/password', () => {
       const mockDB = mocks.mockDB({
         email: TEST_EMAIL,
         uid,
+        emailVerified: true,
       });
       const mockPush = mocks.mockPush();
       const mockMailer = mocks.mockMailer();
       const mockLog = mocks.mockLog();
+      const mockSessionToken = await mockDB.createSessionToken({});
       const mockRequest = mocks.mockRequest({
         payload: {
           email: TEST_EMAIL,
@@ -750,10 +752,7 @@ describe('/password', () => {
           keys: 'true',
         },
         auth: {
-          credentials: {
-            email: TEST_EMAIL,
-            uid,
-          },
+          credentials: mockSessionToken,
         },
         log: mockLog,
         uaBrowser: 'Firefox',
@@ -805,16 +804,15 @@ describe('/password', () => {
       const mockDB = mocks.mockDB({
         email: TEST_EMAIL,
         uid,
+        emailVerified: true,
       });
+      const mockSession = await mockDB.createSessionToken({});
       const mockPush = mocks.mockPush();
       const mockMailer = mocks.mockMailer();
       const mockLog = mocks.mockLog();
       const mockStatsd = mocks.mockStatsd();
       const mockRequest = mocks.mockRequest({
-        credentials: {
-          uid,
-          email: TEST_EMAIL,
-        },
+        credentials: mockSession,
         payload: {
           email: TEST_EMAIL,
           oldAuthPW: crypto.randomBytes(32).toString('hex'),

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -928,10 +928,10 @@ describe('#integration - AccountResolver', () => {
           passwordChangeToken: 'passwordChangeToken',
           authPW: 'authPW',
           wrapKb: 'wrapKb',
+          sessionToken: '3456789abcdef12',
           wrapKbVersion2: 'wrapKbVersion2',
           authPWVersion2: 'authPWVersion2',
           clientSalt: 'clientSalt',
-          sessionToken: '123456789abcdef',
           keys: true,
         });
 
@@ -941,7 +941,7 @@ describe('#integration - AccountResolver', () => {
           {
             authPW: 'authPW',
             wrapKb: 'wrapKb',
-            sessionToken: '123456789abcdef',
+            sessionToken: '3456789abcdef12',
             wrapKbVersion2: 'wrapKbVersion2',
             authPWVersion2: 'authPWVersion2',
             clientSalt: 'clientSalt',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -967,7 +967,7 @@ export class AccountResolver {
       passwordChangeToken: string;
       authPW: string;
       wrapKb: string;
-      sessionToken?: string;
+      sessionToken: string;
       wrapKbVersion2?: string;
       authPWVersion2?: string;
       clientSalt?: string;

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -132,9 +132,10 @@ export const SigninTotpCodeContainer = ({
       // a key stretching upgrade until the session is verified, which the process
       // can only be finished after the account has been verified on accounts that
       // require totp.
-      if (signinState?.sessionToken) {
+      const sessionToken = signinState?.sessionToken;
+      if (sessionToken) {
         await tryFinalizeUpgrade(
-          signinState?.sessionToken,
+          sessionToken,
           sensitiveDataClient,
           'signin-totp',
           credentialStatus,

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -166,10 +166,12 @@ export const SigninUnblockContainer = ({
         });
       }
 
+      const verified = response.data?.signIn.verified;
+      const sessionToken = response.data?.signIn.sessionToken;
       // Attempt to finish key stretching upgrade now that session has been verified.
-      if (response.data?.signIn.verified) {
+      if (verified && sessionToken) {
         await tryFinalizeUpgrade(
-          response.data?.signIn.sessionToken,
+          sessionToken,
           sensitiveDataClient,
           'signin-unblock',
           credentialStatus,


### PR DESCRIPTION
## Because

- We saw an increase in the number of orphaned password change tokens
- This is because unverified sessions can't complete the password change

## This pull request

- Fails fast in `/password/change/start` when unverified session is encountered
- Fixes a couple type safety issue, since the sessionToken is no longer optional for `/password/change/start` and `/password/change/finish` operations.
- Fix to password upgrade logic. It was possible the upgrade could fail due to an unverified session and not be retried after the session was verified. The exact mechanics are murky, and its possible this rarely happened, but the code is now more robust regardless.

## Issue that this pull request solves

Closes: FXA-12181

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
