### PR TITLE
feat(email): Create new email template for 2FA replacement

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -60,6 +60,7 @@ const EMAIL_TYPES = {
   postVerify: 'registration',
   postVerifySecondary: 'secondary_email',
   postAddTwoStepAuthentication: '2fa',
+  postChangeTwoStepAuthentication: '2fa',
   postRemoveTwoStepAuthentication: '2fa',
   postAddAccountRecovery: 'account_recovery',
   postChangeAccountRecovery: 'account_recovery',

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -86,6 +86,7 @@ module.exports = function (log, config, bounces, statsd) {
     postChangePrimary: 'account-email-changed',
     postVerifySecondary: 'account-email-verified',
     postAddTwoStepAuthentication: 'account-two-step-enabled',
+    postChangeTwoStepAuthentication: 'account-two-step-changed',
     postRemoveTwoStepAuthentication: 'account-two-step-disabled',
     postConsumeRecoveryCode: 'account-consume-recovery-code',
     postNewRecoveryCodes: 'account-replace-recovery-codes',
@@ -148,6 +149,7 @@ module.exports = function (log, config, bounces, statsd) {
     postChangePrimary: 'account-email-changed',
     postVerifySecondary: 'manage-account',
     postAddTwoStepAuthentication: 'manage-account',
+    postChangeTwoStepAuthentication: 'manage-account',
     postRemoveTwoStepAuthentication: 'manage-account',
     postConsumeRecoveryCode: 'manage-account',
     postNewRecoveryCodes: 'manage-account',
@@ -1513,6 +1515,47 @@ module.exports = function (log, config, bounces, statsd) {
         passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
         privacyUrl: links.privacyUrl,
         recoveryMethod: message.maskedPhoneNumber ? 'phone' : 'codes',
+        supportLinkAttributes: links.supportLinkAttributes,
+        supportUrl: links.supportUrl,
+        time,
+        twoFactorSupportLink:
+          'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
+      },
+    });
+  };
+
+  Mailer.prototype.postChangeTwoStepAuthenticationEmail = function (message) {
+    log.trace('mailer.postChangeTwoStepAuthenticationEmail', {
+      email: message.email,
+      uid: message.uid,
+    });
+
+    const templateName = 'postChangeTwoStepAuthentication';
+    const links = this._generateSettingLinks(message, templateName);
+    const [time, date] = this._constructLocalTimeString(
+      message.timeZone,
+      message.acceptLanguage
+    );
+
+    const headers = {
+      'X-Link': links.link,
+    };
+
+    return this.send({
+      ...message,
+      headers,
+      template: templateName,
+      templateValues: {
+        androidLink: links.androidLink,
+        date,
+        device: this._formatUserAgentInfo(message),
+        email: message.email,
+        iosLink: links.iosLink,
+        link: links.link,
+        maskedPhoneNumber: message.maskedPhoneNumber,
+        passwordChangeLink: links.passwordChangeLink,
+        passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+        privacyUrl: links.privacyUrl,
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
         time,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -41,6 +41,7 @@
   "verifyShortCode": 5,
   "verifySecondaryCode": 3,
   "postAddTwoStepAuthentication": 11,
+  "postChangeTwoStepAuthentication": 1,
   "postRemoveTwoStepAuthentication": 9,
   "postConsumeRecoveryCode": 8,
   "postNewRecoveryCodes": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/en.ftl
@@ -1,0 +1,9 @@
+postChangeTwoStepAuthentication-preview = Your account is protected
+postChangeTwoStepAuthentication-subject = Two-step authentication updated
+postChangeTwoStepAuthentication-title = Two-step authentication has been updated
+postChangeTwoStepAuthentication-use-new-account = You now need to use the new { -product-mozilla-account } entry in your authenticator app. The older one will no longer work and you can remove it.
+# After the colon, there is a description of the device that the user used to enable two-step authentication
+postChangeTwoStepAuthentication-from-device = You requested this from:
+postChangeTwoStepAuthentication-action = Manage account
+postChangeTwoStepAuthentication-how-protects-link = How this protects your account
+postChangeTwoStepAuthentication-how-protects-plaintext = How this protects your account:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/includes.json
@@ -1,0 +1,14 @@
+{
+  "subject": {
+    "id": "postChangeTwoStepAuthentication-subject",
+    "message": "Two-step authentication updated"
+  },
+  "preview": {
+    "id": "postChangeTwoStepAuthentication-preview",
+    "message": "Your account is protected"
+  },
+  "action": {
+    "id": "postChangeTwoStepAuthentication-action",
+    "message": "Manage account"
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.mjml
@@ -1,0 +1,34 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postChangeTwoStepAuthentication-title">Two-step authentication has been updated</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postChangeTwoStepAuthentication-code-required">You now need to use the new Mozilla account entry in your authenticator app. The older one will no longer work and you can remove it.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <a class="link-blue" href="<%- twoFactorSupportLink %>">
+        <span data-l10n-id="postChangeTwoStepAuthentication-how-protects-link">How this protects your account</span>
+      </a>
+    </mj-text>
+
+    <mj-text css-class="text-body-no-margin">
+      <span data-l10n-id="postChangeTwoStepAuthentication-from-device">You requested this from:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/userInfo/index.mjml') %>
+
+<%- include('/partials/button/index.mjml', {
+  buttonL10nId: "postChangeTwoStepAuthentication-action",
+  buttonText: "Manage account"
+}) %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.stories.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_USER_INFO } from '../../partials/userInfo/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'FxA Emails/Templates/postChangeTwoStepAuthentication',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postChangeTwoStepAuthentication',
+  'Sent to notify that two step authentication was updated.',
+  {
+    ...MOCK_USER_INFO,
+    link: 'http://localhost:3030/settings',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+    twoFactorSupportLink:
+      'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
+  }
+);
+
+export const Default = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.txt
@@ -1,0 +1,13 @@
+postChangeTwoStepAuthentication-title-2 = "Two-step authentication has been updated"
+
+postChangeTwoStepAuthentication-use-new-account = "You now need to use the new Mozilla account entry in your authenticator app. The older one will no longer work and you can remove it."
+
+postChangeTwoStepAuthentication-how-protects-plaintext = "How this protects your account:"
+<%- twoFactorSupportLink %>
+
+postChangeTwoStepAuthentication-from-device-v2 = "You requested this from:"
+<%- include('/partials/userInfo/index.txt') %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -823,6 +823,30 @@ describe('totp', () => {
       assert.calledOnce(glean.twoFactorAuth.replaceSuccess);
     });
 
+    it('should send postChangeTwoStepAuthentication email', async () => {
+      const authenticator = new otplib.authenticator.Authenticator();
+      authenticator.options = Object.assign({}, otplib.authenticator.options, {
+        secret,
+      });
+      requestOptions.payload = {
+        code: authenticator.generate(secret),
+      };
+      await setup(
+        {
+          db: { email: TEST_EMAIL },
+          redis: { secret },
+        },
+        {},
+        '/totp/replace/confirm',
+        requestOptions
+      );
+
+      assert.equal(
+        mailer.sendPostChangeTwoStepAuthenticationEmail.callCount,
+        1
+      );
+    });
+
     it('should fail for an invalid replacement totp code', async () => {
       requestOptions.payload = {
         code: 'INVALID_CODE',

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -1465,6 +1465,42 @@ const TESTS: [string, any, Record<string, any>?][] = [
     }
   ],
 
+  ['postChangeTwoStepAuthenticationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Two-step authentication updated' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-changed', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postChangeTwoStepAuthentication') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postChangeTwoStepAuthentication' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postChangeTwoStepAuthentication }],
+    ])],
+    ['html', [
+      { test: 'include', expected: 'Two-step authentication has been updated' },
+      { test: 'include', expected: 'You now need to use the new Mozilla account entry in your authenticator app. The older one will no longer work and you can remove it.' },
+      { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-two-step-changed', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-two-step-changed', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-two-step-changed', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-two-step-changed', 'support')) },
+      { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'Two-step authentication has been updated' },
+      { test: 'include', expected: 'You now need to use the new Mozilla account entry in your authenticator app. The older one will no longer work and you can remove it.' },
+      { test: 'include', expected: 'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication' },
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-two-step-changed', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `change your password right away:\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-changed', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Accounts Privacy Notice\n${configUrl('privacyUrl', 'account-two-step-changed', 'privacy')}` },
+      { test: 'include', expected: `For more info, visit Mozilla Support:\n${configUrl('supportUrl', 'account-two-step-changed', 'support')}` },
+      { test: 'include', expected: `${MESSAGE.device.uaBrowser} on ${MESSAGE.device.uaOS} ${MESSAGE.device.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'exists', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
   ['postAddRecoveryPhoneEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Recovery phone added' }],
     ['headers', new Map([

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -167,6 +167,7 @@ const MAILER_METHOD_NAMES = [
   'sendPostChangeAccountRecoveryEmail',
   'sendPostAddLinkedAccountEmail',
   'sendPostAddTwoStepAuthenticationEmail',
+  'sendPostChangeTwoStepAuthenticationEmail',
   'sendPostChangePrimaryEmail',
   'sendPostConsumeRecoveryCodeEmail',
   'sendPostNewRecoveryCodesEmail',


### PR DESCRIPTION
## Because

- we have a new endpoint that allows changing 2FA

## This pull request

- Creates a new email template for successful 2FA replacement to be sent in the /totp/replace endpoint

## Issue that this pull request solves

Closes: FXA-12140

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="976" height="658" alt="image" src="https://github.com/user-attachments/assets/439a92de-e7bb-4d7f-92f7-d277cdc71d83" />

## Other information (Optional)

Any other information that is important to this pull request.
