### PR TITLE
fix(settings): Redirect users from /settings if session is unverified

### DIFF
--- a/packages/functional-tests/pages/settings/components/connectedService.ts
+++ b/packages/functional-tests/pages/settings/components/connectedService.ts
@@ -2,31 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { ElementHandle, Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 
 export class ConnectedService {
   name = '';
   constructor(
-    readonly element: ElementHandle<Node>,
+    readonly element: Locator,
     readonly page: Page
   ) {}
 
-  static async create(
-    element: ElementHandle<Node>,
-    page: Page
-  ) {
+  static async create(element: Locator, page: Page) {
     const service = new ConnectedService(element, page);
     service.name = await service.getName();
     return service;
   }
 
   async getName() {
-    const p = await this.element.waitForSelector('[data-testid=service-name]');
+    const p = this.element.locator('[data-testid=service-name]');
     return p.innerText();
   }
 
   async signout() {
-    const button = await this.element.waitForSelector(
+    const button = this.element.locator(
       '[data-testid=connected-service-sign-out]'
     );
     return button.click();

--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -123,13 +123,17 @@ export class TotpRow extends UnitRow {
 
 export class ConnectedServicesRow extends UnitRow {
   async services() {
-    const elements = this.page.locator('[data-testid=settings-connected-service]');
+    const elements = this.page.locator(
+      '[data-testid=settings-connected-service]'
+    );
     // there should be multiple, but you cannot call `.waitFor()` on a locator
     // that returns multiple elements.
     await elements.first().waitFor({ state: 'attached' });
-    const elementHandles = await elements.elementHandles();
+    const count = await elements.count();
     return Promise.all(
-      elementHandles.map((el) => ConnectedService.create(el, this.page))
+      Array.from({ length: count }, (_, i) =>
+        ConnectedService.create(elements.nth(i), this.page)
+      )
     );
   }
 }

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { RouteComponentProps, Router, useLocation } from '@reach/router';
+import {
+  navigate,
+  RouteComponentProps,
+  Router,
+  useLocation,
+} from '@reach/router';
 import {
   lazy,
   Suspense,
@@ -34,8 +39,6 @@ import {
   initializeSettingsContext,
   SettingsContext,
 } from '../../models/contexts/SettingsContext';
-
-import { hardNavigate } from 'fxa-react/lib/utils';
 
 import sentryMetrics from 'fxa-shared/sentry/browser';
 
@@ -348,12 +351,6 @@ export const App = ({
     return <LoadingSpinner fullScreen />;
   }
 
-  // If we're on settings route but user is not signed in, redirect immediately
-  if (window.location.pathname?.includes('/settings') && !isSignedIn) {
-    hardNavigate('/');
-    return <LoadingSpinner fullScreen />;
-  }
-
   return (
     <Router basepath="/">
       <AuthAndAccountSetupRoutes
@@ -389,7 +386,7 @@ const SettingsRoutes = ({
       // For regular RP / web logins, maybe the session token expired. In this
       // case we just send them to the root.
       params.set('redirect_to', location.pathname);
-      hardNavigate(`/?${params.toString()}`);
+      navigate(`/?${params.toString()}`);
     }
 
     return <LoadingSpinner fullScreen />;

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as Sentry from '@sentry/browser';
 import SettingsLayout from './SettingsLayout';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
@@ -47,6 +47,7 @@ export const Settings = ({
   const account = useAccount();
   const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
+  const [sessionVerified, setSessionVerified] = useState<boolean | undefined>();
 
   useEffect(() => {
     /**
@@ -120,7 +121,13 @@ export const Settings = ({
     gleanEnabled && GleanMetrics.pageLoad(location.pathname);
   }, [location.pathname, gleanEnabled]);
 
-  if (loading) {
+  useEffect(() => {
+    (async () => {
+      setSessionVerified(await session.isSessionVerified());
+    })();
+  }, [session]);
+
+  if (loading || sessionVerified === undefined) {
     return <LoadingSpinner fullScreen />;
   }
 
@@ -131,13 +138,14 @@ export const Settings = ({
     return <AppErrorDialog data-testid="error-dialog" />;
   }
 
-  // If the account email isn't verified, kick back to root to prompt for verification.
-  // This should only happen if the user tries to access /settings directly
-  // without entering a confirmation code on confirm_signup_code page.
-  // Session verification requirement and redirect is handled on initial app load
-  // (look for isUnverifiedSessionError in lib/gql.ts for that handling)
-  if (account.primaryEmail.verified === false) {
-    console.warn('Account verification is require to access /settings!');
+  // If the account email isn't verified or the user is an unverified session state,
+  // kick back to root to prompt for verification. This should only happen if the user
+  // tries to access /settings directly without entering a confirmation code on
+  // confirm_signup_code page or signin_token_code page.
+  if (account.primaryEmail.verified === false || sessionVerified === false) {
+    console.warn(
+      'Account or email verification is require to access /settings!'
+    );
     navigateWithQuery('/');
     return <LoadingSpinner fullScreen />;
   }

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -45,6 +45,9 @@ const isUnauthorizedError = (error: GraphQLError | GraphQLFormattedError) => {
  * not verified the login via email/2FA. Note, the email can be verified but not the
  * session. Only certain queries/API calls require a verified session.
  *
+ * TODO: FXA-12454 do we still need this or at least can it be removed for the
+ * '/settings' check?
+ *
  * @param error
  */
 const isUnverifiedSessionError = (


### PR DESCRIPTION
Because:
* Users should not be able to directly bypass /signin_token_code

This commit:
* Uses session.isSessionVerified to check if the user should be redirected away

closes FXA-12472

---

We can now use `session.isSessionVerified` for this as of my last PR.

You can test this with the `SIGNIN_CONFIRMATION_TOKEN_VERIFICATION` flag to get in an unverified state. Try to access settings directly after you're taken to `/signin_token_code`, and see you'll be redirected away from Settings.