### PR TITLE
polish(payments-next): Remove leading from email display on SubMan page

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/layout.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/layout.tsx
@@ -57,11 +57,11 @@ export default async function SubscriptionsLayout({
             />
             <h1
               id="profile-heading"
-              className="leading-6 overflow-hidden font-semibold text-ellipsis text-start text-nowrap tablet:text-xl"
+              className="overflow-hidden font-semibold text-ellipsis text-start text-nowrap tablet:text-xl"
             >
               <div>{session?.user?.name || session?.user?.email}</div>
               {session?.user?.name && (
-                <div className="font-normal leading-6 text-base text-grey-400 mb-0">
+                <div className="font-normal text-base text-grey-400 mb-0">
                   {session?.user?.email}
                 </div>
               )}


### PR DESCRIPTION
## Because

- the bottom of the email was cut off

## This pull request

- removes leading

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Before
<img width="1240" height="314" alt="Screenshot 2025-08-27 at 11 39 31 AM" src="https://github.com/user-attachments/assets/69c471e3-dd83-4c60-8bfd-d32cfe806a92" />

After
<img width="990" height="220" alt="Screenshot 2025-08-27 at 11 40 35 AM" src="https://github.com/user-attachments/assets/4c3db889-a82d-429b-a36b-509815ef10e3" />
