### PR TITLE
fix(mfa): debounce MFA OTP requests in MfaGuard

### DIFF
--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
@@ -5,6 +5,7 @@
 import React, {
   ReactNode,
   useEffect,
+  useRef,
   useState,
   useSyncExternalStore,
 } from 'react';
@@ -35,6 +36,8 @@ export const MfaGuard = ({
   // Let errors be handled by error boundaries in async contexts
   const handleError = useErrorHandler();
 
+  const hasSentConfirmationCode = useRef(false);
+
   // Whether the modal to enter the OTP code is displayed
   const [showModal, setShowModal] = useState(false);
 
@@ -61,12 +64,17 @@ export const MfaGuard = ({
   // Modal Setup
   useEffect(() => {
     (async () => {
+      // To avoid requesting multiple OTPs on mount
+      if (hasSentConfirmationCode.current) {
+        return;
+      }
       // If the JWT doesn't exist, it has either never been set or the error boundary
       // detected an invalid token and deleted it from the cache. Either way, we want
       // to request a new OTP and show the modal so we can obtain a valid JWT again.
       if (!JwtTokenCache.hasToken(sessionToken, requiredScope)) {
         try {
           await authClient.mfaRequestOtp(sessionToken, requiredScope);
+          hasSentConfirmationCode.current = true;
           setShowModal(true);
         } catch (err) {
           // TODO: FXA-12329 - There might be some errors to handle inline like rate-limiting.


### PR DESCRIPTION
## Because

- useEffect is triggered several times on mount in react strict mode

## This pull request

- debounces the request to /mfa/otp/request

## Issue that this pull request solves

Closes: FXA-12333

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
