### PR TITLE
fix(next): update stripe payment method breadcrumb

### DIFF
--- a/libs/payments/ui/src/lib/client/components/Breadcrumbs/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Breadcrumbs/index.tsx
@@ -44,7 +44,7 @@ export function Breadcrumbs(args: {
   };
   const STRIPE_PAYMENT_METHODS = {
     label: l10n.getString(
-      'subscription-management-breadcrumb-payment',
+      'subscription-management-breadcrumb-payment-2',
       {},
       'Manage Payment Methods'
     ),


### PR DESCRIPTION
## Because

- Stripe breadcrumb label needs to be Manage Payment Methods

## This pull request

- Update Stripe breadcrumb label

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1655" height="792" alt="image" src="https://github.com/user-attachments/assets/52c5450a-20fc-48e5-91f8-c414482792ac" />

