### PR TITLE
fix(stripe-webhook): do not require subscription ID for invoice update

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -3556,10 +3556,6 @@ export class StripeHelper extends StripeHelperBase {
     if (typeof customerId !== 'string') {
       throw new Error("customerId must be a string");
     }
-    const subscriptionId = eventData.subscription;
-    if (typeof subscriptionId !== 'string') {
-      throw new Error("subscriptionId must be a string");
-    }
 
     try {
       await this.stripeFirestore.fetchAndInsertInvoice(invoiceId, event.created);


### PR DESCRIPTION
## Because

- Occasionally invoices will not have a subscriptionId

## This pull request

- Removes requirement for an subscriptionID in the invoice event processor