### PR TITLE
feat(fxa): resolve sha.js vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,6 +285,7 @@
     "minimist": "^1.2.6",
     "nest-typed-config/class-validator": "0.14.1",
     "plist": "^3.0.6",
+    "sha.js": "^2.4.12",
     "underscore": ">=1.13.2"
   },
   "packageManager": "yarn@4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -52631,15 +52631,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.4.0, sha.js@npm:^2.4.11, sha.js@npm:^2.4.8":
-  version: 2.4.11
-  resolution: "sha.js@npm:2.4.11"
+"sha.js@npm:^2.4.12":
+  version: 2.4.12
+  resolution: "sha.js@npm:2.4.12"
   dependencies:
-    inherits: "npm:^2.0.1"
-    safe-buffer: "npm:^5.0.1"
+    inherits: "npm:^2.0.4"
+    safe-buffer: "npm:^5.2.1"
+    to-buffer: "npm:^1.2.0"
   bin:
-    sha.js: ./bin.js
-  checksum: 10c0/b7a371bca8821c9cc98a0aeff67444a03d48d745cb103f17228b96793f455f0eb0a691941b89ea1e60f6359207e36081d9be193252b0f128e0daf9cfea2815a5
+    sha.js: bin.js
+  checksum: 10c0/9d36bdd76202c8116abbe152a00055ccd8a0099cb28fc17c01fa7bb2c8cffb9ca60e2ab0fe5f274ed6c45dc2633d8c39cf7ab050306c231904512ba9da4d8ab1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- The sha.js package is flagged as a critical vulnerability

## This pull request

- adds a resolution to force a patched minimum version of 2.4.12

## Issue that this pull request solves

Closes: FXA-12445

## Other information
I always try to avoid resolutions, unfortunately this is a transitive dependency of older packages that we are unable to easily upgrade (no upgrades available or deprecated package, etc). 