### PR TITLE
fix(cms): fix CMS button styles in backbone blocked by CSP

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -56,7 +56,7 @@
           </fieldset>
 
         <div class="flex mt-6">
-          <button id="set-needs-mobile" class="cta-primary-cms cta-xl {{buttonTextShadowClass}}" type="button" disabled {{{buttonStyle}}}>{{#t}}Continue{{/t}}</button>
+          <button id="set-needs-mobile" class="cta-primary-cms cta-xl {{buttonTextShadowClass}}" type="button" disabled>{{#t}}Continue{{/t}}</button>
         </div>
       </form>
 
@@ -75,7 +75,7 @@
 
       <form novalidate>
         <div class="flex">
-          <button id="start-pairing" class="cta-primary-cms cta-xl {{buttonTextShadowClass}}" type="submit" {{{buttonStyle}}}>{{#t}}Continue to sync{{/t}}</button>
+          <button id="start-pairing" class="cta-primary-cms cta-xl {{buttonTextShadowClass}}" type="submit">{{#t}}Continue to sync{{/t}}</button>
         </div>
       </form>
       <p class="mt-5 text-sm text-center"><a id="pair-not-now" class="link-blue" href="/settings">{{#t}}Not now{{/t}}</a></p>

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -109,8 +109,6 @@ class PairIndexView extends FormView {
       GleanMetrics.cadFirefox.choiceView();
     }
 
-    // Apply CMS button color
-    let buttonStyle = '';
     // Apply CMS button text shadow if needed
     let buttonTextShadowClass = '';
     if (
@@ -118,7 +116,6 @@ class PairIndexView extends FormView {
       this.cmsConfig.shared &&
       this.cmsConfig.shared.buttonColor
     ) {
-      buttonStyle = `style="--cta-bg: ${this.cmsConfig.shared.buttonColor}; --cta-border: ${this.cmsConfig.shared.buttonColor}; --cta-active: ${this.cmsConfig.shared.buttonColor}; --cta-disabled: ${this.cmsConfig.shared.buttonColor}60;"`;
       if (
         !hasSufficientContrast(
           this.cmsConfig.shared.buttonColor.trim(),
@@ -194,10 +191,26 @@ class PairIndexView extends FormView {
       graphicId,
       needsMobileConfirmed,
       showSuccessMessage: this.showSuccessMessage(),
-      buttonStyle,
       buttonTextShadowClass,
       tabletBackArrowColor,
     });
+  }
+
+  afterRender() {
+    const buttonColor = this.cmsConfig?.shared?.buttonColor;
+    if (buttonColor) {
+      const applyStyle = (el) => {
+        if (!el) return;
+        el.style.setProperty('--cta-bg', buttonColor);
+        el.style.setProperty('--cta-border', buttonColor);
+        el.style.setProperty('--cta-active', buttonColor);
+        el.style.setProperty('--cta-disabled', `${buttonColor}60`);
+      };
+
+      applyStyle(this.el.querySelector('#set-needs-mobile'));
+      applyStyle(this.el.querySelector('#start-pairing'));
+    }
+    return FormView.prototype.afterRender.call(this);
   }
 
   async setNeedsMobile() {


### PR DESCRIPTION
## Because

- CMS button styles in backbone blocked by CSP

## This pull request

- avoids violating CSP by not using string concat for inline styles

## Issue that this pull request solves

Closes: FXA-12115

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
