### PR TITLE
fix(auth): sanitize plan on eligiblity check

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -26,6 +26,7 @@ import type { AppendedPlayStoreSubscriptionPurchase } from 'fxa-shared/payments/
 import type { AppendedAppStoreSubscriptionPurchase } from 'fxa-shared/payments/iap/apple-app-store/types';
 import { VError } from 'verror';
 import type { ConfigType } from '../../../config';
+import { sanitizePlans } from './stripe';
 
 const DEFAULT_CURRENCY = 'usd';
 
@@ -227,7 +228,9 @@ export class MozillaSubscriptionHandler {
 
     return {
       eligibility: result.subscriptionEligibilityResult,
-      currentPlan: result.eligibleSourcePlan,
+      currentPlan:
+        result.eligibleSourcePlan &&
+        sanitizePlans([result.eligibleSourcePlan]).at(0),
     };
   }
 }


### PR DESCRIPTION
## Because

- Under certain conditions the plan eligibility check returns an unsanitized abbreviated plan of the current plan the customer is subscribed to.

## This pull request

- Sanitize the plan returned by the plan eligibility API so that sensitive data is removed.

## Issue that this pull request solves

Closes: PAY-3275

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
