### PR TITLE
task(auth): Expose more detailed session status info

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -75,6 +75,18 @@ const SESSION_STATUS_GET = {
   ],
 };
 
+const SESSION_STATUS_DETAILED_GET = {
+  ...TAGS_SESSION,
+  description: '/session/status/detailed',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Returns detailed info about the sessions current verification status. This is a more expensive call that /session/status since it also has to do an account look up!
+    `,
+  ],
+};
+
 const SESSION_DUPLICATE_POST = {
   ...TAGS_SESSION,
   description: '/session/duplicate',
@@ -117,7 +129,7 @@ const SESSION_VERIFY_PUSH_POST = {
   notes: [
     dedent`
     🔒 Authenticated with session token
-    
+
     Endpoint that accepts a code and tokenVerificationId to verify a session.
     `,
   ],
@@ -128,6 +140,7 @@ const API_DOCS = {
   SESSION_DUPLICATE_POST,
   SESSION_REAUTH_POST,
   SESSION_STATUS_GET,
+  SESSION_STATUS_DETAILED_GET,
   SESSION_RESEND_CODE_POST,
   SESSION_VERIFY_CODE_POST,
   SESSION_SEND_PUSH_POST,

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -19,6 +19,7 @@ const { recordSecurityEvent } = require('./utils/security-event');
 const { getOptionalCmsEmailConfig } = require('./utils/account');
 const { Container } = require('typedi');
 const { RelyingPartyConfigurationManager } = require('@fxa/shared/cms');
+const authMethods = require('../authMethods');
 
 module.exports = function (
   log,
@@ -284,6 +285,59 @@ module.exports = function (
         return {
           state: sessionToken.state,
           uid: sessionToken.uid,
+        };
+      },
+    },
+    {
+      method: 'GET',
+      path: '/session/status/detailed',
+      options: {
+        ...SESSION_DOCS.SESSION_STATUS_DETAILED_GET,
+        auth: {
+          strategy: 'sessionToken',
+        },
+        response: {
+          schema: isA.object({
+            uid: isA.string().regex(HEX_STRING).required(),
+            accountEmailVerified: isA.boolean(),
+            sessionVerificationMethod: isA.string(),
+            sessionVerificationProvided: isA.boolean(),
+            sessionVerificationMeetsMinimumAAL: isA.boolean(),
+          }),
+        },
+      },
+      handler: async function (request) {
+        log.begin('Session.status', request);
+        const session = request.auth.credentials;
+        const account = await db.account(session.uid);
+
+        // Make sure the account still exists
+        if (!account) {
+          throw error.unknownAccount();
+        }
+
+        // Check account assurance level
+        const accountAmr = await authMethods.availableAuthenticationMethods(
+          db,
+          account
+        );
+        const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
+        const sessionAal = session.authenticatorAssuranceLevel;
+
+        // Build response
+        const uid = session.uid;
+        const accountEmailVerified =
+          account.emails?.primaryEmail?.isVerified || false;
+        const sessionVerificationMethod = session.verificationMethod;
+        const sessionVerificationSuccessful = session.verified;
+        const sessionVerificationMeetsMinimumAAL = accountAal <= sessionAal;
+
+        return {
+          uid,
+          accountEmailVerified,
+          sessionVerificationMethod,
+          sessionVerificationSuccessful,
+          sessionVerificationMeetsMinimumAAL,
         };
       },
     },

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -166,6 +166,197 @@ describe('/session/status', () => {
   });
 });
 
+describe('/session/status/detailed', () => {
+  const log = mocks.mockLog();
+  const db = {
+    account: () => {},
+    totpToken: () => {},
+  };
+  const config = {};
+  const routes = makeRoutes({ log, db, config });
+  const route = getRoute(routes, '/session/status/detailed');
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  it('returns unknown account error', async () => {
+    db.account = sinon.fake.returns(null);
+    let error;
+    try {
+      const request = mocks.mockRequest({
+        credentials: {
+          uid: 'foo',
+        },
+      });
+      await runTest(route, request);
+    } catch (err) {
+      error = err;
+    }
+    assert.equal(error.message, 'Unknown account');
+  });
+
+  it('has unverified primary email', async () => {
+    db.account = sinon.fake.resolves({
+      uid: 'account-123',
+      emails: {},
+    });
+    db.totpToken = sinon.fake.resolves({
+      verified: false,
+      enabled: false,
+    });
+
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'account-123',
+        verified: false,
+        verificationMethod: 'email',
+        authenticatorAssuranceLevel: 1,
+      },
+    });
+    const resp = await runTest(route, request);
+
+    assert.deepEqual(resp, {
+      uid: 'account-123',
+      accountEmailVerified: false,
+      sessionVerificationMethod: 'email',
+      sessionVerificationSuccessful: false,
+      sessionVerificationMeetsMinimumAAL: true,
+    });
+  });
+
+  it('has unverified AAL 1', async () => {
+    db.account = sinon.fake.resolves({
+      uid: 'account-123',
+      emails: {
+        primaryEmail: {
+          isVerified: true,
+        },
+      },
+    });
+    db.totpToken = sinon.fake.resolves({
+      verified: true,
+      enabled: true,
+    });
+
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'account-123',
+        verified: false,
+        verificationMethod: 'email',
+        authenticatorAssuranceLevel: 1,
+      },
+    });
+    const resp = await runTest(route, request);
+
+    assert.deepEqual(resp, {
+      uid: 'account-123',
+      accountEmailVerified: true,
+      sessionVerificationMethod: 'email',
+      sessionVerificationSuccessful: false,
+      sessionVerificationMeetsMinimumAAL: false,
+    });
+  });
+
+  it('has unverified AAL 2', async () => {
+    db.account = sinon.fake.resolves({
+      uid: 'account-123',
+      emails: {
+        primaryEmail: {
+          isVerified: true,
+        },
+      },
+    });
+    db.totpToken = sinon.fake.resolves({
+      verified: true,
+      enabled: true,
+    });
+
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'account-123',
+        verified: true,
+        verificationMethod: 'totp-2fa',
+        authenticatorAssuranceLevel: 1,
+      },
+    });
+    const resp = await runTest(route, request);
+
+    assert.deepEqual(resp, {
+      uid: 'account-123',
+      accountEmailVerified: true,
+      sessionVerificationMethod: 'totp-2fa',
+      sessionVerificationSuccessful: true,
+      sessionVerificationMeetsMinimumAAL: false,
+    });
+  });
+
+  it('has verified AAL 1 state', async () => {
+    db.account = sinon.fake.resolves({
+      uid: 'account-123',
+      emails: {
+        primaryEmail: {
+          isVerified: true,
+        },
+      },
+    });
+    db.totpToken = sinon.fake.resolves({
+      enabled: false,
+    });
+
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'account-123',
+        verified: true,
+        verificationMethod: 'email',
+        authenticatorAssuranceLevel: 1,
+      },
+    });
+    const resp = await runTest(route, request);
+
+    assert.deepEqual(resp, {
+      uid: 'account-123',
+      accountEmailVerified: true,
+      sessionVerificationMethod: 'email',
+      sessionVerificationSuccessful: true,
+      sessionVerificationMeetsMinimumAAL: true,
+    });
+  });
+
+  it('has verified AAL 2', async () => {
+    db.account = sinon.fake.resolves({
+      uid: 'account-123',
+      emails: {
+        primaryEmail: {
+          isVerified: true,
+        },
+      },
+    });
+    db.totpToken = sinon.fake.resolves({
+      verified: true,
+      enabled: true,
+    });
+
+    const request = mocks.mockRequest({
+      credentials: {
+        uid: 'account-123',
+        verified: true,
+        verificationMethod: 'totp-2fa',
+        authenticatorAssuranceLevel: 2,
+      },
+    });
+    const resp = await runTest(route, request);
+
+    assert.deepEqual(resp, {
+      uid: 'account-123',
+      accountEmailVerified: true,
+      sessionVerificationMethod: 'totp-2fa',
+      sessionVerificationSuccessful: true,
+      sessionVerificationMeetsMinimumAAL: true,
+    });
+  });
+});
+
 describe('/session/reauth', () => {
   const TEST_EMAIL = 'foo@example.com';
   const TEST_UID = 'abcdef123456';


### PR DESCRIPTION
## Because

- Just checking the state returned by `/session/status` often isn't enough

## This pull request

- Adds a new endpoint called `/session/status/detailed` that exposes more detailed info about the session status state.

## Issue that this pull request solves

Closes: FXA-12433

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
