### PR TITLE
fix(logo): update cms logo to be left or center position based on if it is ovveride

### DIFF
--- a/packages/fxa-settings/src/components/CmsLogo/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/CmsLogo/__snapshots__/index.test.tsx.snap
@@ -1,10 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CmsLogo renders correctly 1`] = `
+exports[`CmsLogo renders correctly with center positioning 1`] = `
 <div>
   <img
     alt="foo"
-    class="m-auto mb-4 max-h-[160px]"
+    class="justify-center mb-4 max-h-[160px]"
+    src="/foo.svg"
+  />
+</div>
+`;
+
+exports[`CmsLogo renders correctly with default left positioning 1`] = `
+<div>
+  <img
+    alt="foo"
+    class="justify-left mb-4 max-h-[40px]"
     src="/foo.svg"
   />
 </div>

--- a/packages/fxa-settings/src/components/CmsLogo/index.test.tsx
+++ b/packages/fxa-settings/src/components/CmsLogo/index.test.tsx
@@ -7,11 +7,12 @@ import { render, screen } from '@testing-library/react';
 import CmsLogo from '.';
 
 describe('CmsLogo', () => {
-  it('renders correctly', () => {
+  it('renders correctly with default left positioning', () => {
     const { container } = render(
       <CmsLogo
         {...{
           isMobile: false,
+          logoPosition: 'left',
           logos: [
             {
               logoAltText: 'foo',
@@ -26,6 +27,37 @@ describe('CmsLogo', () => {
     expect(img).toBeInTheDocument();
     expect(img.getAttribute('alt')).toEqual('foo');
     expect(img.getAttribute('src')).toEqual('/foo.svg');
+    expect(img).toHaveClass('justify-left');
+    expect(img).toHaveClass('max-h-[40px]');
+    expect(img).not.toHaveClass('justify-center');
+    expect(img).not.toHaveClass('max-h-[160px]');
+    expect(container).toMatchSnapshot();
+  });
+
+  it('renders correctly with center positioning', () => {
+    const { container } = render(
+      <CmsLogo
+        {...{
+          isMobile: false,
+          logoPosition: 'center',
+          logos: [
+            {
+              logoAltText: 'foo',
+              logoUrl: '/foo.svg',
+            },
+          ],
+        }}
+      />
+    );
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute('alt')).toEqual('foo');
+    expect(img.getAttribute('src')).toEqual('/foo.svg');
+    expect(img).toHaveClass('justify-center');
+    expect(img).toHaveClass('max-h-[160px]');
+    expect(img).not.toHaveClass('justify-left');
+    expect(img).not.toHaveClass('max-h-[40px]');
     expect(container).toMatchSnapshot();
   });
 
@@ -34,6 +66,7 @@ describe('CmsLogo', () => {
       <CmsLogo
         {...{
           isMobile: false,
+          logoPosition: 'left',
           logos: [
             {
               logoAltText: undefined,
@@ -59,6 +92,7 @@ describe('CmsLogo', () => {
       <CmsLogo
         {...{
           isMobile: false,
+          logoPosition: 'left',
           logos: [
             {
               logoAltText: 'foo',
@@ -84,6 +118,7 @@ describe('CmsLogo', () => {
       <CmsLogo
         {...{
           isMobile: false,
+          logoPosition: 'left',
           logos: [
             undefined,
             {
@@ -106,6 +141,7 @@ describe('CmsLogo', () => {
       <CmsLogo
         {...{
           isMobile: true,
+          logoPosition: 'left',
           logos: [
             {
               logoAltText: 'foo',

--- a/packages/fxa-settings/src/components/CmsLogo/index.tsx
+++ b/packages/fxa-settings/src/components/CmsLogo/index.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 const CmsLogo = (opts: {
   isMobile: boolean;
+  logoPosition: 'left' | 'center';
   logos: Array<
     | {
         logoUrl?: string;
@@ -23,7 +24,9 @@ const CmsLogo = (opts: {
         <img
           src={logo.logoUrl}
           alt={logo.logoAltText}
-          className="m-auto mb-4 max-h-[160px]"
+          className={`${
+            opts.logoPosition === 'center' ? 'justify-center mb-4 max-h-[160px]' : 'justify-left mb-4 max-h-[40px]'
+          }`}
         />
       )}
     </>

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -109,6 +109,7 @@ export const Index = ({
             {...{
               isMobile,
               logos: [cmsInfo?.EmailFirstPage, cmsInfo?.shared],
+              logoPosition: cmsInfo?.EmailFirstPage?.logoUrl ? 'center' : 'left',
             }}
           />
           <h1 className="card-header">{cmsInfo?.EmailFirstPage?.headline}</h1>

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -289,6 +289,7 @@ export const Signup = ({
             {...{
               isMobile,
               logos: [cmsInfo?.SignupSetPasswordPage, cmsInfo?.shared],
+              logoPosition: cmsInfo?.SignupSetPasswordPage?.logoUrl ? 'center' : 'left',
             }}
           />
           <h1 className="card-header">


### PR DESCRIPTION
## Because

- Override logos should be centered position, shared logos are left position (max height 40px)

## This pull request

- Fixes that

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12280

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

From cms shared logo
<img width="539" height="531" alt="Screenshot 2025-08-19 at 2 05 52 PM" src="https://github.com/user-attachments/assets/311ed913-6131-49f2-9f9f-6aa6e1e06386" />

From per page logo override
<img width="530" height="559" alt="Screenshot 2025-08-19 at 2 05 36 PM" src="https://github.com/user-attachments/assets/0eea61c8-cbce-4053-a072-773e5fce5c64" />

## Other information (Optional)

Any other information that is important to this pull request.
