### PR TITLE
fix(bundle): Remove comments from ftl files when bundling

### DIFF
--- a/_scripts/l10n/bundle.sh
+++ b/_scripts/l10n/bundle.sh
@@ -56,7 +56,9 @@ for d in */; do
     echo '' > main.ftl
     for bundle in "${BUNDLES_LIST[@]}"; do
         if [ -f "$bundle.ftl" ]; then
-            cat "$bundle.ftl" >> main.ftl
+            # Filter out comment lines (starting with #)
+            # Use || true to prevent script failure when grep finds no matches
+            grep -v '^[[:space:]]*#' "$bundle.ftl" >> main.ftl || true
         else
             echo "$PREFIX: Missing bundle - $d$bundle.ftl"
         fi


### PR DESCRIPTION
## Because

- The ftl comments are only useful for translating, we don't need them in bundled ftl files

## This pull request

- Removes lines that start with "#"

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12260

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1570" height="348" alt="Screenshot 2025-08-14 at 2 21 08 PM" src="https://github.com/user-attachments/assets/f9637615-b519-47cb-81cc-9462aba876f3" />

<img width="2161" height="336" alt="Screenshot 2025-08-14 at 3 11 30 PM" src="https://github.com/user-attachments/assets/1c86628c-d758-4c04-831c-45d574947b8a" />

## Other information (Optional)

I'm a bit surprised but this reduces our ftl file sizes by roughly ~50kb per locale (~40%). This seems significant and could help mobile users espeically.
