### PR TITLE
chore(settings): Handle OAuth Integration invalid scope error

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -34,10 +34,21 @@ import { currentAccount } from '../../lib/cache';
 import { MozServices } from '../../lib/types';
 import mockUseSyncEngines from '../../lib/hooks/useSyncEngines/mocks';
 import useSyncEngines from '../../lib/hooks/useSyncEngines';
+import sentryMetrics from 'fxa-shared/sentry/browser';
+import { OAuthError } from '../../lib/oauth';
 
 jest.mock('../../lib/hooks/useSyncEngines', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+
+jest.mock('fxa-shared/sentry/browser', () => ({
+  __esModule: true,
+  default: {
+    enable: jest.fn(),
+    disable: jest.fn(),
+    captureException: jest.fn(),
+  },
 }));
 
 jest.mock('../../models/contexts/SettingsContext', () => ({
@@ -591,5 +602,132 @@ describe('SettingsRoutes', () => {
       expect(hardNavigateSpy).not.toHaveBeenCalled();
     });
     expect(screen.getByTestId('settings-profile')).toBeInTheDocument();
+  });
+});
+
+describe('Integration serviceName error handling', () => {
+  beforeEach(() => {
+    (useSyncEngines as jest.Mock).mockReturnValue(mockUseSyncEngines());
+    (useInitialMetricsQueryState as jest.Mock).mockReturnValue({
+      loading: false,
+    });
+    (useLocalSignedInQueryState as jest.Mock).mockReturnValue({
+      data: { isSignedIn: true },
+    });
+    (useSession as jest.Mock).mockReturnValue({
+      isValid: () => true,
+    });
+    (currentAccount as jest.Mock).mockReturnValue({
+      uid: '123',
+      sessionToken: '123',
+    });
+  });
+
+  afterEach(() => {
+    (useSyncEngines as jest.Mock).mockRestore();
+    (useInitialMetricsQueryState as jest.Mock).mockRestore();
+    (useLocalSignedInQueryState as jest.Mock).mockRestore();
+    (useSession as jest.Mock).mockRestore();
+    (currentAccount as jest.Mock).mockRestore();
+    (sentryMetrics.captureException as jest.Mock).mockClear();
+  });
+
+  it('shows OAuthDataError component when OAuth integration throws', async () => {
+    const mockError = new OAuthError(109, { param: 'scope' });
+    const mockOAuthIntegration = {
+      type: IntegrationType.OAuthWeb,
+      isSync: jest.fn().mockReturnValue(false),
+      isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
+      getServiceName: jest.fn().mockImplementation(() => {
+        throw mockError;
+      }),
+      getClientId: jest.fn(),
+      data: {},
+      getCmsInfo: jest.fn(),
+    };
+
+    (useIntegration as jest.Mock).mockReturnValue(mockOAuthIntegration);
+
+    await act(async () => {
+      renderWithLocalizationProvider(
+        <AppContext.Provider
+          value={{ ...mockAppContext(), ...createAppContext() }}
+        >
+          <App flowQueryParams={updatedFlowQueryParams} />
+        </AppContext.Provider>
+      );
+    });
+
+    expect(sentryMetrics.captureException).toHaveBeenCalledWith(mockError);
+    expect(screen.getByText('Bad Request')).toBeInTheDocument();
+    expect(screen.getByText(mockError.message)).toBeInTheDocument();
+  });
+
+  it('throws error when non-OAuth integration', async () => {
+    const mockError = new Error('Non-OAuth integration error');
+    const mockNonOAuthIntegration = {
+      type: IntegrationType.Web,
+      isSync: jest.fn().mockReturnValue(false),
+      isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
+      getServiceName: jest.fn().mockImplementation(() => {
+        throw mockError;
+      }),
+      getClientId: jest.fn(),
+      data: {},
+      getCmsInfo: jest.fn(),
+    };
+
+    (useIntegration as jest.Mock).mockReturnValue(mockNonOAuthIntegration);
+
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    await expect(
+      act(async () => {
+        renderWithLocalizationProvider(
+          <AppContext.Provider
+            value={{ ...mockAppContext(), ...createAppContext() }}
+          >
+            <App flowQueryParams={updatedFlowQueryParams} />
+          </AppContext.Provider>
+        );
+      })
+    ).rejects.toThrow('Non-OAuth integration error');
+
+    expect(sentryMetrics.captureException).toHaveBeenCalledWith(mockError);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles OAuthNative integration error correctly', async () => {
+    const mockError = new OAuthError(109, { param: 'scope' });
+    const mockOAuthNativeIntegration = {
+      type: IntegrationType.OAuthNative,
+      isSync: jest.fn().mockReturnValue(false),
+      isFirefoxClientServiceRelay: jest.fn().mockReturnValue(false),
+      getServiceName: jest.fn().mockImplementation(() => {
+        throw mockError;
+      }),
+      getClientId: jest.fn(),
+      data: {},
+      getCmsInfo: jest.fn(),
+    };
+
+    (useIntegration as jest.Mock).mockReturnValue(mockOAuthNativeIntegration);
+
+    await act(async () => {
+      renderWithLocalizationProvider(
+        <AppContext.Provider
+          value={{ ...mockAppContext(), ...createAppContext() }}
+        >
+          <App flowQueryParams={updatedFlowQueryParams} />
+        </AppContext.Provider>
+      );
+    });
+
+    expect(sentryMetrics.captureException).toHaveBeenCalledWith(mockError);
+    expect(screen.getByText('Bad Request')).toBeInTheDocument();
+    expect(screen.getByText(mockError.message)).toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -24,6 +24,7 @@ import { MozServices } from '../../lib/types';
 
 import {
   Integration,
+  isOAuthIntegration,
   useConfig,
   useInitialMetricsQueryState,
   useIntegration,
@@ -152,6 +153,7 @@ const AuthorizationContainer = lazy(
   () => import('../../pages/Authorization/container')
 );
 const CookiesDisabled = lazy(() => import('../../pages/CookiesDisabled'));
+const OAuthDataError = lazy(() => import('../OAuthDataError'));
 const ResetPasswordRecoveryChoiceContainer = lazy(
   () =>
     import('../../pages/ResetPassword/ResetPasswordRecoveryChoice/container')
@@ -418,7 +420,7 @@ const AuthAndAccountSetupRoutes = ({
 } & RouteComponentProps) => {
   const localAccount = currentAccount();
   // TODO: MozServices / string discrepancy, FXA-6802
-  const serviceName = integration.getServiceName() as MozServices;
+  let serviceName: MozServices;
   const location = useLocation();
   const { enabled: gleanEnabled } = GleanMetrics.useGlean();
 
@@ -427,6 +429,23 @@ const AuthAndAccountSetupRoutes = ({
   }, [location.pathname, gleanEnabled]);
 
   const useSyncEnginesResult = useSyncEngines(integration);
+  try {
+    // Handle getServiceName() errors that occur when OAuth scope validation fails.
+    // This can happen when scopes are missing, invalid, or filtered out during
+    // trusted/untrusted client validation. For OAuth integrations, show a user-friendly
+    // error page instead of letting it bubble up to the general error boundary.
+    serviceName = integration.getServiceName() as MozServices;
+  } catch (err: any) {
+    sentryMetrics.captureException(err);
+    if (isOAuthIntegration(integration)) {
+      return (
+        <Suspense fallback={<LoadingSpinner fullScreen />}>
+          <OAuthDataError error={err} />
+        </Suspense>
+      );
+    }
+    throw err;
+  }
 
   return (
     <Suspense fallback={<LoadingSpinner fullScreen />}>

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -7,6 +7,12 @@ import {
   OAuthWebIntegration,
   replaceItemInArray,
 } from './oauth-web-integration';
+import * as Sentry from '@sentry/browser';
+import { OAUTH_ERRORS, OAuthError } from '../../lib/oauth';
+
+jest.mock('@sentry/browser', () => ({
+  captureException: jest.fn(),
+}));
 
 describe('models/integrations/oauth-relier', function () {
   let data: ModelDataStore;
@@ -142,6 +148,85 @@ describe('models/integrations/oauth-relier', function () {
         expect(() => {
           integration.getNormalizedScope();
         }).toThrow();
+      });
+    });
+
+    describe('Sentry error capture', () => {
+      const EMPTY_SCOPE = '   '; // Whitespace-only scope that will result in empty permissions
+      const INVALID_UNTRUSTED_SCOPE = 'invalid:scope another:invalid';
+
+      function getIntegrationForSentryTest(
+        scope: string,
+        isTrusted: boolean = false
+      ) {
+        const integration = new OAuthWebIntegration(
+          new GenericData({
+            scope,
+            service: 'test-service',
+          }),
+          new GenericData({}),
+          {
+            scopedKeysEnabled: true,
+            scopedKeysValidation: {},
+            isPromptNoneEnabled: true,
+            isPromptNoneEnabledClientIds: [],
+          }
+        );
+
+        // Set clientId after construction to avoid validation issues
+        integration.data.clientId = 'a1b2c3d4e5f6789012345678901234567890abcd';
+        integration.isTrusted = () => isTrusted;
+        return integration;
+      }
+
+      /**
+       * If a test should expect an OAuth scope error, use this function to assert the error was captured.
+       * @param scope
+       */
+      function expectSentryOAuthScopeError(scope: string) {
+        expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+
+        const sentryCall = (Sentry.captureException as jest.Mock).mock.calls[0];
+        const capturedError = sentryCall[0];
+        const sentryContext = sentryCall[1];
+
+        expect(capturedError).toBeInstanceOf(OAuthError);
+        expect(capturedError.errno).toBe(OAUTH_ERRORS.INVALID_PARAMETER.errno);
+        expect(sentryContext).toEqual({
+          tags: { area: 'OAuthWebIntegration.getPermissions' },
+          extra: {
+            scope,
+            clientId: 'a1b2c3d4e5f6789012345678901234567890abcd',
+            service: 'test-service',
+          },
+        });
+      }
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('captures Sentry error and throws OAuthError when permissions array is empty', () => {
+        const integration = getIntegrationForSentryTest(EMPTY_SCOPE, false);
+
+        expect(() => {
+          integration.getPermissions();
+        }).toThrow(OAuthError);
+
+        expectSentryOAuthScopeError(EMPTY_SCOPE);
+      });
+
+      it('captures Sentry error and throws OAuthError when untrusted scope results in empty permissions', () => {
+        const integration = getIntegrationForSentryTest(
+          INVALID_UNTRUSTED_SCOPE,
+          false
+        );
+
+        expect(() => {
+          integration.getPermissions();
+        }).toThrow(OAuthError);
+
+        expectSentryOAuthScopeError(INVALID_UNTRUSTED_SCOPE);
       });
     });
 


### PR DESCRIPTION
Because:
 - We occasionally see errors about invalid OAuth Parameter: scope

This Commit:
 - Gracefully handles that error and displays the OAuthDataError component
 - Still captures exception in Sentry

Closes: FXA-12088

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Oddly, starting on October 1st, [the error](https://mozilla.sentry.io/issues/6736755671/?environment=prod&project=6231069&query=is%3Aunresolved%20Invalid%20Oauth%20Parameter&referrer=issue-stream) that this issue was originally for dropped significantly (1K+/day, ~15-20/day). 

I'm unsure why that error count dropped so significantly. But, I went ahead and made sure that error is handled gracefully with the `OAuthDataError` component as it was noted in `oauth-web-integration`. I wanted to make sure we don't lose the error if it happens so I also included the sentry captureError.

Admittedly, I'm not sure this is the right path. From the errors that we're getting, it looks like we're getting valid scopes incoming on the request, at least according to sentry they're on the queryParams. The scope matches the client_id on the request, and the error in question only throws if there are _no_ scopes. This at least makes for a nicer user experience than the "General Application Error" they would get today