### PR TITLE
chore(auth): Update ipProfiling allowedRecency to 7 days

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1590,7 +1590,7 @@ const convictConf = convict({
     ipProfiling: {
       allowedRecency: {
         doc: 'Length of time since previously verified event to allow skipping confirmation',
-        default: '72 hours',
+        default: '7 days',
         format: 'duration',
         env: 'IP_PROFILING_RECENCY',
       },


### PR DESCRIPTION
Because:
 - We want to ease the process for new sync logins

This Commit:
 - Increases auth server ipProfiling allowedRecency default value to 7 days

Closes: FXA-12132

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
