### PR TITLE
fix(l10n) - Add spaces to Fluent placeable

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/en.ftl
@@ -27,11 +27,11 @@ subscription-charges-one-time-discount = One-time discount
 subscription-charges-one-time-discount-plaintext = One-time discount: { $invoiceDiscountAmount }
 subscription-charges-repeating-discount =
   { $discountDuration ->
-    *[other] {$discountDuration}-month discount
+    *[other] { $discountDuration }-month discount
   }
 subscription-charges-repeating-discount-plaintext =
   { $discountDuration ->
-    *[other] {$discountDuration}-month discount: { $invoiceDiscountAmount }
+    *[other] { $discountDuration }-month discount: { $invoiceDiscountAmount }
   }
 subscription-charges-discount = Discount
 subscription-charges-discount-plaintext = Discount: { $invoiceDiscountAmount }


### PR DESCRIPTION
## Because

- subscription-charges-repeating-discount and -plaintext contain placeables without spaces between the variablename and the curly brackets


## This pull request

- Adds spaces before and after the variable name for subscription-charges-repeating-discount and -plaintext

