### PR TITLE
chore(cms): Enhance cms error handling when fetching from Strapi

### DIFF
--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -293,13 +293,14 @@ export function useCmsInfoState() {
 
         let config: RelierCmsInfo | undefined;
 
-        if (response.ok) {
-          config = await response.json();
-        } else {
-          Sentry.captureMessage(
-            `Failure to parse CMS config for clientId ${clientId} and entrypoint ${entrypoint}`
-          );
+        if (!response.ok) {
+          Sentry.captureMessage('Non-OK response from CMS fetchConfig.', {
+            tags: { area: 'useCmsInfoState' },
+            extra: { clientId, entrypoint, status: response.status },
+          });
         }
+
+        config = await response.json();
 
         if (mounted) {
           setState({
@@ -309,9 +310,10 @@ export function useCmsInfoState() {
           });
         }
       } catch (error) {
-        Sentry.captureMessage(
-          `Failure to fetch CMS config for clientId ${clientId} and entrypoint ${entrypoint}`
-        );
+        Sentry.captureException(error, {
+          tags: { area: 'useCmsInfoState' },
+          extra: { clientId, entrypoint },
+        });
 
         if (mounted) {
           setState({


### PR DESCRIPTION
Because:
 - We see a series of errors in Sentry about failures to fetch content for various client and entrypoints

This Commit:
 - Sends messages to Sentry with a bit more context and makes sure both messages are unique to pinpoints failures
 - Updates tests for these changes

Closes: #FXA-12487

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
