### PR TITLE
fix(locale): Only use the users preferred locale to check for cms customization

### DIFF
--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -101,6 +101,7 @@ export interface Config {
   nimbusPreview: boolean;
   cms: {
     enabled: boolean;
+    l10nEnabled: boolean;
   };
 }
 
@@ -185,8 +186,8 @@ export function getDefault() {
       showLocaleToggle: false,
     },
     cms: {
-      // Note: Even if this flag is true, the user must be an `en` language
       enabled: false,
+      l10nEnabled: false
     },
     nimbusPreview: false,
   } as Config;


### PR DESCRIPTION
## Because

- Users that have multiple locales specified in browser ie (es, en), with at least one of them being English could be served the cms customization
- This would show the page half with English and half with other locale

## This pull request

- Fixes this by only checking the users preferred locale

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12308

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We should try to uplift this to prod if possible.
