### PR TITLE
bug(auth): Fix AAL check

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
@@ -107,7 +107,7 @@ function strategy(getCredentialsFunc, db, config, statsd) {
         const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
         const sessionAal = token.authenticatorAssuranceLevel;
 
-        if (accountAal !== sessionAal) {
+        if (sessionAal < accountAal) {
           if (skipAalCheckForRoutes?.test(req.route.path)) {
             statsd?.increment('verified_session_token.aal.skipped', [
               `path:${req.route.path}`,


### PR DESCRIPTION
## Because
- AAL Check was too strict
- A session with a higher AAL than the current account AAL should be allowed.

## This pull request
- Uses same logic as in the the mfa auth strategy


## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
