### PR TITLE
fix(stripe-webhook): transactionalize payment method and invoice cache

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -106,7 +106,7 @@ export class StripeFirestore extends StripeFirestoreBase {
     customer: Partial<Stripe.Customer | Stripe.DeletedCustomer>
   ) {
     try {
-      await this.retrieveCustomer({ uid });
+      return await this.retrieveCustomer({ uid });
     } catch (err) {
       if (err.name === FirestoreStripeError.FIRESTORE_CUSTOMER_NOT_FOUND) {
         if (!customer.id) throw new Error('Customer ID must be provided');
@@ -115,10 +115,11 @@ export class StripeFirestore extends StripeFirestoreBase {
         throw err;
       }
     }
-    return this.insertCustomerRecord(uid, customer);
   }
 
   /**
+   * @deprecated This method does not support transactions
+   *
    * Insert a subscription record into Firestore under the customer's stripe id.
    */
   async insertSubscriptionRecord(subscription: Partial<Stripe.Subscription>) {
@@ -141,6 +142,8 @@ export class StripeFirestore extends StripeFirestoreBase {
   }
 
   /**
+   * @deprecated This method does not support transactions
+   *
    * Insert a subscription record into Firestore under the customer's stripe id.
    * If the customer does not exist, this will backfill the customer with all their
    * subscriptions.
@@ -160,6 +163,8 @@ export class StripeFirestore extends StripeFirestoreBase {
   }
 
   /**
+   * @deprecated This method does not support transactions
+   *
    * Insert a payment method record into Firestore under the customer's stripe id.
    * If the customer does not exist, this will backfill the customer with all their
    * subscriptions.


### PR DESCRIPTION
## Because

- We want transactions on our payment method and invoice cache stripe webhook endpoints to avoid situations where stale data could get written.

## This pull request

- Adds firestore transactions to those method within stripe-firestore, and marks non-transactionalized methods as deprecated (we don't want to modify legacy 2.5 code).

## Issue that this pull request solves

Closes: PAY-3183