### PR TITLE
Create MFA Guard that Manages JWTs

### DIFF
--- a/packages/functional-tests/tests/misc/mfa.spec.ts
+++ b/packages/functional-tests/tests/misc/mfa.spec.ts
@@ -19,8 +19,8 @@ test.describe('severity-2 #smoke', () => {
   }) => {
     const credentials = await testAccountTracker.signUpSync();
     const client = target.createAuthClient(2);
-    let resp = await client.mfaRequestOtp(credentials.sessionToken, 'test');
-    expect(resp.status).toBe('success');
+    const resp1 = await client.mfaRequestOtp(credentials.sessionToken, 'test');
+    expect(resp1.status).toBe('success');
 
     // Verify the otp code
     const code = await target.emailClient.getVerifyAccountChangeCode(
@@ -28,20 +28,24 @@ test.describe('severity-2 #smoke', () => {
     );
 
     // Try accessing the protected action test endpoint with jwt
-    resp = await client.mfaOtpVerify(credentials.sessionToken, code, 'test');
-    expect(resp.accessToken).toBeDefined();
-    const jwtAccessToken = resp.accessToken;
+    const resp2 = await client.mfaOtpVerify(
+      credentials.sessionToken,
+      code,
+      'test'
+    );
+    expect(resp2.accessToken).toBeDefined();
+    const jwtAccessToken = resp2.accessToken;
 
     // Try accessing the protected action again
-    resp = await client.mfaTestGet(jwtAccessToken);
-    expect(resp.status).toBe('success');
+    const resp3 = await client.mfaTestGet(jwtAccessToken);
+    expect(resp3.status).toBe('success');
 
-    resp = await client.mfaTestPost(jwtAccessToken);
-    expect(resp.status).toBe('success');
+    const resp4 = await client.mfaTestPost(jwtAccessToken);
+    expect(resp4.status).toBe('success');
 
     let scopeError = undefined;
     try {
-      resp = await client.mfaTestPost2(jwtAccessToken);
+      await client.mfaTestPost2(jwtAccessToken);
     } catch (err) {
       scopeError = err;
     }

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1517,7 +1517,7 @@ export default class AuthClient {
     sessionToken: hexstring,
     action: string,
     headers?: Headers
-  ) {
+  ): Promise<{ status: string }> {
     return this.sessionPost(
       '/mfa/otp/request',
       sessionToken,
@@ -1533,7 +1533,7 @@ export default class AuthClient {
     code: string,
     action: string,
     headers?: Headers
-  ) {
+  ): Promise<{ accessToken: string }> {
     return this.sessionPost(
       '/mfa/otp/verify',
       sessionToken,
@@ -1545,7 +1545,10 @@ export default class AuthClient {
     );
   }
 
-  async mfaTestGet(jwt: string, headers?: Headers) {
+  async mfaTestGet(
+    jwt: string,
+    headers?: Headers
+  ): Promise<{ status: string }> {
     return this.jwtGet('/mfa/test', jwt, headers);
   }
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2402,7 +2402,8 @@ const convictConf = convict({
     },
     ftlUrl: {
       template: {
-        default: 'https://raw.githubusercontent.com/mozilla/fxa-cms-l10n/main/locales/{locale}/cms.ftl',
+        default:
+          'https://raw.githubusercontent.com/mozilla/fxa-cms-l10n/main/locales/{locale}/cms.ftl',
         doc: 'URL template for FTL files. Use {locale} placeholder for locale substitution',
         env: 'CMS_L10N_FTL_URL_TEMPLATE',
         format: String,
@@ -2412,7 +2413,7 @@ const convictConf = convict({
         doc: 'Timeout for FTL requests in milliseconds',
         env: 'CMS_L10N_FTL_TIMEOUT',
         format: Number,
-      }
+      },
     },
     ftlCache: {
       memoryTtl: {
@@ -2520,7 +2521,7 @@ const convictConf = convict({
         env: 'MFA__OTP__WINDOW',
       },
       digits: {
-        default: 8,
+        default: 6,
         doc: 'Length of code',
         format: Number,
         env: 'MFA__OTP__DIGITS',

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
@@ -31,10 +31,16 @@ export const strategy = (config: ConfigType) => {
         audience: config.mfa.jwt.audience,
         issuer: config.mfa.jwt.issuer,
       };
-      const decoded = jwt.verify(token, key, opts) as {
-        sub?: string;
-        scope?: string[];
-      };
+
+      let decoded;
+      try {
+        decoded = jwt.verify(token, key, opts) as {
+          sub?: string;
+          scope?: string[];
+        };
+      } catch (err) {
+        throw AppError.invalidToken(err.message);
+      }
 
       // Ensure required state
       if (decoded.sub == null || decoded.scope == null) {

--- a/packages/fxa-auth-server/test/local/routes/mfa.js
+++ b/packages/fxa-auth-server/test/local/routes/mfa.js
@@ -33,7 +33,7 @@ describe('mfa', () => {
       enabled: true,
       actions: ['test'],
       otp: {
-        digits: 8,
+        digits: 6,
       },
       jwt: {
         secretKey: 'foxes',
@@ -158,6 +158,7 @@ describe('mfa', () => {
       error = err;
     }
     assert.isDefined(error);
+    assert.equal(error.errno, 110);
     assert.equal(error.message, 'jwt malformed');
   });
 
@@ -172,6 +173,7 @@ describe('mfa', () => {
       error = err;
     }
     assert.isDefined(error);
+    assert.equal(error.errno, 110);
     assert.equal(error.message, 'jwt expired');
   });
 });

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.test.tsx
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MfaErrorBoundary } from './error-boundary';
+import { JwtTokenCache } from '../../../lib/cache';
+
+const mockScope = 'test';
+const mockSessionToken = 'session-xyz';
+const mockJwt = 'jwt-123';
+
+describe('MfaErrorBoundary', () => {
+  let removeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    removeSpy = jest.spyOn(JwtTokenCache, 'removeToken');
+  });
+
+  afterEach(() => {
+    removeSpy.mockReset();
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <MfaErrorBoundary
+        requiredScope={mockScope}
+        sessionToken={mockSessionToken}
+        jwt={mockJwt}
+        fallback={<div>fallback</div>}
+      >
+        <div>child</div>
+      </MfaErrorBoundary>
+    );
+
+    expect(screen.getByText('child')).toBeInTheDocument();
+  });
+
+  it('renders fallback and removes JWT on auth error (401/110)', () => {
+    const ref = React.createRef<MfaErrorBoundary>();
+    const { rerender } = render(
+      <MfaErrorBoundary
+        ref={ref}
+        requiredScope={mockScope}
+        sessionToken={mockSessionToken}
+        jwt="jwt-2"
+        fallback={<div>fallback</div>}
+      >
+        <div>child</div>
+      </MfaErrorBoundary>
+    );
+
+    const authError: any = new Error('invalid jwt');
+    authError.code = 401;
+    authError.errno = 110;
+
+    // Simulate boundary catching the error
+    ref.current?.componentDidCatch(authError, {} as any);
+
+    // Trigger a render so updated state is reflected in output
+    rerender(
+      <MfaErrorBoundary
+        ref={ref}
+        requiredScope={mockScope}
+        sessionToken={mockSessionToken}
+        jwt="jwt-2"
+        fallback={<div>fallback</div>}
+      >
+        <div>child</div>
+      </MfaErrorBoundary>
+    );
+
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+    expect(removeSpy).toHaveBeenCalledWith(mockSessionToken, mockScope);
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.tsx
@@ -1,0 +1,80 @@
+import { Component, ReactNode } from 'react';
+import { MfaScope } from '../../../lib/types';
+import { JwtTokenCache } from '../../../lib/cache';
+
+/**
+ * Error Boundary Implementation.
+ *
+ * This error boundary's only job is to handle errors that percolate up related to
+ * invalid JWTs. This can happen if a user leaves a flow open for a while, and
+ * the once-valid JWT expires. In this case, when they submit the JWT an invalid
+ * state will be returned, and we should clear the JWT from our cache so the
+ * user has an opportunity to get a new one via the MfaModalDialog.
+ *
+ * This error boundary is specifically tailored to the MfaGuard. Don't try
+ * to export it or reuse it!
+ */
+type MfaErrorBoundaryProps = {
+  requiredScope: MfaScope;
+  sessionToken: string;
+  jwt: string;
+  children: ReactNode;
+  fallback: ReactNode;
+};
+
+type MfaErrorBoundaryState = { hasError: boolean; error: any | null };
+
+export class MfaErrorBoundary extends Component<
+  MfaErrorBoundaryProps,
+  MfaErrorBoundaryState
+> {
+  state: MfaErrorBoundaryState;
+
+  constructor(props: any) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: any) {
+    if (error && error.code === 401 && error.errno === 110) {
+      return { hasError: true };
+    }
+
+    return undefined;
+  }
+
+  componentDidCatch(error: any, info: any) {
+    if (error && error.code === 401 && error.errno === 110) {
+      this.setState({
+        hasError: true,
+        error: error,
+      });
+
+      JwtTokenCache.removeToken(
+        this.props.sessionToken,
+        this.props.requiredScope
+      );
+    } else {
+      // Causes error to bubble up to the next error boundary
+      throw error;
+    }
+  }
+
+  componentDidUpdate(prevProps: MfaErrorBoundaryProps) {
+    // Until a new code is provided, consider the error to still be valid.
+    if (prevProps.jwt !== this.props.jwt) {
+      this.setState({
+        hasError: false,
+        error: null,
+      });
+    }
+  }
+
+  render() {
+    if (this.state.hasError && this.state.error) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.stories.tsx
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
+import { action } from '@storybook/addon-actions';
+import { AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
+import { MfaGuard } from './index';
+import { JwtTokenCache } from '../../../lib/cache';
+
+const scope: 'test' = 'test';
+const session = 'session-xyz';
+
+function initLocalAccount(sessionToken: string) {
+  // Match Storage fullKey logic: '__fxa_storage.' prefix
+  const NS = '__fxa_storage';
+  const uid = 'abc123';
+  const accounts = {
+    [uid]: {
+      uid,
+      sessionToken,
+      email: 'user@example.com',
+      verified: true,
+      lastLogin: Date.now(),
+    },
+  };
+  window.localStorage.setItem(`${NS}.accounts`, JSON.stringify(accounts));
+  window.localStorage.setItem(`${NS}.currentAccountUid`, JSON.stringify(uid));
+}
+
+const authClient = {
+  mfaRequestOtp: async (st: string, sc: string) => {
+    action('mfaRequestOtp')({ sessionToken: st, scope: sc });
+    return undefined;
+  },
+  mfaOtpVerify: async (st: string, code: string, sc: string) => {
+    action('mfaOtpVerify')({ sessionToken: st, code, scope: sc });
+    return { accessToken: 'storybook-jwt' } as any;
+  },
+} as any;
+
+export default {
+  title: 'Components/Settings/MfaGuard',
+  component: MfaGuard,
+  decorators: [withLocalization, withLocation('/settings')],
+} as Meta;
+
+export const JwtMissingShowsModal = () => {
+  initLocalAccount(session);
+  // Ensure no token present so guard triggers OTP flow
+  try {
+    if (JwtTokenCache.hasToken(session, scope)) {
+      JwtTokenCache.removeToken(session, scope);
+    }
+  } catch {}
+
+  return (
+    <AppContext.Provider value={mockAppContext({ authClient } as any)}>
+      <MfaGuard requiredScope={scope}>
+        <div>Secured content</div>
+      </MfaGuard>
+    </AppContext.Provider>
+  );
+};
+
+export const JwtPresentRendersChildren = () => {
+  initLocalAccount(session);
+  JwtTokenCache.setToken(session, scope, 'jwt-present');
+
+  return (
+    <AppContext.Provider value={mockAppContext({ authClient } as any)}>
+      <MfaGuard requiredScope={scope}>
+        <div>Secured content</div>
+      </MfaGuard>
+    </AppContext.Provider>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../../models/mocks';
+import { MfaGuard } from './index';
+import { JwtTokenCache } from '../../../lib/cache';
+
+const mockSessionToken = 'session-xyz';
+const mockOtp = '123456';
+const mockScope = 'test';
+const mockAuthClient = {
+  mfaRequestOtp: jest.fn().mockResolvedValue(undefined),
+  mfaOtpVerify: jest.fn().mockResolvedValue({ accessToken: 'new-jwt' }),
+};
+const mockFtlMsgResolver = {
+  getMsg: (id: string, fallback: string) => fallback,
+};
+
+jest.mock('../../../lib/cache', () => {
+  const actual = jest.requireActual('../../../lib/cache');
+  return {
+    __esModule: true,
+    ...actual,
+    sessionToken: () => mockSessionToken,
+  };
+});
+
+jest.mock('../../../models', () => ({
+  useAccount: () => ({ email: 'user@example.com' }),
+  useAuthClient: () => mockAuthClient,
+  useFtlMsgResolver: () => mockFtlMsgResolver,
+}));
+
+describe('MfaGuard', () => {
+  beforeEach(() => {
+    if (JwtTokenCache.hasToken(mockSessionToken, mockScope)) {
+      JwtTokenCache.removeToken(mockSessionToken, mockScope);
+    }
+    jest.clearAllMocks();
+  });
+
+  it('requests OTP and shows modal when JWT missing', async () => {
+    renderWithRouter(
+      <MfaGuard requiredScope={mockScope}>
+        <div>secured</div>
+      </MfaGuard>
+    );
+
+    expect(mockAuthClient.mfaRequestOtp).toHaveBeenCalledWith(
+      mockSessionToken,
+      mockScope
+    );
+
+    expect(
+      await screen.findByText('Enter confirmation code')
+    ).toBeInTheDocument();
+
+    // Submit a code to verify integration with onSubmit
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Enter 6-digit code' }),
+      mockOtp
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(mockAuthClient.mfaOtpVerify).toHaveBeenCalledWith(
+      mockSessionToken,
+      mockOtp,
+      mockScope
+    );
+  });
+
+  it('renders children when JWT exists', () => {
+    JwtTokenCache.setToken(mockSessionToken, mockScope, 'jwt-present');
+
+    renderWithRouter(
+      <MfaGuard requiredScope={mockScope}>
+        <div>secured</div>
+      </MfaGuard>
+    );
+
+    expect(screen.getByText('secured')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Enter confirmation code')
+    ).not.toBeInTheDocument();
+    expect(mockAuthClient.mfaRequestOtp).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, {
+  ReactNode,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { useErrorHandler } from 'react-error-boundary';
+
+import { useAccount, useAuthClient } from '../../../models';
+import Modal from '../ModalMfaProtected';
+import {
+  JwtTokenCache,
+  sessionToken as getSessionToken,
+} from '../../../lib/cache';
+import { MfaScope } from '../../../lib/types';
+import { useNavigate } from '@reach/router';
+import { MfaErrorBoundary } from './error-boundary';
+
+/**
+ * This is a guard component designed to wrap around components that perform
+ * security-sensitive actions. It blocks access to the child components until
+ * a JWT is obtained through an OTP code exchange.
+ */
+export const MfaGuard = ({
+  children,
+  requiredScope,
+}: {
+  children: ReactNode;
+  requiredScope: MfaScope;
+}) => {
+  // Let errors be handled by error boundaries in async contexts
+  const handleError = useErrorHandler();
+
+  // Whether the modal to enter the OTP code is displayed
+  const [showModal, setShowModal] = useState(false);
+
+  // Reactive state: if the store state changes, a re-render is triggered
+  const jwtState = useSyncExternalStore(
+    JwtTokenCache.subscribe,
+    JwtTokenCache.getSnapshot
+  );
+  const account = useAccount();
+  const authClient = useAuthClient();
+  const navigate = useNavigate();
+  const sessionToken = getSessionToken();
+
+  // If no session token exists, kick them to sign-in
+  if (!sessionToken) {
+    throw new Error('Invalid state. Missing sessionToken');
+  }
+
+  // jwtState should always return
+  if (!jwtState) {
+    throw new Error('Invalid state. Missing jwt cache.');
+  }
+
+  // Modal Setup
+  useEffect(() => {
+    (async () => {
+      // If the JWT doesn't exist, it has either never been set or the error boundary
+      // detected an invalid token and deleted it from the cache. Either way, we want
+      // to request a new OTP and show the modal so we can obtain a valid JWT again.
+      if (!JwtTokenCache.hasToken(sessionToken, requiredScope)) {
+        try {
+          await authClient.mfaRequestOtp(sessionToken, requiredScope);
+          setShowModal(true);
+        } catch (err) {
+          // TODO: FXA-12329 - There might be some errors to handle inline like rate-limiting.
+          handleError(err);
+        }
+      } else {
+        // We have a token in cache. Assume it's valid and let the
+        // child controls render.
+        setShowModal(false);
+      }
+    })();
+  });
+
+  const onSubmitOtp = async (code: string) => {
+    try {
+      const result = await authClient.mfaOtpVerify(
+        sessionToken,
+        code,
+        requiredScope
+      );
+      JwtTokenCache.setToken(sessionToken, requiredScope, result.accessToken);
+    } catch (err) {
+      // TODO: FXA-12328 - Handle invalid code error state.
+
+      // TODO: FXA-12329 - There might be some errors to handle inline like rate-limiting.
+      handleError(err);
+    }
+  };
+
+  const handleResendCode = async () => {
+    try {
+      await authClient.mfaRequestOtp(sessionToken, requiredScope);
+    } catch (err) {
+      handleError(err);
+    }
+  };
+
+  const onDismiss = () => {
+    navigate('/settings');
+  };
+
+  const clearErrorTooltip = () => {
+    // TODO: FXA-12328 - Handle invalid code error state.
+  };
+
+  const email = account.email;
+  const expirationTime = 5; // TODO get from config
+  const resendCodeLoading = false; // TODO handle state change while calls are in flight.
+  const showResendSuccessBanner = true; // TODO handle request banner.
+
+  const getModal = () => (
+    <Modal
+      {...{
+        email,
+        expirationTime,
+        onSubmit: onSubmitOtp,
+        onDismiss,
+        handleResendCode,
+        clearErrorTooltip,
+        resendCodeLoading,
+        showResendSuccessBanner,
+      }}
+    >
+      <p>Re-verify Account!</p>
+    </Modal>
+  );
+
+  // If we don't have a JWT, we need to open the modal to prompt for it.
+  // Note: I'm torn on whether we should render the child components or not. It seems
+  // like a waste since the user can't interact with them anyway.
+  const missingJwt = !JwtTokenCache.hasToken(sessionToken, requiredScope);
+  if (showModal || missingJwt) {
+    return getModal();
+  }
+
+  // Otherwise, wrap the children in our error boundary and render them.
+  // If an invalid JWT error is encountered, the MfaErrorBoundary will
+  // destroy the current JWT for us, and the modal should be displayed again.
+  const jwt = JwtTokenCache.hasToken(sessionToken, requiredScope)
+    ? JwtTokenCache.getToken(sessionToken, requiredScope)
+    : '';
+  return (
+    <MfaErrorBoundary
+      sessionToken={sessionToken}
+      requiredScope={requiredScope}
+      jwt={jwt}
+      fallback={getModal()}
+    >
+      {showModal || missingJwt ? getModal() : <>{children}</>}
+    </MfaErrorBoundary>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
@@ -69,7 +69,9 @@ export const ModalMfaProtected = ({
           </h2>
         </FtlMsg>
         <FtlMsg id="modal-mfa-protected-subtitle">
-          <p className="text-base mt-1">Help us make sure it’s you changing your account info</p>
+          <p className="text-base mt-1">
+            Help us make sure it’s you changing your account info
+          </p>
         </FtlMsg>
         {showResendSuccessBanner && <ResendCodeSuccessBanner />}
 
@@ -83,7 +85,9 @@ export const ModalMfaProtected = ({
           }}
         >
           <p id="modal-mfa-protected-desc" className="my-6">
-            Enter the code that was sent to <span className="font-bold">{email}</span> within {expirationTime === 1 ? '1 minute' : `${expirationTime} minutes`}.
+            Enter the code that was sent to{' '}
+            <span className="font-bold">{email}</span> within{' '}
+            {expirationTime === 1 ? '1 minute' : `${expirationTime} minutes`}.
           </p>
         </FtlMsg>
 

--- a/packages/fxa-settings/src/components/Settings/PageMfaGuardTest/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageMfaGuardTest/index.tsx
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useState, useEffect, useSyncExternalStore } from 'react';
+import { useAuthClient } from '../../../models';
+import {
+  JwtNotFoundError,
+  JwtTokenCache,
+  sessionToken as getSessionToken,
+} from '../../../lib/cache';
+import { MfaGuard } from '../MfaGuard';
+import { RouteComponentProps } from '@reach/router';
+import { useErrorHandler } from 'react-error-boundary';
+
+export const PageMfaGuardTestWithAuthClient = (props: RouteComponentProps) => {
+  return (
+    <MfaGuard requiredScope="test">
+      <TestWithAuthClient {...{ props }} />
+    </MfaGuard>
+  );
+};
+export default PageMfaGuardTestWithAuthClient;
+
+/**
+ * Serves as a proof of concept that MfaGuard works when dealing with a protected
+ * endpoint called by the auth server.
+ *
+ * This will go away as soon as we actually start applying the guard to real pages/flows.
+ */
+const TestWithAuthClient = (_: RouteComponentProps) => {
+  const errorHandler = useErrorHandler();
+  const jwtCache = useSyncExternalStore(
+    JwtTokenCache.subscribe,
+    JwtTokenCache.getSnapshot
+  );
+  const [status, setStatus] = useState('');
+  const [refresh, setRefresh] = useState(0);
+  const authClient = useAuthClient();
+
+  // Get the session token from cache and make sure it's valid
+  const sessionToken = getSessionToken();
+  if (!sessionToken) {
+    throw new Error('Invalid state. Session token missing!@');
+  }
+
+  // Each page will have a unique scope, possibly shared with other pages
+  const scope = 'test';
+  const jwtKey = `${sessionToken}-${scope}`;
+
+  // Fire off the request to test if the JWT worked or not
+  // If this throws an exception, we should get a 110 errno back
+  // and the guard's modal should pop up again
+  useEffect(() => {
+    (async () => {
+      try {
+        const jwt = JwtTokenCache.getToken(sessionToken, scope);
+        const result = await authClient.mfaTestGet(jwt);
+        setStatus(result.status === 'success' ? 'valid' : 'invalid');
+      } catch (err) {
+        // This lets the error boundary take charge
+        errorHandler(err);
+      }
+    })();
+  }, [jwtCache, authClient, errorHandler, sessionToken]);
+
+  // Wrap the page's content with an MfaGuard to protect it from access without
+  // a JWT that has a scope of "test"
+  return (
+    <>
+      <b>JWT Status Check</b>
+      <br />
+      <br />
+      <p>
+        Your JWT status is: <pre>{status}</pre>
+      </p>
+      <br />
+      <p>
+        Your JWT is held in the cache under:
+        <pre>{jwtKey}</pre>
+      </p>
+      <br />
+      <p>
+        Your JWT value is:
+        <pre>{jwtCache[jwtKey]}</pre>
+      </p>
+      <br />
+      <p>
+        Page Refreshes <pre>{refresh}</pre>
+      </p>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // This just illustrates the persistence of the JWT in the cache.
+          // If you wait long enough, the JWT expires, and hitting
+          // refresh should result in an invalid jwt, and cause the
+          // OTP modal to pop up. Same as above.
+          setRefresh(refresh + 1);
+          e.stopPropagation();
+        }}
+      >
+        Refresh Page
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // This illustrates what happens if a token drops out of cache.
+          // The OTP modal should pop up!
+          JwtTokenCache.removeToken(sessionToken, scope);
+
+          // Important! The click has a race and can bubble
+          // up and close the modal that is going to be rendered
+          // after the JWT gets cleared from the cache
+          e.stopPropagation();
+        }}
+      >
+        Clear JWT from Cache
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // This illustrates what happens if the token held in the cache
+          // expires. In this case, we should get back a 110 errno, and
+          // the MFA error boundary should pick this state up, flush the
+          // token, and the OTP modal should be displayed again.
+          const expiredToken =
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1aWQiLCJzY29wZSI6WyJwcm90ZWN0ZWQtYWN0aW9uczp0ZXN0Il0sImlhdCI6MTc1NTg4MTQ4NiwianRpIjoiY2QyNTJjZjYtM2MwNi00OWYyLWE4OTItNjU5NTc2MjhjZWU5IiwiZXhwIjoxNzU1ODgxNDk2LCJhdWQiOiJmeGEiLCJpc3MiOiJhY2NvdW50cy5maXJlZm94LmNvbSJ9.GB_vrTsRXmpVF5WYKCaUPqCcP5WOBS2wOvuzvkjafiw';
+          JwtTokenCache.setToken(sessionToken, scope, expiredToken);
+          e.stopPropagation();
+        }}
+      >
+        Replace with JWT in cache with expired token.
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // In the event a random error is thrown, the MFA error boundary
+          // should let it bubble up to the AppError boundary, and
+          // we should see the General Error screen
+          errorHandler(new Error('BOOMO!'));
+          e.stopPropagation();
+        }}
+      >
+        Throw unrelated error.
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // In the event a fabricated JWT-not-found error occurs,
+          // the error boundary should catch this, and clear the
+          // token from cache, which will cause the OTP modal to pop up.
+          errorHandler(new JwtNotFoundError());
+          e.stopPropagation();
+        }}
+      >
+        Throw fabricated invalid token error.
+      </button>
+    </>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -37,6 +37,7 @@ import PageRecoveryPhoneRemove from './PageRecoveryPhoneRemove';
 import { SettingsIntegration } from './interfaces';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import Page2faChange from './Page2faChange';
+import PageMfaGuardTestWithAuthClient from './PageMfaGuardTest';
 
 export const Settings = ({
   integration,
@@ -196,6 +197,8 @@ export const Settings = ({
 
           <PageRecoveryPhoneSetup path="/recovery_phone/setup" />
           <PageRecoveryPhoneRemove path="/recovery_phone/remove" />
+
+          <PageMfaGuardTestWithAuthClient path="/mfa_guard/test/auth_client" />
         </ScrollToTop>
       </Router>
     </SettingsLayout>

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -75,3 +75,5 @@ export type TotpInfo = {
   secret: string;
   recoveryCodes?: string[];
 };
+
+export type MfaScope = 'test';


### PR DESCRIPTION
## Because

- We want to wrap certain pages with an MFA requirement

## This pull request

- Updates the cache to hold a JWT
- Creates a guard component that invokes the MFA Modal if the JWT is missing
- Creates an error boundary that clears invalid or expired JWTs

## Issue that this pull request solves

Closes: FXA-12220, FXA-12305, FXA-12304

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Test driver page:
<img width="521" height="766" alt="image" src="https://github.com/user-attachments/assets/69ed5db1-8226-4978-8b6a-cfc2df4ac675" />

<img width="958" height="836" alt="image" src="https://github.com/user-attachments/assets/6c56b5d2-9dfd-4e85-bffe-69aee879b07b" />

## Other information (Optional)

There will be a couple follow ups filed for error handling. This PR doesn't currently address the following things:
- The invalid code errors. We need to trigger the tool tip if the server reports back saying the OTP code is invalid.
- Rate limiting errors. We have some changes planned around how we handle unblock codes anyways, so this wasn't addressed in this PR.

To test manually, create account / login so that you are on the `/settings` page. Then manually navigate to `/settings/mfa_guard/test/auth_client` and test flow / error boundary.
