### PR TITLE
fix(next): do not crash sub manage on canceled sub

### DIFF
--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -188,6 +188,9 @@ export class InvoiceManager {
     const upcomingInvoice = await this.stripeClient.invoicesRetrieveUpcoming({
       customer: customer.id,
       subscription: subscription.id,
+      subscription_details: {
+        cancel_at_period_end: false,
+      },
     });
 
     return stripeInvoiceToInvoicePreviewDTO(upcomingInvoice);


### PR DESCRIPTION
## Because

- Retrieving upcoming invoices using customer and subscription fails for customers with a subscription set to cancel at period end.

## This pull request

- Updates query fetching an upcoming invoice to always behave as if the subscription is not set to cancel at period end.

## Issue that this pull request solves

Closes: #PAY-3290

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="640" height="413" alt="image" src="https://github.com/user-attachments/assets/2b36c511-eed3-4ad4-80ba-23e47a08d06f" />

<img width="658" height="780" alt="image" src="https://github.com/user-attachments/assets/901a8696-a852-4590-b761-ea500ebb3232" />

<img width="640" height="441" alt="image" src="https://github.com/user-attachments/assets/5e7b85b7-9744-4b67-bc15-3e9349b347b4" />

