### PR TITLE
task(admin): Add crud operations for managing relying parties

### DIFF
--- a/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
@@ -36,7 +36,19 @@ describe('support agents', () => {
       ).true;
       expect(
         stageGuard.allow(
-          AdminPanelFeature.RelyingPartiesEditNotes,
+          AdminPanelFeature.UpdateRelyingParty,
+          AdminPanelGroup.AdminStage
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.CreateRelyingParty,
+          AdminPanelGroup.AdminStage
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.DeleteRelyingParty,
           AdminPanelGroup.AdminStage
         )
       ).true;
@@ -52,9 +64,22 @@ describe('support agents', () => {
           AdminPanelGroup.SupportAgentProd
         )
       ).true;
+
       expect(
         prodGuard.allow(
-          AdminPanelFeature.RelyingPartiesEditNotes,
+          AdminPanelFeature.CreateRelyingParty,
+          AdminPanelGroup.AdminProd
+        )
+      ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.UpdateRelyingParty,
+          AdminPanelGroup.AdminProd
+        )
+      ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.DeleteRelyingParty,
           AdminPanelGroup.AdminProd
         )
       ).true;

--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -42,7 +42,9 @@ export enum AdminPanelFeature {
   UnlinkAccount = 'UnlinkAccount',
   DeleteAccount = 'DeleteAccount',
   RelyingParties = 'RelyingParties',
-  RelyingPartiesEditNotes = 'RelyingPartiesEditNotes',
+  CreateRelyingParty = 'CreateRelyingParty',
+  UpdateRelyingParty = 'UpdateRelyingParty',
+  DeleteRelyingParty = 'DeleteRelyingParty',
   UnsubscribeFromMailingLists = 'UnsubscribeFromMailingLists',
 }
 
@@ -176,7 +178,15 @@ const defaultAdminPanelPermissions: Permissions = {
     name: 'View Relying Parties',
     level: PermissionLevel.Support,
   },
-  [AdminPanelFeature.RelyingPartiesEditNotes]: {
+  [AdminPanelFeature.CreateRelyingParty]: {
+    name: 'Edit Relying Parties Notes',
+    level: PermissionLevel.Admin,
+  },
+  [AdminPanelFeature.DeleteRelyingParty]: {
+    name: 'Edit Relying Parties Notes',
+    level: PermissionLevel.Admin,
+  },
+  [AdminPanelFeature.UpdateRelyingParty]: {
     name: 'Edit Relying Parties Notes',
     level: PermissionLevel.Admin,
   },

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.gql.ts
@@ -21,8 +21,20 @@ export const GET_RELYING_PARTIES = gql`
   }
 `;
 
-export const UPDATE_NOTE = gql`
-  mutation updateNotes($id: String!, $notes: String!) {
-    updateNotes(id: $id, notes: $notes)
+export const CREATE_RELYING_PARTY = gql`
+  mutation create($relyingParty: RelyingPartyUpdateDto!) {
+    create(relyingParty: $relyingParty)
+  }
+`;
+
+export const UPDATE_RELYING_PARTY = gql`
+  mutation update($id: String!, $relyingParty: RelyingPartyUpdateDto!) {
+    update(id: $id, relyingParty: $relyingParty)
+  }
+`;
+
+export const DELETE_RELYING_PARTY = gql`
+  mutation delete($id: String!) {
+    delete(id: $id)
   }
 `;

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/mocks.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/mocks.tsx
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { MockedResponse } from '@apollo/client/testing';
-import { RelyingParty } from 'fxa-admin-server/src/graphql';
-import { GET_RELYING_PARTIES, UPDATE_NOTE } from './index.gql';
-import { GraphQLError } from 'graphql';
+import { RelyingPartyDto } from 'fxa-admin-server/src/graphql';
+import { GET_RELYING_PARTIES } from './index.gql';
 
 // Response mocks
 export const MOCK_RP_ALL_FIELDS = {
@@ -20,7 +19,7 @@ export const MOCK_RP_ALL_FIELDS = {
     'https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png',
   allowedScopes: 'https://identity.mozilla.com/apps/send',
   notes: null,
-} as RelyingParty;
+} as RelyingPartyDto;
 
 export const MOCK_RP_FALSY_FIELDS = {
   id: '38a6b9b3a65a1871',
@@ -33,11 +32,11 @@ export const MOCK_RP_FALSY_FIELDS = {
   imageUri: '',
   allowedScopes: null,
   notes: null,
-} as RelyingParty;
+} as RelyingPartyDto;
 
 // Apollo mocks
 export const mockGetRelyingParties = (
-  relyingParties: RelyingParty[] = []
+  relyingParties: RelyingPartyDto[] = []
 ): MockedResponse => ({
   request: {
     query: GET_RELYING_PARTIES,
@@ -46,32 +45,5 @@ export const mockGetRelyingParties = (
     data: {
       relyingParties,
     },
-  },
-});
-
-export const mockUpdateNotes = (id: string, notes: string): MockedResponse => ({
-  request: {
-    query: UPDATE_NOTE,
-    variables: { id, notes },
-  },
-  result: {
-    data: {
-      updateNotes: true,
-    },
-  },
-});
-
-export const mockUpdateNotesError = (
-  id: string,
-  notes: string
-): MockedResponse => ({
-  request: {
-    query: UPDATE_NOTE,
-    variables: { id, notes },
-  },
-  result: () => {
-    return {
-      errors: [new GraphQLError('... ER_DATA_TOO_LONG ...')],
-    };
   },
 });

--- a/packages/fxa-admin-panel/src/components/TableYHeaders/index.tsx
+++ b/packages/fxa-admin-panel/src/components/TableYHeaders/index.tsx
@@ -6,7 +6,7 @@ import { ReactElement } from 'react';
 import { HIDE_ROW } from '../../../constants';
 
 interface TableYHeadersProps {
-  header?: string;
+  header?: string | ReactElement | ReactElement[];
   testId?: string;
   className?: string;
   children:
@@ -46,11 +46,25 @@ export const TableYHeaders = ({
   children,
   testId,
   className = 'table-y-headers border-l-thick',
-}: TableYHeadersProps) => (
-  <>
-    {header && <h3 className="header-lg">{header}</h3>}
-    <table {...{ className }} data-testid={testId}>
-      <tbody>{children}</tbody>
-    </table>
-  </>
-);
+}: TableYHeadersProps) => {
+  const Header = () => {
+    return typeof header === 'string' ? (
+      <h3 className="header-lg">{header}</h3>
+    ) : (
+      <>{header || ''}</>
+    );
+  };
+
+  return (
+    <>
+      <table {...{ className }} data-testid={testId}>
+        <thead>
+          <td colSpan={100}>
+            <Header />
+          </td>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </>
+  );
+};

--- a/packages/fxa-admin-server/src/gql/model/relying-party.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/relying-party.model.ts
@@ -1,13 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { Field, ID, InputType, ObjectType } from '@nestjs/graphql';
 
-@ObjectType()
-export class RelyingParty {
-  @Field((type) => ID)
-  id!: string;
-
+@InputType()
+export class RelyingPartyUpdateDto {
   @Field()
   name!: string;
 
@@ -24,7 +21,37 @@ export class RelyingParty {
   publicClient!: boolean;
 
   @Field()
-  createdAt!: number;
+  trusted!: boolean;
+
+  @Field({ nullable: true })
+  allowedScopes!: string;
+
+  @Field({ nullable: true })
+  notes!: string;
+}
+
+@ObjectType()
+export class RelyingPartyDto {
+  @Field((type) => ID)
+  id!: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  imageUri!: string;
+
+  @Field()
+  redirectUri!: string;
+
+  @Field()
+  canGrant!: boolean;
+
+  @Field()
+  publicClient!: boolean;
 
   @Field()
   trusted!: boolean;

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -41,6 +41,17 @@ export enum ProviderId {
     APPLE = "APPLE"
 }
 
+export interface RelyingPartyUpdateDto {
+    name: string;
+    imageUri: string;
+    redirectUri: string;
+    canGrant: boolean;
+    publicClient: boolean;
+    trusted: boolean;
+    allowedScopes?: Nullable<string>;
+    notes?: Nullable<string>;
+}
+
 export interface Location {
     city?: Nullable<string>;
     country?: Nullable<string>;
@@ -211,14 +222,14 @@ export interface AccountDeleteTaskStatus {
     status: string;
 }
 
-export interface RelyingParty {
+export interface RelyingPartyDto {
     id: string;
+    createdAt: DateTime;
     name: string;
     imageUri: string;
     redirectUri: string;
     canGrant: boolean;
     publicClient: boolean;
-    createdAt: number;
     trusted: boolean;
     allowedScopes?: Nullable<string>;
     notes?: Nullable<string>;
@@ -231,7 +242,7 @@ export interface IQuery {
     getEmailsLike(search: string): Nullable<Email[]> | Promise<Nullable<Email[]>>;
     getRecoveryPhonesLike(search: string): Nullable<RecoveryPhone[]> | Promise<Nullable<RecoveryPhone[]>>;
     getDeleteStatus(taskNames: string[]): AccountDeleteTaskStatus[] | Promise<AccountDeleteTaskStatus[]>;
-    relyingParties(): RelyingParty[] | Promise<RelyingParty[]>;
+    relyingParties(): RelyingPartyDto[] | Promise<RelyingPartyDto[]>;
 }
 
 export interface IMutation {
@@ -245,7 +256,10 @@ export interface IMutation {
     unsubscribeFromMailingLists(uid: string): boolean | Promise<boolean>;
     deleteAccounts(locators: string[]): AccountDeleteResponse[] | Promise<AccountDeleteResponse[]>;
     clearEmailBounce(email: string): boolean | Promise<boolean>;
-    updateNotes(id: string, notes: string): boolean | Promise<boolean>;
+    create(relyingParty: RelyingPartyUpdateDto): string | Promise<string>;
+    update(id: string, relyingParty: RelyingPartyUpdateDto): boolean | Promise<boolean>;
+    delete(id: string): boolean | Promise<boolean>;
 }
 
+export type DateTime = any;
 type Nullable<T> = T | null;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -207,18 +207,23 @@ type AccountDeleteTaskStatus {
   status: String!
 }
 
-type RelyingParty {
+type RelyingPartyDto {
   id: ID!
+  createdAt: DateTime!
   name: String!
   imageUri: String!
   redirectUri: String!
   canGrant: Boolean!
   publicClient: Boolean!
-  createdAt: Float!
   trusted: Boolean!
   allowedScopes: String
   notes: String
 }
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
 
 type Query {
   accountByUid(uid: String!): Account
@@ -227,7 +232,7 @@ type Query {
   getEmailsLike(search: String!): [Email!]
   getRecoveryPhonesLike(search: String!): [RecoveryPhone!]
   getDeleteStatus(taskNames: [String!]!): [AccountDeleteTaskStatus!]!
-  relyingParties: [RelyingParty!]!
+  relyingParties: [RelyingPartyDto!]!
 }
 
 type Mutation {
@@ -241,5 +246,18 @@ type Mutation {
   unsubscribeFromMailingLists(uid: String!): Boolean!
   deleteAccounts(locators: [String!]!): [AccountDeleteResponse!]!
   clearEmailBounce(email: String!): Boolean!
-  updateNotes(id: String!, notes: String!): Boolean!
+  create(relyingParty: RelyingPartyUpdateDto!): String!
+  update(id: String!, relyingParty: RelyingPartyUpdateDto!): Boolean!
+  delete(id: String!): Boolean!
+}
+
+input RelyingPartyUpdateDto {
+  name: String!
+  imageUri: String!
+  redirectUri: String!
+  canGrant: Boolean!
+  publicClient: Boolean!
+  trusted: Boolean!
+  allowedScopes: String
+  notes: String
 }

--- a/packages/fxa-shared/db/models/auth/relying-party.ts
+++ b/packages/fxa-shared/db/models/auth/relying-party.ts
@@ -14,7 +14,7 @@ export class RelyingParty extends BaseAuthModel {
   redirectUri!: string;
   canGrant!: boolean;
   publicClient!: boolean;
-  createdAt!: number;
+  createdAt!: Date;
   trusted!: boolean;
   allowedScopes!: string | null;
   notes!: string | null;


### PR DESCRIPTION
## Because

- We want to manage RP state through the admin panel

## This pull request

- Adds the ability to create a new RP
- Adds the ability to delete a RP
- Adds the ability to update an RPs info
- Adds the ability to filter RPs since we have a long list.

## Issue that this pull request solves

Closes: FXA-11032

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
