### PR TITLE
fix(mfa): make modal scrollable on smaller screens

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -66,6 +66,7 @@ module.exports = {
         48: '12rem',
         64: '16rem',
         100: '25rem',
+        120: '30rem',
       },
       inset: {
         50: '11.50rem',

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -61,12 +61,12 @@ export const Modal = ({
     <Portal id="modal">
       <div
         data-testid={testid}
-        className="flex flex-col justify-center fixed inset-0 z-50 w-full px-2 h-full bg-black/75"
+        className="flex flex-col justify-center fixed inset-0 z-50 w-full p-2 h-full bg-black/75"
       >
         <div
           data-testid="modal-content-container"
           className={classNames(
-            'max-w-md bg-white mx-auto rounded-xl border border-transparent',
+            'max-w-120 bg-white mx-auto rounded-xl border border-transparent overflow-y-auto',
             className
           )}
           ref={modalInsideRef}


### PR DESCRIPTION
## Because

- user can't scroll the modal when it overflows on smaller screens, preventing them from seeing the full modal.
- the modal has a smaller width than the figma design

## This pull request

- adds `overflow-y-auto` to the modal
- match the width of modals to Figma for tablet+

## Issue that this pull request solves

Closes: FXA-12334

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="381" height="672" alt="image" src="https://github.com/user-attachments/assets/f29a509f-d055-4209-a0bf-cc970910a539" />

## Other information (Optional)

Any other information that is important to this pull request.
