### PR TITLE
fix(payments-next): [SP3] Postal Code field on country selector modal allows unlimited characters

### DIFF
--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
@@ -421,6 +421,16 @@ const Expanded = ({
                   invalidPostalCode: false,
                 }));
               }}
+              onInvalid={(e: React.FormEvent<HTMLInputElement>) => {
+                if (e.currentTarget.validity.patternMismatch) {
+                  setServerErrors((prev) => ({
+                    ...prev,
+                    invalidPostalCode: true,
+                  }));
+                }
+              }}
+              pattern="^[\p{L}\p{N}\s\-\.\,]{1,15}$"
+              maxLength={15}
               defaultValue={initialPostalCode}
               required
               aria-required


### PR DESCRIPTION
## Because

- The Postal Code field allows a large number of characters.

## This pull request

- Makes Postal Code field limited to a predefined number of characters.

## Issue that this pull request solves

Closes: #[PAY-3229](https://mozilla-hub.atlassian.net/browse/PAY-3229)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
