### PR TITLE
chore(functional-tests): Update sms references to smsClient

### DIFF
--- a/packages/functional-tests/lib/targets/index.ts
+++ b/packages/functional-tests/lib/targets/index.ts
@@ -27,31 +27,6 @@ export function create(name: TargetName): BaseTarget {
 export { BaseTarget as ServerTarget };
 export { Credentials } from './base';
 
-// Default test number, see Twilio test credentials phone numbers:
-// https://www.twilio.com/docs/iam/test-credentials
-export const TEST_NUMBER = '4159929960';
-
-/**
- * Checks the process env for a configured twilio test phone number. Defaults
- * to generic magic test number if one is not provided.
- * @param targetName The test target name. eg local, stage, prod.
- * @returns
- */
-export function getPhoneNumber(targetName: TargetName) {
-  if (targetName === 'local') {
-    return TEST_NUMBER;
-  }
-  return getFromEnvWithFallback(
-    'FUNCTIONAL_TESTS__TWILIO__TEST_NUMBER',
-    targetName,
-    TEST_NUMBER
-  );
-}
-
-export function usingRealTestPhoneNumber(targetName: TargetName) {
-  return getPhoneNumber(targetName) !== TEST_NUMBER;
-}
-
 /**
  * Helper function to get a value from the environment. If the key + __ + targetName exists, this
  * will be returned. Otherwise, if $key exists it will be returned. Otherwise undefined will be

--- a/packages/functional-tests/lib/totp.ts
+++ b/packages/functional-tests/lib/totp.ts
@@ -4,8 +4,10 @@
 
 import { authenticator as otplibAuthenticator } from 'otplib';
 
-// Generate a TOTP code matching server settings (hex-encoded secret)
-export async function getCode(secretHex: string): Promise<string> {
+/**
+ * Generate a TOTP code matching server settings (hex-encoded secret)
+ */
+export async function getTotpCode(secretHex: string): Promise<string> {
   const auth = new otplibAuthenticator.Authenticator();
   auth.options = Object.assign({}, otplibAuthenticator.options, {
     encoding: 'hex',

--- a/packages/functional-tests/pages/settings/totp.ts
+++ b/packages/functional-tests/pages/settings/totp.ts
@@ -6,7 +6,7 @@ import jsQR from 'jsqr';
 import UPNG from 'upng-js';
 import { expect } from '../../lib/fixtures/standard';
 import { SettingsLayout } from './layout';
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { DataTrioComponent } from './components/dataTrio';
 
 export type TotpCredentials = {
@@ -122,7 +122,7 @@ export class TotpPage extends SettingsLayout {
       throw new Error('No secret found in QR code');
     }
 
-    const code = await getCode(secret);
+    const code = await getTotpCode(secret);
     await this.step1AuthenticationCodeTextbox.fill(code);
     await this.step1SubmitButton.click();
     return secret;
@@ -134,7 +134,7 @@ export class TotpPage extends SettingsLayout {
 
     await this.step1CantScanCodeLink.click();
     const secret = (await this.step1ManualCode.innerText())?.replace(/\s/g, '');
-    const code = await getCode(secret);
+    const code = await getTotpCode(secret);
     await this.step1AuthenticationCodeTextbox.fill(code);
     await this.step1SubmitButton.click();
     return secret;

--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -4,13 +4,7 @@
 
 import { expect, test } from '../../lib/fixtures/standard';
 import { syncDesktopOAuthQueryParams } from '../../lib/query-params';
-import { getCode } from '../../lib/totp';
-import {
-  TargetName,
-  getFromEnvWithFallback,
-  getPhoneNumber,
-  usingRealTestPhoneNumber,
-} from '../../lib/targets';
+import { getTotpCode } from '../../lib/totp';
 
 const ENTRYPOINT_123Done = 'purple';
 const CLIENTID_123Done = 'dcdb5ae7add825d2';
@@ -220,7 +214,7 @@ test.describe('severity-1 #smoke', () => {
       });
 
       // Enter TOTP code
-      const totpCode = await getCode(secret);
+      const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       // Verify successful login
@@ -294,15 +288,12 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(recoveryPhone.addHeader()).toBeVisible();
 
-      await recoveryPhone.enterPhoneNumber(getPhoneNumber(target.name));
+      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
       await recoveryPhone.clickSendCode();
 
       await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      const code = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const code = await target.smsClient.getCode({ ...credentials });
 
       await recoveryPhone.enterCode(code);
       await recoveryPhone.clickConfirm();
@@ -382,10 +373,7 @@ test.describe('severity-1 #smoke', () => {
       });
 
       // Get SMS code and enter it
-      const smsCode = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const smsCode = await target.smsClient.getCode({ ...credentials });
 
       await signinRecoveryPhone.enterCode(smsCode);
       await signinRecoveryPhone.clickConfirm();
@@ -656,7 +644,7 @@ test.describe('severity-1 #smoke', () => {
       });
 
       // Enter TOTP code
-      const totpCode = await getCode(secret);
+      const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       await page.getByRole('link', { name: 'Not now' }).click();

--- a/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { expect, test } from '../../lib/fixtures/standard';
 
 /**
@@ -64,7 +64,7 @@ test.describe('severity-2 #smoke', () => {
 
       await expect(page).toHaveURL(/signin_totp_code/);
 
-      const totpCode = await getCode(totpCredentials.secret);
+      const totpCode = await getTotpCode(totpCredentials.secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       await expect(page).toHaveURL(/settings/);

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../lib/fixtures/standard';
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 
 test.describe('recovery key promo', () => {
   test.describe('inline', () => {
@@ -187,7 +187,7 @@ test.describe('recovery key promo', () => {
 
       await page.waitForURL(/signin_totp_code/);
 
-      const totpCode = await getCode(secret);
+      const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       await inlineRecoveryKey.getInlineRecoveryHeader();

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -5,7 +5,7 @@
 import { FirefoxCommand } from '../../lib/channels';
 import { expect, test } from '../../lib/fixtures/standard';
 import { relayDesktopOAuthQueryParams } from '../../lib/query-params';
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 
 test.describe('relay integration', () => {
   test('signup with Relay desktop', async ({
@@ -119,7 +119,7 @@ test.describe('relay integration', () => {
 
     await page.waitForURL(/signin_totp_code/);
 
-    const totpCode = await getCode(secret);
+    const totpCode = await getTotpCode(secret);
     await signinTotpCode.fillOutCodeForm(totpCode);
 
     await page.waitForURL(/settings/);

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
 import { SigninPage } from '../../pages/signin';
-import { getPhoneNumber } from '../../lib/targets';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('OAuth totp', () => {
@@ -34,7 +33,7 @@ test.describe('severity-1 #smoke', () => {
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
       await expect(page).toHaveURL(/signin_totp_code/);
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(code);
 
       expect(await relier.isLoggedIn()).toBe(true);
@@ -111,7 +110,7 @@ test.describe('severity-1 #smoke', () => {
         /\s/g,
         ''
       );
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await totp.step1AuthenticationCodeTextbox.fill(code);
       await totp.step1SubmitButton.click();
 
@@ -177,7 +176,7 @@ test.describe('severity-1 #smoke', () => {
       const secret = (
         await signin.page.getByTestId('manual-datablock').innerText()
       )?.replace(/\s/g, '');
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
 
       await signin.page
         .getByRole('textbox', { name: 'Authentication code' })
@@ -247,7 +246,7 @@ test.describe('severity-1 #smoke', () => {
       const secret = (
         await signin.page.getByTestId('manual-datablock').innerText()
       )?.replace(/\s/g, '');
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
 
       await signin.page
         .getByRole('textbox', { name: 'Authentication code' })
@@ -315,7 +314,7 @@ test.describe('severity-1 #smoke', () => {
       const secret = (
         await signin.page.getByTestId('manual-datablock').innerText()
       )?.replace(/\s/g, '');
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
 
       await signin.page
         .getByRole('textbox', { name: 'Authentication code' })
@@ -326,15 +325,12 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/inline_recovery_setup/);
 
       await totp.chooseRecoveryPhoneOption();
-      await recoveryPhone.enterPhoneNumber(getPhoneNumber(target.name));
+      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
       await recoveryPhone.clickSendCode();
 
       await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      const smsCode = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const smsCode = await target.smsClient.getCode({ ...credentials });
 
       await recoveryPhone.enterCode(smsCode);
       await recoveryPhone.clickConfirm();
@@ -383,7 +379,7 @@ test.describe('severity-1 #smoke', () => {
         /\s/g,
         ''
       );
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await totp.step1AuthenticationCodeTextbox.fill(code);
       await totp.step1SubmitButton.click();
 
@@ -437,22 +433,19 @@ test.describe('severity-1 #smoke', () => {
         /\s/g,
         ''
       );
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await totp.step1AuthenticationCodeTextbox.fill(code);
       await totp.step1SubmitButton.click();
 
       await page.waitForURL(/inline_recovery_setup/);
 
       await totp.chooseRecoveryPhoneOption();
-      await recoveryPhone.enterPhoneNumber(getPhoneNumber(target.name));
+      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
       await recoveryPhone.clickSendCode();
 
       await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      const smsCode = await target.smsClient.getCode(
-        getPhoneNumber(target.name),
-        credentials.uid
-      );
+      const smsCode = await target.smsClient.getCode({ ...credentials });
 
       await recoveryPhone.enterCode(smsCode);
       await recoveryPhone.clickConfirm();

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { expect, test } from '../../lib/fixtures/standard';
 
 test.describe('severity-1 #smoke', () => {
@@ -35,7 +35,7 @@ test.describe('severity-1 #smoke', () => {
       await signup.fillOutEmailForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
       await page.waitForURL(/signin_totp_code/);
-      const totpCode = await getCode(secret);
+      const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       await expect(page).toHaveURL(/settings/);
@@ -87,7 +87,7 @@ test.describe('severity-1 #smoke', () => {
       await signup.fillOutEmailForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
       await page.waitForURL(/signin_totp_code/);
-      const totpCode = await getCode(secret);
+      const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
       await expect(page).toHaveURL(/pair/);
@@ -134,7 +134,7 @@ test.describe('severity-1 #smoke', () => {
       );
 
       // Required before teardown
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(code);
       await settings.disconnectTotp();
     });

--- a/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { expect, test } from '../../lib/fixtures/standard';
 import { ResetPasswordPage } from '../../pages/resetPassword';
 import { SigninPage } from '../../pages/signin';
@@ -122,7 +122,7 @@ test.describe('severity-1 #smoke', () => {
       await resetPassword.fillOutResetPasswordCodeForm(code);
 
       // Fill out the TOTP form
-      const totpCode = await getCode(secret);
+      const totpCode = await getTotpCode(secret);
       await resetPassword.fillOutTotpForm(totpCode);
 
       await resetPassword.fillOutNewPasswordForm(newPassword);

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { expect, Page, test } from '../../lib/fixtures/standard';
-import { Credentials, getPhoneNumber } from '../../lib/targets';
+import { Credentials } from '../../lib/targets';
 import { SettingsPage } from '../../pages/settings';
 import { TotpCredentials, TotpPage } from '../../pages/settings/totp';
 import { SigninTotpCodePage } from '../../pages/signinTotpCode';
@@ -38,7 +38,7 @@ test.describe('severity-2 #smoke', () => {
       await settings.signOut();
 
       // signin with _new_ 2fa
-      const code = await getCode(newSecret);
+      const code = await getTotpCode(newSecret);
       await signin.emailFirstSignin(credentials);
       await page.waitForURL(/signin_totp_code/);
       await signinTotpCode.fillOutCodeForm(code);
@@ -64,7 +64,7 @@ test.describe('severity-2 #smoke', () => {
       await settings.signOut();
 
       // attempt signin with _old_ 2fa (should fail)
-      const oldSecretCode = await getCode(oldSecret);
+      const oldSecretCode = await getTotpCode(oldSecret);
       await signin.emailFirstSignin(credentials);
       await page.waitForURL(/signin_totp_code/);
       await signinTotpCode.fillOutCodeForm(oldSecretCode);
@@ -266,10 +266,7 @@ const completeSigninWithDualRecovery = async ({
   await signinRecoveryChoice.clickContinue();
   // new RegExp because template literal isn't supported directly inside regex literal
   await page.waitForURL(new RegExp(`signin_recovery_${method.toLowerCase()}`));
-  const code = await target.smsClient.getCode(
-    getPhoneNumber(target.name),
-    credentials.uid
-  );
+  const code = await target.smsClient.getCode({ ...credentials });
   await recoveries[method].fillOutCodeForm(code);
 };
 
@@ -291,10 +288,7 @@ const addPhoneRecovery = async ({
 
   await recoveryPhone.submitPhoneNumber();
 
-  const code = await target.smsClient.getCode(
-    getPhoneNumber(target.name),
-    credentials.uid
-  );
+  const code = await target.smsClient.getCode({ ...credentials });
 
   await recoveryPhone.submitCode(code);
 };

--- a/packages/functional-tests/tests/settings/setup2faWithBackupCodes.spec.ts
+++ b/packages/functional-tests/tests/settings/setup2faWithBackupCodes.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
@@ -180,7 +180,7 @@ async function signinWithTotp(
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.fillOutPasswordForm(credentials.password);
   await expect(page).toHaveURL(/signin_totp_code/);
-  const code = await getCode(secret);
+  const code = await getTotpCode(secret);
   await signinTotpCode.fillOutCodeForm(code);
   await expect(settings.settingsHeading).toBeVisible();
 }

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 import { SettingsPage } from '../../pages/settings';
@@ -279,7 +279,7 @@ test.describe('severity-2 #smoke', () => {
 
       // Now should go to totp code
       await expect(page).toHaveURL(/signin_totp_code/);
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(code);
 
       //Verify logged in on Settings page

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getCode } from '../../lib/totp';
+import { getTotpCode } from '../../lib/totp';
 import { Page, expect, test } from '../../lib/fixtures/standard';
 import { BaseTarget, Credentials } from '../../lib/targets/base';
 
@@ -180,7 +180,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutPasswordForm(credentials.password);
 
       await expect(page).toHaveURL(/signin_totp_code/);
-      const code = await getCode(secret);
+      const code = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(code);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();


### PR DESCRIPTION
Because:
 - We centralized the sms functions onto the smsClient

This Commit:
 - Updates any funcitonal test references to the getPhoneNumber and other functions to use the target.smsClient
 - Updates the call signature for `getCode` for ease of use

Closes: FXA-12293

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
