### PR TITLE
task(settings,graphql): Create example of MFA guard using gql queries

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -1066,5 +1066,23 @@ describe('#integration - AccountResolver', () => {
         });
       });
     });
+
+    describe('mafTest', () => {
+      it('succeeds', async () => {
+        authClient.mfaTestGet = jest.fn().mockResolvedValue({
+          status: 'success',
+        });
+        const result = await resolver.mfaTest(headers, {
+          jwt: 'jwt-123',
+        });
+        expect(authClient.mfaTestGet).toHaveBeenCalledWith(
+          'jwt-123',
+          expect.any(Object)
+        );
+        expect(result).toStrictEqual({
+          status: 'success',
+        });
+      });
+    });
   });
 });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -45,6 +45,7 @@ import {
   DeleteRecoveryKeyInput,
   DeleteTotpInput,
   EmailInput,
+  MfaTestInput,
   PasswordChangeFinishInput,
   PasswordChangeStartInput,
   PasswordForgotCodeStatusInput,
@@ -70,6 +71,7 @@ import {
   ChangeRecoveryCodesPayload,
   CreateTotpPayload,
   CredentialStatusPayload,
+  MfaTestGetPayload,
   PasswordChangeFinishPayload,
   PasswordChangeStartPayload,
   PasswordForgotCodeStatusPayload,
@@ -1000,5 +1002,15 @@ export class AccountResolver {
     input: string
   ) {
     return this.authAPI.wrappedAccountKeys(input, headers);
+  }
+
+  @Mutation((returns) => MfaTestGetPayload)
+  @CatchGatewayError
+  public async mfaTest(
+    @GqlXHeaders() headers: Headers,
+    @Args('input', { type: () => MfaTestInput })
+    input: MfaTestInput
+  ) {
+    return await this.authAPI.mfaTestGet(input.jwt, headers);
   }
 }

--- a/packages/fxa-graphql-api/src/gql/dto/input/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/index.ts
@@ -28,3 +28,4 @@ export { LegalInput } from './legal';
 export * from './credential-status';
 export * from './password-change-finish';
 export * from './password-change-start';
+export * from './mfa';

--- a/packages/fxa-graphql-api/src/gql/dto/input/mfa.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/mfa.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class MfaTestInput {
+  @Field({
+    description: 'A jwt tor provide access to auth server endpoints.',
+    nullable: true,
+  })
+  public jwt!: string;
+}

--- a/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/index.ts
@@ -24,3 +24,4 @@ export * from './credential-status';
 export * from './password-change-start';
 export * from './password-change-finish';
 export * from './wrapped-keys';
+export * from './mfa-test';

--- a/packages/fxa-graphql-api/src/gql/dto/payload/mfa-test.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/payload/mfa-test.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class MfaTestGetPayload {
+  @Field()
+  status!: String;
+}

--- a/packages/fxa-settings/src/components/Settings/PageMfaGuardWithGqlTest/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageMfaGuardWithGqlTest/index.tsx
@@ -1,0 +1,198 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useState, useEffect, useSyncExternalStore } from 'react';
+import {
+  JwtNotFoundError,
+  JwtTokenCache,
+  sessionToken as getSessionToken,
+} from '../../../lib/cache';
+
+import { MfaGuard } from '../MfaGuard';
+import { RouteComponentProps } from '@reach/router';
+import { useErrorHandler } from 'react-error-boundary';
+import { ApolloError, gql, useMutation } from '@apollo/client';
+
+export const PageMfaGuardTestWithGql = (props: RouteComponentProps) => {
+  return (
+    <MfaGuard requiredScope="test">
+      <TestWithGql {...{ props }} />
+    </MfaGuard>
+  );
+};
+
+export default PageMfaGuardTestWithGql;
+
+const MFA_TEST_MUTATION = gql`
+  mutation MfaTest($input: MfaTestInput!) {
+    mfaTest(input: $input) {
+      status
+    }
+  }
+`;
+
+const TestWithGql = (_: RouteComponentProps) => {
+  const errorHandler = useErrorHandler();
+  const jwtCache = useSyncExternalStore(
+    JwtTokenCache.subscribe,
+    JwtTokenCache.getSnapshot
+  );
+  const [status, setStatus] = useState('');
+  const [refresh, setRefresh] = useState(0);
+
+  const [mfaTest] = useMutation(MFA_TEST_MUTATION, {
+    onError() {
+      console.log('!!! on MFA_TEST_MUTATION error');
+    },
+  });
+
+  const sessionToken = getSessionToken();
+  if (!sessionToken) {
+    throw new Error('Invalid state. Session token missing!@');
+  }
+
+  // Each page will have a unique scope, possibly shared with other pages
+  const scope = 'test';
+  const jwtKey = `${sessionToken}-${scope}`;
+
+  // Fire off the request to test if the JWT worked or not
+  // If this throws an exception, we should get a 110 errno back
+  // and the guard's modal should pop up again
+  useEffect(() => {
+    (async () => {
+      const jwt = JwtTokenCache.getToken(sessionToken, scope);
+
+      const result = await mfaTest({
+        variables: {
+          input: {
+            jwt: jwt,
+          },
+        },
+      });
+
+      if (result.data?.mfaTest) {
+        setStatus(
+          result.data?.mfaTest.status === 'success' ? 'valid' : 'invalid'
+        );
+      } else if (result.errors instanceof ApolloError) {
+        // extensions holds the auth server errno and code
+        errorHandler(result.errors?.cause?.extensions);
+      }
+    })();
+  }, [jwtCache, mfaTest, errorHandler, sessionToken]);
+
+  // Wrap the page's content with an MfaGuard to protect it from access without
+  // a JWT that has a scope of "test"
+  return (
+    <>
+      <b>JWT Status Check</b>
+      <br />
+      <br />
+      <p>
+        Your JWT status is: <pre>{status}</pre>
+      </p>
+      <br />
+      <p>
+        Your JWT is held in the cache under:
+        <pre>{jwtKey}</pre>
+      </p>
+      <br />
+      <p>
+        Your JWT value is:
+        <pre>{jwtCache[jwtKey]}</pre>
+      </p>
+      <br />
+      <p>
+        Page Refreshes <pre>{refresh}</pre>
+      </p>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // This just illustrates the persistence of the JWT in the cache.
+          // If you wait long enough, the JWT expires, and hitting
+          // refresh should result in an invalid jwt, and cause the
+          // OTP modal to pop up. Same as above.
+          setRefresh(refresh + 1);
+          e.stopPropagation();
+        }}
+      >
+        Refresh Page
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // This illustrates what happens if a token drops out of cache.
+          // The OTP modal should pop up!
+          JwtTokenCache.removeToken(sessionToken, scope);
+
+          // Important! The click has a race and can bubble
+          // up and close the modal that is going to be rendered
+          // after the JWT gets cleared from the cache
+          e.stopPropagation();
+        }}
+      >
+        Clear JWT from Cache
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // This illustrates what happens if the token held in the cache
+          // expires. In this case, we should get back a 110 errno, and
+          // the MFA error boundary should pick this state up, flush the
+          // token, and the OTP modal should be displayed again.
+          const expiredToken =
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1aWQiLCJzY29wZSI6WyJwcm90ZWN0ZWQtYWN0aW9uczp0ZXN0Il0sImlhdCI6MTc1NTg4MTQ4NiwianRpIjoiY2QyNTJjZjYtM2MwNi00OWYyLWE4OTItNjU5NTc2MjhjZWU5IiwiZXhwIjoxNzU1ODgxNDk2LCJhdWQiOiJmeGEiLCJpc3MiOiJhY2NvdW50cy5maXJlZm94LmNvbSJ9.GB_vrTsRXmpVF5WYKCaUPqCcP5WOBS2wOvuzvkjafiw';
+          JwtTokenCache.setToken(sessionToken, scope, expiredToken);
+          e.stopPropagation();
+        }}
+      >
+        Replace with JWT in cache with expired token.
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // In the event a random error is thrown, the MFA error boundary
+          // should let it bubble up to the AppError boundary, and
+          // we should see the General Error screen
+          errorHandler(new Error('BOOMO!'));
+          e.stopPropagation();
+        }}
+      >
+        Throw unrelated error.
+      </button>
+
+      <br />
+      <br />
+      <button
+        type="button"
+        className="cta-neutral cta-xl flex-1 w-1/2"
+        onClick={(e) => {
+          // In the event a fabricated JWT-not-found error occurs,
+          // the error boundary should catch this, and clear the
+          // token from cache, which will cause the OTP modal to pop up.
+          errorHandler(new JwtNotFoundError());
+          e.stopPropagation();
+        }}
+      >
+        Throw fabricated invalid token error.
+      </button>
+    </>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -38,6 +38,7 @@ import { SettingsIntegration } from './interfaces';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import Page2faChange from './Page2faChange';
 import PageMfaGuardTestWithAuthClient from './PageMfaGuardTest';
+import PageMfaGuardTestWithGql from './PageMfaGuardWithGqlTest';
 
 export const Settings = ({
   integration,
@@ -199,6 +200,7 @@ export const Settings = ({
           <PageRecoveryPhoneRemove path="/recovery_phone/remove" />
 
           <PageMfaGuardTestWithAuthClient path="/mfa_guard/test/auth_client" />
+          <PageMfaGuardTestWithGql path="/mfa_guard/test/gql" />
         </ScrollToTop>
       </Router>
     </SettingsLayout>


### PR DESCRIPTION
## Because

- We also wanted to have an example of using MFA with gql queries

## This pull request

- Adds a new test page `/settings/mfa_guard/test/gql`
- Adds a new mutation to simulate a JWT protected call being proxied to auth-server
- Shows how to deal with GQL error so MFA modal pops up


## Issue that this pull request solves

Closes: FXA-12324

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Same as before, to test:
- Create account
- Once on settings page navigate to `/settings/mfa_guard/test/gql`

Behavior should be the same as `/settings/mfa_guard/test/auth-client` page. Example over [here](https://github.com/mozilla/fxa/pull/19383#issuecomment-3247235595).
