### PR TITLE
feat(settings): Send verification code sending before redirecting to inline TOTP setup

### DIFF
--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -138,7 +138,12 @@ export const InlineTotpSetupContainer = ({
       return;
     }
     if (sessionVerified === false) {
-      navTo('/signin_token_code', signinState ? signinState : undefined);
+      (async () => {
+        // The `/signin_token_code` does not automatically send a verification code, so we need to do it manually
+        // before redirecting to the page
+        await session.sendVerificationCode();
+        navTo('/signin_token_code', signinState ? signinState : undefined);
+      })();
       return;
     }
   }, [
@@ -147,6 +152,7 @@ export const InlineTotpSetupContainer = ({
     totpStatusLoading,
     isSignedIn,
     signinState,
+    session,
     navTo,
     navigateWithQuery,
   ]);


### PR DESCRIPTION
## Because

- Users would not automatically get the session verification email when navigating to the inline_totp_code page

## This pull request

- Sends the email before redirecting 

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12278

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Here are some STR locally

1. Set `SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS=false`, `SIGNIN_CONFIRMATION_MAX_AGE_OF_NEW_ACCOUNTS=0` (0 hours)
2. Create any account and confirm the email address
3. Open 123Done in Chrome
4. Click `Sign in (Require 2FA)`
5. Sign in normally and setup 2FA
