### PR TITLE
bug(setting): Fix issue with empty session in cache.

### DIFF
--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -69,21 +69,22 @@ export class Session implements SessionData {
     }
   }
 
-  private get data() {
-    const { session } = this.apolloClient.cache.readQuery<{
+  private get data(): Session | undefined {
+    const result = this.apolloClient.cache.readQuery<{
       session: Session;
     }>({
       query: GET_SESSION_VERIFIED,
-    })!;
-    return session;
+    });
+
+    return result?.session;
   }
 
   get token(): string {
-    return this.data.token;
+    return this.data?.token || '';
   }
 
   get verified(): boolean {
-    return this.data.verified;
+    return this.data?.verified || false;
   }
 
   // TODO: Use GQL verifyCode instead of authClient


### PR DESCRIPTION
## Because
- There's no guarantee that session is in the apollo cache.
- If there's no session in the cache we'd hit a run time error

## This pull request

- Handles the case that session is missing.
- Creates empty string fallback for token getter
- Creates false fallback for verified getter

## Issue that this pull request solves

Closes: FXA-12299

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I _think_ this is okay to do. Note that sentry issue indicates this happening when users hit the `ModalVerifySession` dialog, and somehow there's not a session in the apollo cache. In this case, this PR works around the issue by essentially falling back to a session state that no sessionToken and is not verified. I feel like this fallback state adequately represents a lack of the session in the cache... This is not a typical state, however, so it's a little difficult to test. Not sure how users get into this scenario...

The other tricky thing about this is that there could be a session in local storage. I considered falling back to its state, but due to the mixed cache states and the fact that state in local storage could be very old, I decided not to. If the user is on the settings page, they should really have a session in the apollo cache...
