### PR TITLE
feat(next): use client signOut function

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -23,7 +23,7 @@ import {
   TermsAndPrivacy,
 } from '@fxa/payments/ui/server';
 import { CartState } from '@fxa/shared/db/mysql/account';
-import { auth, signOut } from 'apps/payments/next/auth';
+import { auth } from 'apps/payments/next/auth';
 import { config } from 'apps/payments/next/config';
 
 export interface CheckoutSearchParams {
@@ -61,10 +61,6 @@ export default async function CheckoutLayout({
       <Header
         auth={{
           user: session?.user,
-          signOut: async () => {
-            'use server';
-            await signOut({ redirect: false });
-          },
         }}
         cart={cart}
       />

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/layout.tsx
@@ -15,7 +15,7 @@ import {
 } from '@fxa/payments/ui/server';
 import { CartState } from '@fxa/shared/db/mysql/account';
 import { config } from 'apps/payments/next/config';
-import { auth, signOut } from 'apps/payments/next/auth';
+import { auth } from 'apps/payments/next/auth';
 
 export default async function UpgradeSuccessLayout({
   children,
@@ -43,10 +43,6 @@ export default async function UpgradeSuccessLayout({
       <Header
         auth={{
           user: session?.user,
-          signOut: async () => {
-            'use server';
-            await signOut({ redirect: false });
-          },
         }}
         cart={cart}
       />

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -15,7 +15,7 @@ import {
   UpgradePurchaseDetails,
 } from '@fxa/payments/ui/server';
 import { config } from 'apps/payments/next/config';
-import { auth, signOut } from 'apps/payments/next/auth';
+import { auth } from 'apps/payments/next/auth';
 
 export default async function UpgradeLayout({
   children,
@@ -53,10 +53,6 @@ export default async function UpgradeLayout({
       <Header
         auth={{
           user: session?.user,
-          signOut: async () => {
-            'use server';
-            await signOut({ redirect: false });
-          },
         }}
         cart={cart}
       />

--- a/apps/payments/next/app/[locale]/subscriptions/layout.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/layout.tsx
@@ -8,7 +8,7 @@ import Image from 'next/image';
 import { Breadcrumbs, Header } from '@fxa/payments/ui';
 import { getApp } from '@fxa/payments/ui/server';
 import defaultAvatarIcon from '@fxa/shared/assets/images/avatar-default.svg';
-import { auth, signOut } from 'apps/payments/next/auth';
+import { auth } from 'apps/payments/next/auth';
 import { config } from 'apps/payments/next/config';
 
 export default async function SubscriptionsLayout({
@@ -30,10 +30,6 @@ export default async function SubscriptionsLayout({
       <Header
         auth={{
           user: session?.user,
-          signOut: async () => {
-            'use server';
-            await signOut({ redirect: false });
-          },
         }}
         redirectPath={`${config.contentServerUrl}/settings`}
       />

--- a/apps/payments/next/auth.ts
+++ b/apps/payments/next/auth.ts
@@ -77,6 +77,17 @@ export const {
         ...token,
       };
     },
+    async redirect({ url, baseUrl }) {
+      // Allows relative callback URLs
+      if (url.startsWith('/')) return `${baseUrl}${url}`;
+
+      // Allows callback URLs on the same origin and to MzAs content server
+      const urlOrigin = new URL(url).origin;
+      if (urlOrigin === baseUrl || urlOrigin === config.contentServerUrl)
+        return url;
+
+      return baseUrl;
+    },
   },
   events: {
     async signIn() {

--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -30,6 +30,7 @@ import {
   useRouter,
   useSearchParams,
 } from 'next/navigation';
+import { signOut } from 'next-auth/react';
 
 function buildSignOutRedirectPath(
   params: Record<string, string | string[]>,
@@ -55,7 +56,6 @@ function buildSignOutRedirectPath(
 type HeaderProps = {
   auth?: {
     user: User | undefined;
-    signOut: () => Promise<void>;
   };
   cart?: {
     taxAddress: {
@@ -74,11 +74,11 @@ export const Header = ({ auth, cart, redirectPath }: HeaderProps) => {
   const signOutRedirectPath =
     cart?.taxAddress.countryCode && cart.taxAddress.postalCode
       ? buildSignOutRedirectPath(
-          params,
-          searchParams,
-          cart.taxAddress.countryCode,
-          cart.taxAddress.postalCode
-        )
+        params,
+        searchParams,
+        cart.taxAddress.countryCode,
+        cart.taxAddress.postalCode
+      )
       : redirectPath || '/';
 
   const signedIn = auth && auth.user;
@@ -388,8 +388,8 @@ export const Header = ({ auth, cart, redirectPath }: HeaderProps) => {
                     <div className="px-4 py-5">
                       <button
                         onClick={async () => {
-                          await auth.signOut();
-                          router.replace(signOutRedirectPath);
+                          const signOutRedirect = await signOut({ redirectTo: signOutRedirectPath, redirect: false })
+                          router.replace(signOutRedirect.url);
                         }}
                         className="pl-3 group"
                       >


### PR DESCRIPTION
## Because

- The Header component currently requires consumers to pass in the signout function, which has typically been a server action calling the next-auth server signOut function.

## This pull request

- Use the next-auth client signOut function to simplify the Header component.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

There should be no difference in functionality. This is purely a simplification of the <Header> component by removing one of it's required props.
