### PR TITLE
bug(settings): Fix issue with connected services refresh

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -81,6 +81,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
     null
   );
   const [reason, setReason] = useState<string>('');
+  const [isRefreshingClients, setIsRefreshingClients] = useState(false);
 
   const clearDisconnectingState = useCallback(
     (errorMessage?: string, error?: ApolloError) => {
@@ -192,6 +193,15 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
     hideAdviceModal();
   }, [clearDisconnectingState, hideAdviceModal]);
 
+  const handleRefreshClients = useCallback(async () => {
+    setIsRefreshingClients(true);
+    try {
+      await account.refresh('clients');
+    } finally {
+      setIsRefreshingClients(false);
+    }
+  }, [account]);
+
   return (
     <section
       data-testid="settings-connected-services"
@@ -212,8 +222,8 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
               title="Refresh connected services"
               classNames="hidden mobileLandscape:inline-block"
               testId="connected-services-refresh"
-              disabled={account.loading}
-              onClick={() => account.refresh('clients')}
+              disabled={isRefreshingClients}
+              onClick={handleRefreshClients}
             />
           </Localized>
         </div>


### PR DESCRIPTION
Because:
 - The refresh button for connected services doesn't re-enabled when the request finishes

This commit:
 - Adds a useState to track the refresh status for connected-services, enabling/disabling the button as necessary.
 - Adds tests for the new functionality

Closes: FXA-3454

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
