### PR TITLE
fix(settings): Ensure backup codes generated when phone not available

### DIFF
--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -323,7 +323,10 @@ describe('InlineRecoverySetupFlowContainer', () => {
             await args.verifyPhoneNumber('12345678900');
           });
           args = (InlineRecoverySetupFlowModule.default as jest.Mock).mock
-            .calls[1][0];
+            .calls[
+            (InlineRecoverySetupFlowModule.default as jest.Mock).mock.calls
+              .length - 1
+          ][0];
           await waitFor(async () => {
             await args.sendSmsCode();
           });
@@ -353,7 +356,10 @@ describe('InlineRecoverySetupFlowContainer', () => {
             await args.backupChoiceCb('code');
           });
           args = (InlineRecoverySetupFlowModule.default as jest.Mock).mock
-            .calls[1][0];
+            .calls[
+            (InlineRecoverySetupFlowModule.default as jest.Mock).mock.calls
+              .length - 1
+          ][0];
           await waitFor(async () => {
             await args.completeBackupCodeSetup('wibble');
           });

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -30,7 +30,7 @@ import { GET_TOTP_STATUS } from '../../components/App/gql';
 import OAuthDataError from '../../components/OAuthDataError';
 import { isFirefoxService } from '../../models/integrations/utils';
 import { SensitiveData } from '../../lib/sensitive-data-client';
-import { Choice, CHOICES } from '../../components/FormChoice';
+import { Choice } from '../../components/FormChoice';
 import { totpUtils } from '../../lib/totp-utils';
 import { getErrorFtlId, getHandledError } from '../../lib/error-utils';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
@@ -115,15 +115,18 @@ export const InlineRecoverySetupFlowContainer = ({
     setBackupCodes(codes);
     setGeneratingCodes(false);
   }, [backupCodes, config.recoveryCodes, generatingCodes]);
+
+  // Always generate codes early; they will only be persisted if the user confirms them
+  useEffect(() => {
+    createRecoveryCodes();
+  }, [createRecoveryCodes]);
+
   const backupChoiceCb = useCallback(
     async (choice: Choice) => {
-      if (choice === CHOICES.code) {
-        await createRecoveryCodes();
-      }
       setBackupMethod(choice);
       navigateForward();
     },
-    [createRecoveryCodes, navigateForward]
+    [navigateForward]
   );
 
   const [verifyTotp] = useMutation<{ verifyTotp: { success: boolean } }>(
@@ -282,6 +285,7 @@ export const InlineRecoverySetupFlowContainer = ({
         currentStep,
         backupMethod,
         backupCodes,
+        generatingCodes,
         phoneData,
         navigateForward,
         navigateBackward,

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.stories.tsx
@@ -42,6 +42,7 @@ export const ChoiceScreen = () => (
     currentStep={1}
     backupMethod={null}
     backupCodes={[]}
+    generatingCodes={false}
     phoneData={{ phoneNumber: '', nationalFormat: '' }}
     {...{
       flowHasPhoneChoice,
@@ -66,6 +67,7 @@ export const BackupCodesCopyAndDownload = () => (
     currentStep={2}
     backupMethod={'code'}
     backupCodes={MOCK_BACKUP_CODES}
+    generatingCodes={false}
     phoneData={{ phoneNumber: '', nationalFormat: '' }}
     {...{
       flowHasPhoneChoice,
@@ -90,6 +92,7 @@ export const BackupCodesConfirmation = () => (
     currentStep={3}
     backupMethod={'code'}
     backupCodes={MOCK_BACKUP_CODES}
+    generatingCodes={false}
     phoneData={{ phoneNumber: '', nationalFormat: '' }}
     {...{
       flowHasPhoneChoice,
@@ -114,6 +117,7 @@ export const BackupCodesChoiceComplete = () => (
     currentStep={4}
     backupMethod={'code'}
     backupCodes={MOCK_BACKUP_CODES}
+    generatingCodes={false}
     phoneData={{ phoneNumber: '', nationalFormat: '' }}
     {...{
       flowHasPhoneChoice,
@@ -138,6 +142,7 @@ export const RecoveryPhoneNumber = () => (
     currentStep={2}
     backupMethod={'phone'}
     backupCodes={[]}
+    generatingCodes={false}
     phoneData={{ phoneNumber: '', nationalFormat: '' }}
     {...{
       flowHasPhoneChoice,
@@ -162,6 +167,7 @@ export const RecoveryPhoneConfirmation = () => (
     currentStep={3}
     backupMethod={'phone'}
     backupCodes={[]}
+    generatingCodes={false}
     phoneData={{
       phoneNumber: '12345678900',
       nationalFormat: '+1 234-567-8900',
@@ -189,6 +195,7 @@ export const RecoveryPhoneChoiceComplete = () => (
     currentStep={4}
     backupMethod={'phone'}
     backupCodes={[]}
+    generatingCodes={false}
     phoneData={{
       phoneNumber: '12345678900',
       nationalFormat: '+1 234-567-8900',

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.test.tsx
@@ -56,6 +56,7 @@ const props = {
   serviceName: MozServices.Default,
   email: MOCK_EMAIL,
   backupCodes: [],
+  generatingCodes: false,
   phoneData: { phoneNumber: '', nationalFormat: '' },
   verifyTotpHandler,
   currentStep: 1,
@@ -112,6 +113,7 @@ describe('InlineRecoverySetupFlow', () => {
           ...props,
           flowHasPhoneChoice: false,
           backupCodes: MOCK_BACKUP_CODES,
+          generatingCodes: false,
         }}
       />
     );
@@ -137,6 +139,7 @@ describe('InlineRecoverySetupFlow', () => {
           ...props,
           flowHasPhoneChoice: false,
           backupCodes: MOCK_BACKUP_CODES,
+          generatingCodes: false,
           currentStep: 2,
         }}
       />
@@ -206,6 +209,7 @@ describe('InlineRecoverySetupFlow', () => {
           currentStep: 4,
           backupMethod: 'code',
           backupCodes: MOCK_BACKUP_CODES,
+          generatingCodes: false,
         }}
       />
     );

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
@@ -26,6 +26,7 @@ const InlineRecoverySetupFlow = ({
   currentStep,
   backupMethod,
   backupCodes,
+  generatingCodes,
   phoneData,
   navigateForward,
   navigateBackward,
@@ -67,6 +68,7 @@ const InlineRecoverySetupFlow = ({
           onContinue: navigateForward,
           onBackButtonClick: navigateBackward,
           localizedPageTitle,
+          loading: generatingCodes,
         }}
       />
     ),
@@ -77,8 +79,10 @@ const InlineRecoverySetupFlow = ({
       localizedPageTitle,
       navigateBackward,
       navigateForward,
+      generatingCodes,
     ]
   );
+
   const CodeConfirm = useCallback(
     () => (
       <FlowSetup2faBackupCodeConfirm

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/interfaces.ts
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/interfaces.ts
@@ -18,6 +18,7 @@ export interface InlineRecoverySetupFlowProps {
   currentStep: number;
   backupMethod: Choice | null;
   backupCodes: string[];
+  generatingCodes: boolean;
   phoneData: {
     phoneNumber: string;
     nationalFormat: string | undefined;


### PR DESCRIPTION
## Because

* Backup codes were not generated when recovery phone was unavailable as a recovery option during inline setup (e.g., for locations outside Canada/US)

## This pull request

* Ensure backup codes are generated and available when setting up 2FA inline, whether choice screen is shown or not

## Issue that this pull request solves

Closes: FXA-12181

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
