### PR TITLE
fix(auth): Account signup email used in chage 2fa endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -1023,8 +1023,7 @@ module.exports = (
       handler: async function (request) {
         log.begin('totp.replace.create', request);
 
-        const { uid } = request.auth.credentials;
-        const account = await db.account(uid);
+        const { uid, email } = request.auth.credentials;
 
         const { tokenVerified, tokenVerificationId } =
           request.auth.credentials || {};
@@ -1032,12 +1031,7 @@ module.exports = (
           throw errors.unverifiedSession();
         }
 
-        await customs.checkAuthenticated(
-          request,
-          uid,
-          account.email,
-          'totpCreate'
-        );
+        await customs.checkAuthenticated(request, uid, email, 'totpCreate');
 
         // the opposite of `/totp/create` this requires that the user already has
         // a verified TOTP token to be replaced.
@@ -1082,7 +1076,7 @@ module.exports = (
         log.info('totpToken.replace.created', { uid });
         await request.emitMetricsEvent('totpToken.replace.created', { uid });
 
-        const otpauth = authenticator.keyuri(account.email, service, secret);
+        const otpauth = authenticator.keyuri(email, service, secret);
 
         const qrCodeUrl = await qrcode.toDataURL(otpauth, qrCodeOptions);
 
@@ -1152,8 +1146,7 @@ module.exports = (
         log.begin('totp.replace.confirm', request);
 
         const code = request.payload.code;
-        const { uid } = request.auth.credentials;
-        const account = await db.account(uid);
+        const { uid, email } = request.auth.credentials;
 
         const { tokenVerified, tokenVerificationId } =
           request.auth.credentials || {};
@@ -1161,12 +1154,7 @@ module.exports = (
           throw errors.unverifiedSession();
         }
 
-        await customs.checkAuthenticated(
-          request,
-          uid,
-          account.email,
-          'totpReplace'
-        );
+        await customs.checkAuthenticated(request, uid, email, 'totpReplace');
         // check the redis cache for the NEW secret. Since the existing code
         // is verified and stored in the db we must use the redis cache
         const newSharedSecret = await authServerCacheRedis.get(


### PR DESCRIPTION
## Because

* Account signup email is used in change 2fa routes instead of primary email

## This pull request

* Pull email from credentials and not original account.email

## Issue that this pull request solves

Closes: FXA-12504

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
