### PR TITLE
fix(metrics): Don't enable code submission until a valid code is entered

### DIFF
--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -67,6 +67,7 @@ const FormVerifyCode = ({
 }: FormVerifyCodeProps) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [isDisabled, setIsDisabled] = useState<boolean>(true);
 
   const ftlMsgResolver = useFtlMsgResolver();
   const localizedLabel = ftlMsgResolver.getMsg(
@@ -81,13 +82,15 @@ const FormVerifyCode = ({
     }
   };
 
-  const { handleSubmit, register, errors } = useForm<FormData>({
+  const { handleSubmit, register, errors, watch } = useForm<FormData>({
     mode: 'onBlur',
     criteriaMode: 'all',
     defaultValues: {
       code: '',
     },
   });
+
+  const codeValue = watch('code');
 
   const localizedDefaultCodeRequiredMessage = ftlMsgResolver.getMsg(
     'form-verify-code-default-error',
@@ -121,6 +124,15 @@ const FormVerifyCode = ({
       onSubmit({ code: pastedText });
     }
   };
+
+  useEffect(() => {
+    if (codeValue && codeValue.length > 0) {
+      const isValid = new RegExp(formAttributes.pattern).test(codeValue);
+      setIsDisabled(!isValid);
+    } else {
+      setIsDisabled(true);
+    }
+  }, [codeValue, formAttributes.pattern]);
 
   return (
     <form
@@ -161,7 +173,7 @@ const FormVerifyCode = ({
         <CmsButtonWithFallback
           type="submit"
           className="cta-primary cta-xl"
-          disabled={isSubmitting}
+          disabled={isSubmitting || isDisabled}
           data-glean-id={gleanDataAttrs?.id}
           data-glean-label={gleanDataAttrs?.label}
           data-glean-type={gleanDataAttrs?.type}

--- a/packages/fxa-settings/src/components/FormVerifyCode/mocks.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/mocks.tsx
@@ -13,10 +13,11 @@ export const Subject = ({
   localizedCustomCodeRequiredMessage = '',
   verifyCode = onFormSubmit,
   submitFormOnPaste = true,
-}: Partial<FormVerifyCodeProps>) => {
+  formAttributes: customFormAttributes,
+}: Partial<FormVerifyCodeProps> & { formAttributes?: FormAttributes }) => {
   const [codeErrorMessage, setCodeErrorMessage] = useState<string>('');
 
-  const formAttributes: FormAttributes = {
+  const formAttributes: FormAttributes = customFormAttributes || {
     inputFtlId: 'demo-input-label-id',
     inputLabelText: 'Enter your 4-digit code',
     pattern: '[0-9]{4}',

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.test.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.test.tsx
@@ -110,7 +110,7 @@ describe('RecoveryKeySetupHint', () => {
     const textInput = screen.getByRole('textbox', {
       name: 'Enter a hint (optional)',
     });
-    await waitFor(() => user.type(textInput, hintValueTooLong));
+    await user.type(textInput, hintValueTooLong);
     expect(textInput).toHaveValue('a'.repeat(MAX_HINT_LENGTH));
   });
 

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/old.tsx
@@ -270,7 +270,7 @@ export const InlineTotpSetupOld = ({
                 formAttributes={{
                   inputLabelText: 'Authentication code',
                   inputFtlId: 'inline-totp-setup-security-code-placeholder',
-                  pattern: 'd{6}',
+                  pattern: '\\d{6}',
                   maxLength: 6,
                   submitButtonText: 'Ready',
                   submitButtonFtlId: 'inline-totp-setup-ready-button',


### PR DESCRIPTION
## Because

- Turns out we allow code submissions even if they are invalid and have no chance of being verified
- Disable to submit button until code entered matches the correct pattern
- When a user submits a code, a submit metric is logged and this skews our conversion rates

## This pull request

- Don't allow submission of codes that do not ahve the correct format
- Uses React Form Hook "watch" to test the code validation
- Adds additional tests in FormVerifyCode component

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11965

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Button disabled on load:
<img width="541" height="589" alt="Screenshot 2025-08-19 at 9 34 51 AM" src="https://github.com/user-attachments/assets/a6aa8ef4-41eb-49d0-afd2-a7cf6ed402ee" />

Button disabled with invalid format code:
<img width="524" height="600" alt="Screenshot 2025-08-19 at 9 34 59 AM" src="https://github.com/user-attachments/assets/571d07aa-4672-4906-b470-40d21241d3f0" />

Button enabled for valid format code:
<img width="514" height="600" alt="Screenshot 2025-08-19 at 9 36 24 AM" src="https://github.com/user-attachments/assets/794e2c24-bee2-44e5-8665-a1f53bdcc79b" />


## Other information (Optional)

I thought about writing a functional test for this but the coverage in unit tests seemed good.
