### PR TITLE
fix(email): Send signin code for sign in with password unverified session case

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -442,7 +442,6 @@ const SigninContainer = ({
         // but we should update 'verified' once we know the real status
         // this will be taken care of in the clean up ticket FXA-12454
         isVerified = await session.isSessionVerified();
-        console.log('HELLO isVerified', isVerified);
         storeAccountData({
           ...accountData,
           verified: isVerified,

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -24,6 +24,7 @@ import {
   useFtlMsgResolver,
   isWebIntegration,
   isOAuthIntegration,
+  useSession,
 } from '../../models';
 import {
   isClientMonitor,
@@ -38,6 +39,7 @@ import Banner from '../../components/Banner';
 import { SensitiveData } from '../../lib/sensitive-data-client';
 import { BannerLinkProps } from '../../components/Banner/interfaces';
 import CmsButtonWithFallback from '../../components/CmsButtonWithFallback';
+import VerificationReasons from '../../constants/verification-reasons';
 
 export const viewName = 'signin';
 
@@ -68,6 +70,7 @@ const Signin = ({
   const ftlMsgResolver = useFtlMsgResolver();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const sensitiveDataClient = useSensitiveDataClient();
+  const session = useSession();
 
   const [localizedBannerError, setLocalizedBannerError] = useState(
     localizedErrorFromLocationState || ''
@@ -227,6 +230,16 @@ const Signin = ({
           setLocalizedBannerError(
             getLocalizedErrorMessage(ftlMsgResolver, navError)
           );
+        } else {
+          // TODO, address signIn.verified vs session.verified discrepancy
+          // currently 'verified' only checks session status, but 'verificationReason'
+          // can tell us if it's a sign up. This will be cleaned up in FXA-12454
+          if (
+            !data.signIn.verified &&
+            data.signIn.verificationReason !== VerificationReasons.SIGN_UP
+          ) {
+            session.sendVerificationCode();
+          }
         }
       }
       if (error) {
@@ -321,6 +334,7 @@ const Signin = ({
       setLocalizedBannerError,
       finishOAuthFlowHandler,
       integration,
+      session,
       location.search,
       webRedirectCheck,
       sensitiveDataClient,


### PR DESCRIPTION
Because:
* When users are taken to '/signin_token_code' from a sign in with password navigation, we don't automatically send the associated email

This commit:
* Ensures the email is sent

fixes FXA-12467

---

See ticket for how to reproduce.