### PR TITLE
feat(mfa): Add ability to pre fetch JWT tokens in functional tests

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -72,8 +72,8 @@ export const test = base.extend<TestOptions, WorkerOptions>({
     await syncBrowserPages.browser?.close();
   },
 
-  testAccountTracker: async ({ target }, use, testInfo) => {
-    const testAccountTracker = new TestAccountTracker(target, testInfo);
+  testAccountTracker: async ({ target, page }, use, testInfo) => {
+    const testAccountTracker = new TestAccountTracker(target, testInfo, page);
 
     await use(testAccountTracker);
 

--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -16,14 +16,16 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
+      const credentials = await testAccountTracker.signUpAndPrimeMfa({
+        scopes: 'email',
+      });
       await signInAccount(target, page, settings, signin, credentials);
       const initialEmail = credentials.email;
       const newEmail = testAccountTracker.generateEmail();
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail, credentials.email);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
 
       await settings.signOut();
 
@@ -51,7 +53,9 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
+      const credentials = await testAccountTracker.signUpAndPrimeMfa({
+        scopes: 'email',
+      });
       await signInAccount(target, page, settings, signin, credentials);
       const initialPassword = credentials.password;
       const newEmail = testAccountTracker.generateEmail();
@@ -59,7 +63,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail, credentials.email);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
 
       await setNewPassword(
         settings,
@@ -92,7 +96,9 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, changePassword, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
+      const credentials = await testAccountTracker.signUpAndPrimeMfa({
+        scopes: 'email',
+      });
       await signInAccount(target, page, settings, signin, credentials);
       const initialEmail = credentials.email;
       const initialPassword = credentials.password;
@@ -101,7 +107,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, secondEmail, credentials.email);
+      await changePrimaryEmail(target, settings, secondaryEmail, secondEmail);
 
       await setNewPassword(
         settings,
@@ -143,14 +149,16 @@ test.describe('severity-1 #smoke', () => {
       },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
+      const credentials = await testAccountTracker.signUpAndPrimeMfa({
+        scopes: 'email',
+      });
       await signInAccount(target, page, settings, signin, credentials);
       const newEmail = testAccountTracker.generateEmail();
       const newPassword = testAccountTracker.generatePassword();
 
       await settings.goto();
 
-      await changePrimaryEmail(target, settings, secondaryEmail, newEmail, credentials.email);
+      await changePrimaryEmail(target, settings, secondaryEmail, newEmail);
       await expect(settings.primaryEmail.status).toHaveText(newEmail);
 
       // Click delete account
@@ -179,13 +187,14 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, secondaryEmail, settings, signin },
       testAccountTracker,
     }) => {
-      const credentials = await testAccountTracker.signUp();
+      const credentials = await testAccountTracker.signUpAndPrimeMfa({
+        scopes: 'email',
+      });
       await signInAccount(target, page, settings, signin, credentials);
       const newEmail = testAccountTracker.generateEmail();
 
       await settings.goto();
       await settings.secondaryEmail.addButton.click();
-      await settings.confirmMfaGuard(credentials.email);
       await secondaryEmail.fillOutEmail(newEmail);
       const code: string =
         await target.emailClient.getVerifySecondaryCode(newEmail);
@@ -235,11 +244,9 @@ async function changePrimaryEmail(
   target: BaseTarget,
   settings: SettingsPage,
   secondaryEmail: SecondaryEmailPage,
-  email: string,
-  primaryEmail: string,
+  email: string
 ): Promise<void> {
   await settings.secondaryEmail.addButton.click();
-  await settings.confirmMfaGuard(primaryEmail);
   await secondaryEmail.fillOutEmail(email);
   const code: string = await target.emailClient.getVerifySecondaryCode(email);
   await secondaryEmail.fillOutVerificationCode(code);

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -137,9 +137,7 @@ module.exports = (
       }
 
       if (
-        account.emails
-          .map((accountEmail) => accountEmail.email)
-          .includes(email)
+        account.emails.map((accountEmail) => accountEmail.email).includes(email)
       ) {
         throw error.alreadyOwnsEmail();
       }
@@ -197,8 +195,7 @@ module.exports = (
               throw error.verifiedPrimaryEmailAlreadyExists();
             }
 
-            const msSinceCreated =
-              Date.now() - secondaryEmailRecord.createdAt;
+            const msSinceCreated = Date.now() - secondaryEmailRecord.createdAt;
             const minUnverifiedAccountTime =
               config.secondaryEmail.minUnverifiedAccountTime;
             const exceedsMinUnverifiedAccountTime =
@@ -299,8 +296,8 @@ module.exports = (
       });
 
       return {};
-    }
-  }
+    },
+  };
 
   return [
     {
@@ -748,9 +745,9 @@ module.exports = (
       },
     },
     {
-    method: 'POST',
-    path: '/mfa/recovery_email',
-    options: {
+      method: 'POST',
+      path: '/mfa/recovery_email',
+      options: {
         ...EMAILS_DOCS.RECOVERY_EMAIL_POST,
         auth: {
           strategy: 'mfa',
@@ -767,7 +764,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: handlers.recoveryEmailPost
+      handler: handlers.recoveryEmailPost,
     },
     {
       method: 'POST',
@@ -788,7 +785,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: handlers.recoveryEmailPost
+      handler: handlers.recoveryEmailPost,
     },
     {
       method: 'POST',
@@ -1091,7 +1088,7 @@ module.exports = (
           }),
         },
       },
-      handler: handlers.recoveryEmailSecondaryVerifyCodePost
+      handler: handlers.recoveryEmailSecondaryVerifyCodePost,
     },
     {
       method: 'POST',
@@ -1117,7 +1114,7 @@ module.exports = (
           }),
         },
       },
-      handler: handlers.recoveryEmailSecondaryVerifyCodePost
+      handler: handlers.recoveryEmailSecondaryVerifyCodePost,
     },
     {
       method: 'POST',


### PR DESCRIPTION
Because:
 - We want to make it possible to pre-fetch JWT tokens in functional tests

This Commit:
 - Adds a new function to the TestAccountTracker to signup and fetch tokens by scope
 - Adds on page load hook to ensure tokens are stored in cache as soon as possible after signin

Closes: FXA-12356

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
