### PR TITLE
task(settings): Change how mfa caches state

### DIFF
--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -277,7 +277,35 @@ export function isInReactExperiment() {
  */
 export class JwtTokenCache {
   /** The following works with React.useSyncExternalStore. */
-  private static state: Record<string, string> = {};
+
+  /** Key where data is held in persistent storage */
+  private static readonly storageKey = 'mfa_token_cache';
+
+  /** Internal state, access is protected by getters / setters below. */
+  private static _state?: Record<string, string>;
+
+  /** Gets the current state with backing in persistent storage */
+  private static get state(): Record<string, string> {
+    if (this._state != null) {
+      return this._state;
+    }
+
+    // Fallback to stored state, if stored state is invalid, then
+    // assume fresh slate, and create new state object
+    this._state = storage.get(this.storageKey);
+    if (this._state == null) {
+      this._state = {};
+    }
+
+    return this._state;
+  }
+
+  /** Writes the current state to persistent storage */
+  private static set state(val: Record<string, string>) {
+    storage.set(this.storageKey, val);
+    this._state = val;
+  }
+
   private static listeners = new Set<() => void>();
   static subscribe(listener: () => void) {
     JwtTokenCache.listeners.add(listener);


### PR DESCRIPTION
## Because
- When app loses focuses on mobile, the browser may dump the page from memory and we lose our cached state.

## This pull request
- Backs up state to persistent store


## Issue that this pull request solves

Closes: FXA-12388

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
