### PR TITLE
chore(functional-tests): Update account destroy to make it more robust

### DIFF
--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -103,6 +103,8 @@ export class SettingsPage extends SettingsLayout {
 
   /**
    * Removes 2FA from the account by clicking the 'disable' button on the 2FA row.
+   * If omitted, the credentials must be passed to 2FA setup so that accountDestroy
+   * has access to the secret.
    */
   async disconnectTotp() {
     await this.totp.disableButton.click();

--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -154,7 +154,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Set up 2FA with QR code and backup codes
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
@@ -220,10 +220,6 @@ test.describe('severity-1 #smoke', () => {
 
       // Verify successful login
       expect(await relier.isLoggedIn()).toBe(true);
-
-      // Cleanup
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('enable 2FA and signin with recovery phone - 123Done', async ({
@@ -286,7 +282,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.confirmMfaGuard(credentials.email);
 
       // Set up 2FA with QR code and recovery phone
-      await totp.startTwoStepAuthWithQrCodeAndRecoveryPhoneChoice();
+      await totp.startTwoStepAuthWithQrCodeAndRecoveryPhoneChoice(credentials);
 
       await expect(recoveryPhone.addHeader()).toBeVisible();
 
@@ -382,10 +378,6 @@ test.describe('severity-1 #smoke', () => {
 
       // Verify successful login
       expect(await relier.isLoggedIn()).toBe(true);
-
-      // Cleanup
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('enable 2FA and signin with backup recovery code - 123Done', async ({
@@ -442,7 +434,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Set up 2FA with QR code and backup codes
       const { recoveryCodes } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
@@ -522,10 +514,6 @@ test.describe('severity-1 #smoke', () => {
 
       // Verify successful login
       expect(await relier.isLoggedIn()).toBe(true);
-
-      // Cleanup
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('enable 2FA and signin with TOTP - Sync', async ({
@@ -588,7 +576,7 @@ test.describe('severity-1 #smoke', () => {
 
       // Set up 2FA with QR code and backup codes
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
@@ -660,9 +648,6 @@ test.describe('severity-1 #smoke', () => {
       // Verify successful login
       await expect(page).toHaveURL(/settings/);
       await expect(settings.settingsHeading).toBeVisible();
-
-      // Cleanup
-      await settings.disconnectTotp();
     });
   });
 });

--- a/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
+++ b/packages/functional-tests/tests/key-stretching-v2/totp.spec.ts
@@ -4,6 +4,7 @@
 
 import { getTotpCode } from '../../lib/totp';
 import { expect, test } from '../../lib/fixtures/standard';
+import { Credentials } from '../../lib/targets';
 
 /**
  * These tests represent various permutations between interacting with V1 and V2
@@ -33,7 +34,8 @@ test.describe('severity-2 #smoke', () => {
       },
       testAccountTracker,
     }) => {
-      const { email, password } = testAccountTracker.generateAccountDetails();
+      const credentials = testAccountTracker.generateAccountDetails();
+      const { email, password } = credentials;
 
       await page.goto(
         `${target.contentServerUrl}/?forceExperiment=generalizedReactApp&forceExperimentGroup=react&${signupVersion.query}`
@@ -51,7 +53,9 @@ test.describe('severity-2 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(email);
       const totpCredentials =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(
+          credentials as unknown as Credentials
+        );
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.totp.status).toHaveText('Enabled');
@@ -78,8 +82,6 @@ test.describe('severity-2 #smoke', () => {
         const status = await client.getCredentialStatusV2(email);
         expect(status.currentVersion).toEqual('v2');
       }
-
-      await settings.disconnectTotp(); // Required before teardown
     });
   }
 });

--- a/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
+++ b/packages/functional-tests/tests/misc/recoveryKeyPromoInline.spec.ts
@@ -176,7 +176,7 @@ test.describe('recovery key promo', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
       await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
 
@@ -200,9 +200,6 @@ test.describe('recovery key promo', () => {
 
       await page.waitForURL(/pair/);
       await expect(connectAnotherDevice.fxaConnected).toBeEnabled();
-
-      await settings.goto();
-      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('click do it later', async ({

--- a/packages/functional-tests/tests/misc/relayIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/relayIntegration.spec.ts
@@ -95,7 +95,8 @@ test.describe('relay integration', () => {
     syncOAuthBrowserPages: { signinTotpCode, totp, page, signin, settings },
     testAccountTracker,
   }) => {
-    const { email, password } = await testAccountTracker.signUp();
+    const credentials = await testAccountTracker.signUp();
+    const { email, password } = credentials;
 
     // Sign-in without Sync, otw you will get prompted to create a recovery key
     await page.goto(target.contentServerUrl, { waitUntil: 'load' });
@@ -106,7 +107,8 @@ test.describe('relay integration', () => {
     await expect(settings.settingsHeading).toBeVisible();
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(email);
-    const { secret } = await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    const { secret } =
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
     await expect(settings.totp.status).toHaveText('Enabled');
     await settings.signOut();
 
@@ -127,7 +129,5 @@ test.describe('relay integration', () => {
 
     await signin.checkWebChannelMessage(FirefoxCommand.OAuthLogin);
     await signin.checkWebChannelMessage(FirefoxCommand.Login);
-
-    await settings.disconnectTotp(); // Required before teardown
   });
 });

--- a/packages/functional-tests/tests/oauth/totp.spec.ts
+++ b/packages/functional-tests/tests/oauth/totp.spec.ts
@@ -22,7 +22,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
@@ -41,7 +41,6 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
       await settings.page.waitForURL(/settings/);
-      await settings.disconnectTotp();
     });
 
     test('can remove TOTP from account and skip confirmation', async ({
@@ -54,7 +53,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.goto();
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
-      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
       await expect(settings.totp.status).toHaveText('Enabled');
       await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
@@ -85,14 +84,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(inlineTotpSetup.introHeading).toBeVisible();
       await inlineTotpSetup.continueButton.click();
       await expect(totp.setup2faAppHeading).toBeVisible();
-      await totp.step1CantScanCodeLink.click();
-      const secret = (await totp.step1ManualCode.innerText())?.replace(
-        /\s/g,
-        ''
-      );
-      const code = await getTotpCode(secret);
-      await totp.step1AuthenticationCodeTextbox.fill(code);
-      await totp.step1SubmitButton.click();
+      await totp.setUp2faAppWithManualCode(credentials);
 
       await page.waitForURL(/inline_recovery_setup/);
 
@@ -102,22 +94,11 @@ test.describe('severity-1 #smoke', () => {
       await page.getByRole('button', { name: /Continue/ }).click();
 
       expect(await relier.isLoggedIn()).toBe(true);
-
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('can setup TOTP inline with recovery phone choice', async ({
       target,
-      pages: {
-        page,
-        relier,
-        settings,
-        signin,
-        totp,
-        recoveryPhone,
-        inlineTotpSetup,
-      },
+      pages: { page, relier, signin, totp, recoveryPhone, inlineTotpSetup },
       testAccountTracker,
     }) => {
       const credentials = await testAccountTracker.signUp();
@@ -132,14 +113,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(inlineTotpSetup.introHeading).toBeVisible();
       await inlineTotpSetup.continueButton.click();
       await expect(totp.setup2faAppHeading).toBeVisible();
-      await totp.step1CantScanCodeLink.click();
-      const secret = (await totp.step1ManualCode.innerText())?.replace(
-        /\s/g,
-        ''
-      );
-      const code = await getTotpCode(secret);
-      await totp.step1AuthenticationCodeTextbox.fill(code);
-      await totp.step1SubmitButton.click();
+      await totp.setUp2faAppWithManualCode(credentials);
 
       await page.waitForURL(/inline_recovery_setup/);
 
@@ -157,9 +131,6 @@ test.describe('severity-1 #smoke', () => {
       await page.getByRole('button', { name: 'Continue' }).click();
 
       expect(await relier.isLoggedIn()).toBe(true);
-
-      await settings.goto();
-      await settings.disconnectTotp();
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/oauthPromptNone.spec.ts
@@ -254,7 +254,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
 
-      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
       await expect(settings.alertBar).toContainText(
         'Two-step authentication has been enabled'
       );
@@ -268,9 +268,6 @@ test.describe('severity-1 #smoke', () => {
 
       //Verify logged in to relier
       expect(await relier.isLoggedIn()).toBe(true);
-
-      await settings.goto();
-      await settings.disconnectTotp(); // Required before teardown
     });
   });
 });

--- a/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
+++ b/packages/functional-tests/tests/react-conversion/signinTotp.spec.ts
@@ -23,7 +23,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
@@ -42,8 +42,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(page).toHaveURL(/settings/);
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.totp.status).toHaveText('Enabled');
-
-      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('add totp, login with sync', async ({
@@ -70,7 +68,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
@@ -95,9 +93,6 @@ test.describe('severity-1 #smoke', () => {
       await page.waitForURL(/pair/);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      await settings.goto();
-      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('error message when totp code is invalid', async ({
@@ -116,7 +111,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toContainText(
@@ -135,11 +130,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(signin.authenticationCodeTextboxTooltip).toHaveText(
         'Invalid two-step authentication code'
       );
-
-      // Required before teardown
-      const code = await getTotpCode(secret);
-      await signinTotpCode.fillOutCodeForm(code);
-      await settings.disconnectTotp();
     });
   });
 });

--- a/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/oauthResetPassword.spec.ts
@@ -106,7 +106,7 @@ test.describe('severity-1 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
       await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
 
@@ -135,18 +135,6 @@ test.describe('severity-1 #smoke', () => {
 
       await expect(page).toHaveURL(target.relierUrl);
       expect(await relier.isLoggedIn()).toBe(true);
-
-      // update password for cleanup function
-      credentials.password = newPassword;
-
-      // Goes to settings and disables totp on user's account (required for cleanup)
-      await signin.goto();
-      await expect(signin.cachedSigninHeading).toBeVisible();
-      await signin.signInButton.click();
-
-      await expect(settings.settingsHeading).toBeVisible();
-      await settings.disconnectTotp();
-      await settings.signOut();
 
       // update password for cleanup function
       credentials.password = newPassword;

--- a/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
+++ b/packages/functional-tests/tests/resetPassword/resetPassword2FA.spec.ts
@@ -23,7 +23,8 @@ test.describe('severity-1 #smoke', () => {
 
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
-    const { secret } = await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    const { secret } =
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -60,9 +61,6 @@ test.describe('severity-1 #smoke', () => {
     testAccountTracker.updateAccountPassword(credentials.email, newPassword);
 
     await expect(settings.settingsHeading).toBeVisible();
-
-    // Remove TOTP before teardown
-    await settings.disconnectTotp();
   });
 
   test('can reset password with 2FA recovery code', async ({
@@ -83,7 +81,7 @@ test.describe('severity-1 #smoke', () => {
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
     const { recoveryCodes } =
-      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -113,9 +111,6 @@ test.describe('severity-1 #smoke', () => {
     await expect(settings.alertBar).toHaveText('Your password has been reset');
 
     testAccountTracker.updateAccountPassword(credentials.email, newPassword);
-
-    // Remove TOTP before teardown
-    await settings.disconnectTotp();
   });
 
   test('can reset password with recovery key without 2FA prompt', async ({
@@ -136,7 +131,7 @@ test.describe('severity-1 #smoke', () => {
 
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
-    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -184,9 +179,6 @@ test.describe('severity-1 #smoke', () => {
 
     // Recovery key has been consumed and a new one created
     await expect(settings.recoveryKey.status).toHaveText('Enabled');
-
-    // Remove TOTP before teardown
-    await settings.disconnectTotp();
   });
 
   test('can reset password with recovery key then delete account', async ({
@@ -215,7 +207,7 @@ test.describe('severity-1 #smoke', () => {
 
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
-    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -290,7 +282,8 @@ test.describe('severity-1 #smoke', () => {
 
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
-    const { secret } = await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    const { secret } =
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -343,9 +336,6 @@ test.describe('severity-1 #smoke', () => {
 
     // Recovery key has been removed
     await expect(settings.recoveryKey.status).toHaveText('Not Set');
-
-    // Remove TOTP before teardown
-    await settings.disconnectTotp();
   });
 
   test('can reset password with unverified 2FA and skip recovery key', async ({
@@ -366,7 +356,7 @@ test.describe('severity-1 #smoke', () => {
 
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
-    await totp.setUp2faAppWithQrCode();
+    await totp.setUp2faAppWithQrCode(credentials);
     await page.goto(`${target.contentServerUrl}/settings`);
 
     await expect(settings.settingsHeading).toBeVisible();
@@ -427,7 +417,7 @@ test.describe('reset password with recovery phone', () => {
 
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
-    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -489,9 +479,6 @@ test.describe('reset password with recovery phone', () => {
     await expect(settings.alertBar).toHaveText('Your password has been reset');
 
     await expect(settings.settingsHeading).toBeVisible();
-
-    // Remove TOTP before teardown
-    await settings.disconnectTotp();
   });
 
   test('can use backup code after failing sms code', async ({
@@ -514,7 +501,7 @@ test.describe('reset password with recovery phone', () => {
     await settings.totp.addButton.click();
     await settings.confirmMfaGuard(credentials.email);
     const { recoveryCodes } =
-      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+      await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
     await expect(settings.settingsHeading).toBeVisible();
     await expect(settings.alertBar).toContainText(
@@ -582,8 +569,5 @@ test.describe('reset password with recovery phone', () => {
     await expect(settings.alertBar).toHaveText('Your password has been reset');
 
     await expect(settings.settingsHeading).toBeVisible();
-
-    // Remove TOTP before teardown
-    await settings.disconnectTotp();
   });
 });

--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -38,6 +38,7 @@ test.describe('severity-1 #smoke', () => {
 
       await settings.goto();
       await setup2faWithBackupCodeChoice(credentials, settings, totp);
+
       await expect(settings.totp.status).toHaveText('Enabled');
       await settings.totp.addRecoveryPhoneButton.click();
 
@@ -48,9 +49,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(recoveryPhone.addErrorBanner).toHaveText(
         /invalid phone number/i
       );
-
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('can setup, confirm and remove recovery phone', async ({
@@ -101,8 +99,6 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/settings/);
       await expect(settings.totp.addRecoveryPhoneButton).toBeVisible();
-
-      await settings.disconnectTotp();
     });
 
     test('can change recovery phone', async ({
@@ -143,8 +139,6 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/settings/);
       await expect(settings.alertBar).toHaveText('Recovery phone changed');
-
-      await settings.disconnectTotp();
     });
 
     test('can sign-in to settings with recovery phone', async ({
@@ -187,11 +181,8 @@ test.describe('severity-1 #smoke', () => {
         target,
       });
 
+      // assert that we're signed in
       await page.waitForURL(/settings/);
-      await expect(settings.settingsHeading).toBeVisible();
-
-      // Remove totp so account can be deleted
-      await settings.disconnectTotp();
     });
 
     test('can sign-in Sync (fx_desktop_v3) with recovery phone', async ({
@@ -247,9 +238,6 @@ test.describe('severity-1 #smoke', () => {
 
       await connectAnotherDevice.clickNotNowPair();
       await page.waitForURL(/settings/);
-
-      // Remove totp so account can be deleted
-      await settings.disconnectTotp();
     });
 
     test('can sign-in Sync (oauth_webchannel_v1) with recovery phone', async ({
@@ -304,9 +292,6 @@ test.describe('severity-1 #smoke', () => {
 
       await connectAnotherDevice.clickNotNowPair();
       await page.waitForURL(/settings/);
-
-      // Remove totp so account can be deleted
-      await settings.disconnectTotp();
     });
 
     test('can sign-in with recovery phone after resend code', async ({
@@ -378,9 +363,6 @@ test.describe('severity-1 #smoke', () => {
       await signinRecoveryPhone.clickConfirm();
 
       await page.waitForURL(/settings/);
-
-      // Remove totp so account can be deleted
-      await settings.disconnectTotp();
     });
 
     test('can sign-in 123Done with recovery phone', async ({
@@ -428,10 +410,6 @@ test.describe('severity-1 #smoke', () => {
       });
 
       expect(await relier.isLoggedIn()).toBe(true);
-
-      // Remove totp so account can be deleted
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('can use recovery code with recovery phone setup', async ({
@@ -492,9 +470,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(settings.totp.status).toHaveText('Enabled');
 
       await expect(settings.settingsHeading).toBeVisible();
-
-      // Remove totp so account can be deleted
-      await settings.disconnectTotp();
     });
 
     test('can still use totp code with recovery phone setup', async ({
@@ -557,9 +532,6 @@ test.describe('severity-1 #smoke', () => {
 
       await page.waitForURL(/settings/);
       await expect(await settings.totp.status).toHaveText('Enabled');
-
-      // Remove totp so account can be deleted
-      await settings.disconnectTotp();
     });
 
     test('can set up recovery phone during initial 2FA setup', async ({
@@ -583,8 +555,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(recoveryPhone.status).toHaveText(
         `(•••) •••-${testNumber.slice(-4)}`
       );
-
-      await settings.disconnectTotp();
     });
 
     test('sign in with only recovery phone available (no backup codes)', async ({
@@ -636,7 +606,6 @@ test.describe('severity-1 #smoke', () => {
       await signinRecoveryPhone.clickConfirm();
       await page.waitForURL(/settings/);
       await expect(settings.settingsHeading).toBeVisible();
-      await settings.disconnectTotp();
     });
   });
 });
@@ -667,7 +636,7 @@ async function setup2faWithBackupCodeChoice(
   await settings.totp.addButton.click();
   await settings.confirmMfaGuard(credentials.email);
   const totpCredentials =
-    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
   await expect(settings.settingsHeading).toBeVisible();
   await expect(settings.alertBar).toContainText(
@@ -690,7 +659,8 @@ async function setup2faWithRecoveryPhoneChoice(
   await settings.totp.addButton.click();
   await settings.confirmMfaGuard(credentials.email);
 
-  const secret = await totp.startTwoStepAuthWithQrCodeAndRecoveryPhoneChoice();
+  const secret =
+    await totp.startTwoStepAuthWithQrCodeAndRecoveryPhoneChoice(credentials);
 
   await expect(recoveryPhone.addHeader()).toBeVisible();
 

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -45,8 +45,6 @@ test.describe('severity-2 #smoke', () => {
       await signinTotpCode.fillOutCodeForm(code);
 
       await expect(settings.settingsHeading).toBeVisible();
-
-      await settings.disconnectTotp();
     });
 
     test('can change 2FA and old 2FA should not work', async ({
@@ -106,8 +104,6 @@ test.describe('severity-2 #smoke', () => {
       });
 
       await expect(settings.settingsHeading).toBeVisible();
-
-      await settings.disconnectTotp();
     });
 
     test('can change 2fa and use existing recovery phone to sign in', async ({
@@ -155,8 +151,6 @@ test.describe('severity-2 #smoke', () => {
       });
 
       await expect(settings.settingsHeading).toBeVisible();
-
-      await settings.disconnectTotp();
     });
   });
 });
@@ -191,7 +185,7 @@ const addThenChange2FA = async ({
   await settings.totp.addButton.click();
   await settings.confirmMfaGuard(credentials.email);
   const { recoveryCodes, secret } =
-    await totp.setUpTwoStepAuthWithManualCodeAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithManualCodeAndBackupCodesChoice(credentials);
 
   await assertEnabled(true);
 
@@ -201,7 +195,7 @@ const addThenChange2FA = async ({
 
   // changing doesn't do anything special or require saving backup codes
   // just call straight to the setup method
-  const newSecret = await totp.setUp2faAppWithQrCode();
+  const newSecret = await totp.setUp2faAppWithQrCode(credentials);
 
   await assertEnabled(false);
 

--- a/packages/functional-tests/tests/settings/setup2faWithBackupCodes.spec.ts
+++ b/packages/functional-tests/tests/settings/setup2faWithBackupCodes.spec.ts
@@ -46,8 +46,6 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await expect(settings.totp.status).toHaveText('Enabled');
-
-      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('enable then disable and sign in', async ({
@@ -69,7 +67,7 @@ test.describe('severity-1 #smoke', () => {
       );
       await expect(settings.totp.status).toHaveText('Enabled');
 
-      await settings.disconnectTotp(); // Required before teardown
+      await settings.disconnectTotp();
 
       // No 2FA prompt on signin
       await settings.signOut();
@@ -100,8 +98,6 @@ test.describe('severity-1 #smoke', () => {
         'Two-step authentication has been enabled'
       );
       await expect(settings.totp.status).toHaveText('Enabled');
-
-      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('delete account with 2FA enabled', async ({
@@ -157,7 +153,7 @@ async function addTotpWithManualCodeAndBackupCodeChoice(
   await settings.totp.addButton.click();
   await settings.confirmMfaGuard(credentials.email);
   const totpCredentials =
-    await totp.setUpTwoStepAuthWithManualCodeAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithManualCodeAndBackupCodesChoice(credentials);
 
   return totpCredentials;
 }
@@ -173,7 +169,7 @@ async function addTotpWithQrCodeAndBackupCodeChoice(
   await settings.totp.addButton.click();
   await settings.confirmMfaGuard(credentials.email);
   const totpCredentials =
-    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
   return totpCredentials;
 }

--- a/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
+++ b/packages/functional-tests/tests/settings/totpRecoveryCode.spec.ts
@@ -45,7 +45,6 @@ test.describe('severity-1 #smoke', () => {
         signinTotpCode
       );
       await expect(settings.settingsHeading).toBeVisible();
-      await settings.disconnectTotp();
     });
 
     test('totp invalid recovery code', async ({
@@ -68,7 +67,7 @@ test.describe('severity-1 #smoke', () => {
         testAccountTracker
       );
       await settings.goto();
-      const { recoveryCodes } = await addTotp(credentials, settings, totp);
+      await addTotp(credentials, settings, totp);
       await settings.signOut();
       await signin.fillOutEmailFirstForm(credentials.email);
       await signin.fillOutPasswordForm(credentials.password);
@@ -79,11 +78,6 @@ test.describe('severity-1 #smoke', () => {
       await expect(
         page.getByText('Invalid backup authentication code')
       ).toBeVisible();
-
-      // Required before teardown
-      await signinRecoveryCode.fillOutCodeForm(recoveryCodes[0]);
-      await expect(settings.settingsHeading).toBeVisible();
-      await settings.disconnectTotp();
     });
 
     test('can get new backup authentication codes', async ({
@@ -133,7 +127,6 @@ test.describe('severity-1 #smoke', () => {
       );
 
       await expect(settings.settingsHeading).toBeVisible();
-      await settings.disconnectTotp(); // Required before teardown
     });
 
     test('can get new backup authentication codes via email', async ({
@@ -206,9 +199,6 @@ test.describe('severity-1 #smoke', () => {
       // abort without completing the flow,
       // we just want to verify that email was sent
       // and link works
-      await settings.goto();
-      // Disconnect totp, required before teardown
-      await settings.disconnectTotp();
     });
   });
 });
@@ -242,7 +232,7 @@ async function addTotp(
   await settings.totp.addButton.click();
   await settings.confirmMfaGuard(credentials.email);
   const totpCredentials =
-    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+    await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
   await expect(settings.settingsHeading).toBeVisible();
   await expect(settings.alertBar).toContainText(

--- a/packages/functional-tests/tests/signin/signinBlocked.spec.ts
+++ b/packages/functional-tests/tests/signin/signinBlocked.spec.ts
@@ -234,7 +234,7 @@ test.describe('severity-2 #smoke', () => {
       await settings.confirmMfaGuard(credentials.email);
 
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
 
       await expect(settings.settingsHeading).toBeVisible();
       await expect(settings.alertBar).toHaveText(

--- a/packages/functional-tests/tests/syncV3/signIn.spec.ts
+++ b/packages/functional-tests/tests/syncV3/signIn.spec.ts
@@ -168,7 +168,7 @@ test.describe('severity-2 #smoke', () => {
       await settings.totp.addButton.click();
       await settings.confirmMfaGuard(credentials.email);
       const { secret } =
-        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice();
+        await totp.setUpTwoStepAuthWithQrAndBackupCodesChoice(credentials);
       await expect(settings.totp.status).toHaveText('Enabled');
       await settings.signOut();
 
@@ -185,10 +185,6 @@ test.describe('severity-2 #smoke', () => {
       await signinTotpCode.fillOutCodeForm(code);
 
       await expect(connectAnotherDevice.fxaConnected).toBeVisible();
-
-      // Required before teardown
-      await settings.goto();
-      await settings.disconnectTotp();
     });
 
     test('verified email, in blocked state', async ({

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -111,6 +111,17 @@ export type SessionReauthedAccountData = Omit<
   'sessionToken'
 >;
 
+export type SessionStatus = {
+  state: 'verified' | 'unverified';
+  uid: string;
+  details: {
+    accountEmailVerified: boolean;
+    sessionVerificationMethod: string | null;
+    sessionVerified: boolean;
+    sessionVerificationMeetsMinimumAAL: boolean;
+  };
+};
+
 export type AuthServerError = Error & {
   error?: string;
   errno?: number;
@@ -1162,16 +1173,7 @@ export default class AuthClient {
   async sessionStatus(
     sessionToken: hexstring,
     headers?: Headers
-  ): Promise<{
-    state: 'verified' | 'unverified';
-    uid: string;
-    details: {
-      accountEmailVerified: boolean;
-      sessionVerificationMethod: string | null;
-      sessionVerified: boolean;
-      sessionVerificationMeetsMinimumAAL: boolean;
-    };
-  }> {
+  ): Promise<SessionStatus> {
     return this.sessionGet('/session/status', sessionToken, headers);
   }
 


### PR DESCRIPTION
Because:
 - We've seen tests have issues during the cleanup

This Commit:
 - Simplifies the large destroyAllAccounts call to make it more manageable
 - Uses `session/status` to determine if AAL elevation is required before disconnecting 2FA and account destroy
 - Defaults the accountDestroy to always fetching a new session token instead of relying on the token in "cache"
 - Updates 2FA setup to store the secret on the account object so it can be used during destroy
 - Updates all tests that setup 2FA to match new pattern

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This now makes the `Credentials` a required parameter when setting up 2FA with the `totp` page functions. The reason being, we _need_ to set the secret on the credential object. If for some reason the test fails between setting up 2FA and the manual disconnect at the end we're now in a state where it's basically a user who lost their 2FA device. We don't have the secret and so we can't elevate a sessionToken to the correct AAL to destroy the account.

Additionally, because we have a more robust tear down that naively fetches a new `sessionToken` every time, and will elevate if the `session/status` endpoint indicates as such, we don't need to call `settings.disconnectTotp()` at the end of tests. It's handled via the API during tear down more consistently now.
