### PR TITLE
fix(settings): correct unverified session and 2FA routing

### DIFF
--- a/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetup/container.tsx
@@ -71,7 +71,11 @@ export const InlineRecoverySetupContainer = ({
     useState<FinishOAuthFlowHandlerResult['error']>();
 
   const { data: totpStatus, loading: totpStatusLoading } =
-    useQuery<TotpStatusResponse>(GET_TOTP_STATUS);
+    useQuery<TotpStatusResponse>(GET_TOTP_STATUS, {
+      // Use fetchPolicy: 'network-only' to bypass Apollo cache so this reflects the
+      // current account state, not possibly cached data from another signed-in account.
+      fetchPolicy: 'network-only',
+    });
 
   const verifyTotpHandler = useCallback(async () => {
     const code = await getCode(totp!.secret);
@@ -131,6 +135,10 @@ export const InlineRecoverySetupContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  // we only care about "verified" here, not "exists"
+  // because "exists" only tells us that totp setup was started.
+  // Prior to using Redis during setup, tokens were directly stored in the database,
+  // but may never be marked as enabled/verified if setup is aborted or unsuccessful.
   if (totpStatus?.account?.totp.verified) {
     navigateWithQuery('/signin_totp_code', {
       state: signinLocationState,

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -226,7 +226,11 @@ export const InlineRecoverySetupFlowContainer = ({
   );
 
   const { data: totpStatus, loading: totpStatusLoading } =
-    useQuery<TotpStatusResponse>(GET_TOTP_STATUS);
+    useQuery<TotpStatusResponse>(GET_TOTP_STATUS, {
+      // Use fetchPolicy: 'network-only' to bypass Apollo cache so this reflects the
+      // current account state, not possibly cached data from another signed-in account.
+      fetchPolicy: 'network-only',
+    });
 
   const successfulSetupHandler = useCallback(async () => {
     // When this is called, we know signinRecoveryLocationState exists.
@@ -255,6 +259,10 @@ export const InlineRecoverySetupFlowContainer = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  // we only care about "verified" here, not "exists"
+  // because "exists" only tells us that totp setup was started.
+  // Prior to using Redis during setup, tokens were directly stored in the database,
+  // but may never be marked as enabled/verified if setup is aborted or unsuccessful.
   if (totpStatus?.account?.totp.verified) {
     navigateWithQuery('/signin_totp_code', {
       state: signinLocationState,

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -149,10 +149,9 @@ describe('InlineTotpSetupContainer', () => {
       render({ isSignedIn: false });
       const location = mockLocationHook();
       await waitFor(() =>
-        expect(mockNavigateHook).toHaveBeenCalledWith(
-          `/signup${location.search}`,
-          { state: undefined }
-        )
+        expect(mockNavigateHook).toHaveBeenCalledWith(`/${location.search}`, {
+          state: undefined,
+        })
       );
     });
 
@@ -166,10 +165,9 @@ describe('InlineTotpSetupContainer', () => {
       const location = mockLocationHook();
       render();
       await waitFor(() => {
-        expect(mockNavigateHook).toHaveBeenCalledWith(
-          `/signup${location.search}`,
-          { state: undefined }
-        );
+        expect(mockNavigateHook).toHaveBeenCalledWith(`/${location.search}`, {
+          state: undefined,
+        });
       });
     });
 
@@ -187,9 +185,32 @@ describe('InlineTotpSetupContainer', () => {
       });
     });
 
-    it('redirects when totp is active on the account', async () => {
+    it('redirects when totp is active on the account (even if the session is verified)', async () => {
       mockSessionHook.mockImplementationOnce(() => ({
         isSessionVerified: async () => true,
+      }));
+      mockTotpStatusQuery.mockImplementation(() => {
+        return {
+          data: MOCK_TOTP_STATUS_VERIFIED,
+          loading: false,
+        };
+      });
+      jest
+        .spyOn(ApolloClientModule, 'useQuery')
+        .mockReturnValue(mockTotpStatusQuery());
+      render();
+      const location = mockLocationHook();
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(
+          `/signin_totp_code${location.search}`,
+          { state: MOCK_SIGNIN_LOCATION_STATE }
+        );
+      });
+    });
+
+    it('redirects when totp is active on the account and the session is not verified', async () => {
+      mockSessionHook.mockImplementationOnce(() => ({
+        isSessionVerified: async () => false,
       }));
       mockTotpStatusQuery.mockImplementation(() => {
         return {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -84,6 +84,10 @@ const SigninTokenCodeContainer = ({
       return;
     }
     const getTotpStatus = async () => {
+      // We only care about "verified" here, not "exists"
+      // because "exists" only tells us that totp setup was started.
+      // Prior to using Redis during setup, tokens were directly stored in the database,
+      // but may never be marked as enabled/verified if setup is aborted or unsuccessful.
       const { verified } = await authClient.checkTotpTokenExists(
         signinState.sessionToken
       );

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -339,19 +339,14 @@ const getUnverifiedNavigationTarget = (
 ) => {
   const { verificationReason, verificationMethod } =
     navigationOptions.signinData;
-  const { integration, queryParams } = navigationOptions;
-  const isOAuth = isOAuthIntegration(integration);
+  const { queryParams } = navigationOptions;
 
   const getUnverifiedNavTo = () => {
-    // TODO in FXA-9177 Consider storing state in Apollo cache instead of location state
-    if (
-      ((verificationReason === VerificationReasons.SIGN_IN ||
-        verificationReason === VerificationReasons.CHANGE_PASSWORD) &&
-        verificationMethod === VerificationMethods.TOTP_2FA) ||
-      (isOAuth && integration.wantsTwoStepAuthentication())
-    ) {
+    if (verificationMethod === VerificationMethods.TOTP_2FA) {
       return `/signin_totp_code${queryParams || ''}`;
-    } else if (verificationReason === VerificationReasons.SIGN_UP) {
+    }
+
+    if (verificationReason === VerificationReasons.SIGN_UP) {
       return `/confirm_signup_code${queryParams || ''}`;
     }
     return `/signin_token_code${queryParams || ''}`;


### PR DESCRIPTION
## Because

* Forced 2FA OAuth flows without existing TOTP were incorrectly routed to TOTP code
* Unverified sessions should complete email verification before 2FA setup

## This pull request

* Revise navigation targets for unverified session
* Update tests to match

## Issue that this pull request solves

Closes: FXA-12285

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
