### PR TITLE
feat(settings, auth): Add device signout message to 2FA setup

### DIFF
--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -157,7 +157,7 @@ test.describe('severity-1 #smoke', () => {
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -303,7 +303,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/settings/);
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -445,7 +445,7 @@ test.describe('severity-1 #smoke', () => {
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -591,7 +591,7 @@ test.describe('severity-1 #smoke', () => {
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -24,7 +24,7 @@ test.describe('severity-1 #smoke', () => {
       const { secret } =
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -56,7 +56,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.confirmMfaGuard(credentials.email);
       await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
       await expect(settings.totp.status).toHaveText('Enabled');
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await settings.disconnectTotp();

--- a/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
@@ -255,7 +255,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.confirmMfaGuard(credentials.email);
 
       await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
 

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -26,7 +26,7 @@ test.describe('severity-1 #smoke', () => {
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -73,7 +73,7 @@ test.describe('severity-1 #smoke', () => {
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -119,7 +119,7 @@ test.describe('severity-1 #smoke', () => {
         await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');

--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -26,7 +26,7 @@ test.describe('severity-1 #smoke', () => {
     const { secret } = await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');
@@ -86,7 +86,7 @@ test.describe('severity-1 #smoke', () => {
       await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');
@@ -139,7 +139,7 @@ test.describe('severity-1 #smoke', () => {
     await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');
@@ -218,7 +218,7 @@ test.describe('severity-1 #smoke', () => {
     await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');
@@ -293,7 +293,7 @@ test.describe('severity-1 #smoke', () => {
     const { secret } = await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');
@@ -430,7 +430,7 @@ test.describe('reset password with recovery phone', () => {
     await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');
@@ -517,7 +517,7 @@ test.describe('reset password with recovery phone', () => {
       await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       'Two-step authentication has been enabled'
     );
     await expect(settings.totp.status).toHaveText('Enabled');

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -670,7 +670,7 @@ async function setup2faWithBackupCodeChoice(
     await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
   await expect(settings.settingsHeading).toBeVisible();
-  await expect(settings.alertBar).toHaveText(
+  await expect(settings.alertBar).toContainText(
     'Two-step authentication has been enabled'
   );
 
@@ -707,7 +707,7 @@ async function setup2faWithRecoveryPhoneChoice(
   await page.waitForURL(/settings/);
 
   await expect(settings.settingsHeading).toBeVisible();
-  await expect(settings.alertBar).toHaveText(
+  await expect(settings.alertBar).toContainText(
     'Two-step authentication has been enabled'
   );
 

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -179,7 +179,7 @@ const addThenChange2FA = async ({
 }): Promise<{ initial: TotpCredentials; new: TotpCredentials }> => {
   async function assertEnabled(isSetup: boolean) {
     await expect(settings.settingsHeading).toBeVisible();
-    await expect(settings.alertBar).toHaveText(
+    await expect(settings.alertBar).toContainText(
       `Two-step authentication has been ${isSetup ? 'enabled' : 'updated'}`
     );
     await expect(settings.totp.status).toHaveText('Enabled');

--- a/packages/functional-tests/tests/settings/setup2faWithBackupCodes.spec.ts
+++ b/packages/functional-tests/tests/settings/setup2faWithBackupCodes.spec.ts
@@ -29,7 +29,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/settings/);
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -64,7 +64,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/settings/);
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -96,7 +96,7 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/settings/);
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -116,7 +116,7 @@ test.describe('severity-1 #smoke', () => {
       await addTotpWithQrCodeAndBackupCodeChoice(credentials, settings, totp);
 
       await expect(settings.settingsHeading).toBeVisible();
-      await expect(settings.alertBar).toHaveText(
+      await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');

--- a/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
+++ b/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
@@ -245,7 +245,7 @@ async function addTotp(
     await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
 
   await expect(settings.settingsHeading).toBeVisible();
-  await expect(settings.alertBar).toHaveText(
+  await expect(settings.alertBar).toContainText(
     'Two-step authentication has been enabled'
   );
   await expect(settings.totp.status).toHaveText('Enabled');

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en.ftl
@@ -11,3 +11,4 @@ postAddTwoStepAuthentication-recovery-method-codes = You also added backup authe
 postAddTwoStepAuthentication-recovery-method-phone = You also added { $maskedPhoneNumber } as your recovery phone number.
 postAddTwoStepAuthentication-how-protects-link = How this protects your account
 postAddTwoStepAuthentication-how-protects-plaintext = How this protects your account:
+postAddTwoStepAuthentication-device-sign-out-message = To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
@@ -32,6 +32,13 @@
       </a>
     </mj-text>
 
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddTwoStepAuthentication-device-sign-out-message">
+        To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.
+      </span>
+    </mj-text>
+
+
     <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span>
     </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
@@ -13,6 +13,8 @@ postAddTwoStepAuthentication-recovery-method-phone = "You also added <%- maskedP
 postAddTwoStepAuthentication-how-protects-plaintext = "How this protects your account:"
 <%- twoFactorSupportLink %>
 
+postAddTwoStepAuthentication-device-sign-out-message = "To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication."
+
 postAddTwoStepAuthentication-from-device-v2 = "You requested this from:"
 <%- include('/partials/userInfo/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/en.ftl
@@ -7,3 +7,4 @@ postChangeTwoStepAuthentication-from-device = You requested this from:
 postChangeTwoStepAuthentication-action = Manage account
 postChangeTwoStepAuthentication-how-protects-link = How this protects your account
 postChangeTwoStepAuthentication-how-protects-plaintext = How this protects your account:
+postChangeTwoStepAuthentication-device-sign-out-message = To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.mjml
@@ -18,6 +18,12 @@
       </a>
     </mj-text>
 
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postChangeTwoStepAuthentication-device-sign-out-message">
+        To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication.
+      </span>
+    </mj-text>
+
     <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="postChangeTwoStepAuthentication-from-device">You requested this from:</span>
     </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangeTwoStepAuthentication/index.txt
@@ -5,6 +5,8 @@ postChangeTwoStepAuthentication-use-new-account = "You now need to use the new M
 postChangeTwoStepAuthentication-how-protects-plaintext = "How this protects your account:"
 <%- twoFactorSupportLink %>
 
+postChangeTwoStepAuthentication-device-sign-out-message = "To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication."
+
 postChangeTwoStepAuthentication-from-device-v2 = "You requested this from:"
 <%- include('/partials/userInfo/index.txt') %>
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/en.ftl
@@ -1,4 +1,5 @@
 flow-setup-2fa-inline-complete-success-banner = Two-step authentication enabled
+flow-setup-2fa-inline-complete-success-banner-description = To protect all your connected devices, you should sign out everywhere you’re using this account, and then sign back in using your new two-step authentication.
 
 flow-setup-2fa-inline-complete-backup-code = Backup authentication codes
 flow-setup-2fa-inline-complete-backup-phone = Recovery phone

--- a/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetup2faComplete/index.tsx
@@ -104,11 +104,14 @@ export const FlowSetup2faComplete = (props: FlowSetup2faCompleteProps) => {
     <FlowContainer hideBackButton={true}>
       <Banner
         type="success"
-        textAlignClassName="text-center"
         content={{
           localizedHeading: ftlMsgResolver.getMsg(
             'flow-setup-2fa-inline-complete-success-banner',
             'Two-step authentication enabled'
+          ),
+          localizedDescription: ftlMsgResolver.getMsg(
+            'flow-setup-2fa-inline-complete-success-banner-description',
+            'To protect all your connected devices, you should sign out everywhere you’re using this account, and then sign back in using your new two-step authentication.'
           ),
         }}
       ></Banner>

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.stories.tsx
@@ -58,6 +58,7 @@ export const Success = () => (
         navigateForward,
       }}
       sendCode={resendCodeSuccess}
+      showRecoveryPhoneSuccessMessage={true}
       verifyRecoveryCode={verifyRecoveryCodeSuccess}
     />
   </SettingsLayout>
@@ -73,6 +74,7 @@ export const Error = () => (
         navigateForward,
       }}
       sendCode={resendCodeFailure}
+      showRecoveryPhoneSuccessMessage={false}
       verifyRecoveryCode={verifyRecoveryCodeFailure}
     />
   </SettingsLayout>

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.test.tsx
@@ -32,6 +32,7 @@ const defaultProps = {
   navigateForward: mockNavigateForward,
   nationalFormatPhoneNumber: MOCK_NATIONAL_FORMAT_PHONE_NUMBER,
   sendCode: mockSendCode,
+  showRecoveryPhoneSuccessMessage: true,
   verifyRecoveryCode: mockVerifyRecoveryCode,
 };
 

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneConfirmCode/index.tsx
@@ -19,12 +19,12 @@ export type FlowSetupRecoveryPhoneConfirmCodeProps = {
   nationalFormatPhoneNumber: string;
   localizedBackButtonTitle?: string;
   localizedPageTitle: string;
-  localizedSuccessMessage?: string;
   navigateBackward: () => void;
-  navigateForward: () => void;
+  navigateForward?: () => void;
   numberOfSteps?: number;
   reason?: RecoveryPhoneSetupReason;
   sendCode: () => Promise<void>;
+  showRecoveryPhoneSuccessMessage: boolean;
   verifyRecoveryCode: (code: string) => Promise<void>;
 };
 
@@ -33,12 +33,12 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
   nationalFormatPhoneNumber,
   localizedBackButtonTitle,
   localizedPageTitle,
-  localizedSuccessMessage,
   navigateBackward,
   navigateForward,
   numberOfSteps = 2,
   reason = RecoveryPhoneSetupReason.setup,
   sendCode,
+  showRecoveryPhoneSuccessMessage,
   verifyRecoveryCode,
 }: FlowSetupRecoveryPhoneConfirmCodeProps) => {
   const [localizedErrorBannerMessage, setLocalizedErrorBannerMessage] =
@@ -56,9 +56,8 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
   const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
 
-  const successMessage = localizedSuccessMessage
-    ? localizedSuccessMessage
-    : reason === RecoveryPhoneSetupReason.setup
+  const successMessage =
+    reason === RecoveryPhoneSetupReason.setup
       ? ftlMsgResolver.getMsg(
           'flow-setup-phone-confirm-code-success-message-v2',
           'Recovery phone added'
@@ -79,7 +78,10 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
       await sendCode();
       setResendStatus(ResendStatus.sent);
     } catch (error) {
-      const localizedError = getLocalizedErrorMessage(ftlMsgResolver, error);
+      const localizedError: string = getLocalizedErrorMessage(
+        ftlMsgResolver,
+        error
+      );
       setLocalizedErrorBannerMessage(localizedError);
     }
     return;
@@ -91,8 +93,8 @@ export const FlowSetupRecoveryPhoneConfirmCode = ({
     try {
       await verifyRecoveryCode(code);
 
-      alertBar.success(successMessage);
-      navigateForward();
+      showRecoveryPhoneSuccessMessage && alertBar.success(successMessage);
+      navigateForward && navigateForward();
     } catch (error) {
       const localizedError = getLocalizedErrorMessage(ftlMsgResolver, error);
       setLocalizedErrorBannerMessage(localizedError);

--- a/packages/fxa-settings/src/components/Settings/Page2faChange/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/Page2faChange/en.ftl
@@ -2,6 +2,7 @@
 
 page-2fa-change-title = Change two-step authentication
 page-2fa-change-success = Two-step authentication has been updated
+page-2fa-change-success-additional-message = To protect all your connected devices, you should sign out everywhere you’re using this account, and then sign back in using your new two-step authentication.
 page-2fa-change-totpinfo-error = There was an error replacing your two-step authentication app. Try again later.
 page-2fa-change-qr-instruction = <strong>Step 1:</strong> Scan this QR code using any authenticator app, like Duo or Google Authenticator. This creates a new connection, any old connections won’t work anymore.
 

--- a/packages/fxa-settings/src/components/Settings/Page2faChange/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faChange/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { MOCK_TOTP_INFO, Subject } from './mocks';
 import userEvent from '@testing-library/user-event';
@@ -88,15 +88,20 @@ describe('Page2faChange', () => {
     });
     await userEvent.type(codeInput, '000000');
     await userEvent.click(continueButton);
-    await waitFor(() =>
-      expect(mockAlertBar.success).toHaveBeenCalledWith(
-        'Two-step authentication has been updated'
-      )
-    );
+    await waitFor(() => {
+      // the success message is a React node, so we need to render it to test the text
+      const node = mockAlertBar.success.mock.calls[0][0] as React.ReactNode;
+      const { getByText, unmount } = render(<>{node}</>);
+      expect(
+        getByText(/Two-step authentication has been updated/i)
+      ).toBeInTheDocument();
+      unmount();
+    });
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        '/settings#two-step-authentication',
-        { replace: true }
+        '/settings#connected-services',
+        { replace: true },
+        false
       );
     });
 
@@ -122,7 +127,8 @@ describe('Page2faChange', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
         '/settings#two-step-authentication',
-        { replace: true }
+        { replace: true },
+        false
       );
     });
   });

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/en.ftl
@@ -5,5 +5,6 @@ page-2fa-setup-totpinfo-error = There was an error setting up two-step authentic
 # code here refers to "backup authentication code"
 page-2fa-setup-incorrect-backup-code-error = That code is not correct. Try again.
 page-2fa-setup-success = Two-step authentication has been enabled
+page-2fa-setup-success-additional-message = To protect all your connected devices, you should sign out everywhere you’re using this account, and then sign back in using two-step authentication.
 
 ##

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.test.tsx
@@ -272,8 +272,9 @@ describe('Page2faSetup', () => {
         );
         expect(account.completeTotpSetupWithJwt).toHaveBeenCalled();
         expect(mockNavigateWithQuery).toHaveBeenCalledWith(
-          '/settings#two-step-authentication',
-          { replace: true }
+          '/settings#connected-services',
+          { replace: true },
+          false
         );
       });
     });

--- a/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecoveryPhoneSetup/index.tsx
@@ -85,7 +85,9 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
     if (currentStep + 1 <= numberOfSteps) {
       setCurrentStep(currentStep + 1);
     } else {
-      navigateWithQuery(SETTINGS_PATH);
+      navigateWithQuery(`${SETTINGS_PATH}#two-step-authentication`, {
+        replace: true,
+      });
     }
   };
 
@@ -177,6 +179,7 @@ export const PageRecoveryPhoneSetup = (_: RouteComponentProps) => {
           nationalFormatPhoneNumber={
             phoneData.nationalFormat || phoneData.phoneNumber
           }
+          showRecoveryPhoneSuccessMessage={true}
           {...{
             localizedBackButtonTitle,
             localizedPageTitle,

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.tsx
@@ -45,7 +45,7 @@ export const UnitRowTwoStepAuth = () => {
 
   const handleAdd2FAClick = useCallback(() => {
     GleanMetrics.accountPref.twoStepAuthSubmit();
-    navigateWithQuery(route);
+    navigateWithQuery(route, { replace: true }, false);
   }, [navigateWithQuery]);
 
   const conditionalUnitRowProps: Partial<UnitRowProps> =
@@ -117,7 +117,7 @@ export const UnitRowTwoStepAuth = () => {
                   alertBar.hide();
                   navigateWithQuery(
                     `${SETTINGS_PATH}/recovery_phone/remove`,
-                    undefined,
+                    {},
                     false
                   );
                 },
@@ -211,6 +211,7 @@ const DisableTwoStepAuthModal = ({
   const alertBar = useAlertBar();
   const account = useAccount();
   const ftlMsgResolver = useFtlMsgResolver();
+  const navigateWithQuery = useNavigateWithQuery();
   const session = useSession();
 
   useEffect(() => {
@@ -229,6 +230,13 @@ const DisableTwoStepAuthModal = ({
         ),
         () => GleanMetrics.accountPref.twoStepAuthDisableSuccessView()
       );
+      navigateWithQuery(
+        `${SETTINGS_PATH}#two-step-authentication`,
+        {
+          replace: true,
+        },
+        false
+      );
     } catch (e) {
       if (isInvalidJwtError(e)) {
         // JWT invalid/expired.
@@ -246,7 +254,14 @@ const DisableTwoStepAuthModal = ({
 
       Sentry.captureException(e);
     }
-  }, [account, hideDisable2FAModal, alertBar, ftlMsgResolver, errorHandler]);
+  }, [
+    account,
+    alertBar,
+    errorHandler,
+    ftlMsgResolver,
+    hideDisable2FAModal,
+    navigateWithQuery,
+  ]);
 
   return (
     <VerifiedSessionGuard

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/index.tsx
@@ -132,6 +132,7 @@ const InlineRecoverySetup = ({
           navigateForward,
           navigateBackward,
           sendCode: sendSmsCode,
+          showRecoveryPhoneSuccessMessage: false,
           verifyRecoveryCode: verifySmsCode,
           localizedPageTitle,
         }}


### PR DESCRIPTION
## Because

* We want to advise users that they should signout and sign back in to their devices and services after adding 2FA

## This pull request

* Add messaging to alert bar, banner and email after successful 2FA setup

## Issue that this pull request solves

Closes: FXA-12493

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

Add 2fa (from settings)

<img width="2242" height="910" alt="image" src="https://github.com/user-attachments/assets/1c2ec2ec-33e5-4f79-a8a9-290e1ae708a5" />

<img width="3012" height="1994" alt="image" src="https://github.com/user-attachments/assets/0fadcbdb-800f-45e2-96b2-f3eea62ccd6c" />

Change 2fa

<img width="2236" height="928" alt="image" src="https://github.com/user-attachments/assets/a11038a3-d3df-4ab6-b570-957b0276b93e" />

<img width="3012" height="1950" alt="image" src="https://github.com/user-attachments/assets/6177a6d0-828e-4469-81ef-5ef560e4d0ae" />

Inline 2fa setup

<img width="1108" height="1142" alt="image" src="https://github.com/user-attachments/assets/6fd28ec8-1032-4f5d-87e5-9549d8e2fea9" />

## Other information (Optional)

Any other information that is important to this pull request.
