### PR TITLE
bug(admin-panel): Admin Panel Server wouldn't start up

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "nx build-css && nx build-react && nx build-ts-client && nx build-ts-server",
     "build-ts-client": "tsc --build",
-    "build-ts-server": "tsc -p server/tsconfig.json",
+    "build-ts-server": "tsc -p server/tsconfig.json && tsc-alias",
     "build-css": "npx tailwindcss -i ./src/styles/tailwind.css -o ./src/styles/tailwind.out.css --postcss",
     "build-react": "SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=/ INLINE_RUNTIME_CHUNK=false CI=false NODE_OPTIONS=--openssl-legacy-provider rescripts build",
     "clean": "rimraf dist",
@@ -83,6 +83,7 @@
     "supertest": "^7.0.0",
     "tailwindcss": "3.4.3",
     "tailwindcss-textshadow": "^2.1.3",
+    "tsc-alias": "^1.8.8",
     "typescript": "5.5.3",
     "webpack": "^5.97.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -32669,6 +32669,7 @@ __metadata:
     supertest: "npm:^7.0.0"
     tailwindcss: "npm:3.4.3"
     tailwindcss-textshadow: "npm:^2.1.3"
+    tsc-alias: "npm:^1.8.8"
     typescript: "npm:5.5.3"
     webpack: "npm:^5.97.0"
   languageName: unknown


### PR DESCRIPTION
## Because
- @fxa/shared/guards could not be located

## This pull request
- Adds `&& tsc-alias` to `build-ts-server` command, which is necessary when using import aliases.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Before:
<img width="1075" height="100" alt="image" src="https://github.com/user-attachments/assets/f6902a84-fd89-4bd3-9e9e-a055beed3b7c" />


After:
<img width="1287" height="52" alt="image" src="https://github.com/user-attachments/assets/97877ff2-80c4-4fe8-bb76-97e892f19bb2" />


## Other information (Optional)

Any other information that is important to this pull request.
