### PR TITLE
bug(settings): Use config's expiration time in MfaGuard.

### DIFF
--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.tsx
@@ -16,6 +16,7 @@ import {
   useAccount,
   useAlertBar,
   useAuthClient,
+  useConfig,
   useFtlMsgResolver,
 } from '../../../models';
 import Modal from '../ModalMfaProtected';
@@ -43,6 +44,8 @@ export const MfaGuard = ({
 }) => {
   // Let errors be handled by error boundaries in async contexts
   const handleError = useErrorHandler();
+
+  const config = useConfig();
 
   const hasSentConfirmationCode = useRef(false);
 
@@ -165,7 +168,7 @@ export const MfaGuard = ({
   };
 
   const email = account.email;
-  const expirationTime = 5; // TODO get from config
+  const expirationTime = config.mfa.otp.expiresInMinutes;
 
   const getModal = () => (
     <Modal


### PR DESCRIPTION
## Because

- I totally forgot to do this...

## This pull request

- Makes sure the UI reflects the configuration settings for OTP codes

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="392" height="307" alt="image" src="https://github.com/user-attachments/assets/3d359eff-0721-46ad-abc5-f30765ee8052" />
<img width="262" height="93" alt="image" src="https://github.com/user-attachments/assets/7bef10c4-64c9-45e9-9440-08eb1789e1bb" />

## Other information (Optional)

Any other information that is important to this pull request.
