### PR TITLE
chore(yarn): Update yarn.lock from dependabot axios 1.8.4 to 1.12.0 upgrade

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25289,6 +25289,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:1.12.0":
+  version: 1.12.0
+  resolution: "axios@npm:1.12.0"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/44a1e4cfb69a2d59aa12bbc441a336e5c18e87c02b904c509fd33607d94e8cb8cc221c17e9d53f67841a4efe13abf1aa1497c85df390cdb8681ee723998d11b0
+  languageName: node
+  linkType: hard
+
 "axios@npm:1.8.4":
   version: 1.8.4
   resolution: "axios@npm:1.8.4"
@@ -34569,7 +34580,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^5.59.0"
     "@typescript-eslint/parser": "npm:^7.1.1"
     audit-filter: "npm:^0.5.0"
-    axios: "npm:1.8.4"
+    axios: "npm:1.12.0"
     chance: "npm:^1.1.8"
     convict: "npm:^6.2.4"
     convict-format-with-moment: "npm:^6.2.0"


### PR DESCRIPTION
#19445 should have included this `yarn.lock` update.