### PR TITLE
Refactor: Default nimbus.preview to false

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -714,7 +714,7 @@ const conf = (module.exports = convict({
       format: Boolean,
     },
     preview: {
-      default: true,
+      default: false,
       doc: 'Enables preview mode for nimbus experiments for development and testing.',
       env: 'NIMBUS_PREVIEW',
       format: Boolean,


### PR DESCRIPTION
## Because

- Nimbus preview is defaulting to true and shouldn't be.

## This pull request

- Defaults it to false.