### PR TITLE
fix(payments-next): Fix avatar and email on new Subscription Management page

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/layout.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/layout.tsx
@@ -53,15 +53,17 @@ export default async function SubscriptionsLayout({
               )}
               width="48"
               height="48"
-              className="w-12 h-12 tablet:w-16 tablet:h-16"
+              className="w-12 h-12 rounded-full tablet:w-16 tablet:h-16"
             />
             <h1
               id="profile-heading"
-              className="overflow-hidden font-semibold text-ellipsis text-start text-nowrap tablet:text-xl"
+              className="overflow-hidden text-start tablet:text-xl"
             >
-              <div>{session?.user?.name || session?.user?.email}</div>
+              <div className="font-semibold mb-1 overflow-hidden text-ellipsis text-nowrap">
+                {session?.user?.name || session?.user?.email}
+              </div>
               {session?.user?.name && (
-                <div className="font-normal text-base text-grey-400 mb-0">
+                <div className="font-normal overflow-hidden text-base text-ellipsis text-grey-400 text-nowrap mb-0">
                   {session?.user?.email}
                 </div>
               )}


### PR DESCRIPTION
## This pull request

- Fixes avatar styling
- Moves ellipsis to display name or email if too long

## Issue that this pull request solves

Closes: PAY-3265, PAY-3266

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
<img width="422" height="834" alt="Screenshot 2025-09-17 at 12 57 11 PM" src="https://github.com/user-attachments/assets/1af566c2-44b4-4c0e-b3a9-2c83983db7df" />