### PR TITLE
chore(functional-tests): add tests for 2fa change workflows

### DIFF
--- a/packages/functional-tests/pages/baseTokenCode.ts
+++ b/packages/functional-tests/pages/baseTokenCode.ts
@@ -33,11 +33,19 @@ export abstract class BaseTokenCodePage extends BaseLayout {
     return this.page.locator('.success');
   }
 
+  get invalidCodeError() {
+    return this.page.getByText(/Invalid two-step authentication code/);
+  }
+
   get tooltip() {
     this.checkPath();
     return this.page.locator('.tooltip');
   }
 
+  /**
+   * Enters the code and clicks 'submit' button.
+   * @param code 2FA backup code
+   */
   async fillOutCodeForm(code: string) {
     this.checkPath();
     await this.codeInput.fill(code);

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -90,6 +90,10 @@ export class TotpRow extends UnitRow {
     return this.page.getByTestId('two-step-unit-row-modal-button');
   }
 
+  get changeButton() {
+    return this.page.getByTestId('two-step-unit-row-route');
+  }
+
   get disableButton() {
     return this.page.getByTestId(
       'two-step-disable-button-unit-row-modal-button'

--- a/packages/functional-tests/pages/settings/recoveryPhone.ts
+++ b/packages/functional-tests/pages/settings/recoveryPhone.ts
@@ -79,4 +79,24 @@ export class RecoveryPhoneSetupPage extends SettingsLayout {
   async clickResendCode() {
     await this.resendCodeButton.click();
   }
+
+  /**
+   * Enters the target's test phone number and clicks `Send Code`
+   */
+  async submitPhoneNumber() {
+    await this.page.waitForURL(/recovery_phone\/setup/);
+    await expect(this.addHeader()).toBeVisible();
+    await this.enterPhoneNumber(this.target.smsClient.getPhoneNumber());
+    await this.clickSendCode();
+  }
+
+  /**
+   * Enters provided code and clicks submit
+   * @param code
+   */
+  async submitCode(code: string) {
+    await expect(this.confirmHeader).toBeVisible();
+    await this.enterCode(code);
+    await this.clickConfirm();
+  }
 }

--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -5,6 +5,7 @@
 import { expect } from '@playwright/test';
 import { BaseLayout } from './layout';
 import { getReactFeatureFlagUrl } from '../lib/react-flag';
+import { Credentials } from '../lib/targets';
 
 export class SigninPage extends BaseLayout {
   readonly path = 'signin';
@@ -143,5 +144,26 @@ export class SigninPage extends BaseLayout {
 
     await this.passwordTextbox.fill(password);
     await this.signInButton.click();
+  }
+
+  /**
+   * Completes steps to sign in with email and password. This will navigate to the correct
+   * page if necessary. No assertions are made after submitting password form, leaving flow
+   * assertions up to the caller.
+   * @param Credentials
+   */
+  async emailFirstSignin({
+    email,
+    password,
+  }: Credentials) {
+    if (this.page.url() !== this.url) {
+      // avoid navigating if we don't need to.
+      // Checking url is faster than an extra navigation
+      await this.goto();
+    }
+    await this.fillOutEmailFirstForm(email);
+    await this.fillOutPasswordForm(password);
+    // no assertion so that tests can use this with flows that would touch
+    // other pages before settings. i.e., totp verify, etc.
   }
 }

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -553,7 +553,7 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/settings/);
 
-      await expect(await settings.totp.status).toHaveText('Enabled');
+      await expect(settings.totp.status).toHaveText('Enabled');
 
       await expect(settings.settingsHeading).toBeVisible();
 

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -1,0 +1,300 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getCode } from 'fxa-settings/src/lib/totp';
+import { expect, Page, test } from '../../lib/fixtures/standard';
+import { Credentials, getPhoneNumber } from '../../lib/targets';
+import { SettingsPage } from '../../pages/settings';
+import { TotpCredentials, TotpPage } from '../../pages/settings/totp';
+import { SigninTotpCodePage } from '../../pages/signinTotpCode';
+import { SigninRecoveryChoicePage } from '../../pages/signinRecoveryChoice';
+import { SigninRecoveryPhonePage } from '../../pages/signinRecoveryPhone';
+import { SigninRecoveryCodePage } from '../../pages/signinRecoveryCode';
+import { SigninPage } from '../../pages/signin';
+import { RecoveryPhoneSetupPage } from '../../pages/settings/recoveryPhone';
+import { BaseTarget } from '../../lib/targets/base';
+
+test.describe('severity-2 #smoke', () => {
+  test.describe('change 2FA', () => {
+    test.beforeAll(({ target }) => {
+      target.smsClient.guardTestPhoneNumber();
+    });
+
+    // happy path
+    test('can change 2FA and signin with new 2FA', async ({
+      page,
+      testAccountTracker,
+      pages: { settings, signin, totp, signinTotpCode },
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await signin.emailFirstSignin(credentials);
+
+      const {
+        new: { secret: newSecret },
+      } = await addThenChange2FA({ settings, totp });
+
+      await settings.signOut();
+
+      // signin with _new_ 2fa
+      const code = await getCode(newSecret);
+      await signin.emailFirstSignin(credentials);
+      await page.waitForURL(/signin_totp_code/);
+      await signinTotpCode.fillOutCodeForm(code);
+
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settings.disconnectTotp();
+    });
+
+    test('can change 2FA and old 2FA should not work', async ({
+      page,
+      testAccountTracker,
+      pages: { settings, signin, totp, signinTotpCode },
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await signin.emailFirstSignin(credentials);
+
+      const {
+        initial: { secret: oldSecret },
+      } = await addThenChange2FA({ settings, totp });
+
+      await settings.signOut();
+
+      // attempt signin with _old_ 2fa (should fail)
+      const oldSecretCode = await getCode(oldSecret);
+      await signin.emailFirstSignin(credentials);
+      await page.waitForURL(/signin_totp_code/);
+      await signinTotpCode.fillOutCodeForm(oldSecretCode);
+
+      // final asserts
+      await expect(signinTotpCode.invalidCodeError).toBeVisible();
+      expect(page.url()).toMatch(/signin_totp_code/);
+    });
+
+    test('can change 2fa and use existing backup codes to sign in', async ({
+      page,
+      testAccountTracker,
+      pages: { settings, signin, totp, signinRecoveryCode, signinTotpCode },
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+
+      await signin.emailFirstSignin(credentials);
+
+      const {
+        initial: { recoveryCodes },
+      } = await addThenChange2FA({ settings, totp });
+
+      await settings.signOut();
+
+      // use recovery code
+      await completeSigninWithBackupCode({
+        code: recoveryCodes[0],
+        credentials,
+        page,
+        signin,
+        signinTotpCode,
+        signinRecoveryCode,
+      });
+
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settings.disconnectTotp();
+    });
+
+    test('can change 2fa and use existing recovery phone to sign in', async ({
+      page,
+      target,
+      testAccountTracker,
+      pages: {
+        recoveryPhone,
+        settings,
+        signin,
+        signinRecoveryCode,
+        signinRecoveryChoice,
+        signinRecoveryPhone,
+        signinTotpCode,
+        totp,
+      },
+    }) => {
+      const credentials = await testAccountTracker.signUp();
+      await signin.emailFirstSignin(credentials);
+
+      await addThenChange2FA({ settings, totp });
+
+      // connect phone
+      await addPhoneRecovery({
+        credentials,
+        recoveryPhone,
+        settings,
+        target,
+      });
+
+      // sign out
+      await settings.signOut();
+
+      // Sign in with recovery phone
+      await completeSigninWithDualRecovery({
+        method: 'Phone',
+        page,
+        signin,
+        signinTotpCode,
+        signinRecoveryChoice,
+        signinRecoveryCode,
+        signinRecoveryPhone,
+        credentials,
+        target,
+      });
+
+      await expect(settings.settingsHeading).toBeVisible();
+
+      await settings.disconnectTotp();
+    });
+  });
+});
+
+/**
+ * Adds a new 2FA authentication method and then changes it. Call when on the settings page.
+ * @returns An object containing the initial and new credentials. NOTE, `new`
+ * does _not_ contain any recovery codes. Initial recovery codes are left intact during change.
+ */
+const addThenChange2FA = async ({
+  settings,
+  totp,
+}: {
+  settings: SettingsPage;
+  totp: TotpPage;
+}): Promise<{ initial: TotpCredentials; new: TotpCredentials }> => {
+  async function assertEnabled(isSetup: boolean) {
+    await expect(settings.settingsHeading).toBeVisible();
+    await expect(settings.alertBar).toHaveText(
+      `Two-step authentication has been ${isSetup ? 'enabled' : 'updated'}`
+    );
+    await expect(settings.totp.status).toHaveText('Enabled');
+  }
+
+  await settings.settingsHeading.waitFor({ state: 'visible' });
+
+  // setup 2fa with backup codes
+  await settings.totp.addButton.click();
+  const { recoveryCodes, secret } =
+    await totp.setUpTwoStepAuthWithManualCodeAndBackupCodesChoice();
+
+  await assertEnabled(true);
+
+  await settings.totp.changeButton.click();
+  // changing doesn't do anything special or require saving backup codes
+  // just call straight to the setup method
+  const newSecret = await totp.setUp2faAppWithQrCode();
+
+  await assertEnabled(false);
+
+  return {
+    initial: { secret, recoveryCodes },
+    new: { secret: newSecret, recoveryCodes: [] },
+  };
+};
+
+/**
+ * Completes the signin process for an account with 2FA enabled and only backup codes.
+ * Success or failure is not assumed, that is up to the caller to verify.
+ * @param pages
+ */
+const completeSigninWithBackupCode = async ({
+  code,
+  credentials,
+  page,
+  signin,
+  signinTotpCode,
+  signinRecoveryCode,
+}: {
+  code: string;
+  credentials: Credentials;
+  page: Page;
+  signin: SigninPage;
+  signinTotpCode: SigninTotpCodePage;
+  signinRecoveryCode: SigninRecoveryCodePage;
+}) => {
+  await signin.emailFirstSignin(credentials);
+  // assert we're on the right page
+  await page.waitForURL(/signin_totp_code/);
+
+  // continue to trouble/pick method page
+  await signinTotpCode.clickTroubleEnteringCode();
+  await page.waitForURL(/signin_recovery_code/);
+  await signinRecoveryCode.fillOutCodeForm(code);
+};
+
+/**
+ * Completes the signin process for a user who
+ * has both backup codes and a recovery phone configured
+ */
+const completeSigninWithDualRecovery = async ({
+  credentials,
+  method,
+  page,
+  signin,
+  signinTotpCode,
+  signinRecoveryChoice,
+  signinRecoveryCode,
+  signinRecoveryPhone,
+  target,
+}: {
+  credentials: Credentials;
+  method: 'Code' | 'Phone';
+  page: Page;
+  signin: SigninPage;
+  signinTotpCode: SigninTotpCodePage;
+  signinRecoveryChoice: SigninRecoveryChoicePage;
+  signinRecoveryCode: SigninRecoveryCodePage;
+  signinRecoveryPhone: SigninRecoveryPhonePage;
+  target: BaseTarget;
+}) => {
+  // since both pages extend the same base we can
+  // do this to prevent conditionals in the test.
+  const recoveries = {
+    Code: signinRecoveryCode,
+    Phone: signinRecoveryPhone,
+  };
+  await signin.emailFirstSignin(credentials);
+  await page.waitForURL(/signin_totp_code/);
+  await signinTotpCode.clickTroubleEnteringCode();
+  await page.waitForURL(/signin_recovery_choice/);
+  await signinRecoveryChoice[`clickChoose${method}`]();
+  await signinRecoveryChoice.clickContinue();
+  // new RegExp because template literal isn't supported directly inside regex literal
+  await page.waitForURL(new RegExp(`signin_recovery_${method.toLowerCase()}`));
+  const code = await target.smsClient.getCode(
+    getPhoneNumber(target.name),
+    credentials.uid
+  );
+  await recoveries[method].fillOutCodeForm(code);
+};
+
+/**
+ * Completes the setup to add a backup phone.
+ */
+const addPhoneRecovery = async ({
+  credentials,
+  recoveryPhone,
+  settings,
+  target,
+}: {
+  credentials: Credentials;
+  recoveryPhone: RecoveryPhoneSetupPage;
+  settings: SettingsPage;
+  target: BaseTarget;
+}) => {
+  await settings.totp.addRecoveryPhoneButton.click();
+
+  await recoveryPhone.submitPhoneNumber();
+
+  const code = await target.smsClient.getCode(
+    getPhoneNumber(target.name),
+    credentials.uid
+  );
+
+  await recoveryPhone.submitCode(code);
+};

--- a/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
+++ b/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
@@ -40,7 +40,6 @@ test.describe('severity-1 #smoke', () => {
         credentials,
         recoveryCodes[0],
         page,
-        settings,
         signin,
         signinRecoveryCode,
         signinTotpCode
@@ -128,7 +127,6 @@ test.describe('severity-1 #smoke', () => {
         credentials,
         newCodes[0],
         page,
-        settings,
         signin,
         signinRecoveryCode,
         signinTotpCode
@@ -147,7 +145,6 @@ test.describe('severity-1 #smoke', () => {
         signinTotpCode,
         signinRecoveryCode,
         totp,
-        configPage,
       },
       testAccountTracker,
     }) => {
@@ -168,7 +165,6 @@ test.describe('severity-1 #smoke', () => {
           credentials,
           recoveryCodes[i],
           page,
-          settings,
           signin,
           signinRecoveryCode,
           signinTotpCode
@@ -181,7 +177,6 @@ test.describe('severity-1 #smoke', () => {
         credentials,
         recoveryCodes[recoveryCodes.length - 1],
         page,
-        settings,
         signin,
         signinRecoveryCode,
         signinTotpCode
@@ -247,7 +242,6 @@ async function signinWithRecoveryCode(
   credentials: Credentials,
   recoveryCode: string,
   page: Page,
-  settings: SettingsPage,
   signin: SigninPage,
   signinRecoveryCode: SigninRecoveryCodePage,
   signinTotpCode: SigninTotpCodePage


### PR DESCRIPTION
## Because
  * We want functional test coverage of the workflows to change 2FA

## This pull request
  * Adds new tests for Change 2FA
  * Adds a few new functions to page objects needed for the Change 2FA
    flows
  * Has a few cleanups of code, removing unsued vars, unneccessary
    await, etc


## Issue that this pull request solves

Closes: FXA-12244

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
