### PR TITLE
feat(signin): return newAccount and newAccountVerification flags with login redirect

### DIFF
--- a/packages/fxa-react/lib/utils.tsx
+++ b/packages/fxa-react/lib/utils.tsx
@@ -14,9 +14,9 @@ const DEFAULT_NAVIGATE_TIMEOUT_MS = 200;
 // intentional.
 export function hardNavigate(
   href: string,
-  additionalQueryParams = {},
+  additionalQueryParams: Record<string, string> = {},
   includeCurrentQueryParams = false,
-  replace: boolean = false,
+  replace: boolean = false
 ) {
   // If there are any query params in the href, we automatically include them in the new url.
   const url = new URL(href, window.location.origin);
@@ -111,7 +111,7 @@ export class FtlMsgResolver {
   constructor(
     public readonly l10n: ReactLocalization,
     public readonly strict: boolean
-  ) { }
+  ) {}
 
   /**
    * A wrapper around l10n.getString that provides more safety. When strict is true, using this function ensures:

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -247,12 +247,17 @@ const ConfirmSignupCode = ({
             goToSettingsWithAlertSuccess();
           } else {
             // Navigate to relying party
-            hardNavigate(redirect);
+            if (origin === 'signup') {
+              hardNavigate(redirect, { newAccount: 'true' });
+            } else {
+              hardNavigate(redirect, {
+                newAccountVerification: 'true',
+              });
+            }
             return;
           }
         }
       } else if (isWebIntegration(integration)) {
-        // SubPlat redirect
         if (integration.data.redirectTo) {
           if (webRedirectCheck.isValid) {
             hardNavigate(integration.data.redirectTo);

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -217,12 +217,14 @@ export const Subject = ({
   finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   offeredSyncEngines,
   declinedSyncEngines,
+  origin,
 }: {
   integration?: ConfirmSignupCodeIntegration;
   newsletterSlugs?: string[];
   finishOAuthFlowHandler?: FinishOAuthFlowHandler;
   offeredSyncEngines?: string[];
   declinedSyncEngines?: string[];
+  origin?: string;
 }) => {
   return (
     <LocationProvider>
@@ -233,6 +235,7 @@ export const Subject = ({
           finishOAuthFlowHandler,
           offeredSyncEngines,
           declinedSyncEngines,
+          origin,
         }}
         flowQueryParams={{ flowId: MOCK_FLOW_ID }}
         email={MOCK_EMAIL}


### PR DESCRIPTION
## Because

- SubPlat is requesting the ability to understand if a user logged in with a new account or with a pre-existing account.

## This pull request

- attaches newAccount=true or newAccountVerification=true query params to the redirect back to RPs based on flow type.

## Issue that this pull request solves

Closes: FXA-12292

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
