### PR TITLE
feat(config): add frontend config for mfa otp expiration time

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -57,6 +57,11 @@
   "recovery_codes": {
     "count": 3
   },
+  "mfa": {
+    "otp": {
+      "expiresInMinutes": 5
+    }
+  },
   "showReactApp": {
     "simpleRoutes": true,
     "resetPasswordRoutes": true,

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -90,6 +90,11 @@ const settingsConfig = {
     count: config.get('recovery_codes.count'),
     length: config.get('recovery_codes.length'),
   },
+  mfa: {
+    otp: {
+      expiresInMinutes: config.get('mfa.otp.expiresInMinutes'),
+    },
+  },
   googleAuthConfig: config.get('googleAuthConfig'),
   appleAuthConfig: config.get('appleAuthConfig'),
   brandMessagingMode: config.get('brandMessagingMode'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -627,6 +627,16 @@ const conf = (module.exports = convict({
       format: 'url',
     },
   },
+  mfa: {
+    otp: {
+      expiresInMinutes: {
+        default: 5,
+        doc: 'The number of minutes before the OTP for MFA expires',
+        env: 'FXA_MFA_OTP_EXPIRES_IN_MINUTES',
+        format: Number,
+      },
+    },
+  },
   mxRecordValidation: {
     enabled: {
       default: true,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -13,6 +13,11 @@ export interface Config {
     baseUrl: string;
   };
   marketingEmailPreferencesUrl: string;
+  mfa: {
+    otp: {
+      expiresInMinutes: number;
+    };
+  };
   metrics: {
     navTiming: {
       enabled: boolean;
@@ -116,6 +121,11 @@ export function getDefault() {
     metrics: {
       navTiming: { enabled: false, endpoint: '/check-your-metrics-config' },
     },
+    mfa: {
+      otp: {
+        expiresInMinutes: 5,
+      },
+    },
     sentry: {
       dsn: '',
       env: 'local',
@@ -187,7 +197,7 @@ export function getDefault() {
     },
     cms: {
       enabled: false,
-      l10nEnabled: false
+      l10nEnabled: false,
     },
     nimbusPreview: false,
   } as Config;


### PR DESCRIPTION
## Because

- MFA OTP verification emails have a configurable expiration time.

## This pull request

- adds frontend config for mfa otp expiration time

## Issue that this pull request solves

Closes: FXA-12313

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Should update webservices-infra as well
