### PR TITLE
Address feedback for language switcher

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -152,14 +152,13 @@ export const AppLayout = ({
           </div>
         )}
       </div>
-      <footer>
-        {/* LocaleToggle positioned in lower left corner of page */}
-        {showLocaleToggle && (
+      {showLocaleToggle && (
+        <footer>
           <div className="fixed bottom-6 left-6 z-10">
-            <LocaleToggle placement="footer" />
+            <LocaleToggle />
           </div>
-        )}
       </footer>
+      )}
       <div id="body-bottom" className="w-full block mobileLandscape:hidden" />
     </>
   );

--- a/packages/fxa-settings/src/components/LocaleToggle/en.ftl
+++ b/packages/fxa-settings/src/components/LocaleToggle/en.ftl
@@ -1,3 +1,4 @@
 ## Locale Toggle Component
 
 locale-toggle-select-label = Select language
+locale-toggle-browser-default = Browser default

--- a/packages/fxa-settings/src/components/LocaleToggle/index.tsx
+++ b/packages/fxa-settings/src/components/LocaleToggle/index.tsx
@@ -5,23 +5,27 @@
 import React from 'react';
 import { useLocaleManager } from '../../lib/hooks/useLocaleManager';
 import { useFtlMsgResolver } from '../../models';
+import { getBrowserDefaultLocaleInfo } from '../../lib/locales';
 
-interface LocaleToggleProps {
-  className?: string;
-  placement?: 'footer' | 'header';
-}
+const BROWSER_DEFAULT_VALUE = 'browser-default';
 
-export const LocaleToggle: React.FC<LocaleToggleProps> = ({
-  className = '',
-  placement = 'footer'
-}) => {
+/**
+* Locale selection dropdown component with browser default support
+* Handles locale switching and preference clearing
+*/
+export const LocaleToggle: React.FC = () => {
   const ftlMsgResolver = useFtlMsgResolver();
-  const { currentLocale, availableLocales, switchLocale, isLoading } = useLocaleManager();
+  const { currentLocale, availableLocales, switchLocale, clearLocalePreference, isUsingBrowserDefault, isLoading } = useLocaleManager();
 
   // Handle locale selection
   const handleLocaleChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
     const newLocale = event.target.value;
-    if (newLocale && newLocale !== currentLocale) {
+
+    if (newLocale === BROWSER_DEFAULT_VALUE) {
+      // User selected browser default - clear the preference
+      await clearLocalePreference();
+    } else if (newLocale && newLocale !== currentLocale) {
+      // User selected a specific locale
       await switchLocale(newLocale);
     }
   };
@@ -31,20 +35,41 @@ export const LocaleToggle: React.FC<LocaleToggleProps> = ({
     'Select language'
   );
 
+  const browserDefaultLabel = ftlMsgResolver.getMsg(
+    'locale-toggle-browser-default',
+    'Browser default'
+  );
+
+  // Get browser's default locale info for functionality (not display)
+  const browserDefaultLocale = getBrowserDefaultLocaleInfo();
+
+  // Determine the current value for the select
+  // If using browser default, show the actual browser locale in the dropdown
+  const currentValue = isUsingBrowserDefault
+    ? (browserDefaultLocale?.code || currentLocale)
+    : currentLocale;
+
   return (
-    <div className={`relative ${className}`}>
+    <div className="bg-grey-10 p-1 tablet:bg-transparent tablet:p-0 rounded-md border border-grey-50 tablet:border-none">
       <label htmlFor="locale-select" className="sr-only">
         {selectLabel}
       </label>
       <select
         id="locale-select"
-        value={currentLocale}
+        value={currentValue}
         onChange={handleLocaleChange}
         disabled={isLoading}
         className="text-xs text-grey-500 hover:text-grey-600 focus:outline-none focus:text-grey-600 disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-0 cursor-pointer appearance-none min-w-[8ch] w-auto"
         data-testid="locale-select"
         aria-label={selectLabel}
       >
+        <option
+          key={BROWSER_DEFAULT_VALUE}
+          value={BROWSER_DEFAULT_VALUE}
+          data-testid="locale-option-browser-default"
+        >
+          {browserDefaultLabel}
+        </option>
         {availableLocales.map((locale) => (
           <option
             key={locale.code}

--- a/packages/fxa-settings/src/lib/hooks/useLocaleManager.ts
+++ b/packages/fxa-settings/src/lib/hooks/useLocaleManager.ts
@@ -7,6 +7,7 @@ import {
   LocaleOption,
   getAvailableLocales,
   isRTLLocale,
+  isUsingBrowserDefault,
   LOCALE_MAPPINGS
 } from '../locales';
 import { useDynamicLocalization } from '../../contexts/DynamicLocalizationContext';
@@ -16,22 +17,27 @@ export interface LocaleManager {
   currentLanguage: LocaleOption | undefined;
   availableLocales: LocaleOption[];
   switchLocale: (newLocale: string) => Promise<void>;
+  clearLocalePreference: () => Promise<void>;
+  isUsingBrowserDefault: boolean;
   isRTL: boolean;
   isLoading: boolean;
 }
 
 export const useLocaleManager = (): LocaleManager => {
-  const { currentLocale, switchLanguage, isLoading } = useDynamicLocalization();
+  const { currentLocale, switchLanguage, clearLanguagePreference, isLoading } = useDynamicLocalization();
   const [availableLocales] = useState<LocaleOption[]>(() => getAvailableLocales());
 
   const currentLanguage = LOCALE_MAPPINGS[currentLocale];
   const isRTL = isRTLLocale(currentLocale);
+  const browserDefault = isUsingBrowserDefault();
 
   return {
     currentLocale,
     currentLanguage,
     availableLocales,
     switchLocale: switchLanguage,
+    clearLocalePreference: clearLanguagePreference,
+    isUsingBrowserDefault: browserDefault,
     isRTL,
     isLoading
   };


### PR DESCRIPTION
## Because

- I missed some feedback comments

## This pull request

- Adds an option "Browser default" that clears the lanuage local storage key and sets the locale to the browser value
- Updates test to use `userEvent`
- Don't render stray `footer`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
