### PR TITLE
fix(aal): Adjust verified-session-token strategy AAL check to match session/status

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
@@ -107,7 +107,7 @@ function strategy(getCredentialsFunc, db, config, statsd) {
         const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
         const sessionAal = token.authenticatorAssuranceLevel;
 
-        if (accountAal !== sessionAal) {
+        if (sessionAal < accountAal) {
           if (skipAalCheckForRoutes?.test(req.route.path)) {
             statsd?.increment('verified_session_token.aal.skipped', [
               `path:${req.route.path}`,

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -194,7 +194,7 @@ module.exports = function (
         );
         const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
         const sessionAal = sessionToken.authenticatorAssuranceLevel;
-        if (accountAal !== sessionAal) {
+        if (sessionAal < accountAal) {
           statsd.increment('session_reauth.all_not_met');
         }
         // End temporary metrics section


### PR DESCRIPTION
Because:
* We can throw an error if a user has disabled 2FA but still has a session token with AAL2

This commit:
* Adjusts the logic to accept this case
