### PR TITLE
fix(settings): MFA modal closes if 2 secondary emails

### DIFF
--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -334,7 +334,7 @@ export const UnitRowSecondaryEmail = () => {
         {verified && isLastVerifiedSecondaryEmail && (
           <SecondaryEmailDefaultContent />
         )}
-        {pendingChangePrimary && (
+        {pendingChangePrimary === email && (
           <MfaGuard
             requiredScope="email"
             reason={MfaReason.changePrimaryEmail}
@@ -345,7 +345,7 @@ export const UnitRowSecondaryEmail = () => {
             <ChangePrimaryOnMount email={email} />
           </MfaGuard>
         )}
-        {pendingSecondaryDelete && (
+        {pendingSecondaryDelete === email && (
           <MfaGuard
             requiredScope="email"
             reason={MfaReason.removeSecondaryEmail}


### PR DESCRIPTION
## Because

* If a user has 2 secondary emails and they are prompted for MFA code to make an email primary or delete an email, the MFA modal closes on click without letting the user enter their MFA code

## This pull request

* Bind the modal to the intended email so only one modal is displayed (not one per secondary email)
* Add a test case

## Issue that this pull request solves

Closes: FXA-12528

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
