### PR TITLE
fix(payments-next): “Cancel subscription” button is active without marking the checkbox for users that had their subscription previously reactivated

### DIFF
--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.tsx
@@ -118,6 +118,7 @@ export const SubscriptionContent = ({
     if (result.ok) {
       setOpenCancellationDialog(true);
       setShowCancel(false);
+      setCheckedState(false);
       setShowCancelActionError(false);
     } else {
       setShowCancelActionError(true);
@@ -463,7 +464,10 @@ export const SubscriptionContent = ({
               <SubmitButton
                 className="h-10 w-full tablet:w-1/2"
                 variant={ButtonVariant.Primary}
-                onClick={() => setShowCancel(false)}
+                onClick={() => {
+                  setCheckedState(false);
+                  setShowCancel(false);
+                }}
                 aria-label={`Stay subscribed to ${productName}`}
                 showLoadingSpinner={false}
               >
@@ -637,7 +641,10 @@ export const SubscriptionContent = ({
                 <SubmitButton
                   className="h-10"
                   variant={ButtonVariant.Secondary}
-                  onClick={() => setShowCancel(true)}
+                  onClick={() => {
+                    setCheckedState(false);
+                    setShowCancel(true);
+                  }}
                   aria-label={`Cancel your subscription for ${productName}`}
                 >
                   Cancel


### PR DESCRIPTION
## Because

- “Cancel subscription” shows as active without clicking on the confirmation checkbox.
- After cancelling, checkedState is true and is never reset back to false.

## This pull request

- Sets checkedState to false when it is not clicked.

## Issue that this pull request solves

Closes: #[PAY-3260](https://mozilla-hub.atlassian.net/browse/PAY-3260)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3260]: https://mozilla-hub.atlassian.net/browse/PAY-3260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ