### PR TITLE
fix(tests): update functional tests to wait for pairing page

### DIFF
--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -570,6 +570,8 @@ test.describe('severity-1 #smoke', () => {
       submitButton = page.getByRole('button', { name: 'Sign in', exact: true });
       await submitButton.click();
 
+      await page.waitForURL(/pair/);
+
       await page.getByRole('link', { name: 'Not now' }).click();
 
       // Verify successful login and go to settings
@@ -646,6 +648,8 @@ test.describe('severity-1 #smoke', () => {
       // Enter TOTP code
       const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
+
+      await page.waitForURL(/pair/);
 
       await page.getByRole('link', { name: 'Not now' }).click();
 

--- a/packages/functional-tests/tests/cms/cms.spec.ts
+++ b/packages/functional-tests/tests/cms/cms.spec.ts
@@ -368,6 +368,8 @@ test.describe('severity-1 #smoke', () => {
         });
         await submitButton.click();
 
+        await page.waitForURL(/pair/);
+
         await page.getByRole('link', { name: 'Not now' }).click();
       });
 
@@ -441,6 +443,8 @@ test.describe('severity-1 #smoke', () => {
           exact: true,
         });
         await submitButton.click();
+
+        await page.waitForURL(/pair/);
 
         await page.getByRole('link', { name: 'Not now', exact: true }).click();
       });

--- a/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/signInTokenCode.spec.ts
@@ -44,7 +44,7 @@ test.describe('severity-2 #smoke', () => {
       const code = await target.emailClient.getVerifyLoginCode(email);
       await signinTokenCode.fillOutCodeForm(code);
 
-      await expect(page).toHaveURL(/pair/);
+      await page.waitForURL(/pair/);
       await connectAnotherDevice.clickNotNowPair();
 
       await expect(page).toHaveURL(/settings/);

--- a/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInConnectAnotherDevice.spec.ts
@@ -20,7 +20,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
-      await expect(page).toHaveURL(/pair/);
+      await page.waitForURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
   });

--- a/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signInRelyingParties.spec.ts
@@ -21,6 +21,8 @@ test.describe('severity-1 #smoke', () => {
     await signin.fillOutEmailFirstForm(credentials.email);
     await signin.fillOutPasswordForm(credentials.password);
 
+    await page.waitForURL(/pair/);
+
     await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     await connectAnotherDevice.clickNotNowPair();
     await expect(page).toHaveURL(/settings/);

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -90,7 +90,7 @@ test.describe('severity-1 #smoke', () => {
       const totpCode = await getTotpCode(secret);
       await signinTotpCode.fillOutCodeForm(totpCode);
 
-      await expect(page).toHaveURL(/pair/);
+      await page.waitForURL(/pair/);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
 

--- a/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/syncV3SignIn.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from '../../lib/fixtures/standard';
 test.describe('severity-2 #smoke', () => {
   test.describe('Firefox Desktop Sync v3 signin react', () => {
     test('verified, does not need to confirm', async ({
-      syncBrowserPages: { connectAnotherDevice, signin },
+      syncBrowserPages: { connectAnotherDevice, signin, page },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -19,6 +19,8 @@ test.describe('severity-2 #smoke', () => {
       await expect(signin.syncSignInHeading).toBeVisible();
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
+
+      await page.waitForURL(/pair/);
 
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
     });
@@ -46,6 +48,6 @@ test.describe('severity-2 #smoke', () => {
 
     await signinTokenCode.fillOutCodeForm(code);
 
-    await expect(page).toHaveURL(/pair/);
+    await page.waitForURL(/pair/);
   });
 });

--- a/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
+++ b/packages/functional-tests/tests/signin/connectAnotherDevice.spec.ts
@@ -19,7 +19,7 @@ test.describe('severity-2 #smoke', () => {
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
 
-      await expect(page).toHaveURL(/pair/);
+      await page.waitForURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
     });
   });


### PR DESCRIPTION
## Because

- Something outside of our tests have changed, FF seems to take longer to respond to the webchannel message for login

## This pull request

- Adds for a `await page.waitForUrl` for pairing page before proceeding to click link

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This does not fix the underlying issues, but at least makes our tests a little more resilent.
