### PR TITLE
fix(locale): Only load cms customization for en only locales (for uplif to 317)

### DIFF
--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -238,8 +238,7 @@ export function useCmsInfoState() {
         return true;
       }
 
-      // Check preferred languages
-      return navigator.languages.some(lang => lang.startsWith('en'));
+      return false;
     }
 
     if (


### PR DESCRIPTION
## Because

- We can not cleanly uplift this fix from main because of changes to how localization is loaded

## This pull request

- Target the train exactly with required fix

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12308

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)