### PR TITLE
feat(settings): Add code resend for secondary email add

### DIFF
--- a/packages/functional-tests/pages/settings/secondaryEmail.ts
+++ b/packages/functional-tests/pages/settings/secondaryEmail.ts
@@ -33,7 +33,18 @@ export class SecondaryEmailPage extends SettingsLayout {
   }
 
   get confirmButton() {
-    return this.page.getByRole('button', { name: 'confirm' });
+    return this.page.getByRole('button', { name: /^Confirm/ });
+  }
+
+  get resendConfirmationCodeButton() {
+    return this.page.getByRole('button', {
+      name: 'Resend confirmation code',
+    });
+  }
+
+  async clickResendConfirmationCode() {
+    await expect(this.step2Heading).toBeVisible();
+    await this.resendConfirmationCodeButton.click();
   }
 
   async submit() {

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1995,6 +1995,28 @@ export default class AuthClient {
   }
 
   /**
+   * Resend secondary email verification code using MFA JWT (email scope).
+   * This route supports resending when the email is reserved in Redis but
+   * not yet persisted in the DB.
+   *
+   * @param jwt MFA JWT with scope 'mfa:email'
+   * @param email Secondary email address to resend code to
+   * @param headers Optional extra headers
+   */
+  async recoveryEmailSecondaryResendCodeWithJwt(
+    jwt: string,
+    email: string,
+    headers?: Headers
+  ) {
+    return this.jwtPost(
+      '/mfa/recovery_email/secondary/resend_code',
+      jwt,
+      { email },
+      headers
+    );
+  }
+
+  /**
    * @deprecated Use createTotpTokenWithJwt instead
    *
    * Create a TOTP secret for the account (session-token variant).

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/en.ftl
@@ -1,7 +1,6 @@
 ## Verify secondary email page
 
 add-secondary-email-step-2 = Step 2 of 2
-verify-secondary-email-error-3 = There was a problem sending the confirmation code
 verify-secondary-email-page-title =
   .title = Secondary email
 verify-secondary-email-verification-code-2 =
@@ -16,5 +15,6 @@ verify-secondary-email-please-enter-code-2 = Please enter the confirmation code 
 # Variables:
 #   $email (String) - the user's email address, which does not need translation.
 verify-secondary-email-success-alert-2 = { $email } successfully added
+verify-secondary-email-resend-code-button = Resend confirmation code
 
 ##

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailVerify/index.stories.tsx
@@ -3,11 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { Meta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { PageSecondaryEmailVerify } from '.';
 import { WindowLocation, LocationProvider } from '@reach/router';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
+import { AppContext } from '../../../models/contexts/AppContext';
+import { mockAppContext } from '../../../models/mocks';
 
 export default {
   title: 'Pages/Settings/SecondaryEmailVerify',
@@ -19,10 +21,49 @@ const mockLocation = {
   state: { email: 'johndope@example.com' },
 } as unknown as WindowLocation;
 
-export const Default = () => (
-  <LocationProvider>
-    <SettingsLayout>
-      <PageSecondaryEmailVerify location={mockLocation} />
-    </SettingsLayout>
-  </LocationProvider>
-);
+type Story = StoryObj<typeof PageSecondaryEmailVerify>;
+
+const SuccessAppCtx = mockAppContext({
+  account: {
+    ...mockAppContext().account,
+    loading: false,
+    resendSecondaryEmailCodeWithJwt: async () => Promise.resolve(),
+    verifySecondaryEmail: async () => Promise.resolve(),
+  } as any,
+});
+
+export const ResendSuccess: Story = {
+  render: () => (
+    <LocationProvider>
+      <AppContext.Provider value={SuccessAppCtx}>
+        <SettingsLayout>
+          <PageSecondaryEmailVerify location={mockLocation} />
+        </SettingsLayout>
+      </AppContext.Provider>
+    </LocationProvider>
+  ),
+};
+
+const ErrorAppCtx = mockAppContext({
+  account: {
+    ...mockAppContext().account,
+    loading: false,
+    resendSecondaryEmailCodeWithJwt: async () => {
+      const err: any = { errno: 114, retryAfterLocalized: '5 minutes' };
+      throw err;
+    },
+    verifySecondaryEmail: async () => Promise.resolve(),
+  } as any,
+});
+
+export const ResendError: Story = {
+  render: () => (
+    <LocationProvider>
+      <AppContext.Provider value={ErrorAppCtx}>
+        <SettingsLayout>
+          <PageSecondaryEmailVerify location={mockLocation} />
+        </SettingsLayout>
+      </AppContext.Provider>
+    </LocationProvider>
+  ),
+};

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1238,6 +1238,13 @@ export class Account implements AccountData {
     );
   }
 
+  async resendSecondaryEmailCodeWithJwt(email: string) {
+    const jwt = this.getCachedJwtByScope('email');
+    return this.withLoadingStatus(
+      this.authClient.recoveryEmailSecondaryResendCodeWithJwt(jwt, email)
+    );
+  }
+
   async createTotpWithJwt() {
     const totp = await this.withLoadingStatus(
       this.authClient.createTotpTokenWithJwt(

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -182,7 +182,7 @@ function mockExperiment() {
 }
 
 export function mockAppContext(context?: AppContextValue) {
-  return Object.assign(
+  const base = Object.assign(
     {
       account: MOCK_ACCOUNT,
       session: mockSession(),
@@ -193,6 +193,13 @@ export function mockAppContext(context?: AppContextValue) {
     },
     context
   ) as AppContextValue;
+  // Ensure a sane default for MFA OTP expiry minutes to avoid flakiness in tests
+  try {
+    if (base.config?.mfa?.otp?.expiresInMinutes === 0) {
+      base.config.mfa.otp.expiresInMinutes = 1;
+    }
+  } catch {}
+  return base;
 }
 
 export function mockSettingsContext(context?: SettingsContextValue) {


### PR DESCRIPTION
## Because

* We want to allow a resend option directly on the verification page
* The resend option on settings will no longer be available on the settings page (unconfirmed emails no longer stored in db and there not displayed in settings)
* We want the resend to be authenticated with the email scoped JWT token

## This pull request

* Add button to resend confirmation code in PageSecondaryEmailVerify
* Adds success/error banner for code resend
* Include cool-off to prevent successive clicks, including disabled state
* Add unit tests, l10n, storybook states
* Add mfa-authed secondary email code resend endpoint that relies on redis, not unconfirmed email in db, and returns an error if no valid reservation is found
* Add route unit tests for the new resend endpoint
* Add functional test for resend

## Issue that this pull request solves

Closes: FXA-12649

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a follow-up to moving the secondary email add to Redis reservations.
