### PR TITLE
feat(payments-next): Remove card display for digital wallets

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -148,21 +148,6 @@ export default async function CheckoutSuccess({
                 width={40}
                 height={24}
               />
-              <span className="flex items-center gap-2">
-                {cart.paymentInfo.brand && (
-                  <Image
-                    src={getCardIcon(cart.paymentInfo.brand, l10n).img}
-                    alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
-                    width={40}
-                    height={24}
-                  />
-                )}
-                {l10n.getString(
-                  'next-payment-confirmation-cc-card-ending-in',
-                  { last4: cart.paymentInfo.last4 ?? '' },
-                  `Card ending in ${cart.paymentInfo.last4}`
-                )}
-              </span>
             </div>
           ) : cart.paymentInfo.walletType === 'google_pay' ? (
             <div className="flex items-center gap-3">
@@ -172,21 +157,6 @@ export default async function CheckoutSuccess({
                 width={40}
                 height={24}
               />
-              <span className="flex items-center gap-2">
-                {cart.paymentInfo.brand && (
-                  <Image
-                    src={getCardIcon(cart.paymentInfo.brand, l10n).img}
-                    alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
-                    width={40}
-                    height={24}
-                  />
-                )}
-                {l10n.getString(
-                  'next-payment-confirmation-cc-card-ending-in',
-                  { last4: cart.paymentInfo.last4 ?? '' },
-                  `Card ending in ${cart.paymentInfo.last4}`
-                )}
-              </span>
             </div>
           ) : cart.paymentInfo.type === 'external_paypal' ? (
             <Image

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
@@ -149,21 +149,6 @@ export default async function UpgradeSuccess({
                   width={40}
                   height={24}
                 />
-                <span className="flex items-center gap-2">
-                  {cart.paymentInfo.brand && (
-                    <Image
-                      src={getCardIcon(cart.paymentInfo.brand, l10n).img}
-                      alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
-                      width={40}
-                      height={24}
-                    />
-                  )}
-                  {l10n.getString(
-                    'next-payment-confirmation-cc-card-ending-in',
-                    { last4: cart.paymentInfo.last4 ?? '' },
-                    `Card ending in ${cart.paymentInfo.last4}`
-                  )}
-                </span>
               </div>
             ) : cart.paymentInfo.walletType === 'google_pay' ? (
               <div className="flex items-center gap-3">
@@ -173,21 +158,6 @@ export default async function UpgradeSuccess({
                   width={40}
                   height={24}
                 />
-                <span className="flex items-center gap-2">
-                  {cart.paymentInfo.brand && (
-                    <Image
-                      src={getCardIcon(cart.paymentInfo.brand, l10n).img}
-                      alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
-                      width={40}
-                      height={24}
-                    />
-                  )}
-                  {l10n.getString(
-                    'next-payment-confirmation-cc-card-ending-in',
-                    { last4: cart.paymentInfo.last4 ?? '' },
-                    `Card ending in ${cart.paymentInfo.last4}`
-                  )}
-                </span>
               </div>
             ) : cart.paymentInfo.type === 'external_paypal' ? (
               <Image

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -98,21 +98,6 @@ export default async function Upgrade({
                   width={40}
                   height={24}
                 />
-                <span className="flex items-center gap-2">
-                  {cart.paymentInfo.brand && (
-                    <Image
-                      src={getCardIcon(cart.paymentInfo.brand, l10n).img}
-                      alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
-                      width={40}
-                      height={24}
-                    />
-                  )}
-                  {l10n.getString(
-                    'next-payment-confirmation-cc-card-ending-in',
-                    { last4: cart.paymentInfo.last4 ?? '' },
-                    `Card ending in ${cart.paymentInfo.last4}`
-                  )}
-                </span>
               </div>
             ) : cart.paymentInfo.walletType === 'google_pay' ? (
               <div className="flex items-center gap-3">
@@ -122,21 +107,6 @@ export default async function Upgrade({
                   width={40}
                   height={24}
                 />
-                <span className="flex items-center gap-2">
-                  {cart.paymentInfo.brand && (
-                    <Image
-                      src={getCardIcon(cart.paymentInfo.brand, l10n).img}
-                      alt={getCardIcon(cart.paymentInfo.brand, l10n).altText}
-                      width={40}
-                      height={24}
-                    />
-                  )}
-                  {l10n.getString(
-                    'next-payment-confirmation-cc-card-ending-in',
-                    { last4: cart.paymentInfo.last4 ?? '' },
-                    `Card ending in ${cart.paymentInfo.last4}`
-                  )}
-                </span>
               </div>
             ) : cart.paymentInfo.type === 'external_paypal' ? (
               <Image

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -199,44 +199,18 @@ export default async function Manage({
                       alt={
                         walletType === 'apple_pay'
                           ? l10n.getString(
-                            'apple-pay-logo-alt-text',
-                            'Apple Pay logo'
-                          )
+                              'apple-pay-logo-alt-text',
+                              'Apple Pay logo'
+                            )
                           : l10n.getString(
-                            'google-pay-logo-alt-text',
-                            'Google Pay logo'
-                          )
+                              'google-pay-logo-alt-text',
+                              'Google Pay logo'
+                            )
                       }
                       width={40}
                       height={24}
                     />
-                    {brand && (
-                      <Image
-                        src={getCardIcon(brand, l10n).img}
-                        alt={getCardIcon(brand, l10n).altText}
-                        width={40}
-                        height={24}
-                      />
-                    )}
-                    {last4 && (
-                      <div>
-                        {l10n.getString(
-                          'subscription-management-card-ending-in',
-                          { last4 },
-                          `Card ending in ${last4}`
-                        )}
-                      </div>
-                    )}
                   </div>
-                  {expirationDate && (
-                    <div>
-                      {l10n.getString(
-                        'subscription-management-card-expires-date',
-                        { expirationDate },
-                        `Expires ${expirationDate}`
-                      )}
-                    </div>
-                  )}
                 </div>
                 <Link
                   className={CSS_SECONDARY_LINK}
@@ -426,10 +400,10 @@ export default async function Manage({
                       >
                         {sub.interval
                           ? l10n.getString(
-                            getSubscriptionIntervalFtlId(sub.interval),
-                            { productName: sub.productName },
-                            `${sub.productName} (${formatPlanInterval(sub.interval)})`
-                          )
+                              getSubscriptionIntervalFtlId(sub.interval),
+                              { productName: sub.productName },
+                              `${sub.productName} (${formatPlanInterval(sub.interval)})`
+                            )
                           : sub.productName}
                       </h3>
                       <LinkExternal
@@ -476,8 +450,8 @@ export default async function Manage({
             </ul>
             {(appleIapSubscriptions.length > 0 ||
               googleIapSubscriptions.length > 0) && (
-                <hr className="border-b border-grey-50 my-6" aria-hidden="true" />
-              )}
+              <hr className="border-b border-grey-50 my-6" aria-hidden="true" />
+            )}
           </>
         )}
 
@@ -554,13 +528,13 @@ export default async function Manage({
                                   date: nextBillDate,
                                 },
                                 elems: {
-                                  strong: <strong />
+                                  strong: <strong />,
                                 },
                               },
                               <>
-                                Your subscription will expire on <strong>${nextBillDate}</strong>
+                                Your subscription will expire on{' '}
+                                <strong>${nextBillDate}</strong>
                               </>
-
                             )}
                           </p>
                         )}
@@ -665,33 +639,35 @@ export default async function Manage({
                         {!!purchase.expiryTimeMillis &&
                           (purchase.autoRenewing
                             ? l10n.getFragmentWithSource(
-                              'subscription-management-iap-sub-next-bill-is-due',
-                              {
-                                vars: {
-                                  date: nextBillDate,
+                                'subscription-management-iap-sub-next-bill-is-due',
+                                {
+                                  vars: {
+                                    date: nextBillDate,
+                                  },
+                                  elems: {
+                                    strong: <strong />,
+                                  },
                                 },
-                                elems: {
-                                  strong: <strong />
-                                },
-                              },
-                              <>
-                                Next bill is due <strong>{nextBillDate}</strong>
-                              </>
-                            )
+                                <>
+                                  Next bill is due{' '}
+                                  <strong>{nextBillDate}</strong>
+                                </>
+                              )
                             : l10n.getFragmentWithSource(
-                              'subscription-management-iap-sub-will-expire-on',
-                              {
-                                vars: {
-                                  date: nextBillDate,
+                                'subscription-management-iap-sub-will-expire-on',
+                                {
+                                  vars: {
+                                    date: nextBillDate,
+                                  },
+                                  elems: {
+                                    strong: <strong />,
+                                  },
                                 },
-                                elems: {
-                                  strong: <strong />
-                                },
-                              },
-                              <>
-                                Your subscription will expire on <strong>{nextBillDate}</strong>
-                              </>
-                            ))}
+                                <>
+                                  Your subscription will expire on{' '}
+                                  <strong>{nextBillDate}</strong>
+                                </>
+                              ))}
                       </p>
                     </div>
                     <div>


### PR DESCRIPTION
Because:

* We should not be displaying information such as a card's last-4 or its expiration date if the customer used Apple Pay or Google Pay

This commit:

* Removes extra card info from the UI in cases where the customer paid with Apple Pay or Google Pay

Closes #PAY-3289

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="1494" height="1162" alt="Screenshot 2025-09-26 at 1 52 07 PM" src="https://github.com/user-attachments/assets/1c3eb2e6-dc73-48c8-9a29-138c0f0dc1e5" />
<img width="1392" height="1297" alt="Screenshot 2025-09-26 at 1 52 46 PM" src="https://github.com/user-attachments/assets/472bde08-8a95-499b-a57d-673354f3e6d6" />
<img width="1718" height="824" alt="Screenshot 2025-09-26 at 1 53 10 PM" src="https://github.com/user-attachments/assets/315fb22c-5c5e-45db-8645-43409bea424f" />

## Other information (Optional)

The same information removal from the UI will apply to payments made with Google Pay
