### PR TITLE
feat(skip): Skip confirmation code for a seen device user agent

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -30,6 +30,13 @@
       "allowedRecency": 0
     }
   },
+  "signinConfirmation": {
+    "deviceFingerprinting": {
+      "enabled": true,
+      "reportOnlyMode": true,
+      "duration": "7 days"
+    }
+  },
   "lastAccessTimeUpdates": {
     "enabled": true,
     "sampleRate": 1

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1605,6 +1605,26 @@ const convictConf = convict({
       default: false,
       env: 'SIGNIN_CONFIRMATION_FORCE_GLOBALLY',
     },
+    deviceFingerprinting: {
+      enabled: {
+        doc: 'Enable device fingerprinting based verification skip',
+        format: Boolean,
+        default: false,
+        env: 'SIGNIN_CONFIRMATION_DEVICE_FINGERPRINTING_ENABLED',
+      },
+      reportOnlyMode: {
+        doc: 'When true, logs device matches but does not skip verification',
+        format: Boolean,
+        default: true,
+        env: 'SIGNIN_CONFIRMATION_DEVICE_FINGERPRINTING_REPORT_ONLY',
+      },
+      duration: {
+        doc: 'How long a recognized device can skip verification',
+        default: '7 days',
+        format: 'duration',
+        env: 'SIGNIN_CONFIRMATION_DEVICE_FINGERPRINTING_DURATION',
+      },
+    },
     tokenVerification: {
       doc: 'If set to false, force sign-in confirmation for logins that do not request scoped keys. Sets "mustVerify: 0" on created session tokens but creates an entry in unverifiedTokens, simulating an unverified session state',
       format: Boolean,

--- a/packages/fxa-auth-server/lib/db.ts
+++ b/packages/fxa-auth-server/lib/db.ts
@@ -1064,6 +1064,17 @@ export const createDB = (
       );
     }
 
+    async verifiedLoginSecurityEventsByUid(params: { uid: string; skipTimeframeMs: number}) {
+      log.trace('DB.verifiedLoginSecurityEventsByUid', {
+        params: params,
+      });
+      const { uid, skipTimeframeMs } = params;
+      return SecurityEvent.findByUidAndVerifiedLogin(
+        uid,
+        skipTimeframeMs
+      );
+    }
+
     async securityEventsByUid(params: { uid: string }) {
       log.trace('DB.securityEventsByUid', {
         params: params,

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.ts
@@ -23,3 +23,35 @@ export async function recordSecurityEvent(name: SecurityEventNames, opts: any) {
     },
   });
 }
+
+export async function isRecognizedDevice(
+  db: any,
+  uid: string,
+  userAgent: string,
+  skipTimeframeMs: number
+): Promise<boolean> {
+  const verifiedLoginEvents = await db.verifiedLoginSecurityEventsByUid({
+    uid,
+    skipTimeframeMs
+  });
+
+  if (!verifiedLoginEvents || verifiedLoginEvents.length === 0) {
+    return false;
+  }
+
+  // Search through the results for matching user agent
+  for (const event of verifiedLoginEvents) {
+    if (event.additionalInfo) {
+      try {
+        const additionalInfo = JSON.parse(event.additionalInfo);
+        if (additionalInfo.userAgent === userAgent) {
+          return true;
+        }
+      } catch (e) {
+        // Skip events with invalid JSON
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/fxa-auth-server/test/local/routes/utils/security-event.ts
+++ b/packages/fxa-auth-server/test/local/routes/utils/security-event.ts
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+const { isRecognizedDevice } = require('../../../../lib/routes/utils/security-event');
+
+describe('isRecognizedDevice', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('should return true when user agent matches in verified login events', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockEvents = [
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 3600000, // 1 hour ago
+        additionalInfo: JSON.stringify({
+          userAgent,
+          location: { country: 'US', state: 'CA' }
+        })
+      }
+    ];
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(mockEvents)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isTrue(result);
+    sinon.assert.calledOnceWithExactly(mockDb.verifiedLoginSecurityEventsByUid, {uid, skipTimeframeMs});
+  });
+
+  it('should return false when user agent does not match in verified login events', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const differentUserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockEvents = [
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 3600000, // 1 hour ago
+        additionalInfo: JSON.stringify({
+          userAgent: differentUserAgent,
+          location: { country: 'US', state: 'CA' }
+        })
+      }
+    ];
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(mockEvents)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isFalse(result);
+  });
+
+  it('should return false when no verified login events exist', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves([])
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isFalse(result);
+  });
+
+  it('should return false when verifiedLoginSecurityEventsByUid returns null', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(null)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isFalse(result);
+  });
+
+  it('should handle events with null additionalInfo', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockEvents = [
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 3600000, // 1 hour ago
+        additionalInfo: null
+      },
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 7200000, // 2 hours ago
+        additionalInfo: JSON.stringify({
+          userAgent,
+          location: { country: 'US', state: 'CA' }
+        })
+      }
+    ];
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(mockEvents)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isTrue(result); // Should still find the valid event
+  });
+
+  it('should search through multiple events and find match', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockEvents = [
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 3600000,
+        additionalInfo: JSON.stringify({
+          userAgent: 'Different User Agent 1',
+          location: { country: 'US', state: 'CA' }
+        })
+      },
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 7200000,
+        additionalInfo: JSON.stringify({
+          userAgent: 'Different User Agent 2',
+          location: { country: 'US', state: 'NY' }
+        })
+      },
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 10800000,
+        additionalInfo: JSON.stringify({
+          userAgent, // This one matches
+          location: { country: 'US', state: 'TX' }
+        })
+      }
+    ];
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(mockEvents)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isTrue(result);
+  });
+
+  it('should handle empty user agent string', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = '';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockEvents = [
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 3600000,
+        additionalInfo: JSON.stringify({
+          userAgent: '',
+          location: { country: 'US', state: 'CA' }
+        })
+      }
+    ];
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(mockEvents)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isTrue(result); // Empty string should match empty string
+  });
+
+  it('should handle events with invalid JSON in additionalInfo', async () => {
+    const uid = 'test-uid-123';
+    const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36';
+    const skipTimeframeMs = 604800000; // 7 days
+
+    const mockEvents = [
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 3600000, // 1 hour ago
+        additionalInfo: 'invalid json'
+      },
+      {
+        name: 'account.login',
+        verified: true,
+        createdAt: Date.now() - 7200000, // 2 hours ago
+        additionalInfo: JSON.stringify({
+          userAgent,
+          location: { country: 'US', state: 'CA' }
+        })
+      }
+    ];
+
+    const mockDb = {
+      verifiedLoginSecurityEventsByUid: sandbox.stub().resolves(mockEvents)
+    };
+
+    const result = await isRecognizedDevice(mockDb, uid, userAgent, skipTimeframeMs);
+
+    assert.isTrue(result); // Should skip invalid JSON and find the valid event
+  });
+});

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -670,6 +670,9 @@ function mockDB(data, errors) {
     verifiedLoginSecurityEvents: sinon.spy(() => {
       return Promise.resolve([]);
     }),
+    verifiedLoginSecurityEventsByUid: sinon.spy(() => {
+      return Promise.resolve([]);
+    }),
     sessionToken: sinon.spy(() => {
       const res = {
         id: data.sessionTokenId || 'fake session token id',

--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -201,4 +201,32 @@ export class SecurityEvent extends BaseAuthModel {
       .orderBy('securityEvents.createdAt', 'DESC')
       .limit(20);
   }
+
+  static async findByUidAndVerifiedLogin(
+    uid: string,
+    timeframeMs: number
+  ) {
+    const id = uuidTransformer.to(uid);
+    const cutoffDate = Date.now() - timeframeMs;
+
+    return SecurityEvent.query()
+      .select(
+        'securityEventNames.name as name',
+        'securityEvents.verified as verified',
+        'securityEvents.createdAt as createdAt',
+        'securityEvents.ipAddr as ipAddr',
+        'securityEvents.additionalInfo as additionalInfo'
+      )
+      .leftJoin(
+        'securityEventNames',
+        'securityEvents.nameId',
+        'securityEventNames.id'
+      )
+      .where('securityEvents.uid', id)
+      .where('securityEvents.verified', 1)
+      .where('securityEvents.nameId', EVENT_NAMES['account.login'])
+      .where('securityEvents.createdAt', '>=', cutoffDate)
+      .orderBy('securityEvents.createdAt', 'DESC')
+      .limit(20);
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25289,6 +25289,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:1.12.0":
+  version: 1.12.0
+  resolution: "axios@npm:1.12.0"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/44a1e4cfb69a2d59aa12bbc441a336e5c18e87c02b904c509fd33607d94e8cb8cc221c17e9d53f67841a4efe13abf1aa1497c85df390cdb8681ee723998d11b0
+  languageName: node
+  linkType: hard
+
 "axios@npm:1.8.4":
   version: 1.8.4
   resolution: "axios@npm:1.8.4"
@@ -34569,7 +34580,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.59.0"
     "@typescript-eslint/parser": "npm:^7.1.1"
     audit-filter: "npm:^0.5.0"
-    axios: "npm:1.8.4"
+    axios: "npm:1.12.0"
     chance: "npm:^1.1.8"
     convict: "npm:^6.2.4"
     convict-format-with-moment: "npm:^6.2.0"


### PR DESCRIPTION
## Because

-   Users were required to verify their login with a confirmation code every time they signed in, even from devices they regularly use

## This pull request

  - Adds device fingerprinting to skip signin confirmation for recognized devices
  - Implements user agent matching against recent verified logins within a configurable timeframe (default
  7 days)
  - Adds configuration options for enabling/disabling the feature and report-only mode
  - Creates new database query methods to retrieve verified login security events

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12422

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test

1. In dev.json for auth-server, set skipForNewAccounts=false, allowedRecency=0
2. Create an account for Sync
3. Login with account for Sync (first time requires confirmation), disconnect
4. Login again with account for Sync (no prompt for email confirmation), disconnect
5. Login with different Firefox browser (maybe Nightly or Beta) (prompted for confirmation)
