### PR TITLE
fix(auth): Don't require 'service' on totp/setup/complete

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -291,7 +291,6 @@ module.exports = (
         },
         validate: {
           payload: isA.object({
-            service: validators.service,
             metricsContext: METRICS_CONTEXT_SCHEMA,
           }),
         },


### PR DESCRIPTION
Because:
* We should not block the user from completing TOTP setup on 'service'

This commit:
* Removes the 'service' requirement from the payload

fixes FXA-12317

---

AMO stage fails on the service validation due to their name. We can either remove the requirement to better match feature parity (this was added in #19314) or [increase the number of allowed characters](https://github.com/mozilla/fxa/blob/add0cb8fd33d7ffae4cd118c9555fc722a2e04b7/packages/fxa-auth-server/lib/routes/validators.js#L118-L119).