### PR TITLE
bug(auth, shared): Make security event names typesafe

### DIFF
--- a/packages/fxa-auth-server/lib/account-events.ts
+++ b/packages/fxa-auth-server/lib/account-events.ts
@@ -158,7 +158,7 @@ export class AccountEventsManager {
    * @param db - auth db
    * @param message - message
    */
-  public recordSecurityEvent(db: AuthDatabase, message: SecurityEvent) {
+  public async recordSecurityEvent(db: AuthDatabase, message: SecurityEvent) {
     const { uid, name, ipAddr, tokenId, additionalInfo } = message;
 
     const eventData: SecurityEvent = {
@@ -174,7 +174,7 @@ export class AccountEventsManager {
     };
 
     try {
-      db.securityEvent(eventData);
+      await db.securityEvent(eventData);
       this.statsd.increment(`accountEvents.recordSecurityEvent.write.${name}`);
     } catch (err) {
       // Failing to write to events shouldn't break anything

--- a/packages/fxa-auth-server/lib/db.ts
+++ b/packages/fxa-auth-server/lib/db.ts
@@ -1026,10 +1026,18 @@ export const createDB = (
       log.trace('DB.securityEvent', {
         securityEvent: event,
       });
-      await SecurityEvent.create({
+
+      const payload = {
         ...event,
+        uid: event.uid,
+        name: event.name,
+        ipAddr: event.ipAddr,
+        tokenId: event.tokenId,
+        additionalInfo: event.additionalInfo,
         ipHmacKey: config.securityHistory.ipHmacKey,
-      });
+      };
+
+      await SecurityEvent.create(payload);
     }
 
     async securityEvents(params: { uid: string; ipAddr: string }) {

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.ts
@@ -2,16 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { SecurityEventNames } from 'fxa-shared/db/models/auth/security-event';
 import { AccountEventsManager } from '../../account-events';
 import { Container } from 'typedi';
 
-export function recordSecurityEvent(name: any, opts: any) {
+export async function recordSecurityEvent(name: SecurityEventNames, opts: any) {
   const mgr = Container.get(AccountEventsManager);
   if (mgr == null || typeof mgr.recordSecurityEvent !== 'function') {
     return;
   }
 
-  mgr.recordSecurityEvent(opts.db, {
+  await mgr.recordSecurityEvent(opts.db, {
     name,
     uid: opts?.account?.uid || opts?.request?.auth?.credentials?.uid,
     ipAddr: opts?.request?.app?.clientAddress,

--- a/packages/fxa-shared/.eslintrc
+++ b/packages/fxa-shared/.eslintrc
@@ -3,20 +3,22 @@
   "plugins": ["fxa"],
   "parserOptions": {
     "ecmaVersion": "2020",
-    "sourceType": "module"
+    "sourceType": "module",
   },
   "env": {
-    "mocha": true
+    "mocha": true,
   },
   "rules": {
     "require-atomic-updates": "off",
     "space-unary-ops": "off",
-    "no-useless-escape": "off"
+    "no-useless-escape": "off",
   },
   "ignorePatterns": [
     "dist",
     "node_modules",
-    "pm2.config.js"
+    "pm2.config.js",
+    // Weird catch 22 resulted in not being able to lint this...
+    "db/models/auth/security-event.ts",
   ],
-  "root": true
+  "root": true,
 }

--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -49,6 +49,12 @@ export const EVENT_NAMES = {
   'account.must_reset': 35,
   'account.recovery_phone_reset_password_success': 36,
   'account.recovery_phone_reset_password_failed': 37,
+  'account.password_upgrade_success': 38,
+  'account.password_upgraded': 39,
+  'account.recovery_phone_setup_failed': 40,
+  'account.recovery_phone_replace_failed': 41,
+  'account.recovery_phone_replace_complete': 42,
+  'account.recovery_phone_reset_password_complete': 43,
 } as const;
 
 export type SecurityEventNames = keyof typeof EVENT_NAMES;


### PR DESCRIPTION
## Because

- Pretty sure this responsible for our DB 'mysql convert' errors
- We can make `recordSecurityEvent` typesafe.

## This pull request
- Adds type safety, so we must define the name
- Improves async/await chain. It should really be up to the calling code, not a deeper layer if the call is fire and forget.
- Adopts auth-server's eslint config in fxa-shared... 

## Issue that this pull request solves

Closes: [FXA-11681](https://mozilla-hub.atlassian.net/browse/FXA-11681)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

- Without this using auth-server's eslint config in fxa-shared, it wouldn't pass pre commit linting. I'm not sure how anybody ever changed this file! Basically, with previous rule set, eslint didn't like `} as const;` trailing the security event names.
- I strongly considered awaiting all the `recordSecurityEvent` calls, but didn't. If we don't away them, and the fail the call stack is spliced, and it's hard to track down where the issue came from, but it still shows up in sentry.


[FXA-11681]: https://mozilla-hub.atlassian.net/browse/FXA-11681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ