### PR TITLE
feat(mfa): Shared helper functions for mfa guard

### DIFF
--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -81,7 +81,9 @@ export class SettingsPage extends SettingsLayout {
     const sync = services.find((s) => s.name.includes(' on '));
 
     await sync?.signout();
-    await this.page.locator('text=Rather not say >> input[name="reason"]').click();
+    await this.page
+      .locator('text=Rather not say >> input[name="reason"]')
+      .click();
     await this.modalConfirmButton.click();
 
     await this.page.evaluate((uid) => {
@@ -106,5 +108,23 @@ export class SettingsPage extends SettingsLayout {
     await expect(this.settingsHeading).toBeVisible();
     await expect(this.alertBar).toHaveText('Two-step authentication disabled');
     await expect(this.totp.status).toHaveText('Disabled');
+  }
+
+  /**
+   * Confirms the MFA modal (MfaGuard) by retrieving the code from the inbox
+   * and submitting it. Use when an action triggers the protected modal.
+   *
+   * @param email - The account email address to fetch the MFA code for.
+   */
+  async confirmMfaGuard(email: string) {
+    const code =
+      await this.target.emailClient.getVerifyAccountChangeCode(email);
+    await this.page
+      .getByRole('heading', { name: 'Enter confirmation code' })
+      .waitFor();
+    await this.page
+      .getByRole('textbox', { name: 'Enter 6-digit code' })
+      .fill(code);
+    await this.page.getByRole('button', { name: 'Confirm' }).click();
   }
 }

--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -85,6 +85,7 @@ module.exports = (printLogs) => {
           const vsc = mail.headers['x-verify-short-code'];
           const sc = mail.headers['x-signin-verify-code'];
           const rpc = mail.headers['x-password-forgot-otp'];
+          const mfa = mail.headers['x-account-change-verify-code'];
           const template = mail.headers['x-template-name'];
 
           // Workaround because the email service wraps this header in `< >`.
@@ -105,6 +106,8 @@ module.exports = (printLogs) => {
             console.log('\x1B[36mReport link:', rul, '\x1B[39m');
           } else if (rpc) {
             console.log('\x1B[36mReset password Otp:', rpc, '\x1B[39m');
+          } else if (mfa) {
+            console.log('\x1B[36mMfa code:', mfa, '\x1B[39m');
           } else if (TEMPLATES_WITH_NO_CODE.has(template)) {
             console.log(`Notification email: ${template}`);
           } else {

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -46,6 +46,15 @@ jest.mock('./ScrollToTop', () => ({
   ),
 }));
 
+// Mock the MFA guard so we can assert guarded pages render it without
+// pulling in the guard's dependencies or child flows
+jest.mock('./MfaGuard', () => ({
+  __esModule: true,
+  MfaGuard: ({ children }: { children: ReactNode }) => (
+    <div data-testid="mfa-guard">MockMfaGuard</div>
+  ),
+}));
+
 const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
@@ -340,6 +349,46 @@ describe('Settings App', () => {
 
     await navigate(SETTINGS_PATH + '/create_password');
     expect(history.location.pathname).toBe('/settings/change_password');
+  });
+
+  describe('guarded routes render MFA guard', () => {
+    // as new guards are added to pages we just add the page name and route here
+    // hasPassword is used to pass needed context to `mockAppContext`
+    const guardedRoutes = [
+      {
+        pageName: 'PageMfaGuardTestWithAuthClient',
+        route: '/mfa_guard/test/auth_client',
+        hasPassword: false,
+      },
+      {
+        pageName: 'PageMfaGuardTestWithGql',
+        route: '/mfa_guard/test/gql',
+        hasPassword: false,
+      },
+    ];
+
+    it.each(guardedRoutes)(
+      'renders $pageName with MFA guard',
+      async ({ route, hasPassword }) => {
+        const session = mockSession(true);
+        const account = {
+          ...MOCK_ACCOUNT,
+          hasPassword,
+        } as unknown as Account;
+        const {
+          getByTestId,
+          history: { navigate },
+        } = renderWithRouter(
+          <AppContext.Provider value={mockAppContext({ session, account })}>
+            <Subject />
+          </AppContext.Provider>,
+          { route: SETTINGS_PATH }
+        );
+        await navigate(SETTINGS_PATH + route);
+
+        expect(getByTestId('mfa-guard')).toBeInTheDocument();
+      }
+    );
   });
 
   describe('prevents access to certain routes when account has no password', () => {

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -19,10 +19,11 @@ import {
   getStoredAccountData,
   sessionToken,
 } from '../lib/cache';
+import { JwtTokenCache } from '../lib/cache';
 import firefox from '../lib/channels/firefox';
 import Storage from '../lib/storage';
 import { AuthUiErrorNos, AuthUiErrors } from '../lib/auth-errors/auth-errors';
-import { LinkedAccountProviderIds, MozServices } from '../lib/types';
+import { LinkedAccountProviderIds, MfaScope, MozServices } from '../lib/types';
 import {
   GET_LOCAL_SIGNED_IN_STATUS,
   GET_TOTP_STATUS,
@@ -1516,5 +1517,23 @@ export class Account implements AccountData {
         },
       },
     });
+  }
+
+  /**
+   * Checks for a JWT token in cache for the given scope.
+   * @param scope MfaScope
+   * @returns JWT token string
+   */
+  private getCachedJwtByScope(scope: MfaScope) {
+    const token = sessionToken();
+    if (!token) {
+      throw AuthUiErrors.INVALID_TOKEN;
+    }
+    const hasJwt = JwtTokenCache.hasToken(token, scope);
+    if (!hasJwt) {
+      throw AuthUiErrors.INVALID_REQUEST_SIGNATURE;
+    }
+
+    return JwtTokenCache.getToken(token, scope);
   }
 }


### PR DESCRIPTION
## Because

* These were initially introduced in FXA-12231 but are intended to be shared by multiple scopes/actions

## This pull request

* Add a utility function in functional tests to confirm an MFA code
* Adds a mail helper to print mfa code in logs
* Adds unit test scaffolding for mfa guards in fxa-settings
* Adds a utility function in Account.ts to check for JWT token in cache

## Issue that this pull request solves

Closes: FXA-12367

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
