### PR TITLE
fix: Missing CSRF middleware

### DIFF
--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -9,6 +9,7 @@ const oauth = require('./oauth');
 const config = require('./config');
 const version = require('./version');
 const cookieSession = require('cookie-session');
+const lusca = require('lusca');
 
 const logger = morgan('short');
 
@@ -43,7 +44,11 @@ app.use(function (req, res, next) {
       secret: config.get('cookie_secret'),
       path: '/api',
       httpOnly: true,
-    })(req, res, next);
+    })(req, res, function(err) {
+      if (err) return next(err);
+      // Add CSRF protection for /api endpoints
+      lusca.csrf()(req, res, next);
+    });
   } else {
     return next();
   }


### PR DESCRIPTION

fix the missing CSRF protection, we should add a CSRF middleware to the API endpoints that use cookie-based authentication. The recommended approach is to use a well-known middleware such as `lusca.csrf` (as suggested in the background), which integrates easily with Express. We need to:

- Import the `lusca` package.
- Add the `lusca.csrf()` middleware to the `/api` endpoints, after the session middleware is set up (so that the CSRF middleware can access the session).
- Ensure that the CSRF token is available to clients (e.g., by exposing it in a response header or as part of a JSON response for endpoints that need it).

All changes should be made within `packages/123done/server.js`, as shown in the snippet.

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
