### PR TITLE
fix(login): Send all oauth data in fxaOauthLogin for third party auth

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -268,7 +268,7 @@ describe('Signin utils', () => {
     });
 
     describe('third party auth with non-Sync services', () => {
-      it('sends fxaOAuthLogin with empty values and navigates to settings', async () => {
+      it('sends fxaOAuthLogin and navigates to settings', async () => {
         const fxaOAuthLoginSpy = jest.spyOn(firefox, 'fxaOAuthLogin');
         const navigationOptions = createBaseNavigationOptions({
           integration: createMockSigninOAuthNativeIntegration({
@@ -277,6 +277,7 @@ describe('Signin utils', () => {
           }),
           isSignInWithThirdPartyAuth: true,
           performNavigation: true,
+          handleFxaOAuthLogin: true,
         });
 
         const result = await handleNavigation(navigationOptions);
@@ -284,9 +285,9 @@ describe('Signin utils', () => {
         expect(result.error).toBeUndefined();
         expect(fxaOAuthLoginSpy).toHaveBeenCalledWith({
           action: 'signin',
-          code: '',
-          redirect: '',
-          state: '',
+          code: MOCK_OAUTH_FLOW_HANDLER_RESPONSE.code,
+          redirect: MOCK_OAUTH_FLOW_HANDLER_RESPONSE.redirect,
+          state: MOCK_OAUTH_FLOW_HANDLER_RESPONSE.state,
         });
         expect(navigateSpy).toHaveBeenCalledWith('/settings', {
           replace: true,


### PR DESCRIPTION
Because:
* This was slightly overcomplicated in the original implementation and doesn't need special handling - let the oauth dance happen, and Fx will see the missing key data

This commit:
* Removes some special casing logic

fixes FXA-12672
