### PR TITLE
feat(signin): show loading spinner in card

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -320,6 +320,7 @@ describe('loading spinner states', () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: jest.fn().mockReturnValueOnce(true),
       isFirefoxClientServiceRelay: jest.fn().mockReturnValueOnce(false),
+      getCmsInfo: jest.fn(),
       data: {
         context: {},
       },
@@ -402,6 +403,7 @@ describe('SettingsRoutes', () => {
       isSync: () => false,
       isFirefoxClientServiceRelay: jest.fn().mockReturnValueOnce(false),
       getServiceName: jest.fn(),
+      getCmsInfo: jest.fn(),
     });
     (useLocalSignedInQueryState as jest.Mock).mockReturnValue({
       data: { isSignedIn: false },
@@ -446,6 +448,7 @@ describe('SettingsRoutes', () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => false,
       isFirefoxClientServiceRelay: () => false,
+      getCmsInfo: jest.fn(),
       data: {
         context: {},
       },
@@ -479,6 +482,7 @@ describe('SettingsRoutes', () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
       isFirefoxClientServiceRelay: () => false,
+      getCmsInfo: jest.fn(),
       data: {
         context: {},
       },
@@ -531,6 +535,7 @@ describe('SettingsRoutes', () => {
     (useIntegration as jest.Mock).mockReturnValue({
       isSync: () => true,
       isFirefoxClientServiceRelay: () => false,
+      getCmsInfo: jest.fn(),
       data: {
         context: {},
       },

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -49,6 +49,7 @@ import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { ScrollToTop } from '../Settings/ScrollToTop';
 import SignupConfirmedSync from '../../pages/Signup/SignupConfirmedSync';
 import useFxAStatus from '../../lib/hooks/useFxAStatus';
+import AppLayout from '../AppLayout';
 
 // Pages
 const IndexContainer = lazy(() => import('../../pages/Index/container'));
@@ -358,13 +359,17 @@ export const App = ({
     isSignedIn === undefined ||
     metricsEnabled === undefined
   ) {
-    return <LoadingSpinner fullScreen />;
+    return window.location.pathname?.includes('/settings') ? (
+      <LoadingSpinner fullScreen />
+    ) : (
+      <AppLayout cmsInfo={integration?.getCmsInfo()} loading />
+    );
   }
 
   // If we're on settings route but user is not signed in, redirect immediately
   if (window.location.pathname?.includes('/settings') && !isSignedIn) {
     navigate('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   return (
@@ -450,7 +455,7 @@ const AuthAndAccountSetupRoutes = ({
     sentryMetrics.captureException(err);
     if (isOAuthIntegration(integration)) {
       return (
-        <Suspense fallback={<LoadingSpinner fullScreen />}>
+        <Suspense fallback={<AppLayout loading />}>
           <OAuthDataError error={err} />
         </Suspense>
       );
@@ -459,7 +464,9 @@ const AuthAndAccountSetupRoutes = ({
   }
 
   return (
-    <Suspense fallback={<LoadingSpinner fullScreen />}>
+    <Suspense
+      fallback={<AppLayout cmsInfo={integration.getCmsInfo()} loading />}
+    >
       <Router>
         {/* Index */}
         <IndexContainer

--- a/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<AppLayout /> snapshots renders correctly with CMS: header logo 1`] = `
 
 exports[`<AppLayout /> snapshots renders correctly with CMS: split layout main 1`] = `
 <main
-  class="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1"
+  class="flex mobileLandscape:items-center flex-1"
 />
 `;
 

--- a/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
@@ -231,3 +231,23 @@ export const WithoutCmsInfo = () => {
     </AppLayout>
   );
 };
+
+export const Loading = () => {
+  return <AppLayout loading>Children</AppLayout>;
+};
+
+export const LoadingWithIntegration = () => {
+  return (
+    <AppLayout cmsInfo={MOCK_CMS_INFO} loading>
+      Children
+    </AppLayout>
+  );
+};
+
+export const LoadingWithSplitLayout = () => {
+  return (
+    <AppLayout cmsInfo={MOCK_CMS_INFO} loading splitLayout>
+      Children
+    </AppLayout>
+  );
+};

--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -290,6 +290,36 @@ describe('<AppLayout />', () => {
     });
   });
 
+  describe('loading functionality', () => {
+    it('shows CardLoadingSpinner when loading is true', () => {
+      renderWithLocalizationProvider(
+        <AppLayout loading={true}>
+          <p>This content should not be visible</p>
+        </AppLayout>
+      );
+
+      // Should show the loading spinner instead of children
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+      expect(
+        screen.queryByText('This content should not be visible')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows children when loading is false (default)', () => {
+      renderWithLocalizationProvider(
+        <AppLayout>
+          <p>This content should be visible</p>
+        </AppLayout>
+      );
+
+      // Should show children instead of loading spinner
+      expect(screen.queryByTestId('loading-spinner')).not.toBeInTheDocument();
+      expect(
+        screen.getByText('This content should be visible')
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('snapshots', () => {
     it('renders correctly with CMS', () => {
       const { container } = renderWithLocalizationProvider(

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -11,6 +11,8 @@ import classNames from 'classnames';
 import { RelierCmsInfo } from '../../models/integrations';
 import { LocaleToggle } from '../LocaleToggle';
 import { useConfig } from '../../models/hooks';
+import { CardLoadingSpinner } from '../CardLoadingSpinner';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
 type AppLayoutProps = {
   // TODO: FXA-6803 - the title prop should be made mandatory
@@ -19,7 +21,7 @@ type AppLayoutProps = {
    * `title` takes precedence over the `cmsInfo.shared.pageTitle` if both are present.
    */
   title?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   widthClass?: string;
   cmsInfo?: RelierCmsInfo;
   /** Whether the content is wrapped in a card.
@@ -30,6 +32,10 @@ type AppLayoutProps = {
   splitLayout?: boolean;
   /** Whether to show the locale toggle in the footer */
   showLocaleToggle?: boolean;
+  /** Whether to show a loading spinner instead of children.
+   * This preserves the background styling while showing a loading state.
+   */
+  loading?: boolean;
 };
 
 export const AppLayout = ({
@@ -39,6 +45,7 @@ export const AppLayout = ({
   cmsInfo,
   splitLayout = false,
   wrapInCard = true,
+  loading = false,
 }: AppLayoutProps) => {
   const { l10n } = useLocalization();
   const config = useConfig();
@@ -114,10 +121,18 @@ export const AppLayout = ({
         </header>
 
         {!splitLayout ? (
-          <main className="mobileLandscape:flex mobileLandscape:items-center mobileLandscape:flex-1">
-            <section>
-              {wrapInCard ? (
-                <div className={classNames('card', widthClass)}>{children}</div>
+          <main className="flex mobileLandscape:items-center flex-1">
+            <section className="relative">
+              {loading ? (
+                <>
+                  <CardLoadingSpinner />
+                </>
+              ) : wrapInCard ? (
+                <>
+                  <div className={classNames('card', widthClass)}>
+                    {children}
+                  </div>
+                </>
               ) : (
                 children
               )}
@@ -147,7 +162,13 @@ export const AppLayout = ({
               }
             />
             <main className="mobileLandscape:items-center tablet:flex-1 tablet:bg-white py-8 px-6 tablet:px-10 mobileLandscape:py-9 tablet:ml-auto flex justify-center flex-1">
-              <section className="max-w-120">{children}</section>
+              <section className="max-w-120">
+                {loading ? (
+                  <LoadingSpinner className="h-full flex items-center" />
+                ) : (
+                  children
+                )}
+              </section>
             </main>
           </div>
         )}

--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.stories.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.stories.tsx
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { CardLoadingSpinner } from './';
+import { SpinnerType } from 'fxa-react/components/LoadingSpinner';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
+
+storiesOf('Components/CardLoadingSpinner', module)
+  .addDecorator((story) => (
+    <AppLocalizationProvider
+      baseDir="./locales"
+      userLocales={navigator.languages}
+    >
+      {story()}
+    </AppLocalizationProvider>
+  ))
+  .add('default', () => (
+    <div className="min-h-screen bg-grey-20 flex items-center justify-center">
+      <CardLoadingSpinner />
+    </div>
+  ))
+  .add('white spinner on dark background', () => (
+    <div className="min-h-screen bg-grey-700 flex items-center justify-center">
+      <CardLoadingSpinner spinnerType={SpinnerType.White} />
+    </div>
+  ))
+  .add('large spinner', () => (
+    <div className="min-h-screen bg-grey-20 flex items-center justify-center">
+      <CardLoadingSpinner spinnerSize="w-16 h-16" />
+    </div>
+  ))
+  .add('with CMS background simulation', () => (
+    <div
+      className="min-h-screen flex items-center justify-center"
+      style={{
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      }}
+    >
+      <CardLoadingSpinner />
+    </div>
+  ));

--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.test.tsx
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { SpinnerType } from 'fxa-react/components/LoadingSpinner';
+import { CardLoadingSpinner } from './';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+
+// Mock the LoadingSpinner component
+jest.mock('fxa-react/components/LoadingSpinner', () => ({
+  __esModule: true,
+  ...jest.requireActual('fxa-react/components/LoadingSpinner'),
+  default: ({ spinnerType, imageClassName }: any) => (
+    <div
+      data-testid="loading-spinner"
+      data-spinner-type={spinnerType}
+      data-image-class={imageClassName}
+    >
+      LoadingSpinner
+    </div>
+  ),
+}));
+
+describe('CardLoadingSpinner', () => {
+  it('renders with default props', () => {
+    renderWithLocalizationProvider(<CardLoadingSpinner />);
+
+    const card = screen.getByTestId('loading-spinner').closest('.card');
+    expect(card).toBeInTheDocument();
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    renderWithLocalizationProvider(
+      <CardLoadingSpinner className="custom-class" />
+    );
+
+    const container = screen.getByTestId('loading-spinner').closest('.card');
+    expect(container).toHaveClass('custom-class');
+  });
+
+  it('renders with white spinner type', () => {
+    renderWithLocalizationProvider(
+      <CardLoadingSpinner spinnerType={SpinnerType.White} />
+    );
+
+    const spinner = screen.getByTestId('loading-spinner');
+    expect(spinner).toHaveAttribute(
+      'data-spinner-type',
+      SpinnerType.White.toString()
+    );
+  });
+
+  it('renders with custom spinner size', () => {
+    renderWithLocalizationProvider(
+      <CardLoadingSpinner spinnerSize="w-16 h-16" />
+    );
+
+    const spinner = screen.getByTestId('loading-spinner');
+    expect(spinner).toHaveAttribute(
+      'data-image-class',
+      'w-16 h-16 animate-spin'
+    );
+  });
+
+  it('has correct default structure', () => {
+    renderWithLocalizationProvider(<CardLoadingSpinner />);
+
+    // Check that the card has the expected classes
+    const card = screen.getByTestId('loading-spinner').closest('.card');
+    expect(card).toHaveClass('flex', 'items-center', 'justify-center');
+  });
+});

--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.tsx
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import LoadingSpinner, {
+  SpinnerType,
+} from 'fxa-react/components/LoadingSpinner';
+import classNames from 'classnames';
+
+export type CardLoadingSpinnerProps = {
+  className?: string;
+  spinnerType?: SpinnerType;
+  spinnerSize?: string;
+};
+
+export const CardLoadingSpinner = ({
+  className,
+  spinnerType = SpinnerType.Blue,
+  spinnerSize = 'w-10 h-10',
+}: CardLoadingSpinnerProps) => {
+  return (
+    <div
+      className={classNames(
+        'card flex items-center justify-center h-full max-w-48 mobileLandscape:h-32',
+        className
+      )}
+    >
+      <LoadingSpinner
+        spinnerType={spinnerType}
+        imageClassName={`${spinnerSize} animate-spin`}
+      />
+    </div>
+  );
+};
+
+export default CardLoadingSpinner;

--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -8,7 +8,7 @@ import * as ReactUtils from 'fxa-react/lib/utils';
 import * as cache from '../../lib/cache';
 
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 import { LocationProvider } from '@reach/router';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
 import { Integration, IntegrationType, WebIntegration } from '../../models';
@@ -62,9 +62,11 @@ jest.mock('../../lib/email-domain-validator', () => ({
   checkEmailDomain: jest.fn(),
 }));
 
-jest.mock('fxa-react/components/LoadingSpinner', () => () => (
-  <div>LoadingSpinner</div>
-));
+jest.mock('fxa-react/components/LoadingSpinner', () => ({
+  __esModule: true,
+  ...jest.requireActual('fxa-react/components/LoadingSpinner'),
+  default: () => <div>LoadingSpinner</div>,
+}));
 
 const mockAuthClient = new AuthClient('http://localhost:9000', {
   keyStretchVersion: 2,
@@ -345,7 +347,7 @@ describe('IndexContainer', () => {
         queryParamModel: { email: 'test@example.com' },
         validationError: null,
       });
-      render(
+      renderWithLocalizationProvider(
         <IndexContainer
           {...{
             integration,
@@ -388,7 +390,7 @@ describe('IndexContainer', () => {
         queryParamModel: { email: 'test@example.com' },
         validationError: null,
       });
-      render(
+      renderWithLocalizationProvider(
         <IndexContainer
           {...{
             integration,
@@ -478,7 +480,7 @@ describe('IndexContainer', () => {
         accountStatusByEmail: jest.fn().mockResolvedValue(mockAccountStatus),
       });
 
-      render(
+      renderWithLocalizationProvider(
         <IndexContainer
           {...{
             integration,
@@ -529,7 +531,7 @@ describe('IndexContainer', () => {
         accountStatusByEmail: jest.fn().mockResolvedValue(mockAccountStatus),
       });
 
-      render(
+      renderWithLocalizationProvider(
         <IndexContainer
           {...{
             integration,
@@ -556,7 +558,7 @@ describe('IndexContainer', () => {
 
     it('should redirect if context is unsupported', async () => {
       mockUnsupportedContextIntegration();
-      render(
+      renderWithLocalizationProvider(
         <IndexContainer
           {...{
             integration,
@@ -592,7 +594,7 @@ describe('IndexContainer', () => {
           'submitSuccess'
         );
 
-        render(
+        renderWithLocalizationProvider(
           <IndexContainer
             {...{
               integration,
@@ -635,7 +637,7 @@ describe('IndexContainer', () => {
           }),
         });
 
-        render(
+        renderWithLocalizationProvider(
           <IndexContainer
             {...{
               integration,
@@ -684,7 +686,7 @@ describe('IndexContainer', () => {
             hasPassword: false,
           }),
         });
-        render(
+        renderWithLocalizationProvider(
           <IndexContainer
             {...{
               integration,
@@ -720,7 +722,7 @@ describe('IndexContainer', () => {
             hasPassword: false,
           }),
         });
-        render(
+        renderWithLocalizationProvider(
           <IndexContainer
             {...{
               integration,
@@ -761,7 +763,7 @@ describe('IndexContainer', () => {
             hasPassword: false,
           }),
         });
-        render(
+        renderWithLocalizationProvider(
           <IndexContainer
             {...{
               integration,
@@ -805,7 +807,7 @@ describe('IndexContainer', () => {
           AuthUiErrors.INVALID_EMAIL_DOMAIN
         );
 
-        render(
+        renderWithLocalizationProvider(
           <IndexContainer
             {...{
               integration,

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -30,8 +30,8 @@ import { getLocalizedEmailValidationErrorMessage } from './errorMessageMapper';
 import { IndexContainerProps, LocationState } from './interfaces';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
 import { hardNavigate } from 'fxa-react/lib/utils';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { isMobileDevice } from '../../lib/utilities';
+import AppLayout from '../../components/AppLayout';
 
 const IndexContainer = ({
   integration,
@@ -277,7 +277,7 @@ const IndexContainer = ({
   // WebAuthn capability probe is fired at app-level (components/App/index.tsx)
 
   return isLoading ? (
-    <LoadingSpinner fullScreen />
+    <AppLayout cmsInfo={integration.getCmsInfo()} loading />
   ) : (
     <Index
       {...{

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -190,6 +190,7 @@ const defaultProps = {
     getClientId: () => MOCK_CLIENT_ID,
     getRedirectWithErrorUrl: (error: AuthUiError) =>
       `https://localhost:8080/?error=${error.errno}`,
+    getCmsInfo: () => undefined,
   } as OAuthIntegration,
   serviceName: MozServices.Default,
 };

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.tsx
@@ -5,12 +5,12 @@
 import { useQuery } from '@apollo/client';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState } from 'react';
 import {
   useFinishOAuthFlowHandler,
   useOAuthKeysCheck,
 } from '../../lib/oauth/hooks';
+import AppLayout from '../../components/AppLayout';
 import { MozServices } from '../../lib/types';
 import {
   Integration,
@@ -248,7 +248,7 @@ export const InlineRecoverySetupContainer = ({
   // Some basic sanity checks
   if (!isSignedIn || !signinRecoveryLocationState?.email || !totp) {
     navigateWithQuery('/signup');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   // we only care about "verified" here, not "exists"
@@ -259,12 +259,13 @@ export const InlineRecoverySetupContainer = ({
     navigateWithQuery('/signin_totp_code', {
       state: signinLocationState,
     });
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   // !recoveryCodes check should happen after checking !totp
+  // TODO: pass in cmsInfo when InlineRecoverySetup supports CMS
   if (totpStatusLoading || loadingAccount) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   if (oAuthDataError) {

--- a/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
+++ b/packages/fxa-settings/src/pages/InlineTotpSetup/container.tsx
@@ -4,10 +4,10 @@
 
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery } from '../../lib/hooks/useNavigateWithQuery';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useCallback, useEffect, useState, useRef } from 'react';
 import InlineTotpSetup from '.';
 import { MozServices, TotpInfo } from '../../lib/types';
+import AppLayout from '../../components/AppLayout';
 import { Integration, useSession, useAuthClient } from '../../models';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { useMutation, useQuery } from '@apollo/client';
@@ -165,7 +165,7 @@ export const InlineTotpSetupContainer = ({
   );
 
   if (!isSignedIn || !signinState) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   if (
@@ -175,7 +175,7 @@ export const InlineTotpSetupContainer = ({
     totp === undefined ||
     sessionVerified === undefined
   ) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Legal/Privacy/index.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Privacy/index.tsx
@@ -6,7 +6,7 @@ import React, { lazy, Suspense } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FetchLegalDoc } from '../../../components/LegalWithMarkdown';
 import { LegalDocFile } from '../../../lib/file-utils-legal';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../../../components/AppLayout';
 
 const LegalWithMarkdown = lazy(
   () => import('../../../components/LegalWithMarkdown')
@@ -24,7 +24,7 @@ const LegalPrivacy = ({
   fetchLegalDoc,
 }: LegalPrivacyProps & RouteComponentProps) => {
   return (
-    <Suspense fallback={<LoadingSpinner fullScreen />}>
+    <Suspense fallback={<AppLayout loading />}>
       <LegalWithMarkdown
         {...{ locale, fetchLegalDoc, viewName }}
         headingTextFtlId="legal-privacy-heading"

--- a/packages/fxa-settings/src/pages/Legal/Terms/index.tsx
+++ b/packages/fxa-settings/src/pages/Legal/Terms/index.tsx
@@ -6,7 +6,7 @@ import React, { lazy, Suspense } from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { FetchLegalDoc } from '../../../components/LegalWithMarkdown';
 import { LegalDocFile } from '../../../lib/file-utils-legal';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../../../components/AppLayout';
 
 const LegalWithMarkdown = lazy(
   () => import('../../../components/LegalWithMarkdown')
@@ -23,7 +23,7 @@ const LegalTerms = ({
   locale,
   fetchLegalDoc,
 }: LegalTermsProps & RouteComponentProps) => (
-  <Suspense fallback={<LoadingSpinner fullScreen />}>
+  <Suspense fallback={<AppLayout loading />}>
     <LegalWithMarkdown
       {...{ locale, fetchLegalDoc, viewName }}
       headingTextFtlId="legal-terms-heading"

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
@@ -7,7 +7,6 @@ import { RouteComponentProps } from '@reach/router';
 import { usePageViewEvent } from '../../../lib/metrics';
 import AppLayout from '../../../components/AppLayout';
 import { REACT_ENTRYPOINT } from '../../../constants';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import Banner from '../../../components/Banner';
 
 // pair/supp is the gateway to the supplicant pairing flow
@@ -24,14 +23,12 @@ export const viewName = 'pair.supp';
 const Supp = ({ error }: SuppProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
-  return (
+  return error ? (
     <AppLayout>
-      {error ? (
-        <Banner type="error" content={{ localizedHeading: error }} />
-      ) : (
-        <LoadingSpinner fullScreen />
-      )}
+      <Banner type="error" content={{ localizedHeading: error }} />
     </AppLayout>
+  ) : (
+    <AppLayout loading />
   );
 };
 

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -5,7 +5,6 @@
 import { RouteComponentProps, useLocation } from '@reach/router';
 import SetPassword from '.';
 import { currentAccount } from '../../../lib/cache';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { Integration, useAuthClient } from '../../../models';
 import { cache } from '../../../lib/cache';
@@ -24,6 +23,7 @@ import GleanMetrics from '../../../lib/glean';
 import { QueryParams } from '../../..';
 import { queryParamsToMetricsContext } from '../../../lib/metrics';
 import type { UseFxAStatusResult } from '../../../lib/hooks/useFxAStatus';
+import AppLayout from '../../../components/AppLayout';
 
 const SetPasswordContainer = ({
   integration,
@@ -178,7 +178,7 @@ const SetPasswordContainer = ({
   // This page is currently always for the Sync flow.
   if (!email || !sessionToken || !uid || !integration.isSync()) {
     navigateWithQuery('/signin', { replace: true });
-    return <LoadingSpinner />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
   if (oAuthDataError) {
     return <OAuthDataError error={oAuthDataError} />;

--- a/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/ResetPasswordRecoveryChoice/container.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import ResetPasswordRecoveryChoice from '.';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import {
   AuthUiErrorNos,
   AuthUiErrors,
@@ -15,6 +14,7 @@ import { CompleteResetPasswordLocationState } from '../CompleteResetPassword/int
 import { getHandledError, HandledError } from '../../../lib/error-utils';
 import { useAuthClient, useFtlMsgResolver } from '../../../models';
 import { formatPhoneNumber } from '../../../lib/recovery-phone-utils';
+import AppLayout from '../../../components/AppLayout';
 
 export const ResetPasswordRecoveryChoiceContainer = (
   _: RouteComponentProps
@@ -223,18 +223,18 @@ export const ResetPasswordRecoveryChoiceContainer = (
   ]);
 
   if (!locationState || !locationState.state.token) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   if (loading) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   if (!phoneData.phoneNumber) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   } else if (!numBackupCodes || numBackupCodes === 0) {
     // Don't do anything here; auto-send is handled in useEffect above
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninBounced/index.tsx
@@ -13,7 +13,6 @@ import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import AppLayout from '../../../components/AppLayout';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import CardHeader from '../../../components/CardHeader';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
 export type SigninBouncedProps = {
   email?: string;
@@ -57,83 +56,81 @@ const SigninBounced = ({
     navigateWithQuery('/signup');
   };
 
+  if (!email) {
+    return <AppLayout loading />;
+  }
+
   return (
     <AppLayout>
-      {email ? (
-        <>
-          <CardHeader
-            headingText="Sorry. We’ve locked your account."
-            headingTextFtlId="signin-bounced-header"
-          />
-          <section>
-            <div className="flex justify-center mx-auto">
-              <EmailBounced className="w-3/5" role="img" />
-            </div>
-            <FtlMsg id="signin-bounced-message" vars={{ email }}>
-              <p className="text-sm mb-6">
-                The confirmation email we sent to {email} was returned and we’ve
-                locked your account to protect your Firefox data.
-              </p>
-            </FtlMsg>
+      <CardHeader
+        headingText="Sorry. We’ve locked your account."
+        headingTextFtlId="signin-bounced-header"
+      />
+      <section>
+        <div className="flex justify-center mx-auto">
+          <EmailBounced className="w-3/5" role="img" />
+        </div>
+        <FtlMsg id="signin-bounced-message" vars={{ email }}>
+          <p className="text-sm mb-6">
+            The confirmation email we sent to {email} was returned and we’ve
+            locked your account to protect your Firefox data.
+          </p>
+        </FtlMsg>
 
-            <FtlMsg
-              id="signin-bounced-help"
-              elems={{
-                linkExternal: (
-                  <button
-                    className="link-blue"
-                    onClick={() => {
-                      logViewEvent(viewName, 'link.support', REACT_ENTRYPOINT);
-                      window.location.replace('https://support.mozilla.org/');
-                    }}
-                  >
-                    let us know
-                  </button>
-                ),
+        <FtlMsg
+          id="signin-bounced-help"
+          elems={{
+            linkExternal: (
+              <button
+                className="link-blue"
+                onClick={() => {
+                  logViewEvent(viewName, 'link.support', REACT_ENTRYPOINT);
+                  window.location.replace('https://support.mozilla.org/');
+                }}
+              >
+                let us know
+              </button>
+            ),
+          }}
+        >
+          <p className="text-sm mb-6 text-grey-400">
+            If this is a valid email address,{' '}
+            <button
+              className="link-blue"
+              onClick={() => {
+                logViewEvent(viewName, 'link.support', REACT_ENTRYPOINT);
+                window.location.replace('https://support.mozilla.org/');
               }}
             >
-              <p className="text-sm mb-6 text-grey-400">
-                If this is a valid email address,{' '}
-                <button
-                  className="link-blue"
-                  onClick={() => {
-                    logViewEvent(viewName, 'link.support', REACT_ENTRYPOINT);
-                    window.location.replace('https://support.mozilla.org/');
-                  }}
-                >
-                  let us know
-                </button>{' '}
-                and we can help unlock your account.
-              </p>
-            </FtlMsg>
+              let us know
+            </button>{' '}
+            and we can help unlock your account.
+          </p>
+        </FtlMsg>
 
-            <div className="flex flex-col link-blue text-sm">
-              <button
-                data-testid="signin-bounced-create-account-btn"
-                id="create-account"
-                className="mb-2 opacity-0 animate-delayed-fade-in"
-                onClick={createAccountHandler}
-              >
-                <FtlMsg id="signin-bounced-create-new-account">
-                  No longer own that email? Create a new account
-                </FtlMsg>
-              </button>
-              {canGoBack && (
-                <button
-                  className="opacity-0 animate-delayed-fade-in"
-                  onClick={handleNavigationBack}
-                  data-testid="signin-bounced-back-btn"
-                  title={backText}
-                >
-                  <FtlMsg id="back">Back</FtlMsg>
-                </button>
-              )}
-            </div>
-          </section>
-        </>
-      ) : (
-        <LoadingSpinner fullScreen />
-      )}
+        <div className="flex flex-col link-blue text-sm">
+          <button
+            data-testid="signin-bounced-create-account-btn"
+            id="create-account"
+            className="mb-2 opacity-0 animate-delayed-fade-in"
+            onClick={createAccountHandler}
+          >
+            <FtlMsg id="signin-bounced-create-new-account">
+              No longer own that email? Create a new account
+            </FtlMsg>
+          </button>
+          {canGoBack && (
+            <button
+              className="opacity-0 animate-delayed-fade-in"
+              onClick={handleNavigationBack}
+              data-testid="signin-bounced-back-btn"
+              title={backText}
+            >
+              <FtlMsg id="back">Back</FtlMsg>
+            </button>
+          )}
+        </div>
+      </section>
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPushCode/container.tsx
@@ -14,7 +14,7 @@ import {
   useSensitiveDataClient,
 } from '../../../models';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../../../components/AppLayout';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useEffect, useState } from 'react';
@@ -73,7 +73,7 @@ export const SigninPushCodeContainer = ({
 
   if (!signinState) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   // redirect if there is 2FA is set up for the account,
@@ -82,7 +82,7 @@ export const SigninPushCodeContainer = ({
     navigateWithQuery('/signin_totp_code', {
       state: signinState,
     });
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   const onCodeVerified = async () => {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.test.tsx
@@ -187,7 +187,13 @@ describe('SigninRecoveryChoice container', () => {
       await waitFor(() => {
         expect(mockAuthClient.getRecoveryCodesExist).toHaveBeenCalled();
         expect(mockAuthClient.recoveryPhoneGet).toHaveBeenCalled();
-        expect(SigninRecoveryChoiceModule.default).not.toHaveBeenCalled();
+        // show loading spinner while navigating
+        expect(SigninRecoveryChoiceModule.default).toHaveBeenCalledWith(
+          expect.objectContaining({
+            loading: true,
+          }),
+          expect.anything()
+        );
         expect(mockNavigate).toHaveBeenCalledWith('/signin_recovery_code', {
           replace: true,
           state: { signinState: mockSigninLocationState },

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/container.tsx
@@ -9,10 +9,10 @@ import { Integration, useAuthClient, useFtlMsgResolver } from '../../../models';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { SigninLocationState } from '../interfaces';
 import { getSigninState } from '../utils';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { formatPhoneNumber } from '../../../lib/recovery-phone-utils';
 import { getHandledError, HandledError } from '../../../lib/error-utils';
+import AppLayout from '../../../components/AppLayout';
 
 export const SigninRecoveryChoiceContainer = ({
   integration,
@@ -217,19 +217,10 @@ export const SigninRecoveryChoiceContainer = ({
   ]);
 
   if (!signinState || !signinState.sessionToken) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
-  if (loading) {
-    return <LoadingSpinner fullScreen />;
-  }
-
-  if (!phoneData.phoneNumber) {
-    return <LoadingSpinner fullScreen />;
-  } else if (!numBackupCodes || numBackupCodes === 0) {
-    // Don't do anything here; auto-send is handled in useEffect above
-    return <LoadingSpinner fullScreen />;
-  }
+  const shouldLoadInCard = loading || !phoneData.phoneNumber || !numBackupCodes;
 
   return (
     <SigninRecoveryChoice
@@ -240,6 +231,7 @@ export const SigninRecoveryChoiceContainer = ({
         numBackupCodes,
         signinState,
         integration,
+        loading: shouldLoadInCard,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryChoice/index.tsx
@@ -34,6 +34,7 @@ export type SigninRecoveryChoiceProps = {
   numBackupCodes: number;
   signinState: SigninLocationState;
   integration?: SigninIntegration;
+  loading?: boolean;
 };
 
 const SigninRecoveryChoice = ({
@@ -43,6 +44,7 @@ const SigninRecoveryChoice = ({
   numBackupCodes,
   signinState,
   integration,
+  loading = false,
 }: SigninRecoveryChoiceProps) => {
   const [errorBannerMessage, setErrorBannerMessage] = React.useState('');
   const [errorBannerDescription, setErrorBannerDescription] =
@@ -140,7 +142,7 @@ const SigninRecoveryChoice = ({
   };
 
   return (
-    <AppLayout cmsInfo={cmsInfo}>
+    <AppLayout cmsInfo={cmsInfo} loading={loading}>
       <div className="relative flex items-center mb-5">
         <ButtonBack
           cmsBackground={cmsInfo?.shared.backgrounds?.defaultLayout}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/index.tsx
@@ -42,6 +42,7 @@ const SigninRecoveryCode = ({
   signinState,
   submitRecoveryCode,
   unwrapBKey,
+  loading = false,
 }: SigninRecoveryCodeProps & RouteComponentProps) => {
   useEffect(() => {
     GleanMetrics.loginBackupCode.view();
@@ -219,7 +220,7 @@ const SigninRecoveryCode = ({
   const cmsInfo = integration.getCmsInfo();
 
   return (
-    <AppLayout cmsInfo={cmsInfo}>
+    <AppLayout cmsInfo={cmsInfo} loading={loading}>
       <div className="relative flex items-center mb-5">
         <ButtonBack
           cmsBackground={cmsInfo?.shared.backgrounds?.defaultLayout}

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/interfaces.ts
@@ -14,6 +14,7 @@ export type SigninRecoveryCodeProps = {
   signinState: SigninLocationState;
   submitRecoveryCode: SubmitRecoveryCode;
   lastFourPhoneDigits?: string;
+  loading?: boolean;
 } & SensitiveData.AuthData;
 
 export type SubmitRecoveryCode = (

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -5,7 +5,7 @@
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import SigninTokenCode from '.';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import AppLayout from '../../../components/AppLayout';
 import {
   Integration,
   useAuthClient,
@@ -98,7 +98,7 @@ const SigninTokenCodeContainer = ({
 
   if (!signinState || !signinState.sessionToken) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   // redirect if there is 2FA is set up for the account,
@@ -107,7 +107,7 @@ const SigninTokenCodeContainer = ({
     navigateWithQuery('/signin_totp_code', {
       state: signinState,
     });
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   if (oAuthDataError) {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -29,7 +29,6 @@ import {
   useFinishOAuthFlowHandler,
   useOAuthKeysCheck,
 } from '../../../lib/oauth/hooks';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import OAuthDataError from '../../../components/OAuthDataError';
 import { getHandledError, HandledError } from '../../../lib/error-utils';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
@@ -44,6 +43,7 @@ import {
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import AppLayout from '../../../components/AppLayout';
 
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
@@ -176,7 +176,7 @@ export const SigninTotpCodeContainer = ({
       signinState.verificationMethod !== VerificationMethods.TOTP_2FA)
   ) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   return (

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -5,8 +5,6 @@
 import { useMutation } from '@apollo/client';
 import { RouteComponentProps, useLocation } from '@reach/router';
 
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
-
 import VerificationMethods from '../../../constants/verification-methods';
 import {
   useAuthClient,
@@ -52,6 +50,7 @@ import { SensitiveData } from '../../../lib/sensitive-data-client';
 import { isFirefoxService } from '../../../models/integrations/utils';
 import { tryFinalizeUpgrade } from '../../../lib/gql-key-stretch-upgrade';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
+import AppLayout from '../../../components/AppLayout';
 
 export const SigninUnblockContainer = ({
   integration,
@@ -229,7 +228,7 @@ export const SigninUnblockContainer = ({
 
   if (!email || !password) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
   return (
     <SigninUnblock

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -89,6 +89,7 @@ function mockSyncDesktopV3Integration() {
     data: { service: 'sync' },
     isDesktopSync: () => true,
     isFirefoxClientServiceRelay: () => false,
+    getCmsInfo: () => undefined,
   } as Integration;
 }
 function mockOAuthWebIntegration(
@@ -103,6 +104,7 @@ function mockOAuthWebIntegration(
     data,
     isDesktopSync: () => false,
     isFirefoxClientServiceRelay: () => false,
+    getCmsInfo: () => undefined,
   } as Integration;
 }
 
@@ -115,6 +117,7 @@ function mockOAuthNativeIntegration() {
     wantsKeys: () => true,
     isDesktopSync: () => true,
     isFirefoxClientServiceRelay: () => false,
+    getCmsInfo: () => undefined,
     data: {
       service: 'sync',
       context: Constants.FX_SYNC_CONTEXT,

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -24,7 +24,6 @@ import {
   OAuthQueryParams,
 } from '../../models/pages/signin';
 import { useCallback, useEffect, useState } from 'react';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import {
   cache,
   currentAccount,
@@ -83,6 +82,7 @@ import {
 } from '../../lib/storage-utils';
 import { cachedSignIn } from './utils';
 import OAuthDataError from '../../components/OAuthDataError';
+import { AppLayout } from '../../components/AppLayout';
 
 /*
  * In Backbone, the `email` param is optional. If it's provided, we
@@ -526,17 +526,17 @@ const SigninContainer = ({
   // For now, just redirect to index-first, until FXA-8289 is done
   if (!email || validationError) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   // Wait for async call (if needed) to complete
   if (hasLinkedAccount === undefined || hasPassword === undefined) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   if (isUnsupportedContext(integration.data.context)) {
     hardNavigate('/update_firefox', {}, true);
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   const deeplink = queryParamModel.deeplink;

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.test.tsx
@@ -110,6 +110,7 @@ function applyMocks() {
   integration = {
     type: ModelsModule.IntegrationType.OAuthWeb,
     wantsKeys: () => false,
+    getCmsInfo: () => undefined,
   } as Integration;
   jest
     .spyOn(ConfirmSignupCodeModule, 'default')
@@ -307,6 +308,7 @@ describe('confirm-signup-container', () => {
       integration = {
         type: ModelsModule.IntegrationType.OAuthNative,
         wantsKeys: () => true,
+        getCmsInfo: () => undefined,
       } as Integration;
       mockSensitiveDataClient.getDataType = jest.fn().mockReturnValue({
         keyFetchToken: undefined,

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -17,7 +17,6 @@ import {
   useSensitiveDataClient,
 } from '../../../models';
 import ConfirmSignupCode from '.';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { GetEmailBounceStatusResponse, LocationState } from './interfaces';
 import { useQuery } from '@apollo/client';
 import { EMAIL_BOUNCE_STATUS_QUERY } from './gql';
@@ -25,6 +24,7 @@ import OAuthDataError from '../../../components/OAuthDataError';
 import { QueryParams } from '../../..';
 import { SensitiveData } from '../../../lib/sensitive-data-client';
 import GleanMetrics from '../../../lib/glean';
+import AppLayout from '../../../components/AppLayout';
 
 export const POLL_INTERVAL = 5000;
 
@@ -125,31 +125,41 @@ const SignupConfirmCodeContainer = ({
   // TODO: This check and related test can be moved up the tree to the App component,
   // where a missing integration should be caught and handled.
   if (!integration) {
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout loading />;
   }
 
   if (!uid || !sessionToken || !email) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   if (oAuthDataError) {
-    return <OAuthDataError error={oAuthDataError} gleanMetric={GleanMetrics.signupConfirmation.error} />;
+    return (
+      <OAuthDataError
+        error={oAuthDataError}
+        gleanMetric={GleanMetrics.signupConfirmation.error}
+      />
+    );
   }
   if (oAuthKeysCheckError) {
     if (!keyFetchToken || !unwrapBKey) {
       const localizedErrorMessage = ftlMsg.getMsg(
         'signin-code-expired-error',
         'Code expired. Please sign in again.'
-      )
+      );
       navigateWithQuery('/signin', {
         state: {
-          localizedErrorMessage
-        }
+          localizedErrorMessage,
+        },
       });
-      return <LoadingSpinner fullScreen />;
+      return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
     }
-    return <OAuthDataError error={oAuthKeysCheckError} gleanMetric={GleanMetrics.signupConfirmation.error}/>;
+    return (
+      <OAuthDataError
+        error={oAuthKeysCheckError}
+        gleanMetric={GleanMetrics.signupConfirmation.error}
+      />
+    );
   }
 
   return (
@@ -166,7 +176,7 @@ const SignupConfirmCodeContainer = ({
         keyFetchToken,
         unwrapBKey,
         flowQueryParams,
-        origin
+        origin,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -47,11 +47,7 @@ import { ApolloClient } from '@apollo/client';
 import { ModelDataProvider } from '../../lib/model-data';
 import AuthClient from 'fxa-auth-client/browser';
 import { LocationProvider } from '@reach/router';
-import {
-  mockLoadingSpinnerModule,
-  MOCK_FLOW_ID,
-  mockGetWebChannelServices,
-} from '../mocks';
+import { MOCK_FLOW_ID, mockGetWebChannelServices } from '../mocks';
 
 // TIP - Sometimes, we want to mock inputs. In this case they can be mocked directly and
 // often times a mocking util isn't even necessary. Note that using the Dependency Inversion
@@ -177,6 +173,12 @@ function mockModelsModule() {
   );
 }
 
+jest.mock('../../components/AppLayout', () => ({
+  __esModule: true,
+  default: ({ children, loading }: any) =>
+    loading ? <div>loading spinner mock</div> : <div>{children}</div>,
+}));
+
 // TIP - Finally, we should create a helper function, so the defacto
 // mock behaviors can be easily applied. Once applied, they can
 // always be overridden as needed.
@@ -195,7 +197,6 @@ function applyMocks() {
   mockFirefoxModule();
   mockCryptoModule();
   mockReachRouterModule();
-  mockLoadingSpinnerModule();
 }
 
 // TIP - Since render looks more or less the same each time, we can tease this out

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -22,7 +22,6 @@ import {
   getCredentialsV2,
   getKeysV2,
 } from 'fxa-auth-client/lib/crypto';
-import { LoadingSpinner } from 'fxa-react/components/LoadingSpinner';
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
 import { KeyStretchExperiment } from '../../models/experiments/key-stretch-experiment';
 import { handleGQLError } from './utils';
@@ -32,6 +31,7 @@ import { QueryParams } from '../..';
 import { isFirefoxService } from '../../models/integrations/utils';
 import { UseFxAStatusResult } from '../../lib/hooks/useFxAStatus';
 import { isMobileDevice } from '../../lib/utilities';
+import AppLayout from '../../components/AppLayout';
 
 /*
  * In content-server, the `email` param is optional. If it's provided, we
@@ -207,7 +207,7 @@ const SignupContainer = ({
 
   if (validationError || !email) {
     navigateWithQuery('/');
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   const deeplink = queryParamModel.deeplink;


### PR DESCRIPTION
## Because

- we want to show the spinner in card to prevent the flashing of the loading screen between auth pages, especially with CMS customized backgrounds

## This pull request

- creates a loading spinner card component and use it in auth flows

## Issue that this pull request solves

Closes: FXA-12344

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Normal layout:
<img width="897" height="814" alt="image" src="https://github.com/user-attachments/assets/e09b5224-f7c1-45c4-a8e7-9a05cb40c935" />

Split Layout:
<img width="903" height="810" alt="image" src="https://github.com/user-attachments/assets/24561718-8a75-4630-9444-74b5bd7caa59" />

Mobile:
<img width="854" height="720" alt="image" src="https://github.com/user-attachments/assets/1e2ae01a-9ef9-4517-bb27-6674a7d476c2" />


## Other information (Optional)

Technically pair routes need this card spinner as well, but I don't think it's worth the effort to replicate this in Backbone
