### PR TITLE
fix(auth, settings): Use redis to store unconfirmed secondary email

### DIFF
--- a/packages/functional-tests/tests/settings/changeEmail.spec.ts
+++ b/packages/functional-tests/tests/settings/changeEmail.spec.ts
@@ -216,21 +216,6 @@ test.describe('severity-1 #smoke', () => {
       await settings.secondaryEmail.deleteButton.click();
 
       await expect(settings.alertBar).toHaveText(/successfully deleted/);
-
-      await settings.secondaryEmail.addButton.click();
-      await secondaryEmail.emailTextbox.fill(newEmail);
-      await secondaryEmail.submit();
-
-      // skip verification
-      await settings.goto();
-
-      await expect(settings.secondaryEmail.unverifiedText).toHaveText(
-        'unconfirmed'
-      );
-
-      await settings.secondaryEmail.deleteButton.click();
-
-      await expect(settings.alertBar).toHaveText(/successfully deleted/);
     });
   });
 });
@@ -274,7 +259,7 @@ async function setNewPassword(
   oldPassword: string,
   newPassword: string,
   target: BaseTarget,
-  email: string,
+  email: string
 ): Promise<void> {
   await settings.password.changeButton.click();
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1745,6 +1745,12 @@ const convictConf = convict({
       format: 'duration',
       env: 'SECONDARY_EMAIL_MIN_UNVERIFIED_ACCOUNT_TIME',
     },
+    pendingTtlSeconds: {
+      doc: 'TTL in seconds for pending secondary email reservations (Redis)',
+      format: 'nat',
+      default: 3600,
+      env: 'SECONDARY_EMAIL_PENDING_TTL_SECONDS',
+    },
   },
   signinCodeSize: {
     doc: 'signinCode size in bytes',

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -583,8 +583,7 @@ AppError.recoveryCodesAlreadyExist = () => {
     code: 400,
     error: 'Bad Request',
     errno: ERRNO.RECOVERY_CODES_ALREADY_EXISTS,
-    message:
-      'Recovery codes or a verified TOTP token already exist',
+    message: 'Recovery codes or a verified TOTP token already exist',
   });
 };
 

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -118,6 +118,7 @@ module.exports = function (
     signupUtils,
     zendeskClient,
     stripeHelper,
+    authServerCacheRedis,
     statsd
   );
   const password = require('./password')(

--- a/packages/fxa-auth-server/test/remote/recovery_email_change_email.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_change_email.js
@@ -7,284 +7,575 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
+const { setupAccountDatabase } = require('@fxa/shared/db/mysql/account');
+const cfg = require('../../config').default.getProperties();
+const { email: emailHelper } = require('fxa-shared');
+const crypto = require('crypto');
 
 let config, server, client, email, secondEmail;
 const password = 'allyourbasearebelongtous',
   newPassword = 'newpassword';
 
-[ {version:""}, {version:"V2"}].forEach((testOptions) => {
+[{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
+  describe(`#integration${testOptions.version} - remote change email`, function () {
+    this.timeout(60000);
 
-describe(`#integration${testOptions.version} - remote change email`, function () {
-  this.timeout(60000);
+    before(async () => {
+      config = require('../../config').default.getProperties();
+      config.securityHistory.ipProfiling = {};
+      server = await TestServer.start(config);
+    });
 
-  before(async () => {
-    config = require('../../config').default.getProperties();
-    config.securityHistory.ipProfiling = {};
-    server = await TestServer.start(config);
-  });
+    after(async () => {
+      await TestServer.stop(server);
+    });
 
-  after(async () => {
-    await TestServer.stop(server);
-  });
+    beforeEach(() => {
+      email = server.uniqueEmail();
+      secondEmail = server.uniqueEmail('@notrestmail.com');
 
-  beforeEach(() => {
-    email = server.uniqueEmail();
-    secondEmail = server.uniqueEmail('@notrestmail.com');
-
-    return Client.createAndVerify(
-      config.publicUrl,
-      email,
-      password,
-      server.mailbox,
-      testOptions
-    )
-      .then((x) => {
-        client = x;
-        assert.ok(client.authAt, 'authAt was set');
-      })
-      .then(() => {
-        return client.emailStatus();
-      })
-      .then((status) => {
-        assert.equal(status.verified, true, 'account is verified');
-        return client.createEmail(secondEmail);
-      })
-      .then((res) => {
-        assert.ok(res, 'ok response');
-        return server.mailbox.waitForEmail(secondEmail);
-      })
-      .then((emailData) => {
-        const templateName = emailData['headers']['x-template-name'];
-        const emailCode = emailData['headers']['x-verify-code'];
-        assert.equal(templateName, 'verifySecondaryCode');
-        assert.ok(emailCode, 'emailCode set');
-        return client.verifySecondaryEmailWithCode(emailCode, secondEmail);
-      })
-      .then((res) => {
-        assert.ok(res, 'ok response');
-        return client.accountEmails();
-      })
-      .then((res) => {
-        assert.equal(res.length, 2, 'returns number of emails');
-        assert.equal(res[1].email, secondEmail, 'returns correct email');
-        assert.equal(res[1].isPrimary, false, 'returns correct isPrimary');
-        assert.equal(res[1].verified, true, 'returns correct verified');
-        return server.mailbox.waitForEmail(email);
-      });
-  });
-
-  describe('should change primary email', () => {
-    it('fails to change email to an that is not owned by user', () => {
-      const userEmail2 = server.uniqueEmail();
-      const anotherEmail = server.uniqueEmail();
       return Client.createAndVerify(
         config.publicUrl,
-        userEmail2,
+        email,
         password,
         server.mailbox,
         testOptions
       )
-        .then((client2) => {
-          return client2.createEmail(anotherEmail);
+        .then((x) => {
+          client = x;
+          assert.ok(client.authAt, 'authAt was set');
         })
         .then(() => {
-          return client.setPrimaryEmail(anotherEmail).then(() => {
-            assert.fail(
-              'Should not have set email that belongs to another account'
-            );
-          });
+          return client.emailStatus();
         })
-        .catch((err) => {
-          assert.equal(err.errno, 148, 'returns correct errno');
-          assert.equal(err.code, 400, 'returns correct error code');
-        });
-    });
-
-    it('fails to change email to unverified email', () => {
-      const someEmail = server.uniqueEmail();
-      return client
-        .createEmail(someEmail)
-        .then(() => {
-          return client.setPrimaryEmail(someEmail).then(() => {
-            assert.fail('Should not have set email to an unverified email');
-          });
+        .then((status) => {
+          assert.equal(status.verified, true, 'account is verified');
+          return client.createEmail(secondEmail);
         })
-        .catch((err) => {
-          assert.equal(err.errno, 147, 'returns correct errno');
-          assert.equal(err.code, 400, 'returns correct error code');
-        });
-    });
-
-    it('can change primary email', () => {
-      return client
-        .setPrimaryEmail(secondEmail)
+        .then((res) => {
+          assert.ok(res, 'ok response');
+          return server.mailbox.waitForEmail(secondEmail);
+        })
+        .then((emailData) => {
+          const templateName = emailData['headers']['x-template-name'];
+          const emailCode = emailData['headers']['x-verify-code'];
+          assert.equal(templateName, 'verifySecondaryCode');
+          assert.ok(emailCode, 'emailCode set');
+          return client.verifySecondaryEmailWithCode(emailCode, secondEmail);
+        })
         .then((res) => {
           assert.ok(res, 'ok response');
           return client.accountEmails();
         })
         .then((res) => {
           assert.equal(res.length, 2, 'returns number of emails');
-          assert.equal(res[0].email, secondEmail, 'returns correct email');
-          assert.equal(res[0].isPrimary, true, 'returns correct isPrimary');
-          assert.equal(res[0].verified, true, 'returns correct verified');
-          assert.equal(res[1].email, email, 'returns correct email');
+          assert.equal(res[1].email, secondEmail, 'returns correct email');
           assert.equal(res[1].isPrimary, false, 'returns correct isPrimary');
           assert.equal(res[1].verified, true, 'returns correct verified');
-
-          return server.mailbox.waitForEmail(secondEmail);
-        })
-        .then((emailData) => {
-          assert.equal(emailData.headers['to'], secondEmail, 'to email set');
-          assert.equal(emailData.headers['cc'], email, 'cc emails set');
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postChangePrimary'
-          );
+          return server.mailbox.waitForEmail(email);
         });
     });
 
-    it('can login', () => {
-      return client
-        .setPrimaryEmail(secondEmail)
-        .then((res) => {
-          assert.ok(res, 'ok response');
-
-          if (testOptions.version === 'V2') {
-            // Note for V2 we can login with new primary email. The password is not encrypted with
-            // the original email, so this now works!
-            return Client.login(
-              config.publicUrl,
-              secondEmail,
-              password,
-              testOptions
-            );
-          } else {
-            // Verify account can login with new primary email
-            return Client.login(
-              config.publicUrl,
-              secondEmail,
-              password,
-              testOptions
-            ).then(() => {
+    describe('should change primary email', () => {
+      it('fails to change email to an that is not owned by user', () => {
+        const userEmail2 = server.uniqueEmail();
+        const anotherEmail = server.uniqueEmail();
+        return Client.createAndVerify(
+          config.publicUrl,
+          userEmail2,
+          password,
+          server.mailbox,
+          testOptions
+        )
+          .then((client2) => {
+            return client2
+              .createEmail(anotherEmail)
+              .then(() => server.mailbox.waitForEmail(anotherEmail))
+              .then((emailData) => {
+                const code = emailData.headers['x-verify-code'];
+                assert.ok(code, 'email code set');
+                return client2.verifySecondaryEmailWithCode(code, anotherEmail);
+              });
+          })
+          .then(() => {
+            return client.setPrimaryEmail(anotherEmail).then(() => {
               assert.fail(
-                new Error(
-                  'Should have returned correct email for user to login'
-                )
+                'Should not have set email that belongs to another account'
               );
             });
-          }
-        })
-        .catch((err) => {
-          // Login should fail for this user and return the normalizedEmail used when
-          // the account was created. We then attempt to re-login with this email and pass
-          // the original email used to login
-          assert.equal(err.code, 400, 'correct error code');
-          assert.equal(err.errno, 120, 'correct errno code');
-          assert.equal(err.email, email, 'correct hashed email returned');
-
-          return Client.login(config.publicUrl, err.email, password, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
+          })
+          .catch((err) => {
+            assert.equal(err.errno, 148, 'returns correct errno');
+            assert.equal(err.code, 400, 'returns correct error code');
           });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        });
-    });
+      });
 
-    it('can change password', () => {
-      return client
-        .setPrimaryEmail(secondEmail)
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return Client.login(config.publicUrl, email, password, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
+      it('fails to change email to unverified email', () => {
+        const someEmail = server.uniqueEmail();
+        return client
+          .createEmail(someEmail)
+          .then(() => {
+            return client.setPrimaryEmail(someEmail).then(() => {
+              assert.fail('Should not have set email to an unverified email');
+            });
+          })
+          .catch((err) => {
+            // we expect the email to be unknown if the email has not been verified
+            // the email is only stored in the database if it has been verified
+            // until then, it is only reserved in Redis and can't be set as primary
+            assert.equal(err.errno, 143, 'returns correct errno');
+            assert.equal(err.code, 400, 'returns correct error code');
           });
-        })
-        .then((res) => {
-          client = res;
-          return client.changePassword(
-            newPassword,
-            undefined,
-            client.sessionToken
-          );
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return Client.login(config.publicUrl, email, newPassword, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
-          });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        });
-    });
+      });
 
-    it('can reset password', () => {
-      return client
-        .setPrimaryEmail(secondEmail)
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return server.mailbox.waitForEmail(secondEmail);
-        })
-        .then((emailData) => {
-          assert.equal(emailData.headers['to'], secondEmail, 'to email set');
-          assert.equal(emailData.headers['cc'], email, 'cc emails set');
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postChangePrimary'
-          );
+      it('fails to to change primary email to an unverified email stored in database (legacy)', async () => {
+        const someEmail = server.uniqueEmail();
+        // Pre-seed the DB with an unverified secondary email record for this uid
+        const db = await setupAccountDatabase(cfg.database.mysql.auth);
+        try {
+          await db
+            .insertInto('emails')
+            .values({
+              email: someEmail,
+              normalizedEmail: emailHelper.helpers.normalizeEmail(someEmail),
+              uid: Buffer.from(client.uid, 'hex'),
+              emailCode: Buffer.from(
+                crypto.randomBytes(16).toString('hex'),
+                'hex'
+              ),
+              isVerified: 0,
+              isPrimary: 0,
+              createdAt: Date.now(),
+            })
+            .execute();
+        } finally {
+          await db.destroy();
+        }
 
-          client.email = secondEmail;
-          return client.forgotPassword();
-        })
-        .then(() => {
-          return server.mailbox.waitForCode(secondEmail);
-        })
-        .then((code) => {
-          assert.ok(code, 'code is set');
-          return resetPassword(client, code, newPassword, undefined, {
-            emailToHashWith: email,
+        return client
+          .setPrimaryEmail(someEmail)
+          .then(() => {
+            assert.fail('Should not have set email to an unverified email');
+          })
+          .catch((err) => {
+            assert.equal(err.errno, 147, 'returns correct errno');
+            assert.equal(err.code, 400, 'returns correct error code');
           });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        })
-        .then(() => {
-          if (testOptions.version === 'V2') {
-            return Client.upgradeCredentials(
-              config.publicUrl,
-              email,
-              newPassword,
-              {
-                originalLoginEmail: secondEmail,
-                version: '',
-                keys: true,
-              }
+      });
+
+      it('can change primary email', () => {
+        return client
+          .setPrimaryEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return client.accountEmails();
+          })
+          .then((res) => {
+            assert.equal(res.length, 2, 'returns number of emails');
+            assert.equal(res[0].email, secondEmail, 'returns correct email');
+            assert.equal(res[0].isPrimary, true, 'returns correct isPrimary');
+            assert.equal(res[0].verified, true, 'returns correct verified');
+            assert.equal(res[1].email, email, 'returns correct email');
+            assert.equal(res[1].isPrimary, false, 'returns correct isPrimary');
+            assert.equal(res[1].verified, true, 'returns correct verified');
+
+            return server.mailbox.waitForEmail(secondEmail);
+          })
+          .then((emailData) => {
+            assert.equal(emailData.headers['to'], secondEmail, 'to email set');
+            assert.equal(emailData.headers['cc'], email, 'cc emails set');
+            assert.equal(
+              emailData.headers['x-template-name'],
+              'postChangePrimary'
             );
-          }
-        })
-        .then(() => {
-          return Client.login(config.publicUrl, email, newPassword, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
           });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        });
+      });
+
+      it('can login', () => {
+        return client
+          .setPrimaryEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response');
+
+            if (testOptions.version === 'V2') {
+              // Note for V2 we can login with new primary email. The password is not encrypted with
+              // the original email, so this now works!
+              return Client.login(
+                config.publicUrl,
+                secondEmail,
+                password,
+                testOptions
+              );
+            } else {
+              // Verify account can login with new primary email
+              return Client.login(
+                config.publicUrl,
+                secondEmail,
+                password,
+                testOptions
+              ).then(() => {
+                assert.fail(
+                  new Error(
+                    'Should have returned correct email for user to login'
+                  )
+                );
+              });
+            }
+          })
+          .catch((err) => {
+            // Login should fail for this user and return the normalizedEmail used when
+            // the account was created. We then attempt to re-login with this email and pass
+            // the original email used to login
+            assert.equal(err.code, 400, 'correct error code');
+            assert.equal(err.errno, 120, 'correct errno code');
+            assert.equal(err.email, email, 'correct hashed email returned');
+
+            return Client.login(config.publicUrl, err.email, password, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          });
+      });
+
+      it('can change password', () => {
+        return client
+          .setPrimaryEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return Client.login(config.publicUrl, email, password, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            client = res;
+            return client.changePassword(
+              newPassword,
+              undefined,
+              client.sessionToken
+            );
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return Client.login(config.publicUrl, email, newPassword, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          });
+      });
+
+      it('can reset password', () => {
+        return client
+          .setPrimaryEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return server.mailbox.waitForEmail(secondEmail);
+          })
+          .then((emailData) => {
+            assert.equal(emailData.headers['to'], secondEmail, 'to email set');
+            assert.equal(emailData.headers['cc'], email, 'cc emails set');
+            assert.equal(
+              emailData.headers['x-template-name'],
+              'postChangePrimary'
+            );
+
+            client.email = secondEmail;
+            return client.forgotPassword();
+          })
+          .then(() => {
+            return server.mailbox.waitForCode(secondEmail);
+          })
+          .then((code) => {
+            assert.ok(code, 'code is set');
+            return resetPassword(client, code, newPassword, undefined, {
+              emailToHashWith: email,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          })
+          .then(() => {
+            if (testOptions.version === 'V2') {
+              return Client.upgradeCredentials(
+                config.publicUrl,
+                email,
+                newPassword,
+                {
+                  originalLoginEmail: secondEmail,
+                  version: '',
+                  keys: true,
+                }
+              );
+            }
+          })
+          .then(() => {
+            return Client.login(config.publicUrl, email, newPassword, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          });
+      });
+
+      it('can delete account', () => {
+        return client
+          .setPrimaryEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return client.destroyAccount();
+          })
+          .then(() => {
+            return Client.login(config.publicUrl, email, newPassword, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            })
+              .then(() => {
+                assert.fail(
+                  'Should not have been able to login after deleting account'
+                );
+              })
+              .catch((err) => {
+                assert.equal(err.errno, 102, 'unknown account error code');
+                assert.equal(err.email, secondEmail, 'returns correct email');
+              });
+          });
+      });
     });
 
-    it('can delete account', () => {
-      return client
-        .setPrimaryEmail(secondEmail)
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return client.destroyAccount();
+    it('change primary email with multiple accounts', async () => {
+      /**
+       * Below tests the following scenario:
+       *
+       * User A with Email A (primary) and Email A1 (secondary)
+       * User B with Email B (primary) and Email B1 (secondary)
+       *
+       * with changing primary emails etc transform to ==>
+       *
+       * User A with Email B (primary)
+       * User B with Email A (primary)
+       *
+       * and can successfully login
+       */
+      let emailData, emailCode;
+      const password2 = 'asdf';
+      const client1Email = server.uniqueEmail();
+      const client1SecondEmail = server.uniqueEmail();
+      const client2Email = server.uniqueEmail();
+      const client2SecondEmail = server.uniqueEmail();
+
+      const client1 = await Client.createAndVerify(
+        config.publicUrl,
+        client1Email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      // Create a second client
+      const client2 = await Client.createAndVerify(
+        config.publicUrl,
+        client2Email,
+        password2,
+        server.mailbox,
+        testOptions
+      );
+
+      // Update client1's email and verify
+      await client1.createEmail(client1SecondEmail);
+      emailData = await server.mailbox.waitForEmail(client1SecondEmail);
+      emailCode = emailData['headers']['x-verify-code'];
+      await client1.verifySecondaryEmailWithCode(emailCode, client1SecondEmail);
+
+      // Update client2
+      await client2.createEmail(client2SecondEmail);
+      emailData = await server.mailbox.waitForEmail(client2SecondEmail);
+      emailCode = emailData['headers']['x-verify-code'];
+      await client2.verifySecondaryEmailWithCode(emailCode, client2SecondEmail);
+
+      await client1.setPrimaryEmail(client1SecondEmail);
+      await client1.deleteEmail(client1Email);
+
+      await client2.setPrimaryEmail(client2SecondEmail);
+      await client2.deleteEmail(client2Email);
+
+      await client1.createEmail(client2Email);
+      emailData = await server.mailbox.waitForEmail(client2Email);
+      emailCode = emailData[2]['headers']['x-verify-code'];
+      await client1.verifySecondaryEmailWithCode(emailCode, client2Email);
+      await client1.setPrimaryEmail(client2Email);
+      await client1.deleteEmail(client1SecondEmail);
+
+      await client2.createEmail(client1Email);
+      emailData = await server.mailbox.waitForEmail(client1Email);
+      emailCode = emailData[2]['headers']['x-verify-code'];
+      await client2.verifySecondaryEmailWithCode(emailCode, client1Email);
+      await client2.setPrimaryEmail(client1Email);
+      await client2.deleteEmail(client2SecondEmail);
+
+      const res = await Client.login(config.publicUrl, client1Email, password, {
+        originalLoginEmail: client2Email,
+        ...testOptions,
+      });
+
+      assert.ok(res, 'ok response');
+    });
+
+    describe('change primary email, deletes old primary', () => {
+      beforeEach(() => {
+        return client
+          .setPrimaryEmail(secondEmail)
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return server.mailbox.waitForEmail(secondEmail);
+          })
+          .then((emailData) => {
+            assert.equal(emailData.headers['to'], secondEmail, 'to email set');
+            assert.equal(emailData.headers['cc'], email, 'cc emails set');
+            assert.equal(
+              emailData.headers['x-template-name'],
+              'postChangePrimary'
+            );
+            return client.deleteEmail(email);
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return client.accountEmails();
+          })
+          .then((res) => {
+            assert.equal(res.length, 1, 'returns number of emails');
+            assert.equal(res[0].email, secondEmail, 'returns correct email');
+            assert.equal(res[0].isPrimary, true, 'returns correct isPrimary');
+            assert.equal(res[0].verified, true, 'returns correct verified');
+
+            // Primary account is notified that secondary email has been removed
+            return server.mailbox.waitForEmail(secondEmail);
+          })
+          .then((emailData) => {
+            const templateName = emailData['headers']['x-template-name'];
+            assert.equal(templateName, 'postRemoveSecondary');
+          });
+      });
+
+      it('can login', () => {
+        if (testOptions.version === 'V2') {
+          // Note that with V2 logins, you can actually use the secondary email to login. This is
+          // due to the fact the salt is now independent of the original email.
+          return Client.login(
+            config.publicUrl,
+            secondEmail,
+            password,
+            testOptions
+          ).then((res) => {
+            assert.exists(res.sessionToken);
+          });
+        }
+
+        // Verify account can still login with new primary email
+        return Client.login(
+          config.publicUrl,
+          secondEmail,
+          password,
+          testOptions
+        )
+          .then(() => {
+            assert.fail(
+              new Error('Should have returned correct email for user to login')
+            );
+          })
+          .catch((err) => {
+            // Login should fail for this user and return the normalizedEmail used when
+            // the account was created. We then attempt to re-login with this email and pass
+            // the original email used to login
+            assert.equal(err.code, 400, 'correct error code');
+            assert.equal(err.errno, 120, 'correct errno code');
+            assert.equal(err.email, email, 'correct hashed email returned');
+
+            return Client.login(config.publicUrl, err.email, password, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          });
+      });
+
+      it('can change password', () => {
+        return Client.login(config.publicUrl, email, password, {
+          originalLoginEmail: secondEmail,
+          ...testOptions,
         })
-        .then(() => {
+          .then((res) => {
+            client = res;
+            return client.changePassword(
+              newPassword,
+              undefined,
+              client.sessionToken
+            );
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+            return Client.login(config.publicUrl, email, newPassword, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          });
+      });
+
+      it('can reset password', () => {
+        client.email = secondEmail;
+        return client
+          .forgotPassword()
+          .then(() => {
+            return server.mailbox.waitForCode(secondEmail);
+          })
+          .then((code) => {
+            assert.ok(code, 'code is set');
+            return resetPassword(client, code, newPassword, undefined, {
+              emailToHashWith: email,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          })
+          .then(() => {
+            if (testOptions.version === 'V2') {
+              return Client.upgradeCredentials(
+                config.publicUrl,
+                email,
+                newPassword,
+                {
+                  originalLoginEmail: secondEmail,
+                  version: '',
+                  keys: true,
+                }
+              );
+            }
+          })
+          .then(() => {
+            return Client.login(config.publicUrl, email, newPassword, {
+              originalLoginEmail: secondEmail,
+              ...testOptions,
+            });
+          })
+          .then((res) => {
+            assert.ok(res, 'ok response');
+          });
+      });
+
+      it('can delete account', () => {
+        return client.destroyAccount().then(() => {
           return Client.login(config.publicUrl, email, newPassword, {
             originalLoginEmail: secondEmail,
             ...testOptions,
@@ -299,254 +590,13 @@ describe(`#integration${testOptions.version} - remote change email`, function ()
               assert.equal(err.email, secondEmail, 'returns correct email');
             });
         });
-    });
-  });
-
-  it('change primary email with multiple accounts', async () => {
-    /**
-     * Below tests the following scenario:
-     *
-     * User A with Email A (primary) and Email A1 (secondary)
-     * User B with Email B (primary) and Email B1 (secondary)
-     *
-     * with changing primary emails etc transform to ==>
-     *
-     * User A with Email B (primary)
-     * User B with Email A (primary)
-     *
-     * and can successfully login
-     */
-    let emailData, emailCode;
-    const password2 = 'asdf';
-    const client1Email = server.uniqueEmail();
-    const client1SecondEmail = server.uniqueEmail();
-    const client2Email = server.uniqueEmail();
-    const client2SecondEmail = server.uniqueEmail();
-
-    const client1 = await Client.createAndVerify(
-      config.publicUrl,
-      client1Email,
-      password,
-      server.mailbox,
-      testOptions
-    );
-
-    // Create a second client
-    const client2 = await Client.createAndVerify(
-      config.publicUrl,
-      client2Email,
-      password2,
-      server.mailbox,
-      testOptions
-    );
-
-    // Update client1's email and verify
-    await client1.createEmail(client1SecondEmail);
-    emailData = await server.mailbox.waitForEmail(client1SecondEmail);
-    emailCode = emailData['headers']['x-verify-code'];
-    await client1.verifySecondaryEmailWithCode(emailCode, client1SecondEmail);
-
-    // Update client2
-    await client2.createEmail(client2SecondEmail);
-    emailData = await server.mailbox.waitForEmail(client2SecondEmail);
-    emailCode = emailData['headers']['x-verify-code'];
-    await client2.verifySecondaryEmailWithCode(emailCode, client2SecondEmail);
-
-    await client1.setPrimaryEmail(client1SecondEmail);
-    await client1.deleteEmail(client1Email);
-
-    await client2.setPrimaryEmail(client2SecondEmail);
-    await client2.deleteEmail(client2Email);
-
-    await client1.createEmail(client2Email);
-    emailData = await server.mailbox.waitForEmail(client2Email);
-    emailCode = emailData[2]['headers']['x-verify-code'];
-    await client1.verifySecondaryEmailWithCode(emailCode, client2Email);
-    await client1.setPrimaryEmail(client2Email);
-    await client1.deleteEmail(client1SecondEmail);
-
-    await client2.createEmail(client1Email);
-    emailData = await server.mailbox.waitForEmail(client1Email);
-    emailCode = emailData[2]['headers']['x-verify-code'];
-    await client2.verifySecondaryEmailWithCode(emailCode, client1Email);
-    await client2.setPrimaryEmail(client1Email);
-    await client2.deleteEmail(client2SecondEmail);
-
-    const res = await Client.login(config.publicUrl, client1Email, password, {
-      originalLoginEmail: client2Email,
-      ...testOptions,
-    });
-
-    assert.ok(res, 'ok response');
-  });
-
-  describe('change primary email, deletes old primary', () => {
-    beforeEach(() => {
-      return client
-        .setPrimaryEmail(secondEmail)
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return server.mailbox.waitForEmail(secondEmail);
-        })
-        .then((emailData) => {
-          assert.equal(emailData.headers['to'], secondEmail, 'to email set');
-          assert.equal(emailData.headers['cc'], email, 'cc emails set');
-          assert.equal(
-            emailData.headers['x-template-name'],
-            'postChangePrimary'
-          );
-          return client.deleteEmail(email);
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return client.accountEmails();
-        })
-        .then((res) => {
-          assert.equal(res.length, 1, 'returns number of emails');
-          assert.equal(res[0].email, secondEmail, 'returns correct email');
-          assert.equal(res[0].isPrimary, true, 'returns correct isPrimary');
-          assert.equal(res[0].verified, true, 'returns correct verified');
-
-          // Primary account is notified that secondary email has been removed
-          return server.mailbox.waitForEmail(secondEmail);
-        })
-        .then((emailData) => {
-          const templateName = emailData['headers']['x-template-name'];
-          assert.equal(templateName, 'postRemoveSecondary');
-        });
-    });
-
-    it('can login', () => {
-      if (testOptions.version === 'V2') {
-        // Note that with V2 logins, you can actually use the secondary email to login. This is
-        // due to the fact the salt is now independent of the original email.
-        return Client.login(
-          config.publicUrl,
-          secondEmail,
-          password,
-          testOptions
-        ).then((res) => {
-          assert.exists(res.sessionToken);
-        });
-      }
-
-      // Verify account can still login with new primary email
-      return Client.login(config.publicUrl, secondEmail, password, testOptions)
-        .then(() => {
-          assert.fail(
-            new Error('Should have returned correct email for user to login')
-          );
-        })
-        .catch((err) => {
-          // Login should fail for this user and return the normalizedEmail used when
-          // the account was created. We then attempt to re-login with this email and pass
-          // the original email used to login
-          assert.equal(err.code, 400, 'correct error code');
-          assert.equal(err.errno, 120, 'correct errno code');
-          assert.equal(err.email, email, 'correct hashed email returned');
-
-          return Client.login(config.publicUrl, err.email, password, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
-          });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        });
-    });
-
-    it('can change password', () => {
-      return Client.login(config.publicUrl, email, password, {
-        originalLoginEmail: secondEmail,
-        ...testOptions,
-      })
-        .then((res) => {
-          client = res;
-          return client.changePassword(
-            newPassword,
-            undefined,
-            client.sessionToken
-          );
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-          return Client.login(config.publicUrl, email, newPassword, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
-          });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        });
-    });
-
-    it('can reset password', () => {
-      client.email = secondEmail;
-      return client
-        .forgotPassword()
-        .then(() => {
-          return server.mailbox.waitForCode(secondEmail);
-        })
-        .then((code) => {
-          assert.ok(code, 'code is set');
-          return resetPassword(client, code, newPassword, undefined, {
-            emailToHashWith: email,
-          });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        })
-        .then(() => {
-          if (testOptions.version === 'V2') {
-            return Client.upgradeCredentials(
-              config.publicUrl,
-              email,
-              newPassword,
-              {
-                originalLoginEmail: secondEmail,
-                version: '',
-                keys: true,
-              }
-            );
-          }
-        })
-        .then(() => {
-          return Client.login(config.publicUrl, email, newPassword, {
-            originalLoginEmail: secondEmail,
-            ...testOptions,
-          });
-        })
-        .then((res) => {
-          assert.ok(res, 'ok response');
-        });
-    });
-
-    it('can delete account', () => {
-      return client.destroyAccount().then(() => {
-        return Client.login(config.publicUrl, email, newPassword, {
-          originalLoginEmail: secondEmail,
-          ...testOptions,
-        })
-          .then(() => {
-            assert.fail(
-              'Should not have been able to login after deleting account'
-            );
-          })
-          .catch((err) => {
-            assert.equal(err.errno, 102, 'unknown account error code');
-            assert.equal(err.email, secondEmail, 'returns correct email');
-          });
       });
     });
+
+    function resetPassword(client, code, newPassword, headers, options) {
+      return client.verifyPasswordResetCode(code, headers, options).then(() => {
+        return client.resetPassword(newPassword, {}, options);
+      });
+    }
   });
-
-
-
-  function resetPassword(client, code, newPassword, headers, options) {
-    return client.verifyPasswordResetCode(code, headers, options).then(() => {
-      return client.resetPassword(newPassword, {}, options);
-    });
-  }
-});
-
 });

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.tsx
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
-import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps } from '@reach/router';
+import { FtlMsg } from 'fxa-react/lib/utils';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { logViewEvent, usePageViewEvent } from '../../../lib/metrics';
 import { SETTINGS_PATH } from '../../../constants';
@@ -12,13 +12,13 @@ import InputText from '../../InputText';
 import FlowContainer from '../FlowContainer';
 import { isEmailMask, isEmailValid } from 'fxa-shared/email/helpers';
 import { useAccount, useAlertBar } from 'fxa-settings/src/models';
-import { AuthUiErrorNos } from 'fxa-settings/src/lib/auth-errors/auth-errors';
-import { getErrorFtlId } from '../../../lib/error-utils';
 import { MfaGuard } from '../MfaGuard';
 import { useErrorHandler } from 'react-error-boundary';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { isInvalidJwtError } from '../../../lib/mfa-guard-utils';
 import { MfaReason } from '../../../lib/types';
+import { useFtlMsgResolver } from '../../../models/hooks';
+import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 
 export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   usePageViewEvent('settings.emails');
@@ -27,11 +27,10 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const [errorText, setErrorText] = useState<string>();
   const [email, setEmail] = useState<string>();
   const inputRefDOM = useRef<HTMLInputElement>(null);
-  const { l10n } = useLocalization();
+  const ftlMsgResolver = useFtlMsgResolver();
 
-  const subtitleText = l10n.getString(
+  const subtitleText = ftlMsgResolver.getMsg(
     'add-secondary-email-step-1',
-    null,
     'Step 1 of 2'
   );
   const navigateWithQuery = useNavigateWithQuery();
@@ -53,24 +52,29 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
           return;
         }
         if (e.errno) {
-          const errorText = l10n.getString(
-            getErrorFtlId(e),
-            { retryAfter: e.retryAfterLocalized },
-            AuthUiErrorNos[e.errno].message
+          const localizedErrorMessage = getLocalizedErrorMessage(
+            ftlMsgResolver,
+            e
           );
-          setErrorText(errorText);
+          setErrorText(localizedErrorMessage);
         } else {
           alertBar.error(
-            l10n.getString(
+            ftlMsgResolver.getMsg(
               'add-secondary-email-error-2',
-              null,
               'There was a problem creating this email'
             )
           );
         }
       }
     },
-    [account, navigateWithQuery, setErrorText, alertBar, l10n, errorHandler]
+    [
+      account,
+      navigateWithQuery,
+      setErrorText,
+      alertBar,
+      errorHandler,
+      ftlMsgResolver,
+    ]
   );
 
   const checkEmail = useCallback(
@@ -83,20 +87,19 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
       setErrorText('');
 
       if (isEmailMask(email)) {
-        const errorText = l10n.getString(
+        const errorText = ftlMsgResolver.getMsg(
           'add-secondary-email-mask',
-          null,
           'Email masks can’t be used as a secondary email'
         );
         setErrorText(errorText);
         setSaveBtnDisabled(true);
       }
     },
-    [setSaveBtnDisabled, setErrorText, l10n]
+    [setSaveBtnDisabled, setErrorText, ftlMsgResolver]
   );
 
   return (
-    <Localized id="add-secondary-email-page-title" attrs={{ title: true }}>
+    <FtlMsg id="add-secondary-email-page-title" attrs={{ title: true }}>
       <FlowContainer title="Secondary email" subtitle={subtitleText}>
         <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
@@ -109,7 +112,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
           }}
         >
           <div className="mt-4 mb-6" data-testid="secondary-email-input">
-            <Localized
+            <FtlMsg
               id="add-secondary-email-enter-address"
               attrs={{ label: true }}
             >
@@ -120,11 +123,11 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
                 inputRefDOM={inputRefDOM}
                 {...{ errorText }}
               />
-            </Localized>
+            </FtlMsg>
           </div>
 
           <div className="flex justify-center mx-auto max-w-64">
-            <Localized id="add-secondary-email-cancel-button">
+            <FtlMsg id="add-secondary-email-cancel-button">
               <button
                 type="button"
                 className="cta-neutral cta-base-p mx-2 flex-1"
@@ -133,8 +136,8 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
               >
                 Cancel
               </button>
-            </Localized>
-            <Localized id="add-secondary-email-save-button">
+            </FtlMsg>
+            <FtlMsg id="add-secondary-email-save-button">
               <button
                 type="submit"
                 className="cta-primary cta-base-p mx-2 flex-1"
@@ -143,11 +146,11 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
               >
                 Save
               </button>
-            </Localized>
+            </FtlMsg>
           </div>
         </form>
       </FlowContainer>
-    </Localized>
+    </FtlMsg>
   );
 };
 

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.tsx
@@ -12,7 +12,10 @@ import { useAccount, useAlertBar } from '../../../models';
 import InputText from '../../InputText';
 import FlowContainer from '../FlowContainer';
 import { useForm } from 'react-hook-form';
-import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import {
+  AuthUiErrors,
+  AuthUiErrorNos,
+} from 'fxa-settings/src/lib/auth-errors/auth-errors';
 import { getErrorFtlId } from '../../../lib/error-utils';
 import { MfaGuard } from '../MfaGuard';
 import { useErrorHandler } from 'react-error-boundary';
@@ -75,11 +78,10 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
           return;
         }
         if (e.errno) {
-          const errorText = l10n.getString(
-            getErrorFtlId(e),
-            null,
-            AuthUiErrors.INVALID_VERIFICATION_CODE.message
-          );
+          const fallback = AuthUiErrorNos[e.errno]
+            ? AuthUiErrorNos[e.errno].message
+            : AuthUiErrors.INVALID_VERIFICATION_CODE.message;
+          const errorText = l10n.getString(getErrorFtlId(e), null, fallback);
           setErrorText(errorText);
         } else {
           alertBar.error(

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../../../lib/cache', () => ({
 
 const account = {
   emails: [mockEmail(), mockEmail('johndope2@example.com', false, false)],
-  resendEmailCode: jest.fn().mockResolvedValue(true),
+  resendSecondaryEmailCode: jest.fn().mockResolvedValue(true),
   makeEmailPrimaryWithJwt: jest.fn().mockResolvedValue(true),
   deleteSecondaryEmail: jest.fn().mockResolvedValue(true),
   refresh: jest.fn(),
@@ -237,7 +237,7 @@ describe('UnitRowSecondaryEmail', () => {
       ];
       const account = {
         emails,
-        resendEmailCode: jest.fn().mockResolvedValue(true),
+        resendSecondaryEmailCode: jest.fn().mockResolvedValue(true),
       } as unknown as Account;
 
       const { history } = renderWithRouter(
@@ -262,7 +262,7 @@ describe('UnitRowSecondaryEmail', () => {
       ];
       const account = {
         emails,
-        resendEmailCode: jest.fn().mockRejectedValue(new Error()),
+        resendSecondaryEmailCode: jest.fn().mockRejectedValue(new Error()),
       } as unknown as Account;
       const context = mockAppContext({ account });
       const settingsContext = mockSettingsContext();

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -48,10 +48,10 @@ export const UnitRowSecondaryEmail = () => {
     .map((email) => email.verified)
     .lastIndexOf(true);
 
-  const resendEmailCode = useCallback(
+  const resendSecondaryEmailCode = useCallback(
     async (email: string) => {
       try {
-        await account.resendEmailCode(email);
+        await account.resendSecondaryEmailCode(email);
         navigateWithQuery(`${SETTINGS_PATH}/emails/verify`, {
           state: { email },
         });
@@ -264,7 +264,7 @@ export const UnitRowSecondaryEmail = () => {
                       className="link-blue"
                       data-testid="secondary-email-resend-code-button"
                       onClick={() => {
-                        resendEmailCode(email);
+                        resendSecondaryEmailCode(email);
                       }}
                     />
                   ),
@@ -276,7 +276,7 @@ export const UnitRowSecondaryEmail = () => {
                     className="link-blue"
                     data-testid="secondary-email-resend-code-button"
                     onClick={() => {
-                      resendEmailCode(email);
+                      resendSecondaryEmailCode(email);
                     }}
                   >
                     Resend confirmation code

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -195,7 +195,8 @@ const ERRORS = {
   RESEND_EMAIL_CODE_TO_UNOWNED_EMAIL: {
     errno: 150,
     message:
-      'Can not change primary email to an email that does not belong to this account',
+      'Can not resend email code to an email that does not belong to this account',
+    version: 2,
   },
   FAILED_TO_SEND_EMAIL: {
     errno: 151,
@@ -322,6 +323,10 @@ const ERRORS = {
     errno: 219,
     message:
       'This phone number has been registered with too many accounts. Please try a different number.',
+  },
+  TOTP_SECRET_DOES_NOT_EXIST: {
+    errno: 220,
+    message: 'TOTP secret does not exist',
   },
   SERVICE_UNAVAILABLE: {
     errno: 998,


### PR DESCRIPTION
## Because

* We don't want to hold on to unconfirmed secondary emails
* Let's use Redis to store the temporary entry and only add to db once verified

## This pull request

* Update emails route handlers to use Redis
* Update front end to handle the flow changes
* Update tests

## Issue that this pull request solves

Closes: FXA-12548

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
