### PR TITLE
chore(functional-tests): Train 321 bandaid for flaky functional test

### DIFF
--- a/packages/functional-tests/pages/settings/components/connectedService.ts
+++ b/packages/functional-tests/pages/settings/components/connectedService.ts
@@ -23,9 +23,24 @@ export class ConnectedService {
   }
 
   async signout() {
+    /**
+     * This is _not_ an ideal solution. Something about this page and how we build these
+     * page objects is behaving oddly. We can see the button click as the trace shows the
+     * button change color, but it doesn't actually click. This is a workaround until we
+     * can figure out the underlying issue.
+     *
+     * TODO: https://mozilla-hub.atlassian.net/browse/FXA-12517
+     */
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await this.page.waitForTimeout(1500);
+    await this.page
+      .locator('[data-testid=nav-link-connected-services]')
+      .click();
+    await this.page.waitForURL(/#connected-services/);
     const button = this.element.locator(
       '[data-testid=connected-service-sign-out]'
     );
-    return button.click();
+
+    await button.click();
   }
 }


### PR DESCRIPTION
Because:
 - Some of the functional tests are flaky on train 321 during the disconnect sync step

This Commit:
 - Adds a bandaid solution to get tests working again on stage until we can understand more what's happening with race conditions and timings

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

There's a race condition happening in the disconnect sync step, this is a temporary fix to get tests passing on train `321` until FXA-12517 can look deeper and implement a proper fix

<img width="419" height="523" alt="image" src="https://github.com/user-attachments/assets/4af4dee3-2484-42c6-8364-15a2590c5e64" />


## Other information (Optional)
