### PR TITLE
feat(cms): Set back arrow color based on CMS BG color

### DIFF
--- a/packages/fxa-settings/src/components/ButtonBack/calculate-contrast.test.tsx
+++ b/packages/fxa-settings/src/components/ButtonBack/calculate-contrast.test.tsx
@@ -1,0 +1,240 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MOCK_CMS_INFO } from '../../pages/mocks';
+import {
+  getTextColorClassName,
+  parseColor,
+  calculateLuminance,
+  calculateContrastRatio,
+  TEXT_COLORS,
+} from './calculate-contrast';
+
+describe('calculate-contrast', () => {
+  describe('getTextColorClassName', () => {
+    describe('default color (text-grey-400)', () => {
+      it('should return text-grey-400 for light solid colors', () => {
+        expect(getTextColorClassName('#ffffff')).toBe('text-grey-400');
+        expect(getTextColorClassName('#FAFAFD')).toBe('text-grey-400');
+        expect(getTextColorClassName('rgb(255, 255, 255)')).toBe(
+          'text-grey-400'
+        );
+        expect(getTextColorClassName('rgba(255, 240, 255, 1)')).toBe(
+          'text-grey-400'
+        );
+      });
+      it('should return text-grey-400 for light gradients', () => {
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(255, 245, 235, 0.8) 0%, rgba(255, 250, 240, 0.6) 100%)'
+          )
+        ).toBe('text-grey-400');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(250, 240, 250, 0.7) 0%, rgba(255, 245, 248, 0.5) 100%)'
+          )
+        ).toBe('text-grey-400');
+      });
+
+      it('should handle semi-transparent colors with alpha blending', () => {
+        expect(getTextColorClassName('rgba(0, 0, 0, 0.7)')).toBe('text-white');
+        expect(getTextColorClassName('rgba(255, 255, 255, 0.1)')).toBe(
+          'text-grey-400'
+        );
+      });
+
+      it('should handle gradients with no extractable colors', () => {
+        expect(
+          getTextColorClassName('linear-gradient(to right, transparent)')
+        ).toBe('text-grey-400');
+      });
+    });
+
+    describe('white text (text-white)', () => {
+      it('should return text-white for dark solid colors that have poor contrast with grey', () => {
+        expect(getTextColorClassName('#8B4000')).toBe('text-white');
+        expect(getTextColorClassName('#000080')).toBe('text-white');
+        expect(getTextColorClassName('#000000')).toBe('text-white');
+        expect(getTextColorClassName('#240005')).toBe('text-white');
+        expect(getTextColorClassName('#4B0082')).toBe('text-white');
+        expect(getTextColorClassName('rgb(0, 0, 0)')).toBe('text-white');
+        expect(getTextColorClassName('rgba(0, 0, 0, 1)')).toBe('text-white');
+      });
+
+      it('should return text-white when all 3 fail contrast', () => {
+        expect(getTextColorClassName('#808000')).toBe('text-white');
+      });
+
+      it('should return text-white for medium colors that have poor contrast with grey', () => {
+        expect(getTextColorClassName('#7037d4')).toBe('text-white');
+        expect(
+          getTextColorClassName(MOCK_CMS_INFO.shared.backgroundColor)
+        ).toBe('text-white');
+      });
+
+      it('should return text-white for dark gradients', () => {
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) 100%)'
+          )
+        ).toBe('text-white');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(139, 64, 0, 1) 0%, rgba(101, 67, 33, 1) 100%)'
+          )
+        ).toBe('text-white');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(75, 0, 130, 1) 0%, rgba(72, 61, 139, 1) 100%)'
+          )
+        ).toBe('text-white');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(0, 0, 128, 1) 0%, rgba(25, 25, 112, 1) 100%)'
+          )
+        ).toBe('text-white');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(128, 128, 0, 1) 0%, rgba(85, 107, 47, 1) 100%)'
+          )
+        ).toBe('text-white');
+      });
+    });
+
+    describe('dark grey text (text-grey-600)', () => {
+      it('should return text-grey-600 when grey-400 and white fail but grey-600 passes', () => {
+        expect(getTextColorClassName('#37d44c')).toBe('text-grey-600');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, #ffeaa7 0%, #fab1a0 100%)'
+          )
+        ).toBe('text-grey-600');
+        expect(
+          getTextColorClassName(
+            'linear-gradient(135deg, rgba(250, 100, 210, 1) 0%, rgba(220, 200, 240, 1) 100%)'
+          )
+        ).toBe('text-grey-600');
+      });
+    });
+  });
+
+  describe('parseColor', () => {
+    it('should parse hex colors correctly', () => {
+      expect(parseColor('#ffffff')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+      expect(parseColor('#000000')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+      expect(parseColor('#fff')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+      expect(parseColor('#abc')).toEqual({ r: 170, g: 187, b: 204, a: 1 });
+      expect(parseColor('#6D37D1')).toEqual({ r: 109, g: 55, b: 209, a: 1 });
+      expect(parseColor('#FFA500')).toEqual({ r: 255, g: 165, b: 0, a: 1 });
+    });
+
+    it('should parse rgb colors correctly', () => {
+      expect(parseColor('rgb(255, 255, 255)')).toEqual({
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 1,
+      });
+      expect(parseColor('rgb(190, 55, 209)')).toEqual({
+        r: 190,
+        g: 55,
+        b: 209,
+        a: 1,
+      });
+      expect(parseColor('rgb(0, 0, 0)')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    it('should parse rgba colors correctly', () => {
+      expect(parseColor('rgba(255, 255, 255, 0.5)')).toEqual({
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 0.5,
+      });
+      expect(parseColor('rgba(0, 0, 0, 0.7)')).toEqual({
+        r: 0,
+        g: 0,
+        b: 0,
+        a: 0.7,
+      });
+      expect(parseColor('rgba(50, 100, 150, 0.9)')).toEqual({
+        r: 50,
+        g: 100,
+        b: 150,
+        a: 0.9,
+      });
+    });
+
+    it('should return default white for invalid colors', () => {
+      expect(parseColor('invalid')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+      expect(parseColor('')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+    });
+  });
+
+  describe('calculateLuminance', () => {
+    it('should calculate correct luminance for black and white', () => {
+      expect(calculateLuminance(0, 0, 0)).toBeCloseTo(0, 5);
+      expect(calculateLuminance(255, 255, 255)).toBeCloseTo(1, 5);
+    });
+
+    it('should calculate luminance for greys', () => {
+      // The values are from a calculator, this just confirms that our expectations match
+      expect(
+        calculateLuminance(
+          TEXT_COLORS['text-grey-400'].r,
+          TEXT_COLORS['text-grey-400'].g,
+          TEXT_COLORS['text-grey-400'].b
+        )
+      ).toBeCloseTo(0.1531, 2);
+      expect(
+        calculateLuminance(
+          TEXT_COLORS['text-grey-600'].r,
+          TEXT_COLORS['text-grey-600'].g,
+          TEXT_COLORS['text-grey-600'].b
+        )
+      ).toBeCloseTo(0.032, 2);
+    });
+  });
+
+  describe('calculateContrastRatio', () => {
+    it('should calculate correct contrast ratio for black and white', () => {
+      const blackLuminance = 0;
+      const whiteLuminance = 1;
+      expect(
+        calculateContrastRatio(blackLuminance, whiteLuminance)
+      ).toBeCloseTo(21, 1);
+    });
+
+    it('should calculate contrast ratio symmetrically', () => {
+      const lum1 = 0.2;
+      const lum2 = 0.8;
+      expect(calculateContrastRatio(lum1, lum2)).toEqual(
+        calculateContrastRatio(lum2, lum1)
+      );
+    });
+
+    it('should meet WCAG AA standard for good contrast', () => {
+      // White text on dark background should have contrast >= 4.5
+      const darkBackgroundLuminance = 0.1;
+      const whiteLuminance = 1;
+      const contrast = calculateContrastRatio(
+        whiteLuminance,
+        darkBackgroundLuminance
+      );
+      expect(contrast).toBeGreaterThanOrEqual(4.5);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty string', () => {
+      expect(getTextColorClassName('')).toBe('text-grey-400');
+    });
+
+    it('should handle malformed gradient', () => {
+      expect(getTextColorClassName('linear-gradient(malformed)')).toBe(
+        'text-grey-400'
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/ButtonBack/calculate-contrast.ts
+++ b/packages/fxa-settings/src/components/ButtonBack/calculate-contrast.ts
@@ -1,0 +1,202 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export interface ColorRGBA {
+  r: number;
+  g: number;
+  b: number;
+  a: number;
+}
+
+const DEFAULT_COLOR = 'text-grey-400';
+export const TEXT_COLORS = {
+  'text-white': { r: 255, g: 255, b: 255 },
+  'text-grey-400': { r: 109, g: 109, b: 110 },
+  'text-grey-600': { r: 50, g: 49, b: 60 },
+};
+
+/**
+ * Determines the optimal text color class to use over a background color based on WCAG AA contrast ratios.
+ * @param cssBackgroundValue CSS background value (solid color or gradient)
+ * @returns text color class name (e.g., 'text-grey-400', 'text-grey-600', 'text-white')
+ */
+export function getTextColorClassName(cssBackgroundValue: string): string {
+  if (cssBackgroundValue.includes('gradient')) {
+    return calculateGradientContrast(cssBackgroundValue);
+  }
+  return calculateSolidColorContrast(cssBackgroundValue);
+}
+
+function calculateGradientContrast(gradient: string): string {
+  // Extract colors from gradient
+  const colorMatches =
+    gradient.match(
+      /#[0-9a-fA-F]{6}|#[0-9a-fA-F]{3}|rgb\([^)]+\)|rgba\([^)]+\)/g
+    ) || [];
+  if (colorMatches.length === 0) {
+    return DEFAULT_COLOR;
+  }
+  const effectiveColor = blendColorsWithAlpha(colorMatches);
+  const backgroundLuminance = calculateLuminance(
+    effectiveColor.r,
+    effectiveColor.g,
+    effectiveColor.b
+  );
+
+  return getTextColorForLuminance(backgroundLuminance);
+}
+
+function calculateSolidColorContrast(color: string): string {
+  const colorRgba = parseColor(color);
+  // Blend with white background (assuming white page background)
+  const blendedColor = blendWithWhiteBackground(colorRgba);
+  const backgroundLuminance = calculateLuminance(
+    blendedColor.r,
+    blendedColor.g,
+    blendedColor.b
+  );
+
+  return getTextColorForLuminance(backgroundLuminance);
+}
+
+function getTextColorForLuminance(backgroundLuminance: number): string {
+  // Calculate luminance for each text color option
+  const whiteLuminance = calculateLuminance(
+    TEXT_COLORS['text-white'].r,
+    TEXT_COLORS['text-white'].g,
+    TEXT_COLORS['text-white'].b
+  );
+  const medGreyLuminance = calculateLuminance(
+    TEXT_COLORS['text-grey-400'].r,
+    TEXT_COLORS['text-grey-400'].g,
+    TEXT_COLORS['text-grey-400'].b
+  );
+  const darkGreyLuminance = calculateLuminance(
+    TEXT_COLORS['text-grey-600'].r,
+    TEXT_COLORS['text-grey-600'].g,
+    TEXT_COLORS['text-grey-600'].b
+  );
+
+  // Calculate contrast ratios
+  const whiteContrast = calculateContrastRatio(
+    whiteLuminance,
+    backgroundLuminance
+  );
+  const medGreyContrast = calculateContrastRatio(
+    medGreyLuminance,
+    backgroundLuminance
+  );
+  const darkGreyContrast = calculateContrastRatio(
+    darkGreyLuminance,
+    backgroundLuminance
+  );
+
+  // Prefer text-grey-400 if it meets WCAG AA
+  // Note 4.5 is for text elements, but non-text elements need a 3:1 ratio to pass.
+  // We'll err on the side of caution anyway since gradients BG colors are estimates.
+  if (medGreyContrast >= 4.5) {
+    return 'text-grey-400';
+  }
+  if (whiteContrast >= 4.5) {
+    return 'text-white';
+  }
+  if (darkGreyContrast >= 4.5) {
+    return 'text-grey-600';
+  }
+
+  // If all values fail AA contrast, we want to use text-grey-400, but if
+  // contrast value for it is terrible (2.25:1 or less), use the next best one.
+  if (medGreyContrast < 2.25) {
+    const bestContrast = Math.max(
+      whiteContrast,
+      medGreyContrast,
+      darkGreyContrast
+    );
+    if (bestContrast === whiteContrast) {
+      return 'text-white';
+    }
+    if (bestContrast === darkGreyContrast) {
+      return 'text-grey-600';
+    }
+  }
+  return 'text-grey-400';
+}
+
+export function parseColor(color: string): ColorRGBA {
+  // Handle hex colors
+  if (color.startsWith('#')) {
+    const hex = color.slice(1);
+    if (hex.length === 3) {
+      return {
+        r: parseInt(hex[0] + hex[0], 16),
+        g: parseInt(hex[1] + hex[1], 16),
+        b: parseInt(hex[2] + hex[2], 16),
+        a: 1,
+      };
+    }
+    return {
+      r: parseInt(hex.slice(0, 2), 16),
+      g: parseInt(hex.slice(2, 4), 16),
+      b: parseInt(hex.slice(4, 6), 16),
+      a: 1,
+    };
+  }
+
+  // Handle rgb/rgba colors
+  const rgbMatch = color.match(/rgba?\(([^)]+)\)/);
+  if (rgbMatch) {
+    const values = rgbMatch[1].split(',').map((v) => parseFloat(v.trim()));
+    return {
+      r: values[0] || 0,
+      g: values[1] || 0,
+      b: values[2] || 0,
+      a: values[3] !== undefined ? values[3] : 1,
+    };
+  }
+  // Default to white BG color if BG color can't be parsed
+  return { r: 255, g: 255, b: 255, a: 1 };
+}
+
+export function calculateLuminance(r: number, g: number, b: number): number {
+  // Convert RGB to relative luminance using the formula for sRGB
+  const normalize = (c: number) => {
+    c = c / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+
+  return 0.2126 * normalize(r) + 0.7152 * normalize(g) + 0.0722 * normalize(b);
+}
+
+export function calculateContrastRatio(lum1: number, lum2: number): number {
+  const lighter = Math.max(lum1, lum2);
+  const darker = Math.min(lum1, lum2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function blendColorsWithAlpha(colors: string[]): ColorRGBA {
+  // Start with white background (255, 255, 255)
+  let result: ColorRGBA = { r: 255, g: 255, b: 255, a: 1 };
+
+  colors.forEach((color) => {
+    const colorRgba = parseColor(color);
+    // Alpha blending: result = alpha * foreground + (1 - alpha) * background
+    result = {
+      r: Math.round(colorRgba.a * colorRgba.r + (1 - colorRgba.a) * result.r),
+      g: Math.round(colorRgba.a * colorRgba.g + (1 - colorRgba.a) * result.g),
+      b: Math.round(colorRgba.a * colorRgba.b + (1 - colorRgba.a) * result.b),
+      a: 1,
+    };
+  });
+
+  return result;
+}
+
+function blendWithWhiteBackground(color: ColorRGBA): ColorRGBA {
+  return {
+    r: Math.round(color.r * color.a + 255 * (1 - color.a)),
+    g: Math.round(color.g * color.a + 255 * (1 - color.a)),
+    b: Math.round(color.b * color.a + 255 * (1 - color.a)),
+    a: 1,
+  };
+}

--- a/packages/fxa-settings/src/components/ButtonBack/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonBack/index.stories.tsx
@@ -8,6 +8,8 @@ import { withLocalization } from 'fxa-react/lib/storybooks';
 import AppLayout from '../AppLayout';
 import ButtonBack from '.';
 import { HeadingPrimary } from '../HeadingPrimary';
+import { RelierCmsInfo } from '../../models/integrations';
+import { MOCK_CMS_INFO } from '../../pages/mocks';
 
 export default {
   title: 'components/ButtonBack',
@@ -15,11 +17,60 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
+interface SubjectProps {
+  cmsBackgroundColor?: string;
+  description: string;
+}
+
+const Subject = ({ cmsBackgroundColor, description }: SubjectProps) => {
+  const cmsInfo: RelierCmsInfo | undefined = cmsBackgroundColor
+    ? {
+        shared: {
+          backgroundColor: cmsBackgroundColor,
+        },
+      } as RelierCmsInfo
+    : undefined;
+
+  return (
+    <AppLayout {...{ cmsInfo }}>
+      <div className="relative flex items-start p-8 min-h-[200px]">
+        <ButtonBack {...{ cmsBackgroundColor }} />
+        <HeadingPrimary>
+          {description}
+        </HeadingPrimary>
+      </div>
+    </AppLayout>
+  );
+};
+
 export const Default = () => (
-  <AppLayout>
-    <div className="relative flex items-start">
-      <ButtonBack />
-      <HeadingPrimary>Our primary header</HeadingPrimary>
-    </div>
-  </AppLayout>
+  <Subject description="Default background - default arrow" />
+);
+
+export const LightBackgroundDefaultArrow = () => (
+  <Subject
+    cmsBackgroundColor="linear-gradient(135deg, rgba(240, 255, 250, 1) 0%, rgba(250, 245, 240, 1) 100%)"
+    description="Light background - default arrow"
+  />
+);
+
+export const MediumBackgroundWhiteArrow = () => (
+  <Subject
+    cmsBackgroundColor={MOCK_CMS_INFO.shared.backgroundColor}
+    description="Light-medium gradient background - white arrow"
+  />
+);
+
+export const DarkBackgroundWhiteArrow = () => (
+  <Subject
+    cmsBackgroundColor="linear-gradient(135deg, #667eea 0%, #764ba2 100%)"
+    description="Dark gradient background - white arrow"
+  />
+);
+
+export const MediumBackgroundDarkArrow = () => (
+  <Subject
+    cmsBackgroundColor="linear-gradient(135deg, #ffeaa7 0%, #fab1a0 100%)"
+    description="Medium gradient background - dark grey arrow"
+  />
 );

--- a/packages/fxa-settings/src/components/ButtonBack/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonBack/index.tsx
@@ -5,12 +5,14 @@
 import React from 'react';
 import { ReactComponent as BackArrow } from './back-arrow.svg';
 import { useFtlMsgResolver } from '../../models';
+import { getTextColorClassName } from './calculate-contrast';
 
 interface ButtonBackProps {
   onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   dataTestId?: string;
   localizedAriaLabel?: string;
   localizedTitle?: string;
+  cmsBackgroundColor?: string;
 }
 
 // This component assumes a parent container with class 'relative flex'
@@ -20,6 +22,7 @@ const ButtonBack = ({
   dataTestId,
   localizedAriaLabel,
   localizedTitle,
+  cmsBackgroundColor,
 }: ButtonBackProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedButtonTitle =
@@ -27,6 +30,24 @@ const ButtonBack = ({
   const localizedButtonAriaLabel =
     localizedAriaLabel ||
     ftlMsgResolver.getMsg('button-back-aria-label', 'Back');
+
+  const getTabletArrowColor = () => {
+    if (!cmsBackgroundColor) {
+      return 'tablet:text-grey-400';
+    }
+
+    const textColorClass = getTextColorClassName(cmsBackgroundColor.trim());
+    // Map to hardcoded class names for Tailwind tree shaking
+    switch (textColorClass) {
+      case 'text-white':
+        return 'tablet:text-white';
+      case 'text-grey-600':
+        return 'tablet:text-grey-600';
+      case 'text-grey-400':
+      default:
+        return 'tablet:text-grey-400';
+    }
+  };
 
   return (
     <button
@@ -36,7 +57,7 @@ const ButtonBack = ({
       aria-label={localizedButtonAriaLabel}
       className="me-4 tablet:me-0 tablet:p-4 tablet:absolute tablet:-start-24 rounded focus-visible-default"
     >
-      <BackArrow className="w-6 h-auto text-grey-400 rtl:transform rtl:-scale-x-100" />
+      <BackArrow className={`w-6 h-auto text-grey-400 ${getTabletArrowColor()} rtl:transform rtl:-scale-x-100`} />
     </button>
   );
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -137,12 +137,12 @@ const SigninRecoveryChoice = ({
   const cmsInfo = integration?.getCmsInfo();
   const cmsButton = {
     color: cmsInfo?.shared?.buttonColor,
-  }
+  };
 
   return (
     <AppLayout cmsInfo={cmsInfo}>
       <div className="relative flex items-center mb-5">
-        <ButtonBack />
+        <ButtonBack cmsBackgroundColor={cmsInfo?.shared?.backgroundColor} />
         {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (
           <img
             src={cmsInfo.shared.logoUrl}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -212,7 +212,7 @@ const SigninRecoveryCode = ({
   return (
     <AppLayout cmsInfo={cmsInfo}>
       <div className="relative flex items-center mb-5">
-        <ButtonBack />
+        <ButtonBack cmsBackgroundColor={cmsInfo?.shared?.backgroundColor} />
         {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (
           <img
             src={cmsInfo.shared.logoUrl}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -164,7 +164,7 @@ const SigninRecoveryPhone = ({
     <AppLayout cmsInfo={cmsInfo}>
 
       <div className="relative flex items-center">
-        <ButtonBack />
+        <ButtonBack cmsBackgroundColor={cmsInfo?.shared?.backgroundColor} />
         {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (
           <img
             src={cmsInfo.shared.logoUrl}


### PR DESCRIPTION
Because:
* Our 'back' arrow contrast with only text-grey-400 is poor against our CMS configurable background colors/gradient

This commit:
* Adds a color contrast check against the BG color or gradient average and returns a white, default (grey-400), or dark (grey-600) color accordingly
* Adds new tests and stories

closes FXA-12207