### PR TITLE
fix(login): Send session verification email at account/login

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1300,7 +1300,8 @@ export class AccountHandler {
         request,
         accountRecord,
         sessionToken,
-        verificationMethod
+        verificationMethod,
+        passwordChangeRequired
       );
 
       // For new logins that don't send some other sort of email,

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2243,7 +2243,7 @@ describe('/account/login', () => {
     payload: {
       authPW: hexString(32),
       email: TEST_EMAIL,
-      service: 'dcdb5ae7add825d2',
+      service: undefined,
       reason: 'signin',
       metricsContext: {
         deviceId: 'blee',

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -517,23 +517,6 @@ describe('Signin component', () => {
             });
           });
 
-          it('calls sendVerificationCode with successful signin, but unverified session', async () => {
-            const beginSigninHandler = jest.fn().mockReturnValueOnce(
-              createBeginSigninResponse({
-                emailVerified: true,
-                sessionVerified: false,
-                verificationReason: undefined,
-              })
-            );
-
-            render({ beginSigninHandler });
-
-            await enterPasswordAndSubmit();
-            await waitFor(() => {
-              expect(mockSendVerificationCode).toHaveBeenCalledTimes(1);
-            });
-          });
-
           it('does not call sendVerificationCode when reason is signup, on successful signin unverified session', async () => {
             const beginSigninHandler = jest.fn().mockReturnValueOnce(
               createBeginSigninResponse({

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -24,8 +24,6 @@ import {
   useFtlMsgResolver,
   isWebIntegration,
   isOAuthIntegration,
-  useSession,
-  isOAuthWebIntegration,
   isOAuthNativeIntegration,
 } from '../../models';
 import {
@@ -71,7 +69,6 @@ const Signin = ({
   const ftlMsgResolver = useFtlMsgResolver();
   const webRedirectCheck = useWebRedirect(integration.data.redirectTo);
   const sensitiveDataClient = useSensitiveDataClient();
-  const session = useSession();
 
   const [localizedBannerError, setLocalizedBannerError] = useState(
     localizedErrorFromLocationState || ''
@@ -236,17 +233,6 @@ const Signin = ({
           setLocalizedBannerError(
             getLocalizedErrorMessage(ftlMsgResolver, navError)
           );
-        } else {
-          if (
-            // Don't send a verification code email if it's non-signup, the user has an unverified
-            // session, and it's an RP redirect flow. We don't need to prompt these users for
-            // a verification code.
-            data.signIn.emailVerified &&
-            !data.signIn.sessionVerified &&
-            !isOAuthWebIntegration(integration)
-          ) {
-            session.sendVerificationCode();
-          }
         }
       }
       if (error) {
@@ -341,7 +327,6 @@ const Signin = ({
       setLocalizedBannerError,
       finishOAuthFlowHandler,
       integration,
-      session,
       location.search,
       webRedirectCheck,
       sensitiveDataClient,


### PR DESCRIPTION
Because:
* We were handling sending this in the front-end, and since VPN uses our account/login endpoint, they were not receiving the session verified email

This commit:
* Removes the front-end checks and adjusts email sending logic to not send the session verification email unless the RP is VPN or wants keys

fixes FXA-12647

---

draft because needs more manual testing + unit test updates

Most testing for this will be for the non-Sync non-2FA unverified session, which you can get into by using a `@mozilla` account locally, and setting `skipForNewAccounts` in auth-server to `false` (create the account, sign out, then try to sign in again). Users in this state should get an emailed code from cached sign-in or sign-in with PW. Sign-ins to RPs in this state should _not_ get the code but if they try to access Settings they'll get kicked to the right page. Users going through Sync (or rather if the request wants keys) should still always be prompted for it.