### PR TITLE
feat(auth server): Add CMS links to subscription emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
@@ -37,8 +37,8 @@ const commonArgs = {
 
 const subplatCommonArgs = {
   email: 'customer@example.com',
-  subscriptionTermsUrl: 'http://localhost:3031/legal-docs',
-  subscriptionPrivacyUrl: 'http://localhost:3031/legal-docs',
+  subscriptionTermsUrl: 'https://payments-next.example.com/tos',
+  subscriptionPrivacyUrl: 'https://payments-next.example.com/privacy',
   cancelSubscriptionUrl: 'http://localhost:3030/subscriptions',
   updateBillingUrl: 'http://localhost:3030/subscriptions',
   reactivateSubscriptionUrl: 'http://localhost:3030/subscriptions',

--- a/packages/fxa-auth-server/test/local/senders/index.js
+++ b/packages/fxa-auth-server/test/local/senders/index.js
@@ -12,6 +12,10 @@ const crypto = require('crypto');
 const mocks = require(`${ROOT_DIR}/test/mocks`);
 const senders = require(`${ROOT_DIR}/lib/senders`);
 const sinon = require('sinon');
+const { Container } = require('typedi');
+const {
+  ProductConfigurationManager,
+} = require('../../../../../libs/shared/cms/src');
 
 const nullLog = mocks.mockLog();
 
@@ -467,10 +471,17 @@ describe('lib/senders/index', () => {
 
     describe('subscriptionAccountReminder Emails', () => {
       it('should send an email if the account is unverified', async () => {
+        mocks.mockProductConfigurationManager();
+        Container.set(
+          ProductConfigurationManager,
+          mocks.mockProductConfigurationManager()
+        );
         const mailer = await createSender(config);
         await mailer.sendSubscriptionAccountReminderFirstEmail(EMAILS, acct, {
           email: 'test@test.com',
           uid: '123',
+          planId: '456',
+          acceptLanguage: 'en-US',
           productId: 'abc',
           productName: 'testProduct',
           token: 'token',
@@ -484,10 +495,16 @@ describe('lib/senders/index', () => {
       });
 
       it('should not send an email if the account is verified', async () => {
+        Container.set(
+          ProductConfigurationManager,
+          mocks.mockProductConfigurationManager()
+        );
         const mailer = await createSender(config);
         await mailer.sendSubscriptionAccountReminderFirstEmail(EMAILS, acct, {
           email: 'test@test.com',
           uid: '123',
+          planId: '456',
+          acceptLanguage: 'en-US',
           productId: 'abc',
           productName: 'testProduct',
           token: 'token',

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -1093,6 +1093,30 @@ function mockPriceManager() {
 function mockProductConfigurationManager() {
   const productConfigurationManager = {
     getIapOfferings: sinon.stub(),
+    getPurchaseWithDetailsOfferingContentByPlanIds: sinon.spy(async () => {
+      return {
+        transformedPurchaseWithCommonContentForPlanId: sinon.spy(() => {
+          return {
+            offering: {
+              commonContent: {
+                privacyNoticeDownloadUrl:
+                  'https://payments-next.example.com/privacy',
+                termsOfServiceDownloadUrl:
+                  'https://payments-next.example.com/tos',
+                localizations: [
+                  {
+                    privacyNoticeDownloadUrl:
+                      'https://payments-next.example.com/privacy',
+                    termsOfServiceDownloadUrl:
+                      'https://payments-next.example.com/tos',
+                  },
+                ],
+              },
+            },
+          };
+        }),
+      };
+    }),
   };
   Container.set(ProductConfigurationManager, productConfigurationManager);
   return productConfigurationManager;


### PR DESCRIPTION
Because:

* Current links go through the SP2 payments server, which blocks sunsetting the server

This commit:

* Uses Strapi-provided CMS links for emails where appropriate

Closes #PAY-3318

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
