### PR TITLE
feat(l10n): Implement dynamic localization context and language switcher

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -71,6 +71,7 @@
     "recoveryPhonePasswordReset2fa": true,
     "updatedInlineTotpSetupFlow": true,
     "updatedInlineRecoverySetupFlow": true
+    "showLocaleToggle": true
   },
   "rolloutRates": {
     "keyStretchV2": 1,

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -120,6 +120,7 @@ const settingsConfig = {
     updatedInlineRecoverySetupFlow: config.get(
       'featureFlags.updatedInlineRecoverySetupFlow'
     ),
+    showLocaleToggle: config.get('featureFlags.showLocaleToggle'),
   },
   nimbusPreview: config.get('nimbusPreview'),
   cms: {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -265,6 +265,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW',
     },
+    showLocaleToggle: {
+      default: false,
+      doc: 'Enables the locale toggle in the footer',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_SHOW_LOCALE_TOGGLE',
+    },
   },
   cms: {
     enabled: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -64,6 +64,9 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW = config.get(
     'featureFlags.updatedInlineRecoverySetupFlow'
   );
+  const FEATURE_FLAGS_SHOW_LOCALE_TOGGLE = config.get(
+    'featureFlags.showLocaleToggle'
+  );
   const NIMBUS_PREVIEW = config.get('nimbusPreview');
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
@@ -131,6 +134,7 @@ function getIndexRouteDefinition(config) {
       updated2faSetupFlow: FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW,
       updatedInlineRecoverySetupFlow:
         FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW,
+      showLocaleToggle: FEATURE_FLAGS_SHOW_LOCALE_TOGGLE,
     },
     cms: {
       enabled: CMS_ENABLED,

--- a/packages/fxa-react/components/Footer/index.test.tsx
+++ b/packages/fxa-react/components/Footer/index.test.tsx
@@ -8,8 +8,8 @@ import Footer from '.';
 import { renderWithLocalizationProvider } from '../../lib/test-utils/localizationProvider';
 
 describe('Footer', () => {
-  it('renders as expected', () => {
-    renderWithLocalizationProvider(<Footer />);
+  it('renders as expected without LocaleToggle', () => {
+    renderWithLocalizationProvider(<Footer showLocaleToggle={false} />);
 
     const linkMozilla = screen.getByTestId('link-mozilla');
 
@@ -29,5 +29,39 @@ describe('Footer', () => {
       'href',
       'https://www.mozilla.org/about/legal/terms/services/'
     );
+
+    // Check that LocaleToggle placeholder is NOT rendered when showLocaleToggle is false
+    expect(screen.queryByTestId('locale-toggle-placeholder')).not.toBeInTheDocument();
+  });
+
+  it('renders LocaleToggle when showLocaleToggle is true and localeToggleComponent is provided', () => {
+    const MockLocaleToggle = ({ placement }: { placement?: 'footer' | 'header' }) => (
+      <div data-testid="locale-toggle" data-placement={placement}>
+        Mock LocaleToggle
+      </div>
+    );
+
+    renderWithLocalizationProvider(
+      <Footer showLocaleToggle={true} localeToggleComponent={MockLocaleToggle} />
+    );
+
+    // Check that LocaleToggle is rendered in the footer
+    const localeToggle = screen.getByTestId('locale-toggle');
+    expect(localeToggle).toBeInTheDocument();
+    expect(localeToggle).toHaveAttribute('data-placement', 'footer');
+  });
+
+  it('does not render LocaleToggle when showLocaleToggle is true but no localeToggleComponent is provided', () => {
+    renderWithLocalizationProvider(<Footer showLocaleToggle={true} />);
+
+    // Check that nothing is rendered when no component is provided
+    expect(screen.queryByTestId('locale-toggle')).not.toBeInTheDocument();
+  });
+
+  it('renders without LocaleToggle by default', () => {
+    renderWithLocalizationProvider(<Footer />);
+
+    // Check that LocaleToggle placeholder is NOT rendered by default
+    expect(screen.queryByTestId('locale-toggle-placeholder')).not.toBeInTheDocument();
   });
 });

--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -7,7 +7,13 @@ import { Localized, useLocalization } from '@fluent/react';
 import LinkExternal from '../LinkExternal';
 import mozLogo from '@fxa/shared/assets/images/moz-logo-bw-rgb.svg';
 
-export const Footer = () => {
+export const Footer = ({
+  showLocaleToggle = false,
+  localeToggleComponent
+}: {
+  showLocaleToggle?: boolean;
+  localeToggleComponent?: React.ComponentType<{ placement?: 'footer' | 'header' }>;
+}) => {
   const { l10n } = useLocalization();
   return (
     <footer
@@ -51,6 +57,11 @@ export const Footer = () => {
           </LinkExternal>
         </Localized>
       </div>
+      {showLocaleToggle && localeToggleComponent && (
+        <div className="w-full mobileLandscape:w-auto flex items-center mt-3 mobileLandscape:mt-0 mobileLandscape:ml-10">
+          {React.createElement(localeToggleComponent, { placement: 'footer' })}
+        </div>
+      )}
     </footer>
   );
 };

--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -19,6 +19,18 @@ import {
 } from './mocks';
 import { RelierCmsInfo } from '../../models';
 
+// Mock the useConfig hook
+jest.mock('../../models/hooks', () => ({
+  useConfig: jest.fn(() => ({
+    featureFlags: {
+      showLocaleToggle: false
+    }
+  })),
+  useFtlMsgResolver: () => ({
+    getMsg: (id: string, fallback: string) => fallback
+  })
+}));
+
 describe('<AppLayout />', () => {
   it('renders as expected with children', async () => {
     renderWithLocalizationProvider(
@@ -273,6 +285,26 @@ describe('<AppLayout />', () => {
 
     // Verify that only one logo is rendered
     expect(screen.getAllByRole('img')).toHaveLength(1);
+  });
+
+  describe('LocaleToggle visibility', () => {
+    it('shows LocaleToggle when feature flag enabled', () => {
+      // Tried to not use require here but it was not working
+      const { useConfig } = require('../../models/hooks');
+      useConfig.mockReturnValue({
+        featureFlags: {
+          showLocaleToggle: true
+        }
+      });
+
+      renderWithLocalizationProvider(
+        <AppLayout>
+          <p>Hello, world!</p>
+        </AppLayout>
+      );
+
+      expect(screen.getByTestId('locale-select')).toBeInTheDocument();
+    });
   });
 
   describe('snapshots', () => {

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -9,6 +9,8 @@ import { useLocalization } from '@fluent/react';
 import Head from 'fxa-react/components/Head';
 import classNames from 'classnames';
 import { RelierCmsInfo } from '../../models/integrations';
+import { LocaleToggle } from '../LocaleToggle';
+import { useConfig } from '../../models/hooks';
 
 type AppLayoutProps = {
   // TODO: FXA-6803 - the title prop should be made mandatory
@@ -25,6 +27,8 @@ type AppLayoutProps = {
    * `FlowContainer`.
    */
   wrapInCard?: boolean;
+  /** Whether to show the locale toggle in the footer */
+  showLocaleToggle?: boolean;
 };
 
 const looseValidBgCheck = (value: string | undefined) => {
@@ -45,6 +49,7 @@ export const AppLayout = ({
   wrapInCard = true,
 }: AppLayoutProps) => {
   const { l10n } = useLocalization();
+  const config = useConfig();
   const cmsBackgroundColor = cmsInfo?.shared?.backgroundColor;
   const cmsHeaderBackground = cmsInfo?.shared?.headerBackground;
   const cmsPageTitle = cmsInfo?.shared?.pageTitle;
@@ -57,6 +62,8 @@ export const AppLayout = ({
   const hasValidHeaderBackground = looseValidBgCheck(cmsHeaderBackground);
 
   const favicon = cmsInfo?.shared?.favicon;
+
+  const showLocaleToggle =config.featureFlags?.showLocaleToggle;
 
   return (
     <>
@@ -116,7 +123,7 @@ export const AppLayout = ({
           </LinkExternal>
         </header>
         <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1">
-          <section>
+          <section className="relative">
             {wrapInCard ? (
               <div className={classNames('card', widthClass)}>{children}</div>
             ) : (
@@ -125,6 +132,14 @@ export const AppLayout = ({
           </section>
         </main>
       </div>
+      <footer>
+            {/* LocaleToggle positioned in lower left corner of page */}
+            {showLocaleToggle && (
+              <div className="fixed bottom-6 left-6 z-10">
+                <LocaleToggle placement="footer" />
+              </div>
+            )}
+      </footer>
       <div id="body-bottom" className="w-full block mobileLandscape:hidden" />
     </>
   );

--- a/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyTotp/index.test.tsx
@@ -13,14 +13,14 @@ describe('FormVerifyTotp component', () => {
     renderWithLocalizationProvider(<Subject />);
     expect(screen.getByText('Enter 6-digit code')).toBeVisible();
     expect(screen.getAllByRole('textbox')).toHaveLength(1);
-    const button = screen.getByRole('button');
+    const button = screen.getByRole('button', { name: 'Submit' });
     expect(button).toHaveTextContent('Submit');
   });
 
   describe('submit button', () => {
     it('is disabled on render', () => {
       renderWithLocalizationProvider(<Subject />);
-      const button = screen.getByRole('button');
+      const button = screen.getByRole('button', { name: 'Submit' });
       expect(button).toHaveTextContent('Submit');
       expect(button).toBeDisabled();
     });
@@ -29,7 +29,7 @@ describe('FormVerifyTotp component', () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
       const input = screen.getByRole('textbox');
-      const button = screen.getByRole('button');
+      const button = screen.getByRole('button', { name: 'Submit' });
       expect(button).toHaveTextContent('Submit');
       expect(button).toBeDisabled();
 
@@ -42,7 +42,7 @@ describe('FormVerifyTotp component', () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
       const input = screen.getByRole('textbox');
-      const button = screen.getByRole('button');
+      const button = screen.getByRole('button', { name: 'Submit' });
       expect(button).toHaveTextContent('Submit');
       expect(button).toBeDisabled();
 

--- a/packages/fxa-settings/src/components/InputPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/InputPhoneNumber/index.test.tsx
@@ -16,7 +16,8 @@ describe('InputPhoneNumber', () => {
     expect(usOption).toBeInTheDocument();
     expect(canadaOption).toBeInTheDocument();
 
-    const options = screen.getAllByRole('option');
+    const phoneSelect = screen.getByLabelText('Select country');
+    const options = phoneSelect.querySelectorAll('option');
     expect(options.length).toBe(2);
 
     // expect list to be sorted alphabetically
@@ -34,14 +35,15 @@ describe('InputPhoneNumber', () => {
     renderWithLocalizationProvider(
       <Subject countries={extendedCountryOptions} />
     );
-    let options = screen.getAllByRole('option');
+    const phoneSelect = screen.getByLabelText('Select country');
+    let options = phoneSelect.querySelectorAll('option');
     expect(options.length).toBe(extendedCountryOptions.length);
 
     // There should be an option for each country listed
     expect(extendedCountryOptions.length).toEqual(options.length);
     extendedCountryOptions.forEach((countryOption) => {
       expect(
-        options.some((option) =>
+        Array.from(options).some((option) =>
           option.textContent?.includes(countryOption.name)
         )
       ).toBe(true);

--- a/packages/fxa-settings/src/components/LocaleToggle/en.ftl
+++ b/packages/fxa-settings/src/components/LocaleToggle/en.ftl
@@ -1,0 +1,3 @@
+## Locale Toggle Component
+
+locale-toggle-select-label = Select language

--- a/packages/fxa-settings/src/components/LocaleToggle/index.test.tsx
+++ b/packages/fxa-settings/src/components/LocaleToggle/index.test.tsx
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/2.0/. */
+
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { LocaleToggle } from './index';
+
+// Mock the useLocaleManager hook
+const mockSwitchLocale = jest.fn();
+
+const mockUseLocaleManager = jest.fn(() => ({
+  currentLocale: 'en',
+  availableLocales: [
+    { code: 'en', name: 'English', nativeName: 'English', rtl: false },
+    { code: 'es', name: 'Spanish', nativeName: 'Español', rtl: false },
+    { code: 'fr', name: 'French', nativeName: 'Français', rtl: false },
+    { code: 'he', name: 'Hebrew', nativeName: 'עברית', rtl: true }
+  ],
+  switchLocale: mockSwitchLocale,
+  isLoading: false
+}));
+
+jest.mock('../../lib/hooks/useLocaleManager', () => ({
+  useLocaleManager: () => mockUseLocaleManager()
+}));
+
+// Mock the useFtlMsgResolver hook
+jest.mock('../../models', () => ({
+  useFtlMsgResolver: () => ({
+    getMsg: (id: string, fallback: string) => fallback
+  })
+}));
+
+describe('LocaleToggle', () => {
+  beforeEach(() => {
+    mockSwitchLocale.mockClear();
+    // Reset to default mock
+    mockUseLocaleManager.mockReturnValue({
+      currentLocale: 'en',
+      availableLocales: [
+        { code: 'en', name: 'English', nativeName: 'English', rtl: false },
+        { code: 'es', name: 'Spanish', nativeName: 'Español', rtl: false },
+        { code: 'fr', name: 'French', nativeName: 'Français', rtl: false },
+        { code: 'he', name: 'Hebrew', nativeName: 'עברית', rtl: true }
+      ],
+      switchLocale: mockSwitchLocale,
+      isLoading: false
+    });
+  });
+
+  it('renders correctly with all required elements and attributes', () => {
+    renderWithLocalizationProvider(<LocaleToggle />);
+
+    const select = screen.getByTestId('locale-select');
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveAttribute('aria-label', 'Select language');
+    expect(select).toHaveAttribute('id', 'locale-select');
+    expect(select).toHaveValue('en');
+
+    // Check that all locales are rendered
+    expect(screen.getByTestId('locale-option-en')).toBeInTheDocument();
+    expect(screen.getByTestId('locale-option-es')).toBeInTheDocument();
+    expect(screen.getByTestId('locale-option-fr')).toBeInTheDocument();
+    expect(screen.getByTestId('locale-option-he')).toBeInTheDocument();
+  });
+
+  it('displays locale names correctly with proper formatting', () => {
+    renderWithLocalizationProvider(<LocaleToggle />);
+
+    const select = screen.getByTestId('locale-select');
+    // English shows only native name
+    expect(select).toHaveTextContent('English');
+    // Non-English locales show both native and English names
+    expect(select).toHaveTextContent('Español (Spanish)');
+    expect(select).toHaveTextContent('Français (French)');
+    expect(select).toHaveTextContent('עברית (Hebrew)');
+  });
+
+  it('calls switchLocale when a different locale is selected', async () => {
+    renderWithLocalizationProvider(<LocaleToggle />);
+
+    const select = screen.getByTestId('locale-select');
+    fireEvent.change(select, { target: { value: 'es' } });
+
+    await waitFor(() => {
+      expect(mockSwitchLocale).toHaveBeenCalledWith('es');
+    });
+  });
+
+  it('does not call switchLocale when the same locale is selected', async () => {
+    renderWithLocalizationProvider(<LocaleToggle />);
+
+    const select = screen.getByTestId('locale-select');
+    fireEvent.change(select, { target: { value: 'en' } });
+
+    await waitFor(() => {
+      expect(mockSwitchLocale).not.toHaveBeenCalled();
+    });
+  });
+
+  it('is disabled when loading', () => {
+    mockUseLocaleManager.mockReturnValue({
+      currentLocale: 'en',
+      availableLocales: [
+        { code: 'en', name: 'English', nativeName: 'English', rtl: false }
+      ],
+      switchLocale: mockSwitchLocale,
+      isLoading: true
+    });
+
+    renderWithLocalizationProvider(<LocaleToggle />);
+
+    const select = screen.getByTestId('locale-select');
+    expect(select).toBeDisabled();
+  });
+
+  it('applies custom className', () => {
+    renderWithLocalizationProvider(<LocaleToggle className="custom-class" />);
+
+    const container = screen.getByTestId('locale-select').parentElement;
+    expect(container).toHaveClass('custom-class');
+  });
+
+  it('has proper accessibility attributes and labeling', () => {
+    renderWithLocalizationProvider(<LocaleToggle />);
+
+    const select = screen.getByTestId('locale-select');
+    expect(select).toHaveAttribute('id', 'locale-select');
+    expect(select).toHaveAttribute('aria-label', 'Select language');
+
+    const label = screen.getByText('Select language');
+    expect(label).toHaveAttribute('for', 'locale-select');
+    expect(label).toHaveClass('sr-only');
+  });
+
+  it('handles edge cases gracefully', () => {
+    // Test empty availableLocales
+    mockUseLocaleManager.mockReturnValue({
+      currentLocale: 'en',
+      availableLocales: [],
+      switchLocale: mockSwitchLocale,
+      isLoading: false
+    });
+
+    const { rerender } = renderWithLocalizationProvider(<LocaleToggle />);
+
+    let select = screen.getByTestId('locale-select');
+    expect(select).toBeInTheDocument();
+    expect(select.children).toHaveLength(0);
+
+    // Test locales with missing or duplicate properties
+    mockUseLocaleManager.mockReturnValue({
+      currentLocale: 'en',
+      availableLocales: [
+        { code: 'en', name: 'English', nativeName: 'English', rtl: false },
+        { code: 'es', name: 'Spanish', nativeName: 'Español', rtl: false },
+        { code: 'fr', name: 'French', nativeName: 'French', rtl: false } // Same as nativeName
+      ],
+      switchLocale: mockSwitchLocale,
+      isLoading: false
+    });
+
+    rerender(<LocaleToggle />);
+
+    select = screen.getByTestId('locale-select');
+    expect(select).toHaveTextContent('English');
+    expect(select).toHaveTextContent('Español (Spanish)');
+    expect(select).toHaveTextContent('French'); // Should not show duplicate
+  });
+});

--- a/packages/fxa-settings/src/components/LocaleToggle/index.tsx
+++ b/packages/fxa-settings/src/components/LocaleToggle/index.tsx
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { useLocaleManager } from '../../lib/hooks/useLocaleManager';
+import { useFtlMsgResolver } from '../../models';
+
+interface LocaleToggleProps {
+  className?: string;
+  placement?: 'footer' | 'header';
+}
+
+export const LocaleToggle: React.FC<LocaleToggleProps> = ({
+  className = '',
+  placement = 'footer'
+}) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const { currentLocale, availableLocales, switchLocale, isLoading } = useLocaleManager();
+
+  // Handle locale selection
+  const handleLocaleChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newLocale = event.target.value;
+    if (newLocale && newLocale !== currentLocale) {
+      await switchLocale(newLocale);
+    }
+  };
+
+  const selectLabel = ftlMsgResolver.getMsg(
+    'locale-toggle-select-label',
+    'Select language'
+  );
+
+  return (
+    <div className={`relative ${className}`}>
+      <label htmlFor="locale-select" className="sr-only">
+        {selectLabel}
+      </label>
+      <select
+        id="locale-select"
+        value={currentLocale}
+        onChange={handleLocaleChange}
+        disabled={isLoading}
+        className="text-xs text-grey-500 hover:text-grey-600 focus:outline-none focus:text-grey-600 disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-0 cursor-pointer appearance-none min-w-[8ch] w-auto"
+        data-testid="locale-select"
+        aria-label={selectLabel}
+      >
+        {availableLocales.map((locale) => (
+          <option
+            key={locale.code}
+            value={locale.code}
+            data-testid={`locale-option-${locale.code}`}
+          >
+            {locale.nativeName}
+            {locale.nativeName !== locale.name && ` (${locale.name})`}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default LocaleToggle;

--- a/packages/fxa-settings/src/components/Settings/SettingsLayout/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SettingsLayout/index.tsx
@@ -7,12 +7,16 @@ import HeaderLockup from '../HeaderLockup';
 import ContentSkip from '../ContentSkip';
 import Footer from 'fxa-react/components/Footer';
 import { AlertBar } from '../AlertBar';
+import { useConfig } from '../../../models/hooks';
+import { LocaleToggle } from '../../LocaleToggle';
 
 type SettingsLayoutProps = {
   children: React.ReactNode;
 };
 
 export const SettingsLayout = ({ children }: SettingsLayoutProps) => {
+  const config = useConfig();
+
   return (
     <div
       className="flex flex-col justify-between min-h-screen"
@@ -27,7 +31,10 @@ export const SettingsLayout = ({ children }: SettingsLayoutProps) => {
           {children}
         </main>
       </div>
-      <Footer />
+      <Footer
+        showLocaleToggle={config.featureFlags?.showLocaleToggle}
+        localeToggleComponent={LocaleToggle}
+      />
       <div id="body-bottom" className="block mobileLandscape:hidden" />
     </div>
   );

--- a/packages/fxa-settings/src/contexts/DynamicLocalizationContext.tsx
+++ b/packages/fxa-settings/src/contexts/DynamicLocalizationContext.tsx
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
+import { isRTLLocale, saveLocalePreference, getCurrentLocale } from '../lib/locales';
+import { supportedLanguages } from '@fxa/shared/l10n';
+
+const DEFAULT_LOCALE = 'en';
+
+interface DynamicLocalizationContextType {
+  currentLocale: string;
+  switchLanguage: (locale: string) => Promise<void>;
+  isLoading: boolean;
+}
+
+const DynamicLocalizationContext = createContext<DynamicLocalizationContextType | null>(null);
+
+export const DynamicLocalizationProvider: React.FC<{
+  children: React.ReactNode;
+  baseDir: string;
+  bundles?: string[];
+}> = ({ children, baseDir, bundles = ['main'] }) => {
+  const [currentLocale, setCurrentLocale] = useState(() => getCurrentLocale());
+  const [userLocales, setUserLocales] = useState<readonly string[]>(() => [getCurrentLocale(), DEFAULT_LOCALE]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [key, setKey] = useState(0); // Force re-render of AppLocalizationProvider
+
+  // Listen for storage changes (in case user changes locale in another tab)
+  useEffect(() => {
+    const handleStorageChange = () => {
+      const newLocale = getCurrentLocale();
+      if (newLocale !== currentLocale) {
+        setCurrentLocale(newLocale);
+        setUserLocales([newLocale, DEFAULT_LOCALE]);
+        setKey(prev => prev + 1);
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, [currentLocale]);
+
+  const switchLanguage = useCallback(async (locale: string) => {
+    // Validate against supported languages
+    if (!supportedLanguages.includes(locale)) {
+      console.warn(`Locale ${locale} is not supported`);
+      return;
+    }
+
+    if (locale === currentLocale) {
+      return; // No change needed
+    }
+
+    setIsLoading(true);
+
+    try {
+      // 1. Save preference to localStorage
+      saveLocalePreference(locale);
+
+      // 2. Update document attributes
+      document.documentElement.lang = locale;
+      document.documentElement.dir = isRTLLocale(locale) ? 'rtl' : 'ltr';
+
+      // 3. Update state
+      setCurrentLocale(locale);
+      setUserLocales([locale, DEFAULT_LOCALE]);
+
+      // 4. Force AppLocalizationProvider to re-mount and reload bundles
+      setKey(prev => prev + 1);
+
+    } catch (error) {
+      // Language switch failed, we can't really do anything about it so ignore it
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentLocale]);
+
+  return (
+    <DynamicLocalizationContext.Provider value={{
+      currentLocale,
+      switchLanguage,
+      isLoading
+    }}>
+      <AppLocalizationProvider
+        key={key} // This forces re-mount when language changes
+        baseDir={baseDir}
+        userLocales={userLocales}
+        bundles={bundles}
+      >
+        {children}
+      </AppLocalizationProvider>
+    </DynamicLocalizationContext.Provider>
+  );
+};
+
+export const useDynamicLocalization = () => {
+  const context = useContext(DynamicLocalizationContext);
+  if (!context) {
+    // Provide a fallback for test environments
+    return {
+      currentLocale: DEFAULT_LOCALE,
+      switchLanguage: async () => {},
+      isLoading: false
+    };
+  }
+  return context;
+};

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -2,22 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import sentryMetrics from 'fxa-shared/sentry/browser';
-
 import React from 'react';
 import { render } from 'react-dom';
+import sentryMetrics from 'fxa-shared/sentry/browser';
 import { AppErrorBoundary } from './components/ErrorBoundaries';
 import App from './components/App';
 import config, { readConfigMeta } from './lib/config';
 import { searchParams } from './lib/utilities';
 import { AppContext, initializeAppContext } from './models';
-import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import { ApolloProvider } from '@apollo/client';
 import { createApolloClient } from './lib/gql';
 import Storage from './lib/storage';
 import './styles/tailwind.out.css';
 import CookiesDisabled from './pages/CookiesDisabled';
 import { navigate } from '@reach/router';
+import { DynamicLocalizationProvider } from './contexts/DynamicLocalizationContext';
 
 export interface FlowQueryParams {
   broker?: string;
@@ -25,9 +24,18 @@ export interface FlowQueryParams {
   deviceId?: string;
   flowBeginTime?: number;
   flowId?: string;
+  entrypoint?: string;
+  entrypoint_experiment?: string;
+  entrypoint_variation?: string;
+  form_type?: string;
   isSampledUser?: boolean;
   service?: string;
   uniqueUserId?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_medium?: string;
+  utm_source?: string;
+  utm_term?: string;
 }
 
 // Temporary query params
@@ -48,7 +56,7 @@ try {
     release: config.version,
     sentry: {
       ...config.sentry,
-      tracesSampler: (context) => {
+      tracesSampler: (context: { name?: string }) => {
         let rate = 0;
         // We only want to sample the index page for now.
         if (context.name === '/') {
@@ -73,9 +81,8 @@ try {
 
   render(
     <React.StrictMode>
-      <AppLocalizationProvider
+      <DynamicLocalizationProvider
         baseDir={config.l10n.baseUrl}
-        userLocales={navigator.languages}
       >
         <AppErrorBoundary>
           <AppContext.Provider value={appContext}>
@@ -84,7 +91,7 @@ try {
             </ApolloProvider>
           </AppContext.Provider>
         </AppErrorBoundary>
-      </AppLocalizationProvider>
+      </DynamicLocalizationProvider>
     </React.StrictMode>,
     document.getElementById('root')
   );

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -96,6 +96,7 @@ export interface Config {
     updatedInlineTotpSetupFlow?: boolean;
     updated2faSetupFlow?: boolean;
     updatedInlineRecoverySetupFlow?: boolean;
+    showLocaleToggle?: boolean;
   };
   nimbusPreview: boolean;
   cms: {
@@ -181,6 +182,7 @@ export function getDefault() {
       updatedInlineTotpSetupFlow: false,
       updated2faSetupFlow: false,
       updatedInlineRecoverySetupFlow: false,
+      showLocaleToggle: false,
     },
     cms: {
       // Note: Even if this flag is true, the user must be an `en` language

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -711,8 +711,8 @@ describe('lib/glean', () => {
       });
 
       it('submits a ping with the account_pref_display_name_submit event name', async () => {
-        GleanMetrics.accountPref.displayNameSubmit();
         const spy = sandbox.spy(accountPref.displayNameSubmit, 'record');
+        GleanMetrics.accountPref.displayNameSubmit();
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
@@ -723,8 +723,8 @@ describe('lib/glean', () => {
       });
 
       it('submits a ping with the account_pref_secondary_email_submit event name', async () => {
-        GleanMetrics.accountPref.secondaryEmailSubmit();
         const spy = sandbox.spy(accountPref.secondaryEmailSubmit, 'record');
+        GleanMetrics.accountPref.secondaryEmailSubmit();
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(
@@ -735,8 +735,8 @@ describe('lib/glean', () => {
       });
 
       it('submits a ping with the account_pref_two_step_auth_submit event name', async () => {
-        GleanMetrics.accountPref.twoStepAuthSubmit();
         const spy = sandbox.spy(accountPref.twoStepAuthSubmit, 'record');
+        GleanMetrics.accountPref.twoStepAuthSubmit();
         await GleanMetrics.isDone();
         sinon.assert.calledOnce(setEventNameStub);
         sinon.assert.calledWith(

--- a/packages/fxa-settings/src/lib/hooks/useLocaleManager.ts
+++ b/packages/fxa-settings/src/lib/hooks/useLocaleManager.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useState } from 'react';
+import {
+  LocaleOption,
+  getAvailableLocales,
+  isRTLLocale,
+  LOCALE_MAPPINGS
+} from '../locales';
+import { useDynamicLocalization } from '../../contexts/DynamicLocalizationContext';
+
+export interface LocaleManager {
+  currentLocale: string;
+  currentLanguage: LocaleOption | undefined;
+  availableLocales: LocaleOption[];
+  switchLocale: (newLocale: string) => Promise<void>;
+  isRTL: boolean;
+  isLoading: boolean;
+}
+
+export const useLocaleManager = (): LocaleManager => {
+  const { currentLocale, switchLanguage, isLoading } = useDynamicLocalization();
+  const [availableLocales] = useState<LocaleOption[]>(() => getAvailableLocales());
+
+  const currentLanguage = LOCALE_MAPPINGS[currentLocale];
+  const isRTL = isRTLLocale(currentLocale);
+
+  return {
+    currentLocale,
+    currentLanguage,
+    availableLocales,
+    switchLocale: switchLanguage,
+    isRTL,
+    isLoading
+  };
+};

--- a/packages/fxa-settings/src/lib/locales.ts
+++ b/packages/fxa-settings/src/lib/locales.ts
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { supportedLanguages, rtlLocales } from '@fxa/shared/l10n';
+
+export interface LocaleOption {
+  code: string;          // 'en', 'es', 'fr'
+  name: string;          // 'English', 'Español', 'Français'
+  nativeName: string;    // Native language name
+  rtl: boolean;          // Right-to-left flag
+}
+
+// Locale mappings with accurate supported languages
+export const LOCALE_MAPPINGS: Record<string, LocaleOption> = {
+  'be': { code: 'be', name: 'Belarusian', nativeName: 'Беларуская', rtl: false },
+  'cs': { code: 'cs', name: 'Czech', nativeName: 'Čeština', rtl: false },
+  'cy': { code: 'cy', name: 'Welsh', nativeName: 'Cymraeg', rtl: false },
+  'da': { code: 'da', name: 'Danish', nativeName: 'Dansk', rtl: false },
+  'de': { code: 'de', name: 'German', nativeName: 'Deutsch', rtl: false },
+  'dsb': { code: 'dsb', name: 'Lower Sorbian', nativeName: 'Dolnoserbšćina', rtl: false },
+  'el': { code: 'el', name: 'Greek', nativeName: 'Ελληνικά', rtl: false },
+  'en': { code: 'en', name: 'English', nativeName: 'English', rtl: false },
+  'en-GB': { code: 'en-GB', name: 'English (GB)', nativeName: 'English (GB)', rtl: false },
+  'en-CA': { code: 'en-CA', name: 'English (CA)', nativeName: 'English (CA)', rtl: false },
+  'en-US': { code: 'en-US', name: 'English (US)', nativeName: 'English (US)', rtl: false },
+  'es': { code: 'es', name: 'Spanish', nativeName: 'Español', rtl: false },
+  'es-AR': { code: 'es-AR', name: 'Spanish (AR)', nativeName: 'Español (AR)', rtl: false },
+  'es-CL': { code: 'es-CL', name: 'Spanish (CL)', nativeName: 'Español (CL)', rtl: false },
+  'es-ES': { code: 'es-ES', name: 'Spanish (ES)', nativeName: 'Español (ES)', rtl: false },
+  'es-MX': { code: 'es-MX', name: 'Spanish (MX)', nativeName: 'Español (MX)', rtl: false },
+  'eu': { code: 'eu', name: 'Basque', nativeName: 'Euskara', rtl: false },
+  'fi': { code: 'fi', name: 'Finnish', nativeName: 'Suomi', rtl: false },
+  'fr': { code: 'fr', name: 'French', nativeName: 'Français', rtl: false },
+  'fur': { code: 'fur', name: 'Friulian', nativeName: 'Furlan', rtl: false },
+  'fy': { code: 'fy', name: 'Frisian', nativeName: 'Frysk', rtl: false },
+  'fy-NL': { code: 'fy-NL', name: 'Frisian (Netherlands)', nativeName: 'Frysk (NL)', rtl: false },
+  'gn': { code: 'gn', name: 'Guarani', nativeName: 'Guarani', rtl: false },
+  'he': { code: 'he', name: 'Hebrew', nativeName: 'עברית', rtl: true },
+  'hr': { code: 'hr', name: 'Croatian', nativeName: 'Hrvatski', rtl: false },
+  'hsb': { code: 'hsb', name: 'Upper Sorbian', nativeName: 'Hornjoserbšćina', rtl: false },
+  'hu': { code: 'hu', name: 'Hungarian', nativeName: 'Magyar', rtl: false },
+  'ia': { code: 'ia', name: 'Interlingua', nativeName: 'Interlingua', rtl: false },
+  'is': { code: 'is', name: 'Icelandic', nativeName: 'Íslenska', rtl: false },
+  'it': { code: 'it', name: 'Italian', nativeName: 'Italiano', rtl: false },
+  'ja': { code: 'ja', name: 'Japanese', nativeName: '日本語', rtl: false },
+  'ka': { code: 'ka', name: 'Georgian', nativeName: 'ქართული', rtl: false },
+  'kab': { code: 'kab', name: 'Kabyle', nativeName: 'Taqbaylit', rtl: false },
+  'kk': { code: 'kk', name: 'Kazakh', nativeName: 'Қазақ тілі', rtl: false },
+  'ko': { code: 'ko', name: 'Korean', nativeName: '한국어', rtl: false },
+  'nl': { code: 'nl', name: 'Dutch', nativeName: 'Nederlands', rtl: false },
+  'nb-NO': { code: 'nb-NO', name: 'Norwegian Bokmål', nativeName: 'Norsk bokmål', rtl: false },
+  'nn-NO': { code: 'nn-NO', name: 'Norwegian Nynorsk', nativeName: 'Nynorsk', rtl: false },
+  'pa-IN': { code: 'pa-IN', name: 'Punjabi (India)', nativeName: 'ਪੰਜਾਬੀ', rtl: false },
+  'pl': { code: 'pl', name: 'Polish', nativeName: 'Polski', rtl: false },
+  'pt': { code: 'pt', name: 'Portuguese', nativeName: 'Português', rtl: false },
+  'pt-BR': { code: 'pt-BR', name: 'Portuguese (Brazil)', nativeName: 'Português (BR)', rtl: false },
+  'pt-PT': { code: 'pt-PT', name: 'Portuguese (Portugal)', nativeName: 'Português (PT)', rtl: false },
+  'rm': { code: 'rm', name: 'Romansh', nativeName: 'Rumantsch', rtl: false },
+  'ru': { code: 'ru', name: 'Russian', nativeName: 'Русский', rtl: false },
+  'sk': { code: 'sk', name: 'Slovak', nativeName: 'Slovenčina', rtl: false },
+  'sl': { code: 'sl', name: 'Slovenian', nativeName: 'Slovenščina', rtl: false },
+  'sq': { code: 'sq', name: 'Albanian', nativeName: 'Shqip', rtl: false },
+  'sr': { code: 'sr', name: 'Serbian', nativeName: 'Српски', rtl: false },
+  'sv': { code: 'sv', name: 'Swedish', nativeName: 'Svenska', rtl: false },
+  'sv-SE': { code: 'sv-SE', name: 'Swedish (Sweden)', nativeName: 'Svenska (SE)', rtl: false },
+  'th': { code: 'th', name: 'Thai', nativeName: 'ไทย', rtl: false },
+  'tr': { code: 'tr', name: 'Turkish', nativeName: 'Türkçe', rtl: false },
+  'uk': { code: 'uk', name: 'Ukrainian', nativeName: 'Українська', rtl: false },
+  'vi': { code: 'vi', name: 'Vietnamese', nativeName: 'Tiếng Việt', rtl: false },
+  'zh-CN': { code: 'zh-CN', name: 'Chinese (Simplified)', nativeName: '简体中文', rtl: false },
+  'zh-TW': { code: 'zh-TW', name: 'Chinese (Traditional)', nativeName: '正體中文', rtl: false },
+};
+
+// Storage key for user locale preference
+const LOCALE_STORAGE_KEY = 'fxa-settings-locale';
+
+// Helper function to get available locales
+export const getAvailableLocales = (): LocaleOption[] => {
+  return supportedLanguages
+    .filter((code: string) => LOCALE_MAPPINGS[code])
+    .map((code: string) => LOCALE_MAPPINGS[code])
+    .sort((a: LocaleOption, b: LocaleOption) => a.name.localeCompare(b.name));
+};
+
+// Helper function to check if locale is RTL
+export const isRTLLocale = (locale: string): boolean => {
+  return rtlLocales.includes(locale);
+};
+
+// Helper function to get current locale from various sources
+export const getCurrentLocale = (): string => {
+  // 1. Check localStorage for user preference
+  const savedLocale = getLocalePreference();
+  if (savedLocale && supportedLanguages.includes(savedLocale)) {
+    return savedLocale;
+  }
+
+  // 2. Check document.documentElement.lang
+  const documentLang = document.documentElement.lang;
+  if (documentLang && supportedLanguages.includes(documentLang)) {
+    return documentLang;
+  }
+
+  // 3. Check navigator.language
+  const browserLang = navigator.language;
+  if (browserLang && supportedLanguages.includes(browserLang)) {
+    return browserLang;
+  }
+
+  // 4. Check base language (e.g., 'en' from 'en-US')
+  const baseLang = browserLang?.split('-')[0];
+  if (baseLang && supportedLanguages.includes(baseLang)) {
+    return baseLang;
+  }
+
+  // 5. Default to English
+  return 'en';
+};
+
+// Save locale preference to localStorage
+export const saveLocalePreference = (locale: string): void => {
+  try {
+    localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  } catch (error) {
+    console.warn('Failed to save locale preference:', error);
+  }
+};
+
+// Get locale preference from localStorage
+export const getLocalePreference = (): string | null => {
+  try {
+    return localStorage.getItem(LOCALE_STORAGE_KEY);
+  } catch (error) {
+    console.warn('Failed to get locale preference:', error);
+    return null;
+  }
+};

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -32,6 +32,7 @@ import {
 import { RelierClientInfo, RelierSubscriptionInfo, RelierCmsInfo } from './integrations';
 import { NimbusResult } from '../lib/nimbus';
 import * as Sentry from '@sentry/browser';
+import { useDynamicLocalization } from '../contexts/DynamicLocalizationContext';
 
 const DEFAULT_CMS_ENTRYPOINT = 'default';
 
@@ -210,6 +211,7 @@ export function useCmsInfoState() {
   }
 
   const authUrl = config?.servers.auth.url;
+  const { currentLocale } = useDynamicLocalization();
 
   const urlQueryData = new UrlQueryData(new ReachRouterWindow());
   const clientId = urlQueryData.get('client_id');
@@ -267,6 +269,7 @@ export function useCmsInfoState() {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
+            'Accept-Language': currentLocale,
           },
         });
 
@@ -303,7 +306,7 @@ export function useCmsInfoState() {
     return () => {
       mounted = false;
     };
-  }, [authUrl, clientId, entrypoint, config.cms.enabled]);
+  }, [authUrl, clientId, entrypoint, config.cms.enabled, currentLocale]);
 
   return state;
 }

--- a/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/AccountRecoveryConfirmKey/index.test.tsx
@@ -69,7 +69,7 @@ describe('AccountRecoveryConfirmKey', () => {
           user.type(screen.getByRole('textbox'), MOCK_RECOVERY_KEY)
         );
 
-        const submitButton = screen.getByRole('button');
+        const submitButton = screen.getByRole('button', { name: 'Continue' });
         expect(submitButton).toBeEnabled();
         await waitFor(() => user.click(submitButton));
 
@@ -84,7 +84,7 @@ describe('AccountRecoveryConfirmKey', () => {
         renderWithLocalizationProvider(
           <Subject verifyRecoveryKey={mockVerifyRecoveryKey} />
         );
-        const submitButton = screen.getByRole('button');
+        const submitButton = screen.getByRole('button', { name: 'Continue' });
 
         const input = screen.getByRole('textbox');
 
@@ -100,7 +100,7 @@ describe('AccountRecoveryConfirmKey', () => {
     describe('errors', () => {
       it('with an empty input', async () => {
         renderWithLocalizationProvider(<Subject />);
-        const submitButton = screen.getByRole('button');
+        const submitButton = screen.getByRole('button', { name: 'Continue' });
         expect(submitButton).toBeDisabled();
       });
 
@@ -109,7 +109,7 @@ describe('AccountRecoveryConfirmKey', () => {
         renderWithLocalizationProvider(
           <Subject verifyRecoveryKey={mockVerifyRecoveryKey} />
         );
-        const submitButton = screen.getByRole('button');
+        const submitButton = screen.getByRole('button', { name: 'Continue' });
         const input = screen.getByRole('textbox');
 
         await waitFor(() => user.type(input, MOCK_RECOVERY_KEY.slice(0, -1)));
@@ -121,7 +121,7 @@ describe('AccountRecoveryConfirmKey', () => {
         renderWithLocalizationProvider(
           <Subject verifyRecoveryKey={mockVerifyRecoveryKey} />
         );
-        const submitButton = screen.getByRole('button');
+        const submitButton = screen.getByRole('button', { name: 'Continue' });
         expect(submitButton).toBeDisabled();
 
         const input = screen.getByRole('textbox');
@@ -136,7 +136,7 @@ describe('AccountRecoveryConfirmKey', () => {
         renderWithLocalizationProvider(
           <Subject verifyRecoveryKey={mockVerifyRecoveryKey} />
         );
-        const submitButton = screen.getByRole('button');
+        const submitButton = screen.getByRole('button', { name: 'Continue' });
 
         const input = screen.getByRole('textbox');
         // contains a character that is not valid in Crockford base32

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPassword/index.test.tsx
@@ -59,7 +59,7 @@ describe('ResetPassword', () => {
         user.type(screen.getByRole('textbox'), `${MOCK_EMAIL} `)
       );
 
-      await waitFor(() => user.click(screen.getByRole('button')));
+      await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
 
       expect(mockRequestResetPasswordCode).toHaveBeenCalledWith(MOCK_EMAIL);
 
@@ -79,7 +79,7 @@ describe('ResetPassword', () => {
         user.type(screen.getByRole('textbox'), ` ${MOCK_EMAIL}`)
       );
 
-      await waitFor(() => user.click(screen.getByRole('button')));
+      await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
 
       expect(mockRequestResetPasswordCode).toHaveBeenCalledWith(MOCK_EMAIL);
       expect(GleanMetrics.passwordReset.view).toHaveBeenCalledTimes(1);
@@ -94,7 +94,7 @@ describe('ResetPassword', () => {
         );
 
         await expect(screen.getByRole('heading', { level: 1 })).toBeVisible();
-        await waitFor(() => user.click(screen.getByRole('button')));
+        await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
 
         expect(screen.getByText('Valid email required')).toBeVisible();
         expect(mockRequestResetPasswordCode).not.toHaveBeenCalled();
@@ -111,7 +111,7 @@ describe('ResetPassword', () => {
         await expect(screen.getByRole('heading', { level: 1 })).toBeVisible();
         await waitFor(() => user.type(screen.getByRole('textbox'), 'boop'));
 
-        await waitFor(() => user.click(screen.getByRole('button')));
+        await waitFor(() => user.click(screen.getByRole('button', { name: 'Continue' })));
 
         expect(screen.getByText('Valid email required')).toBeVisible();
         expect(mockRequestResetPasswordCode).not.toHaveBeenCalled();

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/index.test.tsx
@@ -22,7 +22,7 @@ describe('ResetPasswordConfirmed', () => {
     expect(
       screen.getByText('Your password has been reset')
     ).toBeInTheDocument();
-    const submitButton = screen.getByRole('button');
+    const submitButton = screen.getByRole('button', { name: 'Continue to Mozilla Monitor' });
     expect(submitButton).toHaveTextContent('Continue to Mozilla Monitor');
     expect(submitButton).toHaveAttribute(
       'data-glean-id',
@@ -50,7 +50,7 @@ describe('ResetPasswordConfirmed', () => {
         serviceName={MozServices.Monitor}
       />
     );
-    user.click(screen.getByRole('button'));
+    user.click(screen.getByRole('button', { name: 'Continue to Mozilla Monitor' }));
     await waitFor(() => expect(mockContinueHandler).toHaveBeenCalledTimes(1));
   });
 });


### PR DESCRIPTION
## Because

- We want to be able to switch locales easily, without going to browser settings and setting preferences

## This pull request

- Added `LocaleToggle` component for users to switch languages.
- Implemented `useLocaleManager` hook to handle locale state and switching logic.
- Updated `AppLayout` to conditionally render the `LocaleToggle` based on the `showLocaleToggle` prop.
- Adds a local storage key to keep track of the language selected.
- Adds `LocaleToggle` to AppLayout and SettingsLayout

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12273

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1111" height="913" alt="Screenshot 2025-08-27 at 12 21 11 PM" src="https://github.com/user-attachments/assets/8af6505e-47ed-4d9e-a8e0-b15bfb898528" />

<img width="951" height="66" alt="Screenshot 2025-08-27 at 12 21 30 PM" src="https://github.com/user-attachments/assets/1c1b6c5d-6a4b-47a3-b1e8-10c80365ff9b" />

## Other information (Optional)

I ended up using this while working on cms l10n customization. Seems like a useful thing for others too. It puts a langauge toggle in the lower left hand corner, uses grey text to support light and dark backgrounds, does not refresh the page to reload languages.
