### PR TITLE
fix(mfa): MFA OTP not sent to all emails

### DIFF
--- a/packages/fxa-auth-server/lib/routes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/mfa.ts
@@ -8,7 +8,7 @@ import { StatsD } from 'hot-shots';
 import * as jwt from 'jsonwebtoken';
 import * as uuid from 'uuid';
 import { SecurityEvent } from 'fxa-shared/db/models/auth/security-event';
-import { Account } from 'fxa-shared/db/models/auth';
+import { Account, Email } from 'fxa-shared/db/models/auth';
 import { AuthRequest, SessionTokenAuthCredential } from '../types';
 import { recordSecurityEvent } from './utils/security-event';
 import { ConfigType } from '../../config';
@@ -29,7 +29,7 @@ interface Customs {
 /** Mailer interface for mfa specific operations  */
 interface Mailer {
   sendVerifyAccountChangeEmail(
-    emails: string[],
+    emails: Email[] | undefined,
     account: Account,
     emailOptions: {
       uid: string;
@@ -82,15 +82,11 @@ class MfaHandler {
       // For specifics see: https://www.npmjs.com/package/otplib
       const expirationTime = (options.step * options.window) / 60;
 
-      await this.mailer.sendVerifyAccountChangeEmail(
-        account.emails?.map((x) => x.email) || [account.email],
-        account,
-        {
-          code,
-          uid,
-          expirationTime,
-        }
-      );
+      await this.mailer.sendVerifyAccountChangeEmail(account.emails, account, {
+        code,
+        uid,
+        expirationTime,
+      });
 
       success = true;
     } catch (error) {


### PR DESCRIPTION
## Because

- MFA OTP code emails are sent to the old primary email address after swapping primary and secondary emails

## This pull request

- make it send to both primary and secondary email

## Issue that this pull request solves

Closes: FXA-12409

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
