### PR TITLE
fix(logout): Redirect to email first if user is at settings but not valid session

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -348,6 +348,12 @@ export const App = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  // If we're on settings route but user is not signed in, redirect immediately
+  if (window.location.pathname?.includes('/settings') && !isSignedIn) {
+    hardNavigate('/');
+    return <LoadingSpinner fullScreen />;
+  }
+
   return (
     <Router basepath="/">
       <AuthAndAccountSetupRoutes


### PR DESCRIPTION
## Because

- We currently show the "General application error" message when user is in settings page but the underlying session token becomes invalid
- I suspect its how the pages are being lazy loaded, we did have logic to do this redirect but 

## This pull request

- Does a simple redirect if user is not signed in

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12309

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

There is probably a better way to do this and we should try to find the actual reason why its failing.
