### PR TITLE
fix(settings): 3rd-party auth logos don't render in iOS/Safari 17

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/__snapshots__/index.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`ThirdPartyAuthComponent buttons match snapshot: apple 1`] = `
           "
   type="submit"
 >
-  <svg>
+  <svg
+    class="w-full h-auto"
+  >
     apple-logo-viewbox-white.svg
   </svg>
 </button>
@@ -22,7 +24,9 @@ exports[`ThirdPartyAuthComponent buttons match snapshot: google 1`] = `
           "
   type="submit"
 >
-  <svg>
+  <svg
+    class="w-full h-auto"
+  >
     google-logo-viewbox.svg
   </svg>
 </button>

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -37,7 +37,7 @@ const ThirdPartyAuth = ({
   viewName = 'unknown',
   deeplink,
   flowQueryParams,
-  separatorTextId
+  separatorTextId,
 }: ThirdPartyAuthProps) => {
   const config = useConfig();
 
@@ -78,7 +78,7 @@ const ThirdPartyAuth = ({
               onSubmit: onContinueWithGoogle,
               buttonText: (
                 <>
-                  <GoogleLogo />
+                  <GoogleLogo className="w-full h-auto" />
                 </>
               ),
               deeplink,
@@ -98,7 +98,7 @@ const ThirdPartyAuth = ({
               onSubmit: onContinueWithApple,
               buttonText: (
                 <>
-                  <AppleLogo />
+                  <AppleLogo className="w-full h-auto" />
                 </>
               ),
               deeplink,


### PR DESCRIPTION
## Because

- 3rd-party auth logos don't render in iOS 17/Safari 17

## This pull request

- adds additional CSS to ensure the SVG renders as expected

## Issue that this pull request solves

Closes: FXA-12387

## Screenshots

On Safari 17, before:
<img width="545" height="523" alt="Screenshot 2025-09-11 at 10 27 38 AM" src="https://github.com/user-attachments/assets/6384f63e-6663-4847-8035-1ccd1db7d88b" />

On Safari 17, after:
<img width="538" height="515" alt="Screenshot 2025-09-11 at 11 32 02 AM" src="https://github.com/user-attachments/assets/54076745-b04a-4b94-b854-94040ede7961" />