### PR TITLE
feat(next): dedup glean success and fail events

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -17,7 +17,6 @@ import {
 } from '@fxa/payments/ui/server';
 import {
   getCartOrRedirectAction,
-  recordEmitterEventAction,
 } from '@fxa/payments/ui/actions';
 import { config } from 'apps/payments/next/config';
 import type { Metadata } from 'next';
@@ -62,13 +61,6 @@ export default async function CheckoutError({
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const [cart] = await Promise.all([cartPromise]);
 
-  recordEmitterEventAction(
-    'checkoutFail',
-    { ...params },
-    searchParams,
-    cart.paymentInfo?.type
-  );
-
   const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config, searchParams);
 
   return (
@@ -80,7 +72,7 @@ export default async function CheckoutError({
         {
           // Once more conditionals are added, move this to a separate component
           cart.errorReasonId ===
-          CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME ? (
+            CartErrorReasonId.CART_ELIGIBILITY_STATUS_SAME ? (
             <Image
               src={checkIcon}
               alt=""

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -10,7 +10,6 @@ import { getCardIcon } from '@fxa/payments/ui';
 import {
   fetchCMSData,
   getCartOrRedirectAction,
-  recordEmitterEventAction,
 } from '@fxa/payments/ui/actions';
 import {
   getApp,
@@ -66,13 +65,6 @@ export default async function CheckoutSuccess({
     cartDataPromise,
     sessionPromise,
   ]);
-
-  recordEmitterEventAction(
-    'checkoutSuccess',
-    { ...params },
-    searchParams,
-    cart.paymentInfo.type
-  );
 
   const { successActionButtonUrl, successActionButtonLabel } =
     cms.commonContent.localizations.at(0) || cms.commonContent;

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -16,7 +16,6 @@ import {
 } from '@fxa/payments/ui/server';
 import {
   getCartOrRedirectAction,
-  recordEmitterEventAction,
 } from '@fxa/payments/ui/actions';
 import { config } from 'apps/payments/next/config';
 import { Metadata } from 'next';
@@ -59,13 +58,6 @@ export default async function UpgradeError({
   );
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const [cart] = await Promise.all([cartPromise]);
-
-  recordEmitterEventAction(
-    'checkoutFail',
-    { ...params },
-    searchParams,
-    cart.paymentInfo?.type
-  );
 
   const errorReason = getErrorFtlInfo(cart.errorReasonId, params, config, searchParams);
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
@@ -13,7 +13,6 @@ import {
 import {
   fetchCMSData,
   getCartOrRedirectAction,
-  recordEmitterEventAction,
 } from '@fxa/payments/ui/actions';
 import { CheckoutParams } from '@fxa/payments/ui/server';
 import Image from 'next/image';
@@ -66,13 +65,6 @@ export default async function UpgradeSuccess({
     cartDataPromise,
     sessionPromise,
   ]);
-
-  recordEmitterEventAction(
-    'checkoutSuccess',
-    { ...params },
-    searchParams,
-    cart.paymentInfo.type
-  );
 
   const { successActionButtonUrl, successActionButtonLabel } =
     cms.commonContent.localizations.at(0) || cms.commonContent;
@@ -211,7 +203,7 @@ export default async function UpgradeSuccess({
                 width={70}
                 height={24}
               />
-            ) :(
+            ) : (
               <span className="flex items-center gap-2">
                 {cart.paymentInfo.brand && (
                   <Image

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -823,7 +823,9 @@ export class CartService {
         ? this.subscriptionManager.listForCustomer(cart.stripeCustomerId)
         : undefined,
       cart.stripeCustomerId
-        ? this.customerSessionManager.createCheckoutSession(cart.stripeCustomerId)
+        ? this.customerSessionManager.createCheckoutSession(
+            cart.stripeCustomerId
+          )
         : undefined,
     ]);
     const cartEligibilityStatus =

--- a/libs/payments/customer/src/index.ts
+++ b/libs/payments/customer/src/index.ts
@@ -14,6 +14,7 @@ export * from './lib/promotionCode.manager';
 export * from './lib/setupIntent.manager';
 export * from './lib/subscription.manager';
 export * from './lib/types';
+export * from './lib/factories/paymentMethod.factory';
 export * from './lib/factories/pricing-for-currency.factory';
 export * from './lib/factories/tax-address.factory';
 export * from './lib/customer.error';

--- a/libs/payments/customer/src/lib/factories/paymentMethod.factory.ts
+++ b/libs/payments/customer/src/lib/factories/paymentMethod.factory.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { faker } from '@faker-js/faker';
+import { SubPlatPaymentMethodType, type StripePaymentMethod } from '../types';
+
+export const StripePaymentMethodTypeResponseFactory = (
+  override?: Partial<StripePaymentMethod>
+): StripePaymentMethod => ({
+  type: faker.helpers.arrayElement([
+    SubPlatPaymentMethodType.Card,
+    SubPlatPaymentMethodType.ApplePay,
+    SubPlatPaymentMethodType.GooglePay,
+    SubPlatPaymentMethodType.Link,
+    SubPlatPaymentMethodType.Stripe,
+  ]),
+  paymentMethodId: `pm_${faker.string.alphanumeric({ length: 14 })}`,
+  ...override,
+});

--- a/libs/payments/customer/src/lib/paymentMethod.manager.ts
+++ b/libs/payments/customer/src/lib/paymentMethod.manager.ts
@@ -13,14 +13,8 @@ import {
 import {
   DefaultPaymentMethod,
   SubPlatPaymentMethodType,
-  StripePaymentMethod,
-  PayPalPaymentMethod,
+  type PaymentMethodTypeResponse,
 } from './types';
-
-type PaymentMethodTypeResponse =
-  | StripePaymentMethod
-  | PayPalPaymentMethod
-  | null;
 
 @Injectable()
 export class PaymentMethodManager {
@@ -46,10 +40,7 @@ export class PaymentMethodManager {
     uid: string
   ) {
     let defaultPaymentMethod: DefaultPaymentMethod | undefined;
-    const paymentMethodType = await this.determineType(
-      customer,
-      subscriptions
-    );
+    const paymentMethodType = await this.determineType(customer, subscriptions);
     switch (paymentMethodType?.type) {
       case SubPlatPaymentMethodType.Link:
       case SubPlatPaymentMethodType.Card:
@@ -82,10 +73,10 @@ export class PaymentMethodManager {
     return defaultPaymentMethod;
   }
 
-  async determineType (
+  async determineType(
     customer?: StripeCustomer,
     subscriptions?: StripeSubscription[]
-  ): Promise <PaymentMethodTypeResponse> {
+  ): Promise<PaymentMethodTypeResponse> {
     // First check if payment method is PayPal
     // Note, this needs to happen first since a customer could also have a
     // default payment method. However if PayPal is set as the payment method,
@@ -107,22 +98,22 @@ export class PaymentMethodManager {
         return {
           type: SubPlatPaymentMethodType.ApplePay,
           paymentMethodId: customer.invoice_settings.default_payment_method,
-        }
+        };
       } else if (paymentMethod.card?.wallet?.type === 'google_pay') {
         return {
           type: SubPlatPaymentMethodType.GooglePay,
           paymentMethodId: customer.invoice_settings.default_payment_method,
-        }
+        };
       } else if (paymentMethod.type === 'link') {
         return {
           type: SubPlatPaymentMethodType.Link,
           paymentMethodId: customer.invoice_settings.default_payment_method,
-        }
+        };
       } else if (paymentMethod.type === 'card') {
         return {
           type: SubPlatPaymentMethodType.Card,
           paymentMethodId: customer.invoice_settings.default_payment_method,
-        }
+        };
       } else {
         return {
           type: SubPlatPaymentMethodType.Stripe,
@@ -132,6 +123,5 @@ export class PaymentMethodManager {
     }
 
     return null;
-  };
-
+  }
 }

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -52,6 +52,11 @@ export interface PayPalPaymentMethod {
   type: SubPlatPaymentMethodType.PayPal;
 }
 
+export type PaymentMethodTypeResponse =
+  | StripePaymentMethod
+  | PayPalPaymentMethod
+  | null;
+
 export interface Interval {
   interval: NonNullable<StripePrice['recurring']>['interval'];
   intervalCount: number;

--- a/libs/payments/events/src/lib/util/retrieveAdditionalMetricsData.ts
+++ b/libs/payments/events/src/lib/util/retrieveAdditionalMetricsData.ts
@@ -53,12 +53,14 @@ export async function retrieveAdditionalMetricsData(
           errorReasonId: cartData.value.errorReasonId,
           couponCode: cartData.value.couponCode,
           currency: cartData.value.currency,
+          stripeCustomerId: cartData.value.stripeCustomerId,
         }
       : {
           uid: '',
           errorReasonId: null,
           couponCode: '',
           currency: '',
+          stripeCustomerId: '',
         };
 
   return {

--- a/libs/payments/events/src/lib/util/retrieveAdditionalMetricsdata.spec.ts
+++ b/libs/payments/events/src/lib/util/retrieveAdditionalMetricsdata.spec.ts
@@ -30,6 +30,7 @@ const expectedCartMetricsData = {
   errorReasonId: mockCart.errorReasonId,
   couponCode: mockCart.couponCode,
   currency: mockCart.currency,
+  stripeCustomerId: mockCart.stripeCustomerId,
 };
 
 const emptyCmsMetricsData = {
@@ -41,6 +42,7 @@ const emptyCartMetricsData = {
   errorReasonId: null,
   couponCode: '',
   currency: '',
+  stripeCustomerId: '',
 };
 
 describe('retrieveAdditionalMetricsData', () => {

--- a/libs/payments/metrics/src/lib/glean/glean.factory.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.factory.ts
@@ -51,6 +51,7 @@ export const CartMetricsFactory = (
     errorReasonId: resultCart.errorReasonId,
     couponCode: resultCart.couponCode,
     currency: faker.finance.currencyCode().toLowerCase(),
+    stripeCustomerId: `cus_${faker.string.alphanumeric({ length: 14 })}`,
     ...override,
   };
 };

--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -20,6 +20,7 @@ import { mapRelyingParty } from './utils/mapRelyingParty';
 import { normalizeGleanFalsyValues } from './utils/normalizeGleanFalsyValues';
 import { PaymentsGleanConfig } from './glean.config';
 import { mapSubscriptionCancellation } from './utils/mapSubscriptionCancellation';
+import type { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 
 @Injectable()
 export class PaymentsGleanManager {
@@ -76,7 +77,7 @@ export class PaymentsGleanManager {
       cartMetricsData: CartMetrics;
       cmsMetricsData: CmsMetricsData;
     },
-    paymentProvider?: PaymentProvidersType
+    paymentProvider?: SubPlatPaymentMethodType
   ) {
     const commonMetrics = this.populateCommonMetrics(metrics);
 
@@ -140,6 +141,7 @@ export class PaymentsGleanManager {
       searchParams: {},
     };
     const emptyCartMetricsData: CartMetrics = {
+      stripeCustomerId: '',
       uid: '',
       errorReasonId: null,
       couponCode: '',

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -6,9 +6,7 @@ import Stripe from 'stripe';
 
 export const CheckoutTypes = ['with-accounts', 'without-accounts'] as const;
 export type CheckoutTypesType = (typeof CheckoutTypes)[number];
-import {
-  SubPlatPaymentMethodType,
-} from '@fxa/payments/customer';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 
 export const PaymentProvidersTypePartial = [
   'card',
@@ -34,7 +32,7 @@ export type CommonMetrics = {
 
 export type CartMetrics = Pick<
   ResultCart,
-  'uid' | 'errorReasonId' | 'couponCode' | 'currency'
+  'uid' | 'errorReasonId' | 'couponCode' | 'currency' | 'stripeCustomerId'
 >;
 
 export type CmsMetricsData = {

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
@@ -10,25 +10,20 @@ import { PaymentProvidersType } from '@fxa/payments/cart';
 import { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
 
 async function recordEmitterEventAction(
-  eventName: PaymentsEmitterEventsKeysType,
-  params: Record<string, string | string[]>,
-  searchParams: Record<string, string | string[]>
-): Promise<void>;
-
-async function recordEmitterEventAction(
-  eventName: 'checkoutFail',
-  params: Record<string, string | string[]>,
-  searchParams: Record<string, string | string[]>,
-  paymentProvider?: PaymentProvidersType
-): Promise<void>;
-
-async function recordEmitterEventAction(
-  eventName: 'checkoutSubmit' | 'checkoutSuccess',
+  eventName: 'checkoutSubmit',
   params: Record<string, string | string[]>,
   searchParams: Record<string, string | string[]>,
   paymentProvider: PaymentProvidersType
 ): Promise<void>;
-
+async function recordEmitterEventAction(
+  eventName:
+    | 'checkoutView'
+    | 'checkoutEngage'
+    | 'checkoutSuccess'
+    | 'checkoutFail',
+  params: Record<string, string | string[]>,
+  searchParams: Record<string, string | string[]>
+): Promise<void>;
 async function recordEmitterEventAction(
   eventName: PaymentsEmitterEventsKeysType,
   params: Record<string, string | string[]>,
@@ -44,7 +39,7 @@ async function recordEmitterEventAction(
   return getApp().getActionsService().recordEmitterEvent({
     eventName,
     requestArgs,
-    paymentProvider,
+    paymentProvider: paymentProvider,
   });
 }
 

--- a/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
@@ -7,21 +7,39 @@
 import { getApp } from '../nestapp/app';
 import { redirect } from 'next/navigation';
 import { URLSearchParams } from 'url';
+import { recordEmitterEventAction } from './recordEmitterEvent';
 
 export const submitNeedsInputAndRedirectAction = async (
   cartId: string,
+  params: Record<string, string | string[]>,
   searchParams?: Record<string, string | string[]>
 ) => {
   let redirectPath: string | undefined;
   const urlSearchParams = new URLSearchParams(searchParams);
-  const params = searchParams ? `?${urlSearchParams.toString()}` : '';
+  const searchParamsString = searchParams
+    ? `?${urlSearchParams.toString()}`
+    : '';
   try {
     await getApp().getActionsService().submitNeedsInput({ cartId });
+
+    await recordEmitterEventAction(
+      'checkoutSuccess',
+      { ...params },
+      { ...searchParams }
+    );
+
     redirectPath = 'success';
   } catch (error) {
     console.error('Error submitting needs input', error);
-   redirectPath = 'error';
+
+    await recordEmitterEventAction(
+      'checkoutFail',
+      { ...params },
+      { ...searchParams }
+    );
+
+    redirectPath = 'error';
   }
 
-  redirect(`${redirectPath}${params}`);
+  redirect(`${redirectPath}${searchParamsString}`);
 };

--- a/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
@@ -18,8 +18,9 @@ import { URLSearchParams } from 'url';
 async function validateCartStateAndRedirectAction(
   cartId: string,
   page: SupportedPages,
-  searchParams?: Record<string, string | string[]>
-): Promise<void> {
+  searchParams?: Record<string, string | string[]>,
+  redirectNow = true
+) {
   const urlSearchParams = new URLSearchParams(searchParams);
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';
   const { state } = await getApp().getActionsService().getCartState({
@@ -27,8 +28,19 @@ async function validateCartStateAndRedirectAction(
   });
 
   if (!validateCartState(state, page)) {
-    redirect(getRedirect(state) + params);
+    const redirectToUrl = getRedirect(state) + params;
+
+    if (redirectNow) {
+      redirect(redirectToUrl);
+    } else {
+      return {
+        redirectToUrl,
+        state,
+      };
+    }
   }
+
+  return;
 }
 
 export { validateCartStateAndRedirectAction };

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -75,10 +75,10 @@ interface CheckoutFormProps {
     };
     paymentInfo?: {
       type:
-        | Stripe.PaymentMethod.Type
-        | 'google_iap'
-        | 'apple_iap'
-        | 'external_paypal';
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -240,13 +240,13 @@ export function CheckoutForm({
     const confirmationTokenParams: ConfirmationTokenCreateParams | undefined =
       !isSavedPaymentMethod
         ? {
-            payment_method_data: {
-              billing_details: {
-                name: fullName,
-                email: sessionEmail || undefined,
-              },
+          payment_method_data: {
+            billing_details: {
+              name: fullName,
+              email: sessionEmail || undefined,
             },
-          }
+          },
+        }
         : undefined;
 
     // Create the ConfirmationToken using the details collected by the Payment Element


### PR DESCRIPTION
## Because

- Success and fail events were reported multiple times on page load of the success and error pages.

## This pull request

- Removes glean event reporting from success and error pages.
- Adds glean event reporting to processing and needs_input page redirects to the success or error page.

## Issue that this pull request solves

Closes: #PAY-3181

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
