### PR TITLE
fix(next): use env var for paypal client id

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
@@ -99,7 +99,7 @@ export default async function PaypalPaymentManagementPage({
           </div>
           <PaypalManagement
             sessionUid={sessionUid}
-            paypalClientId={'sb'}
+            paypalClientId={config.paypal.clientId}
             nonce={nonce}
             currency={currency}
           />

--- a/libs/payments/ui/src/lib/client/components/PaypalManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaypalManagement/index.tsx
@@ -58,7 +58,7 @@ export function PaypalManagement({
         components: 'buttons',
       }}
     >
-      <div className="flex justify-center w-full">
+      <div className="flex justify-center items-center max-w-md w-full h-12">
         {isLoading && (
           <Image
             src={spinnerImage}


### PR DESCRIPTION
## Because

- PayPal button used in Subscription Management has the client ID hard coded to sb instead of using the client ID set in env vars.

## This pull request

- Updates PayPal button used in Subscription Management to initialize with env var client ID.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1024" height="481" alt="image" src="https://github.com/user-attachments/assets/7859e2f0-4966-423e-9a75-f8d58b39ba39" />