### PR TITLE
fix(settings): redirect to sub manage landing

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.tsx
@@ -50,7 +50,7 @@ export const Nav = ({
     )}`;
   const subscriptionLink = config.featureFlags
     ?.paymentsNextSubscriptionManagement
-    ? `${config.servers.paymentsNext.url}/subscriptions/manage`
+    ? `${config.servers.paymentsNext.url}/subscriptions/landing`
     : '/subscriptions';
 
   useEffect(() => {


### PR DESCRIPTION
## Because

- When switching between different FxA accounts, the sub manage page would not change to the new account.

## This pull request

- Redirects customers to the sub manage landing page, which will always authenticate to the current signed in user.

## Issue that this pull request solves

Closes: #PAY-3264

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
