### PR TITLE
fix: move from channel-id to channel

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -79,5 +79,5 @@ jobs:
           method: 'chat.postMessage'
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel-id: 'CLV3KMZ8B'
+            channel: 'CLV3KMZ8B'
             text: "New assets have been uploaded to CDN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Because

- github action is broken

## This pull request

- updates to channel instead of channel-id