### PR TITLE
feat(payments-next): Persist 'with-accounts' or 'without-accounts' metrics throughout checkout

### DIFF
--- a/apps/payments/next/app/api/auth/callback/fxa/route.ts
+++ b/apps/payments/next/app/api/auth/callback/fxa/route.ts
@@ -8,6 +8,38 @@ export { POST } from '../../../../../auth';
 export async function GET(request: NextRequest) {
   const requestSearchParams = request.nextUrl.searchParams;
   const requestErrorQuery = requestSearchParams.get('error');
+  const url = new URL(request.url);
+  const newAccount = url.searchParams.get('newAccount');
+  if (newAccount && newAccount === 'true') {
+    const cookieStore = request.cookies;
+    const redirectUrl =
+      cookieStore.get('__Secure-authjs.callback-url') ||
+      cookieStore.get('authjs.callback-url');
+
+    if (redirectUrl?.value) {
+      const updatedRedirectUrl = new URL(redirectUrl.value, request.url);
+      updatedRedirectUrl.searchParams.set('newAccount', 'true');
+
+      const updatedHeaders = new Headers(request.headers);
+      const newCookieHeader = request.cookies
+        .getAll()
+        .map(({ name, value }) => {
+          if (name === 'authjs.callback-url' || name === '__Secure-authjs.callback-url') {
+            return `${name}=${encodeURIComponent(updatedRedirectUrl.toString())}`;
+          }
+          return `${name}=${value}`;
+        })
+        .join('; ');
+      updatedHeaders.set('cookie', newCookieHeader);
+
+      const newRequest = new NextRequest(request.url, {
+        headers: updatedHeaders,
+        method: request.method,
+      });
+
+      return AuthJsGET(newRequest);
+    }
+  }
 
   // Support failure on prompt=none
   // If fxa prompt=none login fails because the user is not logged in

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -4,7 +4,12 @@
 import { ResultCart } from '@fxa/payments/cart';
 import Stripe from 'stripe';
 
-export const CheckoutTypes = ['with-accounts', 'without-accounts'] as const;
+export const CheckoutTypes = [
+  'new_account',
+  'existing_account',
+  'logged_out',
+  'unknown',
+] as const;
 export type CheckoutTypesType = (typeof CheckoutTypes)[number];
 import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 

--- a/libs/payments/metrics/src/lib/glean/utils/determineCheckoutType.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/determineCheckoutType.spec.ts
@@ -4,15 +4,15 @@
 import { determineCheckoutType } from './determineCheckoutType';
 
 describe('determineCheckoutType', () => {
-  it('should return with-accounts if uid provided', () => {
-    expect(determineCheckoutType('validuid')).toEqual('with-accounts');
+  it('should return new_account if isNewAccount is true', () => {
+    expect(determineCheckoutType('true', 'true')).toEqual('new_account');
   });
 
-  it('should return without-accounts if empty uid', () => {
-    expect(determineCheckoutType('')).toEqual('without-accounts');
+  it('should return existing_account if uid provided but isNewAccount is not', () => {
+    expect(determineCheckoutType('true')).toEqual('existing_account');
   });
 
-  it('should return without-accounts if undefined uid', () => {
-    expect(determineCheckoutType(undefined)).toEqual('without-accounts');
+  it('should return logged_out if both isNewAccount and uid are empty', () => {
+    expect(determineCheckoutType('')).toEqual('logged_out');
   });
 });

--- a/libs/payments/metrics/src/lib/glean/utils/determineCheckoutType.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/determineCheckoutType.ts
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import type { CheckoutTypesType } from '../glean.types';
 
-export function determineCheckoutType(accountsUid?: string): CheckoutTypesType {
-  return accountsUid ? 'with-accounts' : 'without-accounts';
+export function determineCheckoutType(accountsUid?: string, isNewAccount?: string): CheckoutTypesType {
+  if (isNewAccount && isNewAccount === 'true') {
+    return 'new_account';
+  }
+
+  return accountsUid ? 'existing_account' : 'logged_out';
 }

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscription.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscription.spec.ts
@@ -26,7 +26,7 @@ describe('mapSubscription', () => {
       cmsMetricsData: mockCmsMetricsData,
     });
     expect(result).toEqual({
-      subscription_checkout_type: 'without-accounts',
+      subscription_checkout_type: 'logged_out',
       subscription_currency: mockCartData.currency,
       subscription_error_id: mockCartData.errorReasonId,
       subscription_interval: mockCommonData.params['interval'],
@@ -58,7 +58,7 @@ describe('mapSubscription', () => {
       cmsMetricsData: mockCmsMetricsData,
     });
     expect(result).toEqual({
-      subscription_checkout_type: 'without-accounts',
+      subscription_checkout_type: 'logged_out',
       subscription_currency: '',
       subscription_error_id: '',
       subscription_interval: '',

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscription.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscription.ts
@@ -24,7 +24,7 @@ export function mapSubscription({
 }) {
   const mappedParams = mapParams(commonMetricsData.params);
   return {
-    subscription_checkout_type: determineCheckoutType(cartMetricsData.uid),
+    subscription_checkout_type: determineCheckoutType(cartMetricsData.uid, commonMetricsData.searchParams['newAccount']),
     subscription_currency: normalizeGleanFalsyValues(cartMetricsData.currency),
     subscription_error_id: normalizeGleanFalsyValues(
       cartMetricsData.errorReasonId

--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -44,6 +44,7 @@ function buildSignOutRedirectPath(
   const allRemainingQueryParams = new URLSearchParams(searchParams.toString());
   allRemainingQueryParams.delete('countryCode');
   allRemainingQueryParams.delete('postalCode');
+  allRemainingQueryParams.delete('newAccount');
   const remainingQueryParams = allRemainingQueryParams.toString();
 
   if (remainingQueryParams) {

--- a/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
+++ b/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
@@ -133,8 +133,7 @@ subscription:
   checkout_type:
     type: string
     description: |
-      Whether the checkout flow is for new users or existing users.
-      One of “with-account” or “without-account"
+      Account status at time of checkout
     lifetime: application
     send_in_pings:
       - events
@@ -143,8 +142,11 @@ subscription:
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
+      - https://mozilla-hub.atlassian.net/browse/PAY-3182
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
+      - https://github.com/mozilla/fxa/issues/19677
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=2000681
     expires: never
     data_sensitivity:
       - interaction


### PR DESCRIPTION
## Because

- Current metrics are tagged as ‘with-accounts’ if the cart has a uid, and ‘without-accounts’ if the cart does not have a uid.
- 'with-accounts’ / ‘without-accounts’ should assess whether the customer had an account prior to checking out, or if they created a new account as part of the checkout process.

## This pull request

- Expands the CheckoutTypes to be 'new_account' | 'existing_account' | 'logged_out' | 'unknown'
- Returns new_account if newAccount is present (new customer).
- If newAccount is not present, uid is present - not a new customer, return 'existing_account'.
- If neither newAccount or uid are not present, customer is not logged in, and we don't know enough about them, so we return 'logged_out'.

## Issue that this pull request solves

Closes: [PAY-3182](https://mozilla-hub.atlassian.net/browse/PAY-3182)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots 

https://github.com/user-attachments/assets/02ff0248-b458-4466-9651-94f5b7b10569


## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3182]: https://mozilla-hub.atlassian.net/browse/PAY-3182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ