### PR TITLE
fix(payments-ui): Fixes for Subscription Management page

### DIFF
--- a/libs/payments/ui/src/lib/client/components/BaseButton/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/BaseButton/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { forwardRef } from "react";
+import { forwardRef } from 'react';
 
 export enum ButtonVariant {
   Primary,
@@ -16,14 +16,19 @@ interface BaseButtonProps
   variant?: ButtonVariant;
 }
 
-export const BaseButton = forwardRef(function BaseButton({ children, variant, ...props }: BaseButtonProps, ref: React.Ref<HTMLButtonElement>) {
+export const BaseButton = forwardRef(function BaseButton(
+  { children, variant, ...props }: BaseButtonProps,
+  ref: React.Ref<HTMLButtonElement>
+) {
   let variantStyles = '';
   switch (variant) {
     case ButtonVariant.Primary:
-      variantStyles = 'bg-blue-500 font-semibold hover:bg-blue-700 aria-disabled:hover:bg-blue-500 text-white';
+      variantStyles =
+        'bg-blue-500 font-semibold hover:bg-blue-700 aria-disabled:hover:bg-blue-500 text-white';
       break;
     case ButtonVariant.Secondary:
-      variantStyles = 'bg-grey-100 font-semibold hover:bg-grey-200 aria-disabled:hover:bg-grey-100 text-black';
+      variantStyles =
+        'bg-grey-100 font-semibold hover:bg-grey-200 aria-disabled:hover:bg-grey-100 text-black';
       break;
     case ButtonVariant.ThirdParty:
       variantStyles =
@@ -34,10 +39,10 @@ export const BaseButton = forwardRef(function BaseButton({ children, variant, ..
   return (
     <button
       {...props}
-      className={`flex items-center justify-center h-12 rounded-md p-4 z-10 cursor-pointer aria-disabled:relative aria-disabled:after:absolute aria-disabled:after:content-[''] aria-disabled:after:top-0 aria-disabled:after:left-0 aria-disabled:after:w-full aria-disabled:after:h-full aria-disabled:after:bg-white aria-disabled:after:opacity-50 aria-disabled:after:z-30 aria-disabled:border-none ${props.className} ${variantStyles}`}
+      className={`flex items-center justify-center rounded-md p-4 z-10 cursor-pointer aria-disabled:relative aria-disabled:after:absolute aria-disabled:after:content-[''] aria-disabled:after:top-0 aria-disabled:after:left-0 aria-disabled:after:w-full aria-disabled:after:h-full aria-disabled:after:bg-white aria-disabled:after:opacity-50 aria-disabled:after:z-30 aria-disabled:border-none ${variantStyles} ${props.className}`}
       ref={ref}
     >
       {children}
     </button>
   );
-})
+});

--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/en.ftl
@@ -30,23 +30,31 @@ subscription-content-button-cancel =
   Cancel
   .aria-label = Cancel your subscription to { $productName }
 subscription-content-cancel-action-error = An unexpected error occurred. Please try again.
-
 subscription-cancellation-dialog-title = We’re sorry to see you go
 # $name (String) - The name of the subscribed product.
 # $date (Date) - Last day of product access
 subscription-cancellation-dialog-msg = Your { $name } subscription has been cancelled. You will still have access to { $name } until { $date }.
 subscription-cancellation-dialog-aside = Have questions? Visit <LinkExternal>{ -brand-mozilla } Support</LinkExternal>.
-
-
 subscription-content-button-resubscribe = Resubscribe
   .aria-label = Resubscribe to { $productName }
-
+# $name (String) - The name of the subscribed product.
 # $date (Date) - Last day of product access
 subscription-content-resubscribe = You will lose access to { $name } on <strong>{ $date }</strong>.
-
+# $name (String) - The name of the subscribed product.
 resubscribe-dialog-title = Want to keep using { $name }?
-resubscribe-dialog-content = Your access to { $name } will continue, and your billing cycle and payment will stay the same. Your next charge will be { $amount } on { $endDate }.
-resubscribe-dialog-action-button = Stay Subscribed
 
+## $name (String) - The name of the subscribed product.
+## $amount (Number) - The amount billed (excluding tax if tax does not exist). It will be formatted as currency.
+## $tax (Number) - The tax added on, not included in amount. It will be formatted as currency.
+## $endDate (Date) - The end date of the subscription period.
+
+resubscribe-dialog-content = Your access to { $name } will continue, and your billing cycle and payment will stay the same. Your next charge will be { $amount } on { $endDate }.
+resubscribe-dialog-content-with-tax = Your access to { $name } will continue, and your billing cycle and payment will stay the same. Your next charge will be { $amount } + { $tax } tax on { $endDate }.
+# $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+resubscribe-dialog-action-button-resubscribe = Resubscribe
+  .aria-label = Resubscribe to { $productName }
 resubscribe-success-dialog-title = Thanks! You’re all set.
-resubscribe-success-dialog-action-button = Close
+resubscribe-success-dialog-action-button-close = Close
+  .aria-label = Close dialog
+
+##

--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.tsx
@@ -12,9 +12,7 @@ import * as Form from '@radix-ui/react-form';
 import { ActionButton, ButtonVariant, SubmitButton } from '@fxa/payments/ui';
 import couponIcon from '@fxa/shared/assets/images/ico-coupon.svg';
 import {
-  getLocalizedCurrency,
   getLocalizedCurrencyString,
-  getLocalizedDate,
   getLocalizedDateString,
 } from '@fxa/shared/l10n';
 import { cancelSubscriptionAtPeriodEndAction } from '../../../actions';
@@ -59,7 +57,6 @@ export const SubscriptionContent = ({
     currentInvoiceTax,
     currentInvoiceTotal,
     currentPeriodEnd,
-    nextInvoiceDate,
     nextInvoiceTax,
     nextInvoiceTotal,
     productName,
@@ -73,9 +70,11 @@ export const SubscriptionContent = ({
 
   const [openCancellationDialog, setOpenCancellationDialog] = useState(false);
   const [openResubscribeDialog, setOpenResubscribeDialog] = useState(false);
-  const [openResubscribeSuccessDialog, setOpenResubscribeSuccessDialog] = useState(false);
+  const [openResubscribeSuccessDialog, setOpenResubscribeSuccessDialog] =
+    useState(false);
   const [pendingResubscribe, setPendingResubscribe] = useState(false);
-  const [showResubscribeActionError, setResubscribeActionError] = useState(false);
+  const [showResubscribeActionError, setResubscribeActionError] =
+    useState(false);
 
   // Fluent React Overlays cause hydration issues due to SSR.
   // Using isClient along with the useEffect ensures its only run Client Side
@@ -90,8 +89,8 @@ export const SubscriptionContent = ({
   const getCurrencyFallbackText = (amount: number) => {
     return getLocalizedCurrencyString(amount, currency, locale);
   };
-  const nextInvoiceDateShortFallback = getLocalizedDateString(
-    nextInvoiceDate,
+  const currentPeriodEndShortFallback = getLocalizedDateString(
+    currentPeriodEnd,
     true,
     locale
   );
@@ -102,7 +101,10 @@ export const SubscriptionContent = ({
   );
 
   async function cancelSubscriptionAtPeriodEnd() {
-    const result = await cancelSubscriptionAtPeriodEndAction(userId, subscription.id)
+    const result = await cancelSubscriptionAtPeriodEndAction(
+      userId,
+      subscription.id
+    );
     if (result.ok) {
       setOpenCancellationDialog(true);
       setShowCancel(false);
@@ -133,98 +135,131 @@ export const SubscriptionContent = ({
     <>
       <Dialog.Root open={openCancellationDialog}>
         <Dialog.Portal>
-          <Dialog.Overlay className='fixed inset-0 bg-black/75 z-50' />
+          <Dialog.Overlay className="fixed inset-0 bg-black/75 z-50" />
           <Dialog.Content
-            className='w-11/12 max-w-[545px] text-center px-7 pt-6 pb-8 rounded-xl shadow inline-block fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[60] bg-white'
+            className="w-11/12 max-w-[545px] text-center px-7 pt-6 pb-8 rounded-xl shadow inline-block fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[60] bg-white"
             aria-labelledby="subscription-cancellation-dialog-title"
             aria-describedby="subscription-cancellation-dialog-description"
             onEscapeKeyDown={() => setOpenCancellationDialog(false)}
             onPointerDownOutside={() => setOpenCancellationDialog(false)}
             onInteractOutside={() => setOpenCancellationDialog(false)}
           >
-            <Dialog.Title id="subscription-cancellation-dialog-title" className='font-bold leading-6 m-5'>
+            <Dialog.Title
+              id="subscription-cancellation-dialog-title"
+              className="font-bold leading-6 m-5"
+            >
               <Localized id="subscription-cancellation-dialog-title">
                 We’re sorry to see you go
               </Localized>
             </Dialog.Title>
-            <Dialog.Description asChild id="subscription-cancellation-dialog-description" className='leading-6 space-y-4'>
+            <Dialog.Description
+              asChild
+              id="subscription-cancellation-dialog-description"
+              className="leading-6 space-y-4"
+            >
               <div>
                 <Localized
                   id="subscription-cancellation-dialog-msg"
                   vars={{
-                    name: subscription.productName,
-                    date: getLocalizedDate(subscription.currentPeriodEnd),
+                    name: productName,
+                    date: currentPeriodEndLongFallback,
                   }}
                 >
                   <p>
-                    Your {subscription.productName} subscription has been cancelled. You will still have access to {subscription.productName} until{' '} {getLocalizedDateString(subscription.currentPeriodEnd, false)}.
+                    Your {subscription.productName} subscription has been
+                    cancelled. You will still have access to {productName} until{' '}
+                    {currentPeriodEndLongFallback}.
                   </p>
                 </Localized>
                 <Localized
                   id="subscription-cancellation-dialog-aside"
                   vars={{ url: supportUrl }}
-                  elems={{ LinkExternal: <LinkExternal href={supportUrl} className="text-blue-500">Mozilla Support</LinkExternal> }}
+                  elems={{
+                    LinkExternal: (
+                      <LinkExternal href={supportUrl} className="text-blue-500">
+                        Mozilla Support
+                      </LinkExternal>
+                    ),
+                  }}
                 >
                   <p>
-                    Have questions? Visit <LinkExternal href={supportUrl} className="text-blue-500">Mozilla Support</LinkExternal>.
+                    Have questions? Visit{' '}
+                    <LinkExternal href={supportUrl} className="text-blue-500">
+                      Mozilla Support
+                    </LinkExternal>
+                    .
                   </p>
                 </Localized>
               </div>
             </Dialog.Description>
-            <Dialog.Close asChild
-            >
+            <Dialog.Close asChild>
               <button
                 className="absolute bg-transparent border-0 cursor-pointer flex items-center justify-center w-6 h-6 m-0 p-0 top-4 right-4 hover:bg-grey-200 hover:rounded focus:border-blue-400 focus:rounded focus:shadow-input-blue-focus after:absolute after:content-[''] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10"
                 onClick={() => setOpenCancellationDialog(false)}
               >
-                <Image src={CloseIcon} alt={l10n.getString('dialog-close', null, 'Close dialog')} />
+                <Image
+                  src={CloseIcon}
+                  alt={l10n.getString('dialog-close', null, 'Close dialog')}
+                />
               </button>
             </Dialog.Close>
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
 
-
       <Dialog.Root open={openResubscribeSuccessDialog}>
         <Dialog.Portal>
-          <Dialog.Overlay className='fixed inset-0 bg-black/75 z-50' />
+          <Dialog.Overlay className="fixed inset-0 bg-black/75 z-50" />
           <Dialog.Content
-            className='w-11/12 max-w-[545px] text-center px-7 pt-6 pb-8 rounded-xl shadow inline-block fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-9999 bg-white'
+            className="w-11/12 max-w-[545px] text-center px-7 pt-6 pb-8 rounded-xl shadow inline-block fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-9999 bg-white"
             aria-labelledby="resubscribe-success-title"
             aria-describedby="resubscribe-success-description"
             onEscapeKeyDown={() => setOpenResubscribeSuccessDialog(false)}
             onPointerDownOutside={() => setOpenResubscribeSuccessDialog(false)}
             onInteractOutside={() => setOpenResubscribeSuccessDialog(false)}
           >
-            <Dialog.Title id="resubscribe-success-title" className='font-bold leading-6 m-5 space-y-5'>
-              <Image src={webIcon} alt={productName} height={64} width={64} className='h-16 w-16 mx-auto' />
-              <Localized
-                id="resubscribe-success-dialog-title"
-              >
+            <Dialog.Title
+              id="resubscribe-success-title"
+              className="font-bold leading-6 m-5 space-y-5"
+            >
+              <Image
+                src={webIcon}
+                alt={productName}
+                height={64}
+                width={64}
+                className="h-16 w-16 mx-auto"
+              />
+              <Localized id="resubscribe-success-dialog-title">
                 <p>Thanks! You’re all set.</p>
               </Localized>
             </Dialog.Title>
-            <Dialog.Description id="resubscribe-success-description" className='leading-6 space-y-4'>
+            <Dialog.Description
+              id="resubscribe-success-description"
+              className="leading-6 space-y-4"
+            >
               <Localized
-                id="resubscribe-success-dialog-action-button"
+                id="resubscribe-success-dialog-action-button-close"
+                attrs={{ 'aria-label': true }}
               >
                 <SubmitButton
                   className="h-10 w-full"
                   variant={ButtonVariant.Primary}
                   onClick={() => setOpenResubscribeSuccessDialog(false)}
-                  aria-label={`Stay subscribed to ${productName}`}
+                  aria-label="Close dialog"
                 >
                   Close
                 </SubmitButton>
               </Localized>
             </Dialog.Description>
-            <Dialog.Close asChild
-            >
+            <Dialog.Close asChild>
               <button
                 className="absolute bg-transparent border-0 cursor-pointer flex items-center justify-center w-6 h-6 m-0 p-0 top-4 right-4 hover:bg-grey-200 hover:rounded focus:border-blue-400 focus:rounded focus:shadow-input-blue-focus after:absolute after:content-[''] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10"
                 onClick={() => setOpenResubscribeSuccessDialog(false)}
               >
-                <Image src={CloseIcon} alt={l10n.getString('dialog-close', null, 'Close dialog')} />
+                <Image
+                  src={CloseIcon}
+                  alt={l10n.getString('dialog-close', null, 'Close dialog')}
+                />
               </button>
             </Dialog.Close>
           </Dialog.Content>
@@ -233,17 +268,26 @@ export const SubscriptionContent = ({
 
       <Dialog.Root open={openResubscribeDialog}>
         <Dialog.Portal>
-          <Dialog.Overlay className='fixed inset-0 bg-black/75 z-50' />
+          <Dialog.Overlay className="fixed inset-0 bg-black/75 z-50" />
           <Dialog.Content
-            className='w-11/12 max-w-[545px] text-center px-7 pt-6 pb-8 rounded-xl shadow inline-block fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-9999 bg-white'
+            className="w-11/12 max-w-[545px] text-center px-7 pt-6 pb-8 rounded-xl shadow inline-block fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-9999 bg-white"
             aria-labelledby="resubscribe-dialog-title"
             aria-describedby="resubscribe-dialog-description"
             onEscapeKeyDown={() => setOpenResubscribeDialog(false)}
             onPointerDownOutside={() => setOpenResubscribeDialog(false)}
             onInteractOutside={() => setOpenResubscribeDialog(false)}
           >
-            <Dialog.Title id="resubscribe-dialog-title" className='font-bold leading-6 m-5 space-y-5'>
-              <Image src={webIcon} alt={productName} height={64} width={64} className='h-16 w-16 mx-auto' />
+            <Dialog.Title
+              id="resubscribe-dialog-title"
+              className="font-bold leading-6 m-5 space-y-5"
+            >
+              <Image
+                src={webIcon}
+                alt={productName}
+                height={64}
+                width={64}
+                className="h-16 w-16 mx-auto"
+              />
               <Localized
                 id="resubscribe-dialog-title"
                 vars={{
@@ -253,26 +297,56 @@ export const SubscriptionContent = ({
                 <p>Want to keep using {productName}?</p>
               </Localized>
             </Dialog.Title>
-            <Dialog.Description asChild id="resubscribe-dialog-description" className='leading-6 space-y-4'>
+            <Dialog.Description
+              asChild
+              id="resubscribe-dialog-description"
+              className="leading-6 space-y-4"
+            >
               <div>
-                <Localized
-                  id="resubscribe-dialog-content"
-                  vars={{
-                    name: productName,
-                    amount: getLocalizedCurrency(nextInvoiceTotal ?? 0, currency),
-                    endDate: getLocalizedDate(currentPeriodEnd),
-                  }}
-                >
-                  <p>
-                    Your access to {productName} will continue, and your billing cycle
-                    and payment will stay the same. Your next charge will be{' '}
-                    {getLocalizedCurrencyString(nextInvoiceTotal ?? 0, currency, locale)} on{' '}
-                    {getLocalizedDateString(currentPeriodEnd, undefined, locale)}.
-                  </p>
-                </Localized>
+                {nextInvoiceTax ? (
+                  <Localized
+                    id="resubscribe-dialog-content-with-tax"
+                    vars={{
+                      name: productName,
+                      amount: getCurrencyFallbackText(nextInvoiceTotal ?? 0),
+                      endDate: currentPeriodEndLongFallback,
+                      tax: getCurrencyFallbackText(nextInvoiceTax),
+                    }}
+                  >
+                    <p>
+                      Your access to {productName} will continue, and your
+                      billing cycle and payment will stay the same. Your next
+                      charge will be{' '}
+                      {getCurrencyFallbackText(nextInvoiceTotal ?? 0)} +{' '}
+                      {getCurrencyFallbackText(nextInvoiceTax)} tax on{' '}
+                      {currentPeriodEndLongFallback}.
+                    </p>
+                  </Localized>
+                ) : (
+                  <Localized
+                    id="resubscribe-dialog-content"
+                    vars={{
+                      name: productName,
+                      amount: getCurrencyFallbackText(nextInvoiceTotal ?? 0),
+                      endDate: currentPeriodEndLongFallback,
+                    }}
+                  >
+                    <p>
+                      Your access to {productName} will continue, and your
+                      billing cycle and payment will stay the same. Your next
+                      charge will be{' '}
+                      {getCurrencyFallbackText(nextInvoiceTotal ?? 0)} on{' '}
+                      {currentPeriodEndLongFallback}.
+                    </p>
+                  </Localized>
+                )}
+
                 {showResubscribeActionError && (
                   <Localized id="subscription-content-cancel-action-error">
-                    <p className="mt-1 text-alert-red font-normal text-start" role="alert">
+                    <p
+                      className="mt-1 text-alert-red font-normal text-start"
+                      role="alert"
+                    >
                       An unexpected error occurred. Please try again.
                     </p>
                   </Localized>
@@ -280,27 +354,29 @@ export const SubscriptionContent = ({
                 <ActionButton
                   className="h-10 w-full"
                   variant={ButtonVariant.Primary}
-                  aria-label={`Stay subscribed to ${productName}`}
+                  aria-label={`Resubscribe to ${productName}`}
                   onClick={resubscribe}
                   pending={pendingResubscribe}
                 >
                   <Localized
-                    id="resubscribe-dialog-action-button"
+                    id="resubscribe-dialog-action-button-resubscribe"
                     vars={{ productName }}
                     attrs={{ 'aria-label': true }}
                   >
-                    Stay Subscribed
+                    Resubscribe
                   </Localized>
                 </ActionButton>
               </div>
             </Dialog.Description>
-            <Dialog.Close asChild
-            >
+            <Dialog.Close asChild>
               <button
                 className="absolute bg-transparent border-0 cursor-pointer flex items-center justify-center w-6 h-6 m-0 p-0 top-4 right-4 hover:bg-grey-200 hover:rounded focus:border-blue-400 focus:rounded focus:shadow-input-blue-focus after:absolute after:content-[''] after:top-0 after:left-0 after:w-full after:h-full after:bg-white after:opacity-50 after:z-10"
                 onClick={() => setOpenResubscribeDialog(false)}
               >
-                <Image src={CloseIcon} alt={l10n.getString('dialog-close', null, 'Close dialog')} />
+                <Image
+                  src={CloseIcon}
+                  alt={l10n.getString('dialog-close', null, 'Close dialog')}
+                />
               </button>
             </Dialog.Close>
           </Dialog.Content>
@@ -410,16 +486,16 @@ export const SubscriptionContent = ({
                 <Localized
                   id="subscription-content-resubscribe"
                   vars={{
-                    name: subscription.productName,
-                    date: getLocalizedDate(subscription.currentPeriodEnd),
+                    name: productName,
+                    date: currentPeriodEndLongFallback,
                   }}
                   elems={{
-                    strong: <strong></strong>
+                    strong: <strong></strong>,
                   }}
                 >
                   <p className="text-sm leading-4 text-grey-400">
-                    You will lose access to {subscription.productName} on{' '}
-                    <strong>{getLocalizedDateString(subscription.currentPeriodEnd, undefined, locale)}</strong>.
+                    You will lose access to {productName} on{' '}
+                    <strong>{currentPeriodEndLongFallback}</strong>.
                   </p>
                 </Localized>
               )}
@@ -502,28 +578,32 @@ export const SubscriptionContent = ({
                         <Localized
                           id="subscription-content-next-bill-with-tax"
                           vars={{
-                            invoiceTotal: getCurrencyFallbackText(nextInvoiceTotal),
-                            nextBillDate: nextInvoiceDateShortFallback,
+                            invoiceTotal:
+                              getCurrencyFallbackText(nextInvoiceTotal),
+                            nextBillDate: currentPeriodEndShortFallback,
                             taxDue: getCurrencyFallbackText(nextInvoiceTax),
                           }}
                         >
                           <p>
-                            Next bill of {getCurrencyFallbackText(nextInvoiceTotal)}{' '}
-                            + {getCurrencyFallbackText(nextInvoiceTax)} tax is due{' '}
-                            {nextInvoiceDateShortFallback}
+                            Next bill of{' '}
+                            {getCurrencyFallbackText(nextInvoiceTotal)} +{' '}
+                            {getCurrencyFallbackText(nextInvoiceTax)} tax is due{' '}
+                            {currentPeriodEndShortFallback}
                           </p>
                         </Localized>
                       ) : (
                         <Localized
                           id="subscription-content-next-bill-no-tax"
                           vars={{
-                            invoiceTotal: getCurrencyFallbackText(nextInvoiceTotal),
-                            nextBillDate: nextInvoiceDateShortFallback,
+                            invoiceTotal:
+                              getCurrencyFallbackText(nextInvoiceTotal),
+                            nextBillDate: currentPeriodEndShortFallback,
                           }}
                         >
                           <p>
-                            Next bill of {getCurrencyFallbackText(nextInvoiceTotal)}{' '}
-                            is due {nextInvoiceDateShortFallback}
+                            Next bill of{' '}
+                            {getCurrencyFallbackText(nextInvoiceTotal)} is due{' '}
+                            {currentPeriodEndShortFallback}
                           </p>
                         </Localized>
                       )}
@@ -547,7 +627,7 @@ export const SubscriptionContent = ({
               </Localized>
             </>
           )}
-        </section >
+        </section>
       )}
     </>
   );


### PR DESCRIPTION
## This pull request

- Includes the following updates:
  - [x] updates the date as the current period end date (as opposed to the next invoice date) shown `Next bill is <nextInvoiceTotal> due <nextBillDate>`
  - [x] updates button to `Resubscribe` (as opposed to `Stay Subscribed`)
  - [x] adds in tax if applicable to Resubscribe modal
  - [x] updates BaseButton so height does not get overridden

## Issue that this pull request solves

Closes: PAY-3213

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
### Update: Revised BaseButton
<img width="960" height="772" alt="Screenshot 2025-08-25 at 9 46 40 AM" src="https://github.com/user-attachments/assets/af4e4761-cc83-4b7b-91e0-b88962e2e4c1" />

### SP3
With tax
<img width="822" height="738" alt="Screenshot 2025-08-21 at 2 46 12 PM" src="https://github.com/user-attachments/assets/b6970d6c-fe02-4a74-8edb-56a534251d6e" />
<img width="824" height="899" alt="Screenshot 2025-08-21 at 2 46 34 PM" src="https://github.com/user-attachments/assets/cb2d73c4-520a-41a2-8a58-88bb2185f6f1" />
<img width="821" height="740" alt="Screenshot 2025-08-21 at 2 46 47 PM" src="https://github.com/user-attachments/assets/4379e550-5c6f-4d10-8049-d7a3e105f854" />
<img width="820" height="743" alt="Screenshot 2025-08-21 at 2 47 00 PM" src="https://github.com/user-attachments/assets/093e34d2-5796-4e70-aad0-00a0b9d91dd6" />
<img width="822" height="830" alt="Screenshot 2025-08-21 at 2 47 10 PM" src="https://github.com/user-attachments/assets/7221ec1a-9307-47c6-9d06-6794c730dbb9" />
<img width="823" height="753" alt="Screenshot 2025-08-21 at 2 47 42 PM" src="https://github.com/user-attachments/assets/5f3d6561-f443-43b1-aa4f-49ff1224ebd1" />

No tax
<img width="817" height="726" alt="Screenshot 2025-08-21 at 2 43 23 PM" src="https://github.com/user-attachments/assets/b06622d4-2982-4916-87f5-721b4f73cee8" />
<img width="818" height="856" alt="Screenshot 2025-08-21 at 2 43 43 PM" src="https://github.com/user-attachments/assets/c861536e-5252-4443-ad36-b6aaa5bccee0" />
<img width="815" height="749" alt="Screenshot 2025-08-21 at 2 43 57 PM" src="https://github.com/user-attachments/assets/e39d254b-2c23-4157-a7d7-9565fd3b2cb0" />
<img width="820" height="791" alt="Screenshot 2025-08-21 at 2 44 09 PM" src="https://github.com/user-attachments/assets/1a073602-3620-4a50-a858-b9cc60cb30f4" />
<img width="819" height="757" alt="Screenshot 2025-08-21 at 2 44 21 PM" src="https://github.com/user-attachments/assets/2b099df0-d416-4930-a061-07f56bfc7ae0" />
<img width="817" height="759" alt="Screenshot 2025-08-21 at 2 45 00 PM" src="https://github.com/user-attachments/assets/6025e2b9-04d2-4fe6-a443-b2350a7f966a" />
<img width="818" height="744" alt="Screenshot 2025-08-21 at 2 45 13 PM" src="https://github.com/user-attachments/assets/ac25edd2-0b0a-43fc-bb1e-d0f0c9f180c7" />

### SP2
<img width="815" height="653" alt="Screenshot 2025-08-21 at 2 48 11 PM" src="https://github.com/user-attachments/assets/b4d79f14-3d10-4207-bb58-0532cb1741a4" />
<img width="810" height="817" alt="Screenshot 2025-08-21 at 2 48 33 PM" src="https://github.com/user-attachments/assets/69ffc65d-f6e4-4f58-a860-fbac32acd7ed" />
<img width="816" height="789" alt="Screenshot 2025-08-21 at 2 48 45 PM" src="https://github.com/user-attachments/assets/171113eb-10f5-4a69-9e55-63eebe2043fd" />
<img width="814" height="492" alt="Screenshot 2025-08-21 at 2 48 57 PM" src="https://github.com/user-attachments/assets/51143681-3ae0-45cf-af77-83b5d8c48ad5" />
<img width="811" height="818" alt="Screenshot 2025-08-21 at 2 49 47 PM" src="https://github.com/user-attachments/assets/d6e83137-1038-480c-8aeb-f84c865c535b" />
<img width="818" height="703" alt="Screenshot 2025-08-21 at 2 50 09 PM" src="https://github.com/user-attachments/assets/4f5f5bd9-d08e-446d-afca-f8312e66377d" />
