### PR TITLE
fix(payments-next): [Payments-Next Subscription] The page loading animation is broken.

### DIFF
--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
@@ -237,7 +237,7 @@ export function PaymentMethodManagement({
         )}
         <Form.Field name="payment">
           <Form.Control asChild>
-            <div className="relative">
+            <div className="relative overflow-hidden">
               <PaymentElement
                 onChange={handlePaymentElementChange}
                 onLoaderStart={handleReady}


### PR DESCRIPTION
## Because

- The loading elements are are exceeding the frame.

## This pull request

- Adds overflow-hidden to fix the issue.

## Issue that this pull request solves

Closes: #[PAY-3236](https://mozilla-hub.atlassian.net/browse/PAY-3236)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:

https://github.com/user-attachments/assets/b2b84973-a6d2-4b3f-8541-45b487d5b58a

<img width="1102" height="940" alt="image" src="https://github.com/user-attachments/assets/67a62f68-5420-4d8e-a87e-0af6c441db2a" />

After:

https://github.com/user-attachments/assets/4a9a312b-3d62-4e2d-ac22-5393be86f296

<img width="1044" height="942" alt="image" src="https://github.com/user-attachments/assets/6567955d-caf3-4d31-9e10-3b484d210b17" />

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3236]: https://mozilla-hub.atlassian.net/browse/PAY-3236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ