### PR TITLE
task(libs/account): Port app errors to libs/accounts/errors

### DIFF
--- a/libs/accounts/errors/.eslintrc.json
+++ b/libs/accounts/errors/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/accounts/errors/README.md
+++ b/libs/accounts/errors/README.md
@@ -1,0 +1,11 @@
+# account-errors
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build accounts-errors` to build the library.
+
+## Running unit tests
+
+Run `nx test-unit accounts-errors` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/accounts/errors/jest.config.ts
+++ b/libs/accounts/errors/jest.config.ts
@@ -1,0 +1,21 @@
+/* eslint-disable */
+export default {
+  displayName: 'accounts-errors',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/accounts/errors',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/lib/accounts/errors',
+        outputName: 'accounts-errors-jest-unit-results.xml',
+      },
+    ],
+  ],
+};

--- a/libs/accounts/errors/package.json
+++ b/libs/accounts/errors/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fxa/accounts/errors",
+  "version": "0.0.1",
+  "dependencies": {},
+  "type": "commonjs",
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "private": true
+}

--- a/libs/accounts/errors/project.json
+++ b/libs/accounts/errors/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "accounts-errors",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/accounts/errors/src",
+  "projectType": "library",
+  "tags": ["scope:shared:lib"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/accounts/errors",
+        "main": "libs/accounts/errors/src/index.ts",
+        "tsConfig": "libs/accounts/errors/tsconfig.lib.json",
+        "assets": ["libs/accounts/errors/*.md"],
+        "format": ["cjs"],
+        "generatePackageJson": true
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/accounts/errors/jest.config.ts",
+        "testPathPattern": ["^(?!.*\\.in\\.spec\\.ts$).*$"]
+      }
+    },
+    "test-integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/accounts/errors/jest.config.ts",
+        "testPathPattern": ["\\.in\\.spec\\.ts$"]
+      }
+    }
+  }
+}

--- a/libs/accounts/errors/src/constants.ts
+++ b/libs/accounts/errors/src/constants.ts
@@ -1,0 +1,220 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Standard error numbers
+ */
+export const ERRNO = {
+  SERVER_CONFIG_ERROR: 100,
+  ACCOUNT_EXISTS: 101,
+  ACCOUNT_UNKNOWN: 102,
+  INCORRECT_PASSWORD: 103,
+  ACCOUNT_UNVERIFIED: 104,
+  INVALID_VERIFICATION_CODE: 105,
+  INVALID_JSON: 106,
+  INVALID_PARAMETER: 107,
+  MISSING_PARAMETER: 108,
+  INVALID_REQUEST_SIGNATURE: 109,
+  INVALID_TOKEN: 110,
+  INVALID_TIMESTAMP: 111,
+  MISSING_CONTENT_LENGTH_HEADER: 112,
+  REQUEST_TOO_LARGE: 113,
+  THROTTLED: 114,
+  INVALID_NONCE: 115,
+  ENDPOINT_NOT_SUPPORTED: 116,
+  INCORRECT_EMAIL_CASE: 120,
+  // ACCOUNT_LOCKED: 121,
+  // ACCOUNT_NOT_LOCKED: 122,
+  DEVICE_UNKNOWN: 123,
+  DEVICE_CONFLICT: 124,
+  REQUEST_BLOCKED: 125,
+  ACCOUNT_RESET: 126,
+  INVALID_UNBLOCK_CODE: 127,
+  // MISSING_TOKEN: 128,
+  INVALID_PHONE_NUMBER: 129,
+  INVALID_REGION: 130,
+  INVALID_MESSAGE_ID: 131,
+  MESSAGE_REJECTED: 132,
+  BOUNCE_COMPLAINT: 133,
+  BOUNCE_HARD: 134,
+  BOUNCE_SOFT: 135,
+  EMAIL_EXISTS: 136,
+  EMAIL_DELETE_PRIMARY: 137,
+  SESSION_UNVERIFIED: 138,
+  USER_PRIMARY_EMAIL_EXISTS: 139,
+  VERIFIED_PRIMARY_EMAIL_EXISTS: 140,
+  MAX_SECONDARY_EMAILS_REACHED: 188,
+  ACCOUNT_OWNS_EMAIL: 189,
+  // If there exists an account that was created under 24hrs and
+  // has not verified their email address, this error is thrown
+  // if another user attempts to add that email to their account
+  // as a secondary email.
+  UNVERIFIED_PRIMARY_EMAIL_NEWLY_CREATED: 141,
+  LOGIN_WITH_SECONDARY_EMAIL: 142,
+  SECONDARY_EMAIL_UNKNOWN: 143,
+  VERIFIED_SECONDARY_EMAIL_EXISTS: 144,
+  RESET_PASSWORD_WITH_SECONDARY_EMAIL: 145,
+  INVALID_SIGNIN_CODE: 146,
+  CHANGE_EMAIL_TO_UNVERIFIED_EMAIL: 147,
+  CHANGE_EMAIL_TO_UNOWNED_EMAIL: 148,
+  LOGIN_WITH_INVALID_EMAIL: 149,
+  RESEND_EMAIL_CODE_TO_UNOWNED_EMAIL: 150,
+  FAILED_TO_SEND_EMAIL: 151,
+  INVALID_TOKEN_VERIFICATION_CODE: 152,
+  EXPIRED_TOKEN_VERIFICATION_CODE: 153,
+  TOTP_TOKEN_EXISTS: 154,
+  TOTP_TOKEN_NOT_FOUND: 155,
+  RECOVERY_CODE_NOT_FOUND: 156,
+  DEVICE_COMMAND_UNAVAILABLE: 157,
+  RECOVERY_KEY_NOT_FOUND: 158,
+  RECOVERY_KEY_INVALID: 159,
+  TOTP_REQUIRED: 160,
+  RECOVERY_KEY_EXISTS: 161,
+  UNKNOWN_CLIENT_ID: 162,
+  INVALID_SCOPES: 163,
+  STALE_AUTH_AT: 164,
+  REDIS_CONFLICT: 165,
+  NOT_PUBLIC_CLIENT: 166,
+  INCORRECT_REDIRECT_URI: 167,
+  INVALID_RESPONSE_TYPE: 168,
+  MISSING_PKCE_PARAMETERS: 169,
+  INSUFFICIENT_ACR_VALUES: 170,
+  INCORRECT_CLIENT_SECRET: 171,
+  UNKNOWN_AUTHORIZATION_CODE: 172,
+  MISMATCH_AUTHORIZATION_CODE: 173,
+  EXPIRED_AUTHORIZATION_CODE: 174,
+  INVALID_PKCE_CHALLENGE: 175,
+  UNKNOWN_SUBSCRIPTION_CUSTOMER: 176,
+  UNKNOWN_SUBSCRIPTION: 177,
+  UNKNOWN_SUBSCRIPTION_PLAN: 178,
+  REJECTED_SUBSCRIPTION_PAYMENT_TOKEN: 179,
+  SUBSCRIPTION_ALREADY_CANCELLED: 180,
+  REJECTED_CUSTOMER_UPDATE: 181,
+  REFRESH_TOKEN_UNKNOWN: 182,
+  INVALID_EXPIRED_OTP_CODE: 183,
+  SUBSCRIPTION_ALREADY_CHANGED: 184,
+  INVALID_PLAN_UPDATE: 185,
+  PAYMENT_FAILED: 186,
+  SUBSCRIPTION_ALREADY_EXISTS: 187,
+  UNKNOWN_SUBSCRIPTION_FOR_SOURCE: 188,
+  BILLING_AGREEMENT_EXISTS: 192,
+  MISSING_PAYPAL_PAYMENT_TOKEN: 193,
+  MISSING_PAYPAL_BILLING_AGREEMENT: 194,
+  UNVERIFIED_PRIMARY_EMAIL_HAS_ACTIVE_SUBSCRIPTION: 195,
+  IAP_INVALID_TOKEN: 196,
+  IAP_INTERNAL_OTHER: 197,
+  IAP_UNKNOWN_APPNAME: 198,
+  INVALID_PROMOTION_CODE: 199,
+  SERVER_BUSY: 201,
+  FEATURE_NOT_ENABLED: 202,
+  BACKEND_SERVICE_FAILURE: 203,
+  DISABLED_CLIENT_ID: 204,
+  THIRD_PARTY_ACCOUNT_ERROR: 205,
+  CANNOT_CREATE_PASSWORD: 206,
+  ACCOUNT_CREATION_REJECTED: 207,
+  IAP_PURCHASE_ALREADY_REGISTERED: 208,
+  INVALID_INVOICE_PREVIEW_REQUEST: 209,
+  UNABLE_TO_LOGIN_NO_PASSWORD_SET: 210,
+  INVALID_CURRENCY: 211,
+  SUBSCRIPTION_PROMO_CODE_NOT_APPLIED: 212,
+  UNSUPPORTED_LOCATION: 213,
+  RECOVERY_PHONE_NUMBER_ALREADY_EXISTS: 214,
+  RECOVERY_PHONE_NUMBER_DOES_NOT_EXIST: 215,
+  SMS_SEND_RATE_LIMIT_EXCEEDED: 216,
+  INVALID_CLOUDTASK_EMAILTYPE: 217,
+  RECOVERY_PHONE_REMOVE_MISSING_RECOVERY_CODES: 218,
+  RECOVERY_PHONE_REGISTRATION_LIMIT_REACHED: 219,
+  TOTP_SECRET_DOES_NOT_EXIST: 220,
+  RECOVERY_CODES_ALREADY_EXISTS: 221,
+  INTERNAL_VALIDATION_ERROR: 998,
+  UNEXPECTED_ERROR: 999,
+};
+
+/**
+ * Takes an object and swaps keys with values. Useful when a value -> key look up is needed.
+ * @param obj - Object to swap keys and values on
+ * @returns An object with keys and values reveresed.
+ */
+function swapObjectKeysAndValues(obj: {
+  [key: string]: string | number;
+}) {
+  const result: { [key: string | number]: string } = {};
+  for (const key in obj) {
+    result[obj[key]] = key;
+  }
+  return result;
+}
+/**
+ * A reversed map of errnos.
+ */
+export const ERRNO_REVERSE_MAP = swapObjectKeysAndValues(ERRNO);
+
+/**
+ * The Default Unexpected Error State
+ */
+export const DEFAULT_ERRROR = {
+  code: 500,
+  error: 'Internal Server Error',
+  errno: ERRNO.UNEXPECTED_ERROR,
+  message: 'Unspecified error',
+  info: 'https://mozilla.github.io/ecosystem-platform/api#section/Response-format',
+};
+
+/**
+ * List of errors that should not be sent to Sentry
+ */
+export const IGNORED_ERROR_NUMBERS = [
+  ERRNO.BOUNCE_HARD,
+  ERRNO.BOUNCE_SOFT,
+  ERRNO.BOUNCE_COMPLAINT,
+];
+
+/**
+ * Regex to determine if message is a payload too large message.
+ */
+export const TOO_LARGE = /^Payload (?:content length|size) greater than maximum allowed/;
+
+/**
+ * Set of errors indicating a bad request signature
+ */
+export const BAD_SIGNATURE_ERRORS = [
+  'Bad mac',
+  'Unknown algorithm',
+  'Missing required payload hash',
+  'Payload is invalid',
+];
+
+/**
+ * Payload properties that might help us debug unexpected errors
+ * when they show up in production. Obviously we don't want to
+ * accidentally send any sensitive data or PII to a 3rd-party,
+ * so the set is opt-in rather than opt-out.
+ */
+export const DEBUGGABLE_PAYLOAD_KEYS = new Set([
+  'availableCommands',
+  'capabilities',
+  'client_id',
+  'code',
+  'command',
+  'duration',
+  'excluded',
+  'features',
+  'messageId',
+  'metricsContext',
+  'name',
+  'preVerified',
+  'publicKey',
+  'reason',
+  'redirectTo',
+  'reminder',
+  'scope',
+  'service',
+  'target',
+  'to',
+  'TTL',
+  'ttl',
+  'type',
+  'unblockCode',
+  'verificationMethod',
+]);

--- a/libs/accounts/errors/src/index.spec.ts
+++ b/libs/accounts/errors/src/index.spec.ts
@@ -1,0 +1,337 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fullStack } from 'verror';
+import { AppError, Request } from './app-error';
+import { OauthError } from './oauth-error';
+import { RequestRoute } from 'hapi';
+
+describe('AppErrors', () => {
+  const mockApp = {
+    acceptLanguage: 'en, fr',
+    locale: 'en',
+    geo: {
+      city: 'Mountain View',
+      state: 'California',
+    },
+    ua: {
+      os: 'Android',
+      osVersion: '9',
+    },
+    devices: Promise.resolve([{ id: 1 }]),
+    metricsContext: Promise.resolve({
+      service: 'sync',
+    }),
+  };
+
+  const mockRequest = {
+    app: mockApp,
+    route: { path: '/foo' },
+  };
+
+  // In a server environment, this should be configured or dynamically
+  // determined from paths registered by the server!
+  const mockOAuthRoutes = [
+    {
+      path: '/token',
+      config: {
+        cors: true,
+      },
+    },
+  ];
+
+  it('converts an OauthError into AppError when not an oauth route', function () {
+    const oauthError = OauthError.invalidAssertion();
+    expect(oauthError.errno).toEqual(104);
+
+    const result = AppError.translate(
+      {
+        app: mockApp,
+        route: { path: '/v1/oauth/token' },
+      },
+      oauthError,
+      mockOAuthRoutes
+    );
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(110);
+  });
+
+  it('keeps an OauthError with an oauth route', () => {
+    const oauthError = OauthError.invalidAssertion();
+    expect(oauthError.errno).toEqual(104);
+
+    const result = AppError.translate(
+      { app: mockApp, route: { path: '/v1/token' } },
+      oauthError,
+      mockOAuthRoutes
+    );
+
+    expect(result).toBeInstanceOf(OauthError);
+    expect(result.errno).toEqual(104);
+  });
+
+  it('should translate with missing required parameters', () => {
+    const result = AppError.translate(
+      mockRequest,
+      {
+        output: {
+          payload: {
+            message: `foo${'is required'}`,
+            validation: {
+              keys: ['bar', 'baz'],
+            },
+          },
+        },
+      },
+      mockOAuthRoutes
+    );
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(108);
+    expect(result.message).toEqual('Missing parameter in request body: bar');
+    expect(result.output.statusCode).toEqual(400);
+    expect(result.output.payload.error).toEqual('Bad Request');
+    expect(result.output.payload.errno).toEqual(result.errno);
+    expect(result.output.payload.message).toEqual(result.message);
+    expect(result.output.payload.param).toEqual('bar');
+  });
+
+  it('should translate with payload data', () => {
+    const data = {
+      TIMESTAMP: '2021-01-16T01:43:33Z',
+      CORRELATIONID: '950b61c42c10d',
+      ACK: 'Failure',
+      VERSION: '204',
+      BUILD: '55251101',
+      L_ERRORCODE0: '11451',
+      L_SHORTMESSAGE0: 'Billing Agreement Id or transaction Id is not valid',
+      L_LONGMESSAGE0: 'Billing Agreement Id or transaction Id is not valid',
+      L_SEVERITYCODE0: 'Error',
+    };
+
+    const result = AppError.translate(
+      mockRequest,
+      {
+        output: {
+          statusCode: 500,
+          payload: {
+            error: 'Internal Server Error',
+          },
+        },
+        data: data,
+      },
+      mockOAuthRoutes
+    );
+
+    expect(JSON.stringify(data)).toEqual(result.output.payload.data);
+  });
+
+  it('should translate with invalid parameter', () => {
+    const result = AppError.translate(
+      mockRequest,
+      {
+        output: {
+          payload: {
+            validation: 'foo',
+          },
+        },
+      },
+      mockOAuthRoutes
+    );
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(107);
+    expect(result.message).toEqual('Invalid parameter in request body');
+    expect(result.output.statusCode).toEqual(400);
+    expect(result.output.payload.error).toEqual('Bad Request');
+    expect(result.output.payload.errno).toEqual(result.errno);
+    expect(result.output.payload.message).toEqual(result.message);
+    expect(result.output.payload.validation).toEqual('foo');
+  });
+
+  it('should translate with missing payload', () => {
+    const result = AppError.translate(
+      mockRequest,
+      {
+        output: {},
+      },
+      mockOAuthRoutes
+    );
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(999);
+    expect(result.message).toEqual('Unspecified error');
+    expect(result.output.statusCode).toEqual(500);
+    expect(result.output.payload.error).toEqual('Internal Server Error');
+    expect(result.output.payload.errno).toEqual(result.errno);
+    expect(result.output.payload.message).toEqual(result.message);
+  });
+
+  it('maps an errno to its key', () => {
+    const error = AppError.cannotLoginNoPasswordSet();
+    const actual = AppError.mapErrnoToKey(error);
+    expect(actual).toEqual('UNABLE_TO_LOGIN_NO_PASSWORD_SET');
+  });
+
+  it('backend error includes a cause error when supplied', () => {
+    const originalError = new Error('Service timed out.');
+    const err = AppError.backendServiceFailure(
+      'test',
+      'checking',
+      {},
+      originalError
+    );
+    const fullError = fullStack(err);
+    expect(fullError).toContain('caused by:');
+    expect(fullError).toContain('Error: Service timed out.');
+  });
+
+  it('tooManyRequests', () => {
+    let result = AppError.tooManyRequests(900, 'in 15 minutes');
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(114);
+    expect(result.message).toEqual('Client has sent too many requests');
+    expect(result.output.statusCode).toEqual(429);
+    expect(result.output.payload.error).toEqual('Too Many Requests');
+    expect(result.output.payload.retryAfter).toEqual(900);
+    expect(result.output.payload.retryAfterLocalized).toEqual('in 15 minutes');
+
+    result = AppError.tooManyRequests(900);
+    expect(result.output.payload.retryAfter).toEqual(900);
+    expect(!result.output.payload.retryAfterLocalized).toBeTruthy();
+  });
+
+  it('iapInvalidToken', () => {
+    const defaultErrorMessage = 'Invalid IAP token';
+    let result = AppError.iapInvalidToken();
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.errno).toEqual(196);
+    expect(result.message).toEqual(defaultErrorMessage);
+    expect(result.output.statusCode).toEqual(400);
+    expect(result.output.payload.error).toEqual('Bad Request');
+
+    result = AppError.iapInvalidToken({
+      name: 'Invalid IAP Token',
+      message: '',
+    });
+    expect(result.message).toEqual(defaultErrorMessage);
+
+    result = AppError.iapInvalidToken({
+      name: 'Invalid IAP Token',
+      message: 'Wow helpful extra info',
+    });
+    expect(result.message).toEqual(
+      `${defaultErrorMessage}: Wow helpful extra info`
+    );
+  });
+
+  it('unexpectedError without request data', () => {
+    const err = AppError.unexpectedError();
+    expect(err).toBeInstanceOf(AppError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.errno).toEqual(999);
+    expect(err.message).toEqual('Unspecified error');
+    expect(err.output.statusCode).toEqual(500);
+    expect(err.output.payload.error).toEqual('Internal Server Error');
+    expect(err.output.payload.request).toBeUndefined();
+  });
+
+  it('unexpectedError with request data', () => {
+    const err = AppError.unexpectedError({
+      app: {
+        acceptLanguage: 'en, fr',
+        locale: 'en',
+        geo: {
+          city: 'Mountain View',
+          state: 'California',
+        },
+        ua: {
+          os: 'Android',
+          osVersion: '9',
+        },
+        devices: Promise.resolve([{ id: 1 }]),
+        metricsContext: Promise.resolve({
+          service: 'sync',
+        }),
+      },
+      method: 'GET',
+      path: '/v1/wibble',
+      route: {
+        path: '/v1/wibble',
+      } as unknown as RequestRoute,
+      query: {
+        foo: 'bar',
+      },
+      payload: {
+        baz: 'qux',
+        email: 'foo@example.com',
+        displayName: 'Foo Bar',
+        metricsContext: {
+          utmSource: 'thingy',
+        },
+        service: 'sync',
+      },
+      headers: {
+        // x-forwarded-for is stripped out because it contains internal server IPs
+        // See https://github.com/mozilla/fxa-private/issues/66
+        'x-forwarded-for': '192.168.1.1 192.168.2.2',
+        wibble: 'blee',
+      },
+    } as unknown as Request);
+    expect(err.errno).toEqual(999);
+    expect(err.message).toEqual('Unspecified error');
+    expect(err.output.statusCode).toEqual(500);
+    expect(err.output.payload.error).toEqual('Internal Server Error');
+    expect(err.output.payload.request).toEqual({
+      acceptLanguage: 'en, fr',
+      locale: 'en',
+      userAgent: {
+        os: 'Android',
+        osVersion: '9',
+      },
+      method: 'GET',
+      path: '/v1/wibble',
+      query: {
+        foo: 'bar',
+      },
+      payload: {
+        metricsContext: {
+          utmSource: 'thingy',
+        },
+        service: 'sync',
+      },
+      headers: {
+        wibble: 'blee',
+      },
+    });
+  });
+
+  const reasons = ['socket hang up', 'ECONNREFUSED'];
+  reasons.forEach((reason) => {
+    it(`converts ${reason} errors to backend service error`, () => {
+      const result = AppError.translate(
+        mockRequest,
+        {
+          output: {
+            payload: {
+              errno: 999,
+              statusCode: 500,
+            },
+          },
+          reason,
+        },
+        mockOAuthRoutes
+      );
+
+      expect(result).toBeInstanceOf(AppError);
+      expect(result.errno).toEqual(203);
+      expect(result.message).toEqual('System unavailable, try again soon');
+      expect(result.output.statusCode).toEqual(500);
+      expect(result.output.payload.error).toEqual('Internal Server Error');
+      expect(result.output.payload.errno).toEqual(
+        AppError.ERRNO.BACKEND_SERVICE_FAILURE
+      );
+      expect(result.output.payload.message).toEqual(
+        'System unavailable, try again soon'
+      );
+    });
+  });
+});

--- a/libs/accounts/errors/src/index.ts
+++ b/libs/accounts/errors/src/index.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './app-error';
+export * from './oauth-error';

--- a/libs/accounts/errors/src/oauth-error.ts
+++ b/libs/accounts/errors/src/oauth-error.ts
@@ -1,0 +1,432 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DEFAULT_ERRROR } from './constants';
+
+// Leaving this here for historical reasons. But we should probably get rid
+// of references to this legacy buff package... See FXA-12594
+const hex = require('buf').to.hex;
+
+// Deprecated. New error types should be defined in lib/error.js
+export class OauthError extends Error {
+  isBoom: boolean;
+  errno: number;
+  output: {
+    statusCode: number;
+    payload: {
+      code: number;
+      errno: number;
+      error: any;
+      message: string;
+      info: Record<string, any>;
+      log?:unknown;
+    };
+    headers: Record<string, string|number>;
+  };
+
+  constructor(options: any, extra?: any, headers?: any) {
+    super(options.message || DEFAULT_ERRROR.message);
+    this.message = options.message || DEFAULT_ERRROR.message;
+    this.isBoom = true;
+    if (options.stack) {
+      this.stack = options.stack;
+    } else {
+      Error.captureStackTrace(this, OauthError);
+    }
+    this.errno = options.errno || DEFAULT_ERRROR.errno;
+    this.output = {
+      statusCode: options.code || DEFAULT_ERRROR.code,
+      payload: {
+        code: options.code || DEFAULT_ERRROR.code,
+        errno: this.errno,
+        error: options.error || DEFAULT_ERRROR.error,
+        message: this.message,
+        info: options.info || DEFAULT_ERRROR.info,
+      },
+      headers: headers || {},
+    };
+    merge(this.output.payload, extra);
+  }
+
+  override toString() {
+    return 'Error: ' + this.message;
+  }
+
+  header(name:string, value:string|number) {
+    this.output.headers[name] = value;
+  }
+
+  translate(response:{output:{payload:any}, stack:string}) {
+    if (response instanceof OauthError) {
+      return response;
+    }
+
+    let error;
+    const payload = response.output.payload;
+    if (payload.validation) {
+      error = OauthError.invalidRequestParameter(payload.validation);
+    } else if (payload.statusCode === 415) {
+      error = OauthError.invalidContentType();
+    } else {
+      error = new OauthError({
+        message: payload.message,
+        code: payload.statusCode,
+        error: payload.error,
+        errno: payload.errno,
+        stack: response.stack,
+      });
+    }
+
+    return error;
+  }
+
+  static isOauthRoute(path:string, routes?:Array<{path:string, config:{cors:any}}>) {
+    if (!routes) {
+      return false;
+    }
+
+    return (
+      // For now we use a fragile heuristic that all oauth routes set cors config
+      // TODO: when we merge oauth errors into auth, rethink this.
+      routes.findIndex((r) => `/v1${r.path}` === path && r.config.cors) > -1
+    );
+  }
+
+  static translate(
+    response: {
+      output: {
+        payload?:any;
+      },
+      stack?:string
+    } | OauthError
+  ):OauthError {
+
+    if (response instanceof OauthError) {
+      return response;
+    }
+
+    const payload = response.output.payload;
+
+    if (payload?.validation) {
+      return OauthError.invalidRequestParameter(payload.validation);
+    }
+
+    if (payload?.statusCode === 415) {
+      return OauthError.invalidContentType();
+    }
+
+    return new OauthError({
+      message: payload?.message,
+      code: payload?.statusCode,
+      error: payload?.error,
+      errno: payload?.errno,
+      stack: response.stack,
+    });
+  }
+
+  backtrace(traced:unknown) {
+    this.output.payload.log = traced;
+  };
+
+  static unexpectedError() {
+    return new OauthError({});
+  }
+
+  static unknownClient(clientId:string|Buffer) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 101,
+        message: 'Unknown client',
+      },
+      {
+        clientId: hex(clientId),
+      }
+    );
+  }
+
+  static incorrectSecret(clientId:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 102,
+        message: 'Incorrect secret',
+      },
+      {
+        clientId: hex(clientId),
+      }
+    );
+  }
+
+  static incorrectRedirect(uri:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 103,
+        message: 'Incorrect redirect_uri',
+      },
+      {
+        redirectUri: uri,
+      }
+    );
+  }
+
+  static invalidAssertion() {
+    return new OauthError({
+      code: 401,
+      error: 'Bad Request',
+      errno: 104,
+      message: 'Invalid assertion',
+    });
+  }
+
+  static unknownCode(code:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 105,
+        message: 'Unknown code',
+      },
+      {
+        requestCode: code,
+      }
+    );
+  }
+
+  static mismatchCode(code:string, clientId:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 106,
+        message: 'Incorrect code',
+      },
+      {
+        requestCode: hex(code),
+        client: hex(clientId),
+      }
+    );
+  }
+
+  static expiredCode(code:string, expiredAt:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 107,
+        message: 'Expired code',
+      },
+      {
+        requestCode: hex(code),
+        expiredAt: expiredAt,
+      }
+    );
+  }
+
+  static invalidToken() {
+    return new OauthError({
+      code: 400,
+      error: 'Bad Request',
+      errno: 108,
+      message: 'Invalid token',
+    });
+  }
+
+  static invalidRequestParameter(val:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 109,
+        message: 'Invalid request parameter',
+      },
+      {
+        validation: val,
+      }
+    );
+  }
+
+  static invalidResponseType() {
+    return new OauthError({
+      code: 400,
+      error: 'Bad Request',
+      errno: 110,
+      message: 'Invalid response_type',
+    });
+  }
+
+  static unauthorized(reason:string) {
+    return new OauthError(
+      {
+        code: 401,
+        error: 'Unauthorized',
+        errno: 111,
+        message: 'Unauthorized for route',
+      },
+      {
+        detail: reason,
+      }
+    );
+  }
+
+  static forbidden() {
+    return new OauthError({
+      code: 403,
+      error: 'Forbidden',
+      errno: 112,
+      message: 'Forbidden',
+    });
+  }
+
+  static invalidContentType() {
+    return new OauthError({
+      code: 415,
+      error: 'Unsupported Media Type',
+      errno: 113,
+      message:
+        'Content-Type must be either application/json or ' +
+        'application/x-www-form-urlencoded',
+    });
+  }
+
+  static invalidScopes(scopes:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Invalid scopes',
+        errno: 114,
+        message: 'Requested scopes are not allowed',
+      },
+      {
+        invalidScopes: scopes,
+      }
+    );
+  }
+
+  static expiredToken(expiredAt:number) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 115,
+        message: 'Expired token',
+      },
+      {
+        expiredAt: expiredAt,
+      }
+    );
+  }
+
+  static notPublicClient(clientId:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 116,
+        message: 'Not a public client',
+      },
+      {
+        clientId: hex(clientId),
+      }
+    );
+  }
+
+  static mismatchCodeChallenge(pkceHashValue:string) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 117,
+        message: 'Incorrect code_challenge',
+      },
+      {
+        requestCodeChallenge: pkceHashValue,
+      }
+    );
+  }
+
+  static missingPkceParameters() {
+    return new OauthError({
+      code: 400,
+      error: 'PKCE parameters missing',
+      errno: 118,
+      message: 'Public clients require PKCE OAuth parameters',
+    });
+  }
+
+  static staleAuthAt(authAt:number) {
+    return new OauthError(
+      {
+        code: 401,
+        error: 'Bad Request',
+        errno: 119,
+        message: 'Stale authentication timestamp',
+      },
+      {
+        authAt: authAt,
+      }
+    );
+  }
+
+  static mismatchAcr(foundValue:boolean) {
+    return new OauthError(
+      {
+        code: 400,
+        error: 'Bad Request',
+        errno: 120,
+        message: 'Mismatch acr value',
+      },
+      { foundValue }
+    );
+  }
+
+  static invalidGrantType() {
+    return new OauthError({
+      code: 400,
+      error: 'Bad Request',
+      errno: 121,
+      message: 'Invalid grant_type',
+    });
+  }
+
+  static unknownToken() {
+    return new OauthError({
+      code: 400,
+      error: 'Bad Request',
+      errno: 122,
+      message: 'Unknown token',
+    });
+  }
+
+  // N.B. `errno: 201` is traditionally our generic "service unavailable" error,
+  // so let's reserve it for that purpose here as well.
+
+  static disabledClient(clientId:string) {
+    return new OauthError(
+      {
+        code: 503,
+        error: 'Client Disabled',
+        errno: 202, // TODO reconcile this with the auth-server version
+        message: 'This client has been temporarily disabled',
+      },
+      { clientId }
+    );
+  }
+}
+
+/**
+ * Utility function to merge one object into an other.
+ * @param target The main object
+ * @param other The object being merged into the main object.
+ */
+function merge(target: any, other: any) {
+  const keys = Object.keys(other || {});
+  for (let i = 0; i < keys.length; i++) {
+    target[keys[i]] = other[keys[i]];
+  }
+}

--- a/libs/accounts/errors/src/util.ts
+++ b/libs/accounts/errors/src/util.ts
@@ -1,0 +1,18 @@
+export function swapObjectKeysAndValues(obj: {
+  [key: string]: string | number;
+}) {
+  const result: { [key: string | number]: string } = {};
+  for (const key in obj) {
+    result[obj[key]] = key;
+  }
+  return result;
+}
+
+// Parse a comma-separated list with allowance for varied whitespace
+export function commaSeparatedListToArray(s: string) {
+  return (s || '')
+    .trim()
+    .split(',')
+    .map((c) => c.trim())
+    .filter((c) => !!c);
+}

--- a/libs/accounts/errors/tsconfig.json
+++ b/libs/accounts/errors/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/accounts/errors/tsconfig.lib.json
+++ b/libs/accounts/errors/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/accounts/errors/tsconfig.spec.json
+++ b/libs/accounts/errors/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "@types/babel__preset-env": "^7",
     "@types/bn.js": "^5",
     "@types/classnames": "2.3.1",
+    "@types/hapi": "^18.0.15",
     "@types/jest": "29.5.14",
     "@types/jsdom": "^21",
     "@types/module-alias": "^2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,7 @@
     "useUnknownInCatchVariables": false,
     "baseUrl": ".",
     "paths": {
+      "@fxa/accounts/errors": ["libs/accounts/errors/src/index.ts"],
       "@fxa/accounts/rate-limit": ["libs/accounts/rate-limit/src/index.ts"],
       "@fxa/accounts/recovery-phone": [
         "libs/accounts/recovery-phone/src/index.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20881,6 +20881,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/boom@npm:*":
+  version: 7.3.5
+  resolution: "@types/boom@npm:7.3.5"
+  checksum: 10c0/6b8577f26b22950b4d0fd1770b30f0d959c6d15275a72a381b91aea3772313675c6293fac6cd484cb40eec7715f1d321cacaacd7b510a68c3d21932af5c5f837
+  languageName: node
+  linkType: hard
+
 "@types/bunyan@npm:1.8.11":
   version: 1.8.11
   resolution: "@types/bunyan@npm:1.8.11"
@@ -20915,6 +20922,13 @@ __metadata:
   version: 0.12.5
   resolution: "@types/caseless@npm:0.12.5"
   checksum: 10c0/b1f8b8a38ce747b643115d37a40ea824c658bd7050e4b69427a10e9d12d1606ed17a0f6018241c08291cd59f70aeb3c1f3754ad61e45f8dbba708ec72dde7ec8
+  languageName: node
+  linkType: hard
+
+"@types/catbox@npm:*":
+  version: 10.0.9
+  resolution: "@types/catbox@npm:10.0.9"
+  checksum: 10c0/ec86aa00b64cf8912152cc937fc06604fecf602f37529aa1ae5c2991be9c957376bcb3df816c244bdbcd66f8822e2b36ac1b46a7ebc03e7d3d4c8e721271021e
   languageName: node
   linkType: hard
 
@@ -21327,6 +21341,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/hapi@npm:^18.0.15":
+  version: 18.0.15
+  resolution: "@types/hapi@npm:18.0.15"
+  dependencies:
+    "@types/boom": "npm:*"
+    "@types/catbox": "npm:*"
+    "@types/iron": "npm:*"
+    "@types/mimos": "npm:*"
+    "@types/node": "npm:*"
+    "@types/podium": "npm:*"
+    "@types/shot": "npm:*"
+    joi: "npm:^17.3.0"
+  checksum: 10c0/c17e6c1fbe1601c49f6d1616ffbe1ccc1275716c6a0ab98be780a51c11e6c2c3f8ab8edb0af184176434fdf49d9e2a1e2c86b50c3322fe7d16fd8e47762157c6
+  languageName: node
+  linkType: hard
+
 "@types/hapi__catbox@npm:*":
   version: 10.2.6
   resolution: "@types/hapi__catbox@npm:10.2.6"
@@ -21464,6 +21494,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/af576e33830196be01b71c48ad5f83380a1c51d62f394a5601e8c2a5b8b31cf6dc8fe71ac39c38d806bcf1d6f1c5c8205c129eca6b6d168c0df7ab3722df23b9
+  languageName: node
+  linkType: hard
+
+"@types/iron@npm:*":
+  version: 5.0.5
+  resolution: "@types/iron@npm:5.0.5"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/02300572301894077e19a63f069a8b8c41e185e4fe0115c33ffd18f304e3bc5cee58c9c901ff59f1782282f2feb7bae3139afd2024754e4f1ca7e60c4a47e11a
   languageName: node
   linkType: hard
 
@@ -21803,6 +21842,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mimos@npm:*":
+  version: 3.0.6
+  resolution: "@types/mimos@npm:3.0.6"
+  dependencies:
+    "@types/mime-db": "npm:*"
+  checksum: 10c0/5a8693e27e0abce0641ec07b38b27f126e11c6ab1e9ea7ad52ff60065617ad1ac5e8209b5041d9184a9ab713aad022c4bee06aebfb6c33a9dfa1a18d1d35029a
+  languageName: node
+  linkType: hard
+
 "@types/minimatch@npm:^3.0.3":
   version: 3.0.5
   resolution: "@types/minimatch@npm:3.0.5"
@@ -22068,6 +22116,13 @@ __metadata:
     pg-protocol: "npm:*"
     pg-types: "npm:^2.2.0"
   checksum: 10c0/8d16660c9a4f050d6d5e391c59f9a62e9d377a2a6a7eb5865f8828082dbdfeab700fd707e585f42d67b29e796b32863aea5bd6d5cbb8ceda2d598da5d0c61693
+  languageName: node
+  linkType: hard
+
+"@types/podium@npm:*":
+  version: 1.0.4
+  resolution: "@types/podium@npm:1.0.4"
+  checksum: 10c0/d7a602f306b31eb5b62c8bdcc0d9f31034fbbf0b5f00bac552f7702128c121b4e21d291b19de2042683642d5af83243c8c6642e8846e6ef3c137594cc20b670b
   languageName: node
   linkType: hard
 
@@ -22456,6 +22511,15 @@ __metadata:
   version: 1.2.0
   resolution: "@types/shimmer@npm:1.2.0"
   checksum: 10c0/6f7bfe1b55601cfc3ae713fc74a03341f3834253b8b91cb2add926d5949e4a63f7e666f59c2a6e40a883a5f9e2f3e3af10f9d3aed9b60fced0bda87659e58d8d
+  languageName: node
+  linkType: hard
+
+"@types/shot@npm:*":
+  version: 4.0.5
+  resolution: "@types/shot@npm:4.0.5"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/c01275b11a6d2694b1c3ee3b31cbfe7b8a48b35a73253185cea03e0ad6fc949a2c348ff40688601d39b8d837581312b96200df9f844bb1f6f786ce4710aa36b7
   languageName: node
   linkType: hard
 
@@ -35281,6 +35345,7 @@ __metadata:
     "@types/babel__preset-env": "npm:^7"
     "@types/bn.js": "npm:^5"
     "@types/classnames": "npm:2.3.1"
+    "@types/hapi": "npm:^18.0.15"
     "@types/jest": "npm:29.5.14"
     "@types/jsdom": "npm:^21"
     "@types/module-alias": "npm:^2"


### PR DESCRIPTION
## Because
- We will need this for subsequent efforts

## This pull request

- Ports `oauth/errors.js` and `errors.js` from auth-server to libs

## Issue that this pull request solves

Closes: FXA-12581

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a requirement for porting email sending code. Other PRs are based on this one. 
