### PR TITLE
task(settings): Wrap 2FA Replace Backup Codes with MFA guard 

### DIFF
--- a/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
+++ b/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
@@ -110,6 +110,7 @@ test.describe('severity-1 #smoke', () => {
       const { recoveryCodes } = await addTotp(settings, totp);
       await settings.totp.getNewBackupCodesButton.click();
 
+      await settings.confirmMfaGuard(credentials.email);
       const newCodes = await totp.getRecoveryCodes();
       expect(newCodes.some((c) => recoveryCodes.includes(c))).toBe(false);
 
@@ -187,6 +188,7 @@ test.describe('severity-1 #smoke', () => {
         credentials.email
       );
       await page.goto(link);
+      await settings.confirmMfaGuard(credentials.email);
       const newCodes = await totp.getRecoveryCodes();
       expect(newCodes.length).toEqual(recoveryCodes.length);
 

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -348,6 +348,21 @@ export default class AuthClient {
     return this.request('POST', path, payload, headers);
   }
 
+  private async jwtPut(
+    path: string,
+    jwt: string,
+    payload: any,
+    headers?: Headers
+  ) {
+    const authorization = 'Bearer ' + jwt;
+    if (!headers) {
+      headers = new Headers({ authorization });
+    } else {
+      headers.set('authorization', authorization);
+    }
+    return this.request('PUT', path, payload, headers);
+  }
+
   private async sessionPost(
     path: string,
     sessionToken: hexstring,
@@ -1997,7 +2012,9 @@ export default class AuthClient {
     return this.sessionGet('/recoveryCodes', sessionToken, headers);
   }
 
-  // update recovery codes with codes created and confirmed client-side
+  /**
+   * @deprecated Use updateRecoveryCodesWithJwt instead!
+   */
   async updateRecoveryCodes(
     sessionToken: hexstring,
     recoveryCodes: string[],
@@ -2009,6 +2026,21 @@ export default class AuthClient {
       { recoveryCodes },
       headers
     );
+  }
+
+  /**
+   * Update recovery codes with codes created and confirmed client-side
+   * @param jwt auth token
+   * @param recoveryCodes new codes
+   * @param headers optional headers
+   * @returns
+   */
+  async updateRecoveryCodesWithJwt(
+    jwt: hexstring,
+    recoveryCodes: string[],
+    headers?: Headers
+  ): Promise<{ success: boolean }> {
+    return this.jwtPut('/mfa/recoveryCodes', jwt, { recoveryCodes }, headers);
   }
 
   async getRecoveryCodesExist(

--- a/packages/fxa-auth-server/docs/swagger/recovery-codes-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-codes-api.ts
@@ -45,6 +45,18 @@ const RECOVERY_CODES_PUT = {
   ],
 };
 
+const MFA_RECOVERY_CODES_PUT = {
+  ...TAGS_RECOVERY_CODE,
+  description: '/mfa/recoveryCodes',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA jwt
+
+      Return new backup authentication codes while removing old ones.
+    `,
+  ],
+};
+
 const SESSION_VERIFY_RECOVERYCODE_POST = {
   description: '/session/verify/recoveryCode',
   notes: [
@@ -60,6 +72,7 @@ const API_DOCS = {
   RECOVERYCODES_GET,
   RECOVERY_CODES_POST,
   RECOVERY_CODES_PUT,
+  MFA_RECOVERY_CODES_PUT,
   SESSION_VERIFY_RECOVERYCODE_POST,
 };
 

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -27,7 +27,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
     RECOVERY_CODE_SANE_MAX_LENGTH
   );
 
-  return [
+  const routes = [
     {
       method: 'GET',
       path: '/recoveryCodes',
@@ -198,6 +198,34 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       },
     },
     {
+      method: 'PUT',
+      path: '/mfa/recoveryCodes',
+      options: {
+        ...RECOVERY_CODES_DOCS.MFA_RECOVERY_CODES_PUT,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:2fa'],
+          payload: false,
+        },
+        validate: {
+          payload: recoveryCodesSchema,
+        },
+        response: {
+          schema: isA.object({
+            success: isA.boolean(),
+          }),
+        },
+      },
+      handler: async function (request) {
+        return routes
+          .find(
+            (route) =>
+              route.path === '/v1/recoveryCodes' && route.method === 'PUT'
+          )
+          .handler(request);
+      },
+    },
+    {
       method: 'GET',
       path: '/recoveryCodes/exists',
       options: {
@@ -331,4 +359,6 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       },
     },
   ];
+
+  return routes;
 };

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -232,23 +232,6 @@ describe('Settings App', () => {
     expect(getByTestId('mock-2fa-setup-page')).toBeInTheDocument();
   });
 
-  it('routes to Page2faReplaceBackupCodes', async () => {
-    const session = mockSession(true);
-    const {
-      getByTestId,
-      history: { navigate },
-    } = renderWithRouter(
-      <AppContext.Provider value={mockAppContext({ session })}>
-        <Subject />
-      </AppContext.Provider>,
-      { route: SETTINGS_PATH }
-    );
-
-    await navigate(SETTINGS_PATH + '/two_step_authentication/replace_codes');
-
-    expect(getByTestId('2fa-backup-codes')).toBeInTheDocument();
-  });
-
   it('routes to PageDeleteAccount', async () => {
     const session = mockSession(true);
     const {
@@ -345,6 +328,11 @@ describe('Settings App', () => {
         pageName: 'PageSecondaryEmailVerify',
         route: '/emails/verify',
         hasPassword: false,
+      },
+      {
+        pageName: 'Page2faReplaceBackupCodes',
+        route: '/two_step_authentication/replace_codes',
+        hasPassword: true,
       },
     ];
 

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -21,7 +21,7 @@ import { MfaGuardPageSecondaryEmailAdd } from './PageSecondaryEmailAdd';
 import { MfaGuardPageSecondaryEmailVerify } from './PageSecondaryEmailVerify';
 import { PageDisplayName } from './PageDisplayName';
 import Page2faSetup from './Page2faSetup';
-import { Page2faReplaceBackupCodes } from './Page2faReplaceBackupCodes';
+import { PageMfaGuard2faReplaceBackupCodes } from './Page2faReplaceBackupCodes';
 import { PageRecoveryPhoneSetup } from './PageRecoveryPhoneSetup';
 import { PageDeleteAccount } from './PageDeleteAccount';
 import { ScrollToTop } from './ScrollToTop';
@@ -165,7 +165,7 @@ export const Settings = ({
               />
               <Page2faSetup path="/two_step_authentication" />
               <MfaGuardPage2faChange path="/two_step_authentication/change" />
-              <Page2faReplaceBackupCodes path="/two_step_authentication/replace_codes" />
+              <PageMfaGuard2faReplaceBackupCodes path="/two_step_authentication/replace_codes" />
             </>
           ) : (
             <>

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1076,8 +1076,9 @@ export class Account implements AccountData {
    * Allows for local code confirmation before updating.
    */
   async updateRecoveryCodes(recoveryCodes: string[]) {
+    const jwt = this.getCachedJwtByScope('2fa');
     const result = await this.withLoadingStatus(
-      this.authClient.updateRecoveryCodes(sessionToken()!, recoveryCodes)
+      this.authClient.updateRecoveryCodesWithJwt(jwt, recoveryCodes)
     );
     await this.refresh('backupCodes');
     return result;


### PR DESCRIPTION
## Because

- We want to protect the 'replace backup codes' action with MFA

## This pull request

- Adds an MFA guard to `Page2faReplaceBackupCodes`

## Issue that this pull request solves

Closes: FXA-12232

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
