### PR TITLE
fix(l10n): Only use strapi element name for l10n id

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/cms/localization.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/cms/localization.ts
@@ -140,7 +140,9 @@ export class CMSLocalization {
       // Convert each string to FTL format
       for (const [fieldPath, value] of Object.entries(strings)) {
         const sanitizedValue = this.sanitizeContent(value);
-        const componentName = fieldPath.replace(/\./g, '-');
+        // Use only the element name (last segment) for the component name
+        const elementName = fieldPath.split('.').pop() || fieldPath;
+        const componentName = elementName.replace(/\./g, '-');
         const ftlId = this.generateFtlId(sanitizedValue, componentName);
 
         allEntries.push({
@@ -743,7 +745,8 @@ export class CMSLocalization {
       } else if (this.shouldIncludeField(key, value)) {
         // This is a localizable string field
         const englishValue = value as string;
-        const componentName = currentFieldPath.replace(/\./g, '-');
+        const elementName = currentFieldPath.split('.').pop() || currentFieldPath;
+        const componentName = elementName.replace(/\./g, '-');
         const hash = this.generateFtlId(englishValue, componentName);
 
 

--- a/packages/fxa-auth-server/test/local/routes/utils/cms/localization.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/cms/localization.js
@@ -96,11 +96,11 @@ describe('CMSLocalization', () => {
       assert.include(result, '# Headline for Email First Page');
       assert.include(result, '# Description for Email First Page');
 
-      // With fxa-prefixed hash IDs, we expect fxa-<component>-<hash> patterns
-      assert.match(result, /fxa-SigninPage-headline-[a-f0-9]{8} = Enter your password/);
-      assert.match(result, /fxa-SigninPage-description-[a-f0-9]{8} = to sign in to Firefox and start syncing/);
-      assert.match(result, /fxa-EmailFirstPage-headline-[a-f0-9]{8} = Welcome to Firefox Sync/);
-      assert.match(result, /fxa-EmailFirstPage-description-[a-f0-9]{8} = Sync your passwords, tabs, and bookmarks/);
+      // With fxa-prefixed hash IDs using only element name, expect fxa-<element>-<hash> patterns
+      assert.match(result, /fxa-headline-[a-f0-9]{8} = Enter your password/);
+      assert.match(result, /fxa-description-[a-f0-9]{8} = to sign in to Firefox and start syncing/);
+      assert.match(result, /fxa-headline-[a-f0-9]{8} = Welcome to Firefox Sync/);
+      assert.match(result, /fxa-description-[a-f0-9]{8} = Sync your passwords, tabs, and bookmarks/);
     });
 
     it('handles empty Strapi data', () => {
@@ -132,9 +132,9 @@ describe('CMSLocalization', () => {
 
       const result = localization.strapiToFtl(strapiData);
 
-      // With fxa-prefixed hash IDs, we expect fxa-<component>-<hash> patterns
-      assert.match(result, /fxa-SigninPage-headline-[a-f0-9]{8} = Enter your password/);
-      assert.match(result, /fxa-SigninPage-description-[a-f0-9]{8} = to sign in/);
+      // With fxa-prefixed hash IDs using only element name, expect fxa-<element>-<hash> patterns
+      assert.match(result, /fxa-headline-[a-f0-9]{8} = Enter your password/);
+      assert.match(result, /fxa-description-[a-f0-9]{8} = to sign in/);
       // Note: The current implementation doesn't filter out all non-string fields
       // This test reflects the actual behavior
     });
@@ -704,7 +704,7 @@ describe('CMSLocalization', () => {
       const generatedFtl = localization.strapiToFtl(strapiData);
 
       // Extract the hash from the generated FTL content
-      const hashMatch = generatedFtl.match(/(fxa-SigninPage-headline-[a-f0-9]{8}) = Enter your password/);
+      const hashMatch = generatedFtl.match(/(fxa-headline-[a-f0-9]{8}) = Enter your password/);
       assert.isNotNull(hashMatch, 'Should find fxa-prefixed hash in generated FTL');
       const fxaHash = hashMatch[1];
 
@@ -796,7 +796,7 @@ describe('CMSLocalization', () => {
       const generatedFtl = localization.strapiToFtl(strapiData);
 
       // Extract the hash from the generated FTL content
-      const hashMatch = generatedFtl.match(/(fxa-SigninPage-headline-[a-f0-9]{8}) = Enter your password/);
+      const hashMatch = generatedFtl.match(/(fxa-headline-[a-f0-9]{8}) = Enter your password/);
       assert.isNotNull(hashMatch, 'Should find fxa-prefixed hash in generated FTL');
       const fxaHash = hashMatch[1];
 


### PR DESCRIPTION
## Because

- We want to reduce the number of duplicate strings 

## This pull request

- Builds the ftl id only on the strapi element name

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12598

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
