### PR TITLE
task(payments): update payments domain to WAF friendly url

### DIFF
--- a/packages/functional-tests/lib/targets/stage.ts
+++ b/packages/functional-tests/lib/targets/stage.ts
@@ -10,8 +10,7 @@ const ACCOUNTS_DOMAIN =
 const ACCOUNTS_API_DOMAIN =
   process.env.ACCOUNTS_API_DOMAIN || 'api-accounts.stage.mozaws.net';
 const PAYMENTS_DOMAIN =
-  process.env.PAYMENTS_DOMAIN ||
-  'payments-stage.fxa.nonprod.cloudops.mozgcp.net';
+  process.env.PAYMENTS_DOMAIN || 'payments-server.allizom.org';
 const RELIER_DOMAIN =
   process.env.RELIER_DOMAIN || 'stage-123done.herokuapp.com';
 const RELIER_CLIENT_ID = 'dcdb5ae7add825d2';


### PR DESCRIPTION
## Because

- I never saved the change to this url in my [previous PR](https://github.com/mozilla/fxa/pull/19257)

## This pull request

- replaces the old url with the newly created Fastly WAF friendly url

## Issue that this pull request solves

Closes: FXA-12157