### PR TITLE
fix(cms): Add max-width for split layout content

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
@@ -195,7 +195,21 @@ export const WithCmsSplitLayoutBackgroundImageHeaderBackground = () => {
   return (
     <AppLayout cmsInfo={mockCmsInfo} splitLayout>
       <h1 className="card-header">Header content</h1>
-      <p className="mt-2">Paragraph content here</p>
+      <p className="mt-2">
+        Lots of text so we can see the max-width! Croissant cookie sesame snaps
+        cake muffin chupa chups jelly-o candy. Chocolate bar chocolate sesame
+        snaps fruitcake pudding danish. Donut marzipan shortbread jelly-o
+        shortbread danish. Topping biscuit macaroon donut sugar plum candy
+        dragée. Tart chupa chups jelly-o gummies oat cake dessert chocolate
+        sweet roll. Danish pie cookie candy candy canes cotton candy gummi
+        bears. Cake jelly-o cake cotton candy powder tart. Pastry tiramisu candy
+        canes pie shortbread. Bear claw carrot cake fruitcake donut icing cotton
+        candy. Donut ice cream chocolate bar pie halvah cake lemon drops muffin.
+        Bonbon brownie biscuit cake cake jujubes.
+      </p>
+      <div className="flex mt-5">
+        <button className="cta-primary cta-xl">I am a button</button>
+      </div>
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -147,7 +147,7 @@ export const AppLayout = ({
               }
             />
             <main className="mobileLandscape:items-center tablet:flex-1 tablet:bg-white py-8 px-6 tablet:px-10 mobileLandscape:py-9 tablet:ml-auto flex justify-center flex-1">
-              <section>{children}</section>
+              <section className="max-w-120">{children}</section>
             </main>
           </div>
         )}
@@ -157,7 +157,7 @@ export const AppLayout = ({
           <div className="fixed bottom-6 left-6 z-10">
             <LocaleToggle />
           </div>
-      </footer>
+        </footer>
       )}
       <div id="body-bottom" className="w-full block mobileLandscape:hidden" />
     </>


### PR DESCRIPTION
Because:
* The design max-width should match our .card class width

This commit:
* Adds the max-width class, adjusts a storybook story to see it

---

Vijay noticed the content looked too wide:
<img width="2141" height="1245" alt="image" src="https://github.com/user-attachments/assets/390ee69f-a51d-4655-8176-69858047887e" />

Here's what this change looks like in Storybook:

<img width="1683" height="861" alt="image" src="https://github.com/user-attachments/assets/04bda303-cac6-4830-8e0e-9bfd25a58d21" />

Here's what it should look like from 123done (modified with dev tools):
<img width="1717" height="877" alt="image" src="https://github.com/user-attachments/assets/fd55591d-e1a9-48c8-97cd-b9801cf54196" />
