### PR TITLE
fix(setting): Show correct success screen after inline 2FA setup

### DIFF
--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
@@ -150,12 +150,12 @@ const InlineRecoverySetupFlow = ({
 
   const Complete = useCallback(
     () =>
-      backupMethod === CHOICES.code ? (
+      backupMethod === CHOICES.phone ? (
         <FlowSetup2faComplete
           {...{
             serviceName,
-            backupType: backupMethod as typeof CHOICES.code,
-            numCodesRemaining: backupCodes.length,
+            backupType: CHOICES.phone,
+            lastFourPhoneDigits: phoneData.phoneNumber.slice(-4),
             reason: GleanClickEventType2FA.inline,
             onContinue: () => {
               successfulSetupHandler();
@@ -163,11 +163,13 @@ const InlineRecoverySetupFlow = ({
           }}
         />
       ) : (
+        // This is the default when enabling a recovery phone is not available
+        // or the user picked backup codes on the choice screen.
         <FlowSetup2faComplete
           {...{
             serviceName,
-            backupType: backupMethod as typeof CHOICES.phone,
-            lastFourPhoneDigits: phoneData.phoneNumber.slice(-4),
+            backupType: CHOICES.code,
+            numCodesRemaining: backupCodes.length,
             reason: GleanClickEventType2FA.inline,
             onContinue: () => {
               successfulSetupHandler();


### PR DESCRIPTION
## Because

* When recovery phone is not available as a recovery method, the incorrect success screen was shown

## This pull request

* Handle the case where no choice screen is shown and user is directly navigated to backup codes
* Adds more unit tests

## Issue that this pull request solves

Closes: FXA-12282

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To test locally:
- Either do not set a geo location override in local env or set the override to a non US/Canada location, this results in recovery phone not being available
- Use the Signin with 2FA required flow from 123Done to trigger the inline 2FA setup flow
- Only backup codes should be available as recovery method and the final confirmation screen should show that backup codes were enabled