### PR TITLE
 task(settings): Wrap create account recovery keys with MFA guard 

### DIFF
--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKey.spec.ts
@@ -114,6 +114,9 @@ test.describe('severity-2 #smoke', () => {
       await settings.goto(`${resetVersion.query}`);
       await page.waitForURL(/settings/);
       await settings.recoveryKey.createButton.click();
+
+      await settings.confirmMfaGuard(accountDetails.email);
+
       const key = await recoveryKey.createRecoveryKey(
         accountDetails.password,
         HINT

--- a/packages/functional-tests/tests/key-stretching-v2/recoveryKeyUpgrade.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/recoveryKeyUpgrade.spec.ts
@@ -29,6 +29,9 @@ test.describe('severity-2 #smoke', () => {
     await expect(settings.recoveryKey.status).toHaveText('Not Set');
 
     await settings.recoveryKey.createButton.click();
+
+    await settings.confirmMfaGuard(email);
+
     await recoveryKey.createRecoveryKey(password, HINT);
 
     await expect(settings.recoveryKey.status).toHaveText('Enabled');

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -64,6 +64,7 @@ test.describe('recovery key promo', () => {
       await signin.fillOutPasswordForm(credentials.password);
       await page.waitForURL(/settings/);
       await settings.recoveryKey.createButton.click();
+      await settings.confirmMfaGuard(credentials.email);
       await recoveryKey.acknowledgeInfoForm();
       await recoveryKey.fillOutConfirmPasswordForm(credentials.password);
       await recoveryKey.clickDownload();

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoSettingsBanner.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoSettingsBanner.spec.ts
@@ -27,6 +27,8 @@ test.describe('recovery key promo', () => {
 
       await inlineRecoveryKey.getBannerCreateLink().click();
 
+      await settings.confirmMfaGuard(credentials.email);
+
       await recoveryKey.acknowledgeInfoForm();
       await recoveryKey.fillOutConfirmPasswordForm(credentials.password);
 
@@ -56,6 +58,8 @@ test.describe('recovery key promo', () => {
       await expect(settings.recoveryKey.status).toHaveText('Not Set');
 
       await inlineRecoveryKey.getBannerCreateLink().click();
+
+      await settings.confirmMfaGuard(credentials.email);
 
       await recoveryKey.acknowledgeInfoForm();
       await recoveryKey.fillOutConfirmPasswordForm(credentials.password);

--- a/packages/functional-tests/tests/resetPassword/oauthResetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPasswordRecoveryKey.spec.ts
@@ -22,6 +22,9 @@ test.describe('severity-1 #smoke', () => {
 
       // Goes to settings and enables the account recovery key on user's account.
       await settings.recoveryKey.createButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       const accountRecoveryKey = await recoveryKey.createRecoveryKey(
         credentials.password,
         'hint'

--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -143,6 +143,9 @@ test.describe('severity-1 #smoke', () => {
 
     // Create recovery key
     await settings.recoveryKey.createButton.click();
+
+    await settings.confirmMfaGuard(credentials.email);
+
     const key = await recoveryKey.createRecoveryKey(
       credentials.password,
       'hint'
@@ -218,6 +221,9 @@ test.describe('severity-1 #smoke', () => {
 
     // Create recovery key
     await settings.recoveryKey.createButton.click();
+
+    await settings.confirmMfaGuard(credentials.email);
+
     const key = await recoveryKey.createRecoveryKey(
       credentials.password,
       'hint'
@@ -287,6 +293,9 @@ test.describe('severity-1 #smoke', () => {
 
     // Create recovery key
     await settings.recoveryKey.createButton.click();
+
+    await settings.confirmMfaGuard(credentials.email);
+
     await recoveryKey.createRecoveryKey(credentials.password, 'hint');
 
     // Verify status as 'enabled'
@@ -357,6 +366,9 @@ test.describe('severity-1 #smoke', () => {
 
     // Create recovery key
     await settings.recoveryKey.createButton.click();
+
+    await settings.confirmMfaGuard(credentials.email);
+
     await recoveryKey.createRecoveryKey(credentials.password, 'hint');
 
     // Verify status as 'enabled'

--- a/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPasswordRecoveryKey.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { emit } from 'node:process';
 import { expect, test } from '../../lib/fixtures/standard';
 import { SettingsPage } from '../../pages/settings';
 import { RecoveryKeyPage } from '../../pages/settings/recoveryKey';
@@ -26,6 +27,7 @@ test.describe('severity-1 #smoke', () => {
       );
 
       const key = await enableRecoveryKey(
+        credentials.email,
         credentials.password,
         recoveryKey,
         settings
@@ -127,7 +129,12 @@ test.describe('severity-1 #smoke', () => {
         signin
       );
 
-      await enableRecoveryKey(credentials.password, recoveryKey, settings);
+      await enableRecoveryKey(
+        credentials.email,
+        credentials.password,
+        recoveryKey,
+        settings
+      );
 
       await settings.signOut();
 
@@ -170,6 +177,7 @@ test.describe('severity-1 #smoke', () => {
       );
 
       const key = await enableRecoveryKey(
+        credentials.email,
         credentials.password,
         recoveryKey,
         settings
@@ -223,6 +231,7 @@ test.describe('severity-1 #smoke', () => {
   }
 
   async function enableRecoveryKey(
+    email: string,
     password: string,
     recoveryKey: RecoveryKeyPage,
     settings: SettingsPage
@@ -230,6 +239,9 @@ test.describe('severity-1 #smoke', () => {
     await expect(settings.recoveryKey.status).toHaveText('Not Set');
 
     await settings.recoveryKey.createButton.click();
+
+    await settings.confirmMfaGuard(email);
+
     const key = await recoveryKey.createRecoveryKey(password, 'hint');
 
     await expect(settings.settingsHeading).toBeVisible();

--- a/packages/functional-tests/tests/settings/recoveryKey.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryKey.spec.ts
@@ -19,7 +19,7 @@ test.describe('severity-1 #smoke', () => {
       pages: { page, recoveryKey, settings, signin },
       testAccountTracker,
     }) => {
-      const { password } = await signInAccount(
+      const { email, password } = await signInAccount(
         target,
         page,
         settings,
@@ -33,6 +33,9 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.recoveryKey.status).toHaveText('Not Set');
 
       await settings.recoveryKey.createButton.click();
+
+      await settings.confirmMfaGuard(email);
+
       await recoveryKey.acknowledgeInfoForm();
       await recoveryKey.fillOutConfirmPasswordForm(password);
 
@@ -61,6 +64,9 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.recoveryKey.status).toHaveText('Not Set');
 
       await settings.recoveryKey.createButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await recoveryKey.acknowledgeInfoForm();
       await recoveryKey.fillOutConfirmPasswordForm(credentials.password);
 
@@ -118,6 +124,9 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.recoveryKey.status).toHaveText('Not Set');
 
       await settings.recoveryKey.createButton.click();
+
+      await settings.confirmMfaGuard(credentials.email);
+
       await recoveryKey.createRecoveryKey(credentials.password, HINT);
       await expect(page.getByRole('alert')).toHaveText(
         'Account recovery key created'

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -2099,6 +2099,16 @@ export default class AuthClient {
     );
   }
 
+  /**
+   * Creates an account recovery key that can be used to restore account data in the password is lost.
+   * @param sessionToken
+   * @param recoveryKeyId
+   * @param recoveryData
+   * @param enabled
+   * @param replaceKey
+   * @param headers
+   * @returns
+   */
   async createRecoveryKey(
     sessionToken: hexstring,
     recoveryKeyId: string,
@@ -2110,6 +2120,37 @@ export default class AuthClient {
     return this.sessionPost(
       '/recoveryKey',
       sessionToken,
+      {
+        recoveryKeyId,
+        recoveryData,
+        enabled,
+        replaceKey,
+      },
+      headers
+    );
+  }
+
+  /**
+   * Creates an account recovery key that can be used to restore account data in the password is lost.
+   * @param sessionToken
+   * @param recoveryKeyId
+   * @param recoveryData
+   * @param enabled
+   * @param replaceKey
+   * @param headers
+   * @returns
+   */
+  async createRecoveryKeyWithJwt(
+    jwt: string,
+    recoveryKeyId: string,
+    recoveryData: any,
+    enabled: boolean = true,
+    replaceKey: boolean = false,
+    headers?: Headers
+  ): Promise<{}> {
+    return this.jwtPost(
+      '/mfa/recoveryKey',
+      jwt,
       {
         recoveryKeyId,
         recoveryData,

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2476,7 +2476,7 @@ const convictConf = convict({
       env: 'MFA__ENABLED',
     },
     actions: {
-      default: ['test', '2fa', 'email'],
+      default: ['test', '2fa', 'email', 'recovery_key'],
       doc: 'Actions protected by MFA',
       format: Array,
       env: 'MFA__ACTIONS',

--- a/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
@@ -21,6 +21,18 @@ const RECOVERYKEY_POST = {
   ],
 };
 
+const MFA_RECOVERY_KEY_POST = {
+  ...TAGS_RECOVERY_KEY,
+  description: '/recoveryKey',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA jwt
+
+      Creates a new account recovery key for a user. Account recovery keys are one-time-use tokens that can be used to recover the user's kB if they forget their password. For more details, see the [account recovery keys](https://mozilla.github.io/ecosystem-platform/reference/tokens#account-recovery-tokens) docs.
+    `,
+  ],
+};
+
 const RECOVERYKEY_RECOVERYKEYID_GET = {
   ...TAGS_RECOVERY_KEY,
   description: '/recoveryKey/{recoveryKeyId}',
@@ -82,6 +94,7 @@ const API_DOCS = {
   RECOVERYKEY_DELETE,
   RECOVERYKEY_EXISTS_POST,
   RECOVERYKEY_POST,
+  MFA_RECOVERY_KEY_POST,
   RECOVERYKEY_RECOVERYKEYID_GET,
   RECOVERYKEY_VERIFY_POST,
   // RECOVERYKEY_HINT_GET,

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -25,7 +25,7 @@ module.exports = (
   mailer,
   glean
 ) => {
-  return [
+  const routes = [
     {
       method: 'POST',
       path: '/recoveryKey',
@@ -184,6 +184,38 @@ module.exports = (
           }
         }
         return {};
+      },
+    },
+    {
+      method: 'POST',
+      path: '/mfa/recoveryKey',
+      options: {
+        ...RECOVERY_KEY_DOCS.MFA_RECOVERY_KEY_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:recovery_key'],
+          payload: false,
+        },
+        validate: {
+          payload: isA.object({
+            recoveryKeyId: validators.recoveryKeyId.description(
+              DESCRIPTION.recoveryKeyId
+            ),
+            recoveryData: validators.recoveryData.description(
+              DESCRIPTION.recoveryData
+            ),
+            enabled: isA.boolean().default(true),
+            replaceKey: isA.boolean().default(false),
+          }),
+        },
+      },
+      handler: async function (request) {
+        return routes
+          .find(
+            (route) =>
+              route.path === '/v1/recoveryKey' && route.method === 'POST'
+          )
+          .handler(request);
       },
     },
     {
@@ -438,4 +470,6 @@ module.exports = (
       },
     },
   ];
+
+  return routes;
 };

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.stories.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import PageRecoveryKeyCreate from '.';
+import { PageRecoveryKeyCreate } from '.';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext, MOCK_ACCOUNT } from '../../../models/mocks';
 import { LocationProvider } from '@reach/router';

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.test.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { usePageViewEvent } from '../../../lib/metrics';
-import PageRecoveryKeyCreate from '.';
+import { PageRecoveryKeyCreate } from '.';
 import {
   mockAppContext,
   MOCK_ACCOUNT,

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryKeyCreate/index.tsx
@@ -13,6 +13,7 @@ import FlowRecoveryKeyDownload from '../FlowRecoveryKeyDownload';
 import FlowRecoveryKeyInfo from '../FlowRecoveryKeyInfo';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import FlowRecoveryKeyHint from '../FlowRecoveryKeyHint';
+import { MfaGuard } from '../MfaGuard';
 
 export const viewName = 'settings.account-recovery';
 const numberOfSteps = 4;
@@ -21,6 +22,14 @@ export enum RecoveryKeyAction {
   Create,
   Change,
 }
+
+export const MfaGuardPageRecoveryKeyCreate = (props: RouteComponentProps) => {
+  return (
+    <MfaGuard requiredScope="recovery_key">
+      <PageRecoveryKeyCreate {...props} />
+    </MfaGuard>
+  );
+};
 
 export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
   usePageViewEvent(viewName);
@@ -104,5 +113,3 @@ export const PageRecoveryKeyCreate = (props: RouteComponentProps) => {
     </>
   );
 };
-
-export default PageRecoveryKeyCreate;

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -339,6 +339,11 @@ describe('Settings App', () => {
         route: '/recovery_phone/setup',
         hasPassword: false,
       },
+      {
+        pageName: 'PageRecoveryKeyCreate',
+        route: '/account_recovery',
+        hasPassword: true,
+      },
     ];
 
     it.each(guardedRoutes)(

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -28,7 +28,7 @@ import { ScrollToTop } from './ScrollToTop';
 import { SETTINGS_PATH } from '../../constants';
 import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
-import PageRecoveryKeyCreate from './PageRecoveryKeyCreate';
+import { MfaGuardPageRecoveryKeyCreate } from './PageRecoveryKeyCreate';
 import { currentAccount } from '../../lib/cache';
 import { hasAccount, setCurrentAccount } from '../../lib/storage-utils';
 import GleanMetrics from '../../lib/glean';
@@ -151,7 +151,7 @@ export const Settings = ({
           <PageDisplayName path="/display_name" />
           <PageAvatar path="/avatar" />
           {account.hasPassword ? (
-            <PageRecoveryKeyCreate path="/account_recovery" />
+            <MfaGuardPageRecoveryKeyCreate path="/account_recovery" />
           ) : (
             <Redirect from="/account_recovery" to="/settings" noThrow />
           )}

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -75,4 +75,4 @@ export type TotpInfo = {
   secret: string;
 };
 
-export type MfaScope = 'test' | '2fa' | 'email';
+export type MfaScope = 'test' | '2fa' | 'email' | 'recovery_key';

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -305,7 +305,11 @@ const CompleteResetPasswordContainer = ({
           // we cannot create a new recovery key if the session is not verified
           if (accountResetData.verified) {
             await account.refresh('account');
-            const recoveryKey = await account.createRecoveryKey(newPassword);
+            const recoveryKey = await account.createRecoveryKey(
+              newPassword,
+              false,
+              false
+            );
             sensitiveDataClient.setDataType(SensitiveData.Key.NewRecoveryKey, {
               recoveryKey,
             });


### PR DESCRIPTION
## Because

- We want to protect the create account recovery keys with an MFA guard

## This pull request

- Adds an MFA guard to to the create account recovery key page

## Issue that this pull request solves

Closes: FXA-12235

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
