### PR TITLE
fix(payments-next): [Payments-Next Subscription] Error message not dismissed when selecting another card

### DIFF
--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
@@ -56,6 +56,7 @@ export function PaymentMethodManagement({
     event: StripePaymentElementChangeEvent
   ) => {
     setIsComplete(event.complete);
+    setError(null);
 
     if (event.value.type !== 'card') {
       setIsNonCardSelected(true);


### PR DESCRIPTION
## Because

- The error message persists until the user changes the default card, adds another card or refreshes the page.

## This pull request

- Dismisses the error when the user selects a different payment method.

## Issue that this pull request solves

Closes: #[PAY-3305](https://mozilla-hub.atlassian.net/browse/PAY-3305)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3305]: https://mozilla-hub.atlassian.net/browse/PAY-3305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ