### PR TITLE
fix: move slack_bot_token out of env and into action call

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -77,8 +77,7 @@ jobs:
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: 'chat.postMessage'
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel-id: 'CLV3KMZ8B'
             text: "New assets have been uploaded to CDN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Because

- the github action is failing

## This pull request

- makes it consistent with the docs @ https://docs.slack.dev/tools/slack-github-action/sending-techniques/sending-data-slack-api-method/
