### PR TITLE
fix(settings): Nav to signin totp if already enabled

### DIFF
--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.test.tsx
@@ -245,6 +245,45 @@ describe('InlineTotpSetupContainer', () => {
         );
       });
     });
+
+    it('does not call createTotp while TOTP status is loading', async () => {
+      mockTotpStatusQuery.mockImplementation(() => {
+        return {
+          data: null,
+          loading: true,
+        };
+      });
+      jest
+        .spyOn(ApolloClientModule, 'useQuery')
+        .mockReturnValue(mockTotpStatusQuery());
+
+      render();
+
+      await waitFor(() => {
+        expect(mockCreateTotpMutation).not.toHaveBeenCalled();
+      });
+    });
+
+    it('does not call createTotp when TOTP is already verified', async () => {
+      mockSessionHook.mockImplementationOnce(() => ({
+        isSessionVerified: async () => true,
+      }));
+      mockTotpStatusQuery.mockImplementation(() => {
+        return {
+          data: MOCK_TOTP_STATUS_VERIFIED,
+          loading: false,
+        };
+      });
+      jest
+        .spyOn(ApolloClientModule, 'useQuery')
+        .mockReturnValue(mockTotpStatusQuery());
+
+      render();
+
+      await waitFor(() => {
+        expect(mockCreateTotpMutation).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('renders', () => {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -91,8 +91,9 @@ export const InlineTotpSetupContainer = ({
   useEffect(() => {
     if (
       totp !== undefined ||
-      totpStatus?.account?.totp.verified === true ||
-      isTotpCreating.current
+      totpStatus?.account?.totp.verified ||
+      isTotpCreating.current ||
+      totpStatusLoading
     ) {
       return;
     }
@@ -171,7 +172,7 @@ export const InlineTotpSetupContainer = ({
   if (
     !isSignedIn ||
     !signinState ||
-    totpStatusLoading === true ||
+    totpStatusLoading ||
     totp === undefined ||
     sessionVerified === undefined
   ) {

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordConfirmed/container.tsx
@@ -53,6 +53,9 @@ const ResetPasswordConfirmedContainer = ({
       error.errno === AuthUiErrors.TOTP_REQUIRED.errno ||
       error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
     ) {
+      // in most cases, this error will be returned because the account doesn't have TOTP enabled
+      // in the case where the account has TOTP enabled, it will be redirected to signin_totp_code
+      // from inline_totp_setup
       navigateWithQuery(`/inline_totp_setup`, {
         state: {
           email,

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -525,8 +525,13 @@ const getOAuthNavigationTarget = async (
       error.errno === AuthUiErrors.INSUFFICIENT_ACR_VALUES.errno
     ) {
       GleanMetrics.login.error({ event: { reason: error.message } });
+      // If user already has TOTP enabled, send them to enter their code instead of setup
+      const hasTotp =
+        locationState.verificationMethod === VerificationMethods.TOTP_2FA;
       return {
-        to: `/inline_totp_setup${navigationOptions.queryParams || ''}`,
+        to: hasTotp
+          ? `/signin_totp_code${navigationOptions.queryParams || ''}`
+          : `/inline_totp_setup${navigationOptions.queryParams || ''}`,
         locationState,
       };
     }


### PR DESCRIPTION
## Because

* We were seeing some AAL errors on createTotp

## This pull request

* Ensure that inline_totp_setup waits for totp status to resolve before starting setup process
* Add a few more navigation intercepts to navigate to signin_totp_code instead of inline_totp_setup if totp already enabled
* Add a couple of tests for inline_totp_setup

## Issue that this pull request solves

Closes: FXA-12681

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is to address some edge cases where users may land on inline_totp_setup when they already have 2FA enabled.
