### PR TITLE
fix(ci): ensure one circleci tests run call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,20 +326,6 @@ commands:
           environment:
             NODE_ENV: test
 
-  check-playwright-test-count:
-    parameters:
-      project:
-        type: string
-    steps:
-      - run:
-          name: Checking Playwright Test Count
-          command: |
-            TEST_COUNT=$(echo $TEST_FILES | circleci tests run --command="xargs yarn playwright test --project=<< parameters.project >> $GREP --list" | wc -l)
-            if [[ "$TEST_COUNT" -eq 0 ]]; then
-              echo "No functional tests targeted to run! Exiting early."
-              circleci-agent step halt
-            fi
-
   run-playwright-tests:
     parameters:
       project:
@@ -352,24 +338,14 @@ commands:
           name: Running Playwright tests
           # Supports 'Re-run failed tests only'. See this for more info: https://circleci.com/docs/rerun-failed-tests-only/
           command: |
-            if [[ "<< parameters.project >>" == "production" ]]; then
-              GREP="--grep=\"severity-1\""
-            elif [[ "<< parameters.project >>" == "stage" ]]; then
-              GREP="--grep=\"severity-(1|2)\""
-            else
-              GREP=""
-            fi
-            echo "targeting project << parameters.project >> $GREP"
-            npx nx build fxa-auth-client
             cd packages/functional-tests/tests
             TEST_FILES=$(circleci tests glob "./**/*.spec.ts")
             cd ..
-
-            echo $TEST_FILES | circleci tests run \
-              --command="xargs yarn playwright test --project=<< parameters.project >> $GREP" \
+            printf '%s\n' $TEST_FILES | circleci tests run \
               --verbose \
               --split-by=timings \
-              --timings-type=classname
+              --timings-type=classname \
+              --command="~/project/.circleci/run-playwright.sh << parameters.project >>"
           environment:
             NODE_OPTIONS: --dns-result-order=ipv4first
             ACCOUNTS_DOMAIN: << pipeline.parameters.accounts-domain >>
@@ -383,10 +359,10 @@ commands:
     steps:
       - run:
           name: Ensure directories
-          command: mkdir -p artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots
+          command: mkdir -p ~/project/artifacts/tests && mkdir -p ~/.pm2/logs && mkdir -p ~/screenshots
           when: always
       - store_artifacts:
-          path: artifacts
+          path: ~/project/artifacts
           when: always
       - store_artifacts:
           path: ~/screenshots
@@ -395,7 +371,7 @@ commands:
           path: ~/.pm2/logs
           when: always
       - store_test_results:
-          path: artifacts/tests
+          path: ~/project/artifacts/tests
           when: always
 
   build:
@@ -763,8 +739,6 @@ jobs:
     steps:
       - git-checkout
       - provision
-      - check-playwright-test-count:
-          project: production
       - run-playwright-tests:
           project: production
       - store-artifacts
@@ -788,8 +762,6 @@ jobs:
       - git-checkout
       - gcp-cli/setup
       - provision
-      - check-playwright-test-count:
-          project: << parameters.project >>
       - run-playwright-tests:
           project: << parameters.project >>
           fail_fast: << parameters.fail_fast >>
@@ -816,8 +788,6 @@ jobs:
       - git-checkout
       - restore-workspace
       - gcp-cli/setup
-      - check-playwright-test-count:
-          project: local
       - run:
           name: Add localhost
           command: |

--- a/.circleci/run-playwright.sh
+++ b/.circleci/run-playwright.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+project="$1"
+if [[ -z "$project" ]]; then
+  echo "Missing required <project> argument (production|stage|local)" >&2
+  exit 2
+fi
+
+# file list from stdin
+files=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+  for f in $line; do
+    [[ -n "$f" ]] && files+=("$f")
+  done
+done
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No functional tests targeted to run! Exiting early."
+  exec circleci-agent step halt
+fi
+
+case "$project" in
+  production) GREP='--grep="severity-1"' ;;
+  stage)      GREP='--grep="severity-(1|2)"' ;;
+  *)          GREP='' ;;
+esac
+echo "targeting project $project $GREP"
+
+npx nx build fxa-auth-client
+
+yarn playwright test \
+  --project="$project" ${GREP} \
+  -- "${files[@]}"


### PR DESCRIPTION
Because:
 - re-run failed tests was not working as the first `circle tests run` consumed the tests list for a count

This commit:
 - removes the check-playwright-test-count step so that there is only a single `circle tests run` call

