### PR TITLE
chore(l10n): Fix linter and term reference issues for strings

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/manage/en.ftl
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/en.ftl
@@ -24,7 +24,7 @@ subscription-management-button-manage-payment-method = Manage
 subscription-management-card-ending-in = Card ending in { $last4 }
 # $expirationDate (Date) - Payment card's expiration date
 subscription-management-card-expires-date = Expires { $expirationDate }
-subscription-management-error-paypal-billing-agreement = There is an issue with your PayPal account. Please resolve the issue to maintain your active subscriptions.
+subscription-management-error-paypal-billing-agreement = There is an issue with your { -brand-paypal } account. Please resolve the issue to maintain your active subscriptions.
 subscription-management-active-subscriptions-heading = Active subscriptions
 subscription-management-you-have-no-active-subscriptions = You have no active subscriptions
 subscription-management-new-subs-will-appear-here = New subscriptions will appear here.

--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/en.ftl
@@ -21,7 +21,7 @@ subscription-content-view-invoice = View invoice
 subscription-management-link-view-invoice-aria = View invoice for { $productName }
 subscription-content-expires-on-expiry-date = Expires on { $date }
 # • is acting as a separator between "Next bill" and the next billing date.
-subscription-content-next-bill = Next bill • { $billedOnDate}
+subscription-content-next-bill = Next bill • { $billedOnDate }
 subscription-content-next-bill-with-tax-1 = { $nextInvoiceTotal } + { $taxDue } tax
 subscription-content-next-bill-no-tax-1 = { $nextInvoiceTotal }
 subscription-content-button-stay-subscribed =


### PR DESCRIPTION
## Because

- subscription-management-error-paypal-billing-agreement doesn't use the brand term and subscription-content-next-bill requires a space before and after the variable name in a placeable

## This pull request

- Fixes the term reference and syntax issue in the placeable

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

