### PR TITLE
fix(payments-next): Date encoded within <strong> tags on the Payments Screen for IAP subscriptions

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -547,12 +547,20 @@ export default async function Manage({
                         </p>
                         {nextBillDate && (
                           <p>
-                            {l10n.getString(
+                            {l10n.getFragmentWithSource(
                               'subscription-management-iap-sub-will-expire-on',
                               {
-                                date: nextBillDate,
+                                vars: {
+                                  date: nextBillDate,
+                                },
+                                elems: {
+                                  strong: <strong />
+                                },
                               },
-                              `Your subscription will expire on ${nextBillDate}`
+                              <>
+                                Your subscription will expire on <strong>${nextBillDate}</strong>
+                              </>
+
                             )}
                           </p>
                         )}
@@ -656,19 +664,33 @@ export default async function Manage({
                       <p>
                         {!!purchase.expiryTimeMillis &&
                           (purchase.autoRenewing
-                            ? l10n.getString(
+                            ? l10n.getFragmentWithSource(
                                 'subscription-management-iap-sub-next-bill-is-due',
                                 {
-                                  date: nextBillDate,
+                                  vars: {
+                                    date: nextBillDate,
+                                  },
+                                  elems: {
+                                    strong: <strong />
+                                  },
                                 },
-                                `Next bill is due ${nextBillDate}`
+                                <>
+                                  Next bill is due <strong>{nextBillDate}</strong>
+                                </>
                               )
-                            : l10n.getString(
+                            : l10n.getFragmentWithSource(
                                 'subscription-management-iap-sub-will-expire-on',
                                 {
-                                  date: nextBillDate,
+                                  vars: {
+                                    date: nextBillDate,
+                                  },
+                                  elems: {
+                                    strong: <strong />
+                                  },
                                 },
-                                `Your subscription will expire on ${nextBillDate}`
+                                <>
+                                  Your subscription will expire on <strong>{nextBillDate}</strong>
+                                </>
                               ))}
                       </p>
                     </div>


### PR DESCRIPTION
## Because

- Date encoded within strong tags on the Payments Screen for IAP subscriptions.
- l10n.getString() was returning the actual string, which included strong tags.

## This pull request

- Uses l10n.getFragmentWithSource() instead.

## Issue that this pull request solves

Closes: #[PAY-3261](https://mozilla-hub.atlassian.net/browse/PAY-3261)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="3004" height="1742" alt="image" src="https://github.com/user-attachments/assets/9b3b4350-cd49-401a-b03d-1487a43ceb80" />

<img width="2998" height="1462" alt="image" src="https://github.com/user-attachments/assets/462a85f3-1211-4a40-b0c3-110d2ba17f5c" />


## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3261]: https://mozilla-hub.atlassian.net/browse/PAY-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ