### PR TITLE
feat(l10n): Update backend to return localized strapi data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ secrets.json
 .es5
 .es5cache
 /artifacts
+**/artifacts
+**/.nx/cache/**/artifacts
 .last-audit
 .eslintcache
 storybooks-publish
@@ -60,6 +62,7 @@ coverage.html
 **/coverage
 **/.nyc_output
 test-results.xml
+**/artifacts/tests/**/*.xml
 
 # Local configuration
 /_dev/firebase/.config

--- a/libs/shared/cms/src/lib/relying-party-configuration.manager.ts
+++ b/libs/shared/cms/src/lib/relying-party-configuration.manager.ts
@@ -5,19 +5,44 @@
 import { getOperationName } from '@apollo/client/utilities';
 import { Inject, Injectable } from '@nestjs/common';
 import { StatsD } from 'hot-shots';
+import { Firestore } from '@google-cloud/firestore';
 
 import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { relyingPartyQuery } from '@fxa/shared/cms';
 import { StrapiClient, StrapiClientEventResponse } from './strapi.client';
+import { Cacheable, CacheClear } from '@type-cacheable/core';
+import {
+  CacheFirstStrategy,
+  FirestoreAdapter,
+  MemoryAdapter,
+  StaleWhileRevalidateWithFallbackStrategy,
+} from '@fxa/shared/db/type-cacheable';
+import * as Sentry from '@sentry/node';
+import { FirestoreService } from '@fxa/shared/db/firestore';
+import { LOGGER_PROVIDER } from '@fxa/shared/log';
+import type { Logger } from '@fxa/shared/log';
+
+const CMS_FTL_CACHE_KEY = 'cmsFtlCache';
 
 @Injectable()
 export class RelyingPartyConfigurationManager {
+  private memoryCacheAdapter: MemoryAdapter;
+  private firestoreCacheAdapter: FirestoreAdapter;
   constructor(
     private strapiClient: StrapiClient,
     @Inject(StatsDService)
-    private statsd: StatsD
+    private statsd: StatsD,
+    @Inject(FirestoreService) private firestore: Firestore,
+    @Inject(LOGGER_PROVIDER) private readonly log: Logger,
   ) {
     this.strapiClient.on('response', this.onStrapiClientResponse.bind(this));
+
+    // Initialize cache adapters
+    this.memoryCacheAdapter = new MemoryAdapter();
+    this.firestoreCacheAdapter = new FirestoreAdapter(
+      this.firestore,
+      CMS_FTL_CACHE_KEY
+    );
   }
 
   onStrapiClientResponse(response: StrapiClientEventResponse) {
@@ -45,10 +70,156 @@ export class RelyingPartyConfigurationManager {
       entrypoint,
     });
   }
+
   async invalidateCache(clientId: string, entrypoint: string) {
     return await this.strapiClient.invalidateQueryCache(relyingPartyQuery, {
       clientId,
       entrypoint,
     });
   }
+
+  /**
+   * Get FTL content for a specific locale with caching
+   * Uses memory cache first, then Firestore cache with fallback strategy
+   *
+   * Expected config structure:
+   * {
+   *   cmsl10n: {
+   *     ftlUrl: { template: string, timeout: number },
+   *     ftlCache: {
+   *       memoryTtlSeconds: number,        // Memory cache TTL (default: 300s)
+   *       firestoreTtlSeconds: number,    // Firestore cache TTL (default: 1800s)
+   *       firestoreOfflineTtlSeconds: number // Firestore offline TTL (default: 604800s)
+   *     }
+   *   }
+   * }
+   */
+  @Cacheable({
+    cacheKey: (args: any) => `ftl:${args[0]}`,
+    strategy: (args: any, context: RelyingPartyConfigurationManager) =>
+      new CacheFirstStrategy(
+        (err) => {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          if (context.log) {
+            context.log.error('cms.ftl.cache.error', { error: errorMessage, locale: args[0] });
+          }
+          Sentry.captureException(err);
+        },
+        (startTime, endTime, result) => {
+          // Report cache hits for memory cache
+          if (result === 'cache') {
+            context.statsd.timing('cms_ftl_cache_hit', endTime - startTime, undefined, {
+              method: 'getFtlContent',
+              cacheType: 'memory',
+              locale: args[0],
+            });
+          }
+        }
+      ),
+    ttlSeconds: (args: any) => {
+      // Get TTL from config, fallback to 5 minutes if not specified
+      const config = args[1];
+      return config?.cmsl10n?.ftlCache?.memoryTtlSeconds || 300;
+    },
+    client: (_, context: RelyingPartyConfigurationManager) => context.memoryCacheAdapter,
+  })
+  @Cacheable({
+    cacheKey: (args: any) => `ftl:${args[0]}`,
+    strategy: (args: any, context: RelyingPartyConfigurationManager) => {
+      // Get TTL from config, fallback to 30 minutes if not specified
+      const config = args[1];
+      const firestoreTtl = config?.cmsl10n?.ftlCache?.firestoreTtlSeconds || 1800;
+
+      return new StaleWhileRevalidateWithFallbackStrategy(
+        firestoreTtl,
+        (err) => {
+          const errorMessage = err instanceof Error ? err.message : String(err);
+          if (context.log) {
+            context.log.error('cms.ftl.cache.error', { error: errorMessage, locale: args[0] });
+          }
+          Sentry.captureException(err);
+        },
+        (startTime, endTime, result) => {
+          context.statsd.timing('cms_ftl_cache_hit', endTime - startTime, undefined, {
+            method: 'getFtlContent',
+            cacheType: result,
+            locale: args[0],
+          });
+        }
+      );
+    },
+    ttlSeconds: (args: any) => {
+      // Get TTL from config, fallback to 7 days if not specified
+      const config = args[1];
+      return config?.cmsl10n?.ftlCache?.firestoreOfflineTtlSeconds || 604800;
+    },
+    client: (_, context: RelyingPartyConfigurationManager) => context.firestoreCacheAdapter,
+  })
+  async getFtlContent(locale: string, config: any): Promise<string> {
+    const requestStartTime = Date.now();
+
+    try {
+      const { ftlUrl } = config.cmsl10n;
+      const urlTemplate = ftlUrl.template;
+
+      if (!urlTemplate) {
+        return '';
+      }
+
+      // Replace {locale} placeholder with actual locale
+      const resolvedUrl = urlTemplate.replace('{locale}', locale);
+
+      const headers: Record<string, string> = {
+        'Accept': 'text/plain'
+      };
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), ftlUrl.timeout);
+
+      try {
+        const response = await fetch(resolvedUrl, {
+          headers,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (!response.ok) {
+          return '';
+        }
+
+        const ftlContent = await response.text();
+
+        return ftlContent;
+      } catch (error) {
+        clearTimeout(timeoutId);
+        throw error;
+      }
+    } catch (error) {
+      const requestEndTime = Date.now();
+      this.statsd.timing('cms_ftl_request', requestEndTime - requestStartTime, undefined, {
+        method: 'getFtlContent',
+        error: 'true',
+        cache: 'false',
+        locale,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Invalidate FTL cache for a specific locale
+   */
+  @CacheClear({
+    cacheKey: (args: any) => `ftl:${args[0]}`,
+    client: (_, context: RelyingPartyConfigurationManager) => context.memoryCacheAdapter,
+  })
+  @CacheClear({
+    cacheKey: (args: any) => `ftl:${args[0]}`,
+    client: (_, context: RelyingPartyConfigurationManager) => context.firestoreCacheAdapter,
+  })
+  async invalidateFtlCache(locale: string): Promise<void> {
+    // Method body is not needed as the decorators handle the cache clearing
+  }
+
 }

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -194,10 +194,7 @@ async function run(config) {
       Container.set(CapabilityManager, capabilityManager);
       Container.set(EligibilityManager, eligibilityManager);
 
-      const cmsAccounts = new RelyingPartyConfigurationManager(
-        strapiClient,
-        statsd
-      );
+      const cmsAccounts = new RelyingPartyConfigurationManager(strapiClient, statsd, firestore, log);
       Container.set(RelyingPartyConfigurationManager, cmsAccounts);
     }
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2097,15 +2097,9 @@ const convictConf = convict({
         env: 'CMS_WEBHOOK_CACHE_INVALIDATION_ENABLED',
         format: Boolean,
       },
-      headerKey: {
-        default: 'fxa-cms-cache-webhook-auth',
-        doc: 'The header key where to location a value to auth the request',
-        env: 'CMS_WEBHOOK_CACHE_INVALIDATION_HEADER',
-        format: String,
-      },
-      headerVal: {
-        default: 'CHANGEME',
-        doc: 'The header key where to location a value to auth the request',
+      secret: {
+        default: 'Bearer CHANGEME',
+        doc: 'The secret used in the Authorization header for the webhook',
         env: 'CMS_WEBHOOK_CACHE_INVALIDATION_SECRET',
         format: String,
       },
@@ -2382,7 +2376,7 @@ const convictConf = convict({
   cmsl10n: {
     enabled: {
       default: false,
-      doc: 'Enable localization logic for accounts relying party configuration',
+      doc: 'Enable localization on the /cms/config endpoint. When enabled, the endpoint will attempt to fetch and merge localized FTL content with the base CMS configuration. When disabled, only the base configuration is returned.',
       env: 'CMS_L10N_ENABLED',
       format: Boolean,
     },
@@ -2394,8 +2388,8 @@ const convictConf = convict({
         format: Boolean,
       },
       secret: {
-        default: 'test',
-        doc: 'Secret key to validate Strapi webhook requests',
+        default: 'Bearer CHANGEME',
+        doc: 'The secret used in the Authorization header for the webhook',
         env: 'CMS_L10N_STRAPI_WEBHOOK_SECRET',
         format: String,
       },
@@ -2404,6 +2398,40 @@ const convictConf = convict({
         doc: 'Strapi webhook URL',
         env: 'CMS_L10N_STRAPI_WEBHOOK_STRAPI_URL',
         format: String,
+      },
+    },
+    ftlUrl: {
+      template: {
+        default: 'https://raw.githubusercontent.com/mozilla/fxa-cms-l10n/main/locales/{locale}/cms.ftl',
+        doc: 'URL template for FTL files. Use {locale} placeholder for locale substitution',
+        env: 'CMS_L10N_FTL_URL_TEMPLATE',
+        format: String,
+      },
+      timeout: {
+        default: 5000, // 5 seconds
+        doc: 'Timeout for FTL requests in milliseconds',
+        env: 'CMS_L10N_FTL_TIMEOUT',
+        format: Number,
+      }
+    },
+    ftlCache: {
+      memoryTtl: {
+        default: 900, // 15 minutes
+        doc: 'TTL for FTL content in memory cache (seconds)',
+        env: 'CMS_L10N_FTL_CACHE_MEMORY_TTL',
+        format: Number,
+      },
+      firestoreTtl: {
+        default: 3600, // 1 hour
+        doc: 'TTL for FTL content in Firestore cache (seconds)',
+        env: 'CMS_L10N_FTL_CACHE_FIRESTORE_TTL',
+        format: Number,
+      },
+      firestoreOfflineTtl: {
+        default: 604800, // 7 days
+        doc: 'TTL for FTL content in Firestore offline cache (seconds)',
+        env: 'CMS_L10N_FTL_CACHE_FIRESTORE_OFFLINE_TTL',
+        format: Number,
       },
     },
     github: {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -897,3 +897,8 @@ module.exports.entrypoint = isA.string()
   .regex(/^[a-zA-Z0-9_.-]+$/) // Only allow letters, digits, underscores, dots, and dashes
   .max(256)
   .required();
+
+module.exports.locale = isA.string()
+  .regex(/^[a-z]{2}(-[A-Z]{2})?$/) // ISO 639-1 language codes (e.g., 'en', 'es', 'en-US', 'es-MX')
+  .max(10)
+  .optional();


### PR DESCRIPTION
## Because

- We need to support localization for CMS content

## This pull request

- Adds localization workflow (fetch flt file from url, convert to strapi data, merge base strapi data, serve the localized data)
- Updates RelyingPartyConfigurationManager to support caching ftl localization files
- Adds fallback logic if localization file is not found (en-US -> en, etc)
- Updated webhook processing to use `secret` config value instead of headerVal/headerKey
- 

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

For a detailed breakdown of the workflow, check out these [docs](https://github.com/mozilla/ecosystem-platform/pull/701)!
