### PR TITLE
fix(payments-next): [Payments-Next Subscription] Only 3 cards are displayed on the Subscription page

### DIFF
--- a/libs/payments/customer/src/lib/customerSession.manager.spec.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.spec.ts
@@ -52,6 +52,7 @@ describe('CustomerSessionManager', () => {
               enabled: true,
               features: {
                 payment_method_redisplay: 'enabled',
+                payment_method_redisplay_limit: 10,
                 payment_method_save: 'disabled',
                 payment_method_remove: 'disabled',
                 payment_method_allow_redisplay_filters: [
@@ -89,6 +90,7 @@ describe('CustomerSessionManager', () => {
               enabled: true,
               features: {
                 payment_method_redisplay: 'enabled',
+                payment_method_redisplay_limit: 10,
                 payment_method_remove: 'disabled',
                 payment_method_allow_redisplay_filters: [
                   'always',

--- a/libs/payments/customer/src/lib/customerSession.manager.ts
+++ b/libs/payments/customer/src/lib/customerSession.manager.ts
@@ -17,6 +17,7 @@ export class CustomerSessionManager {
           enabled: true,
           features: {
             payment_method_redisplay: 'enabled',
+            payment_method_redisplay_limit: 10,
             payment_method_save: 'disabled',
             payment_method_remove: 'disabled',
             payment_method_allow_redisplay_filters: [
@@ -38,6 +39,7 @@ export class CustomerSessionManager {
           enabled: true,
           features: {
             payment_method_redisplay: 'enabled',
+            payment_method_redisplay_limit: 10,
             payment_method_remove: 'disabled',
             payment_method_allow_redisplay_filters: [
               'always',


### PR DESCRIPTION
## Because

- If user has more than 3 saved cards, only 3 of them are showed.

## This pull request

- Shows up to 10 saved cards

## Issue that this pull request solves

Closes: #[PAY-3276](https://mozilla-hub.atlassian.net/browse/PAY-3276)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3276]: https://mozilla-hub.atlassian.net/browse/PAY-3276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ