### PR TITLE
Polish(settings): Center text in 2fa setup/change success alert bar

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Page2faChange/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faChange/index.tsx
@@ -61,7 +61,7 @@ export const Page2faChange = () => {
 
   const alertBarSuccessMessage = useCallback(() => {
     return (
-      <div>
+      <div className="text-center">
         <p>
           <strong>
             {ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/components/Settings/Page2faSetup/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Page2faSetup/index.tsx
@@ -74,7 +74,7 @@ export const Page2faSetup = () => {
 
   const alertBarSuccessMessage = useCallback(() => {
     return (
-      <div>
+      <div className="text-center">
         <p>
           <strong>
             {ftlMsgResolver.getMsg(


### PR DESCRIPTION
## Because

- Other alert bar messages have centered text

## This pull request

- Center the text in the success alert bar for 2FA setup/change

## Issue that this pull request solves

Closes: FXA-12586

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="2507" height="323" alt="image" src="https://github.com/user-attachments/assets/ba402239-fa62-4272-96a2-5583d6ddc09b" />

## Other information (Optional)

Any other information that is important to this pull request.
