### PR TITLE
bug(admin): Missing extra security info when searching by uid

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/index.gql.ts
@@ -159,6 +159,8 @@ export const GET_ACCOUNT_BY_UID = gql`
         verified
         createdAt
         name
+        ipAddr
+        additionalInfo
       }
       totp {
         verified


### PR DESCRIPTION
## Because

- IP was missing when searching by uid
- Extra info was missing when searching by uid

## This pull request

- Adds ipAddr and exra info to gql query.

## Issue that this pull request solves

Closes: FXA-12258

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="589" height="1137" alt="image" src="https://github.com/user-attachments/assets/7222e4cb-ff8f-4cab-9a9d-6f964a527c49" />

## Other information (Optional)

Any other information that is important to this pull request.
