### PR TITLE
feat(fxa-settings): trial adding snapshot testing to Signin page

### DIFF
--- a/packages/fxa-react/lib/test-utils/localizationProvider.tsx
+++ b/packages/fxa-react/lib/test-utils/localizationProvider.tsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
+import { userEvent, UserEvent } from '@testing-library/user-event';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 
 const reportError = () => {};
@@ -11,12 +12,16 @@ const reportError = () => {};
 export function renderWithLocalizationProvider(
   children: JSX.Element,
   messages = { en: ['testo: lol'] }
-): ReturnType<typeof render> {
-  return render(
-    <AppLocalizationProvider {...{ messages, reportError }}>
-      {children}
-    </AppLocalizationProvider>
-  );
+): ReturnType<typeof render> & { user: UserEvent } {
+  const user: UserEvent = userEvent.setup();
+  return {
+    user,
+    ...render(
+      <AppLocalizationProvider {...{ messages, reportError }}>
+        {children}
+      </AppLocalizationProvider>
+    ),
+  };
 }
 
 export function withLocalizationProvider(

--- a/packages/fxa-react/lib/test-utils/mockWindowLocation.ts
+++ b/packages/fxa-react/lib/test-utils/mockWindowLocation.ts
@@ -11,10 +11,11 @@ export function mockWindowLocation({
   search?: string;
   hash?: string;
 }) {
+  const originalLocation = window.location;
   delete (window as any).location;
 
   (window as any).location = {
-    ...window.location,
+    ...originalLocation,
     assign: jest.fn(),
     reload: jest.fn(),
     replace: jest.fn(),

--- a/packages/fxa-settings/src/pages/Signin/__snapshots__/container.test.tsx.snap
+++ b/packages/fxa-settings/src/pages/Signin/__snapshots__/container.test.tsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`signin container snapshots props match snapshot when CMS is disabled and falls back to localStorage email 1`] = `
+{
+  "avatarData": {
+    "account": {
+      "avatar": {
+        "id": null,
+        "url": null,
+      },
+    },
+  },
+  "avatarLoading": false,
+  "beginSigninHandler": [Function],
+  "cachedSigninHandler": [Function],
+  "deeplink": undefined,
+  "email": "johndope@example.com",
+  "finishOAuthFlowHandler": [Function],
+  "flowQueryParams": {
+    "flowId": "00ff",
+  },
+  "hasLinkedAccount": false,
+  "hasPassword": true,
+  "integration": WebIntegration {
+    "clientInfo": undefined,
+    "cmsInfo": undefined,
+    "data": WebIntegrationData {
+      "isDirty": false,
+      "modelData": "{"service":"account settings"}",
+    },
+    "features": {
+      "allowUidChange": false,
+      "fxaStatus": true,
+      "handleSignedInNotification": true,
+      "reuseExistingSession": true,
+      "supportsPairing": false,
+    },
+    "subscriptionInfo": undefined,
+    "type": "Web",
+  },
+  "localizedErrorFromLocationState": undefined,
+  "localizedSuccessBannerDescription": undefined,
+  "localizedSuccessBannerHeading": undefined,
+  "sendUnblockEmailHandler": [Function],
+  "serviceName": "account settings",
+  "sessionToken": "sessionToken",
+}
+`;
+
+exports[`signin container snapshots renders correctly when CMS is enabled and email comes from query param 1`] = `
+{
+  "avatarData": {
+    "account": {
+      "avatar": {
+        "id": null,
+        "url": null,
+      },
+    },
+  },
+  "avatarLoading": false,
+  "beginSigninHandler": [Function],
+  "cachedSigninHandler": [Function],
+  "deeplink": undefined,
+  "email": "from@queryparams.com",
+  "finishOAuthFlowHandler": [Function],
+  "flowQueryParams": {
+    "flowId": "00ff",
+  },
+  "hasLinkedAccount": "true",
+  "hasPassword": "true",
+  "integration": WebIntegration {
+    "clientInfo": undefined,
+    "cmsInfo": undefined,
+    "data": WebIntegrationData {
+      "isDirty": false,
+      "modelData": "{"service":"account settings"}",
+    },
+    "features": {
+      "allowUidChange": false,
+      "fxaStatus": true,
+      "handleSignedInNotification": true,
+      "reuseExistingSession": true,
+      "supportsPairing": false,
+    },
+    "subscriptionInfo": undefined,
+    "type": "Web",
+  },
+  "localizedErrorFromLocationState": undefined,
+  "localizedSuccessBannerDescription": undefined,
+  "localizedSuccessBannerHeading": undefined,
+  "sendUnblockEmailHandler": [Function],
+  "serviceName": "account settings",
+  "sessionToken": undefined,
+}
+`;
+
+exports[`signin container snapshots renders correctly when CMS is enabled and router state takes precedence 1`] = `
+{
+  "avatarData": {
+    "account": {
+      "avatar": {
+        "id": null,
+        "url": null,
+      },
+    },
+  },
+  "avatarLoading": false,
+  "beginSigninHandler": [Function],
+  "cachedSigninHandler": [Function],
+  "deeplink": undefined,
+  "email": "from@routerstate.com",
+  "finishOAuthFlowHandler": [Function],
+  "flowQueryParams": {
+    "flowId": "00ff",
+  },
+  "hasLinkedAccount": false,
+  "hasPassword": true,
+  "integration": WebIntegration {
+    "clientInfo": undefined,
+    "cmsInfo": undefined,
+    "data": WebIntegrationData {
+      "isDirty": false,
+      "modelData": "{"service":"account settings"}",
+    },
+    "features": {
+      "allowUidChange": false,
+      "fxaStatus": true,
+      "handleSignedInNotification": true,
+      "reuseExistingSession": true,
+      "supportsPairing": false,
+    },
+    "subscriptionInfo": undefined,
+    "type": "Web",
+  },
+  "localizedErrorFromLocationState": undefined,
+  "localizedSuccessBannerDescription": undefined,
+  "localizedSuccessBannerHeading": undefined,
+  "sendUnblockEmailHandler": [Function],
+  "serviceName": "account settings",
+  "sessionToken": undefined,
+}
+`;
+
+exports[`signin container snapshots renders correctly with minimal state and no CMS 1`] = `
+{
+  "avatarData": {
+    "account": {
+      "avatar": {
+        "id": null,
+        "url": null,
+      },
+    },
+  },
+  "avatarLoading": false,
+  "beginSigninHandler": [Function],
+  "cachedSigninHandler": [Function],
+  "deeplink": undefined,
+  "email": "fallback@localstorage.com",
+  "finishOAuthFlowHandler": [Function],
+  "flowQueryParams": {
+    "flowId": "00ff",
+  },
+  "hasLinkedAccount": false,
+  "hasPassword": true,
+  "integration": WebIntegration {
+    "clientInfo": undefined,
+    "cmsInfo": undefined,
+    "data": WebIntegrationData {
+      "isDirty": false,
+      "modelData": "{"service":"account settings"}",
+    },
+    "features": {
+      "allowUidChange": false,
+      "fxaStatus": true,
+      "handleSignedInNotification": true,
+      "reuseExistingSession": true,
+      "supportsPairing": false,
+    },
+    "subscriptionInfo": undefined,
+    "type": "Web",
+  },
+  "localizedErrorFromLocationState": undefined,
+  "localizedSuccessBannerDescription": undefined,
+  "localizedSuccessBannerHeading": undefined,
+  "sendUnblockEmailHandler": [Function],
+  "serviceName": "account settings",
+  "sessionToken": "sessionToken",
+}
+`;

--- a/packages/fxa-settings/src/pages/Signin/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/pages/Signin/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,2957 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Signin component snapshots with CMS disabled renders correctly 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-password-needed-header-2"
+          >
+            <h1
+              class="card-header"
+            >
+              Enter your password
+               
+              <span
+                class="card-subheader"
+              >
+                for your Mozilla account
+              </span>
+            </h1>
+          </span>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <form>
+            <input
+              class="hidden"
+              disabled=""
+              type="email"
+              value="johndope@example.com"
+            />
+            <div
+              class="relative"
+            >
+              <label
+                class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-5"
+                data-testid="input-container"
+              >
+                <span
+                  class="block flex-auto"
+                >
+                  <span
+                    class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                    data-testid="input-label"
+                  >
+                    Password
+                  </span>
+                  <input
+                    autocomplete="off"
+                    class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                    data-testid="input-field"
+                    name="password"
+                    spellcheck="false"
+                    type="password"
+                    value=""
+                  />
+                </span>
+              </label>
+              <button
+                aria-label="Your password is currently hidden."
+                aria-pressed="false"
+                class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                data-testid="visibility-toggle"
+                title="Show password"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="stroke-current"
+                  height="18"
+                  width="24"
+                >
+                  eye-open.svg
+                </svg>
+              </button>
+            </div>
+            <div
+              class="flex"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-button"
+              >
+                <button
+                  class="cta-primary cta-xl cta-primary cta-xl"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </span>
+            </div>
+          </form>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="text-sm flex items-center justify-center my-6"
+            >
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+              <span
+                data-testid="ftlmsg-mock"
+                id="third-party-auth-options-or"
+              >
+                <div
+                  class="mx-4 text-base text-grey-300 font-extralight"
+                >
+                  or
+                </div>
+              </span>
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+            </div>
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-forgot-password-link"
+            >
+              <a
+                class="text-sm link-blue mx-auto tablet:mx-0"
+                href="/reset_password"
+              >
+                Forgot password?
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS disabled renders correctly with deeplink 1`] = `
+<div>
+  <div
+    class="flex flex-col"
+  >
+    <div
+      class="flex flex-col"
+    >
+      <form
+        action=""
+        method="GET"
+      >
+        <input
+          data-testid="google-signin-form-state"
+          name="state"
+          type="hidden"
+          value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+        />
+        <input
+          name="client_id"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="scope"
+          type="hidden"
+          value="openid email profile"
+        />
+        <input
+          name="redirect_uri"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="access_type"
+          type="hidden"
+          value="offline"
+        />
+        <input
+          name="prompt"
+          type="hidden"
+          value="consent"
+        />
+        <input
+          name="response_type"
+          type="hidden"
+          value="code"
+        />
+      </form>
+      <form
+        action=""
+        method="GET"
+      >
+        <input
+          data-testid="apple-signin-form-state"
+          name="state"
+          type="hidden"
+          value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+        />
+        <input
+          name="client_id"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="scope"
+          type="hidden"
+          value="email"
+        />
+        <input
+          name="redirect_uri"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="access_type"
+          type="hidden"
+          value="offline"
+        />
+        <input
+          name="prompt"
+          type="hidden"
+          value="consent"
+        />
+        <input
+          name="response_type"
+          type="hidden"
+          value="code id_token"
+        />
+        <input
+          name="response_mode"
+          type="hidden"
+          value="form_post"
+        />
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Signin component snapshots with CMS disabled renders error banner when login is locked 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-password-needed-header-2"
+          >
+            <h1
+              class="card-header"
+            >
+              Enter your password
+               
+              <span
+                class="card-subheader"
+              >
+                for your Mozilla account
+              </span>
+            </h1>
+          </span>
+          <div
+            aria-live="assertive"
+            class="my-4 flex flex-row no-wrap items-center px-4 py-3 gap-3.5 rounded-md border border-transparent text-sm text-start bg-red-100"
+            id=""
+            role="alert"
+            tabindex="-1"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="error-icon-aria-label"
+            >
+              <svg
+                aria-label="Error"
+                class="shrink-0 self-center"
+                role="img"
+              >
+                icon_error_circle_outline_current.min.svg
+              </svg>
+            </span>
+            <div
+              class="flex flex-col grow"
+            >
+              <p
+                class="font-bold"
+              >
+                Reset your password
+              </p>
+            </div>
+          </div>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <form>
+            <input
+              class="hidden"
+              disabled=""
+              type="email"
+              value="johndope@example.com"
+            />
+            <div
+              class="relative"
+            >
+              <label
+                class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-5"
+                data-testid="input-container"
+              >
+                <span
+                  class="block flex-auto"
+                >
+                  <span
+                    class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                    data-testid="input-label"
+                  >
+                    Password
+                  </span>
+                  <input
+                    autocomplete="off"
+                    class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                    data-testid="input-field"
+                    name="password"
+                    spellcheck="false"
+                    type="password"
+                    value=""
+                  />
+                </span>
+              </label>
+              <button
+                aria-label="Your password is currently hidden."
+                aria-pressed="false"
+                class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                data-testid="visibility-toggle"
+                title="Show password"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="stroke-current"
+                  height="18"
+                  width="24"
+                >
+                  eye-open.svg
+                </svg>
+              </button>
+            </div>
+            <div
+              class="flex"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-button"
+              >
+                <button
+                  class="cta-primary cta-xl cta-primary cta-xl"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </span>
+            </div>
+          </form>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="text-sm flex items-center justify-center my-6"
+            >
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+              <span
+                data-testid="ftlmsg-mock"
+                id="third-party-auth-options-or"
+              >
+                <div
+                  class="mx-4 text-base text-grey-300 font-extralight"
+                >
+                  or
+                </div>
+              </span>
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+            </div>
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-forgot-password-link"
+            >
+              <a
+                class="text-sm link-blue mx-auto tablet:mx-0"
+                href="/reset_password"
+              >
+                Forgot password?
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS disabled renders passwordless UI for linked account with no password 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <h1
+            class="card-header"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-header"
+            >
+              Sign in
+            </span>
+          </h1>
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-subheader-without-logo-default"
+          >
+            <p
+              class="card-subheader"
+            >
+              Continue to 
+              account settings
+            </p>
+          </span>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS disabled renders success banner when present 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <div
+            aria-live="polite"
+            class="my-4 flex flex-row no-wrap items-center px-4 py-3 gap-3.5 rounded-md border border-transparent text-sm text-start bg-green-200"
+            id=""
+            role="status"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="shrink-0 self-center"
+              data-testid="aria-hidden-image"
+              role="img"
+            >
+              icon_checkmark_circle_outline_current.min.svg
+            </svg>
+            <div
+              class="flex flex-col grow"
+            >
+              <p
+                class="font-bold"
+              >
+                Success!
+              </p>
+              <p>
+                You have successfully signed in.
+              </p>
+            </div>
+          </div>
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-password-needed-header-2"
+          >
+            <h1
+              class="card-header"
+            >
+              Enter your password
+               
+              <span
+                class="card-subheader"
+              >
+                for your Mozilla account
+              </span>
+            </h1>
+          </span>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <form>
+            <input
+              class="hidden"
+              disabled=""
+              type="email"
+              value="johndope@example.com"
+            />
+            <div
+              class="relative"
+            >
+              <label
+                class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-5"
+                data-testid="input-container"
+              >
+                <span
+                  class="block flex-auto"
+                >
+                  <span
+                    class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                    data-testid="input-label"
+                  >
+                    Password
+                  </span>
+                  <input
+                    autocomplete="off"
+                    class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                    data-testid="input-field"
+                    name="password"
+                    spellcheck="false"
+                    type="password"
+                    value=""
+                  />
+                </span>
+              </label>
+              <button
+                aria-label="Your password is currently hidden."
+                aria-pressed="false"
+                class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                data-testid="visibility-toggle"
+                title="Show password"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="stroke-current"
+                  height="18"
+                  width="24"
+                >
+                  eye-open.svg
+                </svg>
+              </button>
+            </div>
+            <div
+              class="flex"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-button"
+              >
+                <button
+                  class="cta-primary cta-xl cta-primary cta-xl"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </span>
+            </div>
+          </form>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="text-sm flex items-center justify-center my-6"
+            >
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+              <span
+                data-testid="ftlmsg-mock"
+                id="third-party-auth-options-or"
+              >
+                <div
+                  class="mx-4 text-base text-grey-300 font-extralight"
+                >
+                  or
+                </div>
+              </span>
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+            </div>
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-forgot-password-link"
+            >
+              <a
+                class="text-sm link-blue mx-auto tablet:mx-0"
+                href="/reset_password"
+              >
+                Forgot password?
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS enabled renders correctly 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <img
+            alt="SNAPSHOT_TEST Alt text for logo"
+            class="justify-start mb-4 max-h-[40px]"
+            src="https://example.com/SNAPSHOT_TEST.png"
+          />
+          <h1
+            class="card-header"
+          >
+            SNAPSHOT_TEST Custom CMS Headline
+          </h1>
+          <p
+            class="card-subheader"
+          >
+            SNAPSHOT_TEST Custom CMS Description
+          </p>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <form>
+            <input
+              class="hidden"
+              disabled=""
+              type="email"
+              value="johndope@example.com"
+            />
+            <div
+              class="relative"
+            >
+              <label
+                class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-5"
+                data-testid="input-container"
+              >
+                <span
+                  class="block flex-auto"
+                >
+                  <span
+                    class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                    data-testid="input-label"
+                  >
+                    Password
+                  </span>
+                  <input
+                    autocomplete="off"
+                    class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                    data-testid="input-field"
+                    name="password"
+                    spellcheck="false"
+                    type="password"
+                    value=""
+                  />
+                </span>
+              </label>
+              <button
+                aria-label="Your password is currently hidden."
+                aria-pressed="false"
+                class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                data-testid="visibility-toggle"
+                title="Show password"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="stroke-current"
+                  height="18"
+                  width="24"
+                >
+                  eye-open.svg
+                </svg>
+              </button>
+            </div>
+            <div
+              class="flex"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-button"
+              >
+                <button
+                  class="cta-primary-cms cta-xl cta-primary cta-xl"
+                  style="--cta-bg: blue; --cta-border: blue; --cta-active: blue; --cta-disabled: blue60;"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </span>
+            </div>
+          </form>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="text-sm flex items-center justify-center my-6"
+            >
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+              <span
+                data-testid="ftlmsg-mock"
+                id="third-party-auth-options-or"
+              >
+                <div
+                  class="mx-4 text-base text-grey-300 font-extralight"
+                >
+                  or
+                </div>
+              </span>
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+            </div>
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-forgot-password-link"
+            >
+              <a
+                class="text-sm link-blue mx-auto tablet:mx-0"
+                href="/reset_password"
+              >
+                Forgot password?
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS enabled renders correctly with deeplink 1`] = `
+<div>
+  <div
+    class="flex flex-col"
+  >
+    <div
+      class="flex flex-col"
+    >
+      <form
+        action=""
+        method="GET"
+      >
+        <input
+          data-testid="google-signin-form-state"
+          name="state"
+          type="hidden"
+          value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+        />
+        <input
+          name="client_id"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="scope"
+          type="hidden"
+          value="openid email profile"
+        />
+        <input
+          name="redirect_uri"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="access_type"
+          type="hidden"
+          value="offline"
+        />
+        <input
+          name="prompt"
+          type="hidden"
+          value="consent"
+        />
+        <input
+          name="response_type"
+          type="hidden"
+          value="code"
+        />
+      </form>
+      <form
+        action=""
+        method="GET"
+      >
+        <input
+          data-testid="apple-signin-form-state"
+          name="state"
+          type="hidden"
+          value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+        />
+        <input
+          name="client_id"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="scope"
+          type="hidden"
+          value="email"
+        />
+        <input
+          name="redirect_uri"
+          type="hidden"
+          value=""
+        />
+        <input
+          name="access_type"
+          type="hidden"
+          value="offline"
+        />
+        <input
+          name="prompt"
+          type="hidden"
+          value="consent"
+        />
+        <input
+          name="response_type"
+          type="hidden"
+          value="code id_token"
+        />
+        <input
+          name="response_mode"
+          type="hidden"
+          value="form_post"
+        />
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Signin component snapshots with CMS enabled renders error banner when login is locked 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <img
+            alt="SNAPSHOT_TEST Alt text for logo"
+            class="justify-start mb-4 max-h-[40px]"
+            src="https://example.com/SNAPSHOT_TEST.png"
+          />
+          <h1
+            class="card-header"
+          >
+            SNAPSHOT_TEST Custom CMS Headline
+          </h1>
+          <p
+            class="card-subheader"
+          >
+            SNAPSHOT_TEST Custom CMS Description
+          </p>
+          <div
+            aria-live="assertive"
+            class="my-4 flex flex-row no-wrap items-center px-4 py-3 gap-3.5 rounded-md border border-transparent text-sm text-start bg-red-100"
+            id=""
+            role="alert"
+            tabindex="-1"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="error-icon-aria-label"
+            >
+              <svg
+                aria-label="Error"
+                class="shrink-0 self-center"
+                role="img"
+              >
+                icon_error_circle_outline_current.min.svg
+              </svg>
+            </span>
+            <div
+              class="flex flex-col grow"
+            >
+              <p
+                class="font-bold"
+              >
+                Reset your password
+              </p>
+            </div>
+          </div>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <form>
+            <input
+              class="hidden"
+              disabled=""
+              type="email"
+              value="johndope@example.com"
+            />
+            <div
+              class="relative"
+            >
+              <label
+                class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-5"
+                data-testid="input-container"
+              >
+                <span
+                  class="block flex-auto"
+                >
+                  <span
+                    class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                    data-testid="input-label"
+                  >
+                    Password
+                  </span>
+                  <input
+                    autocomplete="off"
+                    class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                    data-testid="input-field"
+                    name="password"
+                    spellcheck="false"
+                    type="password"
+                    value=""
+                  />
+                </span>
+              </label>
+              <button
+                aria-label="Your password is currently hidden."
+                aria-pressed="false"
+                class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                data-testid="visibility-toggle"
+                title="Show password"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="stroke-current"
+                  height="18"
+                  width="24"
+                >
+                  eye-open.svg
+                </svg>
+              </button>
+            </div>
+            <div
+              class="flex"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-button"
+              >
+                <button
+                  class="cta-primary-cms cta-xl cta-primary cta-xl"
+                  style="--cta-bg: blue; --cta-border: blue; --cta-active: blue; --cta-disabled: blue60;"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </span>
+            </div>
+          </form>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="text-sm flex items-center justify-center my-6"
+            >
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+              <span
+                data-testid="ftlmsg-mock"
+                id="third-party-auth-options-or"
+              >
+                <div
+                  class="mx-4 text-base text-grey-300 font-extralight"
+                >
+                  or
+                </div>
+              </span>
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+            </div>
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-forgot-password-link"
+            >
+              <a
+                class="text-sm link-blue mx-auto tablet:mx-0"
+                href="/reset_password"
+              >
+                Forgot password?
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS enabled renders passwordless UI for linked account with no password 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <img
+            alt="SNAPSHOT_TEST Alt text for logo"
+            class="justify-start mb-4 max-h-[40px]"
+            src="https://example.com/SNAPSHOT_TEST.png"
+          />
+          <h1
+            class="card-header"
+          />
+          <p
+            class="card-subheader"
+          />
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;
+
+exports[`Signin component snapshots with CMS enabled renders success banner when present 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 pt-16 pb-0 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-auto mobileLandscape:mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <div
+            aria-live="polite"
+            class="my-4 flex flex-row no-wrap items-center px-4 py-3 gap-3.5 rounded-md border border-transparent text-sm text-start bg-green-200"
+            id=""
+            role="status"
+            tabindex="-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="shrink-0 self-center"
+              data-testid="aria-hidden-image"
+              role="img"
+            >
+              icon_checkmark_circle_outline_current.min.svg
+            </svg>
+            <div
+              class="flex flex-col grow"
+            >
+              <p
+                class="font-bold"
+              >
+                Success!
+              </p>
+              <p>
+                You have successfully signed in.
+              </p>
+            </div>
+          </div>
+          <img
+            alt="SNAPSHOT_TEST Alt text for logo"
+            class="justify-start mb-4 max-h-[40px]"
+            src="https://example.com/SNAPSHOT_TEST.png"
+          />
+          <h1
+            class="card-header"
+          >
+            SNAPSHOT_TEST Custom CMS Headline
+          </h1>
+          <p
+            class="card-subheader"
+          >
+            SNAPSHOT_TEST Custom CMS Description
+          </p>
+          <div
+            class="mt-9"
+          >
+            <img
+              alt="Default avatar"
+              class="rounded-full mx-auto h-24 w-24 tablet:h-40 tablet:w-40"
+              data-testid="avatar-default"
+              src="avatar-default.svg"
+            />
+            <div
+              class="my-5 text-base break-all text-center"
+            >
+              johndope@example.com
+            </div>
+          </div>
+          <form>
+            <input
+              class="hidden"
+              disabled=""
+              type="email"
+              value="johndope@example.com"
+            />
+            <div
+              class="relative"
+            >
+              <label
+                class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-5"
+                data-testid="input-container"
+              >
+                <span
+                  class="block flex-auto"
+                >
+                  <span
+                    class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                    data-testid="input-label"
+                  >
+                    Password
+                  </span>
+                  <input
+                    autocomplete="off"
+                    class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                    data-testid="input-field"
+                    name="password"
+                    spellcheck="false"
+                    type="password"
+                    value=""
+                  />
+                </span>
+              </label>
+              <button
+                aria-label="Your password is currently hidden."
+                aria-pressed="false"
+                class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                data-testid="visibility-toggle"
+                title="Show password"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="stroke-current"
+                  height="18"
+                  width="24"
+                >
+                  eye-open.svg
+                </svg>
+              </button>
+            </div>
+            <div
+              class="flex"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-button"
+              >
+                <button
+                  class="cta-primary-cms cta-xl cta-primary cta-xl"
+                  style="--cta-bg: blue; --cta-border: blue; --cta-active: blue; --cta-disabled: blue60;"
+                  type="submit"
+                >
+                  Sign in
+                </button>
+              </span>
+            </div>
+          </form>
+          <div
+            class="flex flex-col"
+          >
+            <div
+              class="text-sm flex items-center justify-center my-6"
+            >
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+              <span
+                data-testid="ftlmsg-mock"
+                id="third-party-auth-options-or"
+              >
+                <div
+                  class="mx-4 text-base text-grey-300 font-extralight"
+                >
+                  or
+                </div>
+              </span>
+              <div
+                class="flex-1 h-px bg-grey-300 divide-x"
+              />
+            </div>
+            <div
+              class="flex flex-col"
+            >
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="google-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="openid email profile"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    google-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-google-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Google
+                    </p>
+                  </span>
+                </button>
+              </form>
+              <form
+                action=""
+                method="GET"
+              >
+                <input
+                  data-testid="apple-signin-form-state"
+                  name="state"
+                  type="hidden"
+                  value="http%3A%2F%2Flocalhost%2Fsignin%3F"
+                />
+                <input
+                  name="client_id"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="scope"
+                  type="hidden"
+                  value="email"
+                />
+                <input
+                  name="redirect_uri"
+                  type="hidden"
+                  value=""
+                />
+                <input
+                  name="access_type"
+                  type="hidden"
+                  value="offline"
+                />
+                <input
+                  name="prompt"
+                  type="hidden"
+                  value="consent"
+                />
+                <input
+                  name="response_type"
+                  type="hidden"
+                  value="code id_token"
+                />
+                <input
+                  name="response_mode"
+                  type="hidden"
+                  value="form_post"
+                />
+                <button
+                  class="w-full px-2 mt-2 justify-center text-black bg-transparent border-grey-300 border hover:border-black rounded-lg text-md text-center inline-flex items-center focus-visible-default outline-offset-2"
+                  type="submit"
+                >
+                  <svg>
+                    apple-logo.svg
+                  </svg>
+                  <span
+                    data-testid="ftlmsg-mock"
+                    id="continue-with-apple-button"
+                  >
+                    <p
+                      class="pe-4"
+                    >
+                      Continue with Apple
+                    </p>
+                  </span>
+                </button>
+              </form>
+            </div>
+          </div>
+          <div
+            class="text-grey-500 text-xs mt-5"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="terms-privacy-agreement-default-2"
+            >
+              <p>
+                By proceeding, you agree to the
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/terms"
+                >
+                  Terms of Service
+                </a>
+                 
+                and
+                 
+                <a
+                  class="link-grey"
+                  href="/legal/privacy"
+                >
+                  Privacy Notice
+                </a>
+                .
+              </p>
+            </span>
+          </div>
+          <div
+            class="flex flex-col mt-8 tablet:justify-between tablet:flex-row"
+          >
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-use-a-different-account-link"
+            >
+              <a
+                class="text-sm link-blue cursor-pointer mb-4 mx-auto tablet:mx-0 tablet:mb-0"
+                href="/"
+              >
+                Use a different account
+              </a>
+            </span>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-forgot-password-link"
+            >
+              <a
+                class="text-sm link-blue mx-auto tablet:mx-0"
+                href="/reset_password"
+              >
+                Forgot password?
+              </a>
+            </span>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -64,6 +64,17 @@ import {
 } from '../../models/pages/signin';
 import { OAuthError } from '../../lib/oauth';
 
+/**
+ * Lazy config so that tests can mutate as needed, but it's returned
+ * via the mocked `useConfig` hook and mocks are left as is.
+ */
+let testConfig = {
+  featureFlags: {
+    contentManagementSystem: false,
+    recoveryCodeSetupOnSyncSignIn: true,
+  },
+};
+
 jest.mock('../../lib/channels/firefox', () => ({
   ...jest.requireActual('../../lib/channels/firefox'),
   firefox: {
@@ -203,11 +214,7 @@ function mockModelsModule() {
   (ModelsModule.useSensitiveDataClient as jest.Mock).mockImplementation(
     () => mockSensitiveDataClient
   );
-  (ModelsModule.useConfig as jest.Mock).mockImplementation(() => ({
-    featureFlags: {
-      recoveryCodeSetupOnSyncSignIn: true,
-    },
-  }));
+  (ModelsModule.useConfig as jest.Mock).mockImplementation(() => testConfig);
 }
 
 // Call this when testing local storage
@@ -1283,6 +1290,129 @@ describe('signin container', () => {
         true,
         false
       );
+    });
+  });
+  describe('snapshots', () => {
+    it('props match snapshot when CMS is disabled and falls back to localStorage email', async () => {
+      testConfig.featureFlags.contentManagementSystem = true;
+      mockUseValidateModule({
+        queryParams: {
+          email: '',
+          hasPassword: undefined,
+          hasLinkedAccount: undefined,
+          isV2: () => false,
+        },
+      });
+      mockCurrentAccount(MOCK_STORED_ACCOUNT);
+      render([mockGqlAvatarUseQuery()]);
+
+      await waitFor(() => {
+        expect(currentSigninProps?.email).toBe(MOCK_STORED_ACCOUNT.email);
+      });
+
+      expect(currentSigninProps).toMatchSnapshot();
+    });
+    it('renders correctly when CMS is enabled and email comes from query param', async () => {
+      // Simulate CMS on
+      (ModelsModule.useConfig as jest.Mock).mockReturnValue({
+        featureFlags: {
+          contentManagementSystem: true,
+        },
+      });
+
+      mockUseValidateModule({
+        queryParams: {
+          email: MOCK_QUERY_PARAM_EMAIL,
+          hasLinkedAccount: 'true',
+          hasPassword: 'true',
+          isV2: () => false,
+        },
+      });
+
+      render([mockGqlAvatarUseQuery()]);
+
+      await waitFor(() => {
+        expect(currentSigninProps?.email).toBe(MOCK_QUERY_PARAM_EMAIL);
+      });
+
+      expect(currentSigninProps).toMatchSnapshot();
+    });
+
+    it('renders correctly when CMS is enabled and router state takes precedence', async () => {
+      (ModelsModule.useConfig as jest.Mock).mockReturnValue({
+        featureFlags: {
+          contentManagementSystem: true,
+        },
+      });
+
+      mockLocationState = {
+        email: MOCK_ROUTER_STATE_EMAIL,
+        hasLinkedAccount: false,
+        hasPassword: true,
+      };
+
+      mockUseValidateModule({
+        queryParams: {
+          email: MOCK_QUERY_PARAM_EMAIL, // Should be ignored
+          hasLinkedAccount: 'true',
+          hasPassword: 'true',
+          isV2: () => false,
+        },
+      });
+
+      render([mockGqlAvatarUseQuery()]);
+
+      await waitFor(() => {
+        expect(currentSigninProps?.email).toBe(MOCK_ROUTER_STATE_EMAIL);
+      });
+
+      expect(currentSigninProps).toMatchSnapshot();
+    });
+
+    it('renders correctly when CMS is enabled but query param validation fails', async () => {
+      (ModelsModule.useConfig as jest.Mock).mockReturnValue({
+        featureFlags: {
+          contentManagementSystem: true,
+        },
+      });
+
+      jest.spyOn(UseValidateModule, 'useValidatedQueryParams').mockReturnValue({
+        queryParamModel: {},
+        validationError: 'email', // triggers redirect
+      });
+
+      render([mockGqlAvatarUseQuery()]);
+
+      // currentSigninProps will be undefined because <Signin /> is never rendered
+      expect(currentSigninProps).toBeUndefined();
+      // Optionally snapshot the redirect trigger or loading fallback
+      expect(screen.getByLabelText('Loading…')).toBeInTheDocument();
+    });
+
+    it('renders correctly with minimal state and no CMS', async () => {
+      // default CMS config is off
+      mockUseValidateModule({
+        queryParams: {
+          email: '',
+          hasPassword: undefined,
+          hasLinkedAccount: undefined,
+          isV2: () => false,
+        },
+      });
+
+      const fallbackAccount = {
+        ...MOCK_STORED_ACCOUNT,
+        email: 'fallback@localstorage.com',
+      };
+      mockCurrentAccount(fallbackAccount);
+
+      render([mockGqlAvatarUseQuery()]);
+
+      await waitFor(() => {
+        expect(currentSigninProps?.email).toBe('fallback@localstorage.com');
+      });
+
+      expect(currentSigninProps).toMatchSnapshot();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -3,14 +3,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { fireEvent, screen, waitFor, act } from '@testing-library/react';
+import {
+  fireEvent,
+  screen,
+  waitFor,
+  act,
+  RenderResult,
+  Queries,
+  cleanup,
+} from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+
 import GleanMetrics from '../../lib/glean';
 import {
   CACHED_SIGNIN_HANDLER_RESPONSE,
   createBeginSigninResponse,
   createBeginSigninResponseError,
   createCachedSigninResponseError,
+  createMockSigninWebIntegration,
   createMockSigninOAuthIntegration,
   createMockSigninOAuthNativeIntegration,
   createMockSigninOAuthNativeSyncIntegration,
@@ -38,10 +48,11 @@ import {
 } from '../../models/integrations/client-matching';
 import firefox from '../../lib/channels/firefox';
 import { navigate } from '@reach/router';
-import { IntegrationType } from '../../models';
+import { IntegrationData, IntegrationType } from '../../models';
 import { SensitiveData } from '../../lib/sensitive-data-client';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import * as SigninUtils from './utils';
+import { mockWindowLocation } from 'fxa-react/lib/test-utils/mockWindowLocation';
 
 // import { getFtlBundle, testAllL10n } from 'fxa-react/lib/test-utils';
 // import { FluentBundle } from '@fluent/bundle';
@@ -100,17 +111,17 @@ jest.mock('../../models', () => {
   };
 });
 
-const mockLocation = () => {
-  return {
-    pathname: '/signin',
-  };
+const mockLocation: Partial<Location> = {
+  pathname: '/signin',
 };
+
 const mockNavigate = jest.fn();
+
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   navigate: jest.fn(),
   useNavigate: () => mockNavigate,
-  useLocation: () => mockLocation(),
+  useLocation: () => mockLocation,
 }));
 
 const serviceRelayText =
@@ -132,9 +143,8 @@ async function enterPasswordAndSubmit() {
   await user.type(screen.getByLabelText('Password'), MOCK_PASSWORD);
   await submit();
 }
-const render = (props: Partial<SigninProps> = {}) => {
+const render = (props: Partial<SigninProps> = {}) =>
   renderWithLocalizationProvider(<Subject {...props} />);
-};
 
 /* Element rendered or not rendered functions */
 function signInHeaderRendered(service: MozServices = MozServices.Default) {
@@ -198,6 +208,12 @@ describe('Signin component', () => {
 
   beforeEach(() => {
     user = userEvent.setup();
+
+    // because there is a navigation that happens in one test during the forgot password flow,
+    // we need to mock location so that it can be reset fully between each test, otherwise
+    // the reach router holds onto the last location and then renders the forgot password page anchor
+    // with an `aria-current="page"` attribute since it thinks we're on that page when we're not.
+    mockWindowLocation({ pathname: '/signin' });
   });
 
   afterEach(() => {
@@ -1281,6 +1297,95 @@ describe('Signin component', () => {
         'href',
         'https://www.mozilla.org/privacy/subscription-services/'
       );
+    });
+  });
+
+  describe('snapshots', () => {
+    const integrationWithCms = createMockSigninWebIntegration({
+      // if we move forward, this should probably be pulled out into
+      // a factory function to build the snapshot test data to a default state
+      // but allow for overrides where necessary.
+      cmsInfo: {
+        shared: {
+          logoUrl: 'https://example.com/SNAPSHOT_TEST.png',
+          logoAltText: 'SNAPSHOT_TEST Alt text for logo',
+          buttonColor: 'blue',
+        },
+        SigninPage: {
+          headline: 'SNAPSHOT_TEST Custom CMS Headline',
+          description: 'SNAPSHOT_TEST Custom CMS Description',
+          primaryButtonText: 'SNAPSHOT_TEST Custom CMS Button Text',
+        },
+        // these aren't used in the Signin page, but are here to ensure consistency
+        name: 'SNAPSHOT_TEST name',
+        clientId: 'SNAPSHOT_TEST_clientId',
+        entrypoint: 'SNAPSHOT_TEST_entrypoint',
+      },
+    });
+
+    const integrationWithoutCms = createMockSigninWebIntegration({
+      cmsInfo: undefined,
+    });
+
+    beforeEach(() => {
+      HTMLFormElement.prototype.submit = jest.fn();
+    });
+
+    // Tests.
+    // This iterates over the integrations, providing parity between
+    // the two different integration types, with and without CMS.
+    // This allows for coverage of both cases since there may be differences in behavior
+    // when CMS is enabled or not for all the tests.
+    // --
+    // We could go a step further still and create a "test" for each integration type,
+    // i.e., signinWeb, signinOAuth, signinOAuthNative, etc. as those may have different
+    // rendered content.
+    [
+      { integration: integrationWithCms, enabled: 'enabled' },
+      { integration: integrationWithoutCms, enabled: 'disabled' },
+    ].forEach(({ integration, enabled }) => {
+      describe(`with CMS ${enabled}`, () => {
+        it(`renders correctly`, async () => {
+          const { container } = render({ integration });
+
+          expect(container).toMatchSnapshot();
+        });
+
+        // deeplinking and passwordless don't currently change based on CMS,
+        // but having these allow us to detect IF they do change when we don't expect
+        it(`renders correctly with deeplink`, async () => {
+          const { container } = render({ integration, deeplink: 'appleLogin' });
+
+          expect(container).toMatchSnapshot();
+        });
+        it('renders passwordless UI for linked account with no password', () => {
+          const { container } = render({
+            integration,
+            hasLinkedAccount: true,
+            hasPassword: false,
+          });
+
+          expect(container).toMatchSnapshot();
+        });
+
+        it('renders success banner when present', () => {
+          const { container } = render({
+            integration,
+            localizedSuccessBannerHeading: 'Success!',
+            localizedSuccessBannerDescription:
+              'You have successfully signed in.',
+          });
+
+          expect(container).toMatchSnapshot();
+        });
+        it('renders error banner when login is locked', () => {
+          const { container } = render({
+            integration,
+            localizedErrorFromLocationState: 'Reset your password',
+          });
+          expect(container).toMatchSnapshot();
+        });
+      });
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Signin/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/mocks.tsx
@@ -102,7 +102,11 @@ export const mockSigninLocationState = {
   verified: false,
 };
 
-export function createMockSigninWebIntegration(): SigninIntegration {
+export function createMockSigninWebIntegration({
+  cmsInfo,
+}: {
+  cmsInfo?: RelierCmsInfo;
+} = {}): SigninIntegration {
   return {
     type: IntegrationType.Web,
     isSync: () => false,
@@ -114,7 +118,7 @@ export function createMockSigninWebIntegration(): SigninIntegration {
     isDesktopRelay: () => false,
     wantsLogin: () => false,
     wantsTwoStepAuthentication: () => false,
-    getCmsInfo: () => undefined,
+    getCmsInfo: () => cmsInfo,
     isFirefoxMobileClient: () => false,
   };
 }


### PR DESCRIPTION
## Because

- Snapshots give us additional testing coverage
- Snapshots ensure components render correctly with CMS enabled and disabled

## This pull request

- Adds snapshots for fxa-settings Signin page and container initially before rolling out to other pages

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
