### PR TITLE
feat(styling): Adjust styling on mobile for non-settings pages

### DIFF
--- a/packages/fxa-react/styles/flows.css
+++ b/packages/fxa-react/styles/flows.css
@@ -7,7 +7,7 @@
 /* Transparent border around card is for Windows HCM mode */
 
 .card {
-  @apply relative w-full border border-transparent mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-8 py-9 mobileLandscape:shadow-card-grey-drop mb-6;
+  @apply relative w-full border border-transparent mobileLandscape:w-120 mobileLandscape:bg-white rounded-xl px-6 py-8 mobileLandscape:px-8 mobileLandscape:py-9 mobileLandscape:shadow-card-grey-drop mobileLandscape:mb-6;
 
   /* HACK until content-server no longer needs .card, otherwise component classes take precedence */
   &.card-xl {
@@ -15,7 +15,7 @@
   }
 
   &::before {
-    @apply h-16 mobileLandscape:h-20 left-0 block absolute bg-center bg-no-repeat w-full bg-contain top-8 mobileLandscape:-top-10 content-[''];
+    @apply h-16 mobileLandscape:h-20 start-0 block absolute bg-center bg-no-repeat w-full bg-contain top-8 mobileLandscape:-top-10 content-[''];
   }
 
   &-header {
@@ -29,7 +29,7 @@
 
 /* Hide custom cms background on mobile (default) and show on tablet and up */
 @media (min-width: 640px) {
-  [data-testid="app"] {
+  [data-testid='app'] {
     background-image: var(--cms-bg);
   }
 }

--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -60,8 +60,7 @@ describe('<AppLayout />', () => {
         buttonColor: '#0078d4',
         logoUrl: 'https://example.com/logo.png',
         logoAltText: 'Test App Logo',
-        backgroundColor:
-          'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
         pageTitle: 'Test App - Custom Title',
       },
     } as RelierCmsInfo;
@@ -264,7 +263,7 @@ describe('<AppLayout />', () => {
     const cmsLogo = screen.getByAltText('CMS Custom Logo');
     expect(cmsLogo).toBeInTheDocument();
     expect(cmsLogo).toHaveAttribute('src', 'https://example.com/cms-logo.png');
-    expect(cmsLogo).toHaveClass('h-auto', 'w-[140px]', 'mx-auto', 'mobileLandscape:mx-0');
+    expect(cmsLogo).toHaveClass('h-auto', 'w-[140px]', 'mx-0');
   });
 
   it('renders CMS header logo with default alt text when headerLogoAltText is not provided', async () => {

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -60,7 +60,7 @@ export const AppLayout = ({
         data-testid="app"
       >
         <div id="body-top" className="w-full hidden mobileLandscape:block" />
-        <header className="w-full px-6 pt-16 pb-0 mobileLandscape:py-6">
+        <header className="w-full px-6 py-4 mobileLandscape:py-6">
           <LinkExternal
             rel="author"
             href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
@@ -70,7 +70,7 @@ export const AppLayout = ({
               <img
                 src={cmsHeaderLogoUrl}
                 alt={cmsHeaderLogoAltText || 'logo'}
-                className="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+                className="h-auto w-[140px] mx-0"
               />
             ) : (
               <img
@@ -80,7 +80,7 @@ export const AppLayout = ({
                   null,
                   'Mozilla logo'
                 )}
-                className="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+                className="h-auto w-[140px] mx-0"
               />
             )}
           </LinkExternal>


### PR DESCRIPTION
## Because

* Some content of the signin/signup pages is pushed below the fold on mobile

## This pull request

* Adjust AppLayout (for non-settings pages) to align-start the logo and reduce padding between the logo and card content

## Issue that this pull request solves

Closes: FXA-12119

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
