### PR TITLE
task(auth): Add verified session checks to mfa strategy

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -494,7 +494,7 @@ async function create(log, error, config, routes, db, statsd, glean, customs) {
 
   server.auth.scheme(
     'mfa',
-    mfa.strategy(config, makeCredentialFn(db.sessionToken.bind(db)))
+    mfa.strategy(config, makeCredentialFn(db.sessionToken.bind(db)), db, statsd)
   );
   server.auth.strategy('mfa', 'mfa');
 

--- a/packages/fxa-auth-server/test/local/routes/mfa.js
+++ b/packages/fxa-auth-server/test/local/routes/mfa.js
@@ -66,10 +66,18 @@ describe('mfa', () => {
   }
 
   async function runAuthStrategyTest(token) {
-    const { authenticate } = strategy(config, mockGetCredentialsFunc)();
+    const { authenticate } = strategy(
+      config,
+      mockGetCredentialsFunc,
+      db,
+      statsd
+    )();
     const req = {
       headers: {
         authorization: 'Bearer ' + token,
+      },
+      route: {
+        path: '/v1/test',
       },
     };
     const h = {
@@ -91,6 +99,7 @@ describe('mfa', () => {
     db = mocks.mockDB({
       uid: UID,
       email: TEST_EMAIL,
+      emailVerified: true,
     });
     // TODO: Add and check glean events
     // glean = mocks.mockGlean();
@@ -101,6 +110,7 @@ describe('mfa', () => {
       id: SESSION_TOKEN_ID,
       uid: UID,
       uaBrowser: UA_BROWSER,
+      authenticatorAssuranceLevel: 2,
     });
 
     Container.set(OtpUtils, otpUtils);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -724,6 +724,12 @@ function mockDB(data, errors) {
         email: data.email,
       });
     }),
+    totpToken: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string');
+      return Promise.resolve({
+        enabled: false,
+      });
+    }),
   });
 }
 


### PR DESCRIPTION
## Because

- We should ensure the parent session meets the verification requirements

## This pull request

- Copies logic from `verified-session-token.js` into the `mfa.ts` auth strategy

## Issue that this pull request solves

Closes: FXA-12432

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Note, I've also filed a clean up so we can reuse this logic and fix the copy paste. This will done as part of a larger MFA clean up effort.
