### PR TITLE
feat(webhook): add stripe webhook firestore repository

### DIFF
--- a/libs/payments/webhooks/src/index.ts
+++ b/libs/payments/webhooks/src/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+export * from './lib/stripe-event-store.repository';
 export * from './lib/stripeWebhooks.service';
 export * from './lib/stripeEvents.manager';
 export * from './lib/subscriptionHandler.service';

--- a/libs/payments/webhooks/src/lib/factories.ts
+++ b/libs/payments/webhooks/src/lib/factories.ts
@@ -6,7 +6,13 @@ import {
   StripeEventCustomerSubscriptionCreatedFactory,
   StripeSubscriptionFactory,
 } from '@fxa/payments/stripe';
-import { CustomerSubscriptionDeletedResponse } from './types';
+import {
+  CustomerSubscriptionDeletedResponse,
+  type StripeEventStoreEntry,
+  type StripeEventStoreEntryFirestoreRecord,
+} from './types';
+import { Timestamp } from '@google-cloud/firestore';
+import { faker } from '@faker-js/faker';
 
 const subscription = StripeSubscriptionFactory();
 
@@ -16,5 +22,23 @@ export const CustomerSubscriptionDeletedResponseFactory = (
   type: 'customer.subscription.deleted',
   event: StripeEventCustomerSubscriptionCreatedFactory(subscription),
   eventObjectData: subscription,
+  ...override,
+});
+
+export const StripeEventStoreEntryFactory = (
+  override?: Partial<StripeEventStoreEntry>
+): StripeEventStoreEntry => ({
+  eventId: `evt_${faker.string.alphanumeric({ length: 24 })}`,
+  processedAt: new Date(),
+  eventDetails: StripeEventCustomerSubscriptionCreatedFactory(),
+  ...override,
+});
+
+export const StripeEventStoreEntryFirestoreRecordFactory = (
+  override?: Partial<StripeEventStoreEntryFirestoreRecord>
+): StripeEventStoreEntryFirestoreRecord => ({
+  eventId: `evt_${faker.string.alphanumeric({ length: 24 })}`,
+  processedAt: Timestamp.fromDate(new Date()),
+  eventDetails: StripeEventCustomerSubscriptionCreatedFactory(),
   ...override,
 });

--- a/libs/payments/webhooks/src/lib/stripe-event-store.error.ts
+++ b/libs/payments/webhooks/src/lib/stripe-event-store.error.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseError } from '@fxa/shared/error';
+
+/**
+ * AppleIapError is not intended for direct use, except for type-checking errors.
+ * When throwing a new AppleIapError, create a unique extension of the class.
+ */
+export class StripeWebhookEventError extends BaseError {
+  constructor(message: string, info: Record<string, any>, cause?: Error) {
+    super(message, { info, cause });
+    this.name = 'StripeWebhookEventError';
+  }
+}
+
+export class StripeEventStoreEntryAlreadyExistsError extends StripeWebhookEventError {
+  constructor(eventId: string) {
+    super('Stripe Event with provided eventId already exists', { eventId });
+    this.name = 'StripeEventStoreEntryAlreadyExistsError';
+  }
+}
+
+export class StripeEventStoreEntryCreateError extends StripeWebhookEventError {
+  constructor(eventId: string) {
+    super('Failed to create Stripe Event record', { eventId });
+    this.name = 'StripeEventStoreEntryCreateError';
+  }
+}
+
+export class StripeEventStoreEntryNotFoundError extends StripeWebhookEventError {
+  constructor(eventId: string) {
+    super('Stripe event not found', { eventId });
+    this.name = 'StripeEventStoreEntryNotFoundError';
+  }
+}
+
+export class StripeEventStoreEntryMissingRequiredError extends StripeWebhookEventError {
+  constructor(eventId: string, fields: string[]) {
+    super('Stripe Event is missing required fields', { eventId, fields });
+    this.name = 'StripeEventStoreEntryMissingRequiredError';
+  }
+}
+
+export class StripeEventStoreEntryMissingUpdateParamsError extends StripeWebhookEventError {
+  constructor(eventId: string) {
+    super('Must provide at least one update param', { eventId });
+    this.name = 'StripeEventStoreEntryMissingUpdateParamsError';
+  }
+}
+
+export class StripeEventStoreEntryDeleteError extends StripeWebhookEventError {
+  constructor(eventId: string) {
+    super('Stripe Event was not deleted', { eventId });
+    this.name = 'StripeEventStoreEntryDeleteError';
+  }
+}

--- a/libs/payments/webhooks/src/lib/stripe-event-store.repository.spec.ts
+++ b/libs/payments/webhooks/src/lib/stripe-event-store.repository.spec.ts
@@ -1,0 +1,218 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  CollectionReference,
+  DocumentReference,
+  QuerySnapshot,
+  Timestamp,
+  type DocumentSnapshot,
+} from '@google-cloud/firestore';
+import {
+  StripeEventStoreEntryFactory,
+  StripeEventStoreEntryFirestoreRecordFactory,
+} from './factories';
+import {
+  createStripeEventStoreEntry,
+  deleteStripeEventStoreEntry,
+  getStripeEventStoreEntry,
+  updateStripeEventStoreEntry,
+} from './stripe-event-store.repository';
+import {
+  StripeEventStoreEntryAlreadyExistsError,
+  StripeEventStoreEntryCreateError,
+  StripeEventStoreEntryDeleteError,
+  StripeEventStoreEntryMissingRequiredError,
+  StripeEventStoreEntryMissingUpdateParamsError,
+  StripeEventStoreEntryNotFoundError,
+} from './stripe-event-store.error';
+
+describe('Stripe Event Repository', () => {
+  let mockDb: jest.Mocked<CollectionReference>;
+  let mockDoc: jest.Mocked<DocumentReference>;
+
+  const mockStripeEventStoreEntry = StripeEventStoreEntryFactory();
+  const mockStripeEventStoreEntryFirestoreRecord =
+    StripeEventStoreEntryFirestoreRecordFactory({
+      eventId: mockStripeEventStoreEntry.eventId,
+      processedAt: Timestamp.fromDate(mockStripeEventStoreEntry.processedAt),
+      eventDetails: mockStripeEventStoreEntry.eventDetails,
+    });
+  //eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { eventId, ...mockStripeEventStoreEntryUpdate } =
+    mockStripeEventStoreEntry;
+
+  beforeEach(() => {
+    mockDoc = {
+      set: jest.fn().mockResolvedValue(undefined),
+      get: jest
+        .fn()
+        .mockResolvedValue({
+          data: () => mockStripeEventStoreEntryFirestoreRecord,
+        }),
+      update: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<DocumentReference>;
+
+    mockDb = {
+      doc: jest.fn().mockReturnValue(mockDoc),
+      where: jest.fn().mockReturnThis(),
+      get: jest.fn().mockResolvedValue({
+        docs: [
+          {
+            ref: mockDoc,
+            data: () => mockStripeEventStoreEntryFirestoreRecord,
+          },
+        ],
+      } as unknown as QuerySnapshot),
+    } as unknown as jest.Mocked<CollectionReference>;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('createStripeEventStoreEntry', () => {
+    beforeEach(() => {
+      mockDoc.get.mockResolvedValueOnce({
+        data: () => undefined,
+      } as unknown as DocumentSnapshot);
+    });
+
+    it('creates a stripe event record successfully', async () => {
+      const result = await createStripeEventStoreEntry(
+        mockDb,
+        mockStripeEventStoreEntry
+      );
+      expect(result).toEqual(mockStripeEventStoreEntry);
+      expect(mockDb.doc).toHaveBeenCalledWith(
+        mockStripeEventStoreEntry.eventId
+      );
+      expect(mockDoc.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: mockStripeEventStoreEntryFirestoreRecord.eventId,
+          processedAt: mockStripeEventStoreEntryFirestoreRecord.processedAt,
+          eventDetails: mockStripeEventStoreEntryFirestoreRecord.eventDetails,
+        })
+      );
+    });
+
+    it('throws an error if the record is not created', async () => {
+      mockDoc.get = jest.fn().mockResolvedValueOnce({
+        data: () => mockStripeEventStoreEntryFirestoreRecord,
+      } as unknown as DocumentSnapshot);
+
+      await expect(
+        createStripeEventStoreEntry(mockDb, mockStripeEventStoreEntry)
+      ).rejects.toThrow(StripeEventStoreEntryAlreadyExistsError);
+    });
+
+    it('throws an error if the record is not created', async () => {
+      mockDoc.get.mockRejectedValue(
+        new StripeEventStoreEntryNotFoundError('test')
+      );
+
+      await expect(
+        createStripeEventStoreEntry(mockDb, mockStripeEventStoreEntry)
+      ).rejects.toThrow(StripeEventStoreEntryCreateError);
+    });
+  });
+
+  describe('getStripeEventStoreEntry', () => {
+    it('succeeds', async () => {
+      const result = await getStripeEventStoreEntry(
+        mockDb,
+        mockStripeEventStoreEntry.eventId
+      );
+      expect(result).toEqual(mockStripeEventStoreEntry);
+      expect(mockDb.doc).toHaveBeenCalledWith(
+        mockStripeEventStoreEntry.eventId
+      );
+    });
+
+    it('throws an error if no record is found', async () => {
+      mockDoc.get.mockResolvedValueOnce({
+        data: () => undefined,
+      } as unknown as DocumentSnapshot);
+
+      await expect(
+        getStripeEventStoreEntry(mockDb, mockStripeEventStoreEntry.eventId)
+      ).rejects.toThrow(StripeEventStoreEntryNotFoundError);
+    });
+
+    it('throws an error if required fields are missing', async () => {
+      mockDoc.get.mockResolvedValueOnce({
+        data: () => {
+          return {
+            ...mockStripeEventStoreEntryFirestoreRecord,
+            processedAt: undefined,
+          };
+        },
+      } as unknown as DocumentSnapshot);
+
+      await expect(
+        getStripeEventStoreEntry(mockDb, mockStripeEventStoreEntry.eventId)
+      ).rejects.toThrow(StripeEventStoreEntryMissingRequiredError);
+    });
+  });
+
+  describe('updateStripeEventStoreEntry', () => {
+    it('succeeds', async () => {
+      const result = await updateStripeEventStoreEntry(
+        mockDb,
+        mockStripeEventStoreEntry.eventId,
+        mockStripeEventStoreEntryUpdate
+      );
+      expect(result).toEqual(mockStripeEventStoreEntry);
+      expect(mockDb.doc).toHaveBeenCalledWith(
+        mockStripeEventStoreEntry.eventId
+      );
+      expect(mockDoc.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          processedAt: mockStripeEventStoreEntryFirestoreRecord.processedAt,
+          eventDetails: mockStripeEventStoreEntryFirestoreRecord.eventDetails,
+        })
+      );
+    });
+
+    it('throws an error if no update params are provided', async () => {
+      await expect(
+        updateStripeEventStoreEntry(
+          mockDb,
+          mockStripeEventStoreEntry.eventId,
+          {}
+        )
+      ).rejects.toThrow(StripeEventStoreEntryMissingUpdateParamsError);
+    });
+  });
+
+  describe('deleteStripeEventStoreEntry', () => {
+    beforeEach(() => {
+      mockDoc.get.mockResolvedValueOnce({
+        data: () => undefined,
+      } as unknown as DocumentSnapshot);
+    });
+
+    it('succeeds', async () => {
+      const result = await deleteStripeEventStoreEntry(
+        mockDb,
+        mockStripeEventStoreEntry.eventId
+      );
+      expect(result).toBeTruthy();
+      expect(mockDb.doc).toHaveBeenCalledWith(
+        mockStripeEventStoreEntry.eventId
+      );
+    });
+
+    it('thows an error if record is not deleted', async () => {
+      mockDoc.get = jest.fn().mockResolvedValueOnce({
+        data: () => mockStripeEventStoreEntryFirestoreRecord,
+      } as unknown as DocumentSnapshot);
+
+      await expect(
+        deleteStripeEventStoreEntry(mockDb, mockStripeEventStoreEntry.eventId)
+      ).rejects.toThrow(StripeEventStoreEntryDeleteError);
+    });
+  });
+});

--- a/libs/payments/webhooks/src/lib/stripe-event-store.repository.ts
+++ b/libs/payments/webhooks/src/lib/stripe-event-store.repository.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Timestamp, type CollectionReference } from '@google-cloud/firestore';
+import type {
+  StripeEventStoreEntry,
+  StripeEventStoreEntryFirestoreRecord,
+} from './types';
+import {
+  StripeEventStoreEntryAlreadyExistsError,
+  StripeEventStoreEntryCreateError,
+  StripeEventStoreEntryDeleteError,
+  StripeEventStoreEntryMissingRequiredError,
+  StripeEventStoreEntryMissingUpdateParamsError,
+  StripeEventStoreEntryNotFoundError,
+} from './stripe-event-store.error';
+
+export async function createStripeEventStoreEntry(
+  db: CollectionReference,
+  data: StripeEventStoreEntry
+) {
+  const existingRecord = await db.doc(data.eventId).get();
+  if (existingRecord.data()) {
+    throw new StripeEventStoreEntryAlreadyExistsError(data.eventId);
+  }
+
+  const doc = {
+    eventId: data.eventId,
+    processedAt: Timestamp.fromDate(data.processedAt),
+    eventDetails: data.eventDetails,
+  };
+
+  await db.doc(data.eventId).set(doc);
+
+  try {
+    return await getStripeEventStoreEntry(db, data.eventId);
+  } catch (error) {
+    if (error instanceof StripeEventStoreEntryNotFoundError) {
+      throw new StripeEventStoreEntryCreateError(data.eventId);
+    } else {
+      throw error;
+    }
+  }
+}
+
+export async function getStripeEventStoreEntry(
+  db: CollectionReference,
+  eventId: string
+) {
+  const result = await db.doc(eventId).get();
+
+  const doc = result.data();
+
+  if (!doc) {
+    throw new StripeEventStoreEntryNotFoundError(eventId);
+  }
+
+  const processedAtTimestamp = doc['processedAt'] as Timestamp | undefined;
+  if (!processedAtTimestamp || !(processedAtTimestamp instanceof Timestamp)) {
+    throw new StripeEventStoreEntryMissingRequiredError(eventId, [
+      'processedAt',
+    ]);
+  }
+
+  return {
+    ...doc,
+    processedAt: processedAtTimestamp.toDate(),
+  } as StripeEventStoreEntry;
+}
+
+export async function updateStripeEventStoreEntry(
+  db: CollectionReference,
+  eventId: string,
+  update: Partial<Omit<StripeEventStoreEntry, 'eventId'>>
+) {
+  const { processedAt, ...rest } = update;
+  const _update: Partial<
+    Omit<StripeEventStoreEntryFirestoreRecord, 'eventId'>
+  > = {
+    ...rest,
+  };
+  if (processedAt) {
+    _update.processedAt = Timestamp.fromDate(processedAt);
+  }
+
+  if (Object.values(_update).length === 0) {
+    throw new StripeEventStoreEntryMissingUpdateParamsError(eventId);
+  }
+
+  await db.doc(eventId).update(_update);
+
+  return getStripeEventStoreEntry(db, eventId);
+}
+
+export async function deleteStripeEventStoreEntry(
+  db: CollectionReference,
+  eventId: string
+) {
+  await db.doc(eventId).delete();
+
+  const existingRecord = await db.doc(eventId).get();
+  if (existingRecord.data()) {
+    throw new StripeEventStoreEntryDeleteError(eventId);
+  }
+
+  return true;
+}

--- a/libs/payments/webhooks/src/lib/types.ts
+++ b/libs/payments/webhooks/src/lib/types.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Stripe from 'stripe';
+import { Timestamp } from '@google-cloud/firestore';
 
 export interface DefaultResponse {
   type: Exclude<Stripe.Event.Type, 'customer.subscription.deleted'>;
@@ -19,3 +20,15 @@ export interface CustomerSubscriptionDeletedResponse {
 export type StripeWebhookEventResponse =
   | DefaultResponse
   | CustomerSubscriptionDeletedResponse;
+
+export interface StripeEventStoreEntry {
+  eventId: string;
+  processedAt: Date;
+  eventDetails: Stripe.Event;
+}
+
+export interface StripeEventStoreEntryFirestoreRecord {
+  eventId: string;
+  processedAt: Timestamp;
+  eventDetails: Stripe.Event;
+}


### PR DESCRIPTION
## Because

- Store Stripe webhook events and when they were processed

## This pull request

- Adds a repository to store Stripe webhook events and processed dates

## Issue that this pull request solves

Closes: #PAY-3308

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).