### PR TITLE
bug(auth): Make sure mfa strategy fully populates credentials object

### DIFF
--- a/packages/fxa-auth-server/lib/routes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/mfa.ts
@@ -184,6 +184,7 @@ class MfaHandler {
         scope: [`mfa:${scope}`],
         iat: now,
         jti: uuid.v4(),
+        stid: sessionTokenId,
       };
 
       const key = this.config.mfa.jwt.secretKey;

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -491,7 +491,10 @@ async function create(log, error, config, routes, db, statsd, glean, customs) {
   );
   server.auth.strategy('cloudSchedulerOIDC', 'cloudSchedulerOIDC');
 
-  server.auth.scheme('mfa', mfa.strategy(config));
+  server.auth.scheme(
+    'mfa',
+    mfa.strategy(config, makeCredentialFn(db.sessionToken.bind(db)))
+  );
   server.auth.strategy('mfa', 'mfa');
 
   // register all plugins and Swagger configuration


### PR DESCRIPTION
## Because

- The `sessionToken` strategy adds a bunch of meta data to the credentials object

## This pull request

- Mimics what's done in the `sessionToken` strategy in the mfa strategy

## Issue that this pull request solves

Closes: FXA-12359

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
