### PR TITLE
fix(admin-panel): remove sending password reset email from admin panel

### DIFF
--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -43,7 +43,6 @@ export enum AdminPanelFeature {
   DeleteAccount = 'DeleteAccount',
   RelyingParties = 'RelyingParties',
   RelyingPartiesEditNotes = 'RelyingPartiesEditNotes',
-  SendPasswordResetEmail = 'SendPasswordResetEmail',
   UnsubscribeFromMailingLists = 'UnsubscribeFromMailingLists',
 }
 
@@ -180,10 +179,6 @@ const defaultAdminPanelPermissions: Permissions = {
   [AdminPanelFeature.RelyingPartiesEditNotes]: {
     name: 'Edit Relying Parties Notes',
     level: PermissionLevel.Admin,
-  },
-  [AdminPanelFeature.SendPasswordResetEmail]: {
-    name: 'Send Password Reset Email',
-    level: PermissionLevel.Support,
   },
   [AdminPanelFeature.UnsubscribeFromMailingLists]: {
     name: 'Unsubscribe User From Mozilla Mailing Lists',

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -284,15 +284,6 @@ it('displays the locale', async () => {
   expect(getByTestId('edit-account-locale')).toBeInTheDocument();
 });
 
-it('displays send password reset', async () => {
-  const { getByTestId } = render(
-    <MockedProvider>
-      <Account {...accountResponse} />
-    </MockedProvider>
-  );
-  expect(getByTestId('password-reset-button')).toBeInTheDocument();
-});
-
 it('displays key-stretch-version', async () => {
   const lockedAccount = {
     ...accountResponse,

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.gql.ts
@@ -28,12 +28,6 @@ export const REMOVE_2FA = gql`
   }
 `;
 
-export const SEND_PASSWORD_RESET_EMAIL = gql`
-  mutation sendPasswordResetEmail($email: String!) {
-    sendPasswordResetEmail(email: $email)
-  }
-`;
-
 export const UNSUBSCRIBE_FROM_MAILING_LISTS = gql`
   mutation unsubscribeFromMailingLists($uid: String!) {
     unsubscribeFromMailingLists(uid: $uid)

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/DangerZone/index.tsx
@@ -13,7 +13,6 @@ import {
   DISABLE_ACCOUNT,
   ENABLE_ACCOUNT,
   REMOVE_2FA,
-  SEND_PASSWORD_RESET_EMAIL,
   UNSUBSCRIBE_FROM_MAILING_LISTS,
   UNVERIFY_EMAIL,
 } from './index.gql';
@@ -143,16 +142,6 @@ export const DangerZone = ({
     },
   });
 
-  const [sendPasswordResetEmail] = useMutation(SEND_PASSWORD_RESET_EMAIL, {
-    onCompleted: () => {
-      window.alert(`Password reset email sent to ${email.email}`);
-      onCleared();
-    },
-    onError: () => {
-      window.alert('Error sending password reset email.');
-    },
-  });
-
   const [recordAdminSecurityEvent] = useMutation(RECORD_ADMIN_SECURITY_EVENT);
 
   const handleDisable = () => {
@@ -179,13 +168,6 @@ export const DangerZone = ({
     recordAdminSecurityEvent({
       variables: { uid, name: 'account.two_factor_removed' },
     });
-  };
-
-  const handleSendPasswordReset = () => {
-    if (!window.confirm('Are you sure?')) {
-      return;
-    }
-    sendPasswordResetEmail({ variables: { email: email.email } });
   };
 
   // define loading messages
@@ -254,17 +236,6 @@ export const DangerZone = ({
           />
         </Guard>
       )}
-      <Guard features={[AdminPanelFeature.SendPasswordResetEmail]}>
-        <DangerZoneAction
-          header="Send Password Reset Email"
-          description="Send the user a password reset email to all verified emails. For
-          Sync users this will also reset their encryption key so make sure
-          they have a backup of Sync data."
-          buttonHandler={handleSendPasswordReset}
-          buttonText="Password Reset"
-          buttonTestId="password-reset-button"
-        />
-      </Guard>
       <Guard features={[AdminPanelFeature.UnsubscribeFromMailingLists]}>
         <DangerZoneAction
           header="Unsubscribe From Mailing Lists"

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.spec.ts
@@ -508,13 +508,6 @@ describe('#integration - AccountResolver', () => {
     });
   });
 
-  it('sends password reset email', async () => {
-    authClient.passwordForgotSendCode = jest.fn().mockResolvedValue(true);
-    const result = await resolver.sendPasswordResetEmail(USER_1.email);
-    expect(authClient.passwordForgotSendCode).toBeCalledTimes(1);
-    expect(result).toBe(true);
-  });
-
   describe('unsubscribes from mailing lists', () => {
     const fakeToken = '123';
     const uid = USER_1.uid;

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -348,13 +348,6 @@ export class AccountResolver {
     return !!result;
   }
 
-  @Features(AdminPanelFeature.SendPasswordResetEmail)
-  @Mutation((returns) => Boolean)
-  public async sendPasswordResetEmail(@Args('email') email: string) {
-    const result = await this.authAPI.passwordForgotSendCode(email);
-    return !!result;
-  }
-
   @Features(AdminPanelFeature.AccountSearch)
   @Mutation((returns) => Boolean)
   public async recordAdminSecurityEvent(

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -240,7 +240,6 @@ export interface IMutation {
     disableAccount(uid: string): boolean | Promise<boolean>;
     editLocale(uid: string, locale: string): boolean | Promise<boolean>;
     enableAccount(uid: string): boolean | Promise<boolean>;
-    sendPasswordResetEmail(email: string): boolean | Promise<boolean>;
     recordAdminSecurityEvent(uid: string, name: string): boolean | Promise<boolean>;
     unlinkAccount(uid: string): boolean | Promise<boolean>;
     unsubscribeFromMailingLists(uid: string): boolean | Promise<boolean>;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -236,7 +236,6 @@ type Mutation {
   disableAccount(uid: String!): Boolean!
   editLocale(uid: String!, locale: String!): Boolean!
   enableAccount(uid: String!): Boolean!
-  sendPasswordResetEmail(email: String!): Boolean!
   recordAdminSecurityEvent(uid: String!, name: String!): Boolean!
   unlinkAccount(uid: String!): Boolean!
   unsubscribeFromMailingLists(uid: String!): Boolean!


### PR DESCRIPTION
## Because

- password reset email is deprecated and should no longer be used

## This pull request

- removes the functionality to send password reset emails from admin panel

## Issue that this pull request solves

Closes: FXA-10974

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
