### PR TITLE
chore(functional-tests): Train 321 flaky Recovery Code test fix

### DIFF
--- a/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
+++ b/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
@@ -148,6 +148,7 @@ test.describe('severity-1 #smoke', () => {
       },
       testAccountTracker,
     }) => {
+      test.setTimeout(90000); // 1.5 minutes, seeing flakes in CI runs against stage. See FXA-12497.
       const credentials = await signInAccount(
         target,
         page,


### PR DESCRIPTION
Because:
 - The login with backup code tests are long running, and thus bouncing off the 60s limit

This Commit:
 - Temporarily ups the timeout to 90s until optimizations can be made in the test

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Here's the test running locally against stage, _JUST_ over that 60s mark. I have a follow up ticket FXA-12497 to see if we can optimize the test any further.
<img width="1219" height="520" alt="image" src="https://github.com/user-attachments/assets/69aa80ac-3409-4253-bc37-53c448483cfd" />


## Other information (Optional)

Any other information that is important to this pull request.
