### PR TITLE
chore(): remove `buf` package, replace with native Node API

### DIFF
--- a/libs/accounts/errors/src/oauth-error.ts
+++ b/libs/accounts/errors/src/oauth-error.ts
@@ -4,9 +4,8 @@
 
 import { DEFAULT_ERRROR } from './constants';
 
-// Leaving this here for historical reasons. But we should probably get rid
-// of references to this legacy buff package... See FXA-12594
-const hex = require('buf').to.hex;
+const hex = (v: Buffer | string): string =>
+  Buffer.isBuffer(v) ? v.toString('hex') : v;
 
 // Deprecated. New error types should be defined in lib/error.js
 export class OauthError extends Error {
@@ -20,9 +19,9 @@ export class OauthError extends Error {
       error: any;
       message: string;
       info: Record<string, any>;
-      log?:unknown;
+      log?: unknown;
     };
-    headers: Record<string, string|number>;
+    headers: Record<string, string | number>;
   };
 
   constructor(options: any, extra?: any, headers?: any) {
@@ -53,11 +52,11 @@ export class OauthError extends Error {
     return 'Error: ' + this.message;
   }
 
-  header(name:string, value:string|number) {
+  header(name: string, value: string | number) {
     this.output.headers[name] = value;
   }
 
-  translate(response:{output:{payload:any}, stack:string}) {
+  translate(response: { output: { payload: any }; stack: string }) {
     if (response instanceof OauthError) {
       return response;
     }
@@ -81,7 +80,10 @@ export class OauthError extends Error {
     return error;
   }
 
-  static isOauthRoute(path:string, routes?:Array<{path:string, config:{cors:any}}>) {
+  static isOauthRoute(
+    path: string,
+    routes?: Array<{ path: string; config: { cors: any } }>
+  ) {
     if (!routes) {
       return false;
     }
@@ -94,14 +96,15 @@ export class OauthError extends Error {
   }
 
   static translate(
-    response: {
-      output: {
-        payload?:any;
-      },
-      stack?:string
-    } | OauthError
-  ):OauthError {
-
+    response:
+      | {
+          output: {
+            payload?: any;
+          };
+          stack?: string;
+        }
+      | OauthError
+  ): OauthError {
     if (response instanceof OauthError) {
       return response;
     }
@@ -125,15 +128,15 @@ export class OauthError extends Error {
     });
   }
 
-  backtrace(traced:unknown) {
+  backtrace(traced: unknown) {
     this.output.payload.log = traced;
-  };
+  }
 
   static unexpectedError() {
     return new OauthError({});
   }
 
-  static unknownClient(clientId:string|Buffer) {
+  static unknownClient(clientId: string | Buffer) {
     return new OauthError(
       {
         code: 400,
@@ -147,7 +150,7 @@ export class OauthError extends Error {
     );
   }
 
-  static incorrectSecret(clientId:string) {
+  static incorrectSecret(clientId: string) {
     return new OauthError(
       {
         code: 400,
@@ -161,7 +164,7 @@ export class OauthError extends Error {
     );
   }
 
-  static incorrectRedirect(uri:string) {
+  static incorrectRedirect(uri: string) {
     return new OauthError(
       {
         code: 400,
@@ -184,7 +187,7 @@ export class OauthError extends Error {
     });
   }
 
-  static unknownCode(code:string) {
+  static unknownCode(code: string) {
     return new OauthError(
       {
         code: 400,
@@ -198,7 +201,7 @@ export class OauthError extends Error {
     );
   }
 
-  static mismatchCode(code:string, clientId:string) {
+  static mismatchCode(code: string, clientId: string) {
     return new OauthError(
       {
         code: 400,
@@ -213,7 +216,7 @@ export class OauthError extends Error {
     );
   }
 
-  static expiredCode(code:string, expiredAt:string) {
+  static expiredCode(code: string, expiredAt: string) {
     return new OauthError(
       {
         code: 400,
@@ -237,7 +240,7 @@ export class OauthError extends Error {
     });
   }
 
-  static invalidRequestParameter(val:string) {
+  static invalidRequestParameter(val: string) {
     return new OauthError(
       {
         code: 400,
@@ -260,7 +263,7 @@ export class OauthError extends Error {
     });
   }
 
-  static unauthorized(reason:string) {
+  static unauthorized(reason: string) {
     return new OauthError(
       {
         code: 401,
@@ -294,7 +297,7 @@ export class OauthError extends Error {
     });
   }
 
-  static invalidScopes(scopes:string) {
+  static invalidScopes(scopes: string) {
     return new OauthError(
       {
         code: 400,
@@ -308,7 +311,7 @@ export class OauthError extends Error {
     );
   }
 
-  static expiredToken(expiredAt:number) {
+  static expiredToken(expiredAt: number) {
     return new OauthError(
       {
         code: 400,
@@ -322,7 +325,7 @@ export class OauthError extends Error {
     );
   }
 
-  static notPublicClient(clientId:string) {
+  static notPublicClient(clientId: string) {
     return new OauthError(
       {
         code: 400,
@@ -336,7 +339,7 @@ export class OauthError extends Error {
     );
   }
 
-  static mismatchCodeChallenge(pkceHashValue:string) {
+  static mismatchCodeChallenge(pkceHashValue: string) {
     return new OauthError(
       {
         code: 400,
@@ -359,7 +362,7 @@ export class OauthError extends Error {
     });
   }
 
-  static staleAuthAt(authAt:number) {
+  static staleAuthAt(authAt: number) {
     return new OauthError(
       {
         code: 401,
@@ -373,7 +376,7 @@ export class OauthError extends Error {
     );
   }
 
-  static mismatchAcr(foundValue:boolean) {
+  static mismatchAcr(foundValue: boolean) {
     return new OauthError(
       {
         code: 400,
@@ -406,7 +409,7 @@ export class OauthError extends Error {
   // N.B. `errno: 201` is traditionally our generic "service unavailable" error,
   // so let's reserve it for that purpose here as well.
 
-  static disabledClient(clientId:string) {
+  static disabledClient(clientId: string) {
     return new OauthError(
       {
         code: 503,

--- a/packages/fxa-auth-server/bin/update_firestore_from_oauth.js
+++ b/packages/fxa-auth-server/bin/update_firestore_from_oauth.js
@@ -6,7 +6,6 @@
 
 const Firestore = require('@google-cloud/firestore');
 const StatsD = require('hot-shots');
-const hex = require('buf').to.hex;
 
 const config = require('../config').getProperties();
 const mysql = require('../lib/oauth/db/mysql');
@@ -45,7 +44,7 @@ async function main() {
   const results = await oauthDB.getRefreshTokensByClientId(CLIENT_ID);
   let inserted = 0;
   for (const { userId } of results) {
-    const uid = hex(userId);
+    const uid = userId.toString('hex');
     const document = firestore.doc(`${storePrefix}users/${uid}`);
     const doc = await document.get();
     if (doc.exists) {

--- a/packages/fxa-auth-server/lib/oauth/authorized_clients.js
+++ b/packages/fxa-auth-server/lib/oauth/authorized_clients.js
@@ -4,7 +4,6 @@
 
 const OauthError = require('./error');
 const oauthDB = require('./db');
-const hex = require('buf').to.hex;
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
 // Helper function to render each returned record in the expected form.
@@ -13,7 +12,7 @@ function serialize(clientIdHex, token) {
   const lastAccessTime = token.lastUsedAt.getTime();
   return {
     client_id: clientIdHex,
-    refresh_token_id: token.tokenId ? hex(token.tokenId) : undefined,
+    refresh_token_id: token.tokenId ? token.tokenId.toString('hex') : undefined,
     client_name: token.clientName,
     created_time: createdTime,
     last_access_time: lastAccessTime,
@@ -44,7 +43,7 @@ module.exports = {
     // and should be displayed to the user as such. Nice and simple!
     const seenClientIds = new Set();
     for (const token of await oauthDB.getRefreshTokensByUid(uid)) {
-      const clientId = hex(token.clientId);
+      const clientId = token.clientId.toString('hex');
       authorizedClients.push(serialize(clientId, token));
       seenClientIds.add(clientId);
     }
@@ -58,7 +57,7 @@ module.exports = {
     //     hold some other sort of token, and we don't want them to appear in the list twice.
     const accessTokenRecordsByClientId = new Map();
     for (const token of await oauthDB.getAccessTokensByUid(uid)) {
-      const clientId = hex(token.clientId);
+      const clientId = token.clientId.toString('hex');
       if (!seenClientIds.has(clientId) && !token.clientCanGrant) {
         let record = accessTokenRecordsByClientId.get(clientId);
         if (typeof record === 'undefined') {

--- a/packages/fxa-auth-server/lib/oauth/client.js
+++ b/packages/fxa-auth-server/lib/oauth/client.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const crypto = require('crypto');
-const buf = require('buf').hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 const Joi = require('joi');
 
 const OauthError = require('./error');

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const hex = require('buf').to.hex;
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 
 const { config } = require('../../../config');
 const encrypt = require('fxa-shared/auth/encrypt');

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const buf = require('buf').hex;
 const encrypt = require('fxa-shared/auth/encrypt');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const unique = require('../../unique');
@@ -156,6 +155,8 @@ const PRUNE_AUTHZ_CODES =
 const QUERY_SCOPE_FIND = 'SELECT * ' + 'FROM scopes ' + 'WHERE scopes.scope=?;';
 const QUERY_SCOPES_INSERT =
   'INSERT INTO scopes (scope, hasScopedKeys) ' + 'VALUES (?, ?);';
+
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 
 function firstRow(rows) {
   return rows[0];

--- a/packages/fxa-auth-server/lib/oauth/error.js
+++ b/packages/fxa-auth-server/lib/oauth/error.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const util = require('util');
-const hex = require('buf').to.hex;
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 
 const DEFAULTS = {
   code: 500,

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const buf = require('buf').hex;
-const hex = require('buf').to.hex;
 const { Container } = require('typedi');
 
 const { CapabilityService } = require('../payments/capability');
@@ -160,7 +158,7 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
     name: client.name,
     canGrant: client.canGrant,
     publicClient: client.publicClient,
-    userId: buf(verifiedClaims.uid),
+    userId: Buffer.from(verifiedClaims.uid, 'hex'),
     email: verifiedClaims['fxa-verifiedEmail'],
     scope: requestedGrant.scope,
     scopeConfig,
@@ -218,7 +216,7 @@ module.exports.generateTokens = async function generateTokens(grant) {
 
 async function generateIdToken(grant, accessToken) {
   var now = Math.floor(Date.now() / 1000);
-  const clientId = hex(grant.clientId);
+  const clientId = grant.clientId.toString('hex');
   // The IETF spec for `aud` refers to https://openid.net/specs/openid-connect-core-1_0.html#IDToken
   // > REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the
   // > OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain
@@ -252,7 +250,7 @@ async function generateIdToken(grant, accessToken) {
 }
 
 exports.generateAccessToken = async function generateAccessToken(grant) {
-  const clientId = hex(grant.clientId).toLowerCase();
+  const clientId = grant.clientId.toString('hex').toLowerCase();
   const accessToken = await db.generateAccessToken(grant);
   if (
     !JWT_ACCESS_TOKENS_ENABLED ||
@@ -266,9 +264,9 @@ exports.generateAccessToken = async function generateAccessToken(grant) {
   if (grant.scope.contains('profile:subscriptions')) {
     const capabilities =
       await capabilityService.determineClientVisibleSubscriptionCapabilities(
-        hex(clientId),
+        clientId,
         await capabilityService.subscriptionCapabilities(
-          hex(grant.userId),
+          grant.userId.toString('hex'),
           grant.email
         )
       );

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const hex = require('buf').to.hex;
 const OauthError = require('./error');
 const jwt = require('./jwt');
 const sub = require('./jwt_sub');
@@ -16,7 +15,7 @@ const HEADER_TYP = 'at+JWT';
  * Create a JWT access token from `grant`
  */
 exports.create = async function generateJWTAccessToken(accessToken, grant) {
-  const clientId = hex(grant.clientId);
+  const clientId = grant.clientId.toString('hex');
   // For historical reasons (based on an early draft of the JWT-access-token spec) we
   // always include the client_id in the `aud` claim. A future iteration of this code
   // should instead infer an appropriate default `aud` based on the requested scopes.
@@ -35,7 +34,7 @@ exports.create = async function generateJWTAccessToken(accessToken, grant) {
     exp: Math.floor(accessToken.expiresAt / 1000),
     iat: Math.floor(Date.now() / 1000),
     // iss is set in jwt.sign
-    jti: hex(accessToken.token),
+    jti: accessToken.token.toString('hex'),
     scope: grant.scope.toString(),
     sub: await sub(grant.userId, grant.clientId, grant.ppidSeed),
   };

--- a/packages/fxa-auth-server/lib/oauth/jwt_sub.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_sub.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const hex = require('buf').to.hex;
 const hkdf = require('../../lib/crypto/hkdf');
 const { config } = require('../../config');
 const validators = require('./validators');
@@ -33,8 +32,8 @@ module.exports = async function generateSub(
     throw new Error('invalid ppidSeed');
   }
 
-  const clientIdHex = hex(clientIdBuf).toLowerCase();
-  const userIdHex = hex(userIdBuf).toLowerCase();
+  const clientIdHex = clientIdBuf.toString('hex').toLowerCase();
+  const userIdHex = userIdBuf.toString('hex').toLowerCase();
 
   if (PPID_ENABLED && PPID_CLIENT_IDS.has(clientIdHex)) {
     // Input values used in the HKDF must not contain a `.` to ensure
@@ -46,14 +45,14 @@ module.exports = async function generateSub(
     if (PPID_ROTATING_CLIENT_IDS.has(clientIdHex)) {
       timeBasedContext = Math.floor(Date.now() / PPID_ROTATION_PERIOD_MS);
     }
-    return hex(
+    return (
       await hkdf(
         `${clientIdHex}.${userIdHex}.${clientSeed}.${timeBasedContext}`,
         PPID_INFO,
         PPID_SALT,
         userIdBuf.length
       )
-    );
+    ).toString('hex');
   } else {
     return userIdHex;
   }

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -11,7 +11,7 @@ const opentelemetry = require('@opentelemetry/api');
 ('use strict');
 
 const tracer = opentelemetry.trace.getTracer('redis-tracer');
-const hex = require('buf').to.hex;
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 
 function resolveLogger() {
   if (Container.has(AuthLogger)) return Container.get(AuthLogger);

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
@@ -6,7 +6,6 @@
 
 const AppError = require('../../error');
 const joi = require('joi');
-const hex = require('buf').to.hex;
 const validators = require('../validators');
 const { BEARER_AUTH_REGEX } = validators;
 const { OAUTH_SCOPE_OLD_SYNC } = require('fxa-shared/oauth/constants');
@@ -58,10 +57,10 @@ module.exports = function schemeRefreshTokenScheme(config, db) {
         const { ua = {} } = request.app;
 
         const credentials = {
-          uid: hex(refreshToken.userId),
+          uid: refreshToken.userId.toString('hex'),
           emailVerified: true,
           tokenVerified: true,
-          refreshTokenId: hex(tokenId),
+          refreshTokenId: tokenId.toString('hex'),
           uaBrowser: ua.browser,
           uaBrowserVersion: ua.browserVersion,
           uaOS: ua.os,

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -7,7 +7,7 @@
 const { URL } = require('url');
 const Ajv = require('ajv');
 const ajv = new Ajv();
-const hex = require('buf').to.hex;
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 const error = require('../error');
 const fs = require('fs');
 const isA = require('joi');

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const hex = require('buf').to.hex;
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 const Joi = require('joi');
 
 const OauthError = require('../../oauth/error');

--- a/packages/fxa-auth-server/lib/routes/oauth/client/get.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/client/get.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const hex = require('buf').to.hex;
 const Joi = require('joi');
 
 const AppError = require('../../../oauth/error');
@@ -50,7 +49,7 @@ module.exports = ({ log, oauthDB }) => ({
             throw AppError.unknownClient(params.client_id);
           } else {
             return {
-              id: hex(client.id),
+              id: client.id.toString('hex'),
               name: client.name,
               trusted: client.trusted,
               image_uri: client.imageUri,

--- a/packages/fxa-auth-server/lib/routes/oauth/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/destroy.js
@@ -4,7 +4,6 @@
 
 const crypto = require('crypto');
 const Joi = require('joi');
-const hex = require('buf').to.hex;
 
 const OauthError = require('../../oauth/error');
 const AuthError = require('../../error');
@@ -60,7 +59,7 @@ module.exports = ({ log, oauthDB }) => {
       // Log a warning if legacy client_secret is provided, so we can
       // measure whether it's safe to remove this behaviour.
       log.warn('destroy.unexpectedClientSecret', {
-        client_id: hex(token.clientId),
+        client_id: token.clientId.toString('hex'),
       });
     }
     await oauthDB[removeToken](token);

--- a/packages/fxa-auth-server/lib/routes/oauth/introspect.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/introspect.js
@@ -5,7 +5,6 @@
 /*jshint camelcase: false*/
 const Joi = require('joi');
 const validators = require('../../oauth/validators');
-const hex = require('buf').to.hex;
 const AppError = require('../../oauth/error');
 const { getTokenId } = require('../../oauth/token');
 const OAUTH_SERVER_DOCS =
@@ -95,11 +94,11 @@ module.exports = ({ oauthDB }) => ({
 
         Object.assign(response, {
           scope: token.scope.toString(),
-          client_id: hex(token.clientId),
+          client_id: token.clientId.toString('hex'),
           token_type: tokenType,
           iat: token.createdAt.getTime(),
-          sub: hex(token.userId),
-          jti: hex(tokenId),
+          sub: token.userId.toString('hex'),
+          jti: tokenId.toString('hex'),
         });
 
         if (token.expiresAt) {

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -28,8 +28,8 @@
 const crypto = require('crypto');
 const OauthError = require('../../oauth/error');
 const AuthError = require('../../error');
-const buf = require('buf').hex;
-const hex = require('buf').to.hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 const Joi = require('joi');
 
 const {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -78,7 +78,6 @@
     "@types/mjml": "^4.7.4",
     "agentkeepalive": "^4.6.0",
     "ajv": "^8.17.1",
-    "buf": "0.1.1",
     "commander": "2.18.0",
     "convict": "^6.2.4",
     "convict-format-with-moment": "^6.2.0",

--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -5,7 +5,7 @@
 const url = require('url');
 const { assert } = require('chai');
 const nock = require('nock');
-const buf = require('buf').hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 const testServer = require('../lib/server');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const { decodeJWT } = require('../lib/util');

--- a/packages/fxa-auth-server/test/oauth/db/index.js
+++ b/packages/fxa-auth-server/test/oauth/db/index.js
@@ -5,8 +5,8 @@
 const crypto = require('crypto');
 
 const { assert } = require('chai');
-const buf = require('buf').hex;
-const hex = require('buf').to.hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
 const encrypt = require('fxa-shared/auth/encrypt');

--- a/packages/fxa-auth-server/test/oauth/routes/token.js
+++ b/packages/fxa-auth-server/test/oauth/routes/token.js
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const { assert } = require('chai');
-const buf = require('buf').hex;
-const hex = require('buf').to.hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 const path = require('path');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');

--- a/packages/fxa-auth-server/test/remote/attached_clients_tests.js
+++ b/packages/fxa-auth-server/test/remote/attached_clients_tests.js
@@ -11,7 +11,7 @@ const config = require('../../config').default.getProperties();
 const tokens = require('../../lib/tokens')({ trace: () => {} }, config);
 const testUtils = require('../lib/util');
 const ScopeSet = require('fxa-shared').oauth.scopes;
-const buf = require('buf').hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 const hashRefreshToken = require('fxa-shared/auth/encrypt').hash;
 
 const PUBLIC_CLIENT_ID = '3c49430b43dfba77';

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
@@ -9,7 +9,7 @@ const crypto = require('crypto');
 const TestServer = require('../test_server');
 const Client = require('../client')();
 const config = require('../../config').default.getProperties();
-const buf = require('buf').hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 const testUtils = require('../lib/util');
 const encrypt = require('fxa-shared/auth/encrypt');
 const log = { trace() {}, info() {}, error() {}, debug() {}, warn() {} };

--- a/packages/fxa-auth-server/test/scripts/prune-pocket-access-tokens.js
+++ b/packages/fxa-auth-server/test/scripts/prune-pocket-access-tokens.js
@@ -8,8 +8,8 @@ const { assert } = require('chai');
 const util = require('node:util');
 const exec = util.promisify(require('node:child_process').exec);
 const path = require('path');
-const buf = require('buf').hex;
-const hex = require('buf').to.hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
+const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
 const ScopeSet = require('fxa-shared').oauth.scopes;
 const crypto = require('crypto');
 

--- a/packages/fxa-profile-server/lib/db/memory.js
+++ b/packages/fxa-profile-server/lib/db/memory.js
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const buf = require('buf');
-const hex = buf.to.hex;
-
 const config = require('../config');
 const P = require('../promise');
 
@@ -64,8 +61,8 @@ MemoryStore.prototype = {
       providerId: provider,
       userId: uid,
     };
-    this.avatars[hex(id)] = avatar;
-    this.selected[hex(uid)] = {
+    this.avatars[id.toString('hex')] = avatar;
+    this.selected[uid.toString('hex')] = {
       userId: uid,
       avatarId: id,
     };
@@ -73,20 +70,20 @@ MemoryStore.prototype = {
   },
 
   getAvatar: function getAvatar(id) {
-    return P.resolve(this.avatars[hex(id)]);
+    return P.resolve(this.avatars[id.toString('hex')]);
   },
 
   getSelectedAvatar: function getSelectedAvatar(uid) {
-    var selected = this.selected[hex(uid)];
+    var selected = this.selected[uid.toString('hex')];
     if (selected) {
-      var avatar = this.avatars[hex(selected.avatarId)];
+      var avatar = this.avatars[selected.avatarId.toString('hex')];
       return P.resolve(avatar);
     }
     return P.resolve();
   },
 
   deleteAvatar: function deleteAvatar(id) {
-    delete this.avatars[hex(id)];
+    delete this.avatars[id.toString('hex')];
     return P.resolve();
   },
 
@@ -104,18 +101,18 @@ MemoryStore.prototype = {
   },
 
   removeProfile: function removeProfile(uid) {
-    delete this.profile[hex(uid)];
+    delete this.profile[uid.toString('hex')];
     return P.resolve();
   },
 
   getDisplayName: function (uid) {
-    var id = hex(uid);
+    var id = uid.toString('hex');
     var name = this.profile[id] ? this.profile[id].displayName : undefined;
     return P.resolve({ displayName: name });
   },
 
   setDisplayName: function (uid, displayName) {
-    var id = hex(uid);
+    var id = uid.toString('hex');
     if (this.profile[id]) {
       this.profile[id].displayName = displayName;
     } else {

--- a/packages/fxa-profile-server/lib/db/mysql/index.js
+++ b/packages/fxa-profile-server/lib/db/mysql/index.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const mysql = require('mysql');
-const buf = require('buf').hex;
+const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 
 const AppError = require('../../error');
 const config = require('../../config');

--- a/packages/fxa-profile-server/lib/img-workers.js
+++ b/packages/fxa-profile-server/lib/img-workers.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const buf = require('buf');
-const hex = buf.to.hex;
 const P = require('./promise');
 
 const AppError = require('./error');
@@ -16,7 +14,7 @@ const ACCEPT_ENCODING_HEADER = 'identity';
 
 exports.upload = function upload(id, payload, headers) {
   return new P(function(resolve, reject) {
-    var url = WORKER_URL + '/a/' + hex(id);
+    var url = WORKER_URL + '/a/' + id.toString('hex');
 
     // filter incoming headers
     const header_excludes = config.get('worker.headers_exclude');
@@ -68,7 +66,7 @@ exports.upload = function upload(id, payload, headers) {
 
 exports.delete = function deleteAvatar(id) {
   return new P(function(resolve, reject) {
-    var url = WORKER_URL + '/a/' + hex(id);
+    var url = WORKER_URL + '/a/' + id.toString('hex');
     var opts = { method: 'delete', json: true };
     logger.verbose('delete', url);
     request(url, opts, function(err, res, body) {

--- a/packages/fxa-profile-server/lib/routes/avatar/delete.js
+++ b/packages/fxa-profile-server/lib/routes/avatar/delete.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const hex = require('buf').to.hex;
 const Joi = require('joi');
 const P = require('../../promise');
 
@@ -71,7 +70,7 @@ function getAvatar(id, uid) {
     logger.debug('avatar', avatar);
     if (!avatar) {
       throw AppError.notFound();
-    } else if (hex(avatar.userId) !== uid) {
+    } else if (avatar.userId.toString('hex') !== uid) {
       throw AppError.unauthorized('Avatar not owned by user');
     } else {
       return avatar;

--- a/packages/fxa-profile-server/lib/routes/avatar/get.js
+++ b/packages/fxa-profile-server/lib/routes/avatar/get.js
@@ -5,7 +5,6 @@
 const Joi = require('joi');
 
 const db = require('../../db');
-const hex = require('buf').to.hex;
 const validate = require('../../validate');
 const logger = require('../../logging')('routes.avatar.get');
 const avatarShared = require('./_shared');
@@ -16,7 +15,7 @@ async function avatarOrDefault(uid) {
     return {
       avatar: avatar.url,
       avatarDefault: false,
-      id: hex(avatar.id),
+      id: avatar.id.toString('hex'),
     };
   }
   return avatarShared.DEFAULT_AVATAR;

--- a/packages/fxa-profile-server/lib/routes/avatar/upload.js
+++ b/packages/fxa-profile-server/lib/routes/avatar/upload.js
@@ -8,7 +8,6 @@ const Joi = require('joi');
 
 const config = require('../../config');
 const db = require('../../db');
-const hex = require('buf').to.hex;
 const img = require('../../img');
 const notifyProfileUpdated = require('../../updates-queue');
 const validate = require('../../validate');
@@ -60,7 +59,7 @@ module.exports = {
         })
         .then(function uploadDone() {
           notifyProfileUpdated(uid); // Don't wait on promise
-          return h.response({ url: url, id: hex(id) }).code(201);
+          return h.response({ url: url, id: id.toString('hex') }).code(201);
         });
     });
   },

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -25,7 +25,6 @@
     "@hapi/hapi": "^20.2.1",
     "@hapi/inert": "7.1.0",
     "bluebird": "^3.7.2",
-    "buf": "0.1.1",
     "checksum": "1.0.0",
     "compute-cluster": "0.0.9",
     "convict": "^6.2.4",

--- a/packages/fxa-shared/auth/encrypt.ts
+++ b/packages/fxa-shared/auth/encrypt.ts
@@ -2,10 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import crypto from 'crypto';
-
-const buf = require('buf');
-
-export const hex = buf.hex;
+export const hex = (v: Buffer | string) =>
+  Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex');
 
 export function hash(value: any) {
   var sha = crypto.createHash('sha256');

--- a/packages/fxa-shared/connected-services/util.ts
+++ b/packages/fxa-shared/connected-services/util.ts
@@ -8,8 +8,8 @@ import { DeviceSessionToken } from './models/DeviceSessionToken';
 import { SerializableAttachedClient } from './models/SerializableAttachedClient';
 import { Token } from './models/Token';
 import { SessionToken } from './models/SessionToken';
-
-export const hex = require('buf').to.hex;
+export const hex = (v: Buffer | string): string =>
+  Buffer.isBuffer(v) ? v.toString('hex') : v;
 
 // Helper function to render each returned record in the expected form.
 export function serialize(
@@ -20,7 +20,7 @@ export function serialize(
   const lastAccessTime = token.lastUsedAt.getTime();
   return {
     client_id: clientIdHex,
-    refresh_token_id: token.tokenId ? hex(token.tokenId) : undefined,
+    refresh_token_id: token.tokenId ? hex(token.tokenId) : '',
     client_name: token.clientName,
     created_time: createdTime,
     last_access_time: lastAccessTime,

--- a/packages/fxa-shared/db/mysql.ts
+++ b/packages/fxa-shared/db/mysql.ts
@@ -14,8 +14,8 @@ interface DbPoolConfig extends mysql.PoolConfig {
   idleLimitMs: number;
 }
 
-// TODO: Improve types. Ported form javascript...
-const buf = require('buf').hex;
+const buf = (v: Buffer | string) =>
+  Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex');
 
 /**
  * List of mysql error codes

--- a/packages/fxa-shared/db/redis.ts
+++ b/packages/fxa-shared/db/redis.ts
@@ -12,8 +12,8 @@ import { RefreshTokenMetadata } from './models/auth/refresh-token-meta-data';
 
 import opentelemetry from '@opentelemetry/api';
 const tracer = opentelemetry.trace.getTracer('redis-tracer');
-
-const hex = require('buf').to.hex;
+const hex = (v: Buffer | string): string =>
+  Buffer.isBuffer(v) ? v.toString('hex') : v;
 
 export type Config = {
   enabled?: boolean;
@@ -235,7 +235,7 @@ export class RedisShared {
   }
 
   async pruneRefreshTokens(
-    uid: Buffer | String,
+    uid: Buffer | string,
     tokenIdsToPrune: Buffer[] | string[]
   ) {
     this.metrics?.increment('redis.pruneRefreshTokens');
@@ -273,7 +273,7 @@ export class RedisShared {
     }
   }
 
-  async getAccessTokens(uid: Buffer | String) {
+  async getAccessTokens(uid: Buffer | string) {
     this.metrics?.increment('redis.getAccessTokens');
     const span = tracer.startSpan('redis.getAccessTokens');
     try {
@@ -297,7 +297,7 @@ export class RedisShared {
     }
   }
 
-  async getAccessToken(uid: Buffer | String) {
+  async getAccessToken(uid: Buffer | string) {
     this.metrics?.increment('redis.getAccessToken');
     const span = tracer.startSpan('redis.getAccessToken');
     try {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -280,7 +280,6 @@
     "@fluent/langneg": "^0.7.0",
     "accept-language-parser": "^1.5.0",
     "ajv": "^8.17.1",
-    "buf": "^0.1.1",
     "celebrate": "^15.0.1",
     "cldr-localenames-full": "46.0.0",
     "cors": "^2.8.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26262,13 +26262,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buf@npm:0.1.1, buf@npm:^0.1.1":
-  version: 0.1.1
-  resolution: "buf@npm:0.1.1"
-  checksum: 10c0/134a874dab97de9f687b1f6f960228eae7ee5442b34957c7201add93dd8b96e91dcf5dece134bb6e3ed59d089bb17b5ef2f01b0903801439664b7215ae188d6a
-  languageName: node
-  linkType: hard
-
 "buffer-builder@npm:^0.2.0":
   version: 0.2.0
   resolution: "buffer-builder@npm:0.2.0"
@@ -34211,7 +34204,6 @@ __metadata:
     audit-filter: "npm:^0.5.0"
     babel-loader: "npm:^9.1.3"
     binary-split: "npm:1.0.5"
-    buf: "npm:0.1.1"
     chai: "npm:^4.5.0"
     chai-as-promised: "npm:^7.1.1"
     commander: "npm:2.18.0"
@@ -34755,7 +34747,6 @@ __metadata:
     "@types/sharp": "npm:^0"
     audit-filter: "npm:^0.5.0"
     bluebird: "npm:^3.7.2"
-    buf: "npm:0.1.1"
     checksum: "npm:1.0.0"
     commander: "npm:9.3.0"
     compute-cluster: "npm:0.0.9"
@@ -35006,7 +34997,6 @@ __metadata:
     accept-language-parser: "npm:^1.5.0"
     ajv: "npm:^8.17.1"
     audit-filter: "npm:^0.5.0"
-    buf: "npm:^0.1.1"
     celebrate: "npm:^15.0.1"
     chai: "npm:^4.5.0"
     chance: "npm:^1.1.8"


### PR DESCRIPTION
## Because

- The `buf` package appears unmaintained and could be a vulnerability.
- The functionality provided by the `buf` package is already built into Node.
- Removing dependencies reduces maintenance and feels awesome.

## This pull request

- Removes the `buf` package from our repo
- Replaces `buf` package functionality with native code

## Issue that this pull request solves

Closes: FXA-12594

## Other information (Optional)

- In cases where the type can be string or buffer, we use a helper function to respond appropriately or fail fast (ex: if type is object).  For other cases we replace the conversions inline.
- Sorry bout the format changes on libs/accounts/errors/src/oauth-error.ts – it auto-formatted, likely because I ran lint.  Thankfully just that file got reformatted.
