### PR TITLE
fix(next): relative redirect on root

### DIFF
--- a/apps/payments/next/app/route.ts
+++ b/apps/payments/next/app/route.ts
@@ -10,10 +10,7 @@ export async function GET(request: NextRequest) {
     notFound();
   }
   if (config.featureFlagSubManage) {
-    redirect(
-      new URL(`/subscriptions/landing/${request.nextUrl.search}`, request.url)
-        .href
-    );
+    redirect(`/subscriptions/landing/${request.nextUrl.search}`);
   } else {
     redirect(
       `${config.contentServerClientConfig.url}/subscriptions${request.nextUrl.search}`

--- a/apps/payments/next/auth.ts
+++ b/apps/payments/next/auth.ts
@@ -83,8 +83,13 @@ export const {
 
       // Allows callback URLs on the same origin and to MzAs content server
       const urlOrigin = new URL(url).origin;
-      if (urlOrigin === baseUrl || urlOrigin === config.contentServerUrl)
+      if (
+        urlOrigin === baseUrl ||
+        urlOrigin === config.contentServerUrl ||
+        urlOrigin === config.paymentsNextHostedUrl // Support for local HTTPS
+      ) {
         return url;
+      }
 
       return baseUrl;
     },


### PR DESCRIPTION
## Because

- Redirects to subscription manage page from the root page use incorrect hostname when behind a proxy.

## This pull request

- Redirect to relative URL allowing Next.js to determine the correct hostname.

## Issue that this pull request solves

Closes: #PAY-3194

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
