### PR TITLE
feat(next): add sub cancel to sub manage

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -40,6 +40,8 @@ export default async function Manage({
     redirect(redirectToUrl.href);
   }
 
+  const userId = session.user.id;
+
   const { accountCreditBalance, defaultPaymentMethod, subscriptions } =
     await getSubManPageContentAction(session.user?.id);
   const { billingAgreementId, brand, expMonth, expYear, last4, type } =
@@ -267,13 +269,13 @@ export default async function Manage({
                     <h3 id={`${sub.id}-information`} className="font-semibold">
                       {sub.interval
                         ? l10n.getString(
-                            getSubscriptionIntervalFtlId(sub.interval),
-                            { productName: sub.productName },
-                            `${sub.productName} (${formatPlanInterval(sub.interval)})`
-                          )
+                          getSubscriptionIntervalFtlId(sub.interval),
+                          { productName: sub.productName },
+                          `${sub.productName} (${formatPlanInterval(sub.interval)})`
+                        )
                         : sub.productName}
                     </h3>
-                    <SubscriptionContent subscription={sub} locale={locale} />
+                    <SubscriptionContent userId={userId} subscription={sub} locale={locale} supportUrl={`${config.contentServerUrl}/support`} />
                     {index !== subscriptions.length - 1 && (
                       <hr
                         className="border-b border-grey-50 my-6"
@@ -286,8 +288,8 @@ export default async function Manage({
             </ul>
             {(appleIapSubscriptions.length > 0 ||
               googleIapSubscriptions.length > 0) && (
-              <hr className="border-b border-grey-50 my-6" aria-hidden="true" />
-            )}
+                <hr className="border-b border-grey-50 my-6" aria-hidden="true" />
+              )}
           </>
         )}
 
@@ -405,19 +407,19 @@ export default async function Manage({
                         {!!purchase.expiryTimeMillis &&
                           (purchase.autoRenewing
                             ? l10n.getString(
-                                'subscription-management-iap-sub-next-bill',
-                                {
-                                  date: nextBillDateL10n,
-                                },
-                                `Next billed on ${nextBillDate}`
-                              )
+                              'subscription-management-iap-sub-next-bill',
+                              {
+                                date: nextBillDateL10n,
+                              },
+                              `Next billed on ${nextBillDate}`
+                            )
                             : l10n.getString(
-                                'subscription-management-iap-sub-expires-on',
-                                {
-                                  date: nextBillDateL10n,
-                                },
-                                `Expires on ${nextBillDate}`
-                              ))}
+                              'subscription-management-iap-sub-expires-on',
+                              {
+                                date: nextBillDateL10n,
+                              },
+                              `Expires on ${nextBillDate}`
+                            ))}
                       </div>
                     </div>
                     <div>

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -103,6 +103,7 @@ export class CheckoutService {
 
   /**
    * Reload the customer data to reflect a change.
+   * NOTE: This is currently duplicated in subscriptionManagement.service.ts
    */
   private async customerChanged(uid: string) {
     await this.profileClient.deleteCache(uid);

--- a/libs/payments/management/src/lib/factories/subscriptionContent.factory.ts
+++ b/libs/payments/management/src/lib/factories/subscriptionContent.factory.ts
@@ -9,6 +9,8 @@ import { SubscriptionContent } from '../types';
 export const SubscriptionContentFactory = (
   override?: Partial<SubscriptionContent>
 ): SubscriptionContent => ({
+  id: `sub_${faker.string.alphanumeric({ length: 24 })}`,
+  cancelAtPeriodEnd: false,
   productName: faker.string.sample(),
   currency: faker.finance.currencyCode().toLowerCase(),
   interval: faker.helpers.enumValue(SubplatInterval),

--- a/libs/payments/management/src/lib/subscriptionManagement.error.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.error.ts
@@ -16,6 +16,23 @@ export class SubscriptionManagementError extends BaseError {
   }
 }
 
+export class CancelSubscriptionCustomerMismatch extends SubscriptionManagementError {
+  constructor(
+    uid: string,
+    accountCustomer: string,
+    subscriptionCustomer: string,
+    subscriptionId: string
+  ) {
+    super('Subscription customer does not match account customer', {
+      uid,
+      accountCustomer,
+      subscriptionCustomer,
+      subscriptionId,
+    });
+    this.name = 'CancelSubscriptionCustomerMismatch';
+  }
+}
+
 export class GetAccountCustomerMissingStripeId extends SubscriptionManagementError {
   constructor(uid: string) {
     super('Retrieved AccountCustomer is missing a Stripe customer id', { uid });
@@ -32,7 +49,10 @@ export class UpdateAccountCustomerMissingStripeId extends SubscriptionManagement
 
 export class SetDefaultPaymentAccountCustomerMissingStripeId extends SubscriptionManagementError {
   constructor(uid: string) {
-    super('AccountCustomer for updating default payment method is missing a Stripe customer id', { uid });
+    super(
+      'AccountCustomer for updating default payment method is missing a Stripe customer id',
+      { uid }
+    );
     this.name = 'SetDefaultPaymentAccountCustomerMissingStripeId';
   }
 }

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -57,6 +57,7 @@ import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import {
+  CancelSubscriptionCustomerMismatch,
   CurrencyForCustomerNotFoundError,
   GetAccountCustomerMissingStripeId,
   SetDefaultPaymentAccountCustomerMissingStripeId,
@@ -70,6 +71,16 @@ import {
   SubscriptionManagementCouldNotRetrieveProductNamesFromCMSError,
   UpdateAccountCustomerMissingStripeId,
 } from './subscriptionManagement.error';
+import {
+  MockNotifierSnsConfigProvider,
+  NotifierService,
+  NotifierSnsProvider,
+} from '@fxa/shared/notifier';
+import {
+  MockProfileClientConfigProvider,
+  ProfileClient,
+} from '@fxa/profile/client';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
 
 jest.mock('../../../customer/src/lib/util/determinePaymentMethodType');
 const mockDeterminePaymentMethodType = jest.mocked(determinePaymentMethodType);
@@ -97,6 +108,12 @@ describe('SubscriptionManagementService', () => {
   let setupIntentManager: SetupIntentManager;
   let customerSessionManager: CustomerSessionManager;
   let currencyManager: CurrencyManager;
+  let privateCustomerChanged: any;
+
+  const mockLogger = {
+    error: jest.fn(),
+    debug: jest.fn(),
+  };
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -109,16 +126,21 @@ describe('SubscriptionManagementService', () => {
         MockAccountDatabaseNestFactory,
         MockCurrencyConfigProvider,
         MockFirestoreProvider,
+        MockNotifierSnsConfigProvider,
         MockPaypalClientConfigProvider,
+        MockProfileClientConfigProvider,
         MockStatsDProvider,
         MockStrapiClientConfigProvider,
         MockStripeConfigProvider,
+        NotifierService,
+        NotifierSnsProvider,
         PaymentMethodManager,
         PaypalBillingAgreementManager,
         PayPalClient,
         PaypalCustomerManager,
         PriceManager,
         ProductConfigurationManager,
+        ProfileClient,
         StrapiClient,
         StripeClient,
         StripeConfig,
@@ -128,6 +150,10 @@ describe('SubscriptionManagementService', () => {
         CustomerSessionManager,
         CurrencyManager,
         MockCurrencyConfigProvider,
+        {
+          provide: LOGGER_PROVIDER,
+          useValue: mockLogger,
+        },
       ],
     }).compile();
 
@@ -142,6 +168,73 @@ describe('SubscriptionManagementService', () => {
     setupIntentManager = moduleRef.get(SetupIntentManager);
     customerSessionManager = moduleRef.get(CustomerSessionManager);
     currencyManager = moduleRef.get(CurrencyManager);
+
+    privateCustomerChanged = jest
+      .spyOn(subscriptionManagementService as any, 'customerChanged')
+      .mockResolvedValue({});
+  });
+
+  describe('cancelSubscriptionAtPeriodEnd', () => {
+    const mockStripeCustomer = StripeCustomerFactory();
+    const mockAccountCustomer = ResultAccountCustomerFactory({
+      stripeCustomerId: mockStripeCustomer.id,
+    });
+    const mockSubscription = StripeResponseFactory(
+      StripeSubscriptionFactory({
+        customer: mockStripeCustomer.id,
+      })
+    );
+
+    beforeEach(() => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'update')
+        .mockResolvedValue(mockSubscription);
+    });
+
+    it('successfully updates the subscription', async () => {
+      await subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.update).toHaveBeenCalledWith(
+        mockSubscription.id,
+        {
+          cancel_at_period_end: true,
+          metadata: {
+            cancelled_for_customer_at: expect.any(Number),
+          },
+        }
+      );
+      expect(privateCustomerChanged).toHaveBeenCalledWith(
+        mockAccountCustomer.uid
+      );
+    });
+
+    it('fails with error on mismatching customer id between subscription and account', async () => {
+      jest.spyOn(subscriptionManager, 'retrieve').mockResolvedValueOnce(
+        StripeResponseFactory(
+          StripeSubscriptionFactory({
+            customer: 'differentCustomerId',
+          })
+        )
+      );
+
+      await expect(
+        subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+          mockAccountCustomer.uid,
+          mockSubscription.id
+        )
+      ).rejects.toBeInstanceOf(CancelSubscriptionCustomerMismatch);
+      expect(subscriptionManager.update).not.toHaveBeenCalled();
+      expect(privateCustomerChanged).not.toHaveBeenCalled();
+    });
   });
 
   describe('getPageContent', () => {

--- a/libs/payments/management/src/lib/types.ts
+++ b/libs/payments/management/src/lib/types.ts
@@ -5,6 +5,8 @@
 import { SubplatInterval } from '@fxa/payments/customer';
 
 export interface SubscriptionContent {
+  id: string;
+  cancelAtPeriodEnd: boolean;
   productName: string;
   currency: string;
   interval?: SubplatInterval;

--- a/libs/payments/ui/src/lib/actions/cancelSubscriptionAtPeriodEnd.ts
+++ b/libs/payments/ui/src/lib/actions/cancelSubscriptionAtPeriodEnd.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getApp } from '../nestapp/app';
+
+export const cancelSubscriptionAtPeriodEndAction = async (
+  uid: string,
+  subscriptionId: string
+) => {
+  const result = await getApp()
+    .getActionsService()
+    .cancelSubscriptionAtPeriodEnd({
+      uid,
+      subscriptionId,
+    });
+
+  revalidatePath('/[locale]/subscriptions/manage');
+
+  return result;
+};

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export { applyCouponAction } from './applyCoupon';
+export { cancelSubscriptionAtPeriodEndAction } from './cancelSubscriptionAtPeriodEnd';
 export { checkoutCartWithPaypal } from './checkoutCartWithPaypal';
 export { checkoutCartWithStripe } from './checkoutCartWithStripe';
 export { determineCurrencyAction } from './determineCurrency';

--- a/libs/payments/ui/src/lib/client/components/BaseButton/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/BaseButton/index.tsx
@@ -20,14 +20,14 @@ export const BaseButton = forwardRef(function BaseButton({ children, variant, ..
   let variantStyles = '';
   switch (variant) {
     case ButtonVariant.Primary:
-      variantStyles = 'bg-blue-500 font-semibold hover:bg-blue-700 text-white';
+      variantStyles = 'bg-blue-500 font-semibold hover:bg-blue-700 aria-disabled:hover:bg-blue-500 text-white';
       break;
     case ButtonVariant.Secondary:
-      variantStyles = 'bg-grey-100 font-semibold hover:bg-grey-200 text-black';
+      variantStyles = 'bg-grey-100 font-semibold hover:bg-grey-200 aria-disabled:hover:bg-grey-100 text-black';
       break;
     case ButtonVariant.ThirdParty:
       variantStyles =
-        'w-full bg-transparent border border-grey-300 font-normal text-black hover:border-black';
+        'w-full bg-transparent border border-grey-300 font-normal text-black hover:border-black aria-disabled:hover:border-grey-300';
       break;
   }
 

--- a/libs/payments/ui/src/lib/client/components/SubmitButton/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SubmitButton/index.tsx
@@ -13,6 +13,7 @@ import { forwardRef } from 'react';
 interface SubmitButtonProps {
   children: React.ReactNode;
   variant: ButtonVariant;
+  showLoadingSpinner?: boolean;
 }
 
 export const SubmitButton = forwardRef(function SubmitButton({
@@ -20,6 +21,7 @@ export const SubmitButton = forwardRef(function SubmitButton({
   disabled,
   className,
   variant,
+  showLoadingSpinner = true,
   ...otherProps
 }: SubmitButtonProps & React.HTMLProps<HTMLButtonElement>, ref: React.Ref<HTMLButtonElement>) {
   const { pending } = useFormStatus();
@@ -29,11 +31,12 @@ export const SubmitButton = forwardRef(function SubmitButton({
       variant={variant}
       {...otherProps}
       disabled={pending || disabled}
+      aria-disabled={pending || disabled}
       type="submit"
       className={className}
       ref={ref}
     >
-      {pending ? (
+      {pending && showLoadingSpinner ? (
         <>
           <Image
             src={spinnerWhiteImage}

--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/en.ftl
@@ -29,3 +29,12 @@ subscription-content-button-cancel-subscription =
 subscription-content-button-cancel =
   Cancel
   .aria-label = Cancel your subscription to { $productName }
+subscription-content-cancel-action-error = An unexpected error occurred. Please try again.
+
+subscription-cancellation-dialog-title = We’re sorry to see you go
+# $name (String) - The name of the subscribed product.
+# $date (Date) - Last day of product access
+subscription-cancellation-dialog-msg = Your { $name } subscription has been cancelled. You will still have access to { $name } until { $date }.
+subscription-cancellation-dialog-aside = Have questions? Visit <LinkExternal>{ -brand-mozilla } Support</LinkExternal>.
+
+

--- a/libs/payments/ui/src/lib/client/en.ftl
+++ b/libs/payments/ui/src/lib/client/en.ftl
@@ -1,0 +1,1 @@
+dialog-close = Close dialog

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -96,6 +96,8 @@ import { GetStripePaymentManagementDetailsResult } from './validators/GetStripeP
 import { UpdateStripePaymentDetailsArgs } from './validators/UpdateStripePaymentDetailsActionArgs';
 import { UpdateStripePaymentDetailsResult } from './validators/UpdateStripePaymentDetailsActionResult';
 import { SetDefaultStripePaymentDetailsActionArgs } from './validators/SetDefaultStripePaymentDetailsActionArgs';
+import { CancelSubscriptionAtPeriodEndActionArgs } from './validators/CancelSubscriptionAtPeriodEndActionArgs';
+import { CancelSubscriptionAtPeriodEndActionResult } from './validators/CancelSubscriptionAtPeriodEndActionResult';
 
 /**
  * ANY AND ALL methods exposed via this service should be considered publicly accessible and callable with any arguments.
@@ -120,6 +122,33 @@ export class NextJSActionsService {
     @Inject(StatsDService) public statsd: StatsD,
     @Inject(Logger) private log: LoggerService
   ) {}
+
+  @SanitizeExceptions()
+  @NextIOValidator(
+    CancelSubscriptionAtPeriodEndActionArgs,
+    CancelSubscriptionAtPeriodEndActionResult
+  )
+  @WithTypeCachableAsyncLocalStorage()
+  @CaptureTimingWithStatsD()
+  async cancelSubscriptionAtPeriodEnd(args: {
+    uid: string;
+    subscriptionId: string;
+  }) {
+    try {
+      await this.subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+        args.uid,
+        args.subscriptionId
+      );
+
+      return {
+        ok: true,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+      };
+    }
+  }
 
   @SanitizeExceptions()
   @NextIOValidator(GetCartStateActionArgs, GetCartStateActionResult)

--- a/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionAtPeriodEndActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionAtPeriodEndActionArgs.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class CancelSubscriptionAtPeriodEndActionArgs {
+  @IsString()
+  uid!: string;
+
+  @IsString()
+  subscriptionId!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionAtPeriodEndActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionAtPeriodEndActionResult.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsBoolean } from 'class-validator';
+
+export class CancelSubscriptionAtPeriodEndActionResult {
+  @IsBoolean()
+  ok!: boolean;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetSubManPageContentActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetSubManPageContentActionResult.ts
@@ -50,6 +50,9 @@ class DefaultPaymentMethod {
 
 class SubscriptionContent {
   @IsString()
+  id!: string;
+
+  @IsString()
   productName!: string;
 
   @IsString()

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/sdk-trace-web": "^2.0.0",
     "@paypal/react-paypal-js": "^8.7.0",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-form": "^0.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@sentry/browser": "8.42.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11822,6 +11822,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dialog@npm:^1.1.14":
+  version: 1.1.14
+  resolution: "@radix-ui/react-dialog@npm:1.1.14"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.2"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.10"
+    "@radix-ui/react-focus-guards": "npm:1.1.2"
+    "@radix-ui/react-focus-scope": "npm:1.1.7"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-portal": "npm:1.1.9"
+    "@radix-ui/react-presence": "npm:1.1.4"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-slot": "npm:1.2.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.6.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/ab7bc783510ed8fccfe91020b214f4a571d5a1d46d398faa33f4c151bc9f586c47483b307e72b67687b06694c194b3aa80dd1de728460fa765db9f3057690ba3
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-direction@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-direction@npm:1.0.1"
@@ -11912,6 +11944,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-focus-guards@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-focus-guards@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/8d6fa55752b9b6e55d1eebb643178e38a824e8ba418eb29031b2979077a12c4e3922892de9f984dd326f77071a14960cd81e99a960beea07598b8c80da618dc5
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-focus-scope@npm:1.0.3":
   version: 1.0.3
   resolution: "@radix-ui/react-focus-scope@npm:1.0.3"
@@ -11931,6 +11976,27 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/bfff46919666c122f5b812ee427494ae8408c0eebee30337bd2ce0eedf539f0feaa242f790304ef9df15425b837010ffc6061ce467bedd2c5fd9373bee2b95da
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-scope@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-focus-scope@npm:1.1.7"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
   languageName: node
   linkType: hard
 
@@ -22921,7 +22987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-hidden@npm:^1.1.1":
+"aria-hidden@npm:^1.1.1, aria-hidden@npm:^1.2.4":
   version: 1.2.6
   resolution: "aria-hidden@npm:1.2.6"
   dependencies:
@@ -33480,6 +33546,7 @@ __metadata:
     "@opentelemetry/sdk-trace-web": "npm:^2.0.0"
     "@opentelemetry/semantic-conventions": "npm:^1.32.0"
     "@paypal/react-paypal-js": "npm:^8.7.0"
+    "@radix-ui/react-dialog": "npm:^1.1.14"
     "@radix-ui/react-form": "npm:^0.1.0"
     "@radix-ui/react-tooltip": "npm:^1.1.2"
     "@sentry/browser": "npm:8.42.0"
@@ -48623,7 +48690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-remove-scroll-bar@npm:^2.3.3":
+"react-remove-scroll-bar@npm:^2.3.3, react-remove-scroll-bar@npm:^2.3.7":
   version: 2.3.8
   resolution: "react-remove-scroll-bar@npm:2.3.8"
   dependencies:
@@ -48655,6 +48722,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/4952657e6a7b9d661d4ad4dfcef81b9c7fa493e35164abff99c35c0b27b3d172ef7ad70c09416dc44dd14ff2e6b38a5ec7da27e27e90a15cbad36b8fd2fd8054
+  languageName: node
+  linkType: hard
+
+"react-remove-scroll@npm:^2.6.3":
+  version: 2.7.1
+  resolution: "react-remove-scroll@npm:2.7.1"
+  dependencies:
+    react-remove-scroll-bar: "npm:^2.3.7"
+    react-style-singleton: "npm:^2.2.3"
+    tslib: "npm:^2.1.0"
+    use-callback-ref: "npm:^1.3.3"
+    use-sidecar: "npm:^1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7ad8f6ffd3e2aedf9b3d79f0c9088a9a3d7c5332d80c923427a6d97fe0626fb4cb33a6d9174d19fad57d860be69c96f68497a0619c3a8af0e8a5332e49bdde31
   languageName: node
   linkType: hard
 
@@ -48782,7 +48868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-style-singleton@npm:^2.2.1, react-style-singleton@npm:^2.2.2":
+"react-style-singleton@npm:^2.2.1, react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
   version: 2.2.3
   resolution: "react-style-singleton@npm:2.2.3"
   dependencies:
@@ -55606,7 +55692,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-callback-ref@npm:^1.3.0":
+"use-callback-ref@npm:^1.3.0, use-callback-ref@npm:^1.3.3":
   version: 1.3.3
   resolution: "use-callback-ref@npm:1.3.3"
   dependencies:
@@ -55633,7 +55719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sidecar@npm:^1.1.2":
+"use-sidecar@npm:^1.1.2, use-sidecar@npm:^1.1.3":
   version: 1.1.3
   resolution: "use-sidecar@npm:1.1.3"
   dependencies:


### PR DESCRIPTION
## Because

- Cancel Subscription button needs to cancel the selected subscription at period end and display a notification.

## This pull request

- Add functionality to the cancel subscription button and display the subscription cancelation dialog.

## Issue that this pull request solves

Closes: #PAY-2504

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Successful cancelation
<img width="915" height="763" alt="image" src="https://github.com/user-attachments/assets/4bd3fd5e-881d-4b5f-9172-2d7137722e22" />

Error on cancel
<img width="930" height="803" alt="image" src="https://github.com/user-attachments/assets/df7e5e01-35a5-4b22-9150-ec8504105d5e" />


## Other information (Optional)

Any other information that is important to this pull request.
