### PR TITLE
chore(): remove koa resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,7 +286,6 @@
     "css-minimizer-webpack-plugin": ">=4 <5",
     "form-data": "^4.0.4",
     "gobbledygook": "https://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
-    "koa": "^2.16.1",
     "minimist": "^1.2.6",
     "nest-typed-config/class-validator": "0.14.1",
     "plist": "^3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41742,9 +41742,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"koa@npm:^2.16.1":
-  version: 2.16.3
-  resolution: "koa@npm:2.16.3"
+"koa@npm:2.16.1":
+  version: 2.16.1
+  resolution: "koa@npm:2.16.1"
   dependencies:
     accepts: "npm:^1.3.5"
     cache-content-type: "npm:^1.0.0"
@@ -41769,7 +41769,7 @@ __metadata:
     statuses: "npm:^1.5.0"
     type-is: "npm:^1.6.16"
     vary: "npm:^1.1.2"
-  checksum: 10c0/43d614b3e044db9756108a2a8800811b00bc748a37632944412b78ccc336b74dabba4639d5664a978acca0185846dec9dac9792c4698059d35be3fc3520771a5
+  checksum: 10c0/66beb2e4d7968e1081341ea9a9c1f7f3fad4aaa0475c813f1be79ed84c345d9d45de9e34eeee3cdd790fc81ee5efbde2223d49fd5da571e29b0b3bed6baafb8e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- Nx has been upgraded via https://github.com/mozilla/fxa/pull/19604

## This pull request

- removes the Koa resolution that forced the non-vulnerable version (Nx now depends on a safe version of Koa)

## Issue that this pull request solves

Closes: FXA-11905

## Other information (Optional)

- Koa v2.16.1 (non-vulnerable version) is now default-loaded by @module-federation