### PR TITLE
chore(cms): Update required Accounts CMS properties

### DIFF
--- a/libs/shared/cms/src/__generated__/graphql.ts
+++ b/libs/shared/cms/src/__generated__/graphql.ts
@@ -261,12 +261,12 @@ export type ComponentAccountsFeatureFlagsInput = {
 export type ComponentAccountsPageConfig = {
   __typename?: 'ComponentAccountsPageConfig';
   description: Maybe<Scalars['String']['output']>;
-  headline: Maybe<Scalars['String']['output']>;
+  headline: Scalars['String']['output'];
   id: Scalars['ID']['output'];
   logoAltText: Maybe<Scalars['String']['output']>;
   logoUrl: Maybe<Scalars['String']['output']>;
   pageTitle: Maybe<Scalars['String']['output']>;
-  primaryButtonText: Maybe<Scalars['String']['output']>;
+  primaryButtonText: Scalars['String']['output'];
 };
 
 export type ComponentAccountsPageConfigFiltersInput = {
@@ -1727,14 +1727,14 @@ export type QueryUsersPermissionsUsers_ConnectionArgs = {
 
 export type RelyingParty = {
   __typename?: 'RelyingParty';
-  EmailFirstPage: Maybe<ComponentAccountsPageConfig>;
+  EmailFirstPage: ComponentAccountsPageConfig;
   NewDeviceLoginEmail: Maybe<ComponentAccountsEmailConfig>;
-  SigninPage: Maybe<ComponentAccountsPageConfig>;
+  SigninPage: ComponentAccountsPageConfig;
   SigninTokenCodePage: Maybe<ComponentAccountsPageConfig>;
   SigninUnblockCodePage: Maybe<ComponentAccountsPageConfig>;
-  SignupConfirmCodePage: Maybe<ComponentAccountsPageConfig>;
+  SignupConfirmCodePage: ComponentAccountsPageConfig;
   SignupConfirmedSyncPage: Maybe<ComponentAccountsPageConfig>;
-  SignupSetPasswordPage: Maybe<ComponentAccountsPageConfig>;
+  SignupSetPasswordPage: ComponentAccountsPageConfig;
   VerifyLoginCodeEmail: Maybe<ComponentAccountsEmailConfig>;
   VerifyShortCodeEmail: Maybe<ComponentAccountsEmailConfig>;
   clientId: Maybe<Scalars['String']['output']>;
@@ -1744,7 +1744,7 @@ export type RelyingParty = {
   l10nId: Scalars['String']['output'];
   name: Maybe<Scalars['String']['output']>;
   publishedAt: Maybe<Scalars['DateTime']['output']>;
-  shared: Maybe<ComponentAccountsShared>;
+  shared: ComponentAccountsShared;
   updatedAt: Maybe<Scalars['DateTime']['output']>;
 };
 
@@ -2376,7 +2376,7 @@ export type RelyingPartiesQueryVariables = Exact<{
 }>;
 
 
-export type RelyingPartiesQuery = { __typename?: 'Query', relyingParties: Array<{ __typename?: 'RelyingParty', clientId: string | null, entrypoint: string | null, name: string | null, l10nId: string, shared: { __typename?: 'ComponentAccountsShared', buttonColor: string | null, logoUrl: string | null, logoAltText: string | null, emailFromName: string | null, emailLogoUrl: string | null, emailLogoAltText: string | null, emailLogoWidth: string | null, backgroundColor: string | null, headerBackground: string | null, pageTitle: string | null, headerLogoUrl: string | null, headerLogoAltText: string | null, favicon: string | null, featureFlags: { __typename?: 'ComponentAccountsFeatureFlags', syncConfirmedPageHideCTA: boolean | null, syncHidePromoAfterLogin: boolean | null } | null } | null, EmailFirstPage: { __typename?: 'ComponentAccountsPageConfig', logoUrl: string | null, logoAltText: string | null, headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, SignupSetPasswordPage: { __typename?: 'ComponentAccountsPageConfig', logoUrl: string | null, logoAltText: string | null, headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, SignupConfirmCodePage: { __typename?: 'ComponentAccountsPageConfig', headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, SignupConfirmedSyncPage: { __typename?: 'ComponentAccountsPageConfig', headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, SigninPage: { __typename?: 'ComponentAccountsPageConfig', headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, SigninTokenCodePage: { __typename?: 'ComponentAccountsPageConfig', headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, SigninUnblockCodePage: { __typename?: 'ComponentAccountsPageConfig', headline: string | null, description: string | null, primaryButtonText: string | null, pageTitle: string | null } | null, NewDeviceLoginEmail: { __typename?: 'ComponentAccountsEmailConfig', subject: string, headline: string, description: string } | null, VerifyLoginCodeEmail: { __typename?: 'ComponentAccountsEmailConfig', subject: string, headline: string, description: string } | null, VerifyShortCodeEmail: { __typename?: 'ComponentAccountsEmailConfig', subject: string, headline: string, description: string } | null } | null> };
+export type RelyingPartiesQuery = { __typename?: 'Query', relyingParties: Array<{ __typename?: 'RelyingParty', clientId: string | null, entrypoint: string | null, name: string | null, l10nId: string, shared: { __typename?: 'ComponentAccountsShared', buttonColor: string | null, logoUrl: string | null, logoAltText: string | null, emailFromName: string | null, emailLogoUrl: string | null, emailLogoAltText: string | null, emailLogoWidth: string | null, backgroundColor: string | null, headerBackground: string | null, pageTitle: string | null, headerLogoUrl: string | null, headerLogoAltText: string | null, favicon: string | null, featureFlags: { __typename?: 'ComponentAccountsFeatureFlags', syncConfirmedPageHideCTA: boolean | null, syncHidePromoAfterLogin: boolean | null } | null }, EmailFirstPage: { __typename?: 'ComponentAccountsPageConfig', logoUrl: string | null, logoAltText: string | null, headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null }, SignupSetPasswordPage: { __typename?: 'ComponentAccountsPageConfig', logoUrl: string | null, logoAltText: string | null, headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null }, SignupConfirmCodePage: { __typename?: 'ComponentAccountsPageConfig', headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null }, SignupConfirmedSyncPage: { __typename?: 'ComponentAccountsPageConfig', headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null } | null, SigninPage: { __typename?: 'ComponentAccountsPageConfig', headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null }, SigninTokenCodePage: { __typename?: 'ComponentAccountsPageConfig', headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null } | null, SigninUnblockCodePage: { __typename?: 'ComponentAccountsPageConfig', headline: string, description: string | null, primaryButtonText: string, pageTitle: string | null } | null, NewDeviceLoginEmail: { __typename?: 'ComponentAccountsEmailConfig', subject: string, headline: string, description: string } | null, VerifyLoginCodeEmail: { __typename?: 'ComponentAccountsEmailConfig', subject: string, headline: string, description: string } | null, VerifyShortCodeEmail: { __typename?: 'ComponentAccountsEmailConfig', subject: string, headline: string, description: string } | null } | null> };
 
 export type ServicesWithCapabilitiesQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/libs/shared/cms/src/lib/queries/relying-party/types.ts
+++ b/libs/shared/cms/src/lib/queries/relying-party/types.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export interface Page {
-  headline: string | null;
+  headline: string;
   description: string | null;
-  primaryButtonText: string | null;
+  primaryButtonText: string;
   logoUrl: string | null;
   logoAltText: string | null;
   pageTitle: string | null;
@@ -44,14 +44,14 @@ export interface RelyingPartyResult {
   entrypoint: string | null;
   name: string | null;
   l10nId: string;
-  EmailFirstPage?: Page;
-  SignupSetPasswordPage?: Page;
-  SignupConfirmCodePage?: Page;
-  SignupConfirmedSyncPage?: Page;
-  SigninPage?: Page;
+  EmailFirstPage: Page;
+  SignupSetPasswordPage: Page;
+  SignupConfirmCodePage: Page;
+  SignupConfirmedSyncPage: Page;
+  SigninPage: Page;
   SigninTokenCodePage?: Page;
   SigninUnblockCodePage?: Page;
-  shared?: Shared;
+  shared: Shared;
   NewDeviceLoginEmail?: Email;
   VerifyLoginCodeEmail?: Email;
   VerifyShortCodeEmail?: Email;

--- a/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`<AppLayout /> snapshots renders correctly with CMS: background wrapper 
 <div
   class="flex min-h-screen flex-col items-center tablet:[background:var(--cms-bg)]"
   data-testid="app"
-  style="--cms-bg: linear-gradient(135deg, #667eea 0%, #764ba2 100%);"
+  style="--cms-bg: linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%);"
 />
 `;
 
@@ -17,13 +17,13 @@ exports[`<AppLayout /> snapshots renders correctly with CMS: header background 1
 
 exports[`<AppLayout /> snapshots renders correctly with CMS: header logo 1`] = `
 <img
-  alt="Snapshot CMS Custom Logo"
+  alt="custom-header-logo"
   class="h-auto w-[140px] mx-0"
-  src="https://example.com/snapshot-cms-logo.png"
+  src="https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg"
 />
 `;
 
-exports[`<AppLayout /> snapshots renders correctly with CMS: title 1`] = `"Snapshot App - Custom Title | Mozilla accounts"`;
+exports[`<AppLayout /> snapshots renders correctly with CMS: title 1`] = `"MOCK Shared Title | Mozilla accounts"`;
 
 exports[`<AppLayout /> snapshots renders correctly without CMS: background wrapper 1`] = `
 <div

--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -17,7 +17,7 @@ import {
   MOCK_CMS_INFO_DEFAULT_LOGO,
   MOCK_CMS_INFO_HEADER_LOGO_WITH_OTHER_PROPS,
 } from './mocks';
-import { RelierCmsInfo } from '../../models';
+import { MOCK_CMS_INFO } from '../../pages/mocks';
 
 // Mock the useConfig hook
 jest.mock('../../models/hooks', () => ({
@@ -309,24 +309,8 @@ describe('<AppLayout />', () => {
 
   describe('snapshots', () => {
     it('renders correctly with CMS', () => {
-      const mockCmsInfo: RelierCmsInfo = {
-        name: 'Test App',
-        clientId: 'test123',
-        entrypoint: 'snapshot-test',
-        shared: {
-          headerLogoUrl: 'https://example.com/snapshot-cms-logo.png',
-          headerLogoAltText: 'Snapshot CMS Custom Logo',
-          buttonColor: '#0078d4',
-          logoUrl: 'https://example.com/snapshot-cms-logo.png',
-          logoAltText: 'Snapshot App Logo',
-          backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-          headerBackground: 'linear-gradient(135deg, #764ba2 0%, #667eea 100%)',
-          pageTitle: 'Snapshot App - Custom Title',
-        },
-      };
-
       const { container } = renderWithLocalizationProvider(
-        <AppLayout cmsInfo={mockCmsInfo}>
+        <AppLayout cmsInfo={MOCK_CMS_INFO}>
           <p>Hello, world!</p>
         </AppLayout>
       );
@@ -334,9 +318,7 @@ describe('<AppLayout />', () => {
       // title should have override
       const title = document.title;
       // header logo image
-      const headerLogo = screen.getByRole('img', {
-        name: mockCmsInfo.shared?.headerLogoAltText,
-      });
+      const headerLogo = screen.getByRole('img', { name: MOCK_CMS_INFO.shared.headerLogoAltText });
       // div containing the background styling. We use cloneNode to remove
       // child content so the snap is only the background styles we want to ensure
       // are getting passed through

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -61,7 +61,7 @@ export const AppLayout = ({
   const hasValidBackgroundImage = looseValidBgCheck(cmsBackgroundColor);
   const hasValidHeaderBackground = looseValidBgCheck(cmsHeaderBackground);
 
-  const favicon = cmsInfo?.shared?.favicon;
+  const favicon = cmsInfo?.shared.favicon;
 
   const showLocaleToggle =config.featureFlags?.showLocaleToggle;
 

--- a/packages/fxa-settings/src/components/AppLayout/mocks.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/mocks.tsx
@@ -4,7 +4,7 @@
 
 import { RelierCmsInfo } from '../../models/integrations';
 
-export const MOCK_CMS_INFO_VALID_LINEAR_BG: RelierCmsInfo = {
+export const MOCK_CMS_INFO_VALID_LINEAR_BG = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -15,9 +15,9 @@ export const MOCK_CMS_INFO_VALID_LINEAR_BG: RelierCmsInfo = {
     backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
     pageTitle: 'Test App - Custom Title',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_VALID_RADIAL_BG: RelierCmsInfo = {
+export const MOCK_CMS_INFO_VALID_RADIAL_BG = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -28,9 +28,9 @@ export const MOCK_CMS_INFO_VALID_RADIAL_BG: RelierCmsInfo = {
     backgroundColor: 'radial-gradient(circle, #ff6b6b, #4ecdc4)',
     pageTitle: 'Test App - Custom Title',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_NO_BG: RelierCmsInfo = {
+export const MOCK_CMS_INFO_NO_BG = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -40,9 +40,9 @@ export const MOCK_CMS_INFO_NO_BG: RelierCmsInfo = {
     logoAltText: 'Test App Logo',
     pageTitle: 'Test App - Custom Title',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_INVALID_BG_COLOR: RelierCmsInfo = {
+export const MOCK_CMS_INFO_INVALID_BG_COLOR = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -53,9 +53,9 @@ export const MOCK_CMS_INFO_INVALID_BG_COLOR: RelierCmsInfo = {
     backgroundColor: 'solid-color-red',
     pageTitle: 'Test App - Custom Title',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_WITH_PAGE_TITLE: RelierCmsInfo = {
+export const MOCK_CMS_INFO_WITH_PAGE_TITLE = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -65,9 +65,9 @@ export const MOCK_CMS_INFO_WITH_PAGE_TITLE: RelierCmsInfo = {
     logoAltText: 'Test App Logo',
     pageTitle: 'CMS Custom Title',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_NO_PAGE_TITLE: RelierCmsInfo = {
+export const MOCK_CMS_INFO_NO_PAGE_TITLE = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -76,9 +76,9 @@ export const MOCK_CMS_INFO_NO_PAGE_TITLE: RelierCmsInfo = {
     logoUrl: 'https://example.com/logo.png',
     logoAltText: 'Test App Logo',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_HEADER_LOGO: RelierCmsInfo = {
+export const MOCK_CMS_INFO_HEADER_LOGO = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -89,9 +89,9 @@ export const MOCK_CMS_INFO_HEADER_LOGO: RelierCmsInfo = {
     headerLogoUrl: 'https://example.com/cms-logo.png',
     headerLogoAltText: 'CMS Custom Logo',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_HEADER_LOGO_NO_ALT: RelierCmsInfo = {
+export const MOCK_CMS_INFO_HEADER_LOGO_NO_ALT = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -101,9 +101,9 @@ export const MOCK_CMS_INFO_HEADER_LOGO_NO_ALT: RelierCmsInfo = {
     logoAltText: undefined,
     headerLogoUrl: 'https://example.com/cms-logo.png',
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_DEFAULT_LOGO: RelierCmsInfo = {
+export const MOCK_CMS_INFO_DEFAULT_LOGO = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -112,9 +112,9 @@ export const MOCK_CMS_INFO_DEFAULT_LOGO: RelierCmsInfo = {
     logoUrl: undefined,
     logoAltText: undefined,
   },
-};
+} as RelierCmsInfo;
 
-export const MOCK_CMS_INFO_HEADER_LOGO_WITH_OTHER_PROPS: RelierCmsInfo = {
+export const MOCK_CMS_INFO_HEADER_LOGO_WITH_OTHER_PROPS = {
   name: 'Test App',
   clientId: 'test123',
   entrypoint: 'test',
@@ -127,7 +127,7 @@ export const MOCK_CMS_INFO_HEADER_LOGO_WITH_OTHER_PROPS: RelierCmsInfo = {
     backgroundColor: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
     pageTitle: 'Test App - Custom Title',
   },
-};
+} as RelierCmsInfo;
 
 export const INTEGRATION_WITH_UNDEFINED_GETCMSINFO = {
   getCmsInfo: () => undefined,

--- a/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
+++ b/packages/fxa-settings/src/components/ButtonDownloadRecoveryKeyPDF/index.tsx
@@ -154,7 +154,7 @@ export const ButtonDownloadRecoveryKeyPDF = ({
             await downloadFile();
             navigateForward && navigateForward();
           }}
-          buttonColor={cmsInfo?.shared?.buttonColor}
+          buttonColor={cmsInfo?.shared.buttonColor}
         >
           Download and continue
         </CmsButtonWithFallback>

--- a/packages/fxa-settings/src/components/CmsButtonWithFallback/index.tsx
+++ b/packages/fxa-settings/src/components/CmsButtonWithFallback/index.tsx
@@ -95,7 +95,7 @@ const CmsButtonWithFallback: React.FC<CmsButtonWithFallbackProps> = ({
         isCms ? 'cta-primary-cms' : 'cta-primary',
         'cta-xl',
         {
-          // add a text-shadow if the CMS background color does not meet color contast
+          // add a text-shadow if the CMS background color does not meet color contrast
           // standards, as our CTA button text is always white
           'text-shadow-cms': isCms && buttonColor && !hasSufficientContrast(buttonColor.trim(), '#ffffff'),
         },

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`InlineRecoveryKeySetupCreate renders button with CMS passthrough 1`] = 
 <button
   class="cta-primary-cms cta-xl flex justify-center items-center"
   data-glean-id="inline_recovery_key_cta_submit"
-  style="--cta-bg: #000000; --cta-border: #000000; --cta-active: #000000; --cta-disabled: #00000060;"
+  style="--cta-bg: #D41C1C; --cta-border: #D41C1C; --cta-active: #D41C1C; --cta-disabled: #D41C1C60;"
   type="submit"
 >
   <span

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.test.tsx
@@ -5,7 +5,7 @@
 import { screen } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';
-import { RelierCmsInfo } from '../../models';
+import { MOCK_CMS_INFO } from '../../pages/mocks';
 
 describe('InlineRecoveryKeySetupCreate', () => {
   it('renders as expected', () => {
@@ -39,20 +39,11 @@ describe('InlineRecoveryKeySetupCreate', () => {
   });
 
   it('renders button with CMS passthrough', () => {
-    const cmsInfo: RelierCmsInfo = {
-      name: '',
-      clientId: '',
-      entrypoint: '',
-      shared: {
-        buttonColor: '#000000',
-        logoUrl: '',
-        logoAltText: ''
-      }
-    };
+
     // in this test, we don't want the full container, only the button that
     // cms info is passed onto to ensure we're still passing through
     renderWithLocalizationProvider(
-      <Subject cmsInfo={cmsInfo} />
+      <Subject cmsInfo={MOCK_CMS_INFO} />
     );
 
     const cmsButton = screen.queryByRole('button', {

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/index.tsx
@@ -82,7 +82,7 @@ export const InlineRecoveryKeySetupCreate = ({
           onClick={createRecoveryKey}
           disabled={isLoading}
           data-glean-id="inline_recovery_key_cta_submit"
-          buttonColor={cmsInfo?.shared?.buttonColor}
+          buttonColor={cmsInfo?.shared.buttonColor}
         >
           <FtlMsg id="inline-recovery-key-setup-start-button">
             Create account recovery key

--- a/packages/fxa-settings/src/components/Ready/index.tsx
+++ b/packages/fxa-settings/src/components/Ready/index.tsx
@@ -117,7 +117,7 @@ const Ready = ({
 
   const cmsInfo = integration?.getCmsInfo();
   const cmsButton = {
-    color: cmsInfo?.shared?.buttonColor,
+    color: cmsInfo?.shared.buttonColor,
   };
 
   return (

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/__snapshots__/index.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`RecoveryKeySetupDownload renders button with CMS passthrough 1`] = `
 <button
-  class="cta-primary-cms cta-xl text-shadow-cms w-full mt-4"
-  style="--cta-bg: #FF0000; --cta-border: #FF0000; --cta-active: #FF0000; --cta-disabled: #FF000060;"
+  class="cta-primary-cms cta-xl w-full mt-4"
+  style="--cta-bg: #D41C1C; --cta-border: #D41C1C; --cta-active: #D41C1C; --cta-disabled: #D41C1C60;"
 >
   Download and continue
 </button>

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.test.tsx
@@ -6,8 +6,7 @@ import React from 'react';
 import { screen, waitFor, within } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Subject } from './mocks';
-import { MOCK_RECOVERY_KEY_WITH_SPACES } from '../../pages/mocks';
-import { RelierCmsInfo } from '../../models';
+import { MOCK_CMS_INFO, MOCK_RECOVERY_KEY_WITH_SPACES } from '../../pages/mocks';
 
 describe('RecoveryKeySetupDownload', () => {
   it('renders as expected', async () => {
@@ -43,18 +42,8 @@ describe('RecoveryKeySetupDownload', () => {
   // so we have a separate test that targets just the thing that
   // cms is passed through to, the `Download and continue` button.
   it('renders button with CMS passthrough', () => {
-    const mockCmsInfo: RelierCmsInfo = {
-      name: '',
-      clientId: '',
-      entrypoint: '',
-      shared: {
-        buttonColor: '#FF0000',
-        logoUrl: 'https://example.com/logo.png',
-        logoAltText: 'Example Logo',
-      },
-    };
     renderWithLocalizationProvider(
-      <Subject cmsInfo={mockCmsInfo} />
+      <Subject cmsInfo={MOCK_CMS_INFO} />
     );
     const cmsButton = screen.getByRole('button', { name: 'Download and continue' });
     expect(cmsButton).toMatchSnapshot();

--- a/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupHint/index.tsx
@@ -160,7 +160,7 @@ export const RecoveryKeySetupHint = ({
             className="cta-primary cta-xl w-full mt-4 mb-4"
             type="submit"
             disabled={isSubmitDisabled}
-            buttonColor={cmsInfo?.shared?.buttonColor}
+            buttonColor={cmsInfo?.shared.buttonColor}
           >
             Finish
           </CmsButtonWithFallback>

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faApp/index.tsx
@@ -149,7 +149,7 @@ export const FlowSetup2faApp = ({
           'Continue'
         )}
         verifyCode={handleCode}
-        cmsButton={{ color: cmsInfo?.shared?.buttonColor }}
+        cmsButton={{ color: cmsInfo?.shared.buttonColor }}
       />
     </FlowContainer>
   );

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faPrompt/index.tsx
@@ -92,7 +92,7 @@ export const FlowSetup2faPrompt = ({
           type="submit"
           className="cta-primary cta-xl w-full"
           onClick={onContinue}
-          buttonColor={cmsInfo?.shared?.buttonColor}
+          buttonColor={cmsInfo?.shared.buttonColor}
         >
           Continue
         </CmsButtonWithFallback>

--- a/packages/fxa-settings/src/models/integrations/integration.ts
+++ b/packages/fxa-settings/src/models/integrations/integration.ts
@@ -165,36 +165,7 @@ export class GenericIntegration<
   }
 
   getCmsInfo() {
-    const isCmsEnabled = (cmsInfo?: RelierCmsInfo): boolean => {
-      if (
-        !cmsInfo?.EmailFirstPage ||
-        !cmsInfo?.SignupConfirmCodePage ||
-        !cmsInfo?.SignupSetPasswordPage ||
-        !cmsInfo?.SigninPage ||
-        !cmsInfo.shared
-      ) {
-        return false;
-      }
-
-      const requiredFields = [
-        cmsInfo.EmailFirstPage.headline,
-        cmsInfo.EmailFirstPage.primaryButtonText,
-
-        cmsInfo.SignupConfirmCodePage.headline,
-        cmsInfo.SignupConfirmCodePage.primaryButtonText,
-
-        cmsInfo.SignupSetPasswordPage.headline,
-        cmsInfo.SignupSetPasswordPage.primaryButtonText,
-
-        cmsInfo.SigninPage.headline,
-        cmsInfo.SigninPage.description,
-      ];
-
-      return requiredFields.every((field) => !!field);
-    };
-
-    return this.cmsInfo && isCmsEnabled(this.cmsInfo)
-      ? this.cmsInfo
-      : undefined;
+    // Still check for an empty object and only return if not empty.
+    return Object.keys(this.cmsInfo || {}).length > 0 ? this.cmsInfo : undefined;
   }
 }

--- a/packages/fxa-settings/src/models/integrations/relier-interfaces.ts
+++ b/packages/fxa-settings/src/models/integrations/relier-interfaces.ts
@@ -28,9 +28,9 @@ export interface RelierAccount {
 }
 
 export interface PageRelierCmsInfo {
-  headline: string | undefined;
+  headline: string;
   description: string | undefined;
-  primaryButtonText: string | undefined;
+  primaryButtonText: string;
   pageTitle?: string | undefined;
 }
 
@@ -61,15 +61,15 @@ export interface RelierCmsInfo {
   name: string;
   clientId: string;
   entrypoint: string;
-  shared?: SharedRelierCmsInfo;
+  shared: SharedRelierCmsInfo;
 
-  EmailFirstPage?: PageRelierCmsInfoWithLogo;
+  EmailFirstPage: PageRelierCmsInfoWithLogo;
 
-  SignupSetPasswordPage?: PageRelierCmsInfoWithLogo;
-  SignupConfirmCodePage?: PageRelierCmsInfo;
+  SignupSetPasswordPage: PageRelierCmsInfoWithLogo;
+  SignupConfirmCodePage: PageRelierCmsInfo;
   SignupConfirmedSyncPage?: PageRelierCmsInfo;
 
-  SigninPage?: PageRelierCmsInfo;
+  SigninPage: PageRelierCmsInfo;
   SigninTotpCodePage?: PageRelierCmsInfo;
   SigninTokenCodePage?: PageRelierCmsInfo;
   SigninUnblockCodePage?: PageRelierCmsInfo;

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -109,13 +109,13 @@ export const Index = ({
           <CmsLogo
             {...{
               isMobile,
-              logos: [cmsInfo?.EmailFirstPage, cmsInfo?.shared],
-              logoPosition: cmsInfo?.EmailFirstPage?.logoUrl ? 'center' : 'left',
+              logos: [cmsInfo.EmailFirstPage, cmsInfo.shared],
+              logoPosition: cmsInfo.EmailFirstPage.logoUrl ? 'center' : 'left',
             }}
           />
-          <h1 className="card-header">{cmsInfo?.EmailFirstPage?.headline}</h1>
+          <h1 className="card-header">{cmsInfo.EmailFirstPage.headline}</h1>
           <p className="mt-1 mb-9 text-sm">
-            {cmsInfo?.EmailFirstPage?.description}
+            {cmsInfo.EmailFirstPage.description}
           </p>
         </>
       ) : isSync ? (
@@ -187,8 +187,8 @@ export const Index = ({
               type="submit"
               data-glean-id="email_first_submit"
               disabled={isSubmitting}
-              buttonColor={cmsInfo?.shared?.buttonColor}
-              buttonText={cmsInfo?.EmailFirstPage?.primaryButtonText}
+              buttonColor={cmsInfo?.shared.buttonColor}
+              buttonText={cmsInfo?.EmailFirstPage.primaryButtonText}
             >
               Sign up or sign in
             </CmsButtonWithFallback>

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -136,14 +136,14 @@ const SigninRecoveryChoice = ({
 
   const cmsInfo = integration?.getCmsInfo();
   const cmsButton = {
-    color: cmsInfo?.shared?.buttonColor,
+    color: cmsInfo?.shared.buttonColor,
   };
 
   return (
     <AppLayout cmsInfo={cmsInfo}>
       <div className="relative flex items-center mb-5">
-        <ButtonBack cmsBackgroundColor={cmsInfo?.shared?.backgroundColor} />
-        {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (
+        <ButtonBack cmsBackgroundColor={cmsInfo?.shared.backgroundColor} />
+        {cmsInfo?.shared.logoUrl && cmsInfo.shared.logoAltText ? (
           <img
             src={cmsInfo.shared.logoUrl}
             alt={cmsInfo.shared.logoAltText}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -212,8 +212,8 @@ const SigninRecoveryCode = ({
   return (
     <AppLayout cmsInfo={cmsInfo}>
       <div className="relative flex items-center mb-5">
-        <ButtonBack cmsBackgroundColor={cmsInfo?.shared?.backgroundColor} />
-        {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (
+        <ButtonBack cmsBackgroundColor={cmsInfo?.shared.backgroundColor} />
+        {cmsInfo?.shared.logoUrl && cmsInfo.shared.logoAltText ? (
           <img
             src={cmsInfo.shared.logoUrl}
             alt={cmsInfo.shared.logoAltText}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -164,8 +164,8 @@ const SigninRecoveryPhone = ({
     <AppLayout cmsInfo={cmsInfo}>
 
       <div className="relative flex items-center">
-        <ButtonBack cmsBackgroundColor={cmsInfo?.shared?.backgroundColor} />
-        {cmsInfo?.shared?.logoUrl && cmsInfo.shared?.logoAltText ? (
+        <ButtonBack cmsBackgroundColor={cmsInfo?.shared.backgroundColor} />
+        {cmsInfo?.shared.logoUrl && cmsInfo.shared.logoAltText ? (
           <img
             src={cmsInfo.shared.logoUrl}
             alt={cmsInfo.shared.logoAltText}
@@ -241,7 +241,7 @@ const SigninRecoveryPhone = ({
         gleanDataAttrs={{ id: 'login_backup_phone_submit' }}
         className="my-6"
         cmsButton={{
-          color: cmsInfo?.shared?.buttonColor
+          color: cmsInfo?.shared.buttonColor
         }}
       />
       <div className="flex justify-between mt-5 text-sm">

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -214,8 +214,8 @@ const SigninTokenCode = ({
         headingText="Enter confirmation code"
         headingAndSubheadingFtlId="signin-token-code-heading-2"
         {...{
-          cmsLogoUrl: cmsInfo?.shared?.logoUrl,
-          cmsLogoAltText: cmsInfo?.shared?.logoAltText,
+          cmsLogoUrl: cmsInfo?.shared.logoUrl,
+          cmsLogoAltText: cmsInfo?.shared.logoAltText,
           cmsHeadline: cmsInfo?.SigninTokenCodePage?.headline,
           cmsDescription: cmsInfo?.SigninTokenCodePage?.description,
         }}
@@ -267,7 +267,7 @@ const SigninTokenCode = ({
           codeErrorMessage,
           setCodeErrorMessage,
           cmsButton: {
-            color: cmsInfo?.shared?.buttonColor,
+            color: cmsInfo?.shared.buttonColor,
           },
         }}
       />

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -125,7 +125,7 @@ export const SigninTotpCode = ({
     <AppLayout {...{ cmsInfo, title }}>
       {cmsInfo ? (
         <>
-          {cmsInfo.shared?.logoUrl && cmsInfo.shared?.logoAltText && (
+          {cmsInfo.shared.logoUrl && cmsInfo.shared.logoAltText && (
             <img
               src={cmsInfo.shared.logoUrl}
               alt={cmsInfo.shared.logoAltText}
@@ -182,7 +182,7 @@ export const SigninTotpCode = ({
         verifyCode={onSubmit}
         className="my-6"
         cmsButton={{
-          color: cmsInfo?.shared?.buttonColor,
+          color: cmsInfo?.shared.buttonColor,
         }}
       />
       <div className="mt-8 link-blue text-sm flex justify-between">

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -214,8 +214,8 @@ export const SigninUnblock = ({
         headingText="Authorize this sign-in"
         headingTextFtlId="signin-unblock-header"
         {...{
-          cmsLogoUrl: cmsInfo?.shared?.logoUrl,
-          cmsLogoAltText: cmsInfo?.shared?.logoAltText,
+          cmsLogoUrl: cmsInfo?.shared.logoUrl,
+          cmsLogoAltText: cmsInfo?.shared.logoAltText,
           cmsHeadline: cmsInfo?.SigninUnblockCodePage?.headline,
           cmsDescription: cmsInfo?.SigninUnblockCodePage?.description,
         }}
@@ -253,7 +253,7 @@ export const SigninUnblock = ({
           setCodeErrorMessage,
           isLoading,
           cmsButton: {
-            color: cmsInfo?.shared?.buttonColor,
+            color: cmsInfo?.shared.buttonColor,
             text: cmsInfo?.SigninUnblockCodePage?.primaryButtonText,
           },
         }}

--- a/packages/fxa-settings/src/pages/Signin/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/pages/Signin/__snapshots__/index.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`Signin component snapshots - CMS renders AppLayout with CMS header logo 1`] = `
 <img
-  alt="SNAPSHOT_TEST Shared Alt text for header logo"
+  alt="custom-header-logo"
   class="h-auto w-[140px] mx-0"
-  src="https://example.com/SNAPSHOT_TEST_header.png"
+  src="https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg"
 />
 `;
 
@@ -12,7 +12,7 @@ exports[`Signin component snapshots - CMS renders CardHeader with CMS content wh
 <p
   class="card-subheader"
 >
-  SNAPSHOT_TEST Custom CMS Description
+  for your Mozilla account
 </p>
 `;
 
@@ -20,30 +20,30 @@ exports[`Signin component snapshots - CMS renders CardHeader with CMS content wh
 <h1
   class="card-header"
 >
-  SNAPSHOT_TEST Custom CMS Headline
+  Enter your password
 </h1>
 `;
 
 exports[`Signin component snapshots - CMS renders CardHeader with CMS content when password is needed: cms logo 1`] = `
 <img
-  alt="SNAPSHOT_TEST Shared Alt text for logo"
+  alt="logo"
   class="justify-start mb-4 max-h-[40px]"
-  src="https://example.com/SNAPSHOT_TEST.png"
+  src="https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg"
 />
 `;
 
 exports[`Signin component snapshots - CMS renders CardHeader with CMS content when password is not needed 1`] = `
 <img
-  alt="SNAPSHOT_TEST Shared Alt text for logo"
+  alt="logo"
   class="justify-start mb-4 max-h-[40px]"
-  src="https://example.com/SNAPSHOT_TEST.png"
+  src="https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg"
 />
 `;
 
 exports[`Signin component snapshots - CMS renders the CMS-styled submit button 1`] = `
 <button
-  class="cta-primary-cms cta-xl text-shadow-cms cta-primary cta-xl"
-  style="--cta-bg: blue; --cta-border: blue; --cta-active: blue; --cta-disabled: blue60;"
+  class="cta-primary-cms cta-xl cta-primary cta-xl"
+  style="--cta-bg: #D41C1C; --cta-border: #D41C1C; --cta-active: #D41C1C; --cta-disabled: #D41C1C60;"
   type="submit"
 >
   Sign in

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -25,6 +25,7 @@ import {
   Subject,
 } from './mocks';
 import {
+  MOCK_CMS_INFO,
   MOCK_EMAIL,
   MOCK_KEY_FETCH_TOKEN,
   MOCK_OAUTH_FLOW_HANDLER_RESPONSE,
@@ -46,7 +47,7 @@ import {
 } from '../../models/integrations/client-matching';
 import firefox from '../../lib/channels/firefox';
 import { navigate } from '@reach/router';
-import { IntegrationType } from '../../models';
+import { IntegrationType, RelierCmsInfo } from '../../models';
 import { SensitiveData } from '../../lib/sensitive-data-client';
 import userEvent, { UserEvent } from '@testing-library/user-event';
 import * as SigninUtils from './utils';
@@ -1366,38 +1367,19 @@ describe('Signin component', () => {
   });
 
   describe('snapshots - CMS', () => {
-    // The purpose of these snapshots is to ensure that we've implemented the pass
-    // through of CMS data to appropriate components. Because we also have snapshots
-    // on the components we don't need to test with cms "off"
+
     const cmsProps = {
-      cmsInfo: {
-        shared: {
-          logoUrl: 'https://example.com/SNAPSHOT_TEST.png',
-          logoAltText: 'SNAPSHOT_TEST Shared Alt text for logo',
-          buttonColor: 'blue',
-          headerLogoUrl: 'https://example.com/SNAPSHOT_TEST_header.png',
-          headerLogoAltText: 'SNAPSHOT_TEST Shared Alt text for header logo',
-          pageTitle: 'SNAPSHOT_TEST Shared page title',
-          backgroundColor: 'yellow',
-          favicon: 'https://example.com/SNAPSHOT_TEST_favicon.ico',
-        },
-        SigninPage: {
-          headline: 'SNAPSHOT_TEST Custom CMS Headline',
-          description: 'SNAPSHOT_TEST Custom CMS Description',
-          primaryButtonText: 'SNAPSHOT_TEST Custom CMS Button Text',
-        },
-        // these aren't used in the Signin page, but are here to ensure consistency
-        name: 'SNAPSHOT_TEST name',
-        clientId: 'SNAPSHOT_TEST_clientId',
-        entrypoint: 'SNAPSHOT_TEST_entrypoint',
-      },
-    };
+      cmsInfo: MOCK_CMS_INFO
+    }
 
     beforeEach(() => {
       HTMLFormElement.prototype.submit = jest.fn();
     });
 
     it('sets the shared page title from CMS', () => {
+      // Ensure pageTitle is not available on SigninPage, cast to type
+      // to allow undefined
+      (cmsProps.cmsInfo as RelierCmsInfo).SigninPage.pageTitle = undefined;
       render({ integration: createMockSigninWebIntegration(cmsProps) });
 
       expect(document.title).toBe(

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -370,7 +370,7 @@ const Signin = ({
   }
 
   const cmsInfo = integration.getCmsInfo();
-  const title = cmsInfo?.SigninPage?.pageTitle;
+  const title = cmsInfo?.SigninPage.pageTitle;
 
   return (
     <AppLayout {...{ cmsInfo, title }}>
@@ -388,10 +388,10 @@ const Signin = ({
           headingText="Enter your password"
           headingAndSubheadingFtlId="signin-password-needed-header-2"
           {...{
-            cmsLogoUrl: cmsInfo?.shared?.logoUrl,
-            cmsLogoAltText: cmsInfo?.shared?.logoAltText,
-            cmsHeadline: cmsInfo?.SigninPage?.headline,
-            cmsDescription: cmsInfo?.SigninPage?.description,
+            cmsLogoUrl: cmsInfo?.shared.logoUrl,
+            cmsLogoAltText: cmsInfo?.shared.logoAltText,
+            cmsHeadline: cmsInfo?.SigninPage.headline,
+            cmsDescription: cmsInfo?.SigninPage.description,
           }}
         />
       ) : (
@@ -404,8 +404,8 @@ const Signin = ({
           {...{
             clientId,
             serviceName,
-            cmsLogoUrl: cmsInfo?.shared?.logoUrl,
-            cmsLogoAltText: cmsInfo?.shared?.logoAltText,
+            cmsLogoUrl: cmsInfo?.shared.logoUrl,
+            cmsLogoAltText: cmsInfo?.shared.logoAltText,
           }}
         />
       )}
@@ -497,7 +497,7 @@ const Signin = ({
                 className="cta-primary cta-xl"
                 type="submit"
                 disabled={signinLoading}
-                buttonColor={cmsInfo?.shared?.buttonColor}
+                buttonColor={cmsInfo?.shared.buttonColor}
               >
                 Sign in
               </CmsButtonWithFallback>

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -201,7 +201,7 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
   // default is to navigate to settings
   const cmsInfo = integration?.getCmsInfo();
   if (
-    cmsInfo?.shared?.featureFlags?.syncHidePromoAfterLogin &&
+    cmsInfo?.shared.featureFlags?.syncHidePromoAfterLogin &&
     integration.isSync()
   ) {
     navigationOptions.showInlineRecoveryKeySetup = false;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -315,19 +315,19 @@ const ConfirmSignupCode = ({
     <AppLayout {...{ cmsInfo, title }}>
       {cmsInfo ? (
         <>
-          {cmsInfo?.shared?.logoUrl && cmsInfo?.shared?.logoAltText && (
+          {cmsInfo.shared.logoUrl && cmsInfo.shared.logoAltText && (
             <img
               data-testid="cms-logo"
-              src={cmsInfo?.shared.logoUrl}
-              alt={cmsInfo?.shared.logoAltText}
+              src={cmsInfo.shared.logoUrl}
+              alt={cmsInfo.shared.logoAltText}
               className="justify-start mb-4 max-h-[40px]"
             />
           )}
           <h1 className="card-header">
-            {cmsInfo?.SignupConfirmCodePage?.headline}
+            {cmsInfo.SignupConfirmCodePage.headline}
           </h1>
           <p className="mt-1 text-sm">
-            {cmsInfo?.SignupConfirmCodePage?.description}
+            {cmsInfo.SignupConfirmCodePage.description}
           </p>
         </>
       ) : (
@@ -378,8 +378,8 @@ const ConfirmSignupCode = ({
           setCodeErrorMessage,
           submitFormOnPaste,
           cmsButton: {
-            text: cmsInfo?.SignupConfirmCodePage?.primaryButtonText,
-            color: cmsInfo?.shared?.buttonColor,
+            text: cmsInfo?.SignupConfirmCodePage.primaryButtonText,
+            color: cmsInfo?.shared.buttonColor,
           },
         }}
       />

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
@@ -40,9 +40,9 @@ const SignupConfirmedSync = ({
   const showPairLink = integration.isDesktopSync();
 
   const cmsInfo = integration.getCmsInfo();
-  const cmsButtonColor = cmsInfo?.shared?.buttonColor;
+  const cmsButtonColor = cmsInfo?.shared.buttonColor;
   const cmsButtonText = cmsInfo?.SignupConfirmedSyncPage?.primaryButtonText;
-  const cmsHideCTA = !!cmsInfo?.shared?.featureFlags?.syncConfirmedPageHideCTA;
+  const cmsHideCTA = !!cmsInfo?.shared.featureFlags?.syncConfirmedPageHideCTA;
   const title = cmsInfo?.SignupConfirmedSyncPage?.pageTitle;
 
   return (

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -289,15 +289,15 @@ export const Signup = ({
           <CmsLogo
             {...{
               isMobile,
-              logos: [cmsInfo?.SignupSetPasswordPage, cmsInfo?.shared],
-              logoPosition: cmsInfo?.SignupSetPasswordPage?.logoUrl ? 'center' : 'left',
+              logos: [cmsInfo.SignupSetPasswordPage, cmsInfo.shared],
+              logoPosition: cmsInfo.SignupSetPasswordPage.logoUrl ? 'center' : 'left',
             }}
           />
           <h1 className="card-header">
-            {cmsInfo?.SignupSetPasswordPage?.headline}
+            {cmsInfo.SignupSetPasswordPage.headline}
           </h1>
           <p className="mt-1 text-sm">
-            {cmsInfo?.SignupSetPasswordPage?.description}
+            {cmsInfo.SignupSetPasswordPage.description}
           </p>
         </>
       ) : (
@@ -406,8 +406,8 @@ export const Signup = ({
           requirePasswordConfirmation: isSync,
           setSelectedNewsletterSlugs,
           cmsButton: {
-            text: cmsInfo?.SignupSetPasswordPage?.primaryButtonText,
-            color: cmsInfo?.shared?.buttonColor,
+            text: cmsInfo?.SignupSetPasswordPage.primaryButtonText,
+            color: cmsInfo?.shared.buttonColor,
           },
         }}
         loading={beginSignupLoading}

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -101,25 +101,29 @@ export const MOCK_CMS_INFO = {
   name: '123Done - app',
   shared: {
     buttonColor: '#D41C1C',
-    logoUrl:
-      'https://gist.githubusercontent.com/dschom/857ebb2abd5f75937f211f1fd6bbf9a8/raw/33037c8905757a594e07eb29818d8519447fdec0/nightly-logo.svg',
+    logoUrl: 'https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg',
+    headerLogoUrl: 'https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg',
     logoAltText: 'logo',
-    backgroundColor:
-      'linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%)',
+    backgroundColor: 'linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%)',
+    headerBackground: 'linear-gradient(135deg, #764ba2 0%, #667eea 100%)',
+    headerLogoAltText: 'custom-header-logo',
+    pageTitle: 'MOCK Shared Title',
+    featureFlags: {
+      syncConfirmedPageHideCTA: false,
+      syncHidePromoAfterLogin: false,
+    },
+    favicon: ''
   },
   EmailFirstPage: {
-    logoUrl:
-      'https://gist.githubusercontent.com/dschom/c754b76333cda59f50845fe9b0ff6d52/raw/157b0af53142b24e0ddae936c711c010428e7bba/foxy-logo.svg',
+    logoUrl: 'https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg',
     logoAltText: 'custom-email-first-logo',
     headline: 'Sign up or sign in to your Mozilla account',
-    description:
-      'Stay protected with continuous data monitoring and automatic data removal.',
+    description: 'Stay protected with continuous data monitoring and automatic data removal.',
     primaryButtonText: 'Continue',
     pageTitle: 'Sign up or sign in to your Mozilla account',
   },
   SignupSetPasswordPage: {
-    logoUrl:
-      'https://gist.githubusercontent.com/dschom/c754b76333cda59f50845fe9b0ff6d52/raw/157b0af53142b24e0ddae936c711c010428e7bba/foxy-logo.svg',
+    logoUrl: 'https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg',
     logoAltText: 'custom-signup-logo',
     headline: 'Create a password',
     description: 'to continue',
@@ -134,8 +138,7 @@ export const MOCK_CMS_INFO = {
   },
   SignupConfirmedSyncPage: {
     headline: 'Sync is turned on',
-    description:
-      'Your passwords, addresses, bookmarks, history, and more can sync everywhere you use Firefox.',
+    description: 'Your passwords, addresses, bookmarks, history, and more can sync everywhere you use Firefox.',
     primaryButtonText: 'Add another device',
     pageTitle: 'Sync is turned on',
   },
@@ -158,6 +161,12 @@ export const MOCK_CMS_INFO = {
     primaryButtonText: 'Continue',
     pageTitle: 'Authorize this sign-in',
   },
+  SigninTotpCodePage: {
+    headline: 'Enter verification code',
+    description: 'for your Mozilla account',
+    primaryButtonText: 'Continue',
+    pageTitle: 'Enter verification code',
+  }
 };
 
 export const createMockIntegrationWithCms = () =>


### PR DESCRIPTION
Because:
 - We want to make it clearer which pages and properties are required for Accounts CMS

This Commit:
 - Makes several pages and properties of pages required for RelierCmsInfo
 - Updates references to these properties to remove null coalescing
 - Updates tests to use shared MOCK_CMS_INFO

## Issue that this pull request solves

Closes: #FXA-12286

[Sister pr](https://github.com/mozilla/fxa-strapi/pull/112)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)


