### PR TITLE
task(settings): Wrap disable 2FA with MFA guard 

### DIFF
--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -101,13 +101,36 @@ export class SettingsPage extends SettingsLayout {
     }, creds.uid);
   }
 
+  /**
+   * Removes 2FA from the account by clicking the 'disable' button on the 2FA row.
+   */
   async disconnectTotp() {
     await this.totp.disableButton.click();
+
+    // Obtain the MFA JWT if necessary
+    if (await this.isMfaGuardVisible()) {
+      const email = await this.primaryEmail.status.textContent();
+      if (!email) {
+        throw new Error('Could not determine primary email!');
+      }
+      await this.confirmMfaGuard(email);
+    }
+
     await this.modalConfirmButton.click();
 
     await expect(this.settingsHeading).toBeVisible();
     await expect(this.alertBar).toHaveText('Two-step authentication disabled');
     await expect(this.totp.status).toHaveText('Disabled');
+  }
+
+  /**
+   * Indicates that the MFA guard's modal dialog is currently displayed.
+   * @returns true if the MFA modal is open
+   */
+  async isMfaGuardVisible() {
+    return await this.page
+      .getByRole('heading', { name: 'Enter confirmation code' })
+      .isVisible();
   }
 
   /**

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -57,14 +57,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.alertBar).toHaveText(
         'Two-step authentication has been enabled'
       );
-      await settings.totp.disableButton.click();
-      await settings.clickModalConfirm();
-
-      await expect(settings.modalConfirmButton).toBeHidden();
-      await expect(settings.totp.status).toHaveText('Disabled');
-      await expect(settings.alertBar).toHaveText(
-        'Two-step authentication disabled'
-      );
+      await settings.disconnectTotp();
 
       await relier.goto();
       await relier.clickEmailFirst();

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1871,8 +1871,28 @@ export default class AuthClient {
     return this.jwtPost('/mfa/totp/replace/confirm', jwt, { code }, headers);
   }
 
+  /**
+   * @deprecated Use deleteTotpTokenWithJwt instead
+   *
+   * Disables 2FA Protection on the account.
+   *
+   * @param sessionToken - required, must be a verified session token
+   * @param headers - Optional additional headers for the request
+   * @returns A promise that resolves when the 2FA has been removed
+   */
   async deleteTotpToken(sessionToken: hexstring, headers?: Headers) {
     return this.sessionPost('/totp/destroy', sessionToken, {}, headers);
+  }
+
+  /**
+   * Disables 2FA Protection on the account.
+   *
+   * @param jwt - required, must be a verified session token
+   * @param headers - Optional additional headers for the request
+   * @returns A promise that resolves when the 2FA has been removed
+   */
+  async deleteTotpTokenWithJwt(jwt: string, headers?: Headers) {
+    return this.jwtPost('/mfa/totp/destroy', jwt, {}, headers);
   }
 
   async checkTotpTokenExists(

--- a/packages/fxa-auth-server/docs/swagger/totp-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/totp-api.ts
@@ -32,6 +32,17 @@ const TOTP_DESTROY_POST = {
     `,
   ],
 };
+const MFA_TOTP_DESTROY_POST = {
+  ...TAGS_TOTP,
+  description: '/mfa/totp/destroy',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA JWT (scope: mfa:2fa)
+
+      Deletes the current TOTP token for the user. The underlying session needs to have been verified by TOTP to remove it. It does not bypass that requirement.
+    `,
+  ],
+};
 
 const TOTP_EXISTS_GET = {
   ...TAGS_TOTP,
@@ -158,6 +169,7 @@ const API_DOCS = {
   SESSION_VERIFY_TOTP_POST,
   TOTP_CREATE_POST,
   TOTP_DESTROY_POST,
+  MFA_TOTP_DESTROY_POST,
   TOTP_EXISTS_GET,
   TOTP_VERIFY_POST,
   TOTP_VERIFY_RECOVERY_CODE_POST,

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -262,7 +262,7 @@ module.exports = (
     }
   }
 
-  return [
+  const routes = [
     {
       method: 'POST',
       path: '/totp/create',
@@ -586,6 +586,27 @@ module.exports = (
             });
           }
         }
+      },
+    },
+    {
+      method: 'POST',
+      path: '/mfa/totp/destroy',
+      options: {
+        ...TOTP_DOCS.MFA_TOTP_DESTROY_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:2fa'],
+          payload: false,
+        },
+        response: {},
+      },
+      handler: async function (request) {
+        return routes
+          .find(
+            (route) =>
+              route.path === '/v1/totp/destroy' && route.method === 'POST'
+          )
+          .handler(request);
       },
     },
     {
@@ -1163,4 +1184,6 @@ module.exports = (
       handler: handleTotpReplaceConfirm,
     },
   ];
+
+  return routes;
 };

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1126,7 +1126,7 @@ export class Account implements AccountData {
 
   async disableTwoStepAuth() {
     await this.withLoadingStatus(
-      this.authClient.deleteTotpToken(sessionToken()!)
+      this.authClient.deleteTotpTokenWithJwt(this.getCachedJwtByScope('2fa'))
     );
 
     const cache = this.apolloClient.cache;


### PR DESCRIPTION
## Because

- We want to require MFA when disabling 2FA

## This pull request

- Wraps the 2FA row's disable button with an MfaGuard component
- Updates functional tests to supply MfaGuard's OTP code when required

## Issue that this pull request solves

Closes: FXA-12230

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

A lot of tests 'disable 2FA' as part of the test tear down.
