### PR TITLE
feat(auth): add feature flag for price info

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1023,6 +1023,12 @@ const convictConf = convict({
       env: 'SUBSCRIPTIONS_UNSUPPORTED_LOCATIONS',
       format: Array,
     },
+    billingPriceInfoFeature: {
+      doc: 'Display price info along with billing and subscription info in /billings-and-subscriptions api',
+      format: Boolean,
+      env: 'SUBSCRIPTIONS_BILLING_PRICE_INFO_FEATURE',
+      default: false,
+    },
   },
   currenciesToCountries: {
     doc: 'Mapping from ISO 4217 three-letter currency codes to list of ISO 3166-1 alpha-2 two-letter country codes: {"EUR": ["DE", "FR"], "USD": ["CA", "GB", "US" ]}  Requirement for only one currency per country. Tested at runtime. Must be uppercased.',

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -63,7 +63,7 @@ export const createRoutes = (
     );
     routes.push(...supportRoutes(log, db, config, customs, zendeskClient));
     routes.push(
-      ...mozillaSubscriptionRoutes({ log, db, customs, stripeHelper })
+      ...mozillaSubscriptionRoutes({ log, db, config, customs, stripeHelper })
     );
   }
   if (stripeHelper && config.subscriptions.paypalNvpSigCredentials.enabled) {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
@@ -152,6 +152,11 @@ const db = mocks.mockDB({
   locale: ACCOUNT_LOCALE,
 });
 const customs = mocks.mockCustoms();
+const mockConfig = {
+  subscriptions: {
+    billingPriceInfoFeature: true,
+  },
+};
 let stripeHelper;
 let capabilityService;
 
@@ -170,6 +175,7 @@ async function runTest(routePath, routeDependencies = {}) {
     log,
     db,
     customs,
+    config: mockConfig,
     stripeHelper,
     capabilityService,
     playSubscriptions,
@@ -229,6 +235,42 @@ describe('mozilla-subscriptions', () => {
           {
             ...mockAppStoreSubscription,
             priceInfo: mockSubscriptionManagementPriceInfo,
+          },
+        ],
+      });
+      assert.equal(
+        iapFormatterSpy.playStoreSubscriptionPurchaseToPlayStoreSubscriptionDTO
+          .callCount,
+        1
+      );
+      assert.equal(
+        iapFormatterSpy.appStoreSubscriptionPurchaseToAppStoreSubscriptionDTO
+          .callCount,
+        1
+      );
+    });
+
+    it('gets customer billing details and Stripe, Google Play, and App Store subscriptions without priceInfo', async () => {
+      const resp = await runTest(
+        '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
+        {
+          config: { subscriptions: { billingPriceInfoFeature: false } },
+        }
+      );
+      assert.deepEqual(resp, {
+        ...expectedBillingDetails,
+        subscriptions: [
+          {
+            ...mockSubscription,
+            priceInfo: undefined,
+          },
+          {
+            ...mockGooglePlaySubscription,
+            priceInfo: undefined,
+          },
+          {
+            ...mockAppStoreSubscription,
+            priceInfo: undefined,
           },
         ],
       });


### PR DESCRIPTION
## Because

- Need to be able to disable/enable fetching price info for the GET /billing-and-subscriptions API.

## This pull request

- Adds a new feature flag

## Issue that this pull request solves

Closes: #PAY-3237

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
