### PR TITLE
feat(metrics): add nimbus_user_id to subplat metrics

### DIFF
--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -178,6 +178,7 @@ export class PaymentsGleanManager {
       }),
       ...mapUtm(commonMetricsData.searchParams),
       ...mapSubscriptionCancellation(subscriptionCancellationData),
+      nimbus_user_id: '',
     };
   }
 

--- a/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
+++ b/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml
@@ -466,11 +466,16 @@ pay_setup:
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1997429
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
     expires: never
     data_sensitivity:
       - interaction
+    extra_keys:
+      nimbus_user_id:
+        description: Nimbus user ID
+        type: string
   engage:
     description: Checkout engage event
     type: event
@@ -479,11 +484,16 @@ pay_setup:
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1997429
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
     expires: never
     data_sensitivity:
       - interaction
+    extra_keys:
+      nimbus_user_id:
+        description: Nimbus user ID
+        type: string
   submit:
     description: Checkout submit event
     type: event
@@ -492,11 +502,16 @@ pay_setup:
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1997429
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
     expires: never
     data_sensitivity:
       - interaction
+    extra_keys:
+      nimbus_user_id:
+        description: Nimbus user ID
+        type: string
   success:
     description: Checkout engage event
     type: event
@@ -505,11 +520,16 @@ pay_setup:
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1997429
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
     expires: never
     data_sensitivity:
       - interaction
+    extra_keys:
+      nimbus_user_id:
+        description: Nimbus user ID
+        type: string
   fail:
     description: Checkout fail event
     type: event
@@ -518,8 +538,13 @@ pay_setup:
       - subplat-team@mozilla.com
     bugs:
       - https://mozilla-hub.atlassian.net/browse/FXA-7531
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1997429
     data_reviews:
       - https://github.com/mozilla/fxa/issues/18512
     expires: never
     data_sensitivity:
       - interaction
+    extra_keys:
+      nimbus_user_id:
+        description: Nimbus user ID
+        type: string


### PR DESCRIPTION
## Because

- As part of the integration with Nimbus the nimbus_user_id needs to be added to required glean events as an extra key.

## This pull request

- Add nimbus_user_id to all pay_setup events

## Issue that this pull request solves

Closes: #PAY-3248

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
