### PR TITLE
fix(auth): Remove invoice line item if zero

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -302,7 +302,6 @@ module.exports = function (log, config, bounces, statsd) {
   const validPaymentProviders = Object.keys(PAYMENT_METHOD_PROVIDER);
   const validCardTypes = Object.keys(CARD_TYPE_TO_TEXT);
 
-
   function Mailer(mailerConfig, sender) {
     let options = {
       host: mailerConfig.host,
@@ -3280,6 +3279,7 @@ module.exports = function (log, config, bounces, statsd) {
             invoiceTotalCurrency,
             message.acceptLanguage
           ),
+        invoiceTaxAmountInCents,
         invoiceTaxAmount:
           invoiceTaxAmountInCents &&
           this._getLocalizedCurrencyString(
@@ -3294,7 +3294,9 @@ module.exports = function (log, config, bounces, statsd) {
             invoiceTotalCurrency,
             message.acceptLanguage
           ),
-        cardName: validCardTypes.includes(cardType) ? cardTypeToText(cardType) : undefined,
+        cardName: validCardTypes.includes(cardType)
+          ? cardTypeToText(cardType)
+          : undefined,
         lastFour,
         nextInvoiceDate,
         paymentProrated,

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/index.mjml
@@ -124,7 +124,7 @@
   </mj-text>
 <% } %>
 
-<% if (showTaxAmount) { %>
+<% if (showTaxAmount && invoiceTaxAmountInCents > 0 ) { %>
   <mj-text css-class="text-body-table-no-bottom-margin">
     <table width="100%">
       <tr style="line-height: 24px; border-top: 1px solid #E0E0E6;">

--- a/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/subscriptionCharges/index.txt
@@ -25,7 +25,7 @@ subscriptionFirstInvoiceDiscount-content-subtotal = "Subtotal: <%- invoiceSubtot
   subscription-charges-discount-plaintext = "Discount: <%- invoiceDiscountAmount %>"
 <% } %>
 <% } %>
-<% if (showTaxAmount) { %>
+<% if (showTaxAmount && invoiceTaxAmountInCents > 0) { %>
   subscriptionCharges-content-tax = "Taxes & fees: <%- invoiceTaxAmount %>"
 <% } %>
 <% if (invoiceTotalInCents !== invoiceAmountDueInCents) { %>

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -2355,6 +2355,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `<b>Date:</b> March 20, 2020` },
       { test: 'include', expected: `Your next invoice will be issued on April 19, 2020` },
       { test: 'include', expected: `View invoice` },
+      { test: 'notInclude', expected: `Taxes &amp; fees` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]],
@@ -2368,11 +2369,12 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Date: March 20, 2020` },
       { test: 'include', expected: `Your next invoice will be issued on April 19, 2020` },
       { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: `Taxes &amp; fees` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]]]),
     {updateTemplateValues: x => (
-      {...x, cardType: 'Unknown'})}
+      {...x, cardType: 'Unknown', invoiceTaxAmountInCents: 0})}
   ],
 
 


### PR DESCRIPTION
## Because

- The invoice shows 0 as the amount for Taxes and fees

## This pull request

- Removes the invoice line item if zero

## Issue that this pull request solves

Closes: PAY-3317

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.