### PR TITLE
chore(auth): Update skipForNewAccounts max age

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1554,7 +1554,7 @@ const convictConf = convict({
       maxAge: {
         doc: 'Maximum age at which an account is considered "new".',
         format: 'duration',
-        default: '4 hours',
+        default: '48 hours',
         env: 'SIGNIN_CONFIRMATION_MAX_AGE_OF_NEW_ACCOUNTS',
       },
     },


### PR DESCRIPTION
Because:
 - We want to ease the process for new sync login

This Commit:
 - Increases the maxAge for skipForNewAccounts to 48 hours

Closes #FXA-12131

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
