### PR TITLE
feat(mfa): handle invalid MFA OTP error state for MFA guard

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.stories.tsx
@@ -18,14 +18,14 @@ export default {
 
 export const DefaultWithValidCode123456 = () => {
   const [modalRevealed, showModal, hideModal] = useBooleanState(true);
-  const [localizedErrorTooltipMessage, setLocalizedErrorTooltipMessage] =
+  const [localizedErrorBannerMessage, setLocalizedErrorBannerMessage] =
     useState<string | undefined>(undefined);
   const [showResendSuccessBanner, setShowResendSuccessBanner] =
     useState<boolean>(false);
 
   const dismiss = () => {
     hideModal();
-    setLocalizedErrorTooltipMessage(undefined);
+    setLocalizedErrorBannerMessage(undefined);
     setShowResendSuccessBanner(false);
   };
 
@@ -49,18 +49,18 @@ export const DefaultWithValidCode123456 = () => {
             if (code === '123456') {
               dismiss();
             } else {
-              setLocalizedErrorTooltipMessage(
+              setLocalizedErrorBannerMessage(
                 'Invalid or expired confirmation code.'
               );
               setShowResendSuccessBanner(false);
             }
           }}
           {...{
-            localizedErrorTooltipMessage,
+            localizedErrorBannerMessage: localizedErrorBannerMessage,
             showResendSuccessBanner,
           }}
-          clearErrorTooltip={() => {
-            setLocalizedErrorTooltipMessage(undefined);
+          clearErrorMessage={() => {
+            setLocalizedErrorBannerMessage(undefined);
           }}
           onDismiss={dismiss}
           handleResendCode={() => {

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
@@ -15,7 +15,7 @@ const defaultProps = {
   onSubmit: () => {},
   onDismiss: () => {},
   handleResendCode: () => {},
-  clearErrorTooltip: () => {},
+  clearErrorMessage: () => {},
   resendCodeLoading: false,
   showResendSuccessBanner: false,
 };
@@ -98,14 +98,14 @@ describe('ModalMfaProtected', () => {
     expect(onDismiss).toHaveBeenCalled();
   });
 
-  it('displays banners and tooltips', () => {
+  it('displays error banner', () => {
     renderWithRouter(
       <ModalMfaProtected
         {...defaultProps}
-        localizedErrorTooltipMessage="error tooltip"
+        localizedErrorBannerMessage="error banner"
       />
     );
-    expect(screen.getByText('error tooltip')).toBeInTheDocument();
+    expect(screen.getByText('error banner')).toBeInTheDocument();
   });
 
   it('shows code resend success banner', () => {

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
@@ -9,7 +9,7 @@ import InputText from '../../InputText';
 import { useFtlMsgResolver } from '../../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import { EmailCodeImage } from '../../images';
-import { ResendCodeSuccessBanner } from '../../Banner';
+import Banner, { ResendCodeSuccessBanner } from '../../Banner';
 
 type ModalProps = {
   email: string;
@@ -17,8 +17,8 @@ type ModalProps = {
   onSubmit: (code: string) => void;
   onDismiss: () => void;
   handleResendCode: () => void;
-  clearErrorTooltip: () => void;
-  localizedErrorTooltipMessage?: string;
+  clearErrorMessage: () => void;
+  localizedErrorBannerMessage?: string;
   resendCodeLoading: boolean;
   showResendSuccessBanner: boolean;
 };
@@ -33,8 +33,8 @@ export const ModalMfaProtected = ({
   onSubmit,
   onDismiss,
   handleResendCode,
-  clearErrorTooltip,
-  localizedErrorTooltipMessage,
+  clearErrorMessage,
+  localizedErrorBannerMessage,
   resendCodeLoading,
   showResendSuccessBanner,
 }: ModalProps) => {
@@ -74,6 +74,13 @@ export const ModalMfaProtected = ({
           </p>
         </FtlMsg>
         {showResendSuccessBanner && <ResendCodeSuccessBanner />}
+        {localizedErrorBannerMessage && (
+          <Banner
+            type="error"
+            bannerId="modal-mfa-protected-error-banner"
+            content={{ localizedHeading: localizedErrorBannerMessage }}
+          />
+        )}
 
         <EmailCodeImage />
 
@@ -102,10 +109,13 @@ export const ModalMfaProtected = ({
               required: true,
               pattern: /^\s*[0-9]{6}\s*$/,
             })}
-            onChange={clearErrorTooltip}
-            {...{
-              errorText: localizedErrorTooltipMessage,
-            }}
+            onChange={clearErrorMessage}
+            ariaDescribedBy={
+              localizedErrorBannerMessage
+                ? 'modal-mfa-protected-error-banner'
+                : undefined
+            }
+            hasErrors={!!localizedErrorBannerMessage}
           />
         </div>
 


### PR DESCRIPTION
## Because

- invalid MFA OTP error states are not handled for the mfa guard

## This pull request

- shows error tooltip on invalid OTP error in the modal

## Issue that this pull request solves

Closes: FXA-12328

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="489" height="766" alt="image" src="https://github.com/user-attachments/assets/d5b1bc53-3901-4fa6-ad79-415f4fb9ee2d" />

## Other information (Optional)

Any other information that is important to this pull request.
