### PR TITLE
chore(settings): Stop double capturing error in sentry for oauth

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -668,7 +668,6 @@ describe('Integration serviceName error handling', () => {
       );
     });
 
-    expect(sentryMetrics.captureException).toHaveBeenCalledWith(mockError);
     expect(screen.getByText('Bad Request')).toBeInTheDocument();
     expect(screen.getByText(mockError.message)).toBeInTheDocument();
   });
@@ -705,8 +704,6 @@ describe('Integration serviceName error handling', () => {
       })
     ).rejects.toThrow('Non-OAuth integration error');
 
-    expect(sentryMetrics.captureException).toHaveBeenCalledWith(mockError);
-
     consoleSpy.mockRestore();
   });
 
@@ -736,7 +733,6 @@ describe('Integration serviceName error handling', () => {
       );
     });
 
-    expect(sentryMetrics.captureException).toHaveBeenCalledWith(mockError);
     expect(screen.getByText('Bad Request')).toBeInTheDocument();
     expect(screen.getByText(mockError.message)).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -447,7 +447,6 @@ const AuthAndAccountSetupRoutes = ({
     // error page instead of letting it bubble up to the general error boundary.
     serviceName = integration.getServiceName() as MozServices;
   } catch (err: any) {
-    sentryMetrics.captureException(err);
     if (isOAuthIntegration(integration)) {
       return (
         <Suspense fallback={<LoadingSpinner fullScreen />}>

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -242,11 +242,17 @@ export class OAuthWebIntegration extends GenericIntegration<
       const err = new OAuthError(OAUTH_ERRORS.INVALID_PARAMETER.errno, {
         param: 'scope',
       });
+      // capture error to Sentry, but throw so it can be handled
+      // in app/index. We check the integration type and present
+      // an OAuthDataError component.
       Sentry.captureException(err, {
         tags: { area: 'OAuthWebIntegration.getPermissions' },
         extra: {
           scope: this.data.scope,
           clientId: this.data.clientId,
+          trusted: this.isTrusted(),
+          wantsConsent: this.wantsConsent(),
+          clientInfo: this.clientInfo,
           service: this.data.service,
         },
       });


### PR DESCRIPTION

## Because:
 - We explicitly capture an exception for oauth-web-integrations and send it to Sentry, then throw for the app/index to redner correct component
 - And we capture and send the error to Sentry again

## This Commit:
 - Removes the double Sentry logging
 - Adds some more details to captured exception to track down cause of error

Closes: FXA-12088

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

I'm still not seeing _why_ the error is throwing. In most cases I see in sentry, there is a valid clientId and scopes being captured. My only other guess is that we're somehow not getting full `clientInfo` loaded by the time we get to this check, i.e. the apollo `loading` returns false before we actually have data so on that tick we move on, get to this point, and don't have client data... I checked auth-server and don't see any failed requests to `/client/{clientid}` either, so it's not bad requests there

This will at least stop double capturing the exception in Sentry, and hopefully give us a bit more data to understand what's happening.
