### PR TITLE
fix(payments-next): [Payments-Next Subscription] Manage my subscription from subplat redirects to old Subscriptions page

### DIFF
--- a/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getErrorFtlInfo.ts
@@ -41,7 +41,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
-        buttonUrl: `${config.contentServerUrl}/subscriptions${queryParamString}`,
+        buttonUrl: `/subscriptions/landing${queryParamString}`,
         message: 'You’ve already subscribed to this product.',
         messageFtl: 'checkout-error-already-subscribed',
       };
@@ -49,7 +49,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
-        buttonUrl: `${config.contentServerUrl}/subscriptions${queryParamString}`,
+        buttonUrl: `/subscriptions/landing${queryParamString}`,
         message:
           'You have a mobile in-app subscription that conflicts with this product — please contact support so we can help you.',
         messageFtl: 'next-iap-blocked-contact-support',
@@ -138,7 +138,7 @@ export function getErrorFtlInfo(
       return {
         buttonFtl: 'next-payment-error-manage-subscription-button',
         buttonLabel: 'Manage my subscription',
-        buttonUrl: `${config.contentServerUrl}/subscriptions${queryParamString}`,
+        buttonUrl: `/subscriptions/landing${queryParamString}`,
         message:
           'It looks like there was a problem billing your PayPal account. Please re-enable automatic payments for your subscription.',
         messageFtl: 'paypal-active-subscription-no-billing-agreement-error',


### PR DESCRIPTION
## Because

- User is redirected to old Sub Manage page.

## This pull request

- Redirects user to the new Sub Manage page.

## Issue that this pull request solves

Closes: #PAY-3281
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


https://github.com/user-attachments/assets/de394f58-4149-4618-8f49-71a3804ea3f3



## Other information (Optional)

Any other information that is important to this pull request.
