### PR TITLE
polish(admin-server): Make sure crud operations are 'scoped'

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.gql.ts
@@ -22,19 +22,19 @@ export const GET_RELYING_PARTIES = gql`
 `;
 
 export const CREATE_RELYING_PARTY = gql`
-  mutation create($relyingParty: RelyingPartyUpdateDto!) {
-    create(relyingParty: $relyingParty)
+  mutation createRelyingParty($relyingParty: RelyingPartyUpdateDto!) {
+    createRelyingParty(relyingParty: $relyingParty)
   }
 `;
 
 export const UPDATE_RELYING_PARTY = gql`
-  mutation update($id: String!, $relyingParty: RelyingPartyUpdateDto!) {
-    update(id: $id, relyingParty: $relyingParty)
+  mutation updateRelyingParty($id: String!, $relyingParty: RelyingPartyUpdateDto!) {
+    updateRelyingParty(id: $id, relyingParty: $relyingParty)
   }
 `;
 
 export const DELETE_RELYING_PARTY = gql`
-  mutation delete($id: String!) {
-    delete(id: $id)
+  mutation deleteRelyingParty($id: String!) {
+    deleteRelyingParty(id: $id)
   }
 `;

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.test.tsx
@@ -100,7 +100,7 @@ it('creates a new relying party via UI', async () => {
           },
         },
       },
-      result: { data: { create: 'new-id' } },
+      result: { data: { createRelyingParty: 'new-id' } },
     },
     // refetch after success
     mockGetRelyingParties([]),
@@ -181,7 +181,7 @@ it('updates an existing relying party via UI', async () => {
           },
         },
       },
-      result: { data: { update: true } },
+      result: { data: { updateRelyingParty: true } },
     },
     // refetch after success
     mockGetRelyingParties([rp]),
@@ -221,7 +221,7 @@ it('deletes an existing relying party via UI', async () => {
         query: DELETE_RELYING_PARTY,
         variables: { id: rp.id },
       },
-      result: { data: { delete: true } },
+      result: { data: { deleteRelyingParty: true } },
     },
     // refetch after success
     mockGetRelyingParties([rp]),

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.tsx
@@ -186,11 +186,11 @@ const CreateRelyingParty = ({ onExit }: { onExit: () => void }) => {
     setStatus('');
   };
 
-  const [createRelyingParty] = useMutation<{ create: string }>(
+  const [createRelyingParty] = useMutation<{ createRelyingParty: string }>(
     CREATE_RELYING_PARTY,
     {
       onCompleted: (data) => {
-        if (data.create) {
+        if (data.createRelyingParty) {
           setStatus('Success!');
           setTimeout(onExit, 500);
         } else {
@@ -241,11 +241,11 @@ const UpdateRelyingParty = ({
     setStatus('');
   };
 
-  const [updateRelyingParty] = useMutation<{ update: boolean }>(
+  const [updateRelyingParty] = useMutation<{ updateRelyingParty: boolean }>(
     UPDATE_RELYING_PARTY,
     {
       onCompleted: (data) => {
-        if (data.update === true) {
+        if (data.updateRelyingParty === true) {
           setStatus('Success!');
           setTimeout(onExit, 500);
         } else {
@@ -297,11 +297,11 @@ const DeleteRelyingParty = ({
 }) => {
   const [status, setStatus] = useState('');
 
-  const [deleteRelyingParty] = useMutation<{ delete: boolean }>(
+  const [deleteRelyingParty] = useMutation<{ deleteRelyingParty: boolean }>(
     DELETE_RELYING_PARTY,
     {
       onCompleted: (data) => {
-        if (data.delete === true) {
+        if (data.deleteRelyingParty === true) {
           setStatus('Success!');
           setTimeout(onExit, 500);
         } else {

--- a/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.spec.ts
@@ -89,7 +89,7 @@ describe('#integration - RelyingPartyResolver', () => {
       notes: 'test',
     };
 
-    const result = await resolver.create(payload);
+    const result = await resolver.createRelyingParty(payload);
 
     expect(result).toBeDefined();
     expect(
@@ -109,7 +109,7 @@ describe('#integration - RelyingPartyResolver', () => {
       allowedScopes: MOCK_RP.allowedScopes,
       notes: 'test',
     };
-    const result = await resolver.create(payload);
+    const result = await resolver.createRelyingParty(payload);
 
     const payload2 = {
       name: 'foo123',
@@ -121,7 +121,7 @@ describe('#integration - RelyingPartyResolver', () => {
       allowedScopes: '',
       notes: 'test updated',
     };
-    const result2 = await resolver.update(result, payload2);
+    const result2 = await resolver.updateRelyingParty(result, payload2);
     const updatedState = (await resolver.relyingParties()).find(
       (x) => x.id === result
     );
@@ -139,7 +139,7 @@ describe('#integration - RelyingPartyResolver', () => {
   });
 
   it('should delete relying party', async () => {
-    const result = await resolver.delete(MOCK_RP.id);
+    const result = await resolver.deleteRelyingParty(MOCK_RP.id);
 
     expect(result).toBeTruthy();
     expect(

--- a/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
@@ -49,7 +49,7 @@ export class RelyingPartyResolver {
 
   @Features(AdminPanelFeature.CreateRelyingParty)
   @Mutation(() => String)
-  public async create(
+  public async createRelyingParty(
     @Args('relyingParty') relyingParty: RelyingPartyUpdateDto
   ) {
     const id = crypto.randomBytes(8).toString('hex');
@@ -71,7 +71,7 @@ export class RelyingPartyResolver {
 
   @Features(AdminPanelFeature.UpdateRelyingParty)
   @Mutation(() => Boolean)
-  public async update(
+  public async updateRelyingParty(
     @Args('id') id: string,
     @Args('relyingParty') relyingParty: RelyingPartyUpdateDto
   ) {
@@ -89,7 +89,7 @@ export class RelyingPartyResolver {
 
   @Features(AdminPanelFeature.DeleteRelyingParty)
   @Mutation(() => Boolean)
-  public async delete(@Args('id') id: string) {
+  public async deleteRelyingParty(@Args('id') id: string) {
     const result = await this.db.relyingParty
       .query()
       .deleteById(uuidTransformer.to(id));

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -270,9 +270,9 @@ export interface IMutation {
     deleteAccounts(locators: string[]): AccountDeleteResponse[] | Promise<AccountDeleteResponse[]>;
     clearEmailBounce(email: string): boolean | Promise<boolean>;
     clearRateLimits(ip?: Nullable<string>, email?: Nullable<string>, uid?: Nullable<string>): number | Promise<number>;
-    create(relyingParty: RelyingPartyUpdateDto): string | Promise<string>;
-    update(id: string, relyingParty: RelyingPartyUpdateDto): boolean | Promise<boolean>;
-    delete(id: string): boolean | Promise<boolean>;
+    createRelyingParty(relyingParty: RelyingPartyUpdateDto): string | Promise<string>;
+    updateRelyingParty(id: string, relyingParty: RelyingPartyUpdateDto): boolean | Promise<boolean>;
+    deleteRelyingParty(id: string): boolean | Promise<boolean>;
 }
 
 export type DateTime = any;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -260,9 +260,9 @@ type Mutation {
   deleteAccounts(locators: [String!]!): [AccountDeleteResponse!]!
   clearEmailBounce(email: String!): Boolean!
   clearRateLimits(ip: String, email: String, uid: String): Float!
-  create(relyingParty: RelyingPartyUpdateDto!): String!
-  update(id: String!, relyingParty: RelyingPartyUpdateDto!): Boolean!
-  delete(id: String!): Boolean!
+  createRelyingParty(relyingParty: RelyingPartyUpdateDto!): String!
+  updateRelyingParty(id: String!, relyingParty: RelyingPartyUpdateDto!): Boolean!
+  deleteRelyingParty(id: String!): Boolean!
 }
 
 input RelyingPartyUpdateDto {


### PR DESCRIPTION
## Because

- The gql schema doesn't take the resolver's class name into account

## This pull request
- Updates the relying party resolver method names
- Changes delete to deleteRelyingParty
- Changes update to updateRelyingParty
- Changes create to createRelyingParty


## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
