### PR TITLE
fix(payments-next): [expanded payment methods][Link] Save payment method button is displayed on the Manage payment methods page for Link

### DIFF
--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
@@ -47,6 +47,7 @@ export function PaymentMethodManagement({
   const [isNonDefaultCardSelected, setIsNonDefaultCardSelected] =
     useState(false);
   const [isNonCardSelected, setIsNonCardSelected] = useState(false);
+  const [hasPaymentMethod, setHasPaymentMethod] = useState(false);
 
   const handleReady = () => {
     setIsReady(true);
@@ -56,11 +57,19 @@ export function PaymentMethodManagement({
     event: StripePaymentElementChangeEvent
   ) => {
     setIsComplete(event.complete);
+    setHasPaymentMethod(!!event.value.payment_method);
 
     if (event.value.type !== 'card') {
       setIsNonCardSelected(true);
       setIsInputNewCardDetails(false);
       setHasFullNameError(false);
+      if (!!event.value.payment_method) {
+        if (event.value.payment_method.id !== defaultPaymentMethodId) {
+          setIsNonDefaultCardSelected(true);
+        } else {
+          setIsNonDefaultCardSelected(false);
+        }
+      }
       return;
     }
     setIsNonCardSelected(false);
@@ -264,7 +273,7 @@ export function PaymentMethodManagement({
             </Form.Message>
           )}
         </Form.Field>
-        {(isInputNewCardDetails || isNonCardSelected) && (
+        {(isInputNewCardDetails || (isNonCardSelected && !hasPaymentMethod)) && (
           <div className="flex flex-row justify-center pt-4">
             <Form.Submit asChild>
               <BaseButton


### PR DESCRIPTION
## Because

- The Save payment method button is displayed, although there is nothing to save at this point.
- There is no “Set as default payment method” button for Link.

## This pull request

- Fixes the above bugs.

## Issue that this pull request solves

Closes: [PAY-3287](https://mozilla-hub.atlassian.net/browse/PAY-3287)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
