### PR TITLE
fix(l10n): Fix incorrect Fluent syntax in variants (verifyAccountChange)

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyAccountChange/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyAccountChange/en.ftl
@@ -3,7 +3,7 @@
 verifyAccountChange-subject = Use { $code } to change your account
 # Variables:
 # $expirationTime (Number) - Represents the expiration time in minutes
-verifyAccountChange-preview = { $expirationTime: ->
+verifyAccountChange-preview = { $expirationTime ->
   [one] This code expires in { $expirationTime } minute.
   *[other] This code expires in { $expirationTime } minutes.
 }
@@ -13,7 +13,7 @@ verifyAccountChange-safe = Help us keep your account safe by approving this chan
 verifyAccountChange-prompt = If yes, here is your authorization code:
 # Variables:
 # $expirationTime (Number) - Represents the expiration time in minutes
-verifyAccountChange-expiry-notice = { $expirationTime: ->
+verifyAccountChange-expiry-notice = { $expirationTime ->
   [one] It expires in { $expirationTime } minute.
   *[other] It expires in { $expirationTime } minutes.
 }


### PR DESCRIPTION
## Because

Missed during review an extra colon in the variant definition.

## This pull request

Fixes the syntax. No need for new IDs, as the string caused a parsing error (now fixed), so it didn't show up in Pontoon until this morning.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

