### PR TITLE
fix(iap): handle invalid google play store purchaseTokens

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,13 +21,13 @@
       "protocol": "inspector",
       "env": {
         "DEBUG": "1",
-        "NODE_OPTIONS": "--dns-result-order=ipv4first",
+        "NODE_OPTIONS": "--dns-result-order=ipv4first"
       },
       "program": "${workspaceFolder}/node_modules/@playwright/test/cli.js",
       "args": ["test","--config=${workspaceFolder}/packages/functional-tests/playwright.config.ts", "--project=local"],
       "autoAttachChildProcesses": true,
       "cwd":"${workspaceFolder}/packages/functional-tests",
-      "request": "launch",
+      "request": "launch"
     }
   ]
 }

--- a/libs/payments/iap/src/lib/google/google-iap-purchase.manager.spec.ts
+++ b/libs/payments/iap/src/lib/google/google-iap-purchase.manager.spec.ts
@@ -103,7 +103,7 @@ describe('GoogleIapPurchaseManager', () => {
       };
 
       jest
-        .spyOn(googleIapClient, 'getSubscriptions')
+        .spyOn(googleIapClient, 'getSubscription')
         .mockResolvedValue(mockApiResponse);
 
       jest.spyOn(repository, 'getPurchase').mockResolvedValue(undefined);
@@ -114,7 +114,7 @@ describe('GoogleIapPurchaseManager', () => {
 
       const result = await manager.getFromPlayStoreApi(packageName, sku, token);
 
-      expect(googleIapClient.getSubscriptions).toHaveBeenCalledWith(
+      expect(googleIapClient.getSubscription).toHaveBeenCalledWith(
         packageName,
         sku,
         token
@@ -124,7 +124,7 @@ describe('GoogleIapPurchaseManager', () => {
 
     it('throws wrapped error when Firestore fails', async () => {
       const token = faker.string.uuid();
-      jest.spyOn(googleIapClient, 'getSubscriptions').mockResolvedValue({});
+      jest.spyOn(googleIapClient, 'getSubscription').mockResolvedValue({});
       jest.spyOn(repository, 'getPurchase').mockImplementation(() => {
         throw new Error('Firestore failure');
       });

--- a/libs/payments/iap/src/lib/google/google-iap.client.spec.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.client.spec.ts
@@ -32,7 +32,7 @@ describe('GoogleIapClient', () => {
     jest.restoreAllMocks();
   });
 
-  describe('getSubscriptions', () => {
+  describe('getSubscription', () => {
     it('should return subscription data', async () => {
       const mockPackageName = faker.string.uuid();
       const mockSku = faker.string.uuid();
@@ -48,7 +48,7 @@ describe('GoogleIapClient', () => {
         )
         .mockResolvedValue({ data: mockResponseData });
 
-      const result = await googleIapClient.getSubscriptions(
+      const result = await googleIapClient.getSubscription(
         mockPackageName,
         mockSku,
         mockPurchaseToken
@@ -78,7 +78,7 @@ describe('GoogleIapClient', () => {
         .mockRejectedValue(error);
 
       await expect(
-        googleIapClient.getSubscriptions(
+        googleIapClient.getSubscription(
           mockPackageName,
           mockSku,
           mockPurchaseToken

--- a/libs/payments/iap/src/lib/google/google-iap.client.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.client.ts
@@ -13,6 +13,7 @@ import {
   GoogleIapClientUnexpectedTypeError,
   GoogleIapClientUnknownError,
   GoogleIapSubscriptionNotFoundError,
+  GoogleIapSubscriptionPurchaseTokenInvalidError,
 } from './google-iap.error';
 
 @Injectable()
@@ -33,7 +34,7 @@ export class GoogleIapClient {
     });
   }
 
-  async getSubscriptions(
+  async getSubscription(
     packageName: string,
     sku: string,
     purchaseToken: string
@@ -49,7 +50,10 @@ export class GoogleIapClient {
       return apiResponse.data;
     } catch (e) {
       if (e instanceof Error && 'code' in e && e.code === 404) {
-        throw new GoogleIapSubscriptionNotFoundError(packageName, sku, e);
+        throw new GoogleIapSubscriptionNotFoundError(packageName, sku, purchaseToken, e);
+      }
+      if (e instanceof Error && 'code' in e && e.code === 410) {
+        throw new GoogleIapSubscriptionPurchaseTokenInvalidError(packageName, sku, purchaseToken, e);
       }
 
       throw this.convertError(e);

--- a/libs/payments/iap/src/lib/google/google-iap.error.ts
+++ b/libs/payments/iap/src/lib/google/google-iap.error.ts
@@ -16,9 +16,16 @@ export class GoogleIapError extends BaseError {
 }
 
 export class GoogleIapSubscriptionNotFoundError extends GoogleIapError {
-  constructor(packageName: string, sku: string, cause: Error) {
-    super('Google IAP subscription not found', { packageName, sku }, cause);
+  constructor(packageName: string, sku: string, purchaseToken: string, cause: Error) {
+    super('Google IAP subscription not found', { packageName, sku, purchaseToken }, cause);
     this.name = 'GoogleIapSubscriptionNotFoundError';
+  }
+}
+
+export class GoogleIapSubscriptionPurchaseTokenInvalidError extends GoogleIapError {
+  constructor(packageName: string, sku: string, purchaseToken: string, cause: Error) {
+    super('Google IAP subscription purchase token invalid', { packageName, sku, purchaseToken }, cause);
+    this.name = 'GoogleIapSubscriptionPurchaseTokenInvalidError';
   }
 }
 

--- a/packages/fxa-auth-server/lib/payments/iap/google-play/user-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/iap/google-play/user-manager.ts
@@ -99,11 +99,21 @@ export class UserManager extends UserManagerBase {
           this.log.info('queryCurrentSubscriptions.cache.update', {
             purchaseToken: purchase.purchaseToken,
           });
-          purchase = await this.purchaseManager.querySubscriptionPurchase(
-            purchase.packageName,
-            purchase.sku,
-            purchase.purchaseToken
-          );
+          try {
+            purchase = await this.purchaseManager.querySubscriptionPurchase(
+              purchase.packageName,
+              purchase.sku,
+              purchase.purchaseToken
+            );
+          } catch(e) {
+            if (e.name === PurchaseQueryError.INVALID_TOKEN) {
+              this.log.error('queryCurrentSubscriptions.invalidPurchaseToken', {
+                purchaseToken: purchase.purchaseToken,
+              });
+            } else {
+              throw e;
+            }
+          }
         }
 
         // Add the updated purchase to list to returned to clients

--- a/packages/fxa-shared/payments/iap/google-play/purchase-manager.ts
+++ b/packages/fxa-shared/payments/iap/google-play/purchase-manager.ts
@@ -223,7 +223,7 @@ export class PurchaseManager {
 
   private convertPlayAPIErrorToLibraryError(playError: any): Error {
     const libraryError = new Error(playError.message);
-    if (playError.code === 404) {
+    if (playError.code === 404 || playError.code === 410) {
       libraryError.name = PurchaseQueryError.INVALID_TOKEN;
     } else {
       // Unexpected error occurred. It's likely an issue with Service Account

--- a/packages/fxa-shared/payments/iap/google-play/user-manager.ts
+++ b/packages/fxa-shared/payments/iap/google-play/user-manager.ts
@@ -10,6 +10,7 @@ import {
   PlayStoreSubscriptionPurchase,
 } from './subscription-purchase';
 import { SkuType } from './types/purchases';
+import { PurchaseQueryError } from './types/errors';
 
 export class UserManager {
   constructor(
@@ -63,11 +64,21 @@ export class UserManager {
         this.log.info('queryCurrentSubscriptions.cache.update', {
           purchaseToken: purchase.purchaseToken,
         });
-        purchase = await this.purchaseManager.querySubscriptionPurchase(
-          purchase.packageName,
-          purchase.sku,
-          purchase.purchaseToken
-        );
+        try {
+          purchase = await this.purchaseManager.querySubscriptionPurchase(
+            purchase.packageName,
+            purchase.sku,
+            purchase.purchaseToken
+          );
+        } catch(e) {
+          if (e.name === PurchaseQueryError.INVALID_TOKEN) {
+            this.log.error('queryCurrentSubscriptions.invalidPurchaseToken', {
+              purchaseToken: purchase.purchaseToken,
+            });
+          } else {
+            throw e;
+          }
+        }
       }
 
       // Add the updated purchase to list to returned to clients


### PR DESCRIPTION
## Because

- We are seeing issues where some purchaseTokens are returning invalid and blocking user access to their account.

## This pull request

- Ignores purchases with an invalid purchaseToken (can happen after 60 days of expiry, where our Firestore cache missed an update)

## Issue that this pull request solves

Closes: PAY-3244