### PR TITLE
polish(auth): Make sure calls to recordSecurityEvent are awaited

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -619,7 +619,7 @@ export class AccountHandler {
       });
     }
 
-    recordSecurityEvent('account.create', {
+    await recordSecurityEvent('account.create', {
       db: this.db,
       request,
       account,
@@ -976,7 +976,7 @@ export class AccountHandler {
         request
       );
       if (!match) {
-        recordSecurityEvent('account.login.failure', {
+        await recordSecurityEvent('account.login.failure', {
           db: this.db,
           request,
           account: accountRecord,
@@ -1840,7 +1840,7 @@ export class AccountHandler {
     await recoveryKeyDeleteAndEmailNotification();
     await createSessionToken();
     await createKeyFetchToken();
-    recordSecurityEvent('account.reset', {
+    await recordSecurityEvent('account.reset', {
       db: this.db,
       account,
       request,

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -644,7 +644,7 @@ module.exports = (
           throw emailUtils.sendError(err, true);
         }
 
-        recordSecurityEvent('account.secondary_email_added', {
+        await recordSecurityEvent('account.secondary_email_added', {
           db,
           request,
           account,
@@ -745,7 +745,10 @@ module.exports = (
 
         await db.deleteEmail(uid, normalizeEmail(email));
 
-        recordSecurityEvent('account.secondary_email_removed', { db, request });
+        await recordSecurityEvent('account.secondary_email_removed', {
+          db,
+          request,
+        });
 
         await db.resetAccountTokens(uid);
 
@@ -884,7 +887,7 @@ module.exports = (
             uid,
           });
 
-          recordSecurityEvent('account.primary_secondary_swapped', {
+          await recordSecurityEvent('account.primary_secondary_swapped', {
             db,
             request,
           });

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -393,13 +393,13 @@ module.exports = function (
               uid: passwordChangeToken.uid,
             });
 
-            recordSecurityEvent('account.password_upgrade_success', {
+            await recordSecurityEvent('account.password_upgrade_success', {
               db,
               request,
               account: passwordChangeToken,
             });
 
-            recordSecurityEvent('account.password_upgraded', {
+            await recordSecurityEvent('account.password_upgraded', {
               db,
               request,
               account: passwordChangeToken,
@@ -423,13 +423,13 @@ module.exports = function (
             uid: passwordChangeToken.uid,
           });
 
-          recordSecurityEvent('account.password_reset_success', {
+          await recordSecurityEvent('account.password_reset_success', {
             db,
             request,
             account: passwordChangeToken,
           });
 
-          recordSecurityEvent('account.password_changed', {
+          await recordSecurityEvent('account.password_changed', {
             db,
             request,
             account: passwordChangeToken,
@@ -680,7 +680,7 @@ module.exports = function (
 
         await request.emitMetricsEvent('password.forgot.send_otp.completed');
 
-        recordSecurityEvent('account.password_reset_otp_sent', {
+        await recordSecurityEvent('account.password_reset_otp_sent', {
           db,
           request,
           account: { uid: account.uid },
@@ -741,7 +741,7 @@ module.exports = function (
         glean.resetPassword.otpVerified(request);
         await request.emitMetricsEvent('password.forgot.verify_otp.completed');
 
-        recordSecurityEvent('account.password_reset_otp_verified', {
+        await recordSecurityEvent('account.password_reset_otp_verified', {
           db,
           request,
           account: { uid: account.uid },
@@ -977,7 +977,7 @@ module.exports = function (
         });
         await Promise.all([
           request.emitMetricsEvent('password.forgot.resend_code.completed'),
-          recordSecurityEvent('account.password_reset_requested', {
+          await recordSecurityEvent('account.password_reset_requested', {
             db,
             request,
           }),
@@ -1210,7 +1210,7 @@ module.exports = function (
           verifierVersion
         );
 
-        recordSecurityEvent('account.password_added', {
+        await recordSecurityEvent('account.password_added', {
           db,
           request,
           account: { uid },

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -56,7 +56,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
           RECOVERY_CODE_COUNT
         );
 
-        recordSecurityEvent('account.recovery_codes_replaced', {
+        await recordSecurityEvent('account.recovery_codes_replaced', {
           db,
           request,
         });
@@ -124,7 +124,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
 
         // no email notification, notice about codes will be included in postAddTwoStepAuthentication email
 
-        recordSecurityEvent('account.recovery_codes_set', {
+        await recordSecurityEvent('account.recovery_codes_set', {
           db,
           request,
           account,
@@ -184,7 +184,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
           uid,
         });
 
-        recordSecurityEvent('account.recovery_codes_created', {
+        await recordSecurityEvent('account.recovery_codes_created', {
           db,
           request,
           account,
@@ -321,7 +321,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
         await request.emitMetricsEvent('account.confirmed', { uid });
         glean.login.recoveryCodeSuccess(request, { uid });
 
-        recordSecurityEvent('account.recovery_codes_signin_complete', {
+        await recordSecurityEvent('account.recovery_codes_signin_complete', {
           db,
           request,
           account,

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -185,7 +185,7 @@ class RecoveryPhoneHandler {
       this.statsd.increment('account.recoveryPhone.signinSendCode.success');
       await this.glean.twoStepAuthPhoneCode.sent(request);
 
-      recordSecurityEvent('account.recovery_phone_send_code', {
+      await recordSecurityEvent('account.recovery_phone_send_code', {
         db: this.db,
         request,
       });
@@ -263,7 +263,7 @@ class RecoveryPhoneHandler {
 
       this.glean.resetPassword.recoveryPhoneCodeSent(request);
 
-      recordSecurityEvent('account.recovery_phone_send_code', {
+      await recordSecurityEvent('account.recovery_phone_send_code', {
         db: this.db,
         request,
       });
@@ -319,7 +319,7 @@ class RecoveryPhoneHandler {
       );
       if (success) {
         this.statsd.increment('account.recoveryPhone.setupPhoneNumber.success');
-        recordSecurityEvent('account.recovery_phone_send_code', {
+        await recordSecurityEvent('account.recovery_phone_send_code', {
           db: this.db,
           request,
         });
@@ -431,7 +431,7 @@ class RecoveryPhoneHandler {
       // this signals the end of the login flow
       await request.emitMetricsEvent('account.confirmed', { uid });
 
-      recordSecurityEvent('account.recovery_phone_signin_complete', {
+      await recordSecurityEvent('account.recovery_phone_signin_complete', {
         db: this.db,
         request,
       });
@@ -462,7 +462,7 @@ class RecoveryPhoneHandler {
       return { status: RecoveryPhoneStatus.SUCCESS };
     }
 
-    recordSecurityEvent('account.recovery_phone_signin_failed', {
+    await recordSecurityEvent('account.recovery_phone_signin_failed', {
       db: this.db,
       request,
     });
@@ -559,7 +559,7 @@ class RecoveryPhoneHandler {
         }
       }
 
-      recordSecurityEvent('account.recovery_phone_setup_complete', {
+      await recordSecurityEvent('account.recovery_phone_setup_complete', {
         db: this.db,
         request,
       });
@@ -571,7 +571,7 @@ class RecoveryPhoneHandler {
       };
     }
 
-    recordSecurityEvent('account.recovery_phone_setup_failed', {
+    await recordSecurityEvent('account.recovery_phone_setup_failed', {
       db: this.db,
       request,
     });
@@ -631,7 +631,7 @@ class RecoveryPhoneHandler {
     if (!replacedSuccess) {
       await this.glean.twoStepAuthPhoneReplace.failure(request);
       this.statsd.increment('account.recoveryPhone.changePhoneNumber.failure');
-      recordSecurityEvent('account.recovery_phone_replace_failed', {
+      await recordSecurityEvent('account.recovery_phone_replace_failed', {
         db: this.db,
         request,
       });
@@ -646,7 +646,7 @@ class RecoveryPhoneHandler {
     const { phoneNumber, nationalFormat } =
       await this.recoveryPhoneService.hasConfirmed(uid);
 
-    recordSecurityEvent('account.recovery_phone_replace_complete', {
+    await recordSecurityEvent('account.recovery_phone_replace_complete', {
       db: this.db,
       request,
     });
@@ -729,10 +729,13 @@ class RecoveryPhoneHandler {
 
       this.statsd.increment('account.resetPassword.recoveryPhone.success');
 
-      recordSecurityEvent('account.recovery_phone_reset_password_complete', {
-        db: this.db,
-        request,
-      });
+      await recordSecurityEvent(
+        'account.recovery_phone_reset_password_complete',
+        {
+          db: this.db,
+          request,
+        }
+      );
 
       const account = await this.db.account(uid);
       const { acceptLanguage, geo, ua } = request.app;
@@ -764,7 +767,7 @@ class RecoveryPhoneHandler {
       return { status: RecoveryPhoneStatus.SUCCESS };
     }
 
-    recordSecurityEvent('account.recovery_phone_reset_password_failed', {
+    await recordSecurityEvent('account.recovery_phone_reset_password_failed', {
       db: this.db,
       request,
     });
@@ -800,7 +803,7 @@ class RecoveryPhoneHandler {
       const { acceptLanguage, geo, ua } = request.app;
 
       try {
-        recordSecurityEvent('account.recovery_phone_removed', {
+        await recordSecurityEvent('account.recovery_phone_removed', {
           db: this.db,
           request,
           account,

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -491,7 +491,7 @@ module.exports = (
           }
         }
 
-        recordSecurityEvent('account.two_factor_removed', {
+        await recordSecurityEvent('account.two_factor_removed', {
           db,
           request,
         });
@@ -821,7 +821,7 @@ module.exports = (
 
           await request.emitMetricsEvent('totpToken.verified', { uid });
 
-          recordSecurityEvent('account.two_factor_challenge_success', {
+          await recordSecurityEvent('account.two_factor_challenge_success', {
             db,
             request,
           });
@@ -836,7 +836,7 @@ module.exports = (
           });
           await request.emitMetricsEvent('totpToken.unverified', { uid });
 
-          recordSecurityEvent('account.two_factor_challenge_failure', {
+          await recordSecurityEvent('account.two_factor_challenge_failure', {
             db,
             request,
           });
@@ -1065,7 +1065,7 @@ module.exports = (
 
           await authServerCacheRedis.del(toRedisTotpSecretKey(uid));
 
-          recordSecurityEvent('account.two_factor_replace_success', {
+          await recordSecurityEvent('account.two_factor_replace_success', {
             db,
             request,
           });
@@ -1082,7 +1082,7 @@ module.exports = (
             success: true,
           };
         } catch (error) {
-          recordSecurityEvent('account.two_factor_replace_failure', {
+          await recordSecurityEvent('account.two_factor_replace_failure', {
             db,
             request,
           });

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -42,7 +42,7 @@ module.exports = (
   const accountEventsManager = Container.has(AccountEventsManager)
     ? Container.get(AccountEventsManager)
     : {
-        recordSecurityEvent: () => {},
+        recordSecurityEvent: async () => {},
       };
   const cmsManager = Container.has(RelyingPartyConfigurationManager)
     ? Container.get(RelyingPartyConfigurationManager)
@@ -561,8 +561,8 @@ module.exports = (
         }
       }
 
-      function recordSecurityEvent() {
-        accountEventsManager.recordSecurityEvent(db, {
+      async function recordSecurityEvent() {
+        await accountEventsManager.recordSecurityEvent(db, {
           name: 'account.login',
           uid: accountRecord.uid,
           ipAddr: request.app.clientAddress,

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -36,7 +36,7 @@ function makeRoutes(options = {}) {
   };
   const log = mocks.mockLog();
   Container.set(AccountEventsManager, {
-    recordSecurityEvent: () => {},
+    recordSecurityEvent: async () => {},
   });
   Container.set(AccountDeleteManager, { enqueue: () => {} });
   Container.set(AppConfig, config);

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -34,7 +34,7 @@ describe('POST /recoveryKey', () => {
   describe('should create an account recovery key', () => {
     let requestOptions;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       requestOptions = {
         credentials: { uid, email },
         log,
@@ -44,8 +44,11 @@ describe('POST /recoveryKey', () => {
           enabled: true,
         },
       };
-      return setup({ db: { email } }, {}, '/recoveryKey', requestOptions).then(
-        (r) => (response = r)
+      response = await setup(
+        { db: { email } },
+        {},
+        '/recoveryKey',
+        requestOptions
       );
     });
 
@@ -125,7 +128,7 @@ describe('POST /recoveryKey', () => {
   describe('should change account recovery key when an enabled key exists and replaceKey is true', () => {
     let requestOptions;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       requestOptions = {
         credentials: { uid, email },
         log,
@@ -136,12 +139,12 @@ describe('POST /recoveryKey', () => {
           replaceKey: true,
         },
       };
-      return setup(
+      response = await setup(
         { db: { recoveryData, email } },
         {},
         '/recoveryKey',
         requestOptions
-      ).then((r) => (response = r));
+      );
     });
 
     it('returned the correct response', () => {
@@ -237,7 +240,7 @@ describe('POST /recoveryKey', () => {
     let requestOptions;
     let error;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       requestOptions = {
         credentials: { uid, email },
         log,
@@ -248,16 +251,17 @@ describe('POST /recoveryKey', () => {
           replaceKey: false,
         },
       };
-      return setup(
-        { db: { recoveryData, email } },
-        {},
-        '/recoveryKey',
-        requestOptions
-      )
-        .then((r) => (response = r))
-        .catch((e) => {
-          error = e;
-        });
+
+      try {
+        response = await setup(
+          { db: { recoveryData, email } },
+          {},
+          '/recoveryKey',
+          requestOptions
+        );
+      } catch (e) {
+        error = e;
+      }
     });
 
     it('returned the correct response', () => {
@@ -303,14 +307,17 @@ describe('POST /recoveryKey', () => {
   });
 
   describe('should create disabled account recovery key', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const requestOptions = {
         credentials: { uid, email },
         log,
         payload: { recoveryKeyId, recoveryData, enabled: false },
       };
-      return setup({ db: { email } }, {}, '/recoveryKey', requestOptions).then(
-        (r) => (response = r)
+      response = await setup(
+        { db: { email } },
+        {},
+        '/recoveryKey',
+        requestOptions
       );
     });
 
@@ -330,19 +337,19 @@ describe('POST /recoveryKey', () => {
   });
 
   describe('should verify account recovery key', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       mockAccountEventsManager = mocks.mockAccountEventsManager();
       const requestOptions = {
         credentials: { uid, email },
         log,
         payload: { recoveryKeyId, enabled: false },
       };
-      return setup(
+      response = await setup(
         { db: { email } },
         {},
         '/recoveryKey/verify',
         requestOptions
-      ).then((r) => (response = r));
+      );
     });
     after(() => {
       mocks.unMockAccountEventsManager();
@@ -414,21 +421,23 @@ describe('POST /recoveryKey', () => {
   describe('should not verify invalid account recovery key', () => {
     let error;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       mockAccountEventsManager = mocks.mockAccountEventsManager();
       const requestOptions = {
         credentials: { uid, email, tokenVerificationId: true },
         log,
         payload: { recoveryKeyId: recoveryKeyId, enabled: false },
       };
-      return setup(
-        { db: { email } },
-        {},
-        '/recoveryKey/verify',
-        requestOptions
-      ).catch((e) => {
+      try {
+        await setup(
+          { db: { email } },
+          {},
+          '/recoveryKey/verify',
+          requestOptions
+        );
+      } catch (e) {
         error = e;
-      });
+      }
     });
     after(() => {
       mocks.unMockAccountEventsManager();
@@ -499,18 +508,18 @@ describe('POST /recoveryKey', () => {
 
 describe('GET /recoveryKey/{recoveryKeyId}', () => {
   describe('should get account recovery key', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       const requestOptions = {
         credentials: { uid, email },
         params: { recoveryKeyId },
         log,
       };
-      return setup(
+      response = await setup(
         { db: { recoveryData, recoveryKeyId } },
         {},
         '/recoveryKey/{recoveryKeyId}',
         requestOptions
-      ).then((r) => (response = r));
+      );
     });
 
     it('returned the correct response', () => {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -1035,8 +1035,8 @@ function mockAppStoreSubscriptions(methods) {
 
 function mockAccountEventsManager() {
   const mgr = {
-    recordSecurityEvent: sinon.stub(),
-    recordEmailEvent: sinon.stub(),
+    recordSecurityEvent: sinon.stub().resolves({}),
+    recordEmailEvent: sinon.stub().resolves({}),
   };
   Container.set(AccountEventsManager, mgr);
   return mgr;


### PR DESCRIPTION
## Because

- If an error occurs and the call is not awaited, the call stack is spliced and the source of the issue is difficult to track down.
- Not await is likely a premature and unnecessary optimization.

## This pull request

- awaits all the calls to record security event

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

We decided to do this in two steps just in case we needed to rollback this one for performance reasons.

## Other information (Optional)

Any other information that is important to this pull request.
