### PR TITLE
feat(mfa): Wrap secondary email pages in MfaGuard

### DIFF
--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -23,7 +23,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail, credentials.email);
 
       await settings.signOut();
 
@@ -59,7 +59,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail, credentials.email);
 
       await setNewPassword(
         settings,
@@ -101,7 +101,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, secondEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, secondEmail, credentials.email);
 
       await setNewPassword(
         settings,
@@ -150,7 +150,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail, credentials.email);
       await expect(settings.primaryEmail.status).toHaveText(newEmail);
 
       // Click delete account
@@ -185,6 +185,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
+      await settings.confirmMfaGuard(credentials.email);
       await secondaryEmail.fillOutEmail(newEmail);
       const code: string =
         await target.emailClient.getVerifySecondaryCode(newEmail);
@@ -234,9 +235,11 @@ async function changePrimaryEmail(
   target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
-  email: string
+  email: string,
+  primaryEmail: string,
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
+  await settings.confirmMfaGuard(primaryEmail);
   await secondaryEmail.fillOutEmail(email);
   const code: string = await target.emailClient.getVerifySecondaryCode(email);
   await secondaryEmail.fillOutVerificationCode(code);

--- a/packages/functional-tests/tests/settings/changeEmailBlocked.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmailBlocked.spec.ts
@@ -28,7 +28,7 @@ test.describe('severity-1 #smoke', () => {
       const invalidPassword = testAccountTracker.generatePassword();
 
       await settings.goto();
-      await changePrimaryEmail(target, settings, secondaryEmail, blockedEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, blockedEmail, credentials.email);
       await settings.signOut();
       await signin.fillOutEmailFirstForm(blockedEmail);
       await signin.fillOutPasswordForm(invalidPassword);
@@ -67,7 +67,7 @@ test.describe('severity-1 #smoke', () => {
       const blockedEmail = testAccountTracker.generateBlockedEmail();
 
       await settings.goto();
-      await changePrimaryEmail(target, settings, secondaryEmail, blockedEmail);
+      await changePrimaryEmail(target, settings, secondaryEmail, blockedEmail, credentials.email);
       await settings.signOut();
 
       await signin.fillOutEmailFirstForm(blockedEmail);
@@ -110,9 +110,11 @@ async function changePrimaryEmail(
   target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
-  email: string
+  email: string,
+  primaryEmail: string,
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
+  await settings.confirmMfaGuard(primaryEmail);
   await secondaryEmail.fillOutEmail(email);
   const code: string = await target.emailClient.getVerifySecondaryCode(email);
   await secondaryEmail.fillOutVerificationCode(code);

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -166,6 +166,7 @@ test.describe('severity-2 #smoke', () => {
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
+      await settings.confirmMfaGuard(credentials.email);
       await secondaryEmail.fillOutEmail(blockedEmail);
       const verifyCode: string =
         await target.emailClient.getVerifySecondaryCode(blockedEmail);

--- a/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
+++ b/packages/functional-tests/tests/syncV3/fxDesktopV3ForceAuth.spec.ts
@@ -128,7 +128,7 @@ test.describe('severity-1 #smoke', () => {
         uid,
       });
       await signin.fillOutPasswordForm(credentials.password);
-      // fails on this chck for react (message not sent)
+      // fails on this check for react (message not sent)
       await fxDesktopV3ForceAuth.checkWebChannelMessage(
         FirefoxCommand.LinkAccount
       );
@@ -146,7 +146,8 @@ test.describe('severity-1 #smoke', () => {
         target,
         settings,
         secondaryEmail,
-        nonBlockedEmail
+        nonBlockedEmail,
+        credentials.email
       );
       await settings.deleteAccountButton.click();
       await deleteAccount.deleteAccount(credentials.password);
@@ -162,9 +163,11 @@ async function changePrimaryEmail(
   target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
-  email: string
+  email: string,
+  primaryEmail: string
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
+  await settings.confirmMfaGuard(primaryEmail);
   await secondaryEmail.fillOutEmail(email);
   const code: string = await target.emailClient.getVerifySecondaryCode(email);
   await secondaryEmail.fillOutVerificationCode(code);

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1666,23 +1666,15 @@ export default class AuthClient {
     return this.sessionGet('/recovery_emails', sessionToken, headers);
   }
 
-  async recoveryEmailCreate(
-    sessionToken: hexstring,
-    email: string,
-    options: {
-      verificationMethod?: string;
-    } = {},
-    headers?: Headers
-  ) {
-    return this.sessionPost(
-      '/recovery_email',
-      sessionToken,
-      {
-        email,
-        ...options,
-      },
-      headers
-    );
+  /**
+   * Creates a new recovery email for the account.
+   * @param jwt Required scope 'mfa:email'
+   * @param email Recovery email to add to account
+   * @param headers
+   * @returns Response
+   */
+  async recoveryEmailCreate(jwt: string, email: string, headers?: Headers) {
+    return this.jwtPost('/mfa/recovery_email', jwt, { email }, headers);
   }
 
   async recoveryEmailDestroy(
@@ -1713,15 +1705,23 @@ export default class AuthClient {
     );
   }
 
+  /**
+   * Verifies a recovery email by confirming the code sent to that email address.
+   * @param jwt Required scope 'mfa:email'
+   * @param email Recovery email verify
+   * @param code Verification code sent to recovery email
+   * @param headers
+   * @returns Response
+   */
   async recoveryEmailSecondaryVerifyCode(
-    sessionToken: hexstring,
+    jwt: string,
     email: string,
     code: string,
     headers?: Headers
   ): Promise<{}> {
-    return this.sessionPost(
-      '/recovery_email/secondary/verify_code',
-      sessionToken,
+    return this.jwtPost(
+      '/mfa/recovery_email/secondary/verify_code',
+      jwt,
       { email, code },
       headers
     );

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2476,7 +2476,7 @@ const convictConf = convict({
       env: 'MFA__ENABLED',
     },
     actions: {
-      default: ['test', '2fa'],
+      default: ['test', '2fa', 'email'],
       doc: 'Actions protected by MFA',
       format: Array,
       env: 'MFA__ACTIONS',

--- a/packages/fxa-auth-server/docs/swagger/emails-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/emails-api.ts
@@ -110,7 +110,7 @@ const RECOVERY_EMAIL_POST = {
   description: '/recovery_email',
   notes: [
     dedent`
-      🔒 Authenticated with session token
+      🔒 Authenticated with MFA JWT (scope: mfa:email)
       Add a secondary email address to the logged-in account. The created address will be unverified and will not replace the primary email address.
     `,
   ],
@@ -212,7 +212,7 @@ const RECOVERY_EMAIL_SECONDARY_VERIFY_CODE_POST = {
   description: '/recovery_email/secondary/verify_code',
   notes: [
     dedent`
-      🔒 Authenticated with session token
+      🔒 Authenticated with session MFA JWT (scope: mfa:email)
 
       This endpoint verifies a secondary email using a time based (otp) code.
     `,

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -99,6 +99,209 @@ module.exports = (
   const otpOptions = config.otp;
   const otpUtils = require('./utils/otp').default(db, statsd);
 
+  const handlers = {
+    recoveryEmailPost: async (request) => {
+      log.begin('Account.RecoveryEmailCreate', request);
+
+      const sessionToken = request.auth.credentials;
+      const uid = sessionToken.uid;
+      const primaryEmail = sessionToken.email;
+      const { email } = request.payload;
+      const emailData = {
+        email: email,
+        normalizedEmail: normalizeEmail(email),
+        isVerified: false,
+        isPrimary: false,
+        uid: uid,
+      };
+
+      await customs.checkAuthenticated(
+        request,
+        uid,
+        primaryEmail,
+        'createEmail'
+      );
+
+      const account = await db.account(uid);
+      const secondaryEmails = account.emails.filter(
+        (email) => !email.isPrimary
+      );
+      // This is compared against all secondary email
+      // records, both verified and unverified
+      if (secondaryEmails.length >= MAX_SECONDARY_EMAILS) {
+        throw error.maxSecondaryEmailsReached();
+      }
+
+      if (emailsMatch(sessionToken.email, email)) {
+        throw error.yourPrimaryEmailExists();
+      }
+
+      if (
+        account.emails
+          .map((accountEmail) => accountEmail.email)
+          .includes(email)
+      ) {
+        throw error.alreadyOwnsEmail();
+      }
+
+      if (!sessionToken.emailVerified) {
+        throw error.unverifiedAccount();
+      }
+
+      if (sessionToken.tokenVerificationId) {
+        throw error.unverifiedSession();
+      }
+
+      await deleteAccountIfUnverified();
+
+      const hex = await random.hex(16);
+      emailData.emailCode = hex;
+
+      await db.createEmail(uid, emailData);
+
+      const geoData = request.app.geo;
+      try {
+        await mailer.sendVerifySecondaryCodeEmail([emailData], sessionToken, {
+          code: otpUtils.generateOtpCode(hex, otpOptions),
+          deviceId: sessionToken.deviceId,
+          acceptLanguage: request.app.acceptLanguage,
+          email: emailData.email,
+          primaryEmail,
+          location: geoData.location,
+          timeZone: geoData.timeZone,
+          uaBrowser: sessionToken.uaBrowser,
+          uaBrowserVersion: sessionToken.uaBrowserVersion,
+          uaOS: sessionToken.uaOS,
+          uaOSVersion: sessionToken.uaOSVersion,
+          uid,
+        });
+      } catch (err) {
+        log.error('mailer.sendVerifySecondaryCodeEmail', { err: err });
+        await db.deleteEmail(emailData.uid, emailData.normalizedEmail);
+        throw emailUtils.sendError(err, true);
+      }
+
+      await recordSecurityEvent('account.secondary_email_added', {
+        db,
+        request,
+        account,
+      });
+
+      return {};
+
+      async function deleteAccountIfUnverified() {
+        try {
+          const secondaryEmailRecord = await db.getSecondaryEmail(email);
+          if (secondaryEmailRecord.isPrimary) {
+            if (secondaryEmailRecord.isVerified) {
+              throw error.verifiedPrimaryEmailAlreadyExists();
+            }
+
+            const msSinceCreated =
+              Date.now() - secondaryEmailRecord.createdAt;
+            const minUnverifiedAccountTime =
+              config.secondaryEmail.minUnverifiedAccountTime;
+            const exceedsMinUnverifiedAccountTime =
+              msSinceCreated >= minUnverifiedAccountTime;
+            if (
+              exceedsMinUnverifiedAccountTime &&
+              !(await stripeHelper.hasActiveSubscription(
+                secondaryEmailRecord.uid
+              ))
+            ) {
+              await db.deleteAccount(secondaryEmailRecord);
+              log.info('accountDeleted.unverifiedSecondaryEmail', {
+                ...secondaryEmailRecord,
+              });
+              return;
+            } else if (!exceedsMinUnverifiedAccountTime) {
+              throw error.unverifiedPrimaryEmailNewlyCreated();
+            } else {
+              throw error.unverifiedPrimaryEmailHasActiveSubscription();
+            }
+          }
+
+          // Only delete secondary email if it is unverified and does not belong
+          // to the current user.
+          if (
+            !secondaryEmailRecord.isVerified &&
+            !butil.buffersAreEqual(secondaryEmailRecord.uid, uid)
+          ) {
+            await db.deleteEmail(
+              secondaryEmailRecord.uid,
+              secondaryEmailRecord.email
+            );
+            return;
+          }
+        } catch (err) {
+          if (err.errno !== error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
+            throw err;
+          }
+        }
+      }
+    },
+    recoveryEmailSecondaryVerifyCodePost: async (request) => {
+      log.begin('Account.RecoveryEmailSecondaryVerify', request);
+
+      const sessionToken = request.auth.credentials;
+      const { email, code } = request.payload;
+
+      await customs.checkAuthenticated(
+        request,
+        sessionToken.uid,
+        sessionToken.email,
+        'recoveryEmailSecondaryVerifyCode'
+      );
+
+      const { uid } = sessionToken;
+      const account = await db.account(uid);
+      const emails = await db.accountEmails(uid);
+
+      // Get the secondary email code
+      const matchedEmail = emails.find((userEmail) =>
+        emailsMatch(userEmail.normalizedEmail, email)
+      );
+
+      if (!matchedEmail) {
+        throw error.invalidVerificationCode();
+      }
+
+      const secret = matchedEmail.emailCode;
+      const { valid: isValid } = otpUtils.verifyOtpCode(
+        code,
+        secret,
+        otpOptions,
+        'recovery_email.secondary.verify_code'
+      );
+
+      if (!isValid) {
+        throw error.invalidVerificationCode();
+      }
+
+      // User is attempting to verify a secondary email that has already been verified.
+      // Silently succeed and don't send post verification email.
+      if (matchedEmail.isVerified) {
+        log.info('account.verifyEmail.secondary.already-verified', {
+          uid,
+        });
+        return {};
+      }
+
+      await db.verifyEmail(account, matchedEmail.emailCode);
+      log.info('account.verifyEmail.secondary.confirmed', {
+        uid,
+      });
+
+      await mailer.sendPostVerifySecondaryEmail([], account, {
+        acceptLanguage: request.app.acceptLanguage,
+        secondaryEmail: matchedEmail.email,
+        uid,
+      });
+
+      return {};
+    }
+  }
+
   return [
     {
       method: 'GET',
@@ -545,6 +748,28 @@ module.exports = (
       },
     },
     {
+    method: 'POST',
+    path: '/mfa/recovery_email',
+    options: {
+        ...EMAILS_DOCS.RECOVERY_EMAIL_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:email'],
+          payload: false,
+        },
+        validate: {
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailAdd),
+          }),
+        },
+        response: {},
+      },
+      handler: handlers.recoveryEmailPost
+    },
+    {
       method: 'POST',
       path: '/recovery_email',
       options: {
@@ -563,146 +788,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: async function (request) {
-        log.begin('Account.RecoveryEmailCreate', request);
-
-        const sessionToken = request.auth.credentials;
-        const uid = sessionToken.uid;
-        const primaryEmail = sessionToken.email;
-        const { email } = request.payload;
-        const emailData = {
-          email: email,
-          normalizedEmail: normalizeEmail(email),
-          isVerified: false,
-          isPrimary: false,
-          uid: uid,
-        };
-
-        await customs.checkAuthenticated(
-          request,
-          uid,
-          primaryEmail,
-          'createEmail'
-        );
-
-        const account = await db.account(uid);
-        const secondaryEmails = account.emails.filter(
-          (email) => !email.isPrimary
-        );
-        // This is compared against all secondary email
-        // records, both verified and unverified
-        if (secondaryEmails.length >= MAX_SECONDARY_EMAILS) {
-          throw error.maxSecondaryEmailsReached();
-        }
-
-        if (emailsMatch(sessionToken.email, email)) {
-          throw error.yourPrimaryEmailExists();
-        }
-
-        if (
-          account.emails
-            .map((accountEmail) => accountEmail.email)
-            .includes(email)
-        ) {
-          throw error.alreadyOwnsEmail();
-        }
-
-        if (!sessionToken.emailVerified) {
-          throw error.unverifiedAccount();
-        }
-
-        if (sessionToken.tokenVerificationId) {
-          throw error.unverifiedSession();
-        }
-
-        await deleteAccountIfUnverified();
-
-        const hex = await random.hex(16);
-        emailData.emailCode = hex;
-
-        await db.createEmail(uid, emailData);
-
-        const geoData = request.app.geo;
-        try {
-          await mailer.sendVerifySecondaryCodeEmail([emailData], sessionToken, {
-            code: otpUtils.generateOtpCode(hex, otpOptions),
-            deviceId: sessionToken.deviceId,
-            acceptLanguage: request.app.acceptLanguage,
-            email: emailData.email,
-            primaryEmail,
-            location: geoData.location,
-            timeZone: geoData.timeZone,
-            uaBrowser: sessionToken.uaBrowser,
-            uaBrowserVersion: sessionToken.uaBrowserVersion,
-            uaOS: sessionToken.uaOS,
-            uaOSVersion: sessionToken.uaOSVersion,
-            uid,
-          });
-        } catch (err) {
-          log.error('mailer.sendVerifySecondaryCodeEmail', { err: err });
-          await db.deleteEmail(emailData.uid, emailData.normalizedEmail);
-          throw emailUtils.sendError(err, true);
-        }
-
-        await recordSecurityEvent('account.secondary_email_added', {
-          db,
-          request,
-          account,
-        });
-
-        return {};
-
-        async function deleteAccountIfUnverified() {
-          try {
-            const secondaryEmailRecord = await db.getSecondaryEmail(email);
-            if (secondaryEmailRecord.isPrimary) {
-              if (secondaryEmailRecord.isVerified) {
-                throw error.verifiedPrimaryEmailAlreadyExists();
-              }
-
-              const msSinceCreated =
-                Date.now() - secondaryEmailRecord.createdAt;
-              const minUnverifiedAccountTime =
-                config.secondaryEmail.minUnverifiedAccountTime;
-              const exceedsMinUnverifiedAccountTime =
-                msSinceCreated >= minUnverifiedAccountTime;
-              if (
-                exceedsMinUnverifiedAccountTime &&
-                !(await stripeHelper.hasActiveSubscription(
-                  secondaryEmailRecord.uid
-                ))
-              ) {
-                await db.deleteAccount(secondaryEmailRecord);
-                log.info('accountDeleted.unverifiedSecondaryEmail', {
-                  ...secondaryEmailRecord,
-                });
-                return;
-              } else if (!exceedsMinUnverifiedAccountTime) {
-                throw error.unverifiedPrimaryEmailNewlyCreated();
-              } else {
-                throw error.unverifiedPrimaryEmailHasActiveSubscription();
-              }
-            }
-
-            // Only delete secondary email if it is unverified and does not belong
-            // to the current user.
-            if (
-              !secondaryEmailRecord.isVerified &&
-              !butil.buffersAreEqual(secondaryEmailRecord.uid, uid)
-            ) {
-              await db.deleteEmail(
-                secondaryEmailRecord.uid,
-                secondaryEmailRecord.email
-              );
-              return;
-            }
-          } catch (err) {
-            if (err.errno !== error.ERRNO.SECONDARY_EMAIL_UNKNOWN) {
-              throw err;
-            }
-          }
-        }
-      },
+      handler: handlers.recoveryEmailPost
     },
     {
       method: 'POST',
@@ -982,6 +1068,33 @@ module.exports = (
     },
     {
       method: 'POST',
+      path: '/mfa/recovery_email/secondary/verify_code',
+      options: {
+        ...EMAILS_DOCS.RECOVERY_EMAIL_SECONDARY_VERIFY_CODE_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:email'],
+          payload: false,
+        },
+        validate: {
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailSecondaryVerify),
+            code: isA
+              .string()
+              .max(32)
+              .regex(validators.DIGITS)
+              .description(DESCRIPTION.code)
+              .required(),
+          }),
+        },
+      },
+      handler: handlers.recoveryEmailSecondaryVerifyCodePost
+    },
+    {
+      method: 'POST',
       path: '/recovery_email/secondary/verify_code',
       options: {
         ...EMAILS_DOCS.RECOVERY_EMAIL_SECONDARY_VERIFY_CODE_POST,
@@ -1004,66 +1117,7 @@ module.exports = (
           }),
         },
       },
-      handler: async function (request) {
-        log.begin('Account.RecoveryEmailSecondaryVerify', request);
-
-        const sessionToken = request.auth.credentials;
-        const { email, code } = request.payload;
-
-        await customs.checkAuthenticated(
-          request,
-          sessionToken.uid,
-          sessionToken.email,
-          'recoveryEmailSecondaryVerifyCode'
-        );
-
-        const { uid } = sessionToken;
-        const account = await db.account(uid);
-        const emails = await db.accountEmails(uid);
-
-        // Get the secondary email code
-        const matchedEmail = emails.find((userEmail) =>
-          emailsMatch(userEmail.normalizedEmail, email)
-        );
-
-        if (!matchedEmail) {
-          throw error.invalidVerificationCode();
-        }
-
-        const secret = matchedEmail.emailCode;
-        const { valid: isValid } = otpUtils.verifyOtpCode(
-          code,
-          secret,
-          otpOptions,
-          'recovery_email.secondary.verify_code'
-        );
-
-        if (!isValid) {
-          throw error.invalidVerificationCode();
-        }
-
-        // User is attempting to verify a secondary email that has already been verified.
-        // Silently succeed and don't send post verification email.
-        if (matchedEmail.isVerified) {
-          log.info('account.verifyEmail.secondary.already-verified', {
-            uid,
-          });
-          return {};
-        }
-
-        await db.verifyEmail(account, matchedEmail.emailCode);
-        log.info('account.verifyEmail.secondary.confirmed', {
-          uid,
-        });
-
-        await mailer.sendPostVerifySecondaryEmail([], account, {
-          acceptLanguage: request.app.acceptLanguage,
-          secondaryEmail: matchedEmail.email,
-          uid,
-        });
-
-        return {};
-      },
+      handler: handlers.recoveryEmailSecondaryVerifyCodePost
     },
     {
       method: 'POST',

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -384,7 +384,8 @@ describe('#integration - AccountResolver', () => {
     describe('createSecondaryEmail', () => {
       it('succeeds', async () => {
         authClient.recoveryEmailCreate = jest.fn().mockResolvedValue(true);
-        const result = await resolver.createSecondaryEmail('token', headers, {
+        const result = await resolver.createSecondaryEmail(headers, {
+          jwt: 'jwtToken',
           clientMutationId: 'testid',
           email: 'test@example.com',
         });
@@ -404,6 +405,7 @@ describe('#integration - AccountResolver', () => {
           'token',
           headers,
           {
+            jwt: 'jwtToken',
             clientMutationId: 'testid',
             email: 'test@example.com',
           }
@@ -420,7 +422,8 @@ describe('#integration - AccountResolver', () => {
         authClient.recoveryEmailSecondaryVerifyCode = jest
           .fn()
           .mockResolvedValue(true);
-        const result = await resolver.verifySecondaryEmail('token', headers, {
+        const result = await resolver.verifySecondaryEmail(headers, {
+          jwt: 'jwtToken',
           clientMutationId: 'testid',
           email: 'test@example.com',
           code: 'ABCD1234',
@@ -436,6 +439,7 @@ describe('#integration - AccountResolver', () => {
       it('succeeds', async () => {
         authClient.recoveryEmailDestroy = jest.fn().mockResolvedValue(true);
         const result = await resolver.deleteSecondaryEmail('token', headers, {
+          jwt: 'jwtToken',
           clientMutationId: 'testid',
           email: 'test@example.com',
         });
@@ -452,6 +456,7 @@ describe('#integration - AccountResolver', () => {
           .fn()
           .mockResolvedValue(true);
         const result = await resolver.updatePrimaryEmail('token', headers, {
+          jwt: 'jwtToken',
           clientMutationId: 'testid',
           email: 'test@example.com',
         });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -293,29 +293,6 @@ export class AccountResolver {
     };
   }
 
-  // UpdateAvatar is disabled while uploads go directly to profile server.
-  // We need further testing of this implementation at scale before
-  // we enable it in production.
-
-  // @Mutation((returns) => UpdateAvatarPayload, {
-  //   description: 'Update the avatar in use.',
-  // })
-  // @UseGuards(GqlAuthGuard, GqlCustomsGuard)
-  // @CatchGatewayError
-  // public async updateAvatar(
-  //   @GqlSessionToken() token: string,
-  //   @Args('input', { type: () => UpdateAvatarInput }) input: UpdateAvatarInput
-  // ): Promise<UpdateAvatarPayload> {
-  //   const file = await input.file;
-  //   const fileData = await getStream.buffer(file.createReadStream());
-  //   const avatar = await this.profileAPI.avatarUpload(
-  //     token,
-  //     file.mimetype,
-  //     fileData
-  //   );
-  //   return { clientMutationId: input.clientMutationId, avatar };
-  // }
-
   @Mutation((returns) => BasicPayload, {
     description: 'Delete the avatar.',
   })
@@ -336,18 +313,10 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async createSecondaryEmail(
-    @GqlSessionToken() token: string,
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailCreate(
-      token,
-      input.email,
-      {
-        verificationMethod: 'email-otp',
-      },
-      headers
-    );
+    await this.authAPI.recoveryEmailCreate(input.jwt, input.email, headers);
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -375,12 +344,11 @@ export class AccountResolver {
   @UseGuards(GqlAuthGuard)
   @CatchGatewayError
   public async verifySecondaryEmail(
-    @GqlSessionToken() token: string,
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => VerifyEmailInput }) input: VerifyEmailInput
   ) {
     await this.authAPI.recoveryEmailSecondaryVerifyCode(
-      token,
+      input.jwt,
       input.email,
       input.code,
       headers

--- a/packages/fxa-graphql-api/src/gql/dto/input/email.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/email.ts
@@ -13,4 +13,10 @@ export class EmailInput {
 
   @Field({ description: 'The email address to apply this operation to.' })
   public email!: string;
+
+  @Field({
+    description: 'A jwt to provide access to auth server endpoints.',
+    nullable: false,
+  })
+  public jwt!: string;
 }

--- a/packages/fxa-graphql-api/src/gql/dto/input/verify-email.ts
+++ b/packages/fxa-graphql-api/src/gql/dto/input/verify-email.ts
@@ -16,6 +16,12 @@ export class VerifyEmailInput {
 
   @Field({ description: 'The code to check' })
   public code!: string;
+
+  @Field({
+    description: 'A jwt to provide access to auth server endpoints.',
+    nullable: false,
+  })
+  public jwt!: string;
 }
 
 @InputType()

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -10,11 +10,11 @@ import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { SETTINGS_PATH } from '../../../constants';
 import InputText from '../../InputText';
 import FlowContainer from '../FlowContainer';
-import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { isEmailMask, isEmailValid } from 'fxa-shared/email/helpers';
 import { useAccount, useAlertBar } from 'fxa-settings/src/models';
 import { AuthUiErrorNos } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import { getErrorFtlId } from '../../../lib/error-utils';
+import { MfaGuard } from '../MfaGuard';
 
 export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   usePageViewEvent('settings.emails');
@@ -32,6 +32,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const navigateWithQuery = useNavigateWithQuery();
   const alertBar = useAlertBar();
   const account = useAccount();
+
   const goHome = () =>
     navigateWithQuery(SETTINGS_PATH + '#secondary-email', { replace: true });
 
@@ -87,7 +88,6 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   return (
     <Localized id="add-secondary-email-page-title" attrs={{ title: true }}>
       <FlowContainer title="Secondary email" subtitle={subtitleText}>
-        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
           onSubmit={(ev) => {
             ev.preventDefault();
@@ -140,4 +140,10 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   );
 };
 
-export default PageSecondaryEmailAdd;
+export const MfaGuardPageSecondaryEmailAdd = (_: RouteComponentProps) => {
+  return (
+    <MfaGuard requiredScope="email">
+      <PageSecondaryEmailAdd />
+    </MfaGuard>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -11,10 +11,10 @@ import { logViewEvent } from '../../../lib/metrics';
 import { useAccount, useAlertBar } from '../../../models';
 import InputText from '../../InputText';
 import FlowContainer from '../FlowContainer';
-import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { useForm } from 'react-hook-form';
 import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import { getErrorFtlId } from '../../../lib/error-utils';
+import { MfaGuard } from '../MfaGuard';
 
 type FormData = {
   verificationCode: string;
@@ -98,7 +98,6 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
   return (
     <Localized id="verify-secondary-email-page-title" attrs={{ title: true }}>
       <FlowContainer title="Secondary email" subtitle={subtitleText}>
-        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
           data-testid="secondary-email-verify-form"
           onSubmit={handleSubmit(({ verificationCode }) => {
@@ -168,4 +167,10 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
   );
 };
 
-export default PageSecondaryEmailVerify;
+export const MfaGuardPageSecondaryEmailVerify = ( { location }: RouteComponentProps) => {
+  return (
+    <MfaGuard requiredScope="email">
+      <PageSecondaryEmailVerify location={location} />
+    </MfaGuard>
+  );
+};

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -209,40 +209,6 @@ describe('Settings App', () => {
     expect(getByTestId('change-password-requirements')).toBeInTheDocument();
   });
 
-  it('routes to PageSecondaryEmailAdd', async () => {
-    const session = mockSession(true);
-    const {
-      getByTestId,
-      history: { navigate },
-    } = renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ session })}>
-        <Subject />
-      </AppContext.Provider>,
-      { route: SETTINGS_PATH }
-    );
-
-    await navigate(SETTINGS_PATH + '/emails');
-
-    expect(getByTestId('secondary-email-input')).toBeInTheDocument();
-  });
-
-  it('routes to PageSecondaryEmailVerify', async () => {
-    const session = mockSession(true);
-    const {
-      getByTestId,
-      history: { navigate },
-    } = renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ session })}>
-        <Subject />
-      </AppContext.Provider>,
-      { route: SETTINGS_PATH }
-    );
-
-    await navigate(SETTINGS_PATH + '/emails/verify');
-
-    expect(getByTestId('secondary-email-verify-form')).toBeInTheDocument();
-  });
-
   it('routes to two step authentication page', async () => {
     const session = mockSession(true);
     const account = {
@@ -369,6 +335,16 @@ describe('Settings App', () => {
         pageName: 'Page2faChange',
         route: '/two_step_authentication/change',
         hasPassword: true,
+      },
+      {
+        pageName: 'PageSecondaryEmailAdd',
+        route: '/emails',
+        hasPassword: true,
+      },
+      {
+        pageName: 'PageSecondaryEmailVerify',
+        route: '/emails/verify',
+        hasPassword: false,
       },
     ];
 

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -17,8 +17,8 @@ import {
 import PageSettings from './PageSettings';
 import PageChangePassword from './PageChangePassword';
 import PageCreatePassword from './PageCreatePassword';
-import PageSecondaryEmailAdd from './PageSecondaryEmailAdd';
-import PageSecondaryEmailVerify from './PageSecondaryEmailVerify';
+import { MfaGuardPageSecondaryEmailAdd } from './PageSecondaryEmailAdd';
+import { MfaGuardPageSecondaryEmailVerify } from './PageSecondaryEmailVerify';
 import { PageDisplayName } from './PageDisplayName';
 import Page2faSetup from './Page2faSetup';
 import { Page2faReplaceBackupCodes } from './Page2faReplaceBackupCodes';
@@ -188,8 +188,8 @@ export const Settings = ({
               />
             </>
           )}
-          <PageSecondaryEmailAdd path="/emails" />
-          <PageSecondaryEmailVerify path="/emails/verify" />
+          <MfaGuardPageSecondaryEmailAdd path="/emails" />
+          <MfaGuardPageSecondaryEmailVerify path="/emails/verify" />
           <PageRecentActivity path="/recent_activity" />
           <PageDeleteAccount path="/delete_account" />
           <Redirect from="/clients" to="/settings#connected-services" noThrow />

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -76,4 +76,4 @@ export type TotpInfo = {
   recoveryCodes?: string[];
 };
 
-export type MfaScope = 'test' | '2fa';
+export type MfaScope = 'test' | '2fa' | 'email';

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1084,10 +1084,9 @@ export class Account implements AccountData {
   }
 
   async createSecondaryEmail(email: string) {
+    const jwt = this.getCachedJwtByScope('email');
     await this.withLoadingStatus(
-      this.authClient.recoveryEmailCreate(sessionToken()!, email, {
-        verificationMethod: 'email-otp',
-      })
+      this.authClient.recoveryEmailCreate(jwt, email)
     );
     const cache = this.apolloClient.cache;
     cache.modify({
@@ -1108,12 +1107,9 @@ export class Account implements AccountData {
   }
 
   async verifySecondaryEmail(email: string, code: string) {
+    const jwt = this.getCachedJwtByScope('email');
     await this.withLoadingStatus(
-      this.authClient.recoveryEmailSecondaryVerifyCode(
-        sessionToken()!,
-        email,
-        code
-      )
+      this.authClient.recoveryEmailSecondaryVerifyCode(jwt, email, code)
     );
     const cache = this.apolloClient.cache;
     cache.modify({


### PR DESCRIPTION
Because:
 - We want to protect adding a secondary email to an account

This commit:
 - Wraps the SecondaryEmail pages in the MfaGuard
 - Updates Auth Client to require JWT
 - Updates the auth server to use the Mfa auth strategy for
   secondary_email endpoints

Closes: FXA-12224

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
I added some recordings of the flows since those are easier to show. I tested more cases manually, but these are the more major ones.

Happy path:
https://github.com/user-attachments/assets/bba63a4b-0923-4f68-894b-f5ffe70ae17a

Expired token while sitting on `/settings`:
https://github.com/user-attachments/assets/447a6127-1632-466c-b5c8-af0a13753871

Restarting flow for an unconfirmed email:
https://github.com/user-attachments/assets/e656c550-7c50-434e-b024-37e0e0a4b682

## Other information (Optional)

Any other information that is important to this pull request.
