### PR TITLE
fix(payments-next): [Payments-Next Subscription] The Card section borders are cut off

### DIFF
--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
@@ -47,9 +47,14 @@ export function PaymentMethodManagement({
   const [isNonDefaultCardSelected, setIsNonDefaultCardSelected] =
     useState(false);
   const [isNonCardSelected, setIsNonCardSelected] = useState(false);
+  const [hideOverflow, setHideOverflow] = useState(true);
 
   const handleReady = () => {
     setIsReady(true);
+  };
+  const handleElementReady = () => {
+    setIsReady(true);
+    setTimeout(() => setHideOverflow(false), 300);
   };
 
   const handlePaymentElementChange = (
@@ -237,10 +242,11 @@ export function PaymentMethodManagement({
         )}
         <Form.Field name="payment">
           <Form.Control asChild>
-            <div className="relative overflow-hidden">
+            <div className={`relative ${hideOverflow ? 'overflow-hidden' : ''}`}>
               <PaymentElement
                 onChange={handlePaymentElementChange}
                 onLoaderStart={handleReady}
+                onReady={handleElementReady}
                 options={{
                   layout: {
                     type: 'accordion',


### PR DESCRIPTION
## Because

- The bottom border of the bottom payment method is cut off when users want to add a new card under "Manage payment methods."


## This pull request

- Hides overflow while loading (to prevent bug [PAY-3236](https://mozilla-hub.atlassian.net/browse/PAY-3236) ) then does not hide overflow when Element is ready.

## Issue that this pull request solves

Closes: #[PAY-3280](https://mozilla-hub.atlassian.net/browse/PAY-3280)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

https://github.com/user-attachments/assets/dc75effa-e06a-4158-9ab0-b7895922ac6e



## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3236]: https://mozilla-hub.atlassian.net/browse/PAY-3236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAY-3280]: https://mozilla-hub.atlassian.net/browse/PAY-3280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ