### PR TITLE
task(settings): Debounce sending of code on click and render

### DIFF
--- a/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.test.tsx
@@ -5,21 +5,23 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MfaErrorBoundary } from './error-boundary';
-import { JwtTokenCache } from '../../../lib/cache';
+import { JwtTokenCache, MfaOtpRequestCache } from '../../../lib/cache';
 
 const mockScope = 'test';
 const mockSessionToken = 'session-xyz';
 const mockJwt = 'jwt-123';
 
 describe('MfaErrorBoundary', () => {
-  let removeSpy: jest.SpyInstance;
+  let removeJwtSpy: jest.SpyInstance;
+  let removeOtpSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    removeSpy = jest.spyOn(JwtTokenCache, 'removeToken');
+    removeJwtSpy = jest.spyOn(JwtTokenCache, 'removeToken');
+    removeOtpSpy = jest.spyOn(MfaOtpRequestCache, 'remove');
   });
 
   afterEach(() => {
-    removeSpy.mockReset();
+    removeJwtSpy.mockReset();
   });
 
   it('renders children when no error occurs', () => {
@@ -72,6 +74,7 @@ describe('MfaErrorBoundary', () => {
     );
 
     expect(screen.getByText('fallback')).toBeInTheDocument();
-    expect(removeSpy).toHaveBeenCalledWith(mockSessionToken, mockScope);
+    expect(removeJwtSpy).toHaveBeenCalledWith(mockSessionToken, mockScope);
+    expect(removeOtpSpy).toHaveBeenCalledWith(mockSessionToken, mockScope);
   });
 });

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/error-boundary.tsx
@@ -4,7 +4,7 @@
 
 import { Component, ReactNode } from 'react';
 import { MfaScope } from '../../../lib/types';
-import { JwtTokenCache } from '../../../lib/cache';
+import { JwtTokenCache, MfaOtpRequestCache } from '../../../lib/cache';
 
 /**
  * Error Boundary Implementation.
@@ -55,6 +55,10 @@ export class MfaErrorBoundary extends Component<
       });
 
       JwtTokenCache.removeToken(
+        this.props.sessionToken,
+        this.props.requiredScope
+      );
+      MfaOtpRequestCache.remove(
         this.props.sessionToken,
         this.props.requiredScope
       );

--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockAppContext, renderWithRouter } from '../../../models/mocks';
 import { MfaGuard } from './index';
-import { JwtTokenCache } from '../../../lib/cache';
+import { JwtTokenCache, MfaOtpRequestCache } from '../../../lib/cache';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { AppContext } from '../../../models';
 
@@ -56,9 +56,8 @@ async function submitCode(otp: string = mockOtp) {
 
 describe('MfaGuard', () => {
   beforeEach(() => {
-    if (JwtTokenCache.hasToken(mockSessionToken, mockScope)) {
-      JwtTokenCache.removeToken(mockSessionToken, mockScope);
-    }
+    JwtTokenCache.removeToken(mockSessionToken, mockScope);
+    MfaOtpRequestCache.remove(mockSessionToken, mockScope);
     jest.clearAllMocks();
   });
 
@@ -127,7 +126,7 @@ describe('MfaGuard', () => {
   it('clears error banner on input change', async () => {
     renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
-        <MfaGuard requiredScope={mockScope}>
+        <MfaGuard requiredScope={mockScope} debounceIntervalMs={0}>
           <div>secured</div>
         </MfaGuard>
       </AppContext.Provider>
@@ -149,7 +148,7 @@ describe('MfaGuard', () => {
   it('shows resend success banner and hides error banner on resend success', async () => {
     renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
-        <MfaGuard requiredScope={mockScope}>
+        <MfaGuard requiredScope={mockScope} debounceIntervalMs={0}>
           <div>secured</div>
         </MfaGuard>
       </AppContext.Provider>
@@ -179,7 +178,7 @@ describe('MfaGuard', () => {
   it('shows error banner and hide success banner on resend error', async () => {
     renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
-        <MfaGuard requiredScope={mockScope}>
+        <MfaGuard requiredScope={mockScope} debounceIntervalMs={0}>
           <div>secured</div>
         </MfaGuard>
       </AppContext.Provider>
@@ -209,7 +208,7 @@ describe('MfaGuard', () => {
 
     renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
-        <MfaGuard requiredScope={mockScope}>
+        <MfaGuard requiredScope={mockScope} debounceIntervalMs={0}>
           <div>secured</div>
         </MfaGuard>
       </AppContext.Provider>
@@ -226,7 +225,11 @@ describe('MfaGuard', () => {
 
     renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>
-        <MfaGuard requiredScope={mockScope} onDismissCallback={mockOnDismiss}>
+        <MfaGuard
+          requiredScope={mockScope}
+          onDismissCallback={mockOnDismiss}
+          debounceIntervalMs={0}
+        >
           <div>secured</div>
         </MfaGuard>
       </AppContext.Provider>
@@ -235,5 +238,40 @@ describe('MfaGuard', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('debounces OTP resend requests', async () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext()}>
+        <MfaGuard requiredScope={mockScope} debounceIntervalMs={100}>
+          <div>secured</div>
+        </MfaGuard>
+      </AppContext.Provider>
+    );
+
+    // Should be debounced! The dialog just rendered and a code went out...
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Email new code.' })
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 101));
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Email new code.' })
+    );
+    // Should be debounced! The resend request above was just clicked...
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Email new code.' })
+    );
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 101));
+    });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Email new code.' })
+    );
+
+    expect(mockAuthClient.mfaRequestOtp).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Because

- Due to mobile issue the previous debounce technique might still have issues

## This pull request

- Caches record of when MFA OTP code requests occur
- Uses record to determine whether or not to debounce
- Also handles case where some one hammers the 'resend' button

## Issue that this pull request solves

Closes: FXA-12390

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
