### PR TITLE
feat(auth): Add mfa variant of recovery_phone/confirm endpoint

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1531,14 +1531,16 @@ export default class AuthClient {
     } = {},
     headers?: Headers
   ): Promise<SignedInAccountData> {
-
-    const oldCredentials = await this.sessionReauth(sessionToken, options.reauthEmail || email, oldPassword, {
-      keys: true
-    }, headers);
-    const oldCredentialsAuth = await crypto.getCredentials(
-      email,
-      oldPassword
+    const oldCredentials = await this.sessionReauth(
+      sessionToken,
+      options.reauthEmail || email,
+      oldPassword,
+      {
+        keys: true,
+      },
+      headers
     );
+    const oldCredentialsAuth = await crypto.getCredentials(email, oldPassword);
     const oldAuthPW = oldCredentialsAuth.authPW;
 
     const keys = await this.accountKeys(
@@ -1547,10 +1549,7 @@ export default class AuthClient {
       headers
     );
 
-    const newCredentials = await crypto.getCredentials(
-      email,
-      newPassword
-    );
+    const newCredentials = await crypto.getCredentials(email, newPassword);
 
     const wrapKb = crypto.unwrapKB(keys.kB, newCredentials.unwrapBKey);
     const authPW = newCredentials.authPW;
@@ -1600,8 +1599,8 @@ export default class AuthClient {
       if (
         error &&
         error.email &&
-        error.errno === ERRORS.INCORRECT_EMAIL_CASE
-        && !options.skipCaseError
+        error.errno === ERRORS.INCORRECT_EMAIL_CASE &&
+        !options.skipCaseError
       ) {
         options.skipCaseError = true;
         options.reauthEmail = email;
@@ -2850,17 +2849,16 @@ export default class AuthClient {
   }
 
   /**
+   * @deprecated Prefer recoveryPhoneConfirmSetupWithJwt where possible
    * Confirms the code sent to the recovery phone when recoveryPhoneCreate was called.
    *
    * @param sessionToken The user's current session token
    * @param code The otp code sent to the user's phone
-   * @param isInitial2faSetup Whether recovery phone is added during initial 2FA setup or separately
    * @param headers
    */
   async recoveryPhoneConfirmSetup(
     sessionToken: string,
     code: string,
-    isInitial2faSetup: boolean,
     headers?: Headers
   ): Promise<{ nationalFormat?: string }> {
     return this.sessionPost(
@@ -2868,10 +2866,24 @@ export default class AuthClient {
       sessionToken,
       {
         code,
-        isInitial2faSetup,
       },
       headers
     );
+  }
+
+  /**
+   * Confirms the code sent to the recovery phone when recoveryPhoneCreate was called.
+   * @param jwt auth token
+   * @param code the otp code sent to the user's phone
+   * @param headers optional headers
+   * @returns
+   */
+  async recoveryPhoneConfirmSetupWithJwt(
+    jwt: string,
+    code: string,
+    headers?: Headers
+  ): Promise<{ success: boolean }> {
+    return this.jwtPost('/mfa/recovery_phone/confirm', jwt, { code }, headers);
   }
 
   /**

--- a/packages/fxa-auth-server/docs/swagger/recovery-phone-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/recovery-phone-api.ts
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import dedent from 'dedent';
+import TAGS from './swagger-tags';
+
+const TAGS_RECOVERY_PHONE = {
+  tags: TAGS.RECOVERY_PHONE,
+};
+
+const RECOVERY_PHONE_CREATE_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/create',
+  notes: [
+    dedent`
+      🔒 Authenticated with verified session token
+
+      Start recovery phone setup by validating and sending a verification code to the provided number.
+    `,
+  ],
+};
+
+const MFA_RECOVERY_PHONE_CREATE_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/mfa/recovery_phone/create',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA JWT (scope: mfa:2fa)
+
+      Start recovery phone setup (MFA JWT variant) by validating and sending a verification code to the provided number.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_AVAILABLE_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/available',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Returns whether the user can set up a recovery phone in their current region and account state.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_CONFIRM_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/confirm',
+  notes: [
+    dedent`
+      🔒 Authenticated with verified session token
+
+      Confirm recovery phone setup by verifying the code sent via SMS and finalize adding the phone number.
+    `,
+  ],
+};
+
+const MFA_RECOVERY_PHONE_CONFIRM_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/mfa/recovery_phone/confirm',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA JWT (scope: mfa:2fa)
+
+      Confirm recovery phone setup (MFA JWT variant) by verifying the code sent via SMS and finalize adding the phone number.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_CHANGE_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/change',
+  notes: [
+    dedent`
+      🔒 Authenticated with verified session token
+
+      Replace the existing recovery phone with a new one using a valid setup code for the new number.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_SIGNIN_SEND_CODE_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/signin/send_code',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Send an SMS code to the configured recovery phone to complete sign-in as a 2-step verification method.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_SIGNIN_CONFIRM_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/signin/confirm',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Verify the SMS code sent to the recovery phone to complete sign-in.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_RESET_PASSWORD_SEND_CODE_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/reset_password/send_code',
+  notes: [
+    dedent`
+      🔒 Authenticated with password forgot token
+
+      Send an SMS code to the configured recovery phone to confirm a password reset.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_RESET_PASSWORD_CONFIRM_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/reset_password/confirm',
+  notes: [
+    dedent`
+      🔒 Authenticated with password forgot token
+
+      Verify the SMS code sent to the recovery phone to complete password reset verification.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_DELETE = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone',
+  notes: [
+    dedent`
+      🔒 Authenticated with verified session token
+
+      Remove the currently configured recovery phone from the account.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_GET = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token or password forgot token
+
+      Return whether a recovery phone exists and, if permitted, the masked phone number information.
+    `,
+  ],
+};
+
+const RECOVERY_PHONE_MESSAGE_STATUS_POST = {
+  ...TAGS_RECOVERY_PHONE,
+  description: '/recovery_phone/message_status',
+  notes: [
+    dedent`
+      Public webhook (Twilio)
+
+      Accept message status callbacks from Twilio. The request is validated using either an FxA-generated signature or Twilio's signature.
+    `,
+  ],
+};
+
+const API_DOCS = {
+  RECOVERY_PHONE_CREATE_POST,
+  MFA_RECOVERY_PHONE_CREATE_POST,
+  RECOVERY_PHONE_AVAILABLE_POST,
+  RECOVERY_PHONE_CONFIRM_POST,
+  MFA_RECOVERY_PHONE_CONFIRM_POST,
+  RECOVERY_PHONE_CHANGE_POST,
+  RECOVERY_PHONE_SIGNIN_SEND_CODE_POST,
+  RECOVERY_PHONE_SIGNIN_CONFIRM_POST,
+  RECOVERY_PHONE_RESET_PASSWORD_SEND_CODE_POST,
+  RECOVERY_PHONE_RESET_PASSWORD_CONFIRM_POST,
+  RECOVERY_PHONE_DELETE,
+  RECOVERY_PHONE_GET,
+  RECOVERY_PHONE_MESSAGE_STATUS_POST,
+};
+
+export default API_DOCS;

--- a/packages/fxa-auth-server/docs/swagger/swagger-options.ts
+++ b/packages/fxa-auth-server/docs/swagger/swagger-options.ts
@@ -30,6 +30,7 @@ export const swaggerOptions = {
         TAGS.ACCOUNT[1],
         TAGS.RECOVERY_KEY[1],
         TAGS.RECOVERY_CODES[1],
+        TAGS.RECOVERY_PHONE[1],
         TAGS.DEVICES_AND_SESSIONS[1],
         TAGS.EMAILS[1],
         TAGS.MISCELLANEOUS[1],

--- a/packages/fxa-auth-server/docs/swagger/swagger-tags.ts
+++ b/packages/fxa-auth-server/docs/swagger/swagger-tags.ts
@@ -11,6 +11,7 @@ const TAGS = {
   OAUTH: ['api', 'Oauth'],
   OAUTH_SERVER: ['api', 'OAuth Server API Overview'],
   PASSWORD: ['api', 'Password'],
+  RECOVERY_PHONE: ['api', 'Recovery phone'],
   RECOVERY_CODES: ['api', 'Backup authentication codes'],
   RECOVERY_KEY: ['api', 'Account recovery key'],
   SECURITY_EVENTS: ['api', 'Security events'],

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.test.tsx
@@ -259,8 +259,7 @@ describe('Page2faSetup', () => {
       await waitFor(() => {
         expect(account.confirmRecoveryPhone).toHaveBeenCalledWith(
           '000000',
-          MOCK_FULL_PHONE_NUMBER,
-          true
+          MOCK_FULL_PHONE_NUMBER
         );
         expect(account.completeTotpSetup).toHaveBeenCalled();
         expect(account.refresh).toHaveBeenCalledWith('recoveryPhone');

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.tsx
@@ -201,7 +201,7 @@ const Page2faSetup = (_: RouteComponentProps) => {
 
   const handleVerifySmsCode = async (code: string) => {
     // if this errors, error will be handled by try/catch in child component
-    await account.confirmRecoveryPhone(code, phoneData.phoneNumber, true);
+    await account.confirmRecoveryPhone(code, phoneData.phoneNumber);
 
     try {
       await enable2fa();

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.test.tsx
@@ -130,8 +130,7 @@ describe('PageRecoveryPhoneSetup', () => {
     await waitFor(() => expect(confirmRecoveryPhone).toHaveBeenCalledTimes(1));
     expect(confirmRecoveryPhone).toHaveBeenCalledWith(
       otpCode,
-      MOCK_FULL_PHONE_NUMBER,
-      false
+      MOCK_FULL_PHONE_NUMBER
     );
   });
 

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
@@ -111,7 +111,7 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
     // try/catch is in the component that calls this function
     reason === RecoveryPhoneSetupReason.change
       ? await account.changeRecoveryPhone(code)
-      : await account.confirmRecoveryPhone(code, phoneData.phoneNumber, false);
+      : await account.confirmRecoveryPhone(code, phoneData.phoneNumber);
     // get the latest status of recovery phone info
     // ensure correct data is shown on the settings page
     await account.refresh('recoveryPhone');

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1594,17 +1594,9 @@ export class Account implements AccountData {
     return result;
   }
 
-  async confirmRecoveryPhone(
-    code: string,
-    phoneNumber: string,
-    isInitial2faSetup: boolean
-  ) {
+  async confirmRecoveryPhone(code: string, phoneNumber: string) {
     const { nationalFormat } = await this.withLoadingStatus(
-      this.authClient.recoveryPhoneConfirmSetup(
-        sessionToken()!,
-        code,
-        isInitial2faSetup
-      )
+      this.authClient.recoveryPhoneConfirmSetup(sessionToken()!, code)
     );
     const cache = this.apolloClient.cache;
     cache.modify({

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -370,8 +370,7 @@ describe('InlineRecoverySetupContainer', () => {
           });
           expect(confirmRecoveryPhoneFn).toHaveBeenCalledWith(
             '010431',
-            '12345678900',
-            true
+            '12345678900'
           );
           expect(mockCompleteTotpSetup).toHaveBeenCalledTimes(1);
         });

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -162,7 +162,7 @@ export const InlineRecoverySetupContainer = ({
 
   const verifySmsCode = useCallback(
     async (code: string) => {
-      await account.confirmRecoveryPhone(code, phoneData.phoneNumber, true);
+      await account.confirmRecoveryPhone(code, phoneData.phoneNumber);
       await verifyTotpHandler();
     },
     [account, phoneData.phoneNumber, verifyTotpHandler]


### PR DESCRIPTION
## Because

* We want to use this endpoint in mfa-verified flows

## This pull request

* Add mfa variant of recovery_phone/confirm
* Add swagger docs for recovery phone endpoints
* Add client method
* Update the two endpoints to directly check 2FA enabled instead of receiving a flag in payload

## Issue that this pull request solves

Closes: FXA-12461

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
