### PR TITLE
fix(sessions): Add env var for unverified session state + bandaid FE fix

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1600,10 +1600,16 @@ const convictConf = convict({
       },
     },
     forceGlobally: {
-      doc: 'Force sign-in confirmation for all accounts',
+      doc: 'Force sign-in confirmation for all accounts. Sets "mustVerify: 1" on created session tokens and creates an entry in unverifiedTokens, simulating a suspicious request or requesting scoped keys',
       format: Boolean,
       default: false,
       env: 'SIGNIN_CONFIRMATION_FORCE_GLOBALLY',
+    },
+    tokenVerification: {
+      doc: 'If set to false, force sign-in confirmation for logins that do not request scoped keys. Sets "mustVerify: 0" on created session tokens but creates an entry in unverifiedTokens, simulating an unverified session state',
+      format: Boolean,
+      default: true,
+      env: 'SIGNIN_CONFIRMATION_TOKEN_VERIFICATION',
     },
   },
   forcePasswordChange: {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1075,6 +1075,10 @@ export class AccountHandler {
     };
 
     const skipTokenVerification = (request: AuthRequest, account: any) => {
+      // Skip all checks to simulate an unverified session token state
+      if (this.config.signinConfirmation.tokenVerification === false) {
+        return false;
+      }
       // If they're logging in from an IP address on which they recently did
       // another, successfully-verified login, then we can consider this one
       // verified as well without going through the loop again.

--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -122,8 +122,8 @@ module.exports = (log, db, devices, clientUtils) => {
       options: {
         ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_CLIENT_DESTROY_POST,
         auth: {
-          strategy: 'sessionToken',
-          payload: 'required',
+          strategy: 'verifiedSessionToken',
+          payload: 'false',
         },
         validate: {
           payload: isA

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -419,7 +419,7 @@ describe('/account/attached_clients', () => {
 });
 
 describe('/account/attached_client/destroy', () => {
-  let config, uid, log, db, devices, request, route;
+  let config, uid, log, db, devices, request, route, accountRoutes;
 
   beforeEach(() => {
     config = {};
@@ -434,13 +434,21 @@ describe('/account/attached_client/destroy', () => {
       },
       payload: {},
     });
-    const accountRoutes = makeRoutes({
+    accountRoutes = makeRoutes({
       config,
       log,
       db,
       devices,
     });
     route = getRoute(accountRoutes, '/account/attached_client/destroy').handler;
+  });
+
+  it('requires verifiedSessionToken auth strategy', () => {
+    const routeConfig = getRoute(
+      accountRoutes,
+      '/account/attached_client/destroy'
+    );
+    assert.equal(routeConfig.options.auth.strategy, 'verifiedSessionToken');
   });
 
   it('can destroy by deviceId', async () => {

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -53,7 +53,7 @@ export class SessionResolver {
   }
 
   @Query((returns) => SessionType)
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(UnverifiedSessionGuard)
   session(@GqlUserId() uid: string, @GqlUserState() state: string) {
     this.log.info('session', { uid });
     return {

--- a/packages/fxa-settings/src/pages/Authorization/container.tsx
+++ b/packages/fxa-settings/src/pages/Authorization/container.tsx
@@ -100,7 +100,9 @@ const AuthorizationContainer = ({
         const navigationOptions = {
           email: account?.email!,
           signinData: {
-            verified: data.verified,
+            // TODO, address signIn.verified vs session.verified discrepancy
+            // we're currently using 'sessionVerified' from recovery_email/status
+            verified: data.sessionVerified,
             verificationMethod: data.verificationMethod,
             verificationReason: data.verificationReason,
             uid: data.uid,

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -36,7 +36,6 @@ import {
 } from '../mocks';
 import { MozServices } from '../../lib/types';
 import * as utils from 'fxa-react/lib/utils';
-import { storeAccountData } from '../../lib/storage-utils';
 import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import { SigninProps } from './interfaces';
@@ -367,7 +366,6 @@ describe('Signin component', () => {
             });
             expect(GleanMetrics.login.submit).toHaveBeenCalledTimes(1);
             expect(GleanMetrics.login.success).toHaveBeenCalledTimes(1);
-            expect(storeAccountData).toHaveBeenCalled();
           });
 
           it('navigates to /signin_totp_code when TOTP verification requested', async () => {

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -19,7 +19,6 @@ import { REACT_ENTRYPOINT } from '../../constants';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import GleanMetrics from '../../lib/glean';
 import { usePageViewEvent } from '../../lib/metrics';
-import { StoredAccountData, storeAccountData } from '../../lib/storage-utils';
 import {
   useSensitiveDataClient,
   useFtlMsgResolver,
@@ -146,7 +145,9 @@ const Signin = ({
         const navigationOptions = {
           email,
           signinData: {
-            verified: data.verified,
+            // TODO, address signIn.verified vs session.verified discrepancy
+            // we're currently using 'sessionVerified' from recovery_email/status
+            verified: data.sessionVerified,
             verificationMethod: data.verificationMethod,
             verificationReason: data.verificationReason,
             uid: data.uid,
@@ -200,17 +201,6 @@ const Signin = ({
 
       if (data) {
         GleanMetrics.login.success();
-
-        const accountData: StoredAccountData = {
-          email,
-          uid: data.signIn.uid,
-          lastLogin: Date.now(),
-          sessionToken: data.signIn.sessionToken,
-          verified: data.signIn.verified,
-          metricsEnabled: data.signIn.metricsEnabled,
-        };
-
-        storeAccountData(accountData);
 
         const navigationOptions = {
           email,
@@ -509,7 +499,9 @@ const Signin = ({
       {!hideThirdPartyAuth && (
         <ThirdPartyAuth
           showSeparator={true}
-          separatorType={hasLinkedAccountAndNoPassword ? 'signInWith' : undefined}
+          separatorType={
+            hasLinkedAccountAndNoPassword ? 'signInWith' : undefined
+          }
           {...{ viewName, flowQueryParams }}
         />
       )}

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -165,7 +165,9 @@ export const cachedSignIn = async (
         verified,
         // Because the cached signin was a success, we know 'uid' exists
         uid: storedLocalAccount!.uid,
-        sessionVerified, // might not need
+        // TODO, address signIn.verified vs session.verified discrepancy
+        // we're using sessionVerified now
+        sessionVerified,
         emailVerified, // might not need
       },
     };
@@ -209,7 +211,14 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
     navigationOptions.syncHidePromoAfterLogin = true;
   }
 
-  if (!navigationOptions.signinData.verified) {
+  if (
+    !navigationOptions.signinData.verified ||
+    // TODO, address signIn.verified vs session.verified discrepancy
+    // currently 'verified' only checks session status, but 'verificationReason'
+    // can tell us if it's a sign up. This will be cleaned up in FXA-12454
+    navigationOptions.signinData.verificationReason ===
+      VerificationReasons.SIGN_UP
+  ) {
     const { to, locationState } =
       getUnverifiedNavigationTarget(navigationOptions);
     if (


### PR DESCRIPTION
Because:
* Users in a non-Sync, non-2FA unverified session state are taken directly to Settings

This commit:
* Adds a new env var for testing to simulate an account/session in this state
* Adds a bandaid fix for what auth-server is returning in this state around 'verified', which directly references the session verification state, until a better solution is implemented in a follow up
* Adds our new auth strategy to the 'account/attached_client/destroy' endpoint

closes FXA-12406
closes FXA-12402
closes partially? FXA-12361

---

I've sent DM's on Slack to Valerie/Dan about this PR. There is going to be a follow up issue I will file that explains some of the changes here and will correct them so we don't have to "bandaid" override what the server returns to us about the session state. I'll leave a note on the ticket as well for QA.

To test this, turn on the env var and sign up/verify an account normally. Sign out. Now when you sign in next with password, you'll get back an "unverified session" and you'll be taken to `signin_token_code`. Similarly you can test this on the cached sign in for that token.

I see locally there are a few settings tests failing around the key stretching upgrade - I think those will be quick to look at in the morning.