### PR TITLE
feat(auth): Add mfa-authenticated variant of setRecoveryCodes

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/recovery-codes-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-codes-api.ts
@@ -33,6 +33,18 @@ const RECOVERY_CODES_POST = {
   ],
 };
 
+const MFA_RECOVERY_CODES_POST = {
+  ...TAGS_RECOVERY_CODE,
+  description: '/mfa/recoveryCodes',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA jwt (scope: mfa:2fa)
+
+      Set backup authentication codes (intended for initial set up)
+    `,
+  ],
+};
+
 const RECOVERY_CODES_PUT = {
   ...TAGS_RECOVERY_CODE,
   description: '/recoveryCodes',
@@ -50,7 +62,7 @@ const MFA_RECOVERY_CODES_PUT = {
   description: '/mfa/recoveryCodes',
   notes: [
     dedent`
-      🔒 Authenticated with MFA jwt
+      🔒 Authenticated with MFA jwt (scope: mfa:2fa)
 
       Return new backup authentication codes while removing old ones.
     `,
@@ -73,6 +85,7 @@ const API_DOCS = {
   RECOVERY_CODES_POST,
   RECOVERY_CODES_PUT,
   MFA_RECOVERY_CODES_PUT,
+  MFA_RECOVERY_CODES_POST,
   SESSION_VERIFY_RECOVERYCODE_POST,
 };
 

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -138,6 +138,35 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       },
     },
     {
+      method: 'POST',
+      path: '/mfa/recoveryCodes',
+      options: {
+        ...RECOVERY_CODES_DOCS.MFA_RECOVERY_CODES_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:2fa'],
+          payload: false,
+        },
+        validate: {
+          payload: recoveryCodesSchema,
+        },
+        response: {
+          schema: isA.object({
+            success: isA.boolean(),
+          }),
+        },
+      },
+      handler: async function (request) {
+        return routes
+          .find(
+            (route) =>
+              route.path === '/v1/recoveryCodes' && route.method === 'POST'
+          )
+          .handler(request);
+      },
+    },
+
+    {
       method: 'PUT',
       path: '/recoveryCodes',
       options: {


### PR DESCRIPTION
## Because

* For use in mfa-authenticated flows

## This pull request

* Adds an /mfa version of the POST /recoveryCodes endpoints
* Add docs
* Add client method setRecoveryCodesWithJwt

## Issue that this pull request solves

Closes: FXA-12460

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
