### PR TITLE
bug(mfa): Use errorBoundary for MfaGuard if invalid JWT is present

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -15,9 +15,11 @@ import { useAccount, useAlertBar } from 'fxa-settings/src/models';
 import { AuthUiErrorNos } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import { getErrorFtlId } from '../../../lib/error-utils';
 import { MfaGuard } from '../MfaGuard';
+import { useErrorHandler } from 'react-error-boundary';
 
 export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   usePageViewEvent('settings.emails');
+  const errorHandler = useErrorHandler();
   const [saveBtnDisabled, setSaveBtnDisabled] = useState(true);
   const [errorText, setErrorText] = useState<string>();
   const [email, setEmail] = useState<string>();
@@ -42,6 +44,11 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
         await account.createSecondaryEmail(email);
         navigateWithQuery('emails/verify', { state: { email }, replace: true });
       } catch (e) {
+        if (e && e.code === 401 && e.errno === 110) {
+          // JWT invalid/expired
+          errorHandler(e);
+          return;
+        }
         if (e.errno) {
           const errorText = l10n.getString(
             getErrorFtlId(e),
@@ -60,7 +67,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
         }
       }
     },
-    [account, navigateWithQuery, setErrorText, alertBar, l10n]
+    [account, navigateWithQuery, setErrorText, alertBar, l10n, errorHandler]
   );
 
   const checkEmail = useCallback(

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.test.tsx
@@ -11,10 +11,13 @@ import {
   renderWithRouter,
 } from '../../../models/mocks';
 import { Account, AppContext } from '../../../models';
-import { PageSecondaryEmailVerify } from '.';
+import { PageSecondaryEmailVerify, MfaGuardPageSecondaryEmailVerify } from '.';
 import { WindowLocation } from '@reach/router';
 import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
+import { JwtTokenCache } from '../../../lib/cache';
+import AuthClient from 'fxa-auth-client/lib/client';
+import userEvent, { UserEvent } from '@testing-library/user-event';
 
 const mockLocation = {
   state: { email: 'johndope@example.com' },
@@ -23,6 +26,19 @@ const mockLocation = {
 const account = {
   verifySecondaryEmail: jest.fn().mockResolvedValue(true),
 } as unknown as Account;
+
+const mockSessionToken = 'you-get-a-session-token';
+const mockJwt = 'you-get-a-jwt';
+const requiredScope = 'email';
+
+jest.mock('../../../lib/cache', () => {
+  const actual = jest.requireActual('../../../lib/cache');
+  return {
+    __esModule: true,
+    ...actual,
+    sessionToken: () => mockSessionToken,
+  };
+});
 
 window.console.error = jest.fn();
 
@@ -98,5 +114,87 @@ describe('PageSecondaryEmailVerify', () => {
     expect(alertBarInfo.success).toHaveBeenCalledWith(
       'johndope@example.com successfully added'
     );
+  });
+
+  describe('MfaGuard', () => {
+    const mockEmail = 'user@example.com';
+    const mockAuthClient = new AuthClient('http://localhost:9000');
+    let user: UserEvent;
+
+    const setupMockAuthClient = () => {
+      mockAuthClient.mfaRequestOtp = jest.fn().mockResolvedValueOnce({ code: 200, errno: 0 });
+      mockAuthClient.mfaOtpVerify = jest.fn().mockResolvedValueOnce({ accessToken: mockJwt });
+    }
+
+    const resetJwtCache = () => {
+      if (JwtTokenCache.hasToken(mockSessionToken, requiredScope)) {
+        JwtTokenCache.removeToken(mockSessionToken, requiredScope);
+      }
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      resetJwtCache();
+      setupMockAuthClient();
+      user = userEvent.setup();
+    });
+
+    it('renders correctly when JWT exists and is valid', () => {
+      JwtTokenCache.setToken(mockSessionToken, requiredScope, mockJwt);
+      const appCtx = mockAppContext({
+        authClient: mockAuthClient as any,
+        account: { ...(account as any), email: mockEmail },
+      });
+
+      renderWithRouter(
+        <AppContext.Provider value={appCtx}>
+          <MfaGuardPageSecondaryEmailVerify location={{ state: { email: mockEmail } } as any} />
+        </AppContext.Provider>
+      );
+
+      expect(screen.getByTestId('secondary-email-verify-form')).toBeInTheDocument();
+      expect(screen.queryByText('Enter confirmation code')).not.toBeInTheDocument();
+      expect(mockAuthClient.mfaRequestOtp).not.toHaveBeenCalled();
+    });
+
+    it('renders MFA guard if JWT does not exist', () => {
+      const appCtx = mockAppContext({
+        authClient: mockAuthClient as any,
+        account: { ...(account as any), email: mockEmail },
+      });
+
+      renderWithRouter(
+        <AppContext.Provider value={appCtx}>
+          <MfaGuardPageSecondaryEmailVerify location={{ state: { email: mockEmail } } as any} />
+        </AppContext.Provider>
+      );
+
+      expect(screen.getByText('Enter confirmation code')).toBeInTheDocument();
+    });
+
+    it('renders MFA guard if the JWT is invalid', async () => {
+      // an invalid token should be picked up by the guard which will
+      // "send" a new one and display the modal again.
+      JwtTokenCache.setToken(mockSessionToken, requiredScope, 'invalid-jwt');
+      account.verifySecondaryEmail = jest.fn().mockRejectedValue({ code: 401, errno: 110 });
+      const appCtx = mockAppContext({
+        authClient: mockAuthClient as any,
+        account: { ...(account as any), email: mockEmail },
+      });
+
+      renderWithRouter(
+        <AppContext.Provider value={appCtx}>
+          <MfaGuardPageSecondaryEmailVerify location={{ state: { email: mockEmail } } as any} />
+        </AppContext.Provider>
+      );
+
+      // mock the submit for the verification code, which should trigger the MFA guard
+      // because the JWT is considered invalid server-side.
+      await user.type(screen.getByTestId('verification-code-input-field'), '123456');
+      await user.click(screen.getByTestId('secondary-email-verify-submit'));
+
+      expect(account.verifySecondaryEmail).toHaveBeenCalledWith(mockEmail, '123456');
+      expect(await screen.findByText('Enter confirmation code')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -15,12 +15,14 @@ import { useForm } from 'react-hook-form';
 import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import { getErrorFtlId } from '../../../lib/error-utils';
 import { MfaGuard } from '../MfaGuard';
+import { useErrorHandler } from 'react-error-boundary';
 
 type FormData = {
   verificationCode: string;
 };
 
 export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
+  const errorHandler = useErrorHandler();
   const [errorText, setErrorText] = useState<string>();
   const { handleSubmit, register, formState } = useForm<FormData>({
     mode: 'all',
@@ -65,6 +67,11 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         logViewEvent('verify-secondary-email.verification', 'success');
         alertSuccessAndGoHome(email);
       } catch (e) {
+        if (e && e.code === 401 && e.errno === 110) {
+          // JWT invalid/expired
+          errorHandler(e);
+          return;
+        }
         if (e.errno) {
           const errorText = l10n.getString(
             getErrorFtlId(e),
@@ -84,7 +91,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         logViewEvent('verify-secondary-email.verification', 'fail');
       }
     },
-    [account, alertSuccessAndGoHome, setErrorText, alertBar, l10n]
+    [account, alertSuccessAndGoHome, setErrorText, alertBar, l10n, errorHandler]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Because:
  - We want to use the MfaGuard's error-boundary to handle invalid JWTs that are submitted server-side

This Commit:
  - Fixes the Add Secondary Email pages to use the error boundary
  - Adds unit tests for making sure the boundary is correctly respected

Closes: FXA-12383

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
