### PR TITLE
feat(settings): Redirect users from Settings with AAL mismatch

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1161,7 +1161,16 @@ export default class AuthClient {
   async sessionStatus(
     sessionToken: hexstring,
     headers?: Headers
-  ): Promise<{ state: 'verified' | 'unverified'; uid: string }> {
+  ): Promise<{
+    state: 'verified' | 'unverified';
+    uid: string;
+    details: {
+      accountEmailVerified: boolean;
+      sessionVerificationMethod: string | null;
+      sessionVerified: boolean;
+      sessionVerificationMeetsMinimumAAL: boolean;
+    };
+  }> {
     return this.sessionGet('/session/status', sessionToken, headers);
   }
 

--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -70,7 +70,13 @@ const SESSION_STATUS_GET = {
     dedent`
       🔒 Authenticated with session token
 
-      Returns a success response if the session token is valid.
+      Returns a success response if the session token is valid. The response includes detailed information about the session and account state.
+
+      **Response details object:**
+      - \`accountEmailVerified\`: Whether the account's primary email is verified
+      - \`sessionVerificationMethod\`: The verification method used for the session (e.g., 'email-2fa', 'totp-2fa'), or null if not verified
+      - \`sessionVerified\`: Whether the session token itself is verified (no pending token verification)
+      - \`sessionVerificationMeetsMinimumAAL\`: Whether the session's Authentication Assurance Level (AAL) meets or exceeds the account's maximum AAL
     `,
   ],
 };

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -324,7 +324,13 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
           log.info('account.recoveryCode.consumedAllCodes', { uid });
         }
 
-        if (tokenVerificationId) {
+        if (
+          tokenVerificationId ||
+          // If there is no tokenVerificationId but the auth assurance level needs
+          // to be upgraded, then this user was redirected from Settings to
+          // our TOTP page and entered a recovery code to upgrade their session
+          request.auth.credentials.authenticatorAssuranceLevel <= 1
+        ) {
           await db.verifyTokensWithMethod(tokenId, 'recovery-code');
         }
 

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -300,7 +300,7 @@ module.exports = function (
             details: isA.object({
               accountEmailVerified: isA.boolean(),
               sessionVerificationMethod: isA.string().allow(null),
-              sessionVerificationSuccessful: isA.boolean(),
+              sessionVerified: isA.boolean(),
               sessionVerificationMeetsMinimumAAL: isA.boolean(),
             }),
           }),
@@ -325,15 +325,13 @@ module.exports = function (
         const sessionAal = sessionToken.authenticatorAssuranceLevel;
 
         // Build response
-        const accountEmailVerified =
-          account.emails?.primaryEmail?.isVerified || false;
+        const accountEmailVerified = account.primaryEmail.isVerified;
 
-        const sessionVerificationMethod = sessionToken.verificationMethod;
+        const sessionVerificationMethod =
+          sessionToken.verificationMethodValue || null;
 
         // See verified-session-token auth strategy
-        const sessionVerificationSuccessful =
-          sessionToken.tokenVerificationId == null &&
-          sessionToken.tokenVerified !== false;
+        const sessionVerified = !sessionToken.tokenVerificationId;
 
         // Account Assurance Level
         const sessionVerificationMeetsMinimumAAL = sessionAal >= accountAal;
@@ -344,7 +342,7 @@ module.exports = function (
           details: {
             accountEmailVerified,
             sessionVerificationMethod,
-            sessionVerificationSuccessful,
+            sessionVerified,
             sessionVerificationMeetsMinimumAAL,
           },
         };

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -182,7 +182,9 @@ describe('/session/status', () => {
   it('returns status correctly', () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {},
+      primaryEmail: {
+        isVerified: false,
+      },
     });
     db.totpToken = sinon.fake.resolves({
       verified: false,
@@ -192,7 +194,7 @@ describe('/session/status', () => {
       credentials: {
         email: 'foo@example.org',
         state: 'unverified',
-        verificationMethod: 'totp-2fa',
+        verificationMethodValue: 'totp-2fa',
         verified: false,
         tokenVerified: false,
         tokenVerificationId: 'token-123',
@@ -207,7 +209,7 @@ describe('/session/status', () => {
           accountEmailVerified: false,
           sessionVerificationMeetsMinimumAAL: false,
           sessionVerificationMethod: 'totp-2fa',
-          sessionVerificationSuccessful: false,
+          sessionVerified: false,
         },
       });
     });
@@ -216,7 +218,9 @@ describe('/session/status', () => {
   it('has unverified primary email', async () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {},
+      primaryEmail: {
+        isVerified: false,
+      },
     });
     db.totpToken = sinon.fake.resolves({
       verified: false,
@@ -228,8 +232,8 @@ describe('/session/status', () => {
         uid: 'account-123',
         state: 'unverified',
         verified: false,
-        tokenVerified: false,
-        verificationMethod: 'email',
+        tokenVerificationId: 'verification-id',
+        verificationMethodValue: 'email',
         authenticatorAssuranceLevel: 1,
       },
     });
@@ -241,7 +245,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: false,
         sessionVerificationMethod: 'email',
-        sessionVerificationSuccessful: false,
+        sessionVerified: false,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -250,7 +254,9 @@ describe('/session/status', () => {
   it('has unverified session because of defined tokenVerificationId', async () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {},
+      primaryEmail: {
+        isVerified: false,
+      },
     });
     db.totpToken = sinon.fake.resolves({
       verified: false,
@@ -263,7 +269,7 @@ describe('/session/status', () => {
         state: 'unverified',
         verified: false,
         tokenVerificationId: 'token-123',
-        verificationMethod: 'email',
+        verificationMethodValue: 'email',
         authenticatorAssuranceLevel: 1,
       },
     });
@@ -275,7 +281,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: false,
         sessionVerificationMethod: 'email',
-        sessionVerificationSuccessful: false,
+        sessionVerified: false,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -284,10 +290,8 @@ describe('/session/status', () => {
   it('has unverified AAL 1', async () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {
-        primaryEmail: {
-          isVerified: true,
-        },
+      primaryEmail: {
+        isVerified: true,
       },
     });
     db.totpToken = sinon.fake.resolves({
@@ -300,8 +304,8 @@ describe('/session/status', () => {
         uid: 'account-123',
         state: 'unverified',
         verified: false,
-        tokenVerified: false,
-        verificationMethod: 'email',
+        tokenVerificationId: 'verification-id',
+        verificationMethodValue: 'email',
         authenticatorAssuranceLevel: 1,
       },
     });
@@ -313,7 +317,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: true,
         sessionVerificationMethod: 'email',
-        sessionVerificationSuccessful: false,
+        sessionVerified: false,
         sessionVerificationMeetsMinimumAAL: false,
       },
     });
@@ -322,10 +326,8 @@ describe('/session/status', () => {
   it('has unverified AAL 2', async () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {
-        primaryEmail: {
-          isVerified: true,
-        },
+      primaryEmail: {
+        isVerified: true,
       },
     });
     db.totpToken = sinon.fake.resolves({
@@ -338,7 +340,7 @@ describe('/session/status', () => {
         uid: 'account-123',
         state: 'verified',
         verified: true,
-        verificationMethod: 'totp-2fa',
+        verificationMethodValue: 'totp-2fa',
         authenticatorAssuranceLevel: 1,
       },
     });
@@ -350,7 +352,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: true,
         sessionVerificationMethod: 'totp-2fa',
-        sessionVerificationSuccessful: true,
+        sessionVerified: true,
         sessionVerificationMeetsMinimumAAL: false,
       },
     });
@@ -359,10 +361,8 @@ describe('/session/status', () => {
   it('has verified AAL 1 state', async () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {
-        primaryEmail: {
-          isVerified: true,
-        },
+      primaryEmail: {
+        isVerified: true,
       },
     });
     db.totpToken = sinon.fake.resolves({
@@ -374,7 +374,7 @@ describe('/session/status', () => {
         uid: 'account-123',
         state: 'verified',
         verified: true,
-        verificationMethod: 'email',
+        verificationMethodValue: 'email',
         authenticatorAssuranceLevel: 1,
       },
     });
@@ -386,7 +386,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: true,
         sessionVerificationMethod: 'email',
-        sessionVerificationSuccessful: true,
+        sessionVerified: true,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -395,10 +395,8 @@ describe('/session/status', () => {
   it('has verified AAL 2', async () => {
     db.account = sinon.fake.resolves({
       uid: 'account-123',
-      emails: {
-        primaryEmail: {
-          isVerified: true,
-        },
+      primaryEmail: {
+        isVerified: true,
       },
     });
     db.totpToken = sinon.fake.resolves({
@@ -411,7 +409,7 @@ describe('/session/status', () => {
         uid: 'account-123',
         state: 'verified',
         verified: true,
-        verificationMethod: 'totp-2fa',
+        verificationMethodValue: 'totp-2fa',
         authenticatorAssuranceLevel: 2,
       },
     });
@@ -423,7 +421,7 @@ describe('/session/status', () => {
       details: {
         accountEmailVerified: true,
         sessionVerificationMethod: 'totp-2fa',
-        sessionVerificationSuccessful: true,
+        sessionVerified: true,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });

--- a/packages/fxa-auth-server/test/remote/session_tests.js
+++ b/packages/fxa-auth-server/test/remote/session_tests.js
@@ -539,10 +539,10 @@ const config = require('../../config').default.getProperties();
               state: 'unverified',
               uid: uid,
               details: {
-                accountEmailVerified: false,
+                accountEmailVerified: true,
                 sessionVerificationMeetsMinimumAAL: true,
                 sessionVerificationMethod: null,
-                sessionVerificationSuccessful: false,
+                sessionVerified: false,
               },
             });
           });

--- a/packages/fxa-react/components/AppErrorDialog/en.ftl
+++ b/packages/fxa-react/components/AppErrorDialog/en.ftl
@@ -5,8 +5,3 @@ app-general-err-message = Something went wrong. Please try again later.
 
 # Specific handling for issues when bad or missing query parameters are detected
 app-query-parameter-err-heading = Bad Request: Invalid Query Parameters
-
-# Specific handler for issues where something went side with the session. Maybe it did't have proper permissions,
-# or maybe the session token is stale and the user needs to sign back in again.
-app-invalid-session-err-heading = Invalid Session
-app-invalid-session-err-message = Please sign out and sign in again.

--- a/packages/fxa-react/components/AppErrorDialog/index.stories.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.stories.tsx
@@ -31,12 +31,4 @@ storiesOf('Components/AppErrorDialog', module)
     >
       <AppErrorDialog errorType="query-parameter-violation" />
     </AppLocalizationProvider>
-  ))
-  .add('invalid session', () => (
-    <AppLocalizationProvider
-      baseDir="./locales"
-      userLocales={navigator.languages}
-    >
-      <AppErrorDialog errorType="invalid-session" />
-    </AppLocalizationProvider>
   ));

--- a/packages/fxa-react/components/AppErrorDialog/index.test.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.test.tsx
@@ -14,15 +14,4 @@ describe('AppErrorDialog', () => {
 
     expect(queryByTestId('error-loading-app')).toBeInTheDocument();
   });
-
-  it('can trigger another signin attempt in invalid-session case', async () => {
-    const { queryByText } = renderWithLocalizationProvider(
-      <AppErrorDialog errorType="invalid-session" />
-    );
-
-    expect(queryByText('Invalid Session')).toBeInTheDocument();
-    expect(
-      queryByText('Please sign out and sign in again.')
-    ).toBeInTheDocument();
-  });
 });

--- a/packages/fxa-react/components/AppErrorDialog/index.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.tsx
@@ -5,10 +5,7 @@
 import React from 'react';
 import { Localized } from '@fluent/react';
 
-export type ErrorType =
-  | 'general'
-  | 'query-parameter-violation'
-  | 'invalid-session';
+export type ErrorType = 'general' | 'query-parameter-violation';
 
 const AppErrorDialog = ({ errorType }: { errorType?: ErrorType }) => {
   if (errorType == null) {
@@ -45,24 +42,6 @@ const AppErrorDialog = ({ errorType }: { errorType?: ErrorType }) => {
               Something went wrong. Please try again later.
             </p>
           </Localized>
-        )}
-
-        {errorType === 'invalid-session' && (
-          <>
-            <Localized id="app-invalid-session-err-heading">
-              <h2
-                className="text-grey-900 font-header text-lg font-bold mb-3"
-                data-testid="error-invalid-session"
-              >
-                Invalid Session
-              </h2>
-            </Localized>
-            <Localized id="app-invalid-session-err-message">
-              <p className="text-grey-400">
-                Please sign out and sign in again.
-              </p>
-            </Localized>
-          </>
         )}
       </div>
     </div>

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -82,6 +82,7 @@ jest.mock('../../lib/cache', () => ({
   currentAccount: jest.fn(),
 }));
 
+const mockSessionStatus = jest.fn();
 jest.mock('../../models', () => ({
   ...jest.requireActual('../../models'),
   useInitialMetricsQueryState: jest.fn(),
@@ -91,6 +92,9 @@ jest.mock('../../models', () => ({
   useProductInfoState: jest.fn(),
   useIntegration: jest.fn(),
   useSession: jest.fn(),
+  useAuthClient: jest.fn(() => ({
+    sessionStatus: mockSessionStatus,
+  })),
 }));
 
 jest.mock('react-markdown', () => {});
@@ -415,6 +419,12 @@ describe('SettingsRoutes', () => {
       data: {},
     });
     (useInitialSettingsState as jest.Mock).mockReturnValue({ loading: false });
+    mockSessionStatus.mockResolvedValue({
+      details: {
+        sessionVerified: true,
+        sessionVerificationMeetsMinimumAAL: true,
+      },
+    });
   });
 
   afterEach(() => {
@@ -427,6 +437,7 @@ describe('SettingsRoutes', () => {
     (firefox.requestSignedInUser as jest.Mock).mockRestore();
     (useClientInfoState as jest.Mock).mockRestore();
     (useSession as jest.Mock).mockRestore();
+    mockSessionStatus.mockClear();
   });
 
   it('redirects to email-first if isSignedIn is false', async () => {

--- a/packages/fxa-settings/src/components/ErrorBoundaries/index.tsx
+++ b/packages/fxa-settings/src/components/ErrorBoundaries/index.tsx
@@ -6,7 +6,6 @@ import React, { ReactNode } from 'react';
 import { ModelValidationErrors } from '../../lib/model-data';
 import * as Sentry from '@sentry/browser';
 import AppErrorDialog from 'fxa-react/components/AppErrorDialog';
-import { AuthUiErrors, isAuthUiError } from '../../lib/auth-errors/auth-errors';
 
 /**
  * Handles errors that might occur in fxa-settings
@@ -48,16 +47,6 @@ export class AppErrorBoundary extends React.Component<{ children: ReactNode }> {
 }
 
 export const AppError = ({ error }: { error?: Error }) => {
-  // Special handling for invalid session states
-  if (
-    isAuthUiError(error) &&
-    (error.errno === AuthUiErrors.INVALID_TOKEN.errno ||
-      error.errno === AuthUiErrors.UNVERIFIED_SESSION.errno)
-  ) {
-    // TODO: Add functionality so that is easy for a user to sign back in.
-    return <AppErrorDialog errorType="invalid-session" />;
-  }
-
   // Special handling for validation errors
   if (error instanceof ModelValidationErrors) {
     return <AppErrorDialog errorType="query-parameter-violation" />;

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -56,8 +56,7 @@ const ERRORS = {
   },
   INVALID_TOKEN: {
     errno: 110,
-    message: 'Invalid session. Please sign out and sign in again.',
-    version: 2,
+    message: 'Invalid token',
   },
   INVALID_TIMESTAMP: {
     errno: 111,
@@ -140,8 +139,8 @@ const ERRORS = {
   },
   UNVERIFIED_SESSION: {
     errno: 138,
-    message: 'Unconfirmed session. Please sign out and sign in again.',
-    version: 3,
+    message: 'Unconfirmed session',
+    version: 2,
   },
   EMAIL_PRIMARY_EXISTS: {
     errno: 139,

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -4,7 +4,6 @@ auth-error-102 = Unknown account
 auth-error-103 = Incorrect password
 auth-error-105-2 = Invalid confirmation code
 auth-error-110 = Invalid token
-auth-error-110-2 = Invalid session. Please sign out and sign in again.
 # Error shown to users when they have attempted a request (e.g., requesting a password reset) too many times
 # and their requests have been throttled, but the specific amount of time before they can retry is unknown.
 auth-error-114-generic = You’ve tried too many times. Please try again later.
@@ -17,7 +16,6 @@ auth-error-114 = You’ve tried too many times. Please try again { $retryAfter }
 auth-error-125 = The request was blocked for security reasons
 auth-error-129-2 = You entered an invalid phone number. Please check it and try again.
 auth-error-138-2 = Unconfirmed session
-auth-error-138-3 = Unconfirmed Session. Please sign out and sign in again.
 auth-error-139 = Secondary email must be different than your account email
 auth-error-155 = TOTP token not found
 # Error shown when the user submits an invalid backup authentication code

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -76,8 +76,14 @@ const SigninRecoveryCode = ({
     submitButtonText: 'Confirm',
   };
 
-  const { email, sessionToken, uid, verificationMethod, verificationReason } =
-    signinState;
+  const {
+    email,
+    sessionToken,
+    uid,
+    verificationMethod,
+    verificationReason,
+    isSessionAALUpgrade,
+  } = signinState;
 
   const clearBanners = () => {
     setBannerErrorMessage('');
@@ -101,6 +107,7 @@ const SigninRecoveryCode = ({
       finishOAuthFlowHandler,
       redirectTo,
       queryParams: location.search,
+      isSessionAALUpgrade,
       handleFxaLogin: true,
       handleFxaOAuthLogin: true,
       performNavigation: !integration.isFirefoxMobileClient(),
@@ -111,6 +118,7 @@ const SigninRecoveryCode = ({
       setBannerErrorMessage(getLocalizedErrorMessage(ftlMsgResolver, error));
     }
   }, [
+    isSessionAALUpgrade,
     email,
     integration,
     finishOAuthFlowHandler,

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
@@ -169,6 +169,8 @@ describe('SigninRecoveryPhoneContainer', () => {
         resendCode: expect.any(Function),
         verifyCode: expect.any(Function),
         integration: expect.any(Object),
+        numBackupCodes: undefined,
+        sendError: undefined,
       });
     });
 
@@ -196,6 +198,33 @@ describe('SigninRecoveryPhoneContainer', () => {
       await currentPageProps?.resendCode();
       expect(mockRecoveryPhoneSigninSendCode).toHaveBeenCalledWith(
         mockSigninLocationState.sessionToken
+      );
+    });
+
+    it('passes isSessionAALUpgrade as a navigation option to handleNavigation', async () => {
+      mockReachRouter('/signin_recovery_phone', {
+        signinState: {
+          ...mockSigninLocationState,
+          isSessionAALUpgrade: true,
+        },
+        lastFourPhoneDigits: '1234',
+      });
+
+      renderSigninRecoveryPhoneContainer();
+
+      await currentPageProps?.verifyCode('123456');
+
+      expect(storeAccountData).toHaveBeenCalledWith({
+        email: mockSigninLocationState.email,
+        sessionToken: mockSigninLocationState.sessionToken,
+        uid: mockSigninLocationState.uid,
+        verified: true,
+      });
+
+      expect(handleNavigation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isSessionAALUpgrade: true,
+        })
       );
     });
   });

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -5,7 +5,6 @@
 import React, { useContext, useEffect } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import SigninRecoveryPhone from '.';
-import { SigninLocationState } from '../interfaces';
 import { getSigninState, handleNavigation } from '../utils';
 import {
   AppContext,
@@ -32,6 +31,7 @@ import {
 } from './interfaces';
 import { GET_LOCAL_SIGNED_IN_STATUS } from '../../../components/App/gql';
 import GleanMetrics from '../../../lib/glean';
+import { SigninLocationState } from '../interfaces';
 
 const SigninRecoveryPhoneContainer = ({
   integration,
@@ -104,6 +104,17 @@ const SigninRecoveryPhoneContainer = ({
       });
       await new Promise((resolve) => setTimeout(resolve, 100));
 
+      const recoveryPhoneSigninSuccessGleanMetric =
+        GleanMetrics.login.recoveryPhoneSuccessView;
+
+      alertBar.success(
+        ftlMsgResolver.getMsg(
+          'signin-recovery-phone-success-message',
+          'Signed in successfully. Limits may apply if you use your recovery phone again.'
+        ),
+        recoveryPhoneSigninSuccessGleanMetric
+      );
+
       const navigationOptions = {
         email: signinState.email,
         signinData: {
@@ -119,21 +130,11 @@ const SigninRecoveryPhoneContainer = ({
         finishOAuthFlowHandler,
         redirectTo,
         queryParams: location.search,
+        isSessionAALUpgrade: signinState.isSessionAALUpgrade,
         handleFxaLogin: true,
         handleFxaOAuthLogin: true,
         performNavigation: !integration.isFirefoxMobileClient(),
       };
-
-      const recoveryPhoneSigninSuccessGleanMetric =
-        GleanMetrics.login.recoveryPhoneSuccessView;
-
-      alertBar.success(
-        ftlMsgResolver.getMsg(
-          'signin-recovery-phone-success-message',
-          'Signed in successfully. Limits may apply if you use your recovery phone again.'
-        ),
-        recoveryPhoneSigninSuccessGleanMetric
-      );
 
       await handleNavigation(navigationOptions);
     } catch (error) {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/en.ftl
@@ -7,6 +7,12 @@ signin-totp-code-subheader-v2 = Enter two-step authentication code
 signin-totp-code-instruction-v4 = Check your <strong>authenticator app</strong> to confirm your sign-in.
 signin-totp-code-input-label-v4 = Enter 6-digit code
 
+# Shown to users when they need to re-enter their authentication code, for their current device
+signin-totp-code-aal-banner-header = Why are you being asked to authenticate?
+signin-totp-code-aal-banner-content = You set up two-step authentication on your account, but haven’t signed in with a code on this device yet.
+signin-totp-code-aal-sign-out = Sign out on this device
+signin-totp-code-aal-sign-out-error = Sorry, there was a problem signing you out
+
 # Form button to confirm if the authentication code entered by the user is valid
 signin-totp-code-confirm-button = Confirm
 signin-totp-code-other-account-link = Use a different account

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -9,9 +9,14 @@ import { LocationProvider } from '@reach/router';
 import { MozServices } from '../../../lib/types';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { mockOAuthNativeSigninIntegration, mockWebSigninIntegration, Subject } from './mocks';
+import {
+  mockOAuthNativeSigninIntegration,
+  mockWebSigninIntegration,
+  Subject,
+  MOCK_TOTP_LOCATION_STATE,
+} from './mocks';
 import { BeginSigninError } from '../../../lib/error-utils';
-import { SigninIntegration } from '../interfaces';
+import { SigninIntegration, SigninLocationState } from '../interfaces';
 import { MOCK_CMS_INFO } from '../../mocks';
 
 export default {
@@ -24,6 +29,7 @@ const storyWithProps = (props: {
   submitTotpCode: () => Promise<{ error?: BeginSigninError }>;
   serviceName: MozServices;
   integration?: SigninIntegration;
+  signinState?: SigninLocationState;
 }) => {
   const story = () => (
     <LocationProvider>
@@ -37,6 +43,13 @@ export const Default = storyWithProps({
   submitTotpCode: async () => ({}),
   serviceName: MozServices.Default,
   integration: mockWebSigninIntegration,
+});
+
+export const RedirectFromSettingsBecauseAALUpgradeNeeded = storyWithProps({
+  submitTotpCode: async () => ({}),
+  serviceName: MozServices.Default,
+  integration: mockWebSigninIntegration,
+  signinState: { ...MOCK_TOTP_LOCATION_STATE, isSessionAALUpgrade: true },
 });
 
 export const WithOAuthDesktopServiceRelay = storyWithProps({

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -223,6 +223,7 @@ export interface NavigationOptions {
   isSignInWithThirdPartyAuth?: boolean;
   showSignupConfirmedSync?: boolean;
   syncHidePromoAfterLogin?: boolean;
+  isSessionAALUpgrade?: boolean;
   handleFxaLogin?: boolean;
   handleFxaOAuthLogin?: boolean;
   syncEngines?: {
@@ -247,4 +248,5 @@ export interface SigninLocationState {
   verificationReason?: VerificationReasons;
   origin?: NavigationOptions['origin'];
   showInlineRecoveryKeySetup?: boolean;
+  isSessionAALUpgrade?: boolean;
 }

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -102,6 +102,20 @@ describe('Signin utils', () => {
       expect(navigateSpy).toHaveBeenCalledWith('/settings', { replace: true });
     });
 
+    it('navigates to settings when isSessionAALUpgrade is true, even when performNavigation: false', async () => {
+      const navigationOptions = createBaseNavigationOptions({
+        integration: createMockSigninOAuthNativeSyncIntegration(),
+        isSessionAALUpgrade: true,
+        performNavigation: false,
+      });
+      const result = await handleNavigation(navigationOptions);
+
+      expect(result.error).toBeUndefined();
+      expect(navigateSpy).toHaveBeenCalledWith('/settings');
+      expect(hardNavigateSpy).not.toHaveBeenCalled();
+      expect(fxaLoginSpy).not.toHaveBeenCalled();
+    });
+
     describe('unverified session navigation', () => {
       it('returns early for SIGN_UP verification reason', async () => {
         const navigationOptions = createBaseNavigationOptions({
@@ -116,7 +130,10 @@ describe('Signin utils', () => {
         const result = await handleNavigation(navigationOptions);
 
         expect(result.error).toBeUndefined();
-        expect(navigateSpy).toHaveBeenCalledWith('/confirm_signup_code', expect.any(Object));
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/confirm_signup_code',
+          expect.any(Object)
+        );
       });
 
       it('returns early for TOTP verification method', async () => {
@@ -132,12 +149,17 @@ describe('Signin utils', () => {
         const result = await handleNavigation(navigationOptions);
 
         expect(result.error).toBeUndefined();
-        expect(navigateSpy).toHaveBeenCalledWith('/signin_totp_code', expect.any(Object));
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_totp_code',
+          expect.any(Object)
+        );
       });
 
       it('returns early for OAuth integration with wantsTwoStepAuthentication', async () => {
         const mockOAuthIntegration = createMockSigninOAuthIntegration();
-        (mockOAuthIntegration).wantsTwoStepAuthentication = jest.fn().mockReturnValue(true);
+        mockOAuthIntegration.wantsTwoStepAuthentication = jest
+          .fn()
+          .mockReturnValue(true);
 
         const navigationOptions = createBaseNavigationOptions({
           signinData: {
@@ -152,12 +174,17 @@ describe('Signin utils', () => {
         const result = await handleNavigation(navigationOptions);
 
         expect(result.error).toBeUndefined();
-        expect(navigateSpy).toHaveBeenCalledWith('/signin_token_code', expect.any(Object));
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_token_code',
+          expect.any(Object)
+        );
       });
 
       it('navigates to OAuth redirect for successful OAuth flow', async () => {
         const mockOAuthIntegration = createMockSigninOAuthIntegration();
-        (mockOAuthIntegration as any).wantsKeys = jest.fn().mockReturnValue(false);
+        (mockOAuthIntegration as any).wantsKeys = jest
+          .fn()
+          .mockReturnValue(false);
 
         const navigationOptions = createBaseNavigationOptions({
           signinData: {
@@ -187,7 +214,9 @@ describe('Signin utils', () => {
 
       it('returns early for OAuth integration with wantsKeys', async () => {
         const mockOAuthIntegration = createMockSigninOAuthIntegration();
-        (mockOAuthIntegration as any).wantsKeys = jest.fn().mockReturnValue(true);
+        (mockOAuthIntegration as any).wantsKeys = jest
+          .fn()
+          .mockReturnValue(true);
 
         const navigationOptions = createBaseNavigationOptions({
           signinData: {
@@ -202,7 +231,10 @@ describe('Signin utils', () => {
         const result = await handleNavigation(navigationOptions);
 
         expect(result.error).toBeUndefined();
-        expect(navigateSpy).toHaveBeenCalledWith('/signin_token_code', expect.any(Object));
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_token_code',
+          expect.any(Object)
+        );
       });
 
       it('does not send fxaLogin for TOTP verification', async () => {
@@ -220,7 +252,10 @@ describe('Signin utils', () => {
 
         expect(result.error).toBeUndefined();
         expect(fxaLoginSpy).not.toHaveBeenCalled();
-        expect(navigateSpy).toHaveBeenCalledWith('/signin_totp_code', expect.any(Object));
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_totp_code',
+          expect.any(Object)
+        );
       });
     });
   });


### PR DESCRIPTION
Because:
* Users with an AAL mismatch should be prompted to upgrade their sessions when they land in account settings

This commit:
* Reverts a previous temporary error message update
* Fixes session/status endpoint details
* Calls the session/status endpoint in Settings, and redirects users to /signin_totp_code with a new banner and sign out button, if their session needs to be upgraded. Redirects back to settings when a TOTP code, a backup recovery code, or a code from a recovery phone is successfully submitted
* Allows entering a recovery code to upgrade the session, as entering a code from a recovery phone already does

closes FXA-12446

---

Create an account, and signing into it in two browsers (like Nightly/Firefox or one in a private window). Set up 2FA on one of them. On the other, refresh Settings or just try to sign in again with that session token.

You should be able to get back into settings by entering the TOTP code, recovery phone code, or backup authentication code.

Users that sign in with a cached login and then reach Settings will see the same state, rather than redirecting to this page after cached login. I think this is OK - it's less friction for users signing into an RP and they'll only see it when accessing Settings - but if we'd rather not show the new banner at all there and show the "use another account" button which we could show for OAuthWeb logins - we can file a quick follow up.