### PR TITLE
feat(admin-panel): allow admin panel to search by a users recovery phone number

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -136,7 +136,6 @@ export const Account = ({
 
   return (
     <>
-      <hr />
       <section data-testid="account-section">
         <TableYHeaders header="Account Details">
           <TableRowYHeader

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/index.gql.ts
@@ -258,3 +258,140 @@ export const GET_EMAILS_LIKE = gql`
     }
   }
 `;
+
+export const GET_ACCOUNT_BY_RECOVERY_PHONE = gql`
+  query getAccountByRecoveryPhone(
+    $phoneNumber: String!
+    $autoCompleted: Boolean!
+  ) {
+    accountByRecoveryPhone(
+      phoneNumber: $phoneNumber
+      autoCompleted: $autoCompleted
+    ) {
+      uid
+      createdAt
+      clientSalt
+      disabledAt
+      verifierSetAt
+      lockedAt
+      locale
+      email
+      emails {
+        email
+        isVerified
+        isPrimary
+        createdAt
+      }
+      emailBounces {
+        email
+        templateName
+        createdAt
+        bounceType
+        bounceSubType
+        diagnosticCode
+      }
+      securityEvents {
+        uid
+        nameId
+        verified
+        createdAt
+        name
+        ipAddr
+        additionalInfo
+      }
+      totp {
+        verified
+        createdAt
+        enabled
+      }
+      backupCodes {
+        hasBackupCodes
+        count
+      }
+      recoveryPhone {
+        exists
+        lastFourDigits
+      }
+      recoveryKeys {
+        createdAt
+        verifiedAt
+        enabled
+      }
+      linkedAccounts {
+        providerId
+        authAt
+        enabled
+      }
+      accountEvents {
+        name
+        service
+        eventType
+        createdAt
+        template
+      }
+      attachedClients {
+        createdTime
+        createdTimeFormatted
+        lastAccessTime
+        lastAccessTimeFormatted
+        deviceType
+        name
+        clientId
+        userAgent
+        os
+        sessionTokenId
+        location {
+          city
+          state
+          stateCode
+          country
+          countryCode
+        }
+      }
+      subscriptions {
+        created
+        currentPeriodEnd
+        currentPeriodStart
+        cancelAtPeriodEnd
+        endedAt
+        latestInvoice
+        planId
+        productName
+        productId
+        status
+        subscriptionId
+        manageSubscriptionLink
+      }
+      carts {
+        id
+        uid
+        state
+        errorReasonId
+        offeringConfigId
+        interval
+        experiment
+        currency
+        createdAt
+        updatedAt
+        couponCode
+        taxAddress {
+          countryCode
+          postalCode
+        }
+        stripeCustomerId
+        stripeSubscriptionId
+        amount
+        version
+        eligibilityStatus
+      }
+    }
+  }
+`;
+
+export const GET_RECOVERY_PHONES_LIKE = gql`
+  query getRecoveryPhones($search: String!) {
+    getRecoveryPhonesLike(search: $search) {
+      phoneNumber
+    }
+  }
+`;

--- a/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
+++ b/packages/fxa-admin-server/src/event-logging/event-logging.service.ts
@@ -43,7 +43,10 @@ export class EventLoggingService {
    * Records an AccountSearch event and indicates if the query was the result of an autocompletion.
    * @param autocompleted
    */
-  public onAccountSearch(searchType: 'email' | 'uid', autoCompleted: boolean) {
+  public onAccountSearch(
+    searchType: 'email' | 'uid' | 'phoneNumber',
+    autoCompleted: boolean
+  ) {
     this.log.info(this.logType, {
       event: EventNames.AccountSearch,
       'search-type': searchType,

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -48,6 +48,7 @@ import { AccountEvent as AccountEventType } from '../../gql/model/account-events
 import { Account as AccountType } from '../../gql/model/account.model';
 import { AttachedClient } from '../../gql/model/attached-clients.model';
 import { Email as EmailType } from '../../gql/model/emails.model';
+import { RecoveryPhone as RecoveryPhoneType } from '../model/recovery-phone.model';
 import { BasketService } from '../../newsletters/basket.service';
 import { SubscriptionsService } from '../../subscriptions/subscriptions.service';
 import {
@@ -183,12 +184,46 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.AccountSearch)
+  @Query((returns) => [AccountType], { nullable: true })
+  @SentryTraced('accountByRecoveryPhone')
+  public async accountByRecoveryPhone(
+    @Args('phoneNumber', { nullable: false }) phoneNumber: string,
+    @Args('autoCompleted', { nullable: false }) autoCompleted: boolean,
+    @CurrentUser() user: string
+  ) {
+    this.eventLogging.onAccountSearch('phoneNumber', autoCompleted);
+    this.log.info('accountByRecoveryPhone', { phoneNumber, user });
+
+    let accounts = await this.db.account
+      .query()
+      .select(ACCOUNT_COLUMNS.map((c) => 'accounts.' + c))
+      .innerJoin('recoveryPhones', 'recoveryPhones.uid', 'accounts.uid')
+      .where('recoveryPhones.phoneNumber', phoneNumber)
+      .limit(50);
+
+    return accounts;
+  }
+
+  @Features(AdminPanelFeature.AccountSearch)
   @Query((returns) => [EmailType], { nullable: true })
   public getEmailsLike(@Args('search', { nullable: false }) search: string) {
     return this.db.emails
       .query()
       .select(EMAIL_COLUMNS)
       .where('normalizedEmail', 'like', `${search.toLowerCase()}%`)
+      .limit(10);
+  }
+
+  @Features(AdminPanelFeature.AccountSearch)
+  @Query((returns) => [RecoveryPhoneType], { nullable: true })
+  public getRecoveryPhonesLike(
+    @Args('search', { nullable: false }) search: string
+  ) {
+    return this.db.recoveryPhones
+      .query()
+      .select(RECOVERYPHONES_COLUMNS)
+      .where('phoneNumber', 'like', `${search.toLowerCase()}%`)
+      .distinct('phoneNumber')
       .limit(10);
   }
 

--- a/packages/fxa-admin-server/src/gql/model/recovery-phone.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/recovery-phone.model.ts
@@ -5,6 +5,9 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class RecoveryPhone {
+  @Field({ nullable: true })
+  public phoneNumber!: string;
+
   @Field()
   public exists!: boolean;
 

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -171,6 +171,7 @@ export interface BackupCodes {
 }
 
 export interface RecoveryPhone {
+    phoneNumber?: Nullable<string>;
     exists: boolean;
     lastFourDigits?: Nullable<string>;
 }
@@ -226,7 +227,9 @@ export interface RelyingParty {
 export interface IQuery {
     accountByUid(uid: string): Nullable<Account> | Promise<Nullable<Account>>;
     accountByEmail(email: string, autoCompleted: boolean): Nullable<Account> | Promise<Nullable<Account>>;
+    accountByRecoveryPhone(phoneNumber: string, autoCompleted: boolean): Nullable<Account[]> | Promise<Nullable<Account[]>>;
     getEmailsLike(search: string): Nullable<Email[]> | Promise<Nullable<Email[]>>;
+    getRecoveryPhonesLike(search: string): Nullable<RecoveryPhone[]> | Promise<Nullable<RecoveryPhone[]>>;
     getDeleteStatus(taskNames: string[]): AccountDeleteTaskStatus[] | Promise<AccountDeleteTaskStatus[]>;
     relyingParties(): RelyingParty[] | Promise<RelyingParty[]>;
 }

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -167,6 +167,7 @@ type BackupCodes {
 }
 
 type RecoveryPhone {
+  phoneNumber: String
   exists: Boolean!
   lastFourDigits: String
 }
@@ -222,7 +223,9 @@ type RelyingParty {
 type Query {
   accountByUid(uid: String!): Account
   accountByEmail(email: String!, autoCompleted: Boolean!): Account
+  accountByRecoveryPhone(phoneNumber: String!, autoCompleted: Boolean!): [Account!]
   getEmailsLike(search: String!): [Email!]
+  getRecoveryPhonesLike(search: String!): [RecoveryPhone!]
   getDeleteStatus(taskNames: [String!]!): [AccountDeleteTaskStatus!]!
   relyingParties: [RelyingParty!]!
 }


### PR DESCRIPTION
## Because

- we want to allow admin panel to search by a user's recovery phone number

## This pull request

- adds search by recovery phone functionality to the account search page.

## Issue that this pull request solves

Closes: FXA-12033

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1132" height="638" alt="image" src="https://github.com/user-attachments/assets/f007cacc-1b75-4bf9-99cb-4ae2265db88b" />

## Other information (Optional)

Any other information that is important to this pull request.
