### PR TITLE
fix(2fa): full phone number displayed on the “Two-step authentication enabled” page

### DIFF
--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.test.tsx
@@ -57,7 +57,7 @@ const props = {
   email: MOCK_EMAIL,
   backupCodes: [],
   generatingCodes: false,
-  phoneData: { phoneNumber: '', nationalFormat: '' },
+  phoneData: { phoneNumber: '+12345678900', nationalFormat: '(234) 567-8900' },
   verifyTotpHandler,
   currentStep: 1,
   navigateForward,
@@ -239,6 +239,9 @@ describe('InlineRecoverySetupFlow', () => {
     });
     screen.getByText('Two-step authentication enabled');
     screen.getByText('Recovery phone');
+
+    expect(screen.getByText(/•••••• 8900/)).toBeInTheDocument();
+
     await user.click(
       screen.getByRole('button', { name: `Continue to ${MozServices.Default}` })
     );

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
@@ -167,7 +167,7 @@ const InlineRecoverySetupFlow = ({
           {...{
             serviceName,
             backupType: backupMethod as typeof CHOICES.phone,
-            lastFourPhoneDigits: phoneData.phoneNumber,
+            lastFourPhoneDigits: phoneData.phoneNumber.slice(-4),
             reason: GleanClickEventType2FA.inline,
             onContinue: () => {
               successfulSetupHandler();


### PR DESCRIPTION
## Because

- Full phone number is displayed on the “Two-step authentication enabled” page

## This pull request

- makes the page only display the last 4 digits

## Issue that this pull request solves

Closes: FXA-12277

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="571" height="531" alt="image" src="https://github.com/user-attachments/assets/51f2cb8e-fa51-4b27-8ec2-c0deaca4b013" />

## Other information (Optional)

A side note: Currently we just assume that all phone numbers are 10 digits long. We will want to programmatically calculate the number of dots before the last 4 digits when we expand the sms option outside of North America.