### PR TITLE
fix(bug): cleanup when we prompt for email verification

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -236,7 +236,8 @@ const Signin = ({
           // can tell us if it's a sign up. This will be cleaned up in FXA-12454
           if (
             !data.signIn.verified &&
-            data.signIn.verificationReason !== VerificationReasons.SIGN_UP
+            data.signIn.verificationReason !== VerificationReasons.SIGN_UP &&
+            isWebIntegration(integration)
           ) {
             session.sendVerificationCode();
           }


### PR DESCRIPTION
## Because

- We were prompting some OAuth client to confirm email unnecessarily 

## This pull request

- Updates our verification logic to redirect to RP if in a Non OAuthIntegration (ie not Sync)
  - We previously did not require these users to verify login
- Cleans up the verification logic and add comments
- Mor tests

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12520
Closes: https://mozilla-hub.atlassian.net/browse/FXA-12524

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test this flow, in dev.json for auth-server

1. Update dev.json for auth-server, `skipForNewAccount=false` and `securityHistory.ipProfiling.allowRecenty=0`. This effectively forces all logins through a login confirmation on signin
2. Create an account
3. Sign out and try to login to 123Done (should skip login confirmation)
4. Navigate to settings (should prompt for login verification)

With these change we will still require verification before a user gets to settings page.
