### PR TITLE
fix(settings): Add back support to handle sync signout general app error

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -351,6 +351,12 @@ export const App = ({
     return <LoadingSpinner fullScreen />;
   }
 
+  // If we're on settings route but user is not signed in, redirect immediately
+  if (window.location.pathname?.includes('/settings') && !isSignedIn) {
+    navigate('/');
+    return <LoadingSpinner fullScreen />;
+  }
+
   return (
     <Router basepath="/">
       <AuthAndAccountSetupRoutes


### PR DESCRIPTION
Because:
 - When a user signs out of sync from the brwoser, they might still be on settings page and could refresh.
 - And this results in a General Application Error

This Commit:
 - Adds back the check being on settings without being signed in and redirects

Closes: FXA-12538

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
