### PR TITLE
fix(settings): only allow numeric values for OTP code textbox

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.tsx
@@ -50,6 +50,14 @@ export const ModalMfaProtected = ({
   const { isDirty, isValid } = formState;
   const buttonDisabled = !isDirty || !isValid;
 
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // only accept characters that match the code type (numeric or alphanumeric)
+    // strip out any other characters
+    const filteredCode = e.target.value.replace(/[^0-9]/g, '');
+    e.target.value = filteredCode;
+    clearErrorMessage();
+  };
+
   return (
     <Modal
       data-testid="modal-verify-session"
@@ -109,7 +117,9 @@ export const ModalMfaProtected = ({
               required: true,
               pattern: /^\s*[0-9]{6}\s*$/,
             })}
-            onChange={clearErrorMessage}
+            maxLength={6}
+            inputMode="numeric"
+            onChange={onChange}
             ariaDescribedBy={
               localizedErrorBannerMessage
                 ? 'modal-mfa-protected-error-banner'


### PR DESCRIPTION
## Because

- OTP input in ModalMfaProtected does not filter out invalid characters

## This pull request

- filters out invalid characters and limit input length

## Issue that this pull request solves

Closes: FXA-12335

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
