### PR TITLE
docs(contributing): update outdated link in CONTRIBUTING.md and remove inactive contact methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,20 +14,9 @@ problem, thank you for your help and please read below for guidelines.
 
 If you want to write code, and you are not an experienced programmer you will
 probably be more successful [looking for other projects at
-Mozilla](https://whatcanidoformozilla.org) to contribute to. The Firefox
+Mozilla](https://codetribute.mozilla.org/) to contribute to. The Firefox
 Accounts team is happy to support open source contributions but we have limited
 time to assist in getting the FxA codebase up and running on other platforms.
-
-We use the standard `help wanted` and `good first issue` labels on GitHub to
-help identify bugs for contributors to work on.
-
-To get in touch with us and other community members:
-
-- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
-- Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
-- and of course, [the issues list](https://github.com/mozilla/fxa/issues)
-
-UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Because

- the old link https://whatcanidoformozilla.org is outdated
- mailing list and Matrix are inactive, and we also currently don't sync tickets from Jira to GitHub issues.

## This pull request

- updates outdated link in CONTRIBUTING.md
- removes mentions of Matrix, mailing list, and GitHub issues.

## Issue that this pull request solves

Closes:

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

We can update later if/when we are better set up to support contributors
