### PR TITLE
fix(api): Return 'verified' from 'account/login'

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -46,6 +46,7 @@ const ACCOUNT_LOGIN_POST = {
       The response includes:
       - \`emailVerified\`: Whether the account's primary email address has been verified
       - \`sessionVerified\`: Whether the current session token has been verified
+      - \`verified\`: **Deprecated** - Whether both email and session are verified (equivalent to \`emailVerified && sessionVerified\`). Use \`emailVerified\` and \`sessionVerified\` instead.
       - \`verificationMethod\`: Present if verification is incomplete, e.g. \`email\`, \`email-2fa\`, \`email-otp\`, \`totp-2fa\`
       - \`verificationReason\`: Present if verification is incomplete, e.g. \`login\`, \`signup\`
     `,

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1427,6 +1427,11 @@ export class AccountHandler {
         );
       }
 
+      // This has stuck around for backwards compatibility and is not currently
+      // used by our front-end. RPs should be encouraged to use 'sessionVerified'
+      // or 'emailVerified' instead.
+      response.verified = response.emailVerified && response.sessionVerified;
+
       await this.signinUtils.cleanupReminders(response, accountRecord);
 
       if (response.emailVerified && response.sessionVerified) {
@@ -2406,6 +2411,7 @@ export const accountRoutes = (
               .description(DESCRIPTION.verificationReason),
             emailVerified: isA.boolean().required(),
             sessionVerified: isA.boolean().required(),
+            verified: isA.boolean().required(),
             authAt: isA.number().integer().description(DESCRIPTION.authAt),
             metricsEnabled: isA.boolean().required(),
           }),

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2720,6 +2720,12 @@ describe('/account/login', () => {
           false,
           'response indicates account is unverified'
         );
+        // Deprecated
+        assert.equal(
+          response.verified,
+          false,
+          'response includes verified field set to false'
+        );
         assert.equal(
           response.verificationMethod,
           'email',
@@ -2965,6 +2971,11 @@ describe('/account/login', () => {
         assert.ok(
           response.sessionVerified,
           'response indicates session is verified'
+        );
+        // Deprecated
+        assert.ok(
+          response.verified,
+          'response includes verified field set to true'
         );
         assert.ok(
           !response.verificationMethod,


### PR DESCRIPTION
Because:
* We split this into two values in another PR, but at least one other team relies on this value

This commit:
* Adds the field back and marks it as deprecated

---

This needs an issue field but [see thread](https://mozilla.slack.com/archives/CLV3KMZ8B/p1762470282805209). Only ran local auth-server tests locally, so we'll see what CI says.