### PR TITLE
feat(next): validate metadata in payments-customer libs

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -579,10 +579,9 @@ describe('CheckoutService', () => {
         mockSubscription.id,
         {
           metadata: {
-            ...mockSubscription.metadata,
             [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
               mockCart.couponCode,
-          },
+          }
         }
       );
     });
@@ -767,7 +766,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(customerManager, 'getDefaultPaymentMethod')
           .mockResolvedValue(existingPayentMethod);
-        await expect(
+        expect(
           checkoutService.payWithStripe(
             mockCart,
             mockConfirmationToken.id,
@@ -1154,9 +1153,14 @@ describe('CheckoutService', () => {
       });
 
       it('calls customermanager.update', () => {
-        expect(customerManager.update).toHaveBeenCalledWith(mockCustomer.id, {
-          metadata: { paypalAgreementId: mockBillingAgreementId },
-        });
+        expect(customerManager.update).toHaveBeenCalledWith(
+          mockCustomer.id,
+          {
+            metadata: {
+              paypalAgreementId: mockBillingAgreementId,
+            }
+          }
+        );
       });
       it('calls cartManager.updateFreshCart', () => {
         expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
@@ -1380,7 +1384,7 @@ describe('CheckoutService', () => {
             redundantCancellation: 'true',
             autoCancelledRedundantFor: subscription.id,
             cancelled_for_customer_at: expect.anything(),
-          },
+          }
         }
       );
       expect(subscriptionManager.cancel).toHaveBeenCalledWith(

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -280,7 +280,6 @@ export class CheckoutService {
     if (cart.couponCode) {
       await this.subscriptionManager.update(subscription.id, {
         metadata: {
-          ...subscription.metadata,
           [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
             cart.couponCode,
         },
@@ -729,9 +728,12 @@ export class CheckoutService {
 
         await this.subscriptionManager.update(redundantSubscription.id, {
           metadata: {
-            redundantCancellation: 'true',
-            autoCancelledRedundantFor: upgradedSubscription.id,
-            cancelled_for_customer_at: Math.floor(Date.now() / 1000),
+            [STRIPE_SUBSCRIPTION_METADATA.RedundantCancellation]: 'true',
+            [STRIPE_SUBSCRIPTION_METADATA.AutoCancelledRedundantFor]:
+              upgradedSubscription.id,
+            [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]: Math.floor(
+              Date.now() / 1000
+            ),
           },
         });
 

--- a/libs/payments/customer/src/lib/subscription.manager.spec.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.spec.ts
@@ -58,7 +58,7 @@ describe('SubscriptionManager', () => {
         mockPrice.id
       );
 
-      expect(stripeClient.subscriptionsCancel).toBeCalledWith(
+      expect(stripeClient.subscriptionsCancel).toHaveBeenCalledWith(
         mockSubscription.id
       );
     });
@@ -102,7 +102,7 @@ describe('SubscriptionManager', () => {
 
       await subscriptionManager.cancel(mockSubscription.id);
 
-      expect(stripeClient.subscriptionsCancel).toBeCalledWith(
+      expect(stripeClient.subscriptionsCancel).toHaveBeenCalledWith(
         mockSubscription.id,
         undefined
       );
@@ -127,7 +127,10 @@ describe('SubscriptionManager', () => {
 
       const result = await subscriptionManager.create(params, options);
 
-      expect(stripeClient.subscriptionsCreate).toBeCalledWith(params, options);
+      expect(stripeClient.subscriptionsCreate).toHaveBeenCalledWith(
+        params,
+        options
+      );
       expect(result).toEqual(mockResponse);
     });
   });
@@ -143,7 +146,7 @@ describe('SubscriptionManager', () => {
 
       const result = await subscriptionManager.retrieve(mockSubscription.id);
 
-      expect(stripeClient.subscriptionsRetrieve).toBeCalledWith(
+      expect(stripeClient.subscriptionsRetrieve).toHaveBeenCalledWith(
         mockSubscription.id
       );
       expect(result).toEqual(mockResponse);
@@ -167,7 +170,7 @@ describe('SubscriptionManager', () => {
         mockParams
       );
 
-      expect(stripeClient.subscriptionsUpdate).toBeCalledWith(
+      expect(stripeClient.subscriptionsUpdate).toHaveBeenCalledWith(
         mockSubscription.id,
         mockParams
       );
@@ -193,27 +196,11 @@ describe('SubscriptionManager', () => {
         mockParams
       );
 
-      expect(stripeClient.subscriptionsUpdate).toBeCalledWith(
+      expect(stripeClient.subscriptionsUpdate).toHaveBeenCalledWith(
         mockSubscription.id,
         mockParams
       );
       expect(result).toEqual(mockResponse);
-    });
-
-    it('throws if metadata key does not match', async () => {
-      const mockParams = {
-        metadata: {
-          amount: '1200',
-          [STRIPE_SUBSCRIPTION_METADATA.SubscriptionPromotionCode]:
-            'test-coupon',
-          promotionCode: 'test-coupon',
-        },
-      };
-      const mockSubscription = StripeSubscriptionFactory(mockParams);
-
-      expect(() =>
-        subscriptionManager.update(mockSubscription.id, mockParams)
-      ).rejects.toThrow('Invalid metadata key: promotionCode');
     });
   });
 

--- a/libs/payments/customer/src/lib/subscription.manager.ts
+++ b/libs/payments/customer/src/lib/subscription.manager.ts
@@ -7,7 +7,7 @@ import { Stripe } from 'stripe';
 
 import { StripeClient, StripeSubscription } from '@fxa/payments/stripe';
 import { ACTIVE_SUBSCRIPTION_STATUSES } from '@fxa/payments/stripe';
-import { STRIPE_SUBSCRIPTION_METADATA } from './types';
+import { type StripeSubscriptionMetadataInput } from './types';
 
 @Injectable()
 export class SubscriptionManager {
@@ -21,7 +21,9 @@ export class SubscriptionManager {
   }
 
   async create(
-    params: Stripe.SubscriptionCreateParams,
+    params: Omit<Stripe.SubscriptionCreateParams, 'metadata'> & {
+      metadata?: StripeSubscriptionMetadataInput
+    },
     options?: Stripe.RequestOptions
   ) {
     return this.stripeClient.subscriptionsCreate(params, options);
@@ -33,20 +35,10 @@ export class SubscriptionManager {
 
   async update(
     subscriptionId: string,
-    params?: Stripe.SubscriptionUpdateParams
+    params: Omit<Stripe.SubscriptionUpdateParams, 'metadata'> & {
+      metadata?: StripeSubscriptionMetadataInput
+    },
   ) {
-    if (params?.metadata) {
-      const newMetadata = params.metadata;
-      Object.keys(newMetadata).forEach((key) => {
-        if (
-          !Object.values(STRIPE_SUBSCRIPTION_METADATA).includes(
-            key as STRIPE_SUBSCRIPTION_METADATA
-          )
-        ) {
-          throw new Error(`Invalid metadata key: ${key}`);
-        }
-      });
-    }
     return this.stripeClient.subscriptionsUpdate(subscriptionId, params);
   }
 

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -65,19 +65,44 @@ export interface TaxAmount {
   amount: number;
 }
 
+/*
+ * Metadata from Stripe is an object of strings (even if you pass a number or other type)
+ * where values may or may not be present (represented as undefined)
+ */
+type StripeMetadata<T extends string> = {
+  [key in T]?: string;
+};
+/**
+ * Stripe metadata input allows null to "unset" a value.
+ */
+type StripeMetadataInput<T extends string> = {
+  [key in T]?: string | number | null;
+};
+
 export enum STRIPE_CUSTOMER_METADATA {
   PaypalAgreement = 'paypalAgreementId',
+  Userid = 'userid',
+  GeoIpDate = 'geoip_date',
 }
+export type StripeCustomerMetadata = StripeMetadata<STRIPE_CUSTOMER_METADATA>;
+export type StripeCustomerMetadataInput =
+  StripeMetadataInput<STRIPE_CUSTOMER_METADATA>;
 
 export enum STRIPE_PRICE_METADATA {
   AppStoreProductIds = 'appStoreProductIds',
   PlaySkuIds = 'playSkuIds',
   PromotionCodes = 'promotionCodes',
 }
+export type StripePriceMetadata = StripeMetadata<STRIPE_PRICE_METADATA>;
+export type StripePriceMetadataInput =
+  StripeMetadataInput<STRIPE_PRICE_METADATA>;
 
 export enum STRIPE_PRODUCT_METADATA {
   PromotionCodes = 'promotionCodes',
 }
+export type StripeProductMetadata = StripeMetadata<STRIPE_PRODUCT_METADATA>;
+export type StripeProductMetadataInput =
+  StripeMetadataInput<STRIPE_PRODUCT_METADATA>;
 
 export enum STRIPE_SUBSCRIPTION_METADATA {
   Currency = 'currency',
@@ -97,13 +122,19 @@ export enum STRIPE_SUBSCRIPTION_METADATA {
   SessionEntrypoint = 'session_entrypoint',
   SessionEntrypointExperiment = 'session_entrypoint_experiment',
   SessionEntrypointVariation = 'session_entrypoint_variation',
-  LastUpdated = 'last_updated', // TODO - No longer required. Remove once subscription metadata update logic is updated
 }
+export type StripeSubscriptionMetadata =
+  StripeMetadata<STRIPE_SUBSCRIPTION_METADATA>;
+export type StripeSubscriptionMetadataInput =
+  StripeMetadataInput<STRIPE_SUBSCRIPTION_METADATA>;
 
 export enum STRIPE_INVOICE_METADATA {
   RetryAttempts = 'paymentAttempts',
   PaypalTransactionId = 'paypalTransactionId',
 }
+export type StripeInvoiceMetadata = StripeMetadata<STRIPE_INVOICE_METADATA>;
+export type StripeInvoiceMetadataInput =
+  StripeMetadataInput<STRIPE_INVOICE_METADATA>;
 
 export enum SubplatInterval {
   Daily = 'daily',

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -105,12 +105,8 @@ const mockDeterminePaymentMethodType = jest.mocked(determinePaymentMethodType);
 
 jest.mock('@fxa/shared/error', () => ({
   ...jest.requireActual('@fxa/shared/error'),
-  SanitizeExceptions: jest.fn(({ allowlist = [] } = {}) => {
-    return function (
-      target: any,
-      propertyKey: string,
-      descriptor: PropertyDescriptor
-    ) {
+  SanitizeExceptions: jest.fn(() => {
+    return function (_: any, __: string, descriptor: PropertyDescriptor) {
       return descriptor;
     };
   }),
@@ -302,10 +298,10 @@ describe('SubscriptionManagementService', () => {
       const mockStoreId1 = faker.string.sample();
       const mockStoreId2 = faker.string.sample();
       const mockIapOfferingResult1 = IapWithOfferingResultFactory({
-        storeId: mockStoreId1,
+        storeID: mockStoreId1,
       });
       const mockIapOfferingResult2 = IapWithOfferingResultFactory({
-        storeId: mockStoreId2,
+        storeID: mockStoreId2,
       });
       const mockIapResult = {
         [mockStoreId1]: mockIapOfferingResult1,
@@ -489,10 +485,10 @@ describe('SubscriptionManagementService', () => {
       const mockStoreId1 = faker.string.sample();
       const mockStoreId2 = faker.string.sample();
       const mockIapOfferingResult1 = IapWithOfferingResultFactory({
-        storeId: mockStoreId1,
+        storeID: mockStoreId1,
       });
       const mockIapOfferingResult2 = IapWithOfferingResultFactory({
-        storeId: mockStoreId2,
+        storeID: mockStoreId2,
       });
       const mockIapResult = {
         [mockStoreId1]: mockIapOfferingResult1,

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -16,6 +16,7 @@ import {
   SetupIntentManager,
   SubscriptionManager,
   CustomerDeletedError,
+  STRIPE_SUBSCRIPTION_METADATA,
 } from '@fxa/payments/customer';
 import {
   AccountCustomerManager,
@@ -99,8 +100,9 @@ export class SubscriptionManagementService {
     await this.subscriptionManager.update(subscriptionId, {
       cancel_at_period_end: true,
       metadata: {
-        ...(subscription.metadata || {}),
-        cancelled_for_customer_at: Math.floor(Date.now() / 1000),
+        [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]: Math.floor(
+          Date.now() / 1000
+        ),
       },
     });
 
@@ -523,8 +525,7 @@ export class SubscriptionManagementService {
     await this.subscriptionManager.update(subscriptionId, {
       cancel_at_period_end: false,
       metadata: {
-        ...(subscription.metadata || {}),
-        cancelled_for_customer_at: '',
+        [STRIPE_SUBSCRIPTION_METADATA.CancelledForCustomerAt]: '',
       },
     });
 


### PR DESCRIPTION
## Because

- Subscription update will fail validation if existing metadata is invalid.
- Subscription create, and customer update managers do not validate metadata.

## This pull request

- Modify subscription manager update and create and customer manager update metadata types to only allow valid metadata values.

## Issue that this pull request solves

Closes: #PAY-3203

Co-authored-by: Julian Poyourow <julianpoyo@gmail.com>

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
