### PR TITLE
feat(jwt): Add unified password change endpoint using JWT

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/changePassword.spec.ts
@@ -80,6 +80,8 @@ test.describe('severity-2 #smoke', () => {
       await settings.goto(changeVersion.query);
       await settings.clickChangePassword();
 
+      await settings.confirmMfaGuard(email);
+
       await expect(changePassword.changePasswordHeading).toBeVisible();
 
       await changePassword.currentPasswordTextbox.fill(password);
@@ -133,6 +135,8 @@ test.describe('severity-2 #smoke', () => {
       );
       await settings.goto(changeVersion.query);
       await settings.clickChangePassword();
+
+      await settings.confirmMfaGuard(email);
 
       await expect(changePassword.changePasswordHeading).toBeVisible();
 

--- a/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
@@ -185,6 +185,9 @@ test.describe('severity-1 #smoke', () => {
 
       // Change password
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await changePassword.fillOutChangePassword(
         credentials.password,
         newPassword

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -69,8 +69,12 @@ test.describe('severity-1 #smoke', () => {
         settings,
         changePassword,
         initialPassword,
-        newPassword
+        newPassword,
+        target,
+        credentials.email
       );
+
+      credentials.password = newPassword;
 
       await settings.signOut();
 
@@ -113,8 +117,12 @@ test.describe('severity-1 #smoke', () => {
         settings,
         changePassword,
         initialPassword,
-        newPassword
+        newPassword,
+        target,
+        credentials.email
       );
+
+      credentials.password = newPassword;
 
       await settings.signOut();
 
@@ -124,7 +132,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Change back the primary email again
       await settings.secondaryEmail.makePrimaryButton.click();
-      await settings.confirmMfaGuard(secondEmail);
+      await settings.confirmMfaGuard(credentials.email);
       await settings.signOut();
 
       // Login with primary email and new password
@@ -133,6 +141,7 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(settings.settingsHeading).toBeVisible();
 
+      console.log('credentials.password', credentials.password);
       // Update which password to use the account cleanup
       credentials.password = newPassword;
     });
@@ -263,9 +272,14 @@ async function setNewPassword(
   settings: SettingsPage,
   changePassword: ChangePasswordPage,
   oldPassword: string,
-  newPassword: string
+  newPassword: string,
+  target: BaseTarget,
+  email: string,
 ): Promise<void> {
   await settings.password.changeButton.click();
+
+  await settings.confirmMfaGuard(email);
+
   await changePassword.fillOutChangePassword(oldPassword, newPassword);
 
   await expect(settings.settingsHeading).toBeVisible();

--- a/packages/functional-tests/tests/settings/changePassword.spec.ts
+++ b/packages/functional-tests/tests/settings/changePassword.spec.ts
@@ -20,6 +20,9 @@ test.describe('severity-1 #smoke', () => {
 
       // Enter incorrect old password and verify the tooltip error
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await changePassword.fillOutChangePassword(
         'Incorrect Password',
         newPassword
@@ -40,6 +43,9 @@ test.describe('severity-1 #smoke', () => {
 
       // Enter the correct old password and verify that change password is successful
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await changePassword.fillOutChangePassword(initialPassword, newPassword);
 
       await expect(settings.settingsHeading).toBeVisible();
@@ -56,32 +62,6 @@ test.describe('severity-1 #smoke', () => {
       credentials.password = newPassword;
     });
 
-    test('change password with short password tooltip shows, cancel and try to change password again, tooltip is not shown', async ({
-      target,
-      pages: { page, changePassword, settings, signin },
-      testAccountTracker,
-    }) => {
-      const credentials = await testAccountTracker.signUp();
-      await signInAccount(target, page, settings, signin, credentials);
-
-      await settings.goto();
-      await settings.password.changeButton.click();
-
-      await expect(changePassword.changePasswordHeading).toBeVisible();
-
-      await changePassword.newPasswordTextbox.fill('short');
-
-      await expect(changePassword.passwordLengthInvalidIcon).toBeVisible();
-
-      await changePassword.cancelButton.click();
-
-      await expect(settings.settingsHeading).toBeVisible();
-
-      await settings.password.changeButton.click();
-
-      await expect(changePassword.passwordLengthUnsetIcon).toBeVisible();
-    });
-
     test('reset password via settings works', async ({
       target,
       pages: { page, changePassword, resetPassword, settings, signin },
@@ -93,6 +73,8 @@ test.describe('severity-1 #smoke', () => {
       await settings.goto();
 
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
 
       await expect(changePassword.changePasswordHeading).toBeVisible();
 

--- a/packages/functional-tests/tests/settings/changePasswordValidation.spec.ts
+++ b/packages/functional-tests/tests/settings/changePasswordValidation.spec.ts
@@ -41,6 +41,8 @@ test.describe('severity-1 #smoke', () => {
         await settings.goto();
         await settings.password.changeButton.click();
 
+        await settings.confirmMfaGuard(credentials.email);
+
         await expect(changePassword.changePasswordHeading).toBeVisible();
 
         await changePassword.newPasswordTextbox.fill(password);
@@ -66,6 +68,8 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
 
       await expect(changePassword.changePasswordHeading).toBeVisible();
 

--- a/packages/functional-tests/tests/signin/redirect.spec.ts
+++ b/packages/functional-tests/tests/signin/redirect.spec.ts
@@ -63,7 +63,7 @@ test.describe('severity-2 #smoke', () => {
 
     test('allows valid redirect_to parameter', async ({
       target,
-      pages: { page, changePassword, signin },
+      pages: { page, changePassword, signin, settings },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -71,10 +71,14 @@ test.describe('severity-2 #smoke', () => {
       // set a redirect url that is not the usual navigation target after signin
       const redirectTo = `${target.contentServerUrl}/settings/change_password`;
       await page.goto(`${target.contentServerUrl}/?redirect_to=${redirectTo}`);
+
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
       await expect(page).toHaveURL(redirectTo);
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await expect(changePassword.changePasswordHeading).toBeVisible();
     });
   });

--- a/packages/functional-tests/tests/syncV3/settings.spec.ts
+++ b/packages/functional-tests/tests/syncV3/settings.spec.ts
@@ -58,6 +58,9 @@ test.describe('severity-2 #smoke', () => {
 
       //Change password
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await changePassword.fillOutChangePassword(
         credentials.password,
         newPassword
@@ -76,7 +79,7 @@ test.describe('severity-2 #smoke', () => {
         settings,
         signin,
         signinTokenCode,
-        page,
+        page
       },
       testAccountTracker,
       storageState,
@@ -117,6 +120,9 @@ test.describe('severity-2 #smoke', () => {
 
       //Change password
       await settings.password.changeButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await changePassword.fillOutChangePassword(
         credentials.password,
         newPassword

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2498,7 +2498,7 @@ const convictConf = convict({
       env: 'MFA__ENABLED',
     },
     actions: {
-      default: ['test', '2fa', 'email', 'recovery_key'],
+      default: ['test', '2fa', 'email', 'recovery_key', 'password'],
       doc: 'Actions protected by MFA',
       format: Array,
       env: 'MFA__ACTIONS',

--- a/packages/fxa-auth-server/docs/swagger/password-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/password-api.ts
@@ -165,6 +165,18 @@ const PASSWORD_CREATE_POST = {
   ],
 };
 
+const PASSWORD_CHANGE_JWT_POST = {
+  ...TAGS_PASSWORD,
+  description: '/password/change/jwt',
+  notes: [
+    dedent`
+    🔒 Authenticated with MFA JWT (scope: mfa:password)
+
+    Perform the "change password" process using JWT authentication. Returns a session token and a key fetch token.
+    `,
+  ],
+};
+
 const API_DOCS = {
   PASSWORD_CHANGE_FINISH_POST,
   PASSWORD_CHANGE_START_POST,
@@ -175,6 +187,7 @@ const API_DOCS = {
   PASSWORD_FORGOT_STATUS_GET,
   PASSWORD_FORGOT_VERIFY_CODE_POST,
   PASSWORD_CREATE_POST,
+  PASSWORD_CHANGE_JWT_POST,
 };
 
 export default API_DOCS;

--- a/packages/fxa-auth-server/lib/routes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/mfa.ts
@@ -181,6 +181,7 @@ class MfaHandler {
       const scope = action;
 
       // Issue jwt
+      // TODO: Use `/mfa/otp/request` and `/mfa/otp/verify` to issue the jwt
       const now = Math.floor(Date.now() / 1000);
       const claims = {
         sub: account.uid,

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -658,6 +658,10 @@ module.exports = (config) => {
     return this.doRequest('POST', `${this.baseURL}/get_random_bytes`);
   };
 
+  ClientApi.prototype.changePasswordJWT = function (jwt, options = {}) {
+    return this.doRequestWithBearerToken('POST', `${this.baseURL}/mfa/password/change`, jwt, options);
+  }
+
   ClientApi.prototype.passwordChangeStart = async function (
     email,
     oldAuthPW,

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -555,6 +555,10 @@ module.exports = (config) => {
     });
   };
 
+  Client.prototype.changePasswordJWT = function (jwt, options = {}) {
+    return this.api.changePasswordJWT(jwt, options);
+  }
+
   Client.prototype.changePassword = function (
     newPassword,
     headers,

--- a/packages/fxa-auth-server/test/local/routes/mfa.js
+++ b/packages/fxa-auth-server/test/local/routes/mfa.js
@@ -100,7 +100,7 @@ describe('mfa', () => {
       // for testing purposes this is sufficient.
       id: SESSION_TOKEN_ID,
       uid: UID,
-      uaBrowser: UA_BROWSER,
+      uaBrowser: UA_BROWSER
     });
 
     Container.set(OtpUtils, otpUtils);

--- a/packages/fxa-auth-server/test/remote/password_change_jwt_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_change_jwt_tests.js
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const Client = require('../client')();
+const config = require('../../config').default.getProperties();
+const TestServer = require('../test_server');
+const jwt = require('jsonwebtoken');
+const uuid = require('uuid');
+
+describe('#integration - remote password change JWT', function () {
+  this.timeout(60000);
+  let server;
+
+  before(async () => {
+    server = await TestServer.start(config);
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
+  });
+  [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+    describe(`#integration${testOptions.version} - remote password change with JWT`, function () {
+      it('should change password with valid JWT', async function() {
+        const email = server.uniqueEmail();
+        const password = 'allyourbasearebelongtous';
+        const newPassword = 'foobar';
+
+        // Create and verify account
+        const client = await Client.createAndVerify(
+          config.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          {
+            ...testOptions,
+            keys: true
+          }
+        );
+
+        const oldAuthPW = client.authPW.toString('hex');
+
+        // Get the initial keys to compare to after password change keys
+        const originalKeys = await client.keys();
+
+        // Get session token for JWT generation
+        const sessionTokenHex = client.sessionToken;
+        const sessionToken = require('../../lib/tokens')({
+          trace: function() {}
+        }).SessionToken.fromHex(sessionTokenHex);
+        const sessionTokenId = (await sessionToken).id;
+
+        // Generate MFA JWT with password scope
+        const now = Math.floor(Date.now() / 1000);
+        const claims = {
+          sub: client.uid,
+          scope: ['mfa:password'],
+          iat: now,
+          jti: uuid.v4(),
+          stid: sessionTokenId,
+        };
+
+        const jwtToken = jwt.sign(claims, config.mfa.jwt.secretKey, {
+          algorithm: 'HS256',
+          expiresIn: config.mfa.jwt.expiresInSec,
+          audience: config.mfa.jwt.audience,
+          issuer: config.mfa.jwt.issuer,
+        });
+
+        // Prepare new password credentials
+        const newCreds = await client.setupCredentials(email, newPassword);
+
+        client.deriveWrapKbFromKb();
+
+        const payload = {
+          email,
+          oldAuthPW,
+          authPW: newCreds.authPW.toString('hex'),
+          wrapKb: client.wrapKb,
+          clientSalt: client.clientSalt,
+        }
+        if (testOptions.version === 'V2') {
+          // Create new credentials for the new password
+          await client.setupCredentialsV2(email, newPassword);
+
+          // Derive wrapKb from the new unwrapBKey and the current kB. This ensures
+          // kB will remain constant even after a password change.
+          client.deriveWrapKbVersion2FromKb();
+
+          payload.authPWVersion2 = newCreds.authPWVersion2.toString('hex');
+          payload.wrapKbVersion2 = client.wrapKbVersion2;
+        }
+
+        // Call the new JWT endpoint
+        const response = await client.changePasswordJWT(jwtToken, payload)
+
+        // Verify response
+        assert.ok(response.uid);
+        assert.ok(response.sessionToken);
+        assert.ok(response.authAt);
+
+        // Verify we can login with new password
+        const newClient = await Client.login(
+          config.publicUrl,
+          email,
+          newPassword,
+          {
+            ...testOptions,
+            keys: true,
+          }
+        );
+        assert.ok(newClient.sessionToken);
+
+        const newClientKeys = await newClient.keys();
+        assert.equal(newClientKeys.kA.toString('hex'), originalKeys.kA.toString('hex'));
+        assert.equal(newClientKeys.kB.toString('hex'), originalKeys.kB.toString('hex'));
+      });
+    })
+  })
+});

--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.tsx
@@ -5,6 +5,7 @@
 import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { RouteComponentProps } from '@reach/router';
+import { MfaGuard } from '../MfaGuard';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SETTINGS_PATH } from '../../../constants';
 import {
@@ -143,4 +144,8 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   );
 };
 
-export default PageChangePassword;
+const MfaGuardedPageChangePassword = (_: RouteComponentProps) => {
+  return <MfaGuard requiredScope="password"><PageChangePassword /></MfaGuard>;
+};
+
+export default MfaGuardedPageChangePassword;

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -15,7 +15,7 @@ import {
   useLocation,
 } from '@reach/router';
 import PageSettings from './PageSettings';
-import PageChangePassword from './PageChangePassword';
+import MfaGuardedPageChangePassword from './PageChangePassword';
 import PageCreatePassword from './PageCreatePassword';
 import { MfaGuardPageSecondaryEmailAdd } from './PageSecondaryEmailAdd';
 import { MfaGuardPageSecondaryEmailVerify } from './PageSecondaryEmailVerify';
@@ -157,7 +157,7 @@ export const Settings = ({
           )}
           {account.hasPassword ? (
             <>
-              <PageChangePassword path="/change_password" />
+              <MfaGuardedPageChangePassword path="/change_password" />
               <Redirect
                 from="/create_password"
                 to="/settings/change_password"

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -75,4 +75,4 @@ export type TotpInfo = {
   secret: string;
 };
 
-export type MfaScope = 'test' | '2fa' | 'email' | 'recovery_key';
+export type MfaScope = 'test' | '2fa' | 'email' | 'recovery_key' | 'password';


### PR DESCRIPTION
## Because

- It seems odd to now have 2 different types of token, and 2 different endpoints `/password/change/finish` `/password/change/start` to perform a password change

## This pull request

- Creates a new single endpoint to do the password change using the MFA JWT
- There is a lot of dupliction between the new endpoint and the /password/change/finish endpoint, but I think thats ok since the latter can be removed completely

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11105
Closes: https://mozilla-hub.atlassian.net/browse/FXA-12227

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
