### PR TITLE
bug(settings): Add pre-check for JWT expiration

### DIFF
--- a/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/MfaGuard/index.test.tsx
@@ -106,6 +106,29 @@ describe('MfaGuard', () => {
     expect(mockAuthClient.mfaRequestOtp).not.toHaveBeenCalled();
   });
 
+  it('renders dialog when JWT has expired', async () => {
+    // Set an expired token...
+    JwtTokenCache.setToken(
+      mockSessionToken,
+      mockScope,
+      // The middle part of the string is the payload. The other parts don't matter for this test.
+      '__.eyJzdWIiOiI4YjMzNmZlNGE5MmM0ZTk5YmMyNGIyMjFmOTUzMzk0MiIsInNjb3BlIjpbIm1mYTpyZWNvdmVyeV9rZXkiXSwiaWF0IjoxNzU5MjQ3MTE3LCJqdGkiOiJjYmY1N2M2MC1hYzcwLTRhNGEtYTdkMy0wN2U0NTdlM2E4MWYiLCJzdGlkIjoiMzI5ZjQzNTFiMDUwN2QwNDVmNDYxZWQxNWY4MzZmNDM3MDBhMmM0YTk5NmVlMWM1ODMxZTQzNGIxZjc4ZjFhNCIsImV4cCI6MTc1OTI0NzE0NywiYXVkIjoiZnhhIiwiaXNzIjoiYWNjb3VudHMuZmlyZWZveC5jb20ifQ.__'
+    );
+
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext()}>
+        <MfaGuard requiredScope={mockScope}>
+          <div>secured</div>
+        </MfaGuard>
+      </AppContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText('Enter confirmation code')).toBeInTheDocument();
+      expect(mockAuthClient.mfaRequestOtp).toHaveBeenCalled();
+    });
+  });
+
   it('shows error banner on invalid OTP', async () => {
     renderWithRouter(
       <AppContext.Provider value={mockAppContext()}>

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -19,6 +19,7 @@ import {
   getStoredAccountData,
   sessionToken,
   JwtTokenCache,
+  JwtNotFoundError,
 } from '../lib/cache';
 import firefox from '../lib/channels/firefox';
 import Storage from '../lib/storage';
@@ -1631,11 +1632,11 @@ export class Account implements AccountData {
   getCachedJwtByScope(scope: MfaScope) {
     const token = sessionToken();
     if (!token) {
-      throw AuthUiErrors.INVALID_TOKEN;
+      throw new JwtNotFoundError('Missing parent session token.');
     }
     const hasJwt = JwtTokenCache.hasToken(token, scope);
     if (!hasJwt) {
-      throw AuthUiErrors.INVALID_TOKEN;
+      throw new JwtNotFoundError('Missing or expired jwt.');
     }
 
     return JwtTokenCache.getToken(token, scope);


### PR DESCRIPTION
## Because

- If a flow is started with an expired token, the MFA dialog will not render until a web request is made that invalidates the token. Once the token is invalidated, the flow must be restarted... This is pretty annoying!

## This pull request

- Adds the ability to decode the JWT's payload
- Adds a check to determine if the JWT is expired to the hasToken check.
- If the token is expired, hasToken returns false, and the MFA dialog will render, so the user can get a valid JWT before the flow starts.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To make this easier to test, change the config for `mfa.jwt.expiresIn` to 30 seconds in the auth server config.

Testing steps:
- Sign in
- Click account recovery key
- Go through flow
- Wait for JWT to expire
- Click 'change' on account recovery key
- You should see the MFA dialog again
