### PR TITLE
fix(settings): Incorrect cached account selected

### DIFF
--- a/packages/fxa-settings/src/lib/storage-utils.ts
+++ b/packages/fxa-settings/src/lib/storage-utils.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { sessionToken } from './cache';
 import Storage from './storage';
 
 const ORIGINAL_TAB_KEY = 'originalTab';
@@ -99,7 +98,6 @@ export function setCurrentAccount(uid: string) {
 export function storeAccountData(accountData: StoredAccountData) {
   persistAccount(accountData);
   setCurrentAccount(accountData.uid);
-  sessionToken(accountData.sessionToken); // Can we remove this? It seems unnecessary...
 }
 
 export function getCurrentAccountData(): StoredAccountData {

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1039,14 +1039,6 @@ export class Account implements AccountData {
       )
     );
 
-    currentAccount(getStoredAccountData(linkedAccount));
-    sessionToken(linkedAccount.sessionToken);
-
-    this.apolloClient.cache.writeQuery({
-      query: GET_LOCAL_SIGNED_IN_STATUS,
-      data: { isSignedIn: true },
-    });
-
     return linkedAccount;
   }
 


### PR DESCRIPTION
## Because

* If multiple accounts are signed in, the correct account should be signed in during cached signin

## This pull request

* Fix an issue with third party auth signin overwritting session token in local storage
* This issue caused the third party auth account to always be selected during cached signin

## Issue that this pull request solves

Closes: FXA-12395

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

**Pre-requisites:**
Account A created/verified with email + password
Account B created with Third party auth only

**Initial setup (order matters):**
1- Clear cache (localhost:3030/clear)
2- Sign in to account A
3- Observe signed in with account A - Don't sign out!
4- Go to localhost:3030
5- Choose Google auth and sign in with Account B
6- Observe signed in with Account B - Don't sign out!

**Basic STR with web sign in**
1- Go to localhost:3030
2- Account B suggested
3- Click "Use different account"
4- Enter email for account A
5- Cached sign in for Account A (no password input) - click Sign in

Expected result:
Navigated to settings and signed in to Account A

Actual result:
Navigated to settings and singed in to Account B

**Oauth signin** 
1- Go to 123 (localhost:8080)
2- Choose "Email first"
3- Observe suggested sign in to Account B
4- Choose "Use different account"
5- Enter email from account A
6- Cached sign in for Account A (no password input) - click Sign in

Expected result:
Signed in to 123Done with Account A

Actual result:
Signed in to 123Done with Account B

**Subscription checkout**
(see steps in linked ticket)
