### PR TITLE
feat(mfa): create new ModalMfaProtected component

### DIFF
--- a/packages/fxa-react/lib/storybooks.tsx
+++ b/packages/fxa-react/lib/storybooks.tsx
@@ -23,7 +23,7 @@ export const withLocalization: Decorator = (Story) => (
   </AppLocalizationProvider>
 );
 
-export const withLocation: (location: string | undefined) => Decorator =
+export const withLocation: (location?: string) => Decorator =
   (location) => (Story) => {
     if (location === undefined) {
       return (

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/en.ftl
@@ -1,0 +1,23 @@
+## ModalMfaProtected
+
+modal-mfa-protected-title = Enter confirmation code
+modal-mfa-protected-subtitle = Help us make sure it’s you changing your account info
+# This string is used to show a notification to the user for them to enter
+# email confirmation code to update their multi-factor-authentication-protected
+# account settings
+# Variables:
+#   email (String) - the user's email
+#   expirationTime (Number) - the expiration time in minutes
+modal-mfa-protected-instruction = { $expirationTime ->
+    [one] Enter the code that was sent to <email>{ $email }</email> within { $expirationTime } minute.
+    *[other] Enter the code that was sent to <email>{ $email }</email> within { $expirationTime } minutes.
+  }
+modal-mfa-protected-input-label = Enter 6-digit code
+modal-mfa-protected-cancel-button = Cancel
+modal-mfa-protected-confirm-button = Confirm
+
+modal-mfa-protected-code-expired = Code expired?
+# Link to resend a new code to the user's email.
+modal-mfa-protected-resend-code-link = Email new code.
+
+##

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.stories.tsx
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+import { ModalMfaProtected } from '.';
+import { action } from '@storybook/addon-actions';
+import { MOCK_EMAIL } from '../../../pages/mocks';
+
+export default {
+  title: 'Components/Settings/ModalMfaProtected',
+  component: ModalMfaProtected,
+  decorators: [withLocalization, withLocation()],
+} as Meta;
+
+export const DefaultWithValidCode123456 = () => {
+  const [modalRevealed, showModal, hideModal] = useBooleanState(true);
+  const [localizedErrorTooltipMessage, setLocalizedErrorTooltipMessage] =
+    useState<string | undefined>(undefined);
+  const [showResendSuccessBanner, setShowResendSuccessBanner] =
+    useState<boolean>(false);
+
+  const dismiss = () => {
+    hideModal();
+    setLocalizedErrorTooltipMessage(undefined);
+    setShowResendSuccessBanner(false);
+  };
+
+  return (
+    <>
+      <button
+        className="cta-base-p cta-neutral"
+        onClick={(event) => {
+          event.stopPropagation();
+          showModal();
+        }}
+      >
+        Show modal
+      </button>
+      {modalRevealed && (
+        <ModalMfaProtected
+          email={MOCK_EMAIL}
+          expirationTime={5}
+          onSubmit={(code) => {
+            action('Submitted')(code);
+            if (code === '123456') {
+              dismiss();
+            } else {
+              setLocalizedErrorTooltipMessage(
+                'Invalid or expired confirmation code.'
+              );
+              setShowResendSuccessBanner(false);
+            }
+          }}
+          {...{
+            localizedErrorTooltipMessage,
+            showResendSuccessBanner,
+          }}
+          clearErrorTooltip={() => {
+            setLocalizedErrorTooltipMessage(undefined);
+          }}
+          onDismiss={dismiss}
+          handleResendCode={() => {
+            setShowResendSuccessBanner(true);
+          }}
+          resendCodeLoading={false}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../../models/mocks';
+import { ModalMfaProtected } from '.';
+import { MOCK_EMAIL } from '../../../pages/mocks';
+
+const defaultProps = {
+  email: MOCK_EMAIL,
+  expirationTime: 5,
+  onSubmit: () => {},
+  onDismiss: () => {},
+  handleResendCode: () => {},
+  clearErrorTooltip: () => {},
+  resendCodeLoading: false,
+  showResendSuccessBanner: false,
+};
+
+describe('ModalMfaProtected', () => {
+  it('renders correctly', () => {
+    renderWithRouter(<ModalMfaProtected {...defaultProps} />);
+
+    expect(screen.getByText('Enter confirmation code')).toBeInTheDocument();
+    expect(
+      screen.getByText('Help us make sure it’s you changing your account info')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Enter the code that was sent to/)
+    ).toHaveTextContent(
+      `Enter the code that was sent to ${MOCK_EMAIL} within 5 minutes.`
+    );
+    expect(
+      screen.getByRole('textbox', { name: 'Enter 6-digit code' })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('modal-dismiss')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
+    expect(screen.getByText('Code expired?')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Email new code.' })
+    ).toBeInTheDocument();
+  });
+
+  it('handles form submission', async () => {
+    const onSubmit = jest.fn();
+    renderWithRouter(
+      <ModalMfaProtected {...defaultProps} onSubmit={onSubmit} />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Enter 6-digit code' }),
+      '123456'
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('123456');
+  });
+
+  it('calls handleResendCode when Email new code button is clicked', async () => {
+    const handleResendCode = jest.fn();
+    renderWithRouter(
+      <ModalMfaProtected
+        {...defaultProps}
+        handleResendCode={handleResendCode}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Email new code.' })
+    );
+
+    expect(handleResendCode).toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when the close button is clicked', async () => {
+    const onDismiss = jest.fn();
+    renderWithRouter(
+      <ModalMfaProtected {...defaultProps} onDismiss={onDismiss} />
+    );
+
+    await userEvent.click(screen.getByTestId('modal-dismiss'));
+
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when the cancel button is clicked', async () => {
+    const onDismiss = jest.fn();
+    renderWithRouter(
+      <ModalMfaProtected {...defaultProps} onDismiss={onDismiss} />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('displays banners and tooltips', () => {
+    renderWithRouter(
+      <ModalMfaProtected
+        {...defaultProps}
+        localizedErrorTooltipMessage="error tooltip"
+      />
+    );
+    expect(screen.getByText('error tooltip')).toBeInTheDocument();
+  });
+
+  it('shows code resend success banner', () => {
+    renderWithRouter(
+      <ModalMfaProtected {...defaultProps} showResendSuccessBanner={true} />
+    );
+    expect(
+      screen.getByText('A new code was sent to your email.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Add accounts@firefox.com to your contacts to ensure a smooth delivery.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import Modal from '../Modal';
+import InputText from '../../InputText';
+import { useFtlMsgResolver } from '../../../models';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { EmailCodeImage } from '../../images';
+import { ResendCodeSuccessBanner } from '../../Banner';
+
+type ModalProps = {
+  email: string;
+  expirationTime: number;
+  onSubmit: (code: string) => void;
+  onDismiss: () => void;
+  handleResendCode: () => void;
+  clearErrorTooltip: () => void;
+  localizedErrorTooltipMessage?: string;
+  resendCodeLoading: boolean;
+  showResendSuccessBanner: boolean;
+};
+
+type FormData = {
+  confirmationCode: string;
+};
+
+export const ModalMfaProtected = ({
+  email,
+  expirationTime,
+  onSubmit,
+  onDismiss,
+  handleResendCode,
+  clearErrorTooltip,
+  localizedErrorTooltipMessage,
+  resendCodeLoading,
+  showResendSuccessBanner,
+}: ModalProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+
+  const { handleSubmit, register, formState } = useForm<FormData>({
+    mode: 'all',
+    defaultValues: {
+      confirmationCode: '',
+    },
+  });
+
+  const { isDirty, isValid } = formState;
+  const buttonDisabled = !isDirty || !isValid;
+
+  return (
+    <Modal
+      data-testid="modal-verify-session"
+      descId="modal-mfa-protected-desc"
+      headerId="modal-mfa-protected-title"
+      hasButtons={false}
+      onDismiss={onDismiss}
+    >
+      <form
+        onSubmit={handleSubmit(({ confirmationCode }) => {
+          onSubmit(confirmationCode.trim());
+        })}
+      >
+        <FtlMsg id="modal-mfa-protected-title">
+          <h2 id="modal-mfa-protected-title" className="font-bold text-xl">
+            Enter confirmation code
+          </h2>
+        </FtlMsg>
+        <FtlMsg id="modal-mfa-protected-subtitle">
+          <p className="text-base mt-1">Help us make sure it’s you changing your account info</p>
+        </FtlMsg>
+        {showResendSuccessBanner && <ResendCodeSuccessBanner />}
+
+        <EmailCodeImage />
+
+        <FtlMsg
+          id="modal-mfa-protected-instruction"
+          vars={{ email, expirationTime }}
+          elems={{
+            email: <span className="font-bold">{email}</span>,
+          }}
+        >
+          <p id="modal-mfa-protected-desc" className="my-6">
+            Enter the code that was sent to <span className="font-bold">{email}</span> within {expirationTime === 1 ? '1 minute' : `${expirationTime} minutes`}.
+          </p>
+        </FtlMsg>
+
+        <div className="mt-4 mb-8">
+          <InputText
+            name="confirmationCode"
+            label={ftlMsgResolver.getMsg(
+              'modal-mfa-protected-input-label',
+              'Enter 6-digit code'
+            )}
+            inputRef={register({
+              required: true,
+              pattern: /^\s*[0-9]{6}\s*$/,
+            })}
+            onChange={clearErrorTooltip}
+            {...{
+              errorText: localizedErrorTooltipMessage,
+            }}
+          />
+        </div>
+
+        <div className="flex justify-between gap-4 w-full">
+          <FtlMsg id="modal-mfa-protected-cancel-button">
+            <button
+              type="button"
+              className="cta-neutral cta-xl flex-1 w-1/2"
+              onClick={onDismiss}
+            >
+              Cancel
+            </button>
+          </FtlMsg>
+          <FtlMsg id="modal-mfa-protected-confirm-button">
+            <button
+              type="submit"
+              className="cta-primary cta-xl flex-1 w-1/2"
+              disabled={buttonDisabled}
+            >
+              Confirm
+            </button>
+          </FtlMsg>
+        </div>
+      </form>
+      <div className="mt-7 text-grey-500 text-sm inline-flex gap-1">
+        <FtlMsg id="modal-mfa-protected-code-expired">
+          <p>Code expired?</p>
+        </FtlMsg>
+        <FtlMsg id="modal-mfa-protected-resend-code-link">
+          <button
+            className="link-blue"
+            onClick={handleResendCode}
+            disabled={resendCodeLoading}
+          >
+            Email new code.
+          </button>
+        </FtlMsg>
+      </div>
+    </Modal>
+  );
+};
+
+export default ModalMfaProtected;


### PR DESCRIPTION
Closes #

## Because

- we need a modal for MFA confirmation code input for `MfaProtectedActionGuard`

## This pull request

- creates a new `ModalMfaProtected` component, with stories and unit tests.

## Issue that this pull request solves

Closes: FXA-12302

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="523" height="720" alt="image" src="https://github.com/user-attachments/assets/d4332f01-8d95-4802-8d95-df228cfff14b" />

## Other information (Optional)

Any other information that is important to this pull request.
