### PR TITLE
fix: add method to Update upload-assets-to-cdn.yml

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -76,8 +76,9 @@ jobs:
       - name: "Post to fxa-team Slack channel"
         uses: slackapi/slack-github-action@v2.1.1
         with:
-          channel-id: 'CLV3KMZ8B'
-          slack-message: "New assets have been uploaded to CDN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           method: 'chat.postMessage'
+          payload: |
+            channel-id: 'CLV3KMZ8B'
+            text: "New assets have been uploaded to CDN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Because

- This job failed @ https://github.com/mozilla/fxa/actions/runs/19153156941/job/54747965480 

## This pull request

- adds a method directive