### PR TITLE
fix(emails): Subscription invoice emails have outdate email addresses

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -949,6 +949,7 @@ export class StripeWebhookHandler extends StripeHandler {
       {
         acceptLanguage: account.locale,
         ...invoiceDetails,
+        email: account.primaryEmail
       }
     );
     await this.stripeHelper.updateEmailSent(invoice, 'paymentFailed');
@@ -970,6 +971,7 @@ export class StripeWebhookHandler extends StripeHandler {
       {
         acceptLanguage: account.locale,
         ...invoiceDetails,
+        email: account.primaryEmail
       },
     ];
     switch (invoice.billing_reason) {
@@ -1083,6 +1085,7 @@ export class StripeWebhookHandler extends StripeHandler {
           {
             acceptLanguage: account.locale,
             ...invoiceDetails,
+            email: account.primaryEmail
           }
         );
       } else if (!subscription.cancel_at_period_end) {
@@ -1097,6 +1100,7 @@ export class StripeWebhookHandler extends StripeHandler {
             ...invoiceDetails,
             showOutstandingBalance,
             cancelAtEnd: subscription.cancel_at_period_end,
+            email: account.primaryEmail
           }
         );
       }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -2175,6 +2175,7 @@ describe('StripeWebhookHandler', () => {
         {
           acceptLanguage: mockAccount.locale,
           ...mockInvoiceDetails,
+          email: mockAccount.primaryEmail
         }
       );
     });
@@ -2212,6 +2213,7 @@ describe('StripeWebhookHandler', () => {
           {
             acceptLanguage: mockAccount.locale,
             ...mockInvoiceDetails,
+            email: mockAccount.primaryEmail
           }
         );
         if (expectedMethodName === 'sendSubscriptionFirstInvoiceEmail') {
@@ -2223,6 +2225,7 @@ describe('StripeWebhookHandler', () => {
               {
                 acceptLanguage: mockAccount.locale,
                 ...mockInvoiceDetails,
+                email: mockAccount.primaryEmail
               }
             );
           } else {
@@ -2411,6 +2414,7 @@ describe('StripeWebhookHandler', () => {
             {
               acceptLanguage: mockAccount.locale,
               ...mockInvoiceDetails,
+              email: mockAccount.primaryEmail
             }
           );
         } else {
@@ -2451,6 +2455,7 @@ describe('StripeWebhookHandler', () => {
               ...mockInvoiceDetails,
               showOutstandingBalance: options.hasOutstandingBalance,
               cancelAtEnd: subscription.cancel_at_period_end,
+              email: mockAccount.primaryEmail
             }
           );
         } else {


### PR DESCRIPTION
Because:

* When a customer changes their FxA account email, this change is not propagated through to Stripe
* Emails relating to Stripe's invoices pull the customer's email field from their invoice
* This causes these emails to contain outdated email addresses

This commit:

* Because the text of the invoice references the customer receiving the email because there is a Mozilla account with the listed email address, this commit updates the emails to use the account's primary email for these fields.

Closes #PAY-3215

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Prior to updating my email address via FxA Account Settings:
<img width="1155" height="1080" alt="Screenshot 2025-09-23 at 12 46 32 PM" src="https://github.com/user-attachments/assets/4a02cb14-df04-4ab1-a6aa-6be79a3ebb9d" />

After updating my email address
<img width="1211" height="1168" alt="Screenshot 2025-09-23 at 12 47 10 PM" src="https://github.com/user-attachments/assets/2489e16e-129c-4e1f-971c-c0474e3e686e" />

## Other information (Optional)

Any other information that is important to this pull request.
