### PR TITLE
fix(functional-tests): accept WAF 406 response as pass for XSS

### DIFF
--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -28,9 +28,14 @@ test.describe('severity-2 #smoke', () => {
       page,
       pages: { signin },
     }) => {
-      await page.goto(
+      const response = await page.goto(
         `${target.contentServerUrl}/?redirect_to=javascript:alert(1)`
       );
+
+      if (response && response.status() === 406) {
+        // WAF blocked request with 406 (Fastly's default error code) before it reaches app; that's sufficient for pass.
+        return;
+      }
 
       // only error message shown on screen in case of xss redirect_to
       await expect(


### PR DESCRIPTION
## Because

- test is expecting a custom error page, but WAF catches request before it hits our server and returns 406

## This pull request

- modifies the test to accept 406 response as a passing case

## Issue that this pull request solves

Closes: FXA-12283