### PR TITLE
fix(cms): fix CMS button turning white on hover in old browsers

### DIFF
--- a/packages/fxa-react/styles/ctas.css
+++ b/packages/fxa-react/styles/ctas.css
@@ -102,7 +102,8 @@
 
     .cta-caution,
     .cta-primary,
-    .cta-neutral, .cta-primary-cms {
+    .cta-neutral,
+    .cta-primary-cms {
       @apply w-auto;
     }
   }
@@ -114,7 +115,7 @@
     --cta-bg: theme(colors.blue.500);
     --cta-border: theme(colors.blue.600);
     --cta-active: theme(colors.blue.800);
-    --cta-disabled: rgb(59 130 246 / .40);    /* blue-500/40 */
+    --cta-disabled: rgb(59 130 246 / 0.4); /* blue-500/40 */
 
     background-color: var(--cta-bg);
     border-color: var(--cta-border);
@@ -138,11 +139,23 @@
   }
 
   @media (hover: hover) {
-    .cta-primary-cms:hover:not(:disabled):not(:active):not([aria-disabled='true']) {
-      /* subtle darken on hover */
-      background-color: color-mix(in srgb, var(--cta-bg) 90%, black);
-      border-color:   color-mix(in srgb, var(--cta-border) 90%, black);
+    .cta-primary-cms:hover:not(:disabled):not(:active):not(
+        [aria-disabled='true']
+      ) {
       @apply text-white no-underline;
+    }
+  }
+
+  /* prevents rendering issues in older browsers that don't support color-mix */
+  @supports (background-color: color-mix(in srgb, var(--cta-bg) 90%, black)) {
+    @media (hover: hover) {
+      .cta-primary-cms:hover:not(:disabled):not(:active):not(
+          [aria-disabled='true']
+        ) {
+        /* subtle darken on hover */
+        background-color: color-mix(in srgb, var(--cta-bg) 90%, black);
+        border-color: color-mix(in srgb, var(--cta-border) 90%, black);
+      }
     }
   }
 }


### PR DESCRIPTION
## Because

- CMS button turns white on hover in older browsers because of the `color-mix` CSS function is not supported.

## This pull request

- gracefully fallbacks to no darkening

## Issue that this pull request solves

Closes: FXA-12185

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
