### PR TITLE
task(email-render): Concat en.ftl files into emails.ftl

### DIFF
--- a/libs/accounts/email-renderer/README.md
+++ b/libs/accounts/email-renderer/README.md
@@ -14,6 +14,12 @@ Run `nx test-unit accounts-email-renderer` to execute the unit tests via [Jest](
 
 Run `nx storybook accounts-email-renderer`
 
+## L10N Considerations
+
+Run `nx run accounts-email-renderer:l10n-merge` to take the current state of the en.ftl files in the src directory and apply to them to public/locales/en/auth.ftl. Doing so ensures that the current state of the .ftl files is represented in the `/public/locales/en/emails.ftl` file.
+
+If you are actively working on storybooks, running `nx run accounts-email-renderer:l10n-watch` will keep an eye on the ftl files and aumatically update the `public/locales/en/emails.ftl` file whenever changes are made to `src/**/en.ftl` files. This is useful to ensure the the changes to `en.ftl` files are accurate.
+
 ## Using this library in your service
 
 The install is like most other libs, except there's a good chance you'll have to copy assests from this lib into your build's dist folder.

--- a/libs/accounts/email-renderer/gruntfile.js
+++ b/libs/accounts/email-renderer/gruntfile.js
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ module.exports = function(grunt) {
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+  });
+
+  grunt.config('copy', {
+    'branding-ftl': {
+      nonull: true,
+      src: '../../../libs/shared/l10n/src/lib/branding.ftl',
+      dest: 'public/locales/en/branding.ftl',
+    },
+  });
+
+  grunt.config('concat', {
+    'emails-ftl': {
+      src: [
+        'src/**/en.ftl'
+      ],
+      dest: 'public/locales/en/emails.ftl'
+    }
+  });
+
+  grunt.config('watch', {
+    ftl: {
+      files: [
+        'src/**/en.ftl'
+      ],
+      tasks: ['l10n-merge'],
+      options: {
+        interrupt: true,
+      },
+    },
+  });
+
+  grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-concat');
+
+  grunt.registerTask('l10n-watch', ['watch:ftl']);
+  grunt.registerTask('l10n-merge', ['copy:branding-ftl', 'concat:emails-ftl']);
+ }

--- a/libs/accounts/email-renderer/project.json
+++ b/libs/accounts/email-renderer/project.json
@@ -6,7 +6,7 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "dependsOn": ["build-css", "build-ts"],
+      "dependsOn": ["l10n-merge", "build-css", "build-ts"],
       "executor": "nx:run-commands",
       "options": {
         "commands": [
@@ -77,6 +77,34 @@
           "quiet": true
         }
       }
+    },
+    "l10n-watch": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx grunt --gruntfile libs/accounts/email-renderer/gruntfile.js l10n-watch",
+        "cwd": "."
+      },
+      "inputs": [
+        "{projectRoot}/gruntfile.js",
+        "{projectRoot}/src/**/en.ftl"
+      ],
+      "outputs": [
+        "{projectRoot}/public/en/auth.ftl"
+      ]
+    },
+    "l10n-merge": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "yarn grunt --gruntfile libs/accounts/email-renderer/gruntfile.js l10n-merge",
+        "cwd": "."
+      },
+      "inputs": [
+        "{projectRoot}/gruntfile.js",
+        "{projectRoot}/src/**/en.ftl"
+      ],
+      "outputs": [
+        "{projectRoot}/public/en/auth.ftl"
+      ]
     },
     "l10n-copy": {
       "executor": "nx:run-commands",

--- a/libs/accounts/email-renderer/src/l10n.ts
+++ b/libs/accounts/email-renderer/src/l10n.ts
@@ -140,7 +140,7 @@ class Localizer {
     // English strings within the templates are tested and are shown in other envs
     const authPath = `${this.bindings.opts.translations.basePath}/${
       locale || 'en'
-    }/auth.ftl`;
+    }/emails.ftl`;
     results.push(await this.bindings.fetchResource(authPath));
 
     const brandingPath = `${this.bindings.opts.translations.basePath}/${


### PR DESCRIPTION
## Because

- We want to concatenate `en.ftl` strings into `public/locales/en/emails.ftl`

## This pull request

- Concatenates `en.ftl` string into `public/locales/en/emails.ftl`
- Updates rendering code to use the `emails.ftl` file instead the `auth.ftl`
- Adds nx command `l10n-merge`, which concats strings
- Adds nx command `l10n-watch`, which picks up change and concats strings

## Issue that this pull request solves

Closes: FXA-12597

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To validate this is working as expected, run `nx run accounts-email-renderer:storybook`. In another terminal, run `accounts-email-renderer:l10n-watch`. Navigate to storybook, and pick a template. Then go and make a change to the `en.ftl` for that story. You should see the watch kick in on the terminal. Afterwards, you can refresh the page, and you should see the modification displayed in the ui.

Once this change has landed. We are going to coordinating with the L10N team on how to go about picking up this new emails.ftl. There is currently a draft [PR](https://github.com/mozilla/fxa-content-server-l10n/pull/989) here, that has a proposal. We will also need to write a script to port the legacy strings from auth.ftl to emails.ftl.
