### PR TITLE
feat(mfa): Wrap delete secondary email in MfaGuard

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1690,6 +1690,14 @@ export default class AuthClient {
     );
   }
 
+  async recoveryEmailDestroyWithJwt(
+    jwt: string,
+    email: string,
+    headers?: Headers
+  ) {
+    return this.jwtPost('/mfa/recovery_email/destroy', jwt, { email }, headers);
+  }
+
   async recoveryEmailSetPrimaryEmail(
     sessionToken: hexstring,
     email: string,

--- a/packages/fxa-auth-server/docs/swagger/emails-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/emails-api.ts
@@ -156,6 +156,36 @@ const RECOVERY_EMAIL_DESTROY_POST = {
   },
 };
 
+const MFA_RECOVERY_EMAIL_DESTROY_POST = {
+  ...TAGS_EMAILS,
+  description: '/mfa/recovery_email/destroy',
+  notes: [
+    dedent`
+      🔒 Authenticated with session MFA JWT (scope: mfa:email)
+
+      Delete an email address associated with the logged-in user.
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 138\` - Unverified session
+          `,
+        },
+        401: {
+          description: dedent`
+            Failing requests may be caused by the following errors (this is not an exhaustive list):
+            - \`errno: 110\` - Invalid authentication token in request signature
+          `,
+        },
+      },
+    },
+  },
+};
+
 const RECOVERY_EMAIL_SET_PRIMARY_POST = {
   ...TAGS_EMAILS,
   description: '/recovery_email/set_primary',
@@ -235,6 +265,7 @@ const RECOVERY_EMAIL_SECONDARY_VERIFY_CODE_POST = {
 const API_DOCS = {
   EMAILS_REMINDERS_CAD_POST,
   RECOVERY_EMAIL_DESTROY_POST,
+  MFA_RECOVERY_EMAIL_DESTROY_POST,
   RECOVERY_EMAIL_POST,
   RECOVERY_EMAIL_RESEND_CODE_POST,
   RECOVERY_EMAIL_SECONDARY_RESEND_CODE_POST,

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -299,7 +299,7 @@ module.exports = (
     },
   };
 
-  return [
+  const routes = [
     {
       method: 'GET',
       path: '/recovery_email/status',
@@ -862,6 +862,35 @@ module.exports = (
     },
     {
       method: 'POST',
+      path: '/mfa/recovery_email/destroy',
+      options: {
+        ...EMAILS_DOCS.MFA_RECOVERY_EMAIL_DESTROY_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:email'],
+          payload: false,
+        },
+        validate: {
+          payload: isA.object({
+            email: validators
+              .email()
+              .required()
+              .description(DESCRIPTION.emailDelete),
+          }),
+        },
+        response: {},
+      },
+      handler: async function (request) {
+        return routes
+          .find(
+            (r) =>
+              r.path === '/v1/recovery_email/destroy' && r.method === 'POST'
+          )
+          .handler(request);
+      },
+    },
+    {
+      method: 'POST',
       path: '/recovery_email/set_primary',
       options: {
         ...EMAILS_DOCS.RECOVERY_EMAIL_SET_PRIMARY_POST,
@@ -1152,6 +1181,8 @@ module.exports = (
       },
     },
   ];
+
+  return routes;
 };
 
 // Exported for testing purposes.

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/mocks.tsx
@@ -37,3 +37,16 @@ export const MOCK_MANY_SEC_EMAILS_MANY_UNVERIFIED = [
   mockEmail('johndope3@example.com', false, false),
   mockEmail('johndope4@example.com', false, false),
 ];
+
+/**
+ * Creates a mock account to provide to the AppContext. Gives strong typing
+ * and avoids the need to use `as unknown as Account` in tests.
+ * @param overrides
+ * @returns
+ */
+export const createMockAccount = (overrides: Partial<Account> = {}) => {
+  const base: Partial<Account> = {
+    emails: [mockEmail(), mockEmail('johndope2@example.com', false, false)],
+  };
+  return { ...base, ...overrides } as Account;
+};

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1180,6 +1180,27 @@ export class Account implements AccountData {
     });
   }
 
+  async deleteSecondaryEmailWithJwt(email: string) {
+    const jwt = this.getCachedJwtByScope('email');
+    await this.withLoadingStatus(
+      this.authClient.recoveryEmailDestroyWithJwt(jwt, email)
+    );
+    const cache = this.apolloClient.cache;
+    cache.modify({
+      id: cache.identify({ __typename: 'Account' }),
+      fields: {
+        emails(existingEmails) {
+          const emails = [...existingEmails];
+          emails.splice(
+            emails.findIndex((x) => x.email === email),
+            1
+          );
+          return emails;
+        },
+      },
+    });
+  }
+
   async makeEmailPrimary(email: string) {
     await this.withLoadingStatus(
       this.authClient.recoveryEmailSetPrimaryEmail(sessionToken()!, email)


### PR DESCRIPTION
Because:
 - We want additional security for deleting a secondary email

This Commit:
 - Wraps the action to delete the secondary email with an MfaGuard
 - Adds and updates tests for secondary email delete

Closes: FXA-12228

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
