### PR TITLE
fix(emails): Send customized email when coming from a "default" entrypoint

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/account.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.ts
@@ -63,11 +63,15 @@ export const fetchRpCmsData = async (
   logger: AuthLogger
 ): Promise<RelyingPartiesQuery['relyingParties'][0] | null> => {
   const metricsContext = await request.app.metricsContext;
-  if (metricsContext.clientId && metricsContext.entrypoint && cmsManager) {
+
+  // If an entrypoint is not provided, it is possible that there is
+  // a "default" entrypoint config in cms. We check to see if this exists just in case.
+  const entrypoint = metricsContext.entrypoint || 'default';
+  if (metricsContext.clientId && cmsManager) {
     try {
       const res = await cmsManager.fetchCMSData(
         metricsContext.clientId,
-        metricsContext.entrypoint
+        entrypoint
       );
       return res.relyingParties.length > 0 ? res.relyingParties[0] : null;
     } catch (error) {

--- a/packages/fxa-auth-server/test/local/routes/utils/account.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/account.js
@@ -68,7 +68,7 @@ describe('fetchRpCmsData', () => {
     assert.equal(actual, null);
   });
 
-  it('returns null there is no entrypoint in metrics context', async () => {
+  it('uses default entrypoint when entrypoint is missing from metrics context', async () => {
     const mockRequest = {
       app: {
         metricsContext: {
@@ -76,8 +76,22 @@ describe('fetchRpCmsData', () => {
         },
       },
     };
-    const actual = await fetchRpCmsData(mockRequest);
-    assert.equal(actual, null);
+    const rpCmsConfig = {
+      shared: {},
+    };
+    const mockCmsManager = {
+      fetchCMSData: sandbox.stub().resolves({
+        relyingParties: [rpCmsConfig],
+      }),
+    };
+
+    const actual = await fetchRpCmsData(mockRequest, mockCmsManager);
+    sinon.assert.calledOnceWithExactly(
+      mockCmsManager.fetchCMSData,
+      mockRequest.app.metricsContext.clientId,
+      'default' // Should use 'default' as fallback
+    );
+    assert.deepEqual(actual, rpCmsConfig);
   });
 
   it('logs an error', async () => {


### PR DESCRIPTION
## Because

-  Users getting the "default" cms customization would not get the customized emails
- We were not checking if there was a default entrypoint when entrypoint was not specified

## This pull request

- Checks for entrypoint=default before sending customized emails

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12331

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

STR:

1. You can try this with 123Done, create a customization with entrypoint=default
2. Go through the 123Done signup/signin flow, don't add any entrypoint to the query params
3. Verify that you get customized emails
