### PR TITLE
bug(settings): Fix too many re-renders

### DIFF
--- a/packages/fxa-settings/src/pages/Authorization/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.test.tsx
@@ -1,0 +1,247 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+import { screen, waitFor } from '@testing-library/react';
+import AuthorizationContainer from './container';
+import { OAUTH_ERRORS } from '../../lib/oauth/oauth-errors';
+import { Integration } from '../../models';
+import AuthClient from 'fxa-auth-client/browser';
+import VerificationMethods from '../../constants/verification-methods';
+import VerificationReasons from '../../constants/verification-reasons';
+
+// Mocked Modules
+import * as CacheModule from '../../lib/cache';
+import * as SigninUtilsModule from '../Signin/utils';
+import * as ModelsModule from '../../models';
+import * as ReactUtilsModule from 'fxa-react/lib/utils';
+import * as OAuthHooksModule from '../../lib/oauth/hooks';
+import * as HooksModule from '../../lib/hooks/useNavigateWithQuery';
+import * as ReachRouterModule from '@reach/router';
+import * as ModelsHooksModule from '../../models/hooks';
+import * as OAuthWebIntegrationModule from '../../models/integrations/oauth-web-integration';
+
+describe('AuthorizationContainer', () => {
+  const mockAccount = {
+    uid: 'uid-123',
+    email: 'foo@mozilla.com',
+    sessionToken: 'session-123',
+  };
+
+  function render(integration: unknown) {
+    return renderWithLocalizationProvider(
+      <AuthorizationContainer integration={integration as Integration} />
+    );
+  }
+
+  const mockAuthClient = {
+    verifyIdToken: jest.fn(),
+  } as unknown as AuthClient;
+
+  const mockSession = {
+    sendVerificationCode: jest.fn().mockResolvedValue(undefined),
+    validatePromptNoneRequest: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ModelsModule.Session;
+
+  const mockLocation = {
+    search: '',
+  } as unknown as ReachRouterModule.WindowLocation<unknown>;
+
+  const mockUseLocation = jest.spyOn(ReachRouterModule, 'useLocation');
+  const mockUseSession = jest.spyOn(ModelsHooksModule, 'useSession');
+  const mockUseAuthClient = jest.spyOn(ModelsHooksModule, 'useAuthClient');
+  const mockIsOauthWebIntegration = jest.spyOn(
+    OAuthWebIntegrationModule,
+    'isOAuthWebIntegration'
+  );
+  const mockCurrentAccount = jest.spyOn(CacheModule, 'currentAccount');
+  const mockUseFinishOAuthFlowHandler = jest.spyOn(
+    OAuthHooksModule,
+    'useFinishOAuthFlowHandler'
+  );
+  const mockCachedSignIn = jest.spyOn(SigninUtilsModule, 'cachedSignIn');
+  const mockHandleNavigation = jest.spyOn(
+    SigninUtilsModule,
+    'handleNavigation'
+  );
+  const mockHardNavigate = jest.spyOn(ReactUtilsModule, 'hardNavigate');
+  const mockNavigateWithQuery = jest.fn();
+  const mockUseNavigateWithQuery = jest.spyOn(
+    HooksModule,
+    'useNavigateWithQuery'
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockLocation.search = '';
+    mockUseLocation.mockReturnValue(mockLocation);
+    mockUseAuthClient.mockReturnValue(mockAuthClient);
+    mockUseSession.mockReturnValue(mockSession);
+    mockIsOauthWebIntegration.mockReturnValue(true);
+    mockCurrentAccount.mockReturnValue(mockAccount);
+    mockUseFinishOAuthFlowHandler.mockReturnValue({
+      finishOAuthFlowHandler: jest.fn(),
+      oAuthDataError: null,
+    });
+    mockCachedSignIn.mockResolvedValue({
+      data: {
+        verified: true,
+        verificationMethod: VerificationMethods.EMAIL_OTP,
+        verificationReason: VerificationReasons.SIGN_IN,
+        uid: mockAccount.uid,
+        sessionVerified: true,
+        emailVerified: true,
+      },
+      error: undefined,
+    });
+    mockHandleNavigation.mockResolvedValue({ error: undefined });
+    mockHardNavigate.mockImplementation(() => {});
+    mockNavigateWithQuery.mockImplementation(() => {});
+    mockUseNavigateWithQuery.mockImplementation(() => mockNavigateWithQuery);
+  });
+
+  it('renders OAuthDataError when finish oauth handler returns an error', async () => {
+    mockUseFinishOAuthFlowHandler.mockReturnValue({
+      finishOAuthFlowHandler: jest.fn(),
+      oAuthDataError: { errno: 999, message: 'oops' },
+    });
+
+    const mockIntegration = {
+      data: {},
+      wantsPromptNone: jest.fn(),
+    };
+
+    render(mockIntegration);
+
+    expect(await screen.findByText('Bad Request')).toBeInTheDocument();
+  });
+
+  it('handles prompt=none case', async () => {
+    mockIsOauthWebIntegration.mockReturnValue(true);
+
+    const mockIntegration = {
+      data: {
+        redirectTo: '/settings',
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(true),
+      returnOnError: jest.fn().mockReturnValue(false),
+      validatePromptNoneRequest: jest.fn().mockResolvedValue(undefined),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(SigninUtilsModule.handleNavigation).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockIntegration.validatePromptNoneRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uid: mockAccount.uid,
+        email: mockAccount.email,
+        sessionToken: mockAccount.sessionToken,
+        verifyIdToken: expect.any(Function),
+        isDefault: expect.any(Function),
+      })
+    );
+
+    expect(screen.queryByText('Bad Request')).not.toBeInTheDocument();
+  });
+
+  it('redirects with hardNavigate when returnOnError=true and unexpected error occurs', async () => {
+    mockCachedSignIn.mockResolvedValue({
+      error: new Error('BOOM'),
+    });
+
+    const mockIntegration = {
+      data: {
+        redirectTo: '/settings',
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(true),
+      returnOnError: jest.fn().mockReturnValue(true),
+      getRedirectWithErrorUrl: jest
+        .fn()
+        .mockReturnValue('https://mozilla.com/error'),
+      validatePromptNoneRequest: jest.fn().mockResolvedValue(undefined),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(ReactUtilsModule.hardNavigate).toHaveBeenCalledWith(
+        'https://mozilla.com/error'
+      );
+    });
+  });
+
+  it('navigates to /oauth if cached signed in returns PROMPT_NONE_NOT_SIGNED_IN error', async () => {
+    mockCachedSignIn.mockResolvedValue({
+      error: OAUTH_ERRORS.PROMPT_NONE_NOT_SIGNED_IN,
+    });
+
+    const mockIntegration = {
+      data: {
+        redirectTo: '/settings',
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(true),
+      validatePromptNoneRequest: jest.fn().mockResolvedValue(undefined),
+      returnOnError: jest.fn().mockReturnValue(false),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(mockNavigateWithQuery).toHaveBeenCalledWith('/oauth');
+    });
+  });
+
+  it('navigates to /oauth when action=email', async () => {
+    mockLocation.search = '?foo=1&showReactApp=1';
+    const mockIntegration = {
+      data: {
+        redirectTo: '/settings',
+        action: 'email',
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(false),
+      validatePromptNoneRequest: jest.fn().mockResolvedValue(undefined),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(mockNavigateWithQuery).toHaveBeenCalledWith('/oauth');
+    });
+  });
+
+  it('navigates to /signin when action is signin', async () => {
+    mockLocation.search = '?x=1&showReactApp=1';
+    const mockIntegration = {
+      data: {
+        action: 'signin',
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(false),
+    };
+
+    render(mockIntegration);
+
+    await waitFor(() => {
+      expect(ReactUtilsModule.hardNavigate).toHaveBeenCalledWith('/signin?x=1');
+    });
+  });
+
+  it("navigates to '/oauth' when no action is provided and not prompt=none", async () => {
+    const mockOAuthWebIntegration = {
+      data: {
+        action: undefined,
+      },
+      wantsPromptNone: jest.fn().mockReturnValue(false),
+    };
+
+    render(mockOAuthWebIntegration);
+
+    await waitFor(() => {
+      expect(mockNavigateWithQuery).toHaveBeenCalledWith('/oauth');
+    });
+  });
+});

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -12,6 +12,7 @@ import {
   useAuthClient,
   useSession,
 } from '../../models';
+
 import { cache } from '../../lib/cache';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import { currentAccount } from '../../lib/cache';
@@ -54,7 +55,7 @@ const AuthorizationContainer = ({
     null
   );
   const authClient = useAuthClient();
-  const location = useLocation() as ReturnType<typeof useLocation>;
+  const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
   const session = useSession();
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
@@ -62,10 +63,6 @@ const AuthorizationContainer = ({
     integration
   );
   const promptNoneCallCount = useRef(0);
-
-  if (oAuthDataError) {
-    setOauthError(oAuthDataError);
-  }
 
   const promptNoneHandler = useCallback(async () => {
     promptNoneCallCount.current += 1;
@@ -186,6 +183,10 @@ const AuthorizationContainer = ({
     navigateWithQuery,
     promptNoneHandler,
   ]);
+
+  if (oAuthDataError) {
+    return <OAuthDataError error={oAuthDataError} />;
+  }
 
   if (oauthError) {
     return <OAuthDataError error={oauthError} />;


### PR DESCRIPTION
## Because

- The way useState was invoked was incorrect and resulted in re-render loop.
- The container component had no test coverage!

## This pull request

- Simply returns the error page when there is an oAuthDataError.
- Adds full test coverage

## Issue that this pull request solves

Closes: FXA-12296

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="378" height="126" alt="image" src="https://github.com/user-attachments/assets/00cf8973-27e4-4443-abe4-f822b301ea05" />

After:
<img width="524" height="286" alt="image" src="https://github.com/user-attachments/assets/dd175f83-af0a-4997-8903-c415eddd746e" />



## Other information (Optional)

This is easy to trigger. Simply enter a bad redirect_uri in the URL provided to `/authorization`. For example, locally navigating to this URL would trigger the edge case: `http://localhost:3030/authorization/signin?client_id=dcdb5ae7add825d2&redirect_uri=http%3A%2F%2Flocallllhost%3A8080%2Fapi%2Foauth&scope=profile%20openid&response_type=code&state=45bccf18e0db02c8783ff9fa095fb9589d1b43cb480431e55d519f6e5bb07f3d&access_type=offline`
