### PR TITLE
chore(all): Stop certain files from being edited

### DIFF
--- a/_scripts/check-frozen.ts
+++ b/_scripts/check-frozen.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Inspired by: https://github.com/Lisba/prevent-file-changes
+
+import { execSync } from 'child_process';
+
+// Maintain List of frozen files here!
+const frozen: Array<{ pattern: string; reason: string }> = [
+  {
+    pattern: 'packages/fxa-auth-server/(lib|lib/oauth)/error.js',
+    reason: 'Files moved to libs/accounts/errors',
+  },
+];
+
+export const getChangedFiles = () => {
+  const referenceToCompare = execSync(
+    'git rev-parse --verify HEAD >/dev/null 2>&1 && echo HEAD || echo 4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+  );
+  return execSync(`git diff --cached --name-only ${referenceToCompare}`)
+    .toString()
+    .trim()
+    .split('\n');
+};
+
+try {
+  let violations = false;
+  for (const x of frozen) {
+    const re = new RegExp(x.pattern);
+    const changedFiles = getChangedFiles();
+    for (const file of changedFiles) {
+      if (re.test(file)) {
+        console.error(
+          `🚫 Error: Cannot modify frozen file: ${file}\n   Reason: ${x.reason}.\n`
+        );
+        violations = true;
+      }
+    }
+  }
+
+  if (violations) {
+    process.exit(1);
+  } else {
+    console.log('✨ Successful Execution!');
+    process.exit(0);
+  }
+} catch (error: any) {
+  console.error('🚫 Execution Error:', error.message);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "gql:allowlist": "nx run-many -t gql-extract && nx run-many -t gql-copy",
     "check:mysql": "_scripts/check-mysql.sh",
     "check:url": "_scripts/check-url.sh",
-    "prepare": "husky"
+    "prepare": "husky",
+    "check:frozen": "ts-node _scripts/check-frozen.ts"
   },
   "homepage": "https://github.com/mozilla/fxa",
   "bugs": {
@@ -148,6 +149,9 @@
     "node": "^22.15.1"
   },
   "lint-staged": {
+    "*": [
+      "yarn check:frozen"
+    ],
     "packages/!(fxa-payments-server)/**/*.js": [
       "prettier --config _dev/.prettierrc --write",
       "eslint"


### PR DESCRIPTION
## Because
- After porting to libs, we might want to lock a file
- Locking files can prevent unintentional drift
- Using commit hook allows us to bypass if necessary


## This pull request
- Adds the check:frozen yarn script to the husky config
- Configures it to stop modifications on auth-server error modules

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1417" height="966" alt="image" src="https://github.com/user-attachments/assets/eb5871ab-7e6f-4330-8f03-d1ea2305b4c4" />

Round 2, I've updated the error messaging.
<img width="542" height="68" alt="image" src="https://github.com/user-attachments/assets/fb83536d-7485-47f4-85e2-f12685d250ae" />



## Other information (Optional)

To bypass this if in a pinch, a developer can do `git commit -m wip --no-verify`
