### PR TITLE
cleanup(2fa): Remove feature flag on redesigned password reset flow with SMS

### DIFF
--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -313,12 +313,6 @@ test.describe('reset password with recovery phone', () => {
     target.smsClient.guardTestPhoneNumber();
   });
 
-  test.beforeEach(async ({ pages: { configPage } }) => {
-    // Ensure that the feature flag is enabled
-    const config = await configPage.getConfig();
-    test.skip(config.featureFlags.recoveryPhonePasswordReset2fa !== true);
-  });
-
   test('can reset password with 2FA enabled using recovery phone', async ({
     page,
     target,

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -74,7 +74,6 @@
   "featureFlags": {
     "sendFxAStatusOnSettings": true,
     "recoveryCodeSetupOnSyncSignIn": true,
-    "recoveryPhonePasswordReset2fa": true,
     "updatedInlineTotpSetupFlow": true,
     "updatedInlineRecoverySetupFlow": true,
     "showLocaleToggle": true,

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -118,9 +118,6 @@ const settingsConfig = {
     recoveryCodeSetupOnSyncSignIn: config.get(
       'featureFlags.recoveryCodeSetupOnSyncSignIn'
     ),
-    recoveryPhonePasswordReset2fa: config.get(
-      'featureFlags.recoveryPhonePasswordReset2fa'
-    ),
     updatedInlineTotpSetupFlow: config.get(
       'featureFlags.updatedInlineTotpSetupFlow'
     ),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -241,12 +241,6 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN',
     },
-    recoveryPhonePasswordReset2fa: {
-      default: false,
-      doc: 'Enables recovery phone codes for 2FA in password reset',
-      format: Boolean,
-      env: 'FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA',
-    },
     updatedInlineTotpSetupFlow: {
       default: false,
       doc: 'Enables a redesign of the inline TOTP setup',

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -55,9 +55,6 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN = config.get(
     'featureFlags.recoveryCodeSetupOnSyncSignIn'
   );
-  const FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA = config.get(
-    'featureFlags.recoveryPhonePasswordReset2fa'
-  );
   const FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW = config.get(
     'featureFlags.updated2faSetupFlow'
   );
@@ -129,8 +126,6 @@ function getIndexRouteDefinition(config) {
       sendFxAStatusOnSettings: FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS,
       recoveryCodeSetupOnSyncSignIn:
         FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
-      recoveryPhonePasswordReset2fa:
-        FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA,
       updated2faSetupFlow: FEATURE_FLAGS_UPDATED_2FA_SETUP_FLOW,
       updatedInlineRecoverySetupFlow:
         FEATURE_FLAGS_UPDATED_INLINE_RECOVERY_SETUP_FLOW,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -48,7 +48,7 @@ export interface Config {
     };
     paymentsNext: {
       url: string;
-    }
+    };
   };
   oauth: {
     clientId: string;
@@ -100,7 +100,6 @@ export interface Config {
   featureFlags?: {
     keyStretchV2?: boolean;
     recoveryCodeSetupOnSyncSignIn?: boolean;
-    recoveryPhonePasswordReset2fa?: boolean;
     updatedInlineTotpSetupFlow?: boolean;
     updated2faSetupFlow?: boolean;
     updatedInlineRecoverySetupFlow?: boolean;
@@ -151,8 +150,8 @@ export function getDefault() {
         url: '',
       },
       paymentsNext: {
-        url: ''
-      }
+        url: '',
+      },
     },
     oauth: {
       clientId: '',
@@ -196,7 +195,6 @@ export function getDefault() {
     },
     featureFlags: {
       recoveryCodeSetupOnSyncSignIn: false,
-      recoveryPhonePasswordReset2fa: false,
       updatedInlineTotpSetupFlow: false,
       updated2faSetupFlow: false,
       updatedInlineRecoverySetupFlow: false,

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.test.tsx
@@ -17,13 +17,11 @@ jest.mock('../../../models', () => ({
   __esModule: true,
   useAuthClient: () => ({
     checkTotpTokenCodeWithPasswordForgotToken: mockCheckTotp,
-    recoveryPhoneGetWithPasswordForgotToken: mockRecoveryPhoneGetWithPasswordForgotToken,
+    recoveryPhoneGetWithPasswordForgotToken:
+      mockRecoveryPhoneGetWithPasswordForgotToken,
   }),
   useFtlMsgResolver: () => ({
     getMsg: (_id: string, fallback: string) => fallback,
-  }),
-  useConfig: () => ({
-    featureFlags: { recoveryPhonePasswordReset2fa: true },
   }),
 }));
 
@@ -77,7 +75,9 @@ describe('ConfirmTotpResetPasswordContainer', () => {
 
   it('calls authClient then navigates on success', async () => {
     mockCheckTotp.mockResolvedValueOnce({ success: true });
-    mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({ exists: false });
+    mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({
+      exists: false,
+    });
 
     await renderComponent();
 
@@ -102,7 +102,9 @@ describe('ConfirmTotpResetPasswordContainer', () => {
 
   it('sets localized error message when authClient returns success: false', async () => {
     mockCheckTotp.mockResolvedValueOnce({ success: false });
-    mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({ exists: false });
+    mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({
+      exists: false,
+    });
 
     await renderComponent();
 
@@ -115,7 +117,9 @@ describe('ConfirmTotpResetPasswordContainer', () => {
 
   it('forwards location.state when onTroubleWithCode is invoked', async () => {
     mockCheckTotp.mockResolvedValueOnce({ success: true });
-    mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({ exists: true });
+    mockRecoveryPhoneGetWithPasswordForgotToken.mockResolvedValueOnce({
+      exists: true,
+    });
 
     await renderComponent();
 

--- a/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ConfirmTotpResetPassword/container.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
-import { useAuthClient, useFtlMsgResolver, useConfig } from '../../../models';
+import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import ConfirmTotpResetPassword from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { CompleteResetPasswordLocationState } from '../CompleteResetPassword/interfaces';
@@ -12,7 +12,6 @@ import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 
 const ConfirmTotpResetPasswordContainer = (_: RouteComponentProps) => {
-  const config = useConfig();
   const authClient = useAuthClient();
   const location = useLocation();
   const {
@@ -68,13 +67,7 @@ const ConfirmTotpResetPasswordContainer = (_: RouteComponentProps) => {
   };
 
   const onTroubleWithCode = async () => {
-    let nextRoute = '/confirm_backup_code_reset_password';
-
-    const { exists } = await authClient.recoveryPhoneGetWithPasswordForgotToken(token);
-
-    if (config.featureFlags?.recoveryPhonePasswordReset2fa && exists) {
-      nextRoute = '/reset_password_totp_recovery_choice';
-    }
+    const nextRoute = '/reset_password_totp_recovery_choice';
 
     navigateWithQuery(nextRoute, {
       state: {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.test.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryPhone/container.test.tsx
@@ -19,13 +19,11 @@ jest.mock('../../../models', () => ({
   useAuthClient: () => ({
     recoveryPhoneResetPasswordConfirm: mockRecoveryPhoneResetPasswordConfirm,
     recoveryPhonePasswordResetSendCode: mockRecoveryPhonePasswordResetSendCode,
-    recoveryPhoneGetWithPasswordForgotToken: mockRecoveryPhoneGetWithPasswordForgotToken,
+    recoveryPhoneGetWithPasswordForgotToken:
+      mockRecoveryPhoneGetWithPasswordForgotToken,
   }),
   useFtlMsgResolver: () => ({
     getMsg: (_id: string, fallback: string) => fallback,
-  }),
-  useConfig: () => ({
-    featureFlags: { recoveryPhonePasswordReset2fa: true },
   }),
 }));
 
@@ -77,7 +75,9 @@ describe('ResetPasswordRecoveryPhoneContainer', () => {
   });
 
   it('calls authClient then navigates on success', async () => {
-    mockRecoveryPhoneResetPasswordConfirm.mockResolvedValueOnce({ success: true });
+    mockRecoveryPhoneResetPasswordConfirm.mockResolvedValueOnce({
+      success: true,
+    });
 
     await renderComponent();
 


### PR DESCRIPTION
## Because

* This flow is fully rolled out in production

## This pull request

* Removes the FEATURE_FLAGS_RECOVERY_PHONE_PASSWORD_RESET_2FA flag and conditional logic

## Issue that this pull request solves

Closes: FXA-12382

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
