### PR TITLE
bug(settings): Fix drop shadow on cms buttons

### DIFF
--- a/packages/fxa-settings/src/components/CmsButtonWithFallback/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CmsButtonWithFallback/index.stories.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 import React from 'react';
 import { Meta } from '@storybook/react';
 import CmsButtonWithFallback from '.';
@@ -21,10 +20,30 @@ const storyWithProps = (props: any) => {
   return story;
 };
 
+export const WithVeryLightCmsButtonColor = storyWithProps({
+  buttonColor: '#ffffcc',
+  buttonText: 'Continue with Very Light Background',
+  type: 'button',
+});
+
+export const WithVeryLightCmsButtonColorAndDisabled = storyWithProps({
+  buttonColor: '#ffffcc',
+  buttonText: 'Continue with Very Light Background',
+  type: 'button',
+  disabled: true,
+});
+
 export const WithDarkCmsButtonColor = storyWithProps({
   buttonColor: '#350080',
   buttonText: 'Continue with Dark Background',
   type: 'button',
+});
+
+export const WithDarkCmsButtonColorAndDisabled = storyWithProps({
+  buttonColor: '#350080',
+  buttonText: 'Continue with Dark Background',
+  type: 'button',
+  disabled: true,
 });
 
 export const WithLightCmsButtonColor = storyWithProps({
@@ -33,7 +52,20 @@ export const WithLightCmsButtonColor = storyWithProps({
   type: 'button',
 });
 
+export const WithLightCmsButtonColorAndDisabled = storyWithProps({
+  buttonColor: '#f58742',
+  buttonText: 'Continue with Light Background',
+  type: 'button',
+  disabled: true,
+});
+
 export const WithDefaultFallback = storyWithProps({
   buttonText: 'Continue with Default Styling',
   type: 'button',
+});
+
+export const WithDefaultFallbackAndDisabled = storyWithProps({
+  buttonText: 'Continue with Default Styling',
+  type: 'button',
+  disabled: true,
 });


### PR DESCRIPTION
## Because

- Drop shadow looked funny in some cases
- Function to determine contrast didn't take into account disabled

## This pull request

- Simplifies logic and removes drop shadow if it's a CMS button or if it's disabled

## Issue that this pull request solves

Closes: FXA-12318

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

**Before:**
<img width="847" height="142" alt="image" src="https://github.com/user-attachments/assets/7bce8450-779a-4a37-9c65-4f8c9b44ef93" />
<img width="844" height="138" alt="image" src="https://github.com/user-attachments/assets/16272efb-1680-4344-8c12-23fa12a84ffb" />
<img width="746" height="140" alt="image" src="https://github.com/user-attachments/assets/4ab047e4-6269-4855-83b1-38440c3c5159" />
<img width="782" height="138" alt="image" src="https://github.com/user-attachments/assets/e4d87004-1d65-4473-88a9-b6387a499dd5" />
<img width="802" height="138" alt="image" src="https://github.com/user-attachments/assets/5b2d5f8a-f59f-4585-9c08-6541acdadbba" />
<img width="767" height="136" alt="image" src="https://github.com/user-attachments/assets/7e8f2593-1e17-469c-bb46-ced8eb7af46d" />




So, for the fix, we don't do drop shadows, and we use a dark color for the text if the contrast is poor.

**After:**
<img width="282" height="79" alt="image" src="https://github.com/user-attachments/assets/ce9edcda-07f9-46db-be90-e78234c27bbc" />
<img width="284" height="82" alt="image" src="https://github.com/user-attachments/assets/670d86b3-b366-4ff0-8947-85144f31d3d1" />
<img width="323" height="79" alt="image" src="https://github.com/user-attachments/assets/24904431-9bee-4818-b176-4c2075f99d39" />
<img width="319" height="65" alt="image" src="https://github.com/user-attachments/assets/ee6a38dc-30db-42eb-8d50-55e4ad6b3e4f" />


Note that the drop shadow with really light color buttons looked pretty strange, which is why I decided to use a dark text color.
<img width="756" height="259" alt="image" src="https://github.com/user-attachments/assets/c090f0e4-b6b7-4c8e-b475-c3f201239ee3" />

## Other information (Optional)

Any other information that is important to this pull request.
