### PR TITLE
fix(auth): provide price info on billing-and-subscriptions

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -436,6 +436,12 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
     .required()
     .description(DESCRIPTIONS.productId),
   product_name: isA.string().required().description(DESCRIPTIONS.productName),
+  priceInfo: isA.object({
+    amount: isA.number().required(),
+    currency: isA.string().required(),
+    interval: isA.string().required(),
+    interval_count: isA.number().required(),
+  }),
   status: isA.string().required().description(DESCRIPTIONS.status),
   subscription_id: module.exports.subscriptionsSubscriptionId
     .required()
@@ -893,7 +899,8 @@ module.exports.thirdPartyProvider = isA
 module.exports.thirdPartyIdToken = module.exports.jwt.optional();
 module.exports.thirdPartyOAuthCode = isA.string().optional();
 
-module.exports.entrypoint = isA.string()
+module.exports.entrypoint = isA
+  .string()
   .regex(/^[a-zA-Z0-9_.-]+$/) // Only allow letters, digits, underscores, dots, and dashes
   .max(256)
   .required();

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -22,7 +22,7 @@
     "clean": "rimraf dist",
     "clean-up-old-ci-stripe-customers": "node -r esbuild-register ./scripts/clean-up-old-ci-stripe-customers.js --limit 1000",
     "compile": "yarn install-ejs && tsc --noEmit",
-    "create-mock-iap": "NODE_ENV=dev FIRESTORE_EMULATOR_HOST=localhost:9090 node -r esbuild-register ./scripts/create-mock-iap-subscriptions.ts",
+    "create-mock-iap": "CONFIG_FILES='config/secrets.json' NODE_ENV=dev FIRESTORE_EMULATOR_HOST=localhost:9090 node -r esbuild-register ./scripts/create-mock-iap-subscriptions.ts",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "glean-generate": "npx glean translate ../fxa-shared/metrics/glean/fxa-backend-pings.yaml ../fxa-shared/metrics/glean/fxa-backend-metrics.yaml -f typescript_server -o lib/metrics/glean",
     "glean-lint": "npx glean glinter ../fxa-shared/metrics/glean/fxa-backend-pings.yaml ../fxa-shared/metrics/glean/fxa-backend-metrics.yaml",

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/price1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/price1.json
@@ -1,0 +1,77 @@
+{
+  "id": "price_G93lTs8hfK7NNG",
+  "object": "price",
+  "active": true,
+  "aggregate_usage": null,
+  "amount": 499,
+  "amount_decimal": "499",
+  "billing_scheme": "per_unit",
+  "created": 1573274041,
+  "currency": "usd",
+  "currency_options": {
+    "eur": {
+      "custom_unit_amount": null,
+      "tax_behavior": "inclusive",
+      "unit_amount": 499,
+      "unit_amount_decimal": "499"
+    },
+    "usd": {
+      "custom_unit_amount": null,
+      "tax_behavior": "exclusive",
+      "unit_amount": 499,
+      "unit_amount_decimal": "499"
+    }
+  },
+  "interval": "month",
+  "interval_count": 1,
+  "livemode": false,
+  "metadata": {},
+  "nickname": "Basic FPN",
+  "product": {
+    "id": "prod_G93l8Yn7XJHYUs",
+    "object": "product",
+    "active": true,
+    "attributes": [],
+    "caption": null,
+    "created": 1573274017,
+    "deactivate_on": [],
+    "description": null,
+    "images": [],
+    "livemode": false,
+    "metadata": {
+      "webIconURL": "https://example.com/static/icon.svg",
+      "upgradeCTA": "hello <a href=\"http://example.org\">world</a>",
+      "successActionButtonURL": "https://example.com/download",
+      "appStoreLink": "https://example.com/appStoreRedirect",
+      "playStoreLink": "https://example.com/playStoreRedirect",
+      "product:privacyNoticeURL": "https://cdn.accounts.firefox.com/legal/privacy",
+      "product:privacyNoticeDownloadURL": "https://cdn.accounts.firefox.com/legal/privacy.pdf",
+      "product:termsOfServiceURL": "https://cdn.accounts.firefox.com/legal/terms",
+      "product:termsOfServiceDownloadURL": "https://cdn.accounts.firefox.com/legal/terms.pdf",
+      "capabilities:aFakeClientId12345": "more,comma,separated,values",
+      "productSet": "fpn_product",
+      "productOrder": "1"
+    },
+    "name": "FPN Tier 1",
+    "package_dimensions": null,
+    "shippable": null,
+    "statement_descriptor": null,
+    "type": "service",
+    "unit_label": null,
+    "updated": 1573853421,
+    "url": null
+  },
+  "recurring": {
+    "aggregate_usage": null,
+    "interval": "month",
+    "interval_count": 1,
+    "meter": null,
+    "trial_period_days": null,
+    "usage_type": "licensed"
+  },
+  "tiers": null,
+  "tiers_mode": null,
+  "transform_usage": null,
+  "trial_period_days": null,
+  "usage_type": "licensed"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/price2.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/price2.json
@@ -1,0 +1,77 @@
+{
+  "id": "price_G93mMKnIFCjZek",
+  "object": "price",
+  "active": true,
+  "aggregate_usage": null,
+  "amount": 999,
+  "amount_decimal": "999",
+  "billing_scheme": "per_unit",
+  "created": 1573274099,
+  "currency": "usd",
+  "currency_options": {
+    "eur": {
+      "custom_unit_amount": null,
+      "tax_behavior": "inclusive",
+      "unit_amount": 999,
+      "unit_amount_decimal": "999"
+    },
+    "usd": {
+      "custom_unit_amount": null,
+      "tax_behavior": "exclusive",
+      "unit_amount": 999,
+      "unit_amount_decimal": "999"
+    }
+  },
+  "interval": "month",
+  "interval_count": 1,
+  "livemode": false,
+  "metadata": {},
+  "nickname": "FPN Advanced",
+  "product": {
+    "id": "prod_G93mdk6bGPJ7wy",
+    "object": "product",
+    "active": true,
+    "attributes": [],
+    "caption": null,
+    "created": 1573274089,
+    "deactivate_on": [],
+    "description": null,
+    "images": [],
+    "livemode": false,
+    "metadata": {
+      "webIconURL": "https://example.com/static/icon.svg",
+      "upgradeCTA": "hello <a href=\"http://example.org\">world</a>",
+      "successActionButtonURL": "https://example.com/download",
+      "appStoreLink": "https://example.com/appStoreRedirect",
+      "playStoreLink": "https://example.com/playStoreRedirect",
+      "product:privacyNoticeURL": "https://cdn.accounts.firefox.com/legal/privacy",
+      "product:privacyNoticeDownloadURL": "https://cdn.accounts.firefox.com/legal/privacy.pdf",
+      "product:termsOfServiceURL": "https://cdn.accounts.firefox.com/legal/terms",
+      "product:termsOfServiceDownloadURL": "https://cdn.accounts.firefox.com/legal/terms.pdf",
+      "capabilities:aFakeClientId12345": "more,comma,separated,values",
+      "productSet": "fpn_product",
+      "productOrder": "2"
+    },
+    "name": "FPN Tier 2",
+    "package_dimensions": null,
+    "shippable": null,
+    "statement_descriptor": null,
+    "type": "service",
+    "unit_label": null,
+    "updated": 1573837071,
+    "url": null
+  },
+  "recurring": {
+    "aggregate_usage": null,
+    "interval": "month",
+    "interval_count": 1,
+    "meter": null,
+    "trial_period_days": null,
+    "usage_type": "licensed"
+  },
+  "tiers": null,
+  "tiers_mode": null,
+  "transform_usage": null,
+  "trial_period_days": null,
+  "usage_type": "licensed"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/price3.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/price3.json
@@ -1,0 +1,77 @@
+{
+  "id": "price_F4G9jB3x5i6Dpj",
+  "object": "price",
+  "active": true,
+  "aggregate_usage": null,
+  "amount": 100,
+  "amount_decimal": "100",
+  "billing_scheme": "per_unit",
+  "created": 1557867224,
+  "currency": "usd",
+  "currency_options": {
+    "eur": {
+      "custom_unit_amount": null,
+      "tax_behavior": "inclusive",
+      "unit_amount": 100,
+      "unit_amount_decimal": "100"
+    },
+    "usd": {
+      "custom_unit_amount": null,
+      "tax_behavior": "exclusive",
+      "unit_amount": 100,
+      "unit_amount_decimal": "100"
+    }
+  },
+  "interval": "day",
+  "interval_count": 1,
+  "livemode": false,
+  "metadata": {},
+  "nickname": "Daily Subscription",
+  "product": {
+    "id": "prod_EtMczoDntN9YEa",
+    "object": "product",
+    "active": true,
+    "attributes": [],
+    "caption": null,
+    "created": 1555354226,
+    "deactivate_on": [],
+    "description": null,
+    "images": [],
+    "livemode": false,
+    "metadata": {
+      "webIconURL": "https://example.com/static/icon.svg",
+      "upgradeCTA": "hello <a href=\"http://example.org\">world</a>",
+      "successActionButtonURL": "https://example.com/download",
+      "appStoreLink": "https://example.com/appStoreRedirect",
+      "playStoreLink": "https://example.com/playStoreRedirect",
+      "product:privacyNoticeURL": "https://cdn.accounts.firefox.com/legal/privacy",
+      "product:privacyNoticeDownloadURL": "https://cdn.accounts.firefox.com/legal/privacy.pdf",
+      "product:termsOfServiceURL": "https://cdn.accounts.firefox.com/legal/terms",
+      "product:termsOfServiceDownloadURL": "https://cdn.accounts.firefox.com/legal/terms.pdf",
+      "capabilities:aFakeClientId12345": "more,comma,separated,values",
+      "productSet": "daily_subscription",
+      "productOrder": "3"
+    },
+    "name": "Moz_Sub",
+    "package_dimensions": null,
+    "shippable": null,
+    "statement_descriptor": "Moz-Sub",
+    "type": "service",
+    "unit_label": "Moz-Sub",
+    "updated": 1573169050,
+    "url": null
+  },
+  "recurring": {
+    "aggregate_usage": null,
+    "interval": "day",
+    "interval_count": 1,
+    "meter": null,
+    "trial_period_days": null,
+    "usage_type": "licensed"
+  },
+  "tiers": null,
+  "tiers_mode": null,
+  "transform_usage": null,
+  "trial_period_days": null,
+  "usage_type": "licensed"
+}

--- a/packages/fxa-shared/dto/auth/payments/iap-subscription.ts
+++ b/packages/fxa-shared/dto/auth/payments/iap-subscription.ts
@@ -19,6 +19,12 @@ export const iapExtraStripeInfoSchema = joi.object({
   price_id: joi.string().required(),
   product_id: joi.string().required(),
   product_name: joi.string().required(),
+  priceInfo: joi.object({
+    amount: joi.number().required(),
+    currency: joi.string().required(),
+    interval: joi.string().required(),
+    interval_count: joi.number().required(),
+  }),
 });
 
 export type iapExtraStripeInfoSchema = {

--- a/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
+++ b/packages/fxa-shared/payments/iap/apple-app-store/subscription-purchase.ts
@@ -109,7 +109,7 @@ export class AppStoreSubscriptionPurchase {
   private renewalOfferIdentifier?: string;
   private revocationDate?: number;
   private revocationReason?: number;
-  private currency!: string;
+  currency!: string;
   private price!: number;
   private storefront!: string;
   private renewalCurrency?: string;

--- a/packages/fxa-shared/payments/stripe.ts
+++ b/packages/fxa-shared/payments/stripe.ts
@@ -45,6 +45,7 @@ export const SOURCE_RESOURCE = 'sources';
 export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
 export const TAX_RATE_RESOURCE = 'taxRates';
 export const STRIPE_PLANS_CACHE_KEY = 'listStripePlans';
+export const STRIPE_PRICES_CACHE_KEY = 'listStripePrices';
 export const STRIPE_PRODUCTS_CACHE_KEY = 'listStripeProducts';
 
 export const STRIPE_OBJECT_TYPE_TO_RESOURCE: Record<string, string> = {
@@ -165,7 +166,9 @@ export abstract class StripeHelper {
    * @param plan - Plan to validate
    * @returns - true if plan is valid
    */
-  protected abstract validatePlan(plan: Stripe.Plan): Promise<boolean>;
+  protected abstract validatePlan(
+    plan: Stripe.Plan | Stripe.Price
+  ): Promise<boolean>;
 
   /**
    * Fetch all product data and cache it if Redis is enabled.
@@ -313,7 +316,7 @@ export abstract class StripeHelper {
    * Append any matching prices and related info to their corresponding IAP purchases.
    */
   async addPriceInfoToIapPurchases<
-    T extends AppStoreSubscriptionPurchase | PlayStoreSubscriptionPurchase
+    T extends AppStoreSubscriptionPurchase | PlayStoreSubscriptionPurchase,
   >(
     purchases: T[],
     iapType: Omit<SubscriptionType, typeof MozillaSubscriptionTypes.WEB>
@@ -400,6 +403,60 @@ export abstract class StripeHelper {
     return plans;
   }
 
+  /**
+   * Fetches all prices from stripe and returns them.
+   *
+   * Use `allPrices` below to use the cached-enhanced version.
+   *
+   * Note: This is expected to be a temporary method and will be deprecated
+   * as part of PAY-2001
+   */
+  async fetchAllPrices(): Promise<Stripe.Price[]> {
+    const prices: Stripe.Price[] = [];
+
+    for await (const item of this.stripe.prices.list({
+      expand: ['data.product', 'data.currency_options'],
+    })) {
+      if (!item.product) {
+        this.log.error(
+          `fetchAllPrices - Price "${item.id}" missing Product`,
+          item
+        );
+        continue;
+      }
+
+      if (typeof item.product === 'string') {
+        this.log.error(
+          `fetchAllPrices - Price "${item.id}" failed to load Product`,
+          item
+        );
+        continue;
+      }
+
+      if (item.product.deleted === true) {
+        this.log.error(
+          `fetchAllPrices - Price "${item.id}" associated with Deleted Product`,
+          item
+        );
+        continue;
+      }
+
+      item.product.metadata = mapValues(item.product.metadata, (v) => v.trim());
+      item.metadata = mapValues(item.metadata, (v) => v.trim());
+
+      // We should return all the plans when relying on Firestore docs for
+      // their configuration
+      if (
+        this.config.subscriptions.productConfigsFirestore.enabled ||
+        (await this.validatePlan(item))
+      ) {
+        prices.push(item);
+      }
+    }
+
+    return prices;
+  }
+
   async allConfiguredPlans(): Promise<ConfiguredPlan[] | Stripe.Plan[]> {
     // for a transitional period we will include configs from both Firestore
     // docs and Stripe metadata when enabled by the feature flag, making it
@@ -445,6 +502,22 @@ export abstract class StripeHelper {
   })
   async allPlans(): Promise<Stripe.Plan[]> {
     return this.fetchAllPlans();
+  }
+
+  /**
+   * Fetches all prices from stripe and returns them.
+   *
+   * Uses Redis caching if configured.
+   *
+   * Note: This is expected to be a temporary method and will be deprecated
+   * as part of PAY-2001
+   */
+  @Cacheable({
+    cacheKey: STRIPE_PRICES_CACHE_KEY,
+    ttlSeconds: (args, context) => context.plansAndProductsCacheTtlSeconds,
+  })
+  async allPrices(): Promise<Stripe.Price[]> {
+    return this.fetchAllPrices();
   }
 
   async allAbbrevPlans(acceptLanguage = 'en'): Promise<AbbrevPlan[]> {
@@ -609,9 +682,8 @@ export abstract class StripeHelper {
           if (
             err.name === FirestoreStripeError.FIRESTORE_PAYMENT_METHOD_NOT_FOUND
           ) {
-            const paymentMethod = await this.stripe.paymentMethods.retrieve(
-              resource
-            );
+            const paymentMethod =
+              await this.stripe.paymentMethods.retrieve(resource);
             // Payment methods may not be attached to customers, in which case we
             // cannot store it in Firestore.
             if (paymentMethod.customer) {
@@ -658,8 +730,8 @@ export function determineIapIdentifiers(
     iapType === MozillaSubscriptionTypes.IAP_GOOGLE
       ? STRIPE_PRICE_METADATA.PLAY_SKU_IDS
       : iapType === MozillaSubscriptionTypes.IAP_APPLE
-      ? STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS
-      : null;
+        ? STRIPE_PRICE_METADATA.APP_STORE_PRODUCT_IDS
+        : null;
 
   if (!key) {
     throw new Error('Invalid iapType');

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -174,7 +174,13 @@ export type WebSubscription = Pick<
   };
 
 export type IapSubscription = PlayStoreSubscription | AppStoreSubscription;
-export type MozillaSubscription = WebSubscription | IapSubscription;
+export type MozillaSubscription =
+  | (WebSubscription & {
+      priceInfo?: SubscriptionManagementPriceInfo;
+    })
+  | (IapSubscription & {
+      priceInfo?: SubscriptionManagementPriceInfo;
+    });
 
 export const PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT = 'missing_agreement';
 export const PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE = 'funding_source';
@@ -227,4 +233,11 @@ export type SubscriptionChangeEligibility = {
   subscriptionEligibilityResult: SubscriptionEligibilityResult;
   eligibleSourcePlan?: AbbrevPlan;
   redundantOverlaps?: SubscriptionChangeEligibility[];
+};
+
+export type SubscriptionManagementPriceInfo = {
+  amount: string | number | null;
+  currency: string;
+  interval: Stripe.Price.Recurring.Interval;
+  interval_count: number;
 };


### PR DESCRIPTION
## Because

- Currency and pricing information can no longer be reliably retrieved from the /subscriptions/plans API, for a specific price ID, due to the utilization of multi-currency prices.**

## This pull request

- Updates the /billing-and-subscriptions API to return relevant price info for a customers subscriptions, with correct currency and pricing information.

## Issue that this pull request solves

Closes: #PAY-3192

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).