### PR TITLE
fix(locale): Small fix for language selector

### DIFF
--- a/packages/fxa-settings/src/models/hooks.test.ts
+++ b/packages/fxa-settings/src/models/hooks.test.ts
@@ -410,12 +410,12 @@ describe('useCmsInfoState', () => {
   });
 
   it('should fetch when l10nEnabled is false but browser language is English', async () => {
-    // Mock English browser language but non-English selected locale
+    // Mock English browser language and English selected locale
     Object.defineProperty(navigator, 'language', {
       writable: true,
       value: 'en-GB',
     });
-    require('../contexts/DynamicLocalizationContext').useDynamicLocalization.mockReturnValue({ currentLocale: 'fr-FR' });
+    require('../contexts/DynamicLocalizationContext').useDynamicLocalization.mockReturnValue({ currentLocale: 'en-US' });
 
     mockUrlQueryData.get.mockImplementation((key: string) => {
       if (key === 'client_id') return '1234567890abcdef';

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -244,10 +244,14 @@ export function useCmsInfoState() {
 
       // If l10nEnabled is false, only fetch for English locales
       // Check both browser language and user's selected locale
-      const isEnglishBrowser = navigator.language.startsWith('en');
-      const isEnglishSelected = currentLocale.startsWith('en');
+      let isEnglish = false;
+      if (currentLocale) {
+        isEnglish = currentLocale.startsWith('en');
+      } else if (navigator.language) {
+        isEnglish = navigator.language.startsWith('en');
+      }
 
-      return isEnglishBrowser || isEnglishSelected;
+      return isEnglish;
     }
 
     if (


### PR DESCRIPTION
## Because

- We could possibly show translated strings with customization

## This pull request

- If language toggle is set, check that language for en, otherwise check `navigator.language`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
