### PR TITLE
polish(payments-next): Remove "any" from paymentMethod.manager.spec.

### DIFF
--- a/libs/payments/customer/src/lib/paymentMethod.manager.spec.ts
+++ b/libs/payments/customer/src/lib/paymentMethod.manager.spec.ts
@@ -21,6 +21,7 @@ import {
   StripeCustomerFactory,
   StripePaymentMethodFactory,
   StripeSubscriptionFactory,
+  StripeCardPaymentMethodFactory,
 } from '@fxa/payments/stripe';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
@@ -159,11 +160,7 @@ describe('PaymentMethodManager', () => {
           },
       });
 
-      const mockPaymentMethod = StripeResponseFactory(
-        StripePaymentMethodFactory({
-          type: 'card',
-        })
-      );
+      const mockPaymentMethod = StripeResponseFactory(StripeCardPaymentMethodFactory());
       jest.spyOn(paymentMethodManager, 'retrieve').mockResolvedValue(mockPaymentMethod);
 
       await expect(
@@ -222,10 +219,9 @@ describe('PaymentMethodManager', () => {
       });
 
       const mockPaymentMethod = StripeResponseFactory(
-        {
-          type: 'card',
-          card: { wallet: { type: 'apple_pay' } },
-        } as any
+        StripeCardPaymentMethodFactory({
+          walletType: 'apple_pay'
+        })
       );
       jest.spyOn(paymentMethodManager, 'retrieve').mockResolvedValue(mockPaymentMethod);
 
@@ -248,10 +244,9 @@ describe('PaymentMethodManager', () => {
       });
 
       const mockPaymentMethod = StripeResponseFactory(
-        {
-          type: 'card',
-          card: { wallet: { type: 'google_pay' } },
-        } as any
+        StripeCardPaymentMethodFactory({
+          walletType: 'google_pay'
+        })
       );
       jest.spyOn(paymentMethodManager, 'retrieve').mockResolvedValue(mockPaymentMethod);
 

--- a/libs/payments/stripe/src/index.ts
+++ b/libs/payments/stripe/src/index.ts
@@ -33,6 +33,7 @@ export {
 } from './lib/factories/subscription.factory';
 export { StripePromotionCodeFactory } from './lib/factories/promotion-code.factory';
 export { StripePaymentMethodFactory } from './lib/factories/payment-method.factory';
+export { StripeCardPaymentMethodFactory } from './lib/factories/card-payment-method.factory';
 export { StripePaymentIntentFactory } from './lib/factories/payment-intent.factory';
 export { StripeSetupIntentFactory } from './lib/factories/setup-intent.factory';
 export { StripeTaxRateFactory } from './lib/factories/tax-rate.factory';

--- a/libs/payments/stripe/src/lib/factories/card-payment-method.factory.ts
+++ b/libs/payments/stripe/src/lib/factories/card-payment-method.factory.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { StripePaymentMethod, StripeWalletType } from '../stripe.client.types';
+
+export const StripeCardPaymentMethodFactory = (
+  override?: Partial<StripePaymentMethod> & { walletType?: StripeWalletType }
+): StripePaymentMethod => ({
+  id: `pm_${faker.string.alphanumeric({ length: 14 })}`,
+  object: 'payment_method',
+  billing_details: {
+    address: {
+      city: null,
+      country: null,
+      line1: null,
+      line2: null,
+      postal_code: null,
+      state: null,
+    },
+    email: null,
+    name: null,
+    phone: null,
+  },
+  card: {
+    brand: 'visa',
+    checks: {
+      address_line1_check: null,
+      address_postal_code_check: null,
+      cvc_check: 'unchecked',
+    },
+    country: faker.location.countryCode(),
+    display_brand: 'visa',
+    exp_month: faker.date.future().getUTCMonth(),
+    exp_year: faker.date.future().getUTCFullYear(),
+    fingerprint: faker.string.uuid(),
+    funding: 'credit',
+    generated_from: {
+      charge: null,
+      payment_method_details: null,
+      setup_attempt: null,
+    },
+    last4: faker.string.numeric({ length: 4 }),
+    networks: {
+      available: ['visa'],
+      preferred: null,
+    },
+    three_d_secure_usage: {
+      supported: true,
+    },
+    wallet: override?.walletType
+      ? { type: override.walletType, dynamic_last4: null }
+      : null,
+  },
+  created: faker.date.past().getTime() / 1000,
+  customer: null,
+  livemode: true,
+  metadata: {},
+  type: 'card',
+  ...override,
+});

--- a/libs/payments/stripe/src/lib/stripe.client.types.ts
+++ b/libs/payments/stripe/src/lib/stripe.client.types.ts
@@ -353,6 +353,8 @@ export type StripePaymentMethod = NegotiateExpanded<
   'customer'
 >;
 
+export type StripeWalletType = 'apple_pay' | 'google_pay';
+
 /**
  * Stripe.PaymentIntent with expanded fields removed
  */


### PR DESCRIPTION
## Because

- In general, "any" is not allowed in the codebase.

## This pull request

- Removes "any" from the unit test.

## Issue that this pull request solves

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
