### PR TITLE
feat(next): remove payment element delete

### DIFF
--- a/libs/payments/customer/src/lib/customerSession.manager.spec.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.spec.ts
@@ -89,7 +89,7 @@ describe('CustomerSessionManager', () => {
               enabled: true,
               features: {
                 payment_method_redisplay: 'enabled',
-                payment_method_remove: 'enabled',
+                payment_method_remove: 'disabled',
                 payment_method_allow_redisplay_filters: [
                   'always',
                   'limited',

--- a/libs/payments/customer/src/lib/customerSession.manager.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.ts
@@ -19,7 +19,11 @@ export class CustomerSessionManager {
             payment_method_redisplay: 'enabled',
             payment_method_save: 'disabled',
             payment_method_remove: 'disabled',
-            payment_method_allow_redisplay_filters: ['always', 'limited', 'unspecified'],
+            payment_method_allow_redisplay_filters: [
+              'always',
+              'limited',
+              'unspecified',
+            ],
           },
         },
       },
@@ -34,7 +38,7 @@ export class CustomerSessionManager {
           enabled: true,
           features: {
             payment_method_redisplay: 'enabled',
-            payment_method_remove: 'enabled',
+            payment_method_remove: 'disabled',
             payment_method_allow_redisplay_filters: [
               'always',
               'limited',


### PR DESCRIPTION
## Because

- Customers deleting default payment methods from the Stripe payment element leaves the customer without any default payment element that can be used for recurring payments.

## This pull request

- Removes the delete option from the Stripe payment element.

## Issue that this pull request solves

Closes: #PAY-3243

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="640" height="595" alt="image" src="https://github.com/user-attachments/assets/b4bb9700-5b94-405f-94b9-0c806dce80a7" />

