### PR TITLE
fix(layout): Remove 'relative' class from 'section'

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -63,7 +63,7 @@ export const AppLayout = ({
 
   const favicon = cmsInfo?.shared?.favicon;
 
-  const showLocaleToggle =config.featureFlags?.showLocaleToggle;
+  const showLocaleToggle = config.featureFlags?.showLocaleToggle;
 
   return (
     <>
@@ -123,7 +123,7 @@ export const AppLayout = ({
           </LinkExternal>
         </header>
         <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1">
-          <section className="relative">
+          <section>
             {wrapInCard ? (
               <div className={classNames('card', widthClass)}>{children}</div>
             ) : (
@@ -133,12 +133,12 @@ export const AppLayout = ({
         </main>
       </div>
       <footer>
-            {/* LocaleToggle positioned in lower left corner of page */}
-            {showLocaleToggle && (
-              <div className="fixed bottom-6 left-6 z-10">
-                <LocaleToggle placement="footer" />
-              </div>
-            )}
+        {/* LocaleToggle positioned in lower left corner of page */}
+        {showLocaleToggle && (
+          <div className="fixed bottom-6 left-6 z-10">
+            <LocaleToggle placement="footer" />
+          </div>
+        )}
       </footer>
       <div id="body-bottom" className="w-full block mobileLandscape:hidden" />
     </>


### PR DESCRIPTION
Because:
* We don't need this 'relative' class, and it causes issues on the absolutely positioned celebration effect because it anchors the start position to the main content instead of the page

This commit:
* Removes the class

fixes FXA-12330

---

I believe this class was added with the locale toggler (stage only), but is no longer needed since it's displayed in the `<footer>`.

Landing this directly in the train branch because it's already fixed on `main` with #19360.