### PR TITLE
task(settings,auth): Wrap remove account recovery key with MFA guard

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -348,6 +348,21 @@ export default class AuthClient {
     return this.request('POST', path, payload, headers);
   }
 
+  private async jwtDelete(
+    path: string,
+    jwt: string,
+    payload: any,
+    headers?: Headers
+  ) {
+    const authorization = 'Bearer ' + jwt;
+    if (!headers) {
+      headers = new Headers({ authorization });
+    } else {
+      headers.set('authorization', authorization);
+    }
+    return this.request('DELETE', path, payload, headers);
+  }
+
   private async jwtPut(
     path: string,
     jwt: string,
@@ -2410,6 +2425,9 @@ export default class AuthClient {
     return accountData;
   }
 
+  /**
+   * @deprecated Use deleteRecoveryKeyWithJwt instead
+   */
   async deleteRecoveryKey(sessionToken: hexstring, headers?: Headers) {
     return this.hawkRequest(
       'DELETE',
@@ -2419,6 +2437,16 @@ export default class AuthClient {
       {},
       headers
     );
+  }
+
+  /**
+   * Removes the recovery key from the account
+   * @param jwt The MFA jwt for auth
+   * @param headers
+   * @returns
+   */
+  async deleteRecoveryKeyWithJwt(jwt: string, headers?: Headers) {
+    return this.jwtDelete('/mfa/recoveryKey', jwt, {}, headers);
   }
 
   async recoveryKeyExists(

--- a/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-key-api.ts
@@ -60,6 +60,15 @@ const RECOVERYKEY_DELETE = {
   ],
 };
 
+const MFA_RECOVERY_KEY_DELETE = {
+  ...TAGS_RECOVERY_KEY,
+  description: '/recoveryKey',
+  notes: [
+    '🔒 Authenticated with MFA JWT (scope: mfa:recovery_key)',
+    "This route remove an account's account recovery key. When the key is removed, it can no longer be used to restore an account's kB.",
+  ],
+};
+
 const RECOVERYKEY_VERIFY_POST = {
   ...TAGS_RECOVERY_KEY,
   description: '/recoveryKey/verify',
@@ -92,6 +101,7 @@ const RECOVERYKEY_HINT_POST = {
 
 const API_DOCS = {
   RECOVERYKEY_DELETE,
+  MFA_RECOVERY_KEY_DELETE,
   RECOVERYKEY_EXISTS_POST,
   RECOVERYKEY_POST,
   MFA_RECOVERY_KEY_POST,

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -470,6 +470,26 @@ module.exports = (
         return {};
       },
     },
+    {
+      method: 'DELETE',
+      path: '/mfa/recoveryKey',
+      options: {
+        ...RECOVERY_KEY_DOCS.MFA_RECOVERY_KEY_DELETE,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:recovery_key'],
+          payload: false,
+        },
+      },
+      async handler(request) {
+        return routes
+          .find(
+            (route) =>
+              route.path === '/v1/recoveryKey' && route.method === 'DELETE'
+          )
+          .handler(request);
+      },
+    },
   ];
 
   return routes;

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1143,10 +1143,9 @@ export class Account implements AccountData {
     await this.refresh('backupCodes');
   }
 
-  async deleteRecoveryKey() {
-    await this.withLoadingStatus(
-      this.authClient.deleteRecoveryKey(sessionToken()!)
-    );
+  async deleteRecoveryKeyWithJwt() {
+    const jwt = this.getCachedJwtByScope('recovery_key');
+    await this.withLoadingStatus(this.authClient.deleteRecoveryKeyWithJwt(jwt));
     const cache = this.apolloClient.cache;
     cache.modify({
       id: cache.identify({ __typename: 'Account' }),
@@ -1613,7 +1612,7 @@ export class Account implements AccountData {
    * @param scope MfaScope
    * @returns JWT token string
    */
-  private getCachedJwtByScope(scope: MfaScope) {
+  getCachedJwtByScope(scope: MfaScope) {
     const token = sessionToken();
     if (!token) {
       throw AuthUiErrors.INVALID_TOKEN;


### PR DESCRIPTION
## Because

- Want to protect removal of account recovery keys with an MFA guard

## This pull request

- Adds an MFA guard to to the remove account recovery key action

## Issue that this pull request solves

Closes: FXA-12398

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
