### PR TITLE
polish(auth-server): Reduce logging of incoming requests

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -173,63 +173,10 @@ Lug.prototype.summary = function (request, response) {
     phoneNumber: responseBody.formattedPhoneNumber,
   };
 
-  // TODO: Remove after debugging mysterious empty response body reported in FXA-6573
-  //       is complete.
-  if (
-    config.env !== 'prod' &&
-    line.status === 400 &&
-    line.path === '/v1/session/verify_code'
-  ) {
-    try {
-      const body = JSON.stringify(responseBody);
-      this.info('request.summary.debug', {
-        body,
-        bodySize: body.length,
-      });
-    } catch (error) {
-      this.info('request.summary.debug', {
-        bodySize: -1,
-        error,
-      });
-    }
-  }
-
-
-  // TODO: Remove after debugging email confirmations issues
-  if (line.status === 400 &&
-    line.path === '/v1/session/verify_code' &&
-    // Only log for invalid code and invalid parameter errors
-    (line.errno === 107 || line.errno === 183)
-  ) {
-    (async () => {
-      try {
-        const metricsContext = (await request.app.metricsContext) || {};
-        const requestBody = JSON.stringify(payload);
-        const requestQuery = JSON.stringify(query);
-        const requestMetrics = JSON.stringify(metricsContext);
-        const body = JSON.stringify(responseBody);
-        this.info('request.summary.debug.email', {
-          body,
-          requestBody,
-          requestQuery,
-          requestMetrics,
-          bodySize: body.length,
-        });
-      } catch (error) {
-        this.info('request.summary.debug.email', {
-          bodySize: -1,
-          error,
-        });
-      }
-    })();
-  }
-
   if (line.status >= 500) {
     line.trace = request.app.traced;
     line.stack = response.stack;
     this.error('request.summary', line);
-  } else {
-    this.info('request.summary', line);
   }
 };
 

--- a/packages/fxa-auth-server/test/local/log.js
+++ b/packages/fxa-auth-server/test/local/log.js
@@ -718,7 +718,7 @@ describe('log', () => {
     );
   });
 
-  it('.summary should log an info message and call request.emitRouteFlowEvent', () => {
+  it('.summary should not log an info message and should still call request.emitRouteFlowEvent', () => {
     const emitRouteFlowEvent = sinon.spy();
     log.summary(
       {
@@ -762,36 +762,7 @@ describe('log', () => {
       }
     );
 
-    assert.equal(logger.info.callCount, 1);
-    assert.equal(logger.info.args[0][0], 'request.summary');
-    const line = logger.info.args[0][1];
-
-    // Because t is generated using Date.now and subtracting info.received,
-    // it should be >= 0, but we don't know the exact value.
-    assert.isNumber(line.t);
-    assert.isTrue(line.t >= 0);
-
-    // Compare only known values.
-    delete line.t;
-
-    assert.deepEqual(line, {
-      status: 201,
-      errno: 109,
-      rid: 'quuz',
-      path: '/v1/frobnicate',
-      lang: 'en',
-      agent: 'Firefox Fenix',
-      remoteAddressChain: ['95.85.19.180', '78.144.14.50'],
-      accountRecreated: false,
-      uid: 'quid',
-      service: 'corge',
-      reason: 'grault',
-      redirectTo: 'garply',
-      keys: true,
-      method: 'get',
-      email: 'quix',
-      phoneNumber: 'garply',
-    });
+    assert.equal(logger.info.callCount, 0);
 
     assert.equal(emitRouteFlowEvent.callCount, 1);
     assert.equal(emitRouteFlowEvent.args[0].length, 1);
@@ -804,64 +775,6 @@ describe('log', () => {
       },
     });
     assert.equal(logger.error.callCount, 0);
-  });
-
-  it('.summary with email in payload', () => {
-    log.summary(
-      {
-        app: {},
-        auth: {
-          credentials: {
-            uid: 'quid',
-          },
-        },
-        emitRouteFlowEvent: () => {},
-        headers: {},
-        info: {
-          received: Date.now(),
-        },
-        method: 'get',
-        path: '/v1/frobnicate',
-        payload: {
-          email: 'quix',
-        },
-      },
-      {
-        code: 200,
-        statusCode: 201,
-      }
-    );
-
-    assert.equal(logger.info.args[0][1].email, 'quix');
-  });
-
-  it('.summary with email in query', () => {
-    log.summary(
-      {
-        app: {},
-        auth: {
-          credentials: {
-            uid: 'quid',
-          },
-        },
-        emitRouteFlowEvent: () => {},
-        headers: {},
-        info: {
-          received: Date.now(),
-        },
-        method: 'get',
-        path: '/v1/frobnicate',
-        query: {
-          email: 'quix',
-        },
-      },
-      {
-        code: 200,
-        statusCode: 201,
-      }
-    );
-
-    assert.equal(logger.info.args[0][1].email, 'quix');
   });
 
   describe('traceId', () => {


### PR DESCRIPTION
Because:
 - Today we log every single incoming request
 - And this floods our logs making them difficult to use

This Commit:
 - Removes the standard logging of normal/successful requests

Closes: FXA-12521

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
