### PR TITLE
chore(functional-tests): Add test duration to ci reporter

### DIFF
--- a/packages/functional-tests/lib/ci-reporter.ts
+++ b/packages/functional-tests/lib/ci-reporter.ts
@@ -13,6 +13,29 @@ import {
   TestResult,
 } from '@playwright/test/reporter';
 
+/**
+ * Converts milliseconds to human-readable format
+ * If the time is less than 1 second, it shows milliseconds
+ * If the time is less than 1 minute, it shows seconds
+ * And if over 1 minute, it shows minutes and seconds
+ * @param ms
+ */
+const formatTime = (ms: number) => {
+  // protect against bad input so we don't crash the reporter
+  if (ms === undefined || ms === null || isNaN(ms) || ms < 0) {
+    return 'unknown';
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m${seconds % 60}s`;
+};
+
 class CIReporter implements Reporter {
   private fixmeCount = 0;
   private passCount = 0;
@@ -48,7 +71,7 @@ class CIReporter implements Reporter {
     console.log(
       `${status} ${path.relative(process.cwd(), test.location.file)}: ${
         test.title
-      }`
+      } (${formatTime(result.duration)})`
     );
     if (test.outcome() === 'unexpected') {
       console.log(result.error?.stack);


### PR DESCRIPTION
Because:
 - We only capture and report the top 10 slowest tests, that take > 15 seconds
 - And we want better visibility into long running individual tests

This Commit:
 - Adds a human readable format of test duration to each test output for CI

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1563" height="564" alt="image" src="https://github.com/user-attachments/assets/aebca81b-6424-4db6-8338-65dc79497840" />


## Other information (Optional)

Any other information that is important to this pull request.
