### PR TITLE
polish(functional-tests): Use Redis for functional test locking of test number

### DIFF
--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -290,15 +290,17 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(recoveryPhone.addHeader()).toBeVisible();
 
-      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
-      await recoveryPhone.clickSendCode();
+      await target.smsClient.withPhoneLock(async () => {
+        await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
+        await recoveryPhone.clickSendCode();
 
-      await expect(recoveryPhone.confirmHeader).toBeVisible();
+        await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      const code = await target.smsClient.getCode({ ...credentials });
+        const code = await target.smsClient.getCode({ ...credentials });
 
-      await recoveryPhone.enterCode(code);
-      await recoveryPhone.clickConfirm();
+        await recoveryPhone.enterCode(code);
+        await recoveryPhone.clickConfirm();
+      });
 
       await page.waitForURL(/settings/);
 
@@ -375,10 +377,11 @@ test.describe('severity-1 #smoke', () => {
       });
 
       // Get SMS code and enter it
-      const smsCode = await target.smsClient.getCode({ ...credentials });
-
-      await signinRecoveryPhone.enterCode(smsCode);
-      await signinRecoveryPhone.clickConfirm();
+      await target.smsClient.withPhoneLock(async () => {
+        const smsCode = await target.smsClient.getCode({ ...credentials });
+        await signinRecoveryPhone.enterCode(smsCode);
+        await signinRecoveryPhone.clickConfirm();
+      });
 
       // Verify successful login
       expect(await relier.isLoggedIn()).toBe(true);

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -144,15 +144,17 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/inline_recovery_setup/);
 
       await totp.chooseRecoveryPhoneOption();
-      await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
-      await recoveryPhone.clickSendCode();
+      await target.smsClient.withPhoneLock(async () => {
+        await recoveryPhone.enterPhoneNumber(target.smsClient.getPhoneNumber());
+        await recoveryPhone.clickSendCode();
 
-      await expect(recoveryPhone.confirmHeader).toBeVisible();
+        await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-      const smsCode = await target.smsClient.getCode({ ...credentials });
+        const smsCode = await target.smsClient.getCode({ ...credentials });
 
-      await recoveryPhone.enterCode(smsCode);
-      await recoveryPhone.clickConfirm();
+        await recoveryPhone.enterCode(smsCode);
+        await recoveryPhone.clickConfirm();
+      });
 
       await page.getByRole('button', { name: 'Continue' }).click();
 

--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -440,15 +440,17 @@ test.describe('reset password with recovery phone', () => {
 
     await expect(recoveryPhone.addHeader()).toBeVisible();
 
-    await recoveryPhone.enterPhoneNumber(testNumber);
-    await recoveryPhone.clickSendCode();
+    await target.smsClient.withPhoneLock(async () => {
+      await recoveryPhone.enterPhoneNumber(testNumber);
+      await recoveryPhone.clickSendCode();
 
-    await expect(recoveryPhone.confirmHeader).toBeVisible();
+      await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-    let smsCode = await target.smsClient.getCode({ ...credentials });
+      const smsCode = await target.smsClient.getCode({ ...credentials });
 
-    await recoveryPhone.enterCode(smsCode);
-    await recoveryPhone.clickConfirm();
+      await recoveryPhone.enterCode(smsCode);
+      await recoveryPhone.clickConfirm();
+    });
 
     await page.waitForURL(/settings/);
     await expect(settings.alertBar).toHaveText('Recovery phone added');
@@ -475,9 +477,10 @@ test.describe('reset password with recovery phone', () => {
 
     await page.waitForURL(/reset_password_recovery_phone/);
 
-    smsCode = await target.smsClient.getCode({ ...credentials });
-
-    await resetPassword.fillRecoveryPhoneCodeForm(smsCode);
+    await target.smsClient.withPhoneLock(async () => {
+      const smsCode = await target.smsClient.getCode({ ...credentials });
+      await resetPassword.fillRecoveryPhoneCodeForm(smsCode);
+    });
 
     await resetPassword.clickConfirmButton();
 
@@ -527,15 +530,17 @@ test.describe('reset password with recovery phone', () => {
 
     await expect(recoveryPhone.addHeader()).toBeVisible();
 
-    await recoveryPhone.enterPhoneNumber(testNumber);
-    await recoveryPhone.clickSendCode();
+    await target.smsClient.withPhoneLock(async () => {
+      await recoveryPhone.enterPhoneNumber(testNumber);
+      await recoveryPhone.clickSendCode();
 
-    await expect(recoveryPhone.confirmHeader).toBeVisible();
+      await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-    let smsCode = await target.smsClient.getCode({ ...credentials });
+      const smsCode = await target.smsClient.getCode({ ...credentials });
 
-    await recoveryPhone.enterCode(smsCode);
-    await recoveryPhone.clickConfirm();
+      await recoveryPhone.enterCode(smsCode);
+      await recoveryPhone.clickConfirm();
+    });
 
     await page.waitForURL(/settings/);
     await expect(settings.alertBar).toHaveText('Recovery phone added');
@@ -562,11 +567,12 @@ test.describe('reset password with recovery phone', () => {
 
     await page.waitForURL(/reset_password_recovery_phone/);
 
-    smsCode = await target.smsClient.getCode({ ...credentials });
-
-    await resetPassword.fillRecoveryPhoneCodeForm(
-      `${Number(smsCode) + 1}`.padStart(smsCode.length, '0')
-    );
+    await target.smsClient.withPhoneLock(async () => {
+      const smsCode = await target.smsClient.getCode({ ...credentials });
+      await resetPassword.fillRecoveryPhoneCodeForm(
+        `${Number(smsCode) + 1}`.padStart(smsCode.length, '0')
+      );
+    });
 
     await resetPassword.clickConfirmButton();
 

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -299,14 +299,15 @@ const addPhoneRecovery = async ({
   target: BaseTarget;
 }) => {
   await settings.totp.addRecoveryPhoneButton.click();
+  await target.smsClient.withPhoneLock(async () => {
+    await recoveryPhone.submitPhoneNumber();
 
-  await recoveryPhone.submitPhoneNumber();
+    await expect(recoveryPhone.confirmHeader).toBeVisible();
 
-  await expect(recoveryPhone.confirmHeader).toBeVisible();
+    const code = await target.smsClient.getCode({ ...credentials });
 
-  const code = await target.smsClient.getCode({ ...credentials });
-
-  await recoveryPhone.submitCode(code);
+    await recoveryPhone.submitCode(code);
+  });
 
   await expect(settings.alertBar).toHaveText('Recovery phone added');
 };


### PR DESCRIPTION
## Because

- Functional tests require sharing a single phone number for anything that requires a phone

## This pull request

- Creates a locking mechanism for ensuring tests can still run in parallel, but can also take ownership of the phone number when needed

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
