### PR TITLE
fix(next): re-add previously used sub metadata

### DIFF
--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -97,6 +97,7 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   SessionEntrypoint = 'session_entrypoint',
   SessionEntrypointExperiment = 'session_entrypoint_experiment',
   SessionEntrypointVariation = 'session_entrypoint_variation',
+  LastUpdated = 'last_updated', // TODO - No longer required. Remove once subscription metadata update logic is updated
 }
 
 export enum STRIPE_INVOICE_METADATA {


### PR DESCRIPTION
## Because

- Subscription metadata updates are failing due to a previously supported key no longer be in the list of valid keys, however the key is still in the current subscription metadata.

## This pull request

- Temporarily re-add the previously valid key, last_updated.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
