### PR TITLE
chore(functional-tests): Remove deprecated page.* actions

### DIFF
--- a/packages/functional-tests/pages/settings/components/connectedService.ts
+++ b/packages/functional-tests/pages/settings/components/connectedService.ts
@@ -7,12 +7,12 @@ import { ElementHandle, Page } from '@playwright/test';
 export class ConnectedService {
   name = '';
   constructor(
-    readonly element: ElementHandle<HTMLElement | SVGElement>,
+    readonly element: ElementHandle<Node>,
     readonly page: Page
   ) {}
 
   static async create(
-    element: ElementHandle<HTMLElement | SVGElement>,
+    element: ElementHandle<Node>,
     page: Page
   ) {
     const service = new ConnectedService(element, page);

--- a/packages/functional-tests/pages/settings/components/dataTrio.ts
+++ b/packages/functional-tests/pages/settings/components/dataTrio.ts
@@ -23,7 +23,7 @@ export class DataTrioComponent {
       //@ts-ignore
       navigator.clipboard.writeText = (text) => (window.clipboardText = text);
     });
-    await this.page.click('[data-testid=databutton-copy]');
+    await this.page.locator('[data-testid=databutton-copy]').click();
     //@ts-ignore
     return this.page.evaluate(() => window.clipboardText);
   }

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -119,12 +119,13 @@ export class TotpRow extends UnitRow {
 
 export class ConnectedServicesRow extends UnitRow {
   async services() {
-    await this.page.waitForSelector('[data-testid=settings-connected-service]');
-    const elements = await this.page.$$(
-      '[data-testid=settings-connected-service]'
-    );
+    const elements = this.page.locator('[data-testid=settings-connected-service]');
+    // there should be multiple, but you cannot call `.waitFor()` on a locator
+    // that returns multiple elements.
+    await elements.first().waitFor({ state: 'attached' });
+    const elementHandles = await elements.elementHandles();
     return Promise.all(
-      elements.map((el) => ConnectedService.create(el, this.page))
+      elementHandles.map((el) => ConnectedService.create(el, this.page))
     );
   }
 }

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -81,7 +81,7 @@ export class SettingsPage extends SettingsLayout {
     const sync = services.find((s) => s.name.includes(' on '));
 
     await sync?.signout();
-    await this.page.click('text=Rather not say >> input[name="reason"]');
+    await this.page.locator('text=Rather not say >> input[name="reason"]').click();
     await this.modalConfirmButton.click();
 
     await this.page.evaluate((uid) => {

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -69,11 +69,11 @@ export abstract class SettingsLayout extends BaseLayout {
   }
 
   clickModalConfirm() {
-    return this.page.click('[data-testid=modal-confirm]');
+    return this.page.locator('[data-testid=modal-confirm]').click();
   }
 
   clickChangePassword() {
-    return this.page.click('[data-testid=password-unit-row-route]');
+    return this.page.locator('[data-testid=password-unit-row-route]').click();
   }
 
   async clickHelp(): Promise<Page> {


### PR DESCRIPTION
Because:

  * Accessing actinos directly on page, like page.click() are deprecated in favor us locator() context

This Commit:

  * Updates any reference to the deprecated function calls with proper PW actions

Closes #FXA-9658

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
The original ticket (FXA-9658) is calling out that accessing element and other functions directly on the `page` object is deprecated in favor of accessing them through the `locator()` or similar element references. 

One in particular that is also found with a warning from PW is `await page.waitForTimeout()`. This is just not a great practice can introduce flakiness. I've logged a [follow up ticket](https://mozilla-hub.atlassian.net/browse/FXA-12248) though to address those as they'll take some investigation on best way to "work around" some may require looking for elements, or spying on network requests etc.

[PW `page.waitForTimeout()`](https://playwright.dev/docs/api/class-page#page-wait-for-timeout)
> Never wait for timeout in production. Tests that wait for time are inherently flaky. Use [Locator](https://playwright.dev/docs/api/class-locator) actions and web assertions that wait automatically.