### PR TITLE
fix(auth): Do not allow account creation with reserved secondary email

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1742,7 +1742,7 @@ const convictConf = convict({
     pendingTtlSeconds: {
       doc: 'TTL in seconds for pending secondary email reservations (Redis)',
       format: 'nat',
-      default: 3600,
+      default: 600,
       env: 'SECONDARY_EMAIL_PENDING_TTL_SECONDS',
     },
   },

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -77,6 +77,7 @@ module.exports = function (
     stripeHelper,
     pushbox,
     glean,
+    authServerCacheRedis,
     statsd
   );
   const oauth = require('./oauth')(

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -60,6 +60,11 @@ function makeRoutes(options = {}) {
   const glean = gleanMetrics(defaultConfig);
   const { accountRoutes } = require('../../lib/routes/account');
 
+  const authServerCacheRedis = {
+    get: async () => null,
+    del: async () => 0,
+  };
+
   return accountRoutes(
     log,
     db,
@@ -76,6 +81,7 @@ function makeRoutes(options = {}) {
     null,
     null,
     glean,
+    authServerCacheRedis,
     mocks.mockStatsd()
   );
 }

--- a/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
+++ b/packages/fxa-settings/src/lib/auth-errors/auth-errors.ts
@@ -168,7 +168,8 @@ const ERRORS = {
   },
   VERIFIED_SECONDARY_EMAIL_EXISTS: {
     errno: 144,
-    message: 'Address in use by another account',
+    message:
+      'This email is reserved by another account. Try again later or use a different email address.',
   },
   RESET_PASSWORD_WITH_SECONDARY_EMAIL: {
     errno: 145,

--- a/packages/fxa-settings/src/lib/auth-errors/en.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en.ftl
@@ -17,6 +17,9 @@ auth-error-125 = The request was blocked for security reasons
 auth-error-129-2 = You entered an invalid phone number. Please check it and try again.
 auth-error-138-2 = Unconfirmed session
 auth-error-139 = Secondary email must be different than your account email
+# (Email) address has been added as a secondary email for another account and cannot be used to register a new account.
+# The reservation may be temporary. If the reservation is not confirmed before the reservation expires (~10 min), the email will become available again.
+auth-error-144 = This email is reserved by another account. Try again later or use a different email address.
 auth-error-155 = TOTP token not found
 # Error shown when the user submits an invalid backup authentication code
 auth-error-156 = Backup authentication code not found


### PR DESCRIPTION
## Because

* Email temporarily reserved as a unconfirmed secondary email should not be available for account creation unless reservation expires

## This pull request

* Adds a reservation check in POST account/status and account/create

## Issue that this pull request solves

Issue: FXA-12548

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To test:

With account A, start adding a secondary email (EMAIL_B) but do not confirm
In a second tab, try to create an account with (EMAIL_B) within 10 minutes of starting the secondary email setup

Expected: 
Account creation is blocked
Account creation becomes possible again after the reservation expires without email confirmation (~10 min)
