### PR TITLE
fix(emails): Fix subscription management link in emails

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -20,6 +20,7 @@
     "secure": false,
     "redirectDomain": "localhost",
     "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/firefox-private-network/",
+    "subscriptionSettingsUrl": "http://localhost:3035/",
     "user": "local",
     "password": "local"
   },

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -496,10 +496,16 @@ const convictConf = convict({
         'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=ios&creative=button&fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8&utm_source=email',
     },
     supportUrl: {
-      doc: 'url to Mozilla Support product page',
+      doc: 'url to Mozilla account support page',
       format: String,
       default:
         'https://support.mozilla.org/kb/im-having-problems-my-firefox-account',
+    },
+    subscriptionSupportUrl: {
+      doc: 'url to Mozilla subscription support page',
+      format: String,
+      default:
+        'https://support.mozilla.org/products',
     },
     redirectDomain: {
       doc: 'Domain that mail urls are allowed to redirect to',
@@ -523,6 +529,12 @@ const convictConf = convict({
         'https://www.mozilla.org/about/legal/terms/firefox-private-network/',
       doc: 'Subscription terms and cancellation policy URL',
       env: 'SUBSCRIPTION_TERMS_URL',
+      format: String,
+    },
+    subscriptionSettingsUrl: {
+      default: 'https://payments.firefox.com/',
+      doc: 'Subscriptions management URL',
+      env: 'PAYMENTS_NEXT_HOSTED_URL',
       format: String,
     },
     unsubscribeUrl: {
@@ -2621,8 +2633,6 @@ convictConf.set(
   'smtp.verifySecondaryEmailUrl',
   `${baseUri}/verify_secondary_email`
 );
-convictConf.set('smtp.subscriptionSettingsUrl', `${baseUri}/subscriptions`);
-convictConf.set('smtp.subscriptionSupportUrl', `${baseUri}/support`);
 convictConf.set('smtp.syncUrl', `${baseUri}/connect_another_device`);
 
 convictConf.set('isProduction', convictConf.get('env') === 'prod');

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportGetHelp/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionSupportGetHelp/en.ftl
@@ -1,7 +1,7 @@
 subscription-support-get-help = Get help with your subscription
 subscription-support-manage-your-subscription = <a data-l10n-name="manageSubscriptionUrl">Manage your subscription</a>
-# After the colon, there's a link to https://accounts.firefox.com/subscriptions
+# After the colon, there's a link to https://payments.firefox.com/subscriptions
 subscription-support-manage-your-subscription-plaintext = Manage your subscription:
 subscription-support-contact-support = <a data-l10n-name="subscriptionSupportUrl">Contact support</a>
-# After the colon, there's a link to https://accounts.firefox.com/support
+# After the colon, there's a link to https://support.mozilla.com/products
 subscription-support-contact-support-plaintext = Contact support:

--- a/packages/fxa-payments-server/backstage.yaml
+++ b/packages/fxa-payments-server/backstage.yaml
@@ -12,10 +12,10 @@ metadata:
     - node
     - react
   links:
-    - url: https://subscriptions.firefox.com/
+    - url: https://payments.firefox.com/
       title: Production Subscription Platform
       type: website
-    - url: https://payments-server.allizom.org/
+    - url: https://payments-next.allizom.org/
       title: Stage Subscription Platform
       type: website
 spec:

--- a/yarn.lock
+++ b/yarn.lock
@@ -25289,6 +25289,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:1.12.0":
+  version: 1.12.0
+  resolution: "axios@npm:1.12.0"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/44a1e4cfb69a2d59aa12bbc441a336e5c18e87c02b904c509fd33607d94e8cb8cc221c17e9d53f67841a4efe13abf1aa1497c85df390cdb8681ee723998d11b0
+  languageName: node
+  linkType: hard
+
 "axios@npm:1.8.4":
   version: 1.8.4
   resolution: "axios@npm:1.8.4"
@@ -34569,7 +34580,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.59.0"
     "@typescript-eslint/parser": "npm:^7.1.1"
     audit-filter: "npm:^0.5.0"
-    axios: "npm:1.8.4"
+    axios: "npm:1.12.0"
     chance: "npm:^1.1.8"
     convict: "npm:^6.2.4"
     convict-format-with-moment: "npm:^6.2.0"


### PR DESCRIPTION
Because:

* The subscription management link was being set to the content server's /subscription url

This commit:

* The subscription management link now uses the config value
* The subscription management link now points to SP3's page

Closes #PAY-3302

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
