### PR TITLE
feat(admin-panel): Enable 2FA removal ability for support agents

### DIFF
--- a/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.spec.ts
@@ -139,6 +139,18 @@ describe('support agents', () => {
           AdminPanelGroup.AdminStage
         )
       ).true;
+      expect(
+        prodGuard.allow(
+          AdminPanelFeature.Remove2FA,
+          AdminPanelGroup.SupportAgentProd
+        )
+      ).true;
+      expect(
+        stageGuard.allow(
+          AdminPanelFeature.Remove2FA,
+          AdminPanelGroup.SupportAgentStage
+        )
+      ).true;
     });
 
     it('looks up group', () => {

--- a/libs/shared/guards/src/lib/admin-panel-guard.ts
+++ b/libs/shared/guards/src/lib/admin-panel-guard.ts
@@ -162,7 +162,7 @@ const defaultAdminPanelPermissions: Permissions = {
   },
   [AdminPanelFeature.Remove2FA]: {
     name: 'Reset 2FA',
-    level: PermissionLevel.Admin,
+    level: PermissionLevel.Support,
   },
   [AdminPanelFeature.UnverifyEmail]: {
     name: 'Unconfirm Email Address',


### PR DESCRIPTION
## Because

- There is an option to remove 2FA in the admin panel now, but you have to have admin permissions to use it. We want to change that to allow support personnel to use it.

## This pull request

- updates permission requirement of 2FA removal to Support.

## Issue that this pull request solves

Closes: FXA-12516

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
