### PR TITLE
task(libs/accounts): Port email sending code to libs

### DIFF
--- a/_scripts/check-frozen.ts
+++ b/_scripts/check-frozen.ts
@@ -12,6 +12,10 @@ const frozen: Array<{ pattern: string; reason: string }> = [
     pattern: 'packages/fxa-auth-server/(lib|lib/oauth)/error.js',
     reason: 'Files moved to libs/accounts/errors',
   },
+  {
+    pattern: 'packages/fxa-auth-server/lib/senders/email.js',
+    reason: 'Files moved to libs/accounts/email-sender',
+  },
 ];
 
 export const getChangedFiles = () => {

--- a/libs/accounts/email-sender/.eslintrc.json
+++ b/libs/accounts/email-sender/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/accounts/email-sender/README.md
+++ b/libs/accounts/email-sender/README.md
@@ -1,0 +1,11 @@
+# accounts-email-sender
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build accounts-email-senders` to build the library.
+
+## Running unit tests
+
+Run `nx test-unit accounts-email-senders` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/accounts/email-sender/jest.config.ts
+++ b/libs/accounts/email-sender/jest.config.ts
@@ -1,0 +1,21 @@
+/* eslint-disable */
+export default {
+  displayName: 'accounts-email-sender',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/accounts/email-sender',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/lib/accounts/email-sender',
+        outputName: 'accounts-email-sender-jest-unit-results.xml',
+      },
+    ],
+  ],
+};

--- a/libs/accounts/email-sender/package.json
+++ b/libs/accounts/email-sender/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@fxa/accounts/email-sender",
+  "version": "0.0.1",
+  "dependencies": {},
+  "type": "commonjs",
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "private": true
+}

--- a/libs/accounts/email-sender/project.json
+++ b/libs/accounts/email-sender/project.json
@@ -1,0 +1,37 @@
+{
+  "name": "accounts-email-sender",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/accounts/email-sender/src",
+  "projectType": "library",
+  "tags": ["scope:shared:lib"],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/accounts/email-sender",
+        "main": "libs/accounts/email-sender/src/index.ts",
+        "tsConfig": "libs/accounts/email-sender/tsconfig.lib.json",
+        "assets": ["libs/accounts/email-sender/*.md"],
+        "format": ["cjs"],
+        "generatePackageJson": true
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/accounts/email-sender/jest.config.ts",
+        "testPathPattern": ["^(?!.*\\.in\\.spec\\.ts$).*$"]
+      }
+    },
+    "test-integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/accounts/email-sender/jest.config.ts",
+        "testPathPattern": ["\\.in\\.spec\\.ts$"]
+      }
+    }
+  }
+}

--- a/libs/accounts/email-sender/src/bounces.ts
+++ b/libs/accounts/email-sender/src/bounces.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AppError } from '@fxa/accounts/errors';
+
+export type BouncesConfig = {
+  enabled: boolean;
+  hard: Record<number, number>;
+  soft: Record<number, number>;
+  complaint: Record<number, number>;
+  ignoreTemplates: string[];
+};
+
+export type Bounce = {
+  bounceType: number;
+  createdAt: number;
+};
+
+export type Tally = {
+  count: number;
+  latest: number;
+};
+
+export type BounceDb = {
+  emailBounces: {
+    findByEmail(email: string): Promise<Array<Bounce>>;
+  };
+};
+
+const BOUNCE_TYPE_HARD = 1;
+const BOUNCE_TYPE_SOFT = 2;
+const BOUNCE_TYPE_COMPLAINT = 3;
+
+export class Bounces {
+  private readonly bounceRules: Record<number, any>;
+
+  constructor(
+    private readonly config: BouncesConfig,
+    private readonly db: BounceDb
+  ) {
+    this.bounceRules = {
+      [BOUNCE_TYPE_HARD]: Object.freeze(config.hard || {}),
+      [BOUNCE_TYPE_SOFT]: Object.freeze(config.soft || {}),
+      [BOUNCE_TYPE_COMPLAINT]: Object.freeze(config.complaint || {}),
+    };
+  }
+
+  async check(email: string, template: string) {
+    if (this.config.enabled) {
+      return await this.checkBounces(email, template);
+    }
+  }
+
+  async checkBounces(email: string, template: string) {
+    if (this.config.ignoreTemplates.includes(template)) {
+      return;
+    }
+
+    const bounces = await this.db.emailBounces.findByEmail(email);
+    this.applyRules(bounces);
+  }
+
+  private applyRules(bounces: Array<Bounce>) {
+    const tallies: Record<number, any> = {
+      [BOUNCE_TYPE_HARD]: {
+        count: 0,
+        latest: 0,
+      },
+      [BOUNCE_TYPE_COMPLAINT]: {
+        count: 0,
+        latest: 0,
+      },
+      [BOUNCE_TYPE_SOFT]: {
+        count: 0,
+        latest: 0,
+      },
+    };
+    const now = Date.now();
+
+    bounces.forEach((bounce: Bounce) => {
+      const type = bounce.bounceType;
+      const ruleSet = this.bounceRules[type];
+      if (ruleSet) {
+        const tally = tallies[type];
+        const tier = ruleSet[tally.count];
+        if (!tally.latest) {
+          tally.latest = bounce.createdAt;
+        }
+        if (tier && bounce.createdAt > now - tier) {
+          if (type === BOUNCE_TYPE_HARD) {
+            throw AppError.emailBouncedHard(tally.latest);
+          }
+          if (type === BOUNCE_TYPE_COMPLAINT) {
+            throw AppError.emailComplaint(tally.latest);
+          }
+          if (type === BOUNCE_TYPE_SOFT) {
+            throw AppError.emailBouncedSoft(tally.latest);
+          }
+        }
+        tally.count++;
+      }
+    });
+    return tallies;
+  }
+}

--- a/libs/accounts/email-sender/src/email-sender.ts
+++ b/libs/accounts/email-sender/src/email-sender.ts
@@ -1,0 +1,303 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { SES } from '@aws-sdk/client-ses';
+import { Bounces } from './bounces';
+import { StatsD } from 'hot-shots';
+import { ILogger } from '@fxa/shared/log';
+import * as nodemailer from 'nodemailer';
+import { isAppError } from '@fxa/accounts/errors';
+import * as Sentry from '@sentry/node';
+
+/**
+ * Config required for the mailer
+ */
+export type MailerConfig = {
+  /** SMTP Host */
+  host: string;
+  /** The SMTP server port */
+  port: number;
+  /** If host is 'secured' ie uses TLS */
+  secure: boolean;
+  /** Can connections be pooled */
+  pool: boolean;
+  /** Max number of connections */
+  maxConnections: number;
+  /** Max messages that can be outstanding */
+  maxMessages: number;
+  /** Max rate at which messages can be sent. */
+  sendingRate: number;
+  /** Connectiong timeout for smtp server. */
+  connectionTimeout: number;
+  /** Greeting time out for smtp server. */
+  greetingTimeout: number;
+  /** Socket timeout for smtp server connection. */
+  socketTimeout: number;
+  /** DNS timeout for smtp server connection. */
+  dnsTimeout: number;
+
+  /** Optional user name.  If not supplied, we fallback to local SES config. */
+  user?: string;
+  /** Optional password. If not supplied, we fallback to local SES config. */
+  password?: string;
+  sesConfigurationSet?: string;
+  sender: string;
+};
+
+/**
+ * Represents an email that can be sent out
+ */
+export type Email = {
+  /** Email recipient */
+  to: string;
+  /** Optional cc recipeents */
+  cc?: string[];
+  /** Email sender */
+  from: string;
+  /** Name of template used to render email */
+  template: string;
+  /** The version of the template used to render email */
+  version: number;
+  /** Subject of email */
+  subject: string;
+  /** Preview text of email */
+  preview: string;
+  /** HTML content of email */
+  html: string;
+  /** Text content of email */
+  text: string;
+  /** Email headers */
+  headers: Record<string, string>;
+};
+
+/**
+ * Sends an email to end end user.
+ */
+export class EmailSender {
+  private readonly emailClient: nodemailer.Transporter;
+
+  constructor(
+    private readonly config: MailerConfig,
+    private readonly bounces: Bounces,
+    private readonly statsd: StatsD,
+    private readonly log: ILogger
+  ) {
+    // Determine auth credentials
+    const auth = (() => {
+      // If the user name and password are set use this
+      if (config.user && config.password) {
+        return {
+          auth: {
+            user: config.user,
+            pass: config.password,
+          },
+        };
+      }
+
+      // Otherwise fallback to the SES configuration
+      const ses = new SES({
+        // The key apiVersion is no longer supported in v3, and can be removed.
+        // @deprecated The client uses the "latest" apiVersion.
+        apiVersion: '2010-12-01',
+      });
+      return {
+        SES: { ses },
+        sendingRate: 5,
+        maxConnections: 10,
+      };
+    })();
+
+    // Build node mailer options
+    const options = {
+      host: config.host,
+      secure: config.secure,
+      ignoreTLS: !config.secure,
+      port: config.port,
+      pool: config.pool,
+      maxConnections: config.maxConnections,
+      maxMessages: config.maxMessages,
+      connectionTimeout: config.connectionTimeout,
+      greetingTimeout: config.greetingTimeout,
+      socketTimeout: config.socketTimeout,
+      dnsTimeout: config.dnsTimeout,
+      sendingRate: this.config.sendingRate,
+      ...auth,
+    };
+    this.emailClient = nodemailer.createTransport(options);
+  }
+
+  /**
+   * Builds standard email headers
+   */
+  async buildHeaders({
+    template,
+    context,
+    headers,
+  }: {
+    template: {
+      name: string;
+      version: number;
+      metricsName?: string;
+    };
+    context: {
+      serverName: string;
+      language: string;
+      deviceId?: string;
+      flowId?: string;
+      flowBeginTime?: number;
+      service?: string;
+      uid?: string;
+      entrypoint?: string;
+      cmsRpClientId?: string;
+    };
+    headers: Record<string, string>;
+  }) {
+    const optionalHeader = (key: string, value?: string | number) => {
+      if (value) {
+        return { [key]: value.toString() };
+      }
+      return {};
+    };
+
+    headers = {
+      'Content-Language': context.language,
+      'X-Template-Name': template.name,
+      'X-Template-Version': template.version.toString(),
+      ...headers,
+      ...optionalHeader('X-Device-Id', context.deviceId),
+      ...optionalHeader('X-Flow-Id', context.flowId),
+      ...optionalHeader('X-Flow-Begin-Time', context.flowBeginTime),
+      ...optionalHeader('X-Service-Id', context.service),
+      ...optionalHeader('X-Uid', context.uid),
+    };
+
+    if (this.config.sesConfigurationSet) {
+      const sesHeaders = [
+        `messageType=fxa-${template.metricsName || template.name}`,
+        'app=fxa',
+        `service=${context.serverName}`,
+        `ses:feedback-id-a=fxa-${template.name}`,
+      ];
+      if (context.cmsRpClientId && context.entrypoint) {
+        sesHeaders.push(`cmsRp=${context.cmsRpClientId}-${context.entrypoint}`);
+      }
+
+      // Note on SES Event Publishing: The X-SES-CONFIGURATION-SET and
+      // X-SES-MESSAGE-TAGS email headers will be stripped by SES from the
+      // actual outgoing email messages.
+      headers['X-SES-CONFIGURATION-SET'] = this.config.sesConfigurationSet;
+      headers['X-SES-MESSAGE-TAGS'] = sesHeaders.join(', ');
+    }
+
+    return headers;
+  }
+
+  /**
+   * Send out an email.
+   * @param email Email to send
+   * @returns
+   */
+  async send(email: Email) {
+    // Always check for email bounces. Don't send if there bounce errors
+    if (await this.hasBounceErrors(email)) {
+      return {
+        sent: false,
+        message: 'Has bounce errors!',
+      };
+    }
+    return await this.sendMail(email);
+  }
+
+  private async hasBounceErrors({
+    to,
+    template,
+  }: Pick<Email, 'to' | 'template'>) {
+    // Check for email bounce first. If the bounce limit error is hit, don't
+    // keep don't send email!
+    try {
+      await this.bounces.check(to, template);
+    } catch (err) {
+      const tags = { template: template, error: err.errno };
+      this.statsd.increment('email.bounce.limit', tags);
+      this.log.error('email.bounce.limit', {
+        err: err.message,
+        errno: err.errno,
+        to,
+        template,
+      });
+      return true;
+    }
+
+    return false;
+  }
+
+  private async sendMail(email: Email): Promise<{
+    sent: boolean;
+    message?: string;
+    messageId?: string;
+    response?: string;
+  }> {
+    try {
+      // Make sure X-Mailer: '' is set in headers. This used to be done by setting
+      // xMailer to false in the options below.
+      email.headers['X-Mailer'] = '';
+
+      const info = await this.emailClient.sendMail({
+        from: email.from,
+        to: email.to,
+        cc: email.cc,
+        subject: email.subject,
+        text: email.text,
+        html: email.html,
+        headers: email.headers,
+
+        // Legacy auth-server implmentation provided these, but they are not valid nodemailer options...
+        // preview: email.preview,
+        // xMailer: false,
+      });
+      this.log.debug('mailer.send', {
+        status: info.message,
+        id: info.messageId,
+        to: email.to,
+      });
+
+      this.log.debug('mailer.send.1', {
+        email: email.to,
+        template: email.template,
+        headers: Object.keys(email.headers).join(','),
+      });
+
+      // Relay email payload and send status back to calling code.
+      return {
+        sent: true,
+        message: info?.message,
+        messageId: info?.messageId,
+        response: info?.response,
+      };
+    } catch (err) {
+      // Make sure error is logged & captured
+      if (isAppError(err)) {
+        this.log.error('mailer.send.error', {
+          err: err.message,
+          code: err.code,
+          errno: err.errno,
+          to: email.to,
+          template: email.template,
+        });
+      } else {
+        this.log.error('mailer.send.error', {
+          err: err.message,
+          to: email.to,
+          template: email.template,
+        });
+      }
+
+      // Being paranoid and capturing error manually...
+      Sentry.captureException(err);
+
+      // Throw error back to calling code.
+      throw err;
+    }
+  }
+}

--- a/libs/accounts/email-sender/src/index.ts
+++ b/libs/accounts/email-sender/src/index.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './email-sender';
+export * from './bounces';

--- a/libs/accounts/email-sender/tsconfig.json
+++ b/libs/accounts/email-sender/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/accounts/email-sender/tsconfig.lib.json
+++ b/libs/accounts/email-sender/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/accounts/email-sender/tsconfig.spec.json
+++ b/libs/accounts/email-sender/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
     "baseUrl": ".",
     "paths": {
       "@fxa/accounts/errors": ["libs/accounts/errors/src/index.ts"],
+      "@fxa/accounts/email-sender": ["libs/accounts/email-sender/src/index.ts"],
       "@fxa/accounts/rate-limit": ["libs/accounts/rate-limit/src/index.ts"],
       "@fxa/accounts/recovery-phone": [
         "libs/accounts/recovery-phone/src/index.ts"


### PR DESCRIPTION
## Because

- We need to send emails outside of the `auth-server` context

## This pull request

- Ports email sending to `libs/accounts/email-sender` from `auth-server`
- Decouples email sending from email rendering

## Issue that this pull request solves

Closes: FXA-12582

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is part of a multi part PR. The next part is email rendering.
