### PR TITLE
feat(payments-management): Add Paypal billingagreement support

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/manage/en.ftl
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/en.ftl
@@ -7,6 +7,8 @@ subscription-management-button-add-payment-method-aria = Add payment method
 subscription-management-button-add-payment-method = Add
 subscription-management-button-change-payment-method-aria = Change payment method
 subscription-management-button-change-payment-method = Change
+subscription-management-button-manage-payment-method-aria = Manage payment method
+subscription-management-button-manage-payment-method = Manage
 # $last4 (String) - Last four numbers of credit card
 subscription-management-card-ending-in = Card ending in { $last4 }
 # $expirationDate (Date) - Payment card's expiration date
@@ -35,3 +37,5 @@ subscription-management-page-subscription-interval-weekly = { $productName } (we
 subscription-management-page-subscription-interval-monthly = { $productName } (monthly)
 subscription-management-page-subscription-interval-halfyearly = { $productName } (6-month)
 subscription-management-page-subscription-interval-yearly = { $productName } (yearly)
+subscription-management-page-paypal-error-banner = Invalid payment information; there is an error with your account.
+subscription-management-page-paypal-error-banner-link = Manage

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { URLSearchParams } from 'url';
 
 import {
+  AlertBar,
   formatPlanInterval,
   getCardIcon,
   ManageParams,
@@ -53,15 +54,18 @@ export default async function Manage({
   } = await getSubManPageContentAction(session.user?.id);
   const { billingAgreementId, brand, expMonth, expYear, last4, type } =
     defaultPaymentMethod || {};
+  const isPaypalBillingAgreementError =
+    type === 'external_paypal' && brand === 'paypal' && !billingAgreementId;
   const expirationDate =
     expMonth && expYear
       ? l10n.getLocalizedMonthYearString(expMonth, expYear, locale)
       : undefined;
 
-  const CSS_PRIMARY_LINK =
-    "flex items-center justify-center h-10 rounded-md p-4 z-10 cursor-pointer aria-disabled:relative aria-disabled:after:absolute aria-disabled:after:content-[''] aria-disabled:after:top-0 aria-disabled:after:left-0 aria-disabled:after:w-full aria-disabled:after:h-full aria-disabled:after:bg-white aria-disabled:after:opacity-50 aria-disabled:after:z-30 aria-disabled:border-none bg-blue-500 font-semibold hover:bg-blue-700 text-white";
-  const CSS_SECONDARY_LINK =
-    "flex items-center justify-center h-10 rounded-md p-4 z-10 cursor-pointer aria-disabled:relative aria-disabled:after:absolute aria-disabled:after:content-[''] aria-disabled:after:top-0 aria-disabled:after:left-0 aria-disabled:after:w-full aria-disabled:after:h-full aria-disabled:after:bg-white aria-disabled:after:opacity-50 aria-disabled:after:z-30 aria-disabled:border-none bg-grey-100 font-semibold hover:bg-grey-200 text-black";
+  const CSS_LINK_SHARED =
+    "flex items-center justify-center h-10 rounded-md p-4 z-10 cursor-pointer aria-disabled:relative aria-disabled:after:absolute aria-disabled:after:content-[''] aria-disabled:after:top-0 aria-disabled:after:left-0 aria-disabled:after:w-full aria-disabled:after:h-full aria-disabled:after:bg-white aria-disabled:after:opacity-50 aria-disabled:after:z-30 aria-disabled:border-none font-semibold";
+  const CSS_PRIMARY_LINK = `${CSS_LINK_SHARED} bg-blue-500 hover:bg-blue-700 text-white`;
+  const CSS_SECONDARY_LINK = `${CSS_LINK_SHARED} bg-grey-100 hover:bg-grey-200 text-black`;
+  const CSS_ERROR_LINK = `${CSS_LINK_SHARED} bg-red-500 hover:bg-red-600 text-white`;
 
   const getSubscriptionIntervalFtlId = (interval: string) => {
     switch (interval) {
@@ -80,6 +84,26 @@ export default async function Manage({
   };
   return (
     <>
+      {isPaypalBillingAgreementError && (
+        <AlertBar>
+          <span className={'font-semibold'}>
+            {l10n.getString(
+              'subscription-management-page-paypal-error-banner',
+              'Invalid payment information; there is an error with your account.'
+            )}
+
+            <Link
+              className={'underline hover:text-grey-100 pl-1'}
+              href={`${config.paymentsNextHostedUrl}/${locale}/subscriptions/payments/paypal`}
+            >
+              {l10n.getString(
+                'subscription-management-page-paypal-error-banner-link',
+                'Manage'
+              )}
+            </Link>
+          </span>
+        </AlertBar>
+      )}
       {accountCreditBalance.balance > 0 &&
         accountCreditBalance.currency !== null && (
           <>
@@ -235,21 +259,39 @@ export default async function Manage({
                   />
                 </div>
 
-                <LinkExternal
-                  className={CSS_SECONDARY_LINK}
-                  href={`${config.csp.paypalApi}/myaccount/autopay/connect/${billingAgreementId}`}
-                  aria-label={l10n.getString(
-                    'subscription-management-button-change-payment-method-aria',
-                    'Change payment method'
-                  )}
-                >
-                  <span>
-                    {l10n.getString(
-                      'subscription-management-button-change-payment-method',
-                      'Change'
+                {isPaypalBillingAgreementError ? (
+                  <LinkExternal
+                    className={CSS_ERROR_LINK}
+                    href={`${config.paymentsNextHostedUrl}/${locale}/subscriptions/payments/paypal`}
+                    aria-label={l10n.getString(
+                      'subscription-management-button-manage-payment-method-aria',
+                      'Manage payment method'
                     )}
-                  </span>
-                </LinkExternal>
+                  >
+                    <span>
+                      {l10n.getString(
+                        'subscription-management-button-manage-payment-method',
+                        'Manage'
+                      )}
+                    </span>
+                  </LinkExternal>
+                ) : (
+                  <LinkExternal
+                    className={CSS_SECONDARY_LINK}
+                    href={`${config.csp.paypalApi}/myaccount/autopay/connect/${billingAgreementId}`}
+                    aria-label={l10n.getString(
+                      'subscription-management-button-change-payment-method-aria',
+                      'Change payment method'
+                    )}
+                  >
+                    <span>
+                      {l10n.getString(
+                        'subscription-management-button-change-payment-method',
+                        'Change'
+                      )}
+                    </span>
+                  </LinkExternal>
+                )}
               </div>
             )}
           </section>

--- a/apps/payments/next/app/[locale]/subscriptions/payments/paypal/en.ftl
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/paypal/en.ftl
@@ -1,0 +1,2 @@
+paypal-payment-management-page-invalid-header = Invalid billing information
+paypal-payment-management-page-invalid-description = There seems to be an error with your PayPal account, we need you to take the necessary steps to resolve this payment issue.

--- a/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { ManageParams } from '@fxa/payments/ui';
+import { auth } from 'apps/payments/next/auth';
+import { config } from 'apps/payments/next/config';
+import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
+import { PaypalManagement } from '@fxa/payments/ui';
+import {
+  determineCurrencyForCustomerAction,
+  getPayPalBillingAgreementId,
+} from '@fxa/payments/ui/actions';
+import { getApp } from '@fxa/payments/ui/server';
+import Image from 'next/image';
+import errorIcon from '@fxa/shared/assets/images/error.svg';
+
+export default async function PaypalPaymentManagementPage({
+  params,
+  searchParams,
+}: {
+  params: ManageParams;
+  searchParams: Record<string, string | string[]> | undefined;
+}) {
+  const acceptLanguage = headers().get('accept-language');
+  const l10n = getApp().getL10n(acceptLanguage);
+  const session = await auth();
+  const { locale } = params;
+
+  const nonce = headers().get('x-nonce') || undefined;
+  if (!session?.user?.id) {
+    redirect(`${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`);
+  }
+  const sessionUid = session.user.id;
+  const [{ paypalBillingAgreementId }, { currency }] = await Promise.all([
+    getPayPalBillingAgreementId(session.user.id),
+    determineCurrencyForCustomerAction(session.user.id),
+  ]);
+
+  if (paypalBillingAgreementId || !currency) {
+    redirect(`${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`);
+  }
+
+  return (
+    <section
+      className="px-4 tablet:px-8"
+      data-testid="paypal-payment-management"
+      aria-labelledby="paypal-payment-management"
+    >
+      <div className="flex flex-col items-center text-center pb-8 mt-5 desktop:mt-2 h-[640px]">
+        <Image
+          src={errorIcon}
+          alt=""
+          className="h-10 w-10"
+          aria-hidden="true"
+        />
+        <h2 className="font-semibold text-grey-600 text-xl my-5">
+          {l10n.getString(
+            'paypal-payment-management-page-invalid-header',
+            'Invalid billing information'
+          )}
+        </h2>
+        <span className={'px-24 leading-6'}>
+          {l10n.getString(
+            'paypal-payment-management-page-invalid-description',
+            'There seems to be an error with your PayPal account, we need you to take the necessary steps to resolve this payment issue.'
+          )}
+        </span>
+        <div className="flex items-center w-2/3 py-10">
+          <hr
+            className="border-b border-grey-100 my-6 grow"
+            aria-hidden="true"
+          />
+          <span className="flex-none px-4">
+            {l10n.getString('next-pay-with-heading-paypal', 'Pay with PayPal')}
+          </span>
+          <hr
+            className="border-b border-grey-100 my-6 grow"
+            aria-hidden="true"
+          />
+        </div>
+        <PaypalManagement
+          sessionUid={sessionUid}
+          paypalClientId={'sb'}
+          nonce={nonce}
+          currency={currency}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
@@ -15,7 +15,7 @@ import { redirect } from 'next/navigation';
 import { v4 as uuidv4 } from 'uuid';
 import { getStripeClientSession } from '@fxa/payments/ui/actions';
 
-export default async function Manage({
+export default async function StripePaymentManagementPage({
   params,
   searchParams,
 }: {

--- a/libs/payments/management/src/lib/subscriptionManagement.error.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.error.ts
@@ -75,6 +75,16 @@ export class SetDefaultPaymentAccountCustomerMissingStripeId extends Subscriptio
   }
 }
 
+export class CreateBillingAgreementAccountCustomerMissingStripeId extends SubscriptionManagementError {
+  constructor(uid: string) {
+    super(
+      'AccountCustomer for updating default payment method is missing a Stripe customer id',
+      { uid }
+    );
+    this.name = 'SetDefaultPaymentAccountCustomerMissingStripeId';
+  }
+}
+
 export class SetupIntentInvalidStatusError extends SubscriptionManagementError {
   constructor(setupIntentId?: string, status?: string) {
     super('ConfirmationToken failed to create successful SetupIntent', {

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -16,6 +16,7 @@ import {
   SetupIntentManager,
   SubscriptionManager,
   CustomerDeletedError,
+  STRIPE_CUSTOMER_METADATA,
 } from '@fxa/payments/customer';
 import {
   AccountCustomerManager,
@@ -50,6 +51,7 @@ import {
   UpdateAccountCustomerMissingStripeId,
   CancelSubscriptionCustomerMismatch,
   ResubscribeSubscriptionCustomerMismatch,
+  CreateBillingAgreementAccountCustomerMissingStripeId,
 } from './subscriptionManagement.error';
 import { NotifierService } from '@fxa/shared/notifier';
 import { ProfileClient } from '@fxa/profile/client';
@@ -60,6 +62,10 @@ import {
   GoogleIapSubscriptionContent,
   SubscriptionContent,
 } from './types';
+import {
+  PaypalBillingAgreementManager,
+  PaypalCustomerManager,
+} from '@fxa/payments/paypal';
 
 @Injectable()
 export class SubscriptionManagementService {
@@ -77,7 +83,9 @@ export class SubscriptionManagementService {
     private profileClient: ProfileClient,
     private productConfigurationManager: ProductConfigurationManager,
     private setupIntentManager: SetupIntentManager,
-    private subscriptionManager: SubscriptionManager
+    private subscriptionManager: SubscriptionManager,
+    private paypalBillingAgreementManager: PaypalBillingAgreementManager,
+    private paypalCustomerManager: PaypalCustomerManager
   ) {}
 
   @SanitizeExceptions()
@@ -454,6 +462,45 @@ export class SubscriptionManagementService {
     };
   }
 
+  async getCurrencyForCustomer(uid: string) {
+    const accountCustomer =
+      await this.accountCustomerManager.getAccountCustomerByUid(uid);
+
+    if (!accountCustomer.stripeCustomerId) {
+      throw new GetAccountCustomerMissingStripeId(uid);
+    }
+
+    const defaultPaymentMethodPromise =
+      this.customerManager.getDefaultPaymentMethod(
+        accountCustomer.stripeCustomerId
+      );
+
+    const customerPromise = this.customerManager.retrieve(
+      accountCustomer.stripeCustomerId
+    );
+
+    const [customer, defaultPaymentMethod] = await Promise.all([
+      customerPromise,
+      defaultPaymentMethodPromise,
+    ]);
+
+    let currency = customer.currency;
+    if (!currency && customer.shipping?.address?.country) {
+      currency = this.currencyManager.getCurrencyForCountry(
+        customer.shipping.address.country
+      );
+    }
+    if (!currency && defaultPaymentMethod?.billing_details.address?.country) {
+      currency = this.currencyManager.getCurrencyForCountry(
+        defaultPaymentMethod.billing_details.address.country
+      );
+    }
+
+    return {
+      currency,
+    };
+  }
+
   @SanitizeExceptions({ allowlist: [AccountCustomerNotFoundError] })
   async getStripePaymentManagementDetails(uid: string) {
     const accountCustomer =
@@ -616,6 +663,25 @@ export class SubscriptionManagementService {
         default_payment_method: paymentMethodId,
       },
       name: fullName,
+    });
+  }
+
+  @SanitizeExceptions()
+  async createPaypalBillingAgreementId(uid: string, token: string) {
+    await this.paypalCustomerManager.deletePaypalCustomersByUid(uid);
+    const [billingAgreementId, accountCustomer] = await Promise.all([
+      this.paypalBillingAgreementManager.create(uid, token),
+      this.accountCustomerManager.getAccountCustomerByUid(uid),
+    ]);
+
+    if (!accountCustomer.stripeCustomerId) {
+      throw new CreateBillingAgreementAccountCustomerMissingStripeId(uid);
+    }
+
+    await this.customerManager.update(accountCustomer.stripeCustomerId, {
+      metadata: {
+        [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: billingAgreementId,
+      },
     });
   }
 }

--- a/libs/payments/ui/src/index.ts
+++ b/libs/payments/ui/src/index.ts
@@ -5,6 +5,7 @@
 // Use this file to export React client components (e.g. those with 'use client' directive) or other non-server utilities
 
 export * from './lib/client/components/ActionButton';
+export * from './lib/client/components/AlertBar';
 export * from './lib/client/components/Banner';
 export * from './lib/client/components/BaseButton';
 export * from './lib/client/components/Breadcrumbs';
@@ -18,6 +19,7 @@ export * from './lib/client/components/PaymentStateObserver';
 export * from './lib/client/components/PaymentInputHandler';
 export * from './lib/client/components/PaymentSection';
 export * from './lib/client/components/PaymentMethodManagement';
+export * from './lib/client/components/PaypalManagement';
 export * from './lib/client/components/PurchaseDetails';
 export * from './lib/client/components/SelectTaxLocation';
 export * from './lib/client/components/SignInForm';

--- a/libs/payments/ui/src/lib/actions/createPayPalBillingAgreementId.ts
+++ b/libs/payments/ui/src/lib/actions/createPayPalBillingAgreementId.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const createPayPalBillingAgreementId = async (
+  uid: string,
+  token: string
+) => {
+  return await getApp()
+    .getActionsService()
+    .createPayPalBillingAgreementId({ uid, token });
+};

--- a/libs/payments/ui/src/lib/actions/determineCurrencyForCustomer.ts
+++ b/libs/payments/ui/src/lib/actions/determineCurrencyForCustomer.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const determineCurrencyForCustomerAction = async (uid: string) => {
+  const { currency } = await getApp()
+    .getActionsService()
+    .determineCurrencyForCustomer({
+      uid,
+    });
+
+  return currency;
+};

--- a/libs/payments/ui/src/lib/actions/getPayPalBillingAgreementId.ts
+++ b/libs/payments/ui/src/lib/actions/getPayPalBillingAgreementId.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const getPayPalBillingAgreementId = async (uid: string) => {
+  return await getApp()
+    .getActionsService()
+    .getPaypalBillingAgreementActiveId({ uid });
+};

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -7,11 +7,14 @@ export { cancelSubscriptionAtPeriodEndAction } from './cancelSubscriptionAtPerio
 export { checkoutCartWithPaypal } from './checkoutCartWithPaypal';
 export { checkoutCartWithStripe } from './checkoutCartWithStripe';
 export { determineCurrencyAction } from './determineCurrency';
+export { determineCurrencyForCustomerAction } from './determineCurrencyForCustomer';
 export { fetchCMSData } from './fetchCMSData';
 export { getCartAction } from './getCart';
 export { getCartOrRedirectAction } from './getCartOrRedirect';
 export { getMetricsFlowAction } from './getMetricsFlow';
 export { getPayPalCheckoutToken } from './getPayPalCheckoutToken';
+export { getPayPalBillingAgreementId } from './getPayPalBillingAgreementId';
+export { createPayPalBillingAgreementId } from './createPayPalBillingAgreementId';
 export { getSubManPageContentAction } from './getSubManPageContent';
 export { getTaxAddressAction } from './getTaxAddress';
 export { handleStripeErrorAction } from './handleStripeError';

--- a/libs/payments/ui/src/lib/client/components/AlertBar/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/AlertBar/index.tsx
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use client';
+
+import { Localized } from '@fluent/react';
+import classNames from 'classnames';
+import * as Dialog from '@radix-ui/react-dialog';
+import Image from 'next/image';
+import checkLogo from '@fxa/shared/assets/images/check.svg';
+import closeIcon from '@fxa/shared/assets/images/close.svg';
+import { useEffect, useState } from 'react';
+
+export enum AlertBarVariant {
+  ERROR,
+  SUCCESS,
+}
+
+export type AlertBarProps = {
+  checked?: boolean;
+  children: React.ReactNode;
+  ariaId?: string;
+  variant?: AlertBarVariant;
+  onClick?: () => any;
+  containerRef?: HTMLElement | null;
+};
+
+export const AlertBar = ({
+  checked,
+  children,
+  variant = AlertBarVariant.ERROR,
+  ariaId,
+  onClick,
+  containerRef = null,
+}: AlertBarProps) => {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!containerRef) {
+      setContainer(document.getElementById('header'));
+    }
+  }, []);
+
+  let alertTypeStyle;
+  switch (variant) {
+    case AlertBarVariant.ERROR:
+      alertTypeStyle = 'bg-red-600 text-white';
+      break;
+
+    case AlertBarVariant.SUCCESS:
+      alertTypeStyle = 'bg-grey-700 text-white';
+      break;
+  }
+
+  return (
+    <>
+      <Dialog.Root open={true} modal={false}>
+        <Dialog.Portal container={container}>
+          <Dialog.Content
+            className={
+              'left-0 w-full  absolute flex font-medium items-center justify-center pt-32 tablet:pt-40'
+            }
+          >
+            <div
+              aria-labelledby={ariaId}
+              className={classNames(
+                'w-2/3 tablet:w-[640px] flex font-medium items-center justify-center min-h-[32px] my-1 mx-auto p-2 relative rounded-md text-sm tablet:max-w-[640px]',
+                alertTypeStyle
+              )}
+              data-testid="alert-container"
+              role="dialog"
+            >
+              <div className="text-center w-[80%]">
+                {checked && (
+                  <Image
+                    src={checkLogo}
+                    alt=""
+                    className="h-4 my-0 mx-1 relative top-[3px] w-4"
+                  />
+                )}
+                {children}
+              </div>
+              {onClick && (
+                <Localized id="close-aria">
+                  <span
+                    data-testid="clear-success-alert"
+                    className="grid"
+                    aria-label="Close modal"
+                    onClick={() => onClick()}
+                    role="button"
+                  >
+                    <Image src={closeIcon} alt="" className="w-4 h-4" />
+                  </span>
+                </Localized>
+              )}
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
+  );
+};
+export default AlertBar;

--- a/libs/payments/ui/src/lib/client/components/Breadcrumbs/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Breadcrumbs/index.tsx
@@ -46,22 +46,38 @@ export function Breadcrumbs(args: {
     label: l10n.getString(
       'subscription-management-breadcrumb-payment',
       {},
-      'Payment Methods'
+      'Manage Payment Methods'
     ),
     href: `${args.paymentsNextUrl}/subscriptions/payments/stripe`,
+  };
+  const PAYPAL_PAYMENT_METHODS = {
+    label: l10n.getString(
+      'subscription-management-breadcrumb-payment',
+      {},
+      'Manage Payment Methods'
+    ),
+    href: `${args.paymentsNextUrl}/subscriptions/payments/paypal`,
   };
 
   let breadcrumbs: Breadcrumb[] = [];
   switch (path) {
-    case `/${params.locale}/subscriptions/manage`:
-      breadcrumbs = [ACCOUNT_SETTINGS, SUBSCRIPTION_MANAGEMENT];
-      break;
     case `/${params.locale}/subscriptions/payments/stripe`:
       breadcrumbs = [
         ACCOUNT_SETTINGS,
         SUBSCRIPTION_MANAGEMENT,
         STRIPE_PAYMENT_METHODS,
       ];
+      break;
+    case `/${params.locale}/subscriptions/payments/paypal`:
+      breadcrumbs = [
+        ACCOUNT_SETTINGS,
+        SUBSCRIPTION_MANAGEMENT,
+        PAYPAL_PAYMENT_METHODS,
+      ];
+      break;
+    case `/${params.locale}/subscriptions/manage`:
+    default:
+      breadcrumbs = [ACCOUNT_SETTINGS, SUBSCRIPTION_MANAGEMENT];
       break;
   }
 

--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -154,6 +154,7 @@ export const Header = ({ auth, cart, redirectPath }: HeaderProps) => {
     <header
       className="bg-white fixed flex justify-between items-center shadow h-16 left-0 top-0 mx-auto my-0 px-4 py-0 w-full z-40 tablet:h-20"
       role="banner"
+      id="header"
     >
       <div className="flex items-center">
         <Image

--- a/libs/payments/ui/src/lib/client/components/PaypalManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaypalManagement/index.tsx
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use client';
+
+import {
+  PayPalButtons,
+  PayPalScriptProvider,
+  ReactPayPalScriptOptions,
+} from '@paypal/react-paypal-js';
+import {
+  createPayPalBillingAgreementId,
+  getPayPalCheckoutToken,
+} from '@fxa/payments/ui/actions';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+import Image from 'next/image';
+import spinnerImage from '@fxa/shared/assets/images/spinner.svg';
+
+const paypalInitialOptions: ReactPayPalScriptOptions = {
+  clientId: '',
+  vault: true,
+  commit: false,
+  intent: 'capture',
+  disableFunding: ['credit', 'card'],
+};
+
+interface PaypalManagementProps {
+  nonce?: string;
+  paypalClientId: string;
+  sessionUid: string;
+  currency: string;
+}
+
+export function PaypalManagement({
+  nonce,
+  paypalClientId,
+  sessionUid,
+  currency,
+}: PaypalManagementProps) {
+  const router = useRouter();
+  const { locale } = useParams();
+  const searchParams = useSearchParams();
+  const queryParamString = searchParams.toString()
+    ? `?${searchParams.toString()}`
+    : '';
+
+  const [isLoading, setLoading] = useState<boolean>(true);
+
+  return (
+    <PayPalScriptProvider
+      options={{
+        ...paypalInitialOptions,
+        clientId: paypalClientId,
+        dataCspNonce: nonce,
+        dataNamespace: 'paypal_management',
+        components: 'buttons',
+      }}
+    >
+      <div className="flex justify-center w-full">
+        {isLoading && (
+          <Image
+            src={spinnerImage}
+            alt=""
+            className="absolute animate-spin h-8 w-8"
+          />
+        )}
+        <PayPalButtons
+          style={{
+            layout: 'horizontal',
+            color: 'gold',
+            shape: 'rect',
+            label: 'paypal',
+            height: 48,
+            borderRadius: 6,
+            tagline: false,
+          }}
+          className="flex justify-center w-full"
+          createOrder={async () =>
+            getPayPalCheckoutToken(currency.toLowerCase())
+          }
+          onApprove={async (data: { orderID: string }) => {
+            await createPayPalBillingAgreementId(sessionUid, data.orderID);
+            router.push(`/${locale}/subscriptions/manage` + queryParamString);
+          }}
+          onError={async (error) => {
+            console.error(error);
+          }}
+          onInit={() => setLoading(false)}
+        />
+      </div>
+    </PayPalScriptProvider>
+  );
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/CreatePaypalBillingAgreementIdArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CreatePaypalBillingAgreementIdArgs.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class CreatePaypalBillingAgreementIdArgs {
+  @IsString()
+  uid!: string;
+
+  @IsString()
+  token!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/CreatePaypalBillingAgreementIdResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CreatePaypalBillingAgreementIdResult.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class CreatePaypalBillingAgreementIdResult {
+  @IsString()
+  paypalBillingAgreementId!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyForCustomerActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyForCustomerActionArgs.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class DetermineCurrencyForCustomerActionArgs {
+  @IsString()
+  uid!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyForCustomerActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/DetermineCurrencyForCustomerActionResult.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsOptional, IsString } from 'class-validator';
+
+export class DetermineCurrencyForCustomerActionResult {
+  @IsString()
+  @IsOptional()
+  currency?: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetPaypalBillingAgreementActiveIdArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetPaypalBillingAgreementActiveIdArgs.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class GetPaypalBillingAgreementActiveIdArgs {
+  @IsString()
+  uid!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/GetPaypalBillingAgreementActiveIdResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetPaypalBillingAgreementActiveIdResult.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsOptional, IsString } from 'class-validator';
+
+export class GetPaypalBillingAgreementActiveIdResult {
+  @IsString()
+  @IsOptional()
+  paypalBillingAgreementId?: string;
+}


### PR DESCRIPTION
Because:

* Customers currently cannot fix an invalid paypal billing agreement via the SP3 subman page

This commit:

* Adds in a page at /{locale}/subscriptions/payments/paypal that lets the user recreate their billing agreement
* Updates the logic of the management page to render CTAs in the case of a paypal billing agreement error
* Adds in an AlertBar component

Closes #PAY-2533

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1680" height="1038" alt="Screenshot 2025-08-25 at 8 12 35 PM" src="https://github.com/user-attachments/assets/699081f4-9517-47db-ad48-de892cc25098" />
<img width="618" height="633" alt="Screenshot 2025-08-25 at 8 10 56 PM" src="https://github.com/user-attachments/assets/99abbdf4-ac45-44a9-9381-fa3821961cc8" />
<img width="1679" height="1039" alt="Screenshot 2025-08-25 at 8 13 37 PM" src="https://github.com/user-attachments/assets/9c72d2d9-ecdf-4614-9cf6-c6ed3d012977" />
<img width="622" height="665" alt="Screenshot 2025-08-25 at 8 06 55 PM" src="https://github.com/user-attachments/assets/d4b154f8-a8cb-44b9-84ff-f4816cf5ef2c" />


## Other information (Optional)

Any other information that is important to this pull request.
