### PR TITLE
fix(settings): meet WCAG AA standard for 3rd-party auth divider text

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.stories.tsx
@@ -16,9 +16,18 @@ export default {
 } as Meta;
 
 export const Default = () => {
+  // Default separator type is 'or'
   return (
     <AppLayout>
       <Subject showSeparator />
+    </AppLayout>
+  );
+};
+
+export const SignInWithSeparator = () => {
+  return (
+    <AppLayout>
+      <Subject showSeparator separatorType="signInWith" />
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -64,7 +64,7 @@ const ThirdPartyAuth = ({
                   separatorType === 'signInWith' ? 'Sign in with' : 'or';
                 return (
                   <FtlMsg id={id}>
-                    <div className="mx-4 text-base text-grey-300 font-extralight">
+                    <div className="mx-4 text-base text-grey-500 font-extralight">
                       {defaultText}
                     </div>
                   </FtlMsg>


### PR DESCRIPTION
## Because

- 3rd party auth text ("Or", "Sign in with") doesn't meet WCAG AA standard

## This pull request

- darkens the text color to `#5E5E72`
- (I also added a storybook state specific for "Sign in with" case, which was missing)

## Issue that this pull request solves

Closes: FXA-12419

## Screenshots 

Before:
<img width="503" height="484" alt="Screenshot 2025-09-19 at 12 17 24 PM" src="https://github.com/user-attachments/assets/a27b27d6-8269-4a90-b17d-167e288317d3" />


After (it's subtle 😉):
<img width="504" height="492" alt="Screenshot 2025-09-19 at 12 17 50 PM" src="https://github.com/user-attachments/assets/a6a22d76-1af9-4b5e-969f-eee5f063dec6" />
