### PR TITLE
chore(mfa): Remove redudant checks for mfa

### DIFF
--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -101,16 +101,6 @@ module.exports = function (
         // The subsequent call to 'getKeys' would fail, ultimately orphaning a passwordChangeToken...
         const sessionToken = request.auth.credentials;
 
-        if (!sessionToken.emailVerified) {
-          statsd.increment('passwordChange.start.emailNotVerified');
-          throw error.unverifiedAccount();
-        }
-
-        if (sessionToken.tokenVerificationId) {
-          statsd.increment('passwordChange.start.sessionNotVerified');
-          throw error.unverifiedSession();
-        }
-
         await customs.checkAuthenticated(
           request,
           sessionToken.uid,

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -44,13 +44,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       async handler(request) {
         log.begin('replaceRecoveryCodes', request);
 
-        const { authenticatorAssuranceLevel, uid } = request.auth.credentials;
-
-        // Since TOTP and backup authentication codes go hand in hand, you should only be
-        // able to replace backup authentication codes in a TOTP verified session.
-        if (!authenticatorAssuranceLevel || authenticatorAssuranceLevel <= 1) {
-          throw errors.unverifiedSession();
-        }
+        const { uid } = request.auth.credentials;
 
         const recoveryCodes = await db.replaceRecoveryCodes(
           uid,
@@ -158,13 +152,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       async handler(request) {
         log.begin('updateRecoveryCodes', request);
 
-        const { authenticatorAssuranceLevel, uid } = request.auth.credentials;
-
-        // Since TOTP and backup authentication codes go hand in hand, you should only be
-        // able to replace backup authentication codes in a TOTP verified session.
-        if (!authenticatorAssuranceLevel || authenticatorAssuranceLevel <= 1) {
-          throw errors.unverifiedSession();
-        }
+        const { uid } = request.auth.credentials;
 
         const { recoveryCodes } = request.payload;
         await db.updateRecoveryCodes(uid, recoveryCodes);

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -53,10 +53,6 @@ module.exports = (
 
         const sessionToken = request.auth.credentials;
 
-        if (sessionToken.tokenVerificationId) {
-          throw errors.unverifiedSession();
-        }
-
         const { uid } = sessionToken;
         const { recoveryKeyId, recoveryData, enabled, replaceKey } =
           request.payload;
@@ -434,11 +430,7 @@ module.exports = (
       async handler(request) {
         log.begin('recoveryKeyDelete', request);
 
-        const { tokenVerificationId, uid } = request.auth.credentials;
-
-        if (tokenVerificationId) {
-          throw errors.unverifiedSession();
-        }
+        const { uid } = request.auth.credentials;
 
         await db.deleteRecoveryKey(uid);
         await recordSecurityEvent('account.recovery_key_removed', {

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -98,15 +98,11 @@ module.exports = (
       handler: async function (request) {
         log.begin('totp.create', request);
 
-        const { email, uid, tokenVerificationId } = request.auth.credentials;
+        const { email, uid } = request.auth.credentials;
 
         const account = await db.account(uid);
         if (!account.emailVerified) {
           throw errors.unverifiedAccount();
-        }
-
-        if (tokenVerificationId) {
-          throw errors.unverifiedSession();
         }
 
         await customs.checkAuthenticated(request, uid, email, 'totpCreate');

--- a/packages/fxa-auth-server/test/local/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-codes.js
@@ -117,16 +117,6 @@ describe('backup authentication codes', () => {
         );
       });
     });
-
-    it("should't replace codes in non-TOTP verified session", () => {
-      requestOptions.credentials.authenticatorAssuranceLevel = 1;
-      return runTest('/recoveryCodes', requestOptions, 'GET').then(
-        assert.fail,
-        (err) => {
-          assert.equal(err.errno, error.ERRNO.SESSION_UNVERIFIED);
-        }
-      );
-    });
   });
 
   describe('PUT /recoveryCodes', () => {
@@ -167,17 +157,6 @@ describe('backup authentication codes', () => {
           }
         );
       });
-    });
-
-    it("should't overwrite codes for non-TOTP verified session", () => {
-      requestOptions.credentials.authenticatorAssuranceLevel = 1;
-      requestOptions.payload.recoveryCodes = ['123'];
-      return runTest('/recoveryCodes', requestOptions, 'PUT').then(
-        assert.fail,
-        (err) => {
-          assert.equal(err.errno, error.ERRNO.SESSION_UNVERIFIED);
-        }
-      );
     });
   });
 

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -784,35 +784,6 @@ describe('DELETE /recoveryKey', () => {
       );
     });
   });
-
-  describe('should fail for unverified session', () => {
-    beforeEach(() => {
-      mockAccountEventsManager = mocks.mockAccountEventsManager();
-      const requestOptions = {
-        method: 'DELETE',
-        credentials: { uid, email, tokenVerificationId: 'unverified' },
-        log,
-      };
-      return setup(
-        { db: { recoveryData } },
-        {},
-        '/recoveryKey',
-        requestOptions
-      ).then(assert.fail, (err) => (response = err));
-    });
-
-    after(() => {
-      mocks.unMockAccountEventsManager();
-    });
-
-    it('returned the correct response', () => {
-      assert.equal(
-        response.errno,
-        errors.ERRNO.SESSION_UNVERIFIED,
-        'unverified session'
-      );
-    });
-  });
 });
 
 describe('POST /recoveryKey/hint', () => {

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -110,18 +110,6 @@ describe('totp', () => {
       });
     });
 
-    it('should be disabled in unverified session', () => {
-      requestOptions.credentials.tokenVerificationId = 'notverified';
-      return setup(
-        { db: { email: TEST_EMAIL, emailVerified: true } },
-        {},
-        '/totp/create',
-        requestOptions
-      ).then(assert.fail, (err) => {
-        assert.deepEqual(err.errno, 138, 'unverified session error');
-      });
-    });
-
     it('should be disabled for unverified email', () => {
       return setup(
         { db: { email: TEST_EMAIL, emailVerified: false } },


### PR DESCRIPTION
## Because

- These checks are now being handled in the `sessionVerifiedToken` auth scheme

## This pull request

- Removes reduduant checks

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12437

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
