### PR TITLE
fix(settings): redirect user on AAL mismatch in mfa guard

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.test.tsx
@@ -59,11 +59,18 @@ const mockAuthClient = {
     kA: 'kA-key',
     kB: 'kB-key',
   }),
+  sessionStatus: jest.fn().mockResolvedValue({
+    details: {
+      sessionVerificationMeetsMinimumAAL: true,
+    },
+  }),
 } as any; // Use 'as any' to avoid TypeScript strict typing for mock
 
 // Mock the cache module to provide session token and JWT cache
 const mockSessionToken = 'mock-session-token';
-const mockJwtState: Record<string, string> = { [`${mockSessionToken}-password`]: 'mock-jwt-token' };
+const mockJwtState: Record<string, string> = {
+  [`${mockSessionToken}-password`]: 'mock-jwt-token',
+};
 jest.mock('../../../lib/cache', () => {
   const actual = jest.requireActual('../../../lib/cache');
   return {
@@ -102,7 +109,12 @@ const settingsContext = mockSettingsContext();
 
 const render = async (mockAccount = account) => {
   renderWithRouter(
-    <AppContext.Provider value={mockAppContext({ account: mockAccount, authClient: mockAuthClient })}>
+    <AppContext.Provider
+      value={mockAppContext({
+        account: mockAccount,
+        authClient: mockAuthClient,
+      })}
+    >
       <SettingsContext.Provider value={settingsContext}>
         <PageChangePassword />
       </SettingsContext.Provider>

--- a/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowRecoveryKey/index.test.tsx
@@ -40,7 +40,13 @@ const accountWithoutPassword = {
   recoveryKey: { exists: false },
 } as unknown as Account;
 
-const authClient = {} as unknown as AuthClient;
+const authClient = {
+  sessionStatus: jest.fn().mockResolvedValue({
+    details: {
+      sessionVerificationMeetsMinimumAAL: true,
+    },
+  }),
+} as unknown as AuthClient;
 
 const renderWithContext = (
   account: Partial<Account>,

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.test.tsx
@@ -54,6 +54,9 @@ describe('UnitRowSecondaryEmail', () => {
     mockAuthClient.mfaOtpVerify = jest
       .fn()
       .mockResolvedValue({ accessToken: mockJwt });
+    mockAuthClient.sessionStatus = jest.fn().mockResolvedValue({
+      details: { sessionVerificationMeetsMinimumAAL: true },
+    });
   };
 
   const resetJwtCache = () => {

--- a/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowTwoStepAuth/index.test.tsx
@@ -20,6 +20,9 @@ jest.mock('../../../models', () => ({
   ...jest.requireActual('../../../models'),
   useAuthClient: () => ({
     mfaRequestOtp: jest.fn(),
+    sessionStatus: jest.fn().mockResolvedValue({
+      details: { sessionVerificationMeetsMinimumAAL: true },
+    }),
   }),
 }));
 


### PR DESCRIPTION
## Because

- General Application Error when interacting with site after 2FA enabled

## This pull request

- redirects user on AAL mismatch in MFA guard

## Issue that this pull request solves

Closes: FXA-12576

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
