### PR TITLE
feat(admin-panel): implement rate limit search and clear

### DIFF
--- a/libs/accounts/rate-limit/src/lib/models.ts
+++ b/libs/accounts/rate-limit/src/lib/models.ts
@@ -5,14 +5,18 @@
 /** The attributes we can count and block on. */
 export type BlockOn = 'ip' | 'email' | 'uid' | 'ip_email' | 'ip_uid';
 
+export function isBlockOn(value: unknown): value is BlockOn {
+  return (
+    value === 'ip' ||
+    value === 'email' ||
+    value === 'uid' ||
+    value === 'ip_email' ||
+    value === 'ip_uid'
+  );
+}
+
 /** Standard set of fields that can be blocked on. */
-export type BlockOnOpts = {
-  email?: string;
-  ip?: string;
-  ip_email?: string;
-  uid?: string;
-  ip_uid?: string;
-};
+export type BlockOnOpts = Partial<Record<BlockOn, string>>;
 
 /**
  * Controls how the block is applied.
@@ -20,6 +24,11 @@ export type BlockOnOpts = {
  *  - ban - will apply to the current action and all other actions being checked for the given rules ip, email, or uid.
  **/
 export type BlockPolicy = 'block' | 'ban' | 'report';
+export type RateLimitKeyType = BlockPolicy | 'attempts';
+
+export function isBlockPolicy(value: unknown): value is BlockPolicy {
+  return value === 'block' || value === 'ban' || value === 'report';
+}
 
 /** Constant for the common error message, too-many-attempts. */
 export const TOO_MANY_ATTEMPTS = 'too-many-attempts';
@@ -84,4 +93,10 @@ export type BlockStatus = {
   attempt: number;
   /** The type of block which occurred */
   policy: BlockPolicy;
+};
+
+export type SearchOpts = {
+  ip?: string;
+  email?: string;
+  uid?: string;
 };

--- a/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
+++ b/libs/accounts/rate-limit/src/lib/rate-limit.spec.ts
@@ -185,6 +185,345 @@ describe('rate-limit', () => {
     expect(statsd.increment).toBeCalledWith('rate_limit.ignore.uid');
   });
 
+  describe('rate limit search', () => {
+    let mockScan: jest.Mock;
+    let mockGet: jest.Mock;
+
+    beforeEach(() => {
+      mockScan = jest.fn();
+      mockGet = jest.fn();
+      redis.scan = mockScan;
+      redis.get = mockGet;
+    });
+
+    afterEach(() => {
+      mockScan.mockReset();
+      mockGet.mockReset();
+    });
+
+    it('should return empty array when no identifiers provided', async () => {
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({});
+      expect(result).toEqual([]);
+      expect(mockScan).not.toHaveBeenCalled();
+    });
+
+    it('should search by IP address', async () => {
+      const testIp = '192.168.1.1';
+      const mockBlockRecord = {
+        action: 'login',
+        usedDefaultRule: false,
+        blockingOn: 'ip',
+        blockedValue: testIp,
+        startTime: Date.now() - 5000,
+        duration: 3600,
+        attempts: 3,
+        reason: 'too-many-attempts',
+        policy: 'block',
+      };
+
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          [`rate-limit:block:ip=${testIp}:login:1-60-3600`],
+        ]) // for ip
+        .mockResolvedValueOnce(['0', []]) // for ip_email
+        .mockResolvedValueOnce(['0', []]); // for ip_uid
+
+      mockGet.mockResolvedValue(JSON.stringify(mockBlockRecord));
+
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({ ip: testIp });
+
+      expect(mockScan).toHaveBeenCalledTimes(3); // ip, ip_email, ip_uid
+      expect(mockScan).toHaveBeenNthCalledWith(
+        1,
+        '0',
+        'MATCH',
+        `rate-limit:*:ip=${testIp}*`,
+        'COUNT',
+        1000
+      );
+      expect(mockScan).toHaveBeenNthCalledWith(
+        2,
+        '0',
+        'MATCH',
+        `rate-limit:*:ip_email=${testIp}_**`,
+        'COUNT',
+        1000
+      );
+      expect(mockScan).toHaveBeenNthCalledWith(
+        3,
+        '0',
+        'MATCH',
+        `rate-limit:*:ip_uid=${testIp}_**`,
+        'COUNT',
+        1000
+      );
+      expect(mockGet).toHaveBeenCalledWith(
+        `rate-limit:block:ip=${testIp}:login:1-60-3600`
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].action).toBe('login');
+      expect(result[0].blockingOn).toBe('ip');
+      expect(result[0].policy).toBe('block');
+    });
+
+    it('should search by email', async () => {
+      const testEmail = 'test@example.com';
+      const mockBanRecord = {
+        action: 'passwordReset',
+        usedDefaultRule: false,
+        blockingOn: 'email',
+        blockedValue: testEmail,
+        startTime: Date.now() - 10000,
+        duration: 7200,
+        attempts: 5,
+        reason: 'too-many-attempts',
+        policy: 'ban',
+      };
+
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          [`rate-limit:ban:email=${testEmail}:passwordReset:5-60-7200`],
+        ]) // for email
+        .mockResolvedValueOnce(['0', []]); // for ip_email
+
+      mockGet.mockResolvedValue(JSON.stringify(mockBanRecord));
+
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({ email: testEmail });
+
+      expect(mockScan).toHaveBeenCalledTimes(2); // email, ip_email
+      expect(mockScan).toHaveBeenNthCalledWith(
+        1,
+        '0',
+        'MATCH',
+        `rate-limit:*:email=${testEmail}*`,
+        'COUNT',
+        1000
+      );
+      expect(mockScan).toHaveBeenNthCalledWith(
+        2,
+        '0',
+        'MATCH',
+        `rate-limit:*:ip_email=*_${testEmail}*`,
+        'COUNT',
+        1000
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].action).toBe('passwordReset');
+      expect(result[0].blockingOn).toBe('email');
+      expect(result[0].policy).toBe('ban');
+    });
+
+    it('should search by UID', async () => {
+      const testUid = 'user-123';
+
+      mockScan
+        .mockResolvedValueOnce(['0', []]) // for uid
+        .mockResolvedValueOnce(['0', []]); // for ip_uid
+
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({ uid: testUid });
+
+      expect(mockScan).toHaveBeenCalledTimes(2); // uid, ip_uid
+      expect(mockScan).toHaveBeenNthCalledWith(
+        1,
+        '0',
+        'MATCH',
+        `rate-limit:*:uid=${testUid}*`,
+        'COUNT',
+        1000
+      );
+      expect(mockScan).toHaveBeenNthCalledWith(
+        2,
+        '0',
+        'MATCH',
+        `rate-limit:*:ip_uid=*_${testUid}*`,
+        'COUNT',
+        1000
+      );
+      expect(result).toHaveLength(0);
+    });
+
+    it('should search by multiple identifiers including composite keys', async () => {
+      const testIp = '10.0.0.1';
+      const testEmail = 'user@test.com';
+      const testUid = 'uid-456';
+
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          [`rate-limit:block:ip=${testIp}:login:1-60-3600`],
+        ])
+        .mockResolvedValueOnce([
+          '0',
+          [`rate-limit:ban:email=${testEmail}:signup:3-120-7200`],
+        ])
+        .mockResolvedValueOnce(['0', []])
+        .mockResolvedValueOnce([
+          '0',
+          [
+            `rate-limit:block:ip_email=${testIp}_${testEmail}:transfer:2-30-1800`,
+          ],
+        ])
+        .mockResolvedValueOnce(['0', []]);
+
+      const mockRecord1 = {
+        action: 'login',
+        usedDefaultRule: false,
+        blockingOn: 'ip',
+        blockedValue: testIp,
+        startTime: Date.now(),
+        duration: 3600,
+        attempts: 1,
+        reason: 'too-many-attempts',
+        policy: 'block',
+      };
+
+      const mockRecord2 = {
+        action: 'signup',
+        usedDefaultRule: false,
+        blockingOn: 'email',
+        blockedValue: testEmail,
+        startTime: Date.now(),
+        duration: 7200,
+        attempts: 3,
+        reason: 'too-many-attempts',
+        policy: 'ban',
+      };
+
+      const mockRecord3 = {
+        action: 'transfer',
+        usedDefaultRule: false,
+        blockingOn: 'ip_email',
+        blockedValue: `${testIp}_${testEmail}`,
+        startTime: Date.now(),
+        duration: 1800,
+        attempts: 2,
+        reason: 'too-many-attempts',
+        policy: 'block',
+      };
+
+      mockGet
+        .mockResolvedValueOnce(JSON.stringify(mockRecord1))
+        .mockResolvedValueOnce(JSON.stringify(mockRecord2))
+        .mockResolvedValueOnce(JSON.stringify(mockRecord3));
+
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({
+        ip: testIp,
+        email: testEmail,
+        uid: testUid,
+      });
+
+      expect(mockScan).toHaveBeenCalledTimes(5);
+      expect(result).toHaveLength(3);
+      expect(result.map((r) => r.action)).toEqual([
+        'login',
+        'signup',
+        'transfer',
+      ]);
+      expect(result.map((r) => r.policy)).toEqual(['block', 'ban', 'block']);
+    });
+
+    it('should handle Redis scan pagination', async () => {
+      const testIp = '127.0.0.1';
+
+      // Since the search method processes identifiers in parallel,
+      // we need to handle the scan calls in the order they're processed
+      mockScan
+        .mockResolvedValueOnce([
+          '123',
+          [`rate-limit:block:ip=${testIp}:action1:1-60-3600`],
+        ]) // First call for IP identifier
+        .mockResolvedValueOnce(['0', []]) // ip_email scan
+        .mockResolvedValueOnce(['0', []]) // ip_uid scan
+        .mockResolvedValueOnce([
+          '0',
+          [`rate-limit:block:ip=${testIp}:action2:1-60-3600`],
+        ]); // Second call for IP pagination
+
+      const mockRecord1 = {
+        action: 'action1',
+        usedDefaultRule: false,
+        blockingOn: 'ip',
+        blockedValue: testIp,
+        startTime: Date.now(),
+        duration: 3600,
+        attempts: 1,
+        reason: 'too-many-attempts',
+        policy: 'block',
+      };
+
+      const mockRecord2 = {
+        action: 'action2',
+        usedDefaultRule: false,
+        blockingOn: 'ip',
+        blockedValue: testIp,
+        startTime: Date.now(),
+        duration: 3600,
+        attempts: 1,
+        reason: 'too-many-attempts',
+        policy: 'block',
+      };
+
+      mockGet
+        .mockResolvedValueOnce(JSON.stringify(mockRecord1))
+        .mockResolvedValueOnce(JSON.stringify(mockRecord2));
+
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({ ip: testIp });
+
+      expect(mockScan).toHaveBeenCalledTimes(4); // 2 for ip pagination + ip_email + ip_uid
+      expect(result).toHaveLength(2);
+    });
+
+    it('should filter out null results from invalid block records', async () => {
+      const testEmail = 'test@example.com';
+
+      // Mock scan calls for email and ip_email patterns
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          [
+            `rate-limit:block:email=${testEmail}:valid:1-60-3600`,
+            `rate-limit:attempt:email=${testEmail}:invalid:1-60-3600`,
+          ],
+        ]) // for email
+        .mockResolvedValueOnce(['0', []]); // for ip_email
+
+      const validRecord = {
+        action: 'valid',
+        usedDefaultRule: false,
+        blockingOn: 'email',
+        blockedValue: testEmail,
+        startTime: Date.now(),
+        duration: 3600,
+        attempts: 1,
+        reason: 'too-many-attempts',
+        policy: 'block',
+      };
+      const invalidRecord = {
+        ...validRecord,
+        action: 'invalid',
+        policy: 'attempt', // not a policy type
+      };
+
+      mockGet
+        .mockResolvedValueOnce(JSON.stringify(validRecord))
+        .mockResolvedValueOnce(JSON.stringify(invalidRecord));
+
+      rateLimit = new RateLimit({ rules: {} }, redis, statsd);
+      const result = await rateLimit.search({ email: testEmail });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].action).toBe('valid');
+    });
+  });
+
   describe('configuration rules', () => {
     it('parses rule set', () => {
       const ruleSet = parseConfigRules(`
@@ -285,6 +624,148 @@ describe('rate-limit', () => {
       expect(() => parseConfigRules('foo:bar:1')).toThrowError();
       expect(() => parseConfigRules('foo!23:ip:1:1s:1s:')).toThrowError();
       expect(() => parseConfigRules('foo!23:ip:1:1s:1s:foo')).toThrowError();
+    });
+  });
+
+  describe('searchAndClear', () => {
+    let mockScan: jest.Mock;
+    let mockDel: jest.Mock;
+
+    beforeEach(() => {
+      mockScan = jest.fn();
+      mockDel = jest.fn();
+      redis.scan = mockScan;
+      redis.del = mockDel;
+
+      rateLimit = new RateLimit(
+        { rules: parseConfigRules(['test:ip:1:1s:1s:block']) },
+        redis,
+        statsd
+      );
+    });
+
+    it('should search and clear both blocks and bans by IP', async () => {
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          [
+            'rate-limit:block:ip=192.168.1.1:test',
+            'rate-limit:ban:ip=192.168.1.1:other',
+          ],
+        ]) // for ip
+        .mockResolvedValueOnce([
+          '0',
+          [
+            'rate-limit:block:ip_email=192.168.1.1_user@example.com:test',
+            'rate-limit:ban:ip_email=192.168.1.1_another@example.com:other',
+          ],
+        ]) // for ip_email
+        .mockResolvedValueOnce([
+          '0',
+          [
+            'rate-limit:block:ip_uid=192.168.1.1_uid123:test',
+            'rate-limit:ban:ip_uid=192.168.1.1_uid456:other',
+          ],
+        ]); // for ip_uid
+      mockDel.mockResolvedValue(1);
+
+      const result = await rateLimit.searchAndClear({ ip: '192.168.1.1' });
+
+      expect(result).toBe(6); // 2 + 2 + 2 = 6 keys deleted
+      expect(mockScan).toHaveBeenCalledTimes(3); // ip, ip_email, ip_uid
+      expect(mockDel).toHaveBeenCalledTimes(6);
+    });
+
+    it('should search and clear by email', async () => {
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          ['rate-limit:block:email=test@example.com:test'],
+        ]) // for email
+        .mockResolvedValueOnce([
+          '0',
+          ['rate-limit:block:ip_email=192.168.1.1_test@example.com:test'],
+        ]); // for ip_email
+      mockDel.mockResolvedValue(1);
+
+      const result = await rateLimit.searchAndClear({
+        email: 'test@example.com',
+      });
+
+      expect(result).toBe(2); // 1 + 1 = 2 keys deleted
+      expect(mockScan).toHaveBeenCalledTimes(2); // email, ip_email
+      expect(mockDel).toHaveBeenCalledTimes(2);
+    });
+
+    it('should search and clear by UID', async () => {
+      mockScan
+        .mockResolvedValueOnce(['0', []]) // for uid
+        .mockResolvedValueOnce(['0', []]); // for ip_uid
+      mockDel.mockResolvedValue(1);
+
+      const result = await rateLimit.searchAndClear({
+        uid: 'user123',
+      });
+
+      expect(result).toBe(0);
+      expect(mockScan).toHaveBeenCalledTimes(2); // uid, ip_uid
+      expect(mockDel).not.toHaveBeenCalled();
+    });
+
+    it('should handle multiple identifiers', async () => {
+      mockScan.mockImplementation((cursor, matchType, pattern) => {
+        if (pattern.includes('ip=192.168.1.1')) {
+          return Promise.resolve([
+            '0',
+            ['rate-limit:block:ip=192.168.1.1:test'],
+          ]);
+        }
+        if (pattern.includes('email=test@example.com')) {
+          return Promise.resolve([
+            '0',
+            ['rate-limit:block:email=test@example.com:test'],
+          ]);
+        }
+        if (pattern.includes('ip_email=192.168.1.1_test@example.com')) {
+          return Promise.resolve([
+            '0',
+            ['rate-limit:block:ip_email=192.168.1.1_test@example.com:test'],
+          ]);
+        }
+        return Promise.resolve(['0', []]);
+      });
+      mockDel.mockResolvedValue(1);
+
+      const result = await rateLimit.searchAndClear({
+        ip: '192.168.1.1',
+        email: 'test@example.com',
+      });
+
+      expect(result).toBe(3);
+      expect(mockDel).toHaveBeenCalledTimes(3);
+    });
+
+    it('should ignore attempt and report keys', async () => {
+      mockScan
+        .mockResolvedValueOnce([
+          '0',
+          [
+            'rate-limit:block:ip=192.168.1.1:test',
+            'rate-limit:attempt:ip=192.168.1.1:test', // should be ignored
+            'rate-limit:report:ip=192.168.1.1:test', // should be ignored
+            'rate-limit:ban:ip=192.168.1.1:other',
+          ],
+        ]) // for ip
+        .mockResolvedValueOnce(['0', []]) // for email
+        .mockResolvedValueOnce(['0', []]) // for uid
+        .mockResolvedValueOnce(['0', []]) // for ip_email
+        .mockResolvedValueOnce(['0', []]); // for ip_uid
+      mockDel.mockResolvedValue(1);
+
+      const result = await rateLimit.searchAndClear({ ip: '192.168.1.1' });
+
+      expect(result).toBe(2);
+      expect(mockDel).toHaveBeenCalledTimes(4);
     });
   });
 });

--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -46,6 +46,7 @@ export enum AdminPanelFeature {
   UpdateRelyingParty = 'UpdateRelyingParty',
   DeleteRelyingParty = 'DeleteRelyingParty',
   UnsubscribeFromMailingLists = 'UnsubscribeFromMailingLists',
+  RateLimiting = 'RateLimiting',
 }
 
 /** Enum of known user groups */
@@ -192,6 +193,10 @@ const defaultAdminPanelPermissions: Permissions = {
   },
   [AdminPanelFeature.UnsubscribeFromMailingLists]: {
     name: 'Unsubscribe User From Mozilla Mailing Lists',
+    level: PermissionLevel.Support,
+  },
+  [AdminPanelFeature.RateLimiting]: {
+    name: 'View Rate Limiting Blocks and Bans',
     level: PermissionLevel.Support,
   },
 };

--- a/packages/fxa-admin-panel/src/App.tsx
+++ b/packages/fxa-admin-panel/src/App.tsx
@@ -13,6 +13,7 @@ import { IClientConfig, IUserInfo } from '../interfaces';
 import { AdminPanelFeature, AdminPanelGuard } from '@fxa/shared/guards';
 import PageRelyingParties from './components/PageRelyingParties';
 import PageAccountDelete from './components/PageAccountDelete';
+import PageRateLimiting from './components/PageRateLimiting';
 
 const App = ({ config }: { config: IClientConfig }) => {
   const [guard, setGuard] = useState<AdminPanelGuard>(config.guard);
@@ -37,6 +38,9 @@ const App = ({ config }: { config: IClientConfig }) => {
               )}
               {guard.allow(AdminPanelFeature.AccountDelete, user.group) && (
                 <Route path="/account-delete" element={<PageAccountDelete />} />
+              )}
+              {guard.allow(AdminPanelFeature.RateLimiting, user.group) && (
+                <Route path="/rate-limiting" element={<PageRateLimiting />} />
               )}
               <Route path="/permissions" element={<PagePermissions />} />
             </Routes>

--- a/packages/fxa-admin-panel/src/components/Nav/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Nav/index.tsx
@@ -67,6 +67,21 @@ export const Nav = () => (
             </NavLink>
           </li>
         </Guard>
+        <Guard features={[AdminPanelFeature.RateLimiting]}>
+          <li>
+            <NavLink
+              to="/rate-limiting"
+              className={({ isActive }) => getNavLinkClassName(isActive)}
+            >
+              <img
+                className="inline-flex mr-2 w-4"
+                src={logsIcon}
+                alt="rate limit icon"
+              />
+              Rate Limiting
+            </NavLink>
+          </li>
+        </Guard>
         <li>
           <NavLink
             to="/permissions"

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/BlockStatus/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/BlockStatus/index.test.tsx
@@ -1,0 +1,36 @@
+import { BlockStatus } from '.';
+import { render, screen } from '@testing-library/react';
+import { mockBlockStatusData1 } from '../mocks';
+import { getFormattedDate } from '../../../lib/utils';
+
+describe('BlockStatus', () => {
+  it('renders correctly', () => {
+    render(<BlockStatus status={mockBlockStatusData1} />);
+
+    expect(screen.getByText('Action:')).toBeInTheDocument();
+    expect(screen.getByText('login')).toBeInTheDocument();
+
+    expect(screen.getByText('Policy:')).toBeInTheDocument();
+    expect(screen.getByText('block')).toBeInTheDocument();
+
+    expect(screen.getByText('Reason:')).toBeInTheDocument();
+    expect(screen.getByText('Too many requests')).toBeInTheDocument();
+
+    expect(screen.getByText('Blocking On:')).toBeInTheDocument();
+    expect(screen.getByText('IP + Email')).toBeInTheDocument();
+
+    expect(screen.getByText('Duration:')).toBeInTheDocument();
+    expect(screen.getByText('1h 0m 0s')).toBeInTheDocument();
+
+    expect(screen.getByText('Start Time:')).toBeInTheDocument();
+    expect(
+      screen.getByText(getFormattedDate(mockBlockStatusData1.startTime))
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Retry After:')).toBeInTheDocument();
+    expect(screen.getByText('30m 0s')).toBeInTheDocument();
+
+    expect(screen.getByText('Attempt:')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/BlockStatus/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/BlockStatus/index.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { BlockStatus as BlockStatusData } from 'fxa-admin-server/src/graphql';
+import { getFormattedDuration, getFormattedDate } from '../../../lib/utils';
+
+interface BlockStatusProps {
+  status: BlockStatusData;
+}
+
+const StatusField = ({ label, value }) => {
+  return (
+    <li className="mb-2">
+      <span className="font-medium text-sm text-grey-700">{label}:</span>
+      <span className="ml-2 text-sm">{value}</span>
+    </li>
+  );
+};
+
+export const BlockStatus = ({ status }: BlockStatusProps) => {
+  const getBlockingOnLabel = () => {
+    switch (status.blockingOn) {
+      case 'ip':
+        return 'IP Address';
+      case 'email':
+        return 'Email';
+      case 'uid':
+        return 'UID';
+      case 'ip_email':
+        return 'IP + Email';
+      case 'ip_uid':
+        return 'IP + UID';
+      default:
+        return status.blockingOn;
+    }
+  };
+
+  return (
+    <div className="border border-grey-200 bg-grey-50 rounded-md p-4">
+      <div className="grid grid-cols-1 tablet:grid-cols-2 gap-4">
+        <ul>
+          <StatusField label="Action" value={status.action} />
+          <StatusField label="Policy" value={status.policy} />
+          <StatusField label="Reason" value={status.reason} />
+          <StatusField label="Blocking On" value={getBlockingOnLabel()} />
+        </ul>
+
+        <ul>
+          <StatusField
+            label="Start Time"
+            value={getFormattedDate(status.startTime)}
+          />
+          <StatusField
+            label="Duration"
+            value={getFormattedDuration(status.duration)}
+          />
+          <StatusField
+            label="Retry After"
+            value={getFormattedDuration(Math.round(status.retryAfter / 1000))}
+          />
+          <StatusField label="Attempt" value={status.attempt} />
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/index.gql.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+
+export const GET_RATE_LIMITS = gql`
+  query getRateLimits($ip: String, $email: String, $uid: String) {
+    rateLimits(ip: $ip, email: $email, uid: $uid) {
+      retryAfter
+      reason
+      action
+      blockingOn
+      startTime
+      duration
+      attempt
+      policy
+    }
+  }
+`;
+
+export const CLEAR_RATE_LIMITS = gql`
+  mutation clearRateLimits($ip: String, $email: String, $uid: String) {
+    clearRateLimits(ip: $ip, email: $email, uid: $uid)
+  }
+`;

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/index.test.tsx
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MockedProvider } from '@apollo/client/testing';
+import { PageRateLimiting } from './index';
+import { GetRateLimits, ClearRateLimits } from './mocks';
+import {
+  AdminPanelGuard,
+  GuardEnv,
+  AdminPanelGroup,
+} from '../../../../../libs/shared/guards/src';
+import { IClientConfig } from '../../../interfaces';
+import { mockConfigBuilder } from '../../lib/config';
+
+const mockGuard = new AdminPanelGuard(GuardEnv.Prod);
+const mockGroup = mockGuard.getGroup(AdminPanelGroup.SupportAgentProd);
+
+export const mockConfig: IClientConfig = mockConfigBuilder({
+  user: {
+    email: 'test@mozilla.com',
+    group: mockGroup,
+  },
+});
+
+jest.mock('../../hooks/UserContext.ts', () => ({
+  useUserContext: () => {
+    const ctx = {
+      guard: mockGuard,
+      user: mockConfig.user,
+      setUser: () => {},
+    };
+    return ctx;
+  },
+}));
+
+let alertSpy: jest.SpyInstance;
+
+function renderView(mocks?: any[]) {
+  render(
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <PageRateLimiting />
+    </MockedProvider>
+  );
+}
+
+describe('PageRateLimiting', () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+    alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    renderView();
+    expect(screen.getByText('Rate Limiting')).toBeInTheDocument();
+    expect(screen.getByLabelText('IP Address')).toBeInTheDocument();
+    expect(screen.getByLabelText('Email')).toBeInTheDocument();
+    expect(screen.getByLabelText('UID')).toBeInTheDocument();
+    expect(screen.getByText('Search Rate Limits')).toBeInTheDocument();
+    expect(screen.getByText('Clear Rate Limits')).toBeInTheDocument();
+  });
+
+  describe('Search rate limits', () => {
+    it('shows alert when searching without any input', async () => {
+      renderView();
+      await user.click(screen.getByText('Search Rate Limits'));
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Please enter at least one of: IP address, email, or UID'
+      );
+    });
+
+    it('searches with IP address and shows empty results', async () => {
+      const testIp = '192.168.1.1';
+      renderView([GetRateLimits.emptyMock(testIp)]);
+
+      await user.type(screen.getByLabelText('IP Address'), testIp);
+      await user.click(screen.getByText('Search Rate Limits'));
+
+      expect(await screen.findByText('Active Blocks (0)')).toBeInTheDocument();
+      expect(await screen.findByText('Active Bans (0)')).toBeInTheDocument();
+      expect(
+        await screen.findByText('No active blocks found.')
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByText('No active bans found.')
+      ).toBeInTheDocument();
+    });
+
+    it('searches with email and shows non-empty results', async () => {
+      const testEmail = 'test@example.com';
+      renderView([GetRateLimits.nonEmptyMock(undefined, testEmail)]);
+
+      await user.type(screen.getByLabelText('Email'), testEmail);
+      await user.click(screen.getByText('Search Rate Limits'));
+
+      expect(await screen.findByText('Active Blocks (2)')).toBeInTheDocument();
+      expect(await screen.findByText('Active Bans (1)')).toBeInTheDocument();
+
+      // Check for items
+      expect(await screen.findByText('login')).toBeInTheDocument();
+      expect(await screen.findByText('passwordChange')).toBeInTheDocument();
+      expect(await screen.findByText('accountLoginFailed')).toBeInTheDocument();
+    });
+
+    it('shows error state when rate limits query fails', async () => {
+      const testEmail = 'test@example.com';
+      renderView([GetRateLimits.errorMock(undefined, testEmail)]);
+
+      await user.type(screen.getByLabelText('Email'), testEmail);
+      await user.click(screen.getByText('Search Rate Limits'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Failed to fetch rate limits')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Clear rate limits', () => {
+    it('shows alert when trying to clear without any input', async () => {
+      renderView();
+      await user.click(screen.getByText('Clear Rate Limits'));
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Please enter at least one of: IP address, email, or UID'
+      );
+    });
+
+    it('successfully clears rate limits with IP address', async () => {
+      const testIp = '192.168.1.1';
+      const clearedCount = 5;
+
+      renderView([
+        GetRateLimits.nonEmptyMock(testIp), // Initial search results
+        ClearRateLimits.successMock(clearedCount, testIp), // Clear mutation
+        GetRateLimits.emptyMock(testIp), // Refetch after clear
+      ]);
+
+      await user.type(screen.getByLabelText('IP Address'), testIp);
+      await user.click(screen.getByText('Clear Rate Limits'));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          `Successfully cleared ${clearedCount} rate limit record(s)`
+        );
+      });
+    });
+
+    it('successfully clears rate limits with email and UID', async () => {
+      const testEmail = 'test@example.com';
+      const testUid = 'user123';
+      const clearedCount = 3;
+
+      renderView([
+        ClearRateLimits.successMock(
+          clearedCount,
+          undefined,
+          testEmail,
+          testUid
+        ),
+        GetRateLimits.emptyMock(undefined, testEmail, testUid),
+      ]);
+
+      await user.type(screen.getByLabelText('Email'), testEmail);
+      await user.type(screen.getByLabelText('UID'), testUid);
+      await user.click(screen.getByText('Clear Rate Limits'));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          `Successfully cleared ${clearedCount} rate limit record(s)`
+        );
+      });
+    });
+
+    it('shows error when clear mutation fails', async () => {
+      const testIp = '192.168.1.1';
+
+      renderView([ClearRateLimits.errorMock(testIp)]);
+
+      await user.type(screen.getByLabelText('IP Address'), testIp);
+      await user.click(screen.getByText('Clear Rate Limits'));
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          'Failed to clear: Failed to clear rate limits'
+        );
+      });
+    });
+  });
+});

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/index.tsx
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useLazyQuery, useMutation, ApolloError } from '@apollo/client';
+import iconSearch from '../../images/icon-search.svg';
+import ErrorAlert from '../ErrorAlert';
+import { BlockStatus } from './BlockStatus';
+import { GET_RATE_LIMITS, CLEAR_RATE_LIMITS } from './index.gql';
+import { BlockStatus as BlockStatusData } from 'fxa-admin-server/src/graphql';
+
+interface RateLimitSearchState {
+  ip: string;
+  email: string;
+  uid: string;
+}
+
+type RateLimitQuery = Partial<RateLimitSearchState>;
+
+const createRateLimitQuery = (data: RateLimitSearchState): RateLimitQuery => {
+  const [ip, email, uid] = [data.ip.trim(), data.email.trim(), data.uid.trim()];
+
+  return {
+    ip: ip || undefined,
+    email: email || undefined,
+    uid: uid || undefined,
+  };
+};
+
+const validateQuery = (query: RateLimitQuery): boolean => {
+  return Boolean(query.ip || query.email || query.uid);
+};
+
+export const PageRateLimiting = () => {
+  const { register, handleSubmit, reset, getValues } =
+    useForm<RateLimitSearchState>({
+      defaultValues: {
+        ip: '',
+        email: '',
+        uid: '',
+      },
+    });
+  const [showResults, setShowResults] = useState<boolean>(false);
+
+  const [getRateLimits, rateLimitsResult] = useLazyQuery<
+    { rateLimits: BlockStatusData[] },
+    RateLimitQuery
+  >(GET_RATE_LIMITS);
+  const [clearMutation] = useMutation<
+    { clearRateLimits: number },
+    RateLimitQuery
+  >(CLEAR_RATE_LIMITS);
+
+  const onSubmit = (data: RateLimitSearchState) => {
+    const variables = createRateLimitQuery(data);
+
+    if (!validateQuery(variables)) {
+      window.alert('Please enter at least one of: IP address, email, or UID');
+      return;
+    }
+
+    getRateLimits({ variables });
+    setShowResults(true);
+
+    // keep form values after submit
+    reset(data);
+  };
+
+  const handleClear = async () => {
+    const values = getValues();
+    const variables = createRateLimitQuery(values);
+
+    if (!validateQuery(variables)) {
+      window.alert('Please enter at least one of: IP address, email, or UID');
+      return;
+    }
+
+    try {
+      const result = await clearMutation({
+        variables,
+        refetchQueries: [{ query: GET_RATE_LIMITS, variables }],
+        awaitRefetchQueries: true,
+      });
+      const count = result.data?.clearRateLimits || 0;
+      window.alert(`Successfully cleared ${count} rate limit record(s)`);
+      // No need for manual refetch since refetchQueries handles it
+    } catch (error) {
+      window.alert(
+        `Failed to clear: ${error instanceof Error ? error.message : 'Unknown error'}`
+      );
+    } finally {
+      // keep form values after submit
+      reset(values);
+    }
+  };
+
+  const SearchField = ({
+    id,
+    label,
+    type = 'text',
+  }: {
+    id: keyof RateLimitSearchState;
+    label: string;
+    type?: string;
+  }) => {
+    return (
+      <div>
+        <label
+          htmlFor={`rate-limit-${id}`}
+          className="block uppercase text-sm text-grey-500 mb-2"
+        >
+          {label}
+        </label>
+        <input
+          id={`rate-limit-${id}`}
+          name={id}
+          type={type}
+          placeholder={label}
+          className="bg-grey-50 rounded w-full py-2 px-3 placeholder-grey-500"
+          ref={register}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <h2 className="header-page">Rate Limiting</h2>
+      <p className="mb-4">
+        Search for active rate limiting blocks and bans by IP address, email,
+        and/or UID. Please provide as much fields as possible for more accurate
+        results.
+      </p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-5">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+          <SearchField id="ip" label="IP Address" />
+          <SearchField id="email" label="Email" type="email" />
+          <SearchField id="uid" label="UID" />
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            className="bg-grey-100 hover:bg-grey-200 text-black px-4 py-2 rounded flex items-center gap-2"
+          >
+            <img className="w-4 h-4" src={iconSearch} alt="search icon" />
+            Search Rate Limits
+          </button>
+
+          <button
+            type="button"
+            onClick={handleClear}
+            className="bg-red-100 hover:bg-red-200 text-black px-4 py-2 rounded"
+          >
+            Clear Rate Limits
+          </button>
+        </div>
+      </form>
+
+      {showResults && <RateLimitResults rateLimitsResult={rateLimitsResult} />}
+    </div>
+  );
+};
+
+interface RateLimitResultsProps {
+  rateLimitsResult: {
+    loading: boolean;
+    error?: ApolloError;
+    data?: { rateLimits: BlockStatusData[] };
+  };
+}
+
+const RateLimitResults = ({ rateLimitsResult }: RateLimitResultsProps) => {
+  if (rateLimitsResult.loading) {
+    return (
+      <>
+        <hr className="my-4" />
+        <p className="mt-2">Loading rate limit information...</p>
+      </>
+    );
+  }
+
+  if (rateLimitsResult.error) {
+    return (
+      <>
+        <hr className="my-4" />
+        <ErrorAlert error={rateLimitsResult.error} />
+      </>
+    );
+  }
+
+  const allRateLimits = rateLimitsResult.data?.rateLimits || [];
+
+  const blocks = allRateLimits.filter((item) => item.policy === 'block');
+  const bans = allRateLimits.filter((item) => item.policy === 'ban');
+
+  return (
+    <>
+      <hr className="my-4" />
+      <div className="mt-4">
+        <div className="mb-6">
+          <h3 className="text-lg font-semibold mb-3">
+            Active Blocks ({blocks.length})
+          </h3>
+          {blocks.length === 0 ? (
+            <p className="text-grey-600">No active blocks found.</p>
+          ) : (
+            <div className="space-y-3">
+              {blocks.map((block) => (
+                <BlockStatus
+                  key={`block-${block.action}-${block.blockingOn}-${block.startTime}`}
+                  status={block}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="mb-6">
+          <h3 className="text-lg font-semibold mb-3">
+            Active Bans ({bans.length})
+          </h3>
+          {bans.length === 0 ? (
+            <p className="text-grey-600">No active bans found.</p>
+          ) : (
+            <div className="space-y-3">
+              {bans.map((ban) => (
+                <BlockStatus
+                  key={`ban-${ban.action}-${ban.blockingOn}-${ban.startTime}`}
+                  status={ban}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default PageRateLimiting;

--- a/packages/fxa-admin-panel/src/components/PageRateLimiting/mocks.ts
+++ b/packages/fxa-admin-panel/src/components/PageRateLimiting/mocks.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { MockedResponse } from '@apollo/client/testing';
+import { BlockStatus } from 'fxa-admin-server/src/graphql';
+import { GET_RATE_LIMITS, CLEAR_RATE_LIMITS } from './index.gql';
+
+export const mockBlockStatusData1: BlockStatus = {
+  retryAfter: 30 * 60 * 1000, // 30 minutes in milliseconds
+  reason: 'Too many requests',
+  action: 'login',
+  blockingOn: 'ip_email',
+  startTime: 1760454159000,
+  duration: 60 * 60, // 1 hour in seconds
+  attempt: 5,
+  policy: 'block',
+};
+
+export const mockBlockStatusData2: BlockStatus = {
+  retryAfter: 10 * 60 * 1000, // 10 minutes in milliseconds
+  reason: 'Suspicious activity detected',
+  action: 'passwordChange',
+  blockingOn: 'uid',
+  startTime: 1760457759000,
+  duration: 2 * 60 * 60, // 2 hours in seconds
+  attempt: 3,
+  policy: 'block',
+};
+
+export const mockBanStatusData: BlockStatus = {
+  retryAfter: 24 * 60 * 60 * 1000, // 24 hours in milliseconds
+  reason: 'Ban reason',
+  action: 'accountLoginFailed',
+  blockingOn: 'email',
+  startTime: 1760450000000,
+  duration: 24 * 60 * 60, // 24 hours in seconds
+  attempt: 10,
+  policy: 'ban',
+};
+
+// Apollo mocks
+export class GetRateLimits {
+  static request(ip?: string, email?: string, uid?: string) {
+    return {
+      query: GET_RATE_LIMITS,
+      variables: {
+        ip: ip || undefined,
+        email: email || undefined,
+        uid: uid || undefined,
+      },
+    };
+  }
+
+  static result(rateLimits: BlockStatus[]) {
+    return {
+      data: {
+        rateLimits: rateLimits,
+      },
+    };
+  }
+
+  static mock(
+    rateLimits: BlockStatus[],
+    ip?: string,
+    email?: string,
+    uid?: string,
+    error?: Error
+  ): MockedResponse {
+    const mockResponse: MockedResponse = {
+      request: this.request(ip, email, uid),
+      result: this.result(rateLimits),
+    };
+
+    if (error) {
+      mockResponse.error = error;
+      delete mockResponse.result;
+    }
+
+    return mockResponse;
+  }
+
+  static emptyMock(ip?: string, email?: string, uid?: string): MockedResponse {
+    return this.mock([], ip, email, uid);
+  }
+
+  static nonEmptyMock(
+    ip?: string,
+    email?: string,
+    uid?: string
+  ): MockedResponse {
+    return this.mock(
+      [mockBlockStatusData1, mockBlockStatusData2, mockBanStatusData],
+      ip,
+      email,
+      uid
+    );
+  }
+
+  static errorMock(ip?: string, email?: string, uid?: string): MockedResponse {
+    return this.mock(
+      [],
+      ip,
+      email,
+      uid,
+      new Error('Failed to fetch rate limits')
+    );
+  }
+}
+
+export class ClearRateLimits {
+  static request(ip?: string, email?: string, uid?: string) {
+    return {
+      query: CLEAR_RATE_LIMITS,
+      variables: {
+        ip: ip || undefined,
+        email: email || undefined,
+        uid: uid || undefined,
+      },
+    };
+  }
+
+  static result(count: number) {
+    return {
+      data: {
+        clearRateLimits: count,
+      },
+    };
+  }
+
+  static mock(
+    count: number,
+    ip?: string,
+    email?: string,
+    uid?: string,
+    error?: Error
+  ): MockedResponse {
+    const mockResponse: MockedResponse = {
+      request: this.request(ip, email, uid),
+      result: this.result(count),
+    };
+
+    if (error) {
+      mockResponse.error = error;
+      delete mockResponse.result;
+    }
+
+    return mockResponse;
+  }
+
+  static successMock(
+    count: number = 3,
+    ip?: string,
+    email?: string,
+    uid?: string
+  ): MockedResponse {
+    return this.mock(count, ip, email, uid);
+  }
+
+  static errorMock(ip?: string, email?: string, uid?: string): MockedResponse {
+    return this.mock(
+      0,
+      ip,
+      email,
+      uid,
+      new Error('Failed to clear rate limits')
+    );
+  }
+}

--- a/packages/fxa-admin-panel/src/lib/utils.spec.ts
+++ b/packages/fxa-admin-panel/src/lib/utils.spec.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getFormattedDuration } from './utils';
+
+describe('utils', () => {
+  describe('formatDuration', () => {
+    it('should format seconds only when less than 60', () => {
+      expect(getFormattedDuration(0)).toBe('0s');
+      expect(getFormattedDuration(59)).toBe('59s');
+    });
+
+    it('should format minutes and seconds when less than an hour', () => {
+      expect(getFormattedDuration(60)).toBe('1m 0s');
+      expect(getFormattedDuration(60 * 60 - 1)).toBe('59m 59s');
+    });
+
+    it('should format hours, minutes, and seconds when more than an hour', () => {
+      expect(getFormattedDuration(60 * 60)).toBe('1h 0m 0s');
+      expect(getFormattedDuration(60 * 60 + 60 + 1)).toBe('1h 1m 1s');
+      expect(getFormattedDuration(25 * 60 * 60 + 59 * 60 + 59)).toBe(
+        '25h 59m 59s'
+      );
+    });
+  });
+});

--- a/packages/fxa-admin-panel/src/lib/utils.ts
+++ b/packages/fxa-admin-panel/src/lib/utils.ts
@@ -8,3 +8,12 @@ const DATE_FORMAT = 'yyyy-mm-dd @ HH:MM:ss Z';
 
 export const getFormattedDate = (raw: Nullable<number> | undefined) =>
   dateFormat(new Date(raw || 0), DATE_FORMAT);
+
+export const getFormattedDuration = (seconds: number) => {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  return `${hours}h ${minutes}m ${secs}s`;
+};

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -72,6 +72,32 @@ const conf = convict({
     fxa_oauth: makeMySQLConfig('OAUTH', 'fxa_oauth'),
   },
   redis: makeRedisConfig(),
+  rateLimit: {
+    ignoreIPs: {
+      default: undefined,
+      doc: 'Set of IPs to ignore while rate limiting. Rules will not apply to these values.',
+      env: 'RATE_LIMIT__IGNORE_IPS',
+      format: Array,
+    },
+    ignoreUIDs: {
+      default: undefined,
+      doc: 'Set of UIDs to ignore while rate limiting. Rules will not apply to these values.',
+      env: 'RATE_LIMIT__IGNORE_UIDS',
+      format: Array,
+    },
+    ignoreEmails: {
+      default: undefined,
+      doc: 'Set of emails to ignore while rate limiting. Rules will not apply to these values. Values can be a string or parsable regex.',
+      env: 'RATE_LIMIT__IGNORE_EMAILS',
+      format: Array,
+    },
+    rules: {
+      default: '',
+      doc: 'Rules for rate limiting user actions. These are essentially customs v2 rules.',
+      env: 'RATE_LIMIT__RULES',
+      format: String,
+    },
+  },
   env: {
     default: 'production',
     doc: 'The current node.js environment',

--- a/packages/fxa-admin-server/src/gql/gql.module.ts
+++ b/packages/fxa-admin-server/src/gql/gql.module.ts
@@ -17,6 +17,11 @@ import { SubscriptionModule } from '../subscriptions/subscriptions.module';
 import { AccountResolver } from './account/account.resolver';
 import { EmailBounceResolver } from './email-bounce/email-bounce.resolver';
 import { RelyingPartyResolver } from './relying-party/relying-party.resolver';
+import { RateLimitingResolver } from './rate-limiting/rate-limiting.resolver';
+import {
+  RateLimitProvider,
+  RateLimitRedisProvider,
+} from '@fxa/accounts/rate-limit';
 import { APP_FILTER } from '@nestjs/core';
 import { SentryGlobalFilter } from '@sentry/nestjs/setup';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
@@ -34,6 +39,9 @@ import { CartModule } from './cart.module';
   providers: [
     AccountResolver,
     EmailBounceResolver,
+    RateLimitingResolver,
+    RateLimitProvider,
+    RateLimitRedisProvider,
     LegacyStatsDProvider,
     LegacyNotifierServiceProvider,
     LegacyNotifierSnsFactory,

--- a/packages/fxa-admin-server/src/gql/model/block-status.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/block-status.model.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType, Int, Float } from '@nestjs/graphql';
+
+@ObjectType()
+export class BlockStatus {
+  @Field(() => Float)
+  public retryAfter!: number;
+
+  @Field()
+  public reason!: string;
+
+  @Field()
+  public action!: string;
+
+  @Field()
+  public blockingOn!: string;
+
+  @Field(() => Float)
+  public startTime!: number;
+
+  @Field(() => Int)
+  public duration!: number;
+
+  @Field(() => Int)
+  public attempt!: number;
+
+  @Field()
+  public policy!: string;
+}

--- a/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.spec.ts
@@ -1,0 +1,165 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { MozLoggerService } from '@fxa/shared/mozlog';
+import { RateLimitClient } from '@fxa/accounts/rate-limit';
+import { EventLoggingService } from '../../event-logging/event-logging.service';
+import { RateLimitingResolver } from './rate-limiting.resolver';
+import { BlockStatus } from '../model/block-status.model';
+
+describe('RateLimitingResolver', () => {
+  let resolver: RateLimitingResolver;
+  let logger: any;
+  let rateLimit: any;
+
+  const mockBlockStatus: BlockStatus = {
+    retryAfter: 3600,
+    reason: 'too-many-attempts',
+    action: 'login',
+    blockingOn: 'ip',
+    startTime: Date.now() - 5000,
+    duration: 3600,
+    attempt: 3,
+    policy: 'block',
+  };
+
+  beforeEach(async () => {
+    logger = { debug: jest.fn(), error: jest.fn(), info: jest.fn() };
+    rateLimit = {
+      search: jest.fn(),
+      searchAndClear: jest.fn(),
+    };
+
+    const MockMozLoggerService: Provider = {
+      provide: MozLoggerService,
+      useValue: logger,
+    };
+
+    const MockConfig: Provider = {
+      provide: ConfigService,
+      useValue: {
+        get: jest.fn().mockReturnValue({ authHeader: 'test' }),
+      },
+    };
+
+    const MockMetricsFactory: Provider = {
+      provide: 'METRICS',
+      useFactory: () => undefined,
+    };
+
+    const MockRateLimit: Provider = {
+      provide: RateLimitClient,
+      useValue: rateLimit,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateLimitingResolver,
+        EventLoggingService,
+        MockMozLoggerService,
+        MockConfig,
+        MockMetricsFactory,
+        MockRateLimit,
+      ],
+    }).compile();
+
+    resolver = module.get<RateLimitingResolver>(RateLimitingResolver);
+  });
+
+  describe('rateLimits', () => {
+    it('should return rate limits for IP address', async () => {
+      const testIp = '192.168.1.1';
+      rateLimit.search.mockResolvedValue([mockBlockStatus]);
+
+      const result = await resolver.rateLimits('testUser', testIp);
+
+      expect(result).toEqual([mockBlockStatus]);
+      expect(rateLimit.search).toHaveBeenCalledWith({
+        ip: testIp,
+        email: undefined,
+        uid: undefined,
+      });
+      expect(logger.info).toHaveBeenCalledWith('rateLimits', {
+        user: 'testUser',
+        query: { ip: testIp, email: undefined, uid: undefined },
+      });
+    });
+  });
+
+  describe('clear', () => {
+    it('should clear IP address and return count', async () => {
+      const testIp = '192.168.1.1';
+      rateLimit.searchAndClear.mockResolvedValue(5);
+
+      const result = await resolver.clearRateLimits('testUser', testIp);
+
+      expect(result).toBe(5);
+      expect(rateLimit.searchAndClear).toHaveBeenCalledWith({
+        ip: testIp,
+        email: undefined,
+        uid: undefined,
+      });
+      expect(logger.info).toHaveBeenCalledWith('clear', {
+        user: 'testUser',
+        ip: testIp,
+        email: undefined,
+        uid: undefined,
+      });
+    });
+
+    it('should clear with email and uid', async () => {
+      const testEmail = 'test@example.com';
+      const testUid = 'user123';
+      rateLimit.searchAndClear.mockResolvedValue(2);
+
+      const result = await resolver.clearRateLimits(
+        'testUser',
+        undefined,
+        testEmail,
+        testUid
+      );
+
+      expect(result).toBe(2);
+      expect(rateLimit.searchAndClear).toHaveBeenCalledWith({
+        ip: undefined,
+        email: testEmail,
+        uid: testUid,
+      });
+      expect(logger.info).toHaveBeenCalledWith('clear', {
+        user: 'testUser',
+        ip: undefined,
+        email: testEmail,
+        uid: testUid,
+      });
+    });
+
+    it('should clear with multiple parameters', async () => {
+      const testIp = '192.168.1.1';
+      const testEmail = 'test@example.com';
+      rateLimit.searchAndClear.mockResolvedValue(3);
+
+      const result = await resolver.clearRateLimits(
+        'testUser',
+        testIp,
+        testEmail
+      );
+
+      expect(result).toBe(3);
+      expect(rateLimit.searchAndClear).toHaveBeenCalledWith({
+        ip: testIp,
+        email: testEmail,
+        uid: undefined,
+      });
+      expect(logger.info).toHaveBeenCalledWith('clear', {
+        user: 'testUser',
+        ip: testIp,
+        email: testEmail,
+        uid: undefined,
+      });
+    });
+  });
+});

--- a/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { UseGuards, Inject } from '@nestjs/common';
+import { Args, Query, Resolver, Mutation } from '@nestjs/graphql';
+import { AdminPanelFeature } from '@fxa/shared/guards';
+import { MozLoggerService } from '@fxa/shared/mozlog';
+
+import { RateLimit, RateLimitClient } from '@fxa/accounts/rate-limit';
+import { CurrentUser } from '../../auth/auth-header.decorator';
+import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
+import { Features } from '../../auth/user-group-header.decorator';
+import { BlockStatus } from '../model/block-status.model';
+
+@UseGuards(GqlAuthHeaderGuard)
+@Resolver(() => BlockStatus)
+export class RateLimitingResolver {
+  constructor(
+    private log: MozLoggerService,
+    @Inject(RateLimitClient) private rateLimit: RateLimit
+  ) {}
+
+  @Query(() => [BlockStatus])
+  @Features(AdminPanelFeature.RateLimiting)
+  public async rateLimits(
+    @CurrentUser() user: string,
+    @Args('ip', { nullable: true }) ip?: string,
+    @Args('email', { nullable: true }) email?: string,
+    @Args('uid', { nullable: true }) uid?: string
+  ): Promise<BlockStatus[]> {
+    this.log.info('rateLimits', { user, query: { ip, email, uid } });
+    return await this.rateLimit.search({ ip, email, uid });
+  }
+
+  @Mutation(() => Number)
+  @Features(AdminPanelFeature.RateLimiting)
+  public async clearRateLimits(
+    @CurrentUser() user: string,
+    @Args('ip', { type: () => String, nullable: true }) ip?: string,
+    @Args('email', { type: () => String, nullable: true }) email?: string,
+    @Args('uid', { type: () => String, nullable: true }) uid?: string
+  ): Promise<number> {
+    this.log.info('clear', { user, ip, email, uid });
+
+    return await this.rateLimit.searchAndClear({ ip, email, uid });
+  }
+}

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -235,6 +235,17 @@ export interface RelyingPartyDto {
     notes?: Nullable<string>;
 }
 
+export interface BlockStatus {
+    retryAfter: number;
+    reason: string;
+    action: string;
+    blockingOn: string;
+    startTime: number;
+    duration: number;
+    attempt: number;
+    policy: string;
+}
+
 export interface IQuery {
     accountByUid(uid: string): Nullable<Account> | Promise<Nullable<Account>>;
     accountByEmail(email: string, autoCompleted: boolean): Nullable<Account> | Promise<Nullable<Account>>;
@@ -242,6 +253,7 @@ export interface IQuery {
     getEmailsLike(search: string): Nullable<Email[]> | Promise<Nullable<Email[]>>;
     getRecoveryPhonesLike(search: string): Nullable<RecoveryPhone[]> | Promise<Nullable<RecoveryPhone[]>>;
     getDeleteStatus(taskNames: string[]): AccountDeleteTaskStatus[] | Promise<AccountDeleteTaskStatus[]>;
+    rateLimits(ip?: Nullable<string>, email?: Nullable<string>, uid?: Nullable<string>): BlockStatus[] | Promise<BlockStatus[]>;
     relyingParties(): RelyingPartyDto[] | Promise<RelyingPartyDto[]>;
 }
 
@@ -256,6 +268,7 @@ export interface IMutation {
     unsubscribeFromMailingLists(uid: string): boolean | Promise<boolean>;
     deleteAccounts(locators: string[]): AccountDeleteResponse[] | Promise<AccountDeleteResponse[]>;
     clearEmailBounce(email: string): boolean | Promise<boolean>;
+    clearRateLimits(ip?: Nullable<string>, email?: Nullable<string>, uid?: Nullable<string>): number | Promise<number>;
     create(relyingParty: RelyingPartyUpdateDto): string | Promise<string>;
     update(id: string, relyingParty: RelyingPartyUpdateDto): boolean | Promise<boolean>;
     delete(id: string): boolean | Promise<boolean>;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -225,6 +225,17 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
+type BlockStatus {
+  retryAfter: Float!
+  reason: String!
+  action: String!
+  blockingOn: String!
+  startTime: Float!
+  duration: Int!
+  attempt: Int!
+  policy: String!
+}
+
 type Query {
   accountByUid(uid: String!): Account
   accountByEmail(email: String!, autoCompleted: Boolean!): Account
@@ -232,6 +243,7 @@ type Query {
   getEmailsLike(search: String!): [Email!]
   getRecoveryPhonesLike(search: String!): [RecoveryPhone!]
   getDeleteStatus(taskNames: [String!]!): [AccountDeleteTaskStatus!]!
+  rateLimits(ip: String, email: String, uid: String): [BlockStatus!]!
   relyingParties: [RelyingPartyDto!]!
 }
 
@@ -246,6 +258,7 @@ type Mutation {
   unsubscribeFromMailingLists(uid: String!): Boolean!
   deleteAccounts(locators: [String!]!): [AccountDeleteResponse!]!
   clearEmailBounce(email: String!): Boolean!
+  clearRateLimits(ip: String, email: String, uid: String): Float!
   create(relyingParty: RelyingPartyUpdateDto!): String!
   update(id: String!, relyingParty: RelyingPartyUpdateDto!): Boolean!
   delete(id: String!): Boolean!

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -37,7 +37,8 @@
       "@fxa/shared/notifier": ["libs/shared/notifier/src/index"],
       "@fxa/shared/mozlog": ["libs/shared/mozlog/src/index"],
       "@fxa/shared/sentry-nest": ["libs/shared/sentry-nest/src/index"],
-      "@fxa/shared/sentry-utils": ["libs/shared/sentry-utils/src/index"]
+      "@fxa/shared/sentry-utils": ["libs/shared/sentry-utils/src/index"],
+      "@fxa/accounts/rate-limit": ["libs/accounts/rate-limit/src/index"]
     }
   }
 }


### PR DESCRIPTION
## Because

- we want to search for and clear rate limits in admin panel

## This pull request

- implements rate limit search
- implements rate limit clear

## Issue that this pull request solves

Closes: FXA-11930 FXA-11931

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1426" height="830" alt="image" src="https://github.com/user-attachments/assets/767c10c5-3c84-472f-a01c-ec1e61972fb3" />

## Other information (Optional)

Any other information that is important to this pull request.
