### PR TITLE
polish(auth-server): Remove duplicate key stretch security event logging

### DIFF
--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -389,12 +389,6 @@ module.exports = function (
               account: passwordChangeToken,
             });
 
-            await recordSecurityEvent('account.password_upgraded', {
-              db,
-              request,
-              account: passwordChangeToken,
-            });
-
             return { result, account, isPasswordUpgrade };
           }
 
@@ -783,25 +777,22 @@ module.exports = function (
               account: { uid },
             });
 
-            await recordSecurityEvent('account.password_upgraded', {
-              db,
-              request,
-              account: { uid },
-            });
-
             return { result, account, isPasswordUpgrade };
           }
 
-          const result = await db.resetAccount({ uid }, {
-            authSalt: authSalt,
-            clientSalt: clientSalt,
-            verifierVersion: password.version,
-            verifyHash: verifyHash,
-            verifyHashVersion2: verifyHashVersion2,
-            wrapWrapKb: wrapWrapKb,
-            wrapWrapKbVersion2: wrapWrapKbVersion2,
-            keysHaveChanged: false,
-          });
+          const result = await db.resetAccount(
+            { uid },
+            {
+              authSalt: authSalt,
+              clientSalt: clientSalt,
+              verifierVersion: password.version,
+              verifyHash: verifyHash,
+              verifyHashVersion2: verifyHashVersion2,
+              wrapWrapKb: wrapWrapKb,
+              wrapWrapKbVersion2: wrapWrapKbVersion2,
+              keysHaveChanged: false,
+            }
+          );
 
           await request.emitMetricsEvent('account.changedPassword', {
             uid: uid,
@@ -832,10 +823,7 @@ module.exports = function (
 
           if (devicesToNotify) {
             // Notify the devices that the account has changed.
-            push.notifyPasswordChanged(
-              uid,
-              devicesToNotify
-            );
+            push.notifyPasswordChanged(uid, devicesToNotify);
           }
 
           log.notifyAttachedServices('passwordChange', request, {
@@ -955,7 +943,8 @@ module.exports = function (
           const response: any = {
             uid: newSessionToken.uid,
             sessionToken: newSessionToken.data,
-            verified: newSessionToken.emailVerified && newSessionToken.tokenVerified,
+            verified:
+              newSessionToken.emailVerified && newSessionToken.tokenVerified,
             authAt: newSessionToken.lastAuthAt(),
           };
 

--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -54,7 +54,12 @@ export const EVENT_NAMES: Record<string, number> = {
   'account.two_factor_replace_success': 40,
   'account.two_factor_replace_failure': 41,
   'account.password_upgrade_success': 42,
-  'account.password_upgraded': 43,
+  /*
+   * This was added as a duplicate, however to avoid having breaking changes
+   * with migrations, removing security event records, etc., we're leaving it here
+   * for reference.
+   */
+  //'account.password_upgraded': 43,
   'account.recovery_phone_setup_failed': 44,
   'account.mfa_send_otp_code': 45,
   'account.mfa_verify_otp_code_success': 46,
@@ -203,10 +208,7 @@ export class SecurityEvent extends BaseAuthModel {
       .limit(20);
   }
 
-  static async findByUidAndVerifiedLogin(
-    uid: string,
-    timeframeMs: number
-  ) {
+  static async findByUidAndVerifiedLogin(uid: string, timeframeMs: number) {
     const id = uuidTransformer.to(uid);
     const cutoffDate = Date.now() - timeframeMs;
 


### PR DESCRIPTION
Because:
 - We have a duplicate security event being logged during key stretching upgrade

This Commit:
 - Removes the call to the duplicate, and comments out the event name so we don't accidentally add it back.

Closes: FXA-12545

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
