### PR TITLE
feat(functional-tests): tag sms messages with meta data if test account

### DIFF
--- a/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
+++ b/packages/functional-tests/tests/settings/recoveryPhone.spec.ts
@@ -738,11 +738,17 @@ async function fillOutRecoveryPhoneFromEmailFirst({
   await page.waitForURL(/signin_recovery_choice/);
 
   await signinRecoveryChoice.clickChoosePhone();
+  const signalTime = Date.now();
   await signinRecoveryChoice.clickContinue();
 
   await page.waitForURL(/signin_recovery_phone/);
 
-  const code = await target.smsClient.getCode({ ...credentials });
+  const code = await target.smsClient.getCode({
+    ...credentials,
+    // given there's a page load between between click and getCode,
+    // we use a longer startTime to ensure we don't miss the code.
+    startTime: Date.now() - signalTime,
+  });
 
   // Enter the new code and login
   await signinRecoveryPhone.enterCode(code);

--- a/packages/functional-tests/tests/settings/replace2fa.spec.ts
+++ b/packages/functional-tests/tests/settings/replace2fa.spec.ts
@@ -271,10 +271,14 @@ const completeSigninWithDualRecovery = async ({
   await signinTotpCode.clickTroubleEnteringCode();
   await page.waitForURL(/signin_recovery_choice/);
   await signinRecoveryChoice[`clickChoose${method}`]();
+  const signalTime = Date.now();
   await signinRecoveryChoice.clickContinue();
   // new RegExp because template literal isn't supported directly inside regex literal
   await page.waitForURL(new RegExp(`signin_recovery_${method.toLowerCase()}`));
-  const code = await target.smsClient.getCode({ ...credentials });
+  const code = await target.smsClient.getCode({
+    ...credentials,
+    startTime: Date.now() - signalTime,
+  });
   await recoveries[method].fillOutCodeForm(code);
 };
 

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -216,6 +216,46 @@ describe('/recovery_phone', () => {
       );
       assert.equal(route.options.auth.strategy, 'sessionToken');
     });
+
+    it('includes email metadata in messages for test email addresses', async () => {
+      let capturedCallback;
+      mockRecoveryPhoneService.sendCode = sinon.fake(async (uid, callback) => {
+        capturedCallback = callback;
+        return true;
+      });
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/signin/send_code',
+        credentials: { uid, email: 'testuser@restmail.net' },
+      });
+
+      assert.isDefined(capturedCallback);
+      const messages = await capturedCallback('123456');
+      assert.include(messages.msg, '[testuser]');
+      assert.include(messages.shortMsg, '[testuser]');
+      assert.include(messages.failsafeMsg, '[testuser]');
+    });
+
+    it('does not include email metadata in messages for non-test email addresses', async () => {
+      let capturedCallback;
+      mockRecoveryPhoneService.sendCode = sinon.fake(async (uid, callback) => {
+        capturedCallback = callback;
+        return true;
+      });
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/signin/send_code',
+        credentials: { uid, email: 'testuser@mozilla.com' },
+      });
+
+      assert.isDefined(capturedCallback);
+      const messages = await capturedCallback('123456');
+      assert.notInclude(messages.msg, '[');
+      assert.notInclude(messages.shortMsg, '[');
+      assert.notInclude(messages.failsafeMsg, '[');
+    });
   });
 
   describe('POST /recovery_phone/reset_password/send_code', () => {
@@ -335,6 +375,54 @@ describe('/recovery_phone', () => {
         'POST'
       );
       assert.equal(route.options.auth.strategy, 'passwordForgotToken');
+    });
+
+    it('includes email metadata in messages for test email addresses', async () => {
+      let capturedCallback;
+      mockRecoveryPhoneService.sendCode = sinon.fake(async (uid, callback) => {
+        capturedCallback = callback;
+        return true;
+      });
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/reset_password/send_code',
+        credentials: { uid, email: 'testuser@restmail.net' },
+      });
+
+      // artificial delay since the metrics and security event related calls
+      // are not awaited
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.isDefined(capturedCallback);
+      const messages = await capturedCallback('123456');
+      assert.include(messages.msg, '[testuser]');
+      assert.include(messages.shortMsg, '[testuser]');
+      assert.include(messages.failsafeMsg, '[testuser]');
+    });
+
+    it('does not include email metadata in messages for non-test email addresses', async () => {
+      let capturedCallback;
+      mockRecoveryPhoneService.sendCode = sinon.fake(async (uid, callback) => {
+        capturedCallback = callback;
+        return true;
+      });
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/reset_password/send_code',
+        credentials: { uid, email: 'testuser@mozilla.com' },
+      });
+
+      // artificial delay since the metrics and security event related calls
+      // are not awaited
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assert.isDefined(capturedCallback);
+      const messages = await capturedCallback('123456');
+      assert.notInclude(messages.msg, '[');
+      assert.notInclude(messages.shortMsg, '[');
+      assert.notInclude(messages.failsafeMsg, '[');
     });
   });
 
@@ -491,6 +579,56 @@ describe('/recovery_phone', () => {
     it('requires verified session authorization', () => {
       const route = getRoute(routes, '/recovery_phone/create', 'POST');
       assert.equal(route.options.auth.strategy, 'verifiedSessionToken');
+    });
+
+    it('includes email metadata in messages for test email addresses', async () => {
+      let capturedCallback;
+      mockRecoveryPhoneService.setupPhoneNumber = sinon.fake(
+        async (uid, phoneNumber, callback) => {
+          capturedCallback = callback;
+          return true;
+        }
+      );
+      mockRecoveryPhoneService.getNationalFormat =
+        sinon.fake.returns(nationalFormat);
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/create',
+        credentials: { uid, email: 'testuser@restmail.net' },
+        payload: { phoneNumber },
+      });
+
+      assert.isDefined(capturedCallback);
+      const messages = await capturedCallback('123456');
+      assert.include(messages.msg, '[testuser]');
+      assert.include(messages.shortMsg, '[testuser]');
+      assert.include(messages.failsafeMsg, '[testuser]');
+    });
+
+    it('does not include email metadata in messages for non-test email addresses', async () => {
+      let capturedCallback;
+      mockRecoveryPhoneService.setupPhoneNumber = sinon.fake(
+        async (uid, phoneNumber, callback) => {
+          capturedCallback = callback;
+          return true;
+        }
+      );
+      mockRecoveryPhoneService.getNationalFormat =
+        sinon.fake.returns(nationalFormat);
+
+      await makeRequest({
+        method: 'POST',
+        path: '/recovery_phone/create',
+        credentials: { uid, email: 'testuser@mozilla.com' },
+        payload: { phoneNumber },
+      });
+
+      assert.isDefined(capturedCallback);
+      const messages = await capturedCallback('123456');
+      assert.notInclude(messages.msg, '[');
+      assert.notInclude(messages.shortMsg, '[');
+      assert.notInclude(messages.failsafeMsg, '[');
     });
   });
 

--- a/packages/fxa-shared/email/helpers.ts
+++ b/packages/fxa-shared/email/helpers.ts
@@ -74,3 +74,17 @@ export function isEmailValid(email: string): boolean {
 export function isEmailMask(email: string): boolean {
   return emailMaskRegex.test(email);
 }
+
+/**
+ * Only returns the email local part _if_ it's a test address ending in "@restmail.net".
+ *
+ * For example, "test@restmail.net" will return "test", but "test@example.com" will return undefined.
+ *
+ * @param email - The email address to get the local part of.
+ * @returns The local part of the email address, or undefined if it's not a test address.
+ */
+export function getTestEmailLocalPart(email: string): string | undefined {
+  return email.toLowerCase().endsWith('@restmail.net')
+    ? email.split('@')[0]
+    : undefined;
+}

--- a/packages/fxa-shared/test/email/helpers.js
+++ b/packages/fxa-shared/test/email/helpers.js
@@ -100,4 +100,12 @@ describe('email/helpers:', () => {
       assert.isFalse(Helpers.isEmailValid('a’b@example.com'));
     });
   });
+  describe('getTestEmailLocalPart', () => {
+    it('returns the local part of a test address', () => {
+      assert.equal(Helpers.getTestEmailLocalPart('test@restmail.net'), 'test');
+    });
+    it('returns undefined for a non-test address', () => {
+      assert.isUndefined(Helpers.getTestEmailLocalPart('test@example.com'));
+    });
+  });
 });


### PR DESCRIPTION
Because:
 - We're limited today to running tests in serial so we don't collide on
   sms codes

This Commit:
 - Adds a feature that includes the account email local part if it's a
   test account in the sms.
 - This allows tests to "look" for their message
 - Adds tests for new changes to recovery-phone routes

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Here's two back-to-back messages. First one was for an account using my `@mozilla` domain, and second was using an `@restmail.net` domain
<img width="678" height="106" alt="image" src="https://github.com/user-attachments/assets/7c08a379-8308-4166-8b4f-576a4847f481" />


## Other information (Optional)

Any other information that is important to this pull request.
