### PR TITLE
fix(l10n): Update cms localization to reuse strings

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/cms.js
+++ b/packages/fxa-auth-server/test/local/routes/cms.js
@@ -10,6 +10,7 @@ const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
 const { Container } = require('typedi');
 const proxyquire = require('proxyquire');
+const crypto = require('crypto');
 
 let log, mockConfig, mockStatsD, routes, route, request;
 let mockCmsManager, mockLocalization;
@@ -399,7 +400,11 @@ describe('cms', () => {
       const baseConfig = createBaseConfig();
       const mockResult = { relyingParties: [baseConfig] };
 
-      const ftlContent = 'Spanish FTL content';
+      // Create hash-based FTL content
+      const headlineHash = crypto.createHash('md5').update('Enter your password').digest('hex').substring(0, 8);
+      const descriptionHash = crypto.createHash('md5').update('Please enter your password to continue').digest('hex').substring(0, 8);
+
+      const ftlContent = `${headlineHash} = Introduzca su contraseña\n${descriptionHash} = para iniciar sesión en Firefox`;
 
       const localizedData = {
         SigninPage: {

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -126,6 +126,7 @@ const settingsConfig = {
   nimbusPreview: config.get('nimbusPreview'),
   cms: {
     enabled: config.get('cms.enabled'),
+    l10nEnabled: config.get('cms.l10nEnabled'),
   },
 };
 

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -261,6 +261,12 @@ const conf = (module.exports = convict({
       env: 'CMS_ENABLED',
       format: Boolean,
     },
+    l10nEnabled: {
+      default: false,
+      doc: 'Enables serving localization content of the CMS',
+      env: 'CMS_L10N_ENABLED',
+      format: Boolean,
+    },
   },
   showReactApp: {
     emailFirstRoutes: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -67,6 +67,7 @@ function getIndexRouteDefinition(config) {
   const GLEAN_LOG_PINGS = config.get('glean.logPings');
   const GLEAN_DEBUG_VIEW_TAG = config.get('glean.debugViewTag');
   const CMS_ENABLED = config.get('cms.enabled');
+  const CMS_L10N_ENABLED = config.get('cms.l10nEnabled');
 
   // Rather than relay all rollout rates, hand pick the ones that are applicable
   const ROLLOUT_RATES = config.get('rolloutRates');
@@ -126,6 +127,7 @@ function getIndexRouteDefinition(config) {
     },
     cms: {
       enabled: CMS_ENABLED,
+      l10nEnabled: CMS_L10N_ENABLED,
     },
     nimbusPreview: NIMBUS_PREVIEW,
     glean: {


### PR DESCRIPTION
## Because

- l10n team wants us to reuse strings instead of having a unique id for each

## This pull request

- Updates ftl id to be `fxa-<hash of text>`
- Updates Github PR generation
- Updates config merging based on the hash ftl id

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12539

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Notes

Here is an example of the PR created by Github now hhttps://github.com/vbudhram/fxa-cms-l10n/pull/16
