### PR TITLE
fix(script): flush std{out,err} -> process.exit on inactive accts script

### DIFF
--- a/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
+++ b/packages/fxa-auth-server/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
@@ -630,5 +630,11 @@ if (require.main === module) {
         .bind(statsd)()
         .then(() => exitCode);
     })
-    .then((exitCode: number) => process.exit(exitCode));
+    .then((exitCode: number) =>
+      // flush the stdout and stderr buffers
+      Promise.allSettled([
+        new Promise((resolve) => process.stdout.write('', resolve)),
+        new Promise((resolve) => process.stderr.write('', resolve)),
+      ]).then(() => process.exit(exitCode))
+    );
 }


### PR DESCRIPTION
Because previously the process could exit before the buffers flush