### PR TITLE
feat(next): add nimbus preview as query param

### DIFF
--- a/apps/payments/next/.env
+++ b/apps/payments/next/.env
@@ -150,7 +150,6 @@ FEATURE_FLAG_SUB_MANAGE=true
 
 # Nimbus Client
 NIMBUS_CLIENT__API_URL=http://localhost:8001/v2/features/
-NIMBUS_CLIENT__PREVIEW_ENABLED=
 NIMBUS_CLIENT__TIMEOUT_MS=100
 
 # Nimbus Manager

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -57,7 +57,8 @@ export default async function Manage({
   const experiments = await getExperimentsAction({
     fxaUid: userId,
     language: locale,
-  });
+    experimentationPreview: searchParams?.experimentationPreview === 'true',
+  })
 
   const {
     accountCreditBalance,
@@ -117,7 +118,7 @@ export default async function Manage({
               className="font-normal text-blue-500 hover:text-blue-600 cursor-pointer underline"
               href={
                 hasPaymentMethodError.paymentMethodType ===
-                SubPlatPaymentMethodType.PayPal
+                  SubPlatPaymentMethodType.PayPal
                   ? `${config.paymentsNextHostedUrl}/${locale}/subscriptions/payments/paypal`
                   : `${config.paymentsNextHostedUrl}/${locale}/subscriptions/payments/stripe`
               }
@@ -173,46 +174,25 @@ export default async function Manage({
       {(subscriptions.length > 0 ||
         appleIapSubscriptions.length > 0 ||
         googleIapSubscriptions.length > 0) && (
-        <nav
-          className="px-4 tablet:hidden"
-          aria-labelledby="mobile-quick-links-menu"
-        >
-          <h2 id="mobile-quick-links-menu" className="font-bold my-6">
-            {l10n.getString(
-              'subscription-management-jump-to-heading',
-              'Jump to'
-            )}
-          </h2>
-          <ul className="flex flex-col gap-6">
-            <li>
-              <Link
-                className="flex items-center justify-between text-blue-500 hover:text-blue-600 cursor-pointer underline"
-                href="#payment-details"
-              >
-                {l10n.getString(
-                  'subscription-management-nav-payment-details',
-                  'Payment details'
-                )}
-                <Image
-                  src={arrowDownIcon}
-                  alt=""
-                  width={12}
-                  height={12}
-                  aria-hidden="true"
-                />
-              </Link>
-            </li>
-            {(subscriptions.length > 0 ||
-              appleIapSubscriptions.length > 0 ||
-              googleIapSubscriptions.length > 0) && (
+          <nav
+            className="px-4 tablet:hidden"
+            aria-labelledby="mobile-quick-links-menu"
+          >
+            <h2 id="mobile-quick-links-menu" className="font-bold my-6">
+              {l10n.getString(
+                'subscription-management-jump-to-heading',
+                'Jump to'
+              )}
+            </h2>
+            <ul className="flex flex-col gap-6">
               <li>
                 <Link
                   className="flex items-center justify-between text-blue-500 hover:text-blue-600 cursor-pointer underline"
-                  href="#active-subscriptions"
+                  href="#payment-details"
                 >
                   {l10n.getString(
-                    'subscription-management-nav-active-subscriptions',
-                    'Active subscriptions'
+                    'subscription-management-nav-payment-details',
+                    'Payment details'
                   )}
                   <Image
                     src={arrowDownIcon}
@@ -223,10 +203,31 @@ export default async function Manage({
                   />
                 </Link>
               </li>
-            )}
-          </ul>
-        </nav>
-      )}
+              {(subscriptions.length > 0 ||
+                appleIapSubscriptions.length > 0 ||
+                googleIapSubscriptions.length > 0) && (
+                  <li>
+                    <Link
+                      className="flex items-center justify-between text-blue-500 hover:text-blue-600 cursor-pointer underline"
+                      href="#active-subscriptions"
+                    >
+                      {l10n.getString(
+                        'subscription-management-nav-active-subscriptions',
+                        'Active subscriptions'
+                      )}
+                      <Image
+                        src={arrowDownIcon}
+                        alt=""
+                        width={12}
+                        height={12}
+                        aria-hidden="true"
+                      />
+                    </Link>
+                  </li>
+                )}
+            </ul>
+          </nav>
+        )}
 
       <section
         id="payment-details"
@@ -507,126 +508,53 @@ export default async function Manage({
         {(subscriptions.length > 0 ||
           appleIapSubscriptions.length > 0 ||
           googleIapSubscriptions.length > 0) && (
-          <>
-            <ul
-              aria-label={l10n.getString(
-                'subscription-management-your-active-subscriptions-aria',
-                'Your active subscriptions'
-              )}
-            >
-              {subscriptions.map((sub, index: number) => {
-                return (
-                  <li
-                    key={`${sub.productName}-${index}`}
-                    aria-labelledby={`${sub.productName}-information`}
-                    className="leading-6 pb-4"
-                  >
-                    <div className="w-full py-6 text-grey-600 bg-white rounded-xl border border-grey-200 opacity-100 shadow-[0_0_16px_0_rgba(0,0,0,0.08)] tablet:px-6 tablet:py-8">
-                      <div className="flex flex-col px-4 tablet:px-0 tablet:flex-row tablet:items-start">
-                        <div className="tablet:min-w-[160px]">
-                          <Image
-                            src={sub.webIcon}
-                            alt={sub.productName}
-                            height={64}
-                            width={64}
-                          />
-                        </div>
-                        <div className="flex flex-col gap-4 w-full">
-                          <div className="flex items-start justify-between mt-4 tablet:mt-0">
-                            <div>
-                              <h3
-                                id={`${sub.productName}-information`}
-                                className="font-bold text-lg"
-                              >
-                                {sub.productName}
-                              </h3>
-                              <p className="text-grey-500">
-                                {sub.interval &&
-                                  formatPlanInterval(sub.interval)}
-                              </p>
-                            </div>
-                            <LinkExternal
-                              href={sub.supportUrl}
-                              className="text-blue-500 hover:text-blue-600 cursor-pointer overflow-hidden text-ellipsis underline whitespace-nowrap"
-                              aria-label={l10n.getString(
-                                'subscription-management-button-support-aria',
-                                { productName: sub.productName },
-                                `Get help for ${sub.productName}`
-                              )}
-                              data-testid={`link-external-support-${sub.productName}`}
-                            >
-                              <span>
-                                {l10n.getString(
-                                  'subscription-management-button-support',
-                                  'Get help'
-                                )}
-                              </span>
-                            </LinkExternal>
-                          </div>
-                          <SubscriptionContent
-                            userId={userId}
-                            subscription={sub}
-                            locale={locale}
-                            supportUrl={sub.supportUrl}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-
-            {appleIapSubscriptions.length > 0 && (
+            <>
               <ul
                 aria-label={l10n.getString(
-                  'subscription-management-your-apple-iap-subscriptions-aria',
-                  'Your Apple In-App Subscriptions'
+                  'subscription-management-your-active-subscriptions-aria',
+                  'Your active subscriptions'
                 )}
               >
-                {appleIapSubscriptions.map((purchase, index: number) => {
-                  let nextBillDate: string | undefined;
-                  if (purchase.expiresDate) {
-                    const dateExpired = new Date(purchase.expiresDate);
-                    nextBillDate = l10n.getLocalizedDateString(
-                      Math.floor(dateExpired.getTime() / 1000),
-                      false,
-                      locale
-                    );
-                  }
+                {subscriptions.map((sub, index: number) => {
                   return (
                     <li
-                      key={`${purchase.storeId}-${index}`}
-                      aria-labelledby={`${purchase.productName}-heading`}
+                      key={`${sub.productName}-${index}`}
+                      aria-labelledby={`${sub.productName}-information`}
                       className="leading-6 pb-4"
                     >
                       <div className="w-full py-6 text-grey-600 bg-white rounded-xl border border-grey-200 opacity-100 shadow-[0_0_16px_0_rgba(0,0,0,0.08)] tablet:px-6 tablet:py-8">
                         <div className="flex flex-col px-4 tablet:px-0 tablet:flex-row tablet:items-start">
                           <div className="tablet:min-w-[160px]">
                             <Image
-                              src={purchase.webIcon}
-                              alt={purchase.productName}
+                              src={sub.webIcon}
+                              alt={sub.productName}
                               height={64}
                               width={64}
                             />
                           </div>
                           <div className="flex flex-col gap-4 w-full">
                             <div className="flex items-start justify-between mt-4 tablet:mt-0">
-                              <h3
-                                id={`${purchase.productName}-heading`}
-                                className="font-bold text-lg"
-                              >
-                                {purchase.productName}
-                              </h3>
+                              <div>
+                                <h3
+                                  id={`${sub.productName}-information`}
+                                  className="font-bold text-lg"
+                                >
+                                  {sub.productName}
+                                </h3>
+                                <p className="text-grey-500">
+                                  {sub.interval &&
+                                    formatPlanInterval(sub.interval)}
+                                </p>
+                              </div>
                               <LinkExternal
-                                href={purchase.supportUrl}
-                                className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
+                                href={sub.supportUrl}
+                                className="text-blue-500 hover:text-blue-600 cursor-pointer overflow-hidden text-ellipsis underline whitespace-nowrap"
                                 aria-label={l10n.getString(
                                   'subscription-management-button-support-aria',
-                                  { productName: purchase.productName },
-                                  `Get help for ${purchase.productName}`
+                                  { productName: sub.productName },
+                                  `Get help for ${sub.productName}`
                                 )}
-                                data-testid={`link-external-support-${purchase.productName}`}
+                                data-testid={`link-external-support-${sub.productName}`}
                               >
                                 <span>
                                   {l10n.getString(
@@ -636,77 +564,12 @@ export default async function Manage({
                                 </span>
                               </LinkExternal>
                             </div>
-                            <div className="bg-grey-10 leading-6 p-4 rounded-lg">
-                              <div className="flex items-center -my-2 -mx-3">
-                                <Image
-                                  src={iapAppleLogo}
-                                  alt=""
-                                  width={46}
-                                  height={46}
-                                  aria-hidden="true"
-                                />
-                                <p>
-                                  {l10n.getString(
-                                    'subscription-management-apple-in-app-purchase-2',
-                                    'Apple in-app purchase'
-                                  )}
-                                </p>
-                              </div>
-                              {nextBillDate && (
-                                <>
-                                  <div
-                                    className="border-none h-px bg-grey-100 my-2"
-                                    role="separator"
-                                    aria-hidden="true"
-                                  ></div>
-                                  <div className="flex items-center gap-1">
-                                    <Image
-                                      src={alertIcon}
-                                      alt=""
-                                      width={20}
-                                      height={20}
-                                      aria-hidden="true"
-                                    />
-                                    <p className="text-sm text-yellow-800">
-                                      {l10n.getString(
-                                        'subscription-management-iap-sub-expires-on-expiry-date',
-                                        {
-                                          date: nextBillDate,
-                                        },
-                                        `Expires on ${nextBillDate}`
-                                      )}
-                                    </p>
-                                  </div>
-                                </>
-                              )}
-                            </div>
-                            <div className="flex justify-end w-full tablet:w-auto">
-                              <LinkExternal
-                                className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
-                                href={`https://apps.apple.com/account/subscriptions`}
-                                aria-label={l10n.getString(
-                                  'subscription-management-button-manage-subscription-aria',
-                                  {
-                                    productName: purchase.productName,
-                                  },
-                                  `Manage subscription for ${purchase.productName}`
-                                )}
-                              >
-                                <span>
-                                  {l10n.getString(
-                                    'subscription-management-button-manage-subscription-1',
-                                    'Manage subscription'
-                                  )}
-                                </span>
-                                <Image
-                                  src={newWindowIcon}
-                                  alt=""
-                                  width={16}
-                                  height={16}
-                                  aria-hidden="true"
-                                />
-                              </LinkExternal>
-                            </div>
+                            <SubscriptionContent
+                              userId={userId}
+                              subscription={sub}
+                              locale={locale}
+                              supportUrl={sub.supportUrl}
+                            />
                           </div>
                         </div>
                       </div>
@@ -714,98 +577,89 @@ export default async function Manage({
                   );
                 })}
               </ul>
-            )}
 
-            {googleIapSubscriptions.length > 0 && (
-              <ul
-                aria-label={l10n.getString(
-                  'subscription-management-your-google-iap-subscriptions-aria',
-                  'Your Google In-App Subscriptions'
-                )}
-              >
-                {googleIapSubscriptions.map((purchase, index: number) => {
-                  const nextBillDate = l10n.getLocalizedDateString(
-                    purchase.expiryTimeMillis / 1000,
-                    false,
-                    locale
-                  );
-                  return (
-                    <li
-                      key={`${purchase.storeId}-${index}`}
-                      aria-labelledby={`${purchase.productName}-heading`}
-                      className="leading-6 pb-4"
-                    >
-                      <div className="w-full py-6 text-grey-600 bg-white rounded-xl border border-grey-200 opacity-100 shadow-[0_0_16px_0_rgba(0,0,0,0.08)] tablet:px-6 tablet:py-8">
-                        <div className="flex flex-col px-4 tablet:px-0 tablet:flex-row tablet:items-start">
-                          <div className="tablet:min-w-[160px]">
-                            <Image
-                              src={purchase.webIcon}
-                              alt={purchase.productName}
-                              height={64}
-                              width={64}
-                            />
-                          </div>
-                          <div className="flex flex-col gap-4 w-full">
-                            <div className="flex items-start justify-between mt-4 tablet:mt-0">
-                              <h3
-                                id={`${purchase.productName}-heading`}
-                                className="font-bold text-lg"
-                              >
-                                {purchase.productName}
-                              </h3>
-                              <LinkExternal
-                                href={purchase.supportUrl}
-                                className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
-                                aria-label={l10n.getString(
-                                  'subscription-management-button-support-aria',
-                                  { productName: purchase.productName },
-                                  `Get help for ${purchase.productName}`
-                                )}
-                                data-testid={`link-external-support-${purchase.productName}`}
-                              >
-                                <span>
-                                  {l10n.getString(
-                                    'subscription-management-button-support',
-                                    'Get help'
-                                  )}
-                                </span>
-                              </LinkExternal>
+              {appleIapSubscriptions.length > 0 && (
+                <ul
+                  aria-label={l10n.getString(
+                    'subscription-management-your-apple-iap-subscriptions-aria',
+                    'Your Apple In-App Subscriptions'
+                  )}
+                >
+                  {appleIapSubscriptions.map((purchase, index: number) => {
+                    let nextBillDate: string | undefined;
+                    if (purchase.expiresDate) {
+                      const dateExpired = new Date(purchase.expiresDate);
+                      nextBillDate = l10n.getLocalizedDateString(
+                        Math.floor(dateExpired.getTime() / 1000),
+                        false,
+                        locale
+                      );
+                    }
+                    return (
+                      <li
+                        key={`${purchase.storeId}-${index}`}
+                        aria-labelledby={`${purchase.productName}-heading`}
+                        className="leading-6 pb-4"
+                      >
+                        <div className="w-full py-6 text-grey-600 bg-white rounded-xl border border-grey-200 opacity-100 shadow-[0_0_16px_0_rgba(0,0,0,0.08)] tablet:px-6 tablet:py-8">
+                          <div className="flex flex-col px-4 tablet:px-0 tablet:flex-row tablet:items-start">
+                            <div className="tablet:min-w-[160px]">
+                              <Image
+                                src={purchase.webIcon}
+                                alt={purchase.productName}
+                                height={64}
+                                width={64}
+                              />
                             </div>
-                            <div className="bg-grey-10 leading-6 p-4 rounded-lg">
-                              <div className="flex items-center -my-2 -mx-3">
-                                <Image
-                                  src={iapGoogleLogo}
-                                  alt=""
-                                  width={46}
-                                  height={46}
-                                  aria-hidden="true"
-                                />
-                                <p>
-                                  {l10n.getString(
-                                    'subscription-management-google-in-app-purchase-2',
-                                    'Google in-app purchase'
+                            <div className="flex flex-col gap-4 w-full">
+                              <div className="flex items-start justify-between mt-4 tablet:mt-0">
+                                <h3
+                                  id={`${purchase.productName}-heading`}
+                                  className="font-bold text-lg"
+                                >
+                                  {purchase.productName}
+                                </h3>
+                                <LinkExternal
+                                  href={purchase.supportUrl}
+                                  className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
+                                  aria-label={l10n.getString(
+                                    'subscription-management-button-support-aria',
+                                    { productName: purchase.productName },
+                                    `Get help for ${purchase.productName}`
                                   )}
-                                </p>
+                                  data-testid={`link-external-support-${purchase.productName}`}
+                                >
+                                  <span>
+                                    {l10n.getString(
+                                      'subscription-management-button-support',
+                                      'Get help'
+                                    )}
+                                  </span>
+                                </LinkExternal>
                               </div>
-                              {!!purchase.expiryTimeMillis && (
-                                <>
-                                  <div
-                                    className="border-none h-px bg-grey-100 my-2"
-                                    role="separator"
+                              <div className="bg-grey-10 leading-6 p-4 rounded-lg">
+                                <div className="flex items-center -my-2 -mx-3">
+                                  <Image
+                                    src={iapAppleLogo}
+                                    alt=""
+                                    width={46}
+                                    height={46}
                                     aria-hidden="true"
-                                  ></div>
-
-                                  {purchase.autoRenewing ? (
-                                    <p className="text-grey-500 text-sm">
-                                      {l10n.getFragmentWithSource(
-                                        'subscription-management-iap-sub-next-bill-1',
-                                        {
-                                          vars: { date: nextBillDate },
-                                        },
-                                        <p>Next bill &bull; {nextBillDate}</p>
-                                      )}
-                                    </p>
-                                  ) : (
+                                  />
+                                  <p>
+                                    {l10n.getString(
+                                      'subscription-management-apple-in-app-purchase-2',
+                                      'Apple in-app purchase'
+                                    )}
+                                  </p>
+                                </div>
+                                {nextBillDate && (
+                                  <>
+                                    <div
+                                      className="border-none h-px bg-grey-100 my-2"
+                                      role="separator"
+                                      aria-hidden="true"
+                                    ></div>
                                     <div className="flex items-center gap-1">
                                       <Image
                                         src={alertIcon}
@@ -824,49 +678,196 @@ export default async function Manage({
                                         )}
                                       </p>
                                     </div>
-                                  )}
-                                </>
-                              )}
-                            </div>
-                            <div className="flex justify-end w-full tablet:w-auto">
-                              <LinkExternal
-                                className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
-                                href={`https://play.google.com/store/account/subscriptions?sku=${encodeURIComponent(
-                                  purchase.sku
-                                )}&package=${encodeURIComponent(purchase.packageName)}`}
-                                aria-label={l10n.getString(
-                                  'subscription-management-button-manage-subscription-aria',
-                                  {
-                                    productName: purchase.productName,
-                                  },
-                                  `Manage subscription for ${purchase.productName}`
+                                  </>
                                 )}
-                              >
-                                <span>
-                                  {l10n.getString(
-                                    'subscription-management-button-manage-subscription-1',
-                                    'Manage subscription'
+                              </div>
+                              <div className="flex justify-end w-full tablet:w-auto">
+                                <LinkExternal
+                                  className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
+                                  href={`https://apps.apple.com/account/subscriptions`}
+                                  aria-label={l10n.getString(
+                                    'subscription-management-button-manage-subscription-aria',
+                                    {
+                                      productName: purchase.productName,
+                                    },
+                                    `Manage subscription for ${purchase.productName}`
                                   )}
-                                </span>
-                                <Image
-                                  src={newWindowIcon}
-                                  alt=""
-                                  width={16}
-                                  height={16}
-                                  aria-hidden="true"
-                                />
-                              </LinkExternal>
+                                >
+                                  <span>
+                                    {l10n.getString(
+                                      'subscription-management-button-manage-subscription-1',
+                                      'Manage subscription'
+                                    )}
+                                  </span>
+                                  <Image
+                                    src={newWindowIcon}
+                                    alt=""
+                                    width={16}
+                                    height={16}
+                                    aria-hidden="true"
+                                  />
+                                </LinkExternal>
+                              </div>
                             </div>
                           </div>
                         </div>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </>
-        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              {googleIapSubscriptions.length > 0 && (
+                <ul
+                  aria-label={l10n.getString(
+                    'subscription-management-your-google-iap-subscriptions-aria',
+                    'Your Google In-App Subscriptions'
+                  )}
+                >
+                  {googleIapSubscriptions.map((purchase, index: number) => {
+                    const nextBillDate = l10n.getLocalizedDateString(
+                      purchase.expiryTimeMillis / 1000,
+                      false,
+                      locale
+                    );
+                    return (
+                      <li
+                        key={`${purchase.storeId}-${index}`}
+                        aria-labelledby={`${purchase.productName}-heading`}
+                        className="leading-6 pb-4"
+                      >
+                        <div className="w-full py-6 text-grey-600 bg-white rounded-xl border border-grey-200 opacity-100 shadow-[0_0_16px_0_rgba(0,0,0,0.08)] tablet:px-6 tablet:py-8">
+                          <div className="flex flex-col px-4 tablet:px-0 tablet:flex-row tablet:items-start">
+                            <div className="tablet:min-w-[160px]">
+                              <Image
+                                src={purchase.webIcon}
+                                alt={purchase.productName}
+                                height={64}
+                                width={64}
+                              />
+                            </div>
+                            <div className="flex flex-col gap-4 w-full">
+                              <div className="flex items-start justify-between mt-4 tablet:mt-0">
+                                <h3
+                                  id={`${purchase.productName}-heading`}
+                                  className="font-bold text-lg"
+                                >
+                                  {purchase.productName}
+                                </h3>
+                                <LinkExternal
+                                  href={purchase.supportUrl}
+                                  className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
+                                  aria-label={l10n.getString(
+                                    'subscription-management-button-support-aria',
+                                    { productName: purchase.productName },
+                                    `Get help for ${purchase.productName}`
+                                  )}
+                                  data-testid={`link-external-support-${purchase.productName}`}
+                                >
+                                  <span>
+                                    {l10n.getString(
+                                      'subscription-management-button-support',
+                                      'Get help'
+                                    )}
+                                  </span>
+                                </LinkExternal>
+                              </div>
+                              <div className="bg-grey-10 leading-6 p-4 rounded-lg">
+                                <div className="flex items-center -my-2 -mx-3">
+                                  <Image
+                                    src={iapGoogleLogo}
+                                    alt=""
+                                    width={46}
+                                    height={46}
+                                    aria-hidden="true"
+                                  />
+                                  <p>
+                                    {l10n.getString(
+                                      'subscription-management-google-in-app-purchase-2',
+                                      'Google in-app purchase'
+                                    )}
+                                  </p>
+                                </div>
+                                {!!purchase.expiryTimeMillis && (
+                                  <>
+                                    <div
+                                      className="border-none h-px bg-grey-100 my-2"
+                                      role="separator"
+                                      aria-hidden="true"
+                                    ></div>
+
+                                    {purchase.autoRenewing ? (
+                                      <p className="text-grey-500 text-sm">
+                                        {l10n.getFragmentWithSource(
+                                          'subscription-management-iap-sub-next-bill-1',
+                                          {
+                                            vars: { date: nextBillDate },
+                                          },
+                                          <p>Next bill &bull; {nextBillDate}</p>
+                                        )}
+                                      </p>
+                                    ) : (
+                                      <div className="flex items-center gap-1">
+                                        <Image
+                                          src={alertIcon}
+                                          alt=""
+                                          width={20}
+                                          height={20}
+                                          aria-hidden="true"
+                                        />
+                                        <p className="text-sm text-yellow-800">
+                                          {l10n.getString(
+                                            'subscription-management-iap-sub-expires-on-expiry-date',
+                                            {
+                                              date: nextBillDate,
+                                            },
+                                            `Expires on ${nextBillDate}`
+                                          )}
+                                        </p>
+                                      </div>
+                                    )}
+                                  </>
+                                )}
+                              </div>
+                              <div className="flex justify-end w-full tablet:w-auto">
+                                <LinkExternal
+                                  className="text-blue-500 hover:text-blue-600 cursor-pointer flex items-center gap-1 flex-shrink-0 overflow-hidden text-ellipsis underline whitespace-nowrap"
+                                  href={`https://play.google.com/store/account/subscriptions?sku=${encodeURIComponent(
+                                    purchase.sku
+                                  )}&package=${encodeURIComponent(purchase.packageName)}`}
+                                  aria-label={l10n.getString(
+                                    'subscription-management-button-manage-subscription-aria',
+                                    {
+                                      productName: purchase.productName,
+                                    },
+                                    `Manage subscription for ${purchase.productName}`
+                                  )}
+                                >
+                                  <span>
+                                    {l10n.getString(
+                                      'subscription-management-button-manage-subscription-1',
+                                      'Manage subscription'
+                                    )}
+                                  </span>
+                                  <Image
+                                    src={newWindowIcon}
+                                    alt=""
+                                    width={16}
+                                    height={16}
+                                    aria-hidden="true"
+                                  />
+                                </LinkExternal>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </>
+          )}
       </section>
     </div>
   );

--- a/libs/payments/events/src/lib/emitter.service.ts
+++ b/libs/payments/events/src/lib/emitter.service.ts
@@ -95,6 +95,8 @@ export class PaymentsEmitterService {
           nimbusUserId: generatedNimbusUserId,
           language: additionalData.locale,
           region: additionalData.cartMetricsData.taxAddress?.countryCode,
+          preview:
+            eventData?.searchParams?.['experimentationPreview'] === 'true',
         });
       } catch (error) {
         this.log.error(error);

--- a/libs/payments/experiments/src/lib/nimbus.manager.ts
+++ b/libs/payments/experiments/src/lib/nimbus.manager.ts
@@ -19,8 +19,10 @@ export class NimbusManager {
     nimbusUserId,
     language,
     region,
+    preview,
   }: {
     nimbusUserId: string;
+    preview: boolean;
     language?: string;
     region?: string;
   }) {
@@ -28,10 +30,21 @@ export class NimbusManager {
       return null;
     }
 
+    // Temporarily log payload for debugging purposes
+    this.log.log(
+      JSON.stringify({
+        msg: 'NimbusPayload',
+        clientId: nimbusUserId,
+        context: { language: language || null, region: region || null },
+        preview,
+      })
+    );
+
     const results =
       await this.nimbusClient.fetchExperiments<SubPlatNimbusResult>({
         clientId: nimbusUserId,
         context: { language: language || null, region: region || null },
+        preview,
       });
 
     // Temporarily log results for debugging purposes

--- a/libs/payments/ui/src/lib/actions/getExperimentsAction.ts
+++ b/libs/payments/ui/src/lib/actions/getExperimentsAction.ts
@@ -9,6 +9,7 @@ import { getIpAddress } from '../utils/getIpAddress';
 import { headers } from 'next/headers';
 
 export const getExperimentsAction = async (args: {
+  experimentationPreview: boolean;
   language: string;
   fxaUid?: string;
 }) => {

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -194,6 +194,7 @@ export class NextJSActionsService {
   async getExperiments(args: {
     language: string;
     ip: string;
+    experimentationPreview: boolean;
     fxaUid?: string;
     experimentationId?: string;
   }) {
@@ -206,6 +207,7 @@ export class NextJSActionsService {
       nimbusUserId,
       language: args.language,
       region: location?.countryCode,
+      preview: args.experimentationPreview,
     });
 
     if (experiments) {
@@ -234,11 +236,20 @@ export class NextJSActionsService {
   }
 
   @SanitizeExceptions()
-  @NextIOValidator(GetChurnInterventionDataActionArgs, GetChurnInterventionDataActionResult)
+  @NextIOValidator(
+    GetChurnInterventionDataActionArgs,
+    GetChurnInterventionDataActionResult
+  )
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async getChurnInterventionEntryData(args: { customerId: string; churnInterventionId: string }) {
-    const data = await this.churnInterventionManager.getEntry(args.customerId, args.churnInterventionId);
+  async getChurnInterventionEntryData(args: {
+    customerId: string;
+    churnInterventionId: string;
+  }) {
+    const data = await this.churnInterventionManager.getEntry(
+      args.customerId,
+      args.churnInterventionId
+    );
     return data;
   }
 

--- a/libs/payments/ui/src/lib/nestapp/validators/GetExperimentsActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetExperimentsActionArgs.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class GetExperimentsActionArgs {
   @IsString()
@@ -11,11 +11,14 @@ export class GetExperimentsActionArgs {
   @IsString()
   ip!: string;
 
-  @IsString()
-  @IsOptional()
-  experimentationId?: string;
+  @IsBoolean()
+  experimentationPreview!: boolean;
 
   @IsString()
   @IsOptional()
   fxaUid?: string;
+
+  @IsString()
+  @IsOptional()
+  experimentationId?: string;
 }

--- a/libs/shared/experiments/src/lib/nimbus.client.spec.ts
+++ b/libs/shared/experiments/src/lib/nimbus.client.spec.ts
@@ -78,15 +78,16 @@ describe('NimbusClient', () => {
     });
 
     it('successfully calls with preview enabled', async () => {
-      mockNimbusClientConfig.previewEnabled = true;
       const expectedUrl =
         mockNimbusClientConfig.apiUrl + '?nimbus_preview=true';
-      await nimbusClient.fetchExperiments(mockFetchExperimentsParams);
+      await nimbusClient.fetchExperiments({
+        ...mockFetchExperimentsParams,
+        preview: true,
+      });
       expect(fetch).toHaveBeenCalledWith(expectedUrl, expect.anything());
     });
 
     it('successfully calls with preview disabled', async () => {
-      mockNimbusClientConfig.previewEnabled = false;
       const expectedUrl =
         mockNimbusClientConfig.apiUrl + '?nimbus_preview=false';
       await nimbusClient.fetchExperiments(mockFetchExperimentsParams);

--- a/libs/shared/experiments/src/lib/nimbus.client.ts
+++ b/libs/shared/experiments/src/lib/nimbus.client.ts
@@ -25,6 +25,7 @@ export class NimbusClient {
   @CaptureTimingWithStatsD()
   async fetchExperiments<ResultT>(params: {
     clientId: string;
+    preview: boolean;
     context: NimbusContext;
   }) {
     const { clientId, context } = params;
@@ -35,7 +36,7 @@ export class NimbusClient {
     });
 
     const queryParams = new URLSearchParams({
-      nimbus_preview: this.config.previewEnabled === true ? 'true' : 'false',
+      nimbus_preview: params.preview ? 'true' : 'false',
     });
 
     const controller = new AbortController();

--- a/libs/shared/experiments/src/lib/nimbus.config.ts
+++ b/libs/shared/experiments/src/lib/nimbus.config.ts
@@ -4,14 +4,11 @@
 
 import { faker } from '@faker-js/faker';
 import { Provider } from '@nestjs/common';
-import { IsBoolean, IsNumber, IsUrl } from 'class-validator';
+import { IsNumber, IsUrl } from 'class-validator';
 
 export class NimbusClientConfig {
   @IsUrl({ require_tld: false })
   public readonly apiUrl!: string;
-
-  @IsBoolean()
-  public readonly previewEnabled!: boolean;
 
   @IsNumber()
   public readonly timeoutMs!: number;
@@ -19,7 +16,6 @@ export class NimbusClientConfig {
 
 export const MockNimbusClientConfig = {
   apiUrl: faker.internet.url(),
-  previewEnabled: faker.datatype.boolean(),
   timeoutMs: faker.number.int({ min: 100, max: 2000 }),
 } satisfies NimbusClientConfig;
 


### PR DESCRIPTION
## Because

- Nimbus preview should not be enabled via a config variable.

## This pull request

- Removes nimbus preview as a config variable.
- Updates nimbus.client to support preview as an input param
- Adds support for preview via query params

## Issue that this pull request solves

Closes: #PAY-3410

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).