### PR TITLE
fix(glean): Extra keys from webauthn capabilities were dropped

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -104,11 +104,6 @@ const settingsConfig = {
   glean: { ...config.get('glean'), appDisplayVersion: config.get('version') },
   redirectAllowlist: config.get('redirect_check.allow_list'),
   sendFxAStatusOnSettings: config.get('featureFlags.sendFxAStatusOnSettings'),
-  metrics: {
-    webauthnCapabilitiesSampleRate: config.get(
-      'metrics.webauthnCapabilitiesSampleRate'
-    ),
-  },
   showReactApp: {
     signUpRoutes: config.get('showReactApp.signUpRoutes'),
     signInRoutes: config.get('showReactApp.signInRoutes'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -83,14 +83,6 @@ const conf = (module.exports = convict({
       env: 'DISABLE_CLIENT_METRICS_STDERR',
     },
   },
-  metrics: {
-    webauthnCapabilitiesSampleRate: {
-      default: 0.1,
-      doc: 'Sampling rate (0..1) for WebAuthn capabilities probe in Settings',
-      env: 'WEBAUTHN_CAPABILITIES_SAMPLE_RATE',
-      format: Number,
-    },
-  },
   client_sessions: {
     cookie_name: 'session',
     duration: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -91,11 +91,6 @@ function getIndexRouteDefinition(config) {
     paymentsNextHostedUrl: PAYMENTS_NEXT_HOSTED_URL,
     maxEventOffset: MAX_EVENT_OFFSET,
     env: ENV,
-    metrics: {
-      webauthnCapabilitiesSampleRate: config.get(
-        'metrics.webauthnCapabilitiesSampleRate'
-      ),
-    },
     isCoppaEnabled: COPPA_ENABLED,
     isPromptNoneEnabled: PROMPT_NONE_ENABLED,
     googleAuthConfig: GOOGLE_AUTH_CONFIG,

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -299,16 +299,6 @@ export const App = ({
     );
   }, [metricsEnabled, integration, config.glean, config.version, metricsFlow]);
 
-  // Fire the WebAuthn capability probe once at app level after metrics are initialized.
-  useEffect(() => {
-    if (!metricsEnabled) {
-      return;
-    }
-    maybeRecordWebAuthnCapabilities(
-      config.metrics?.webauthnCapabilitiesSampleRate
-    );
-  }, [metricsEnabled, config.metrics?.webauthnCapabilitiesSampleRate]);
-
   useEffect(() => {
     if (!metricsEnabled) {
       return;
@@ -339,6 +329,7 @@ export const App = ({
   useEffect(() => {
     if (metricsEnabled || isSignedIn === false) {
       sentryMetrics.enable();
+      maybeRecordWebAuthnCapabilities();
     } else {
       sentryMetrics.disable();
     }

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -23,7 +23,6 @@ export interface Config {
       enabled: boolean;
       endpoint: string;
     };
-    webauthnCapabilitiesSampleRate?: number;
   };
   sentry: {
     dsn: string;
@@ -124,7 +123,6 @@ export function getDefault() {
     marketingEmailPreferencesUrl: 'https://basket.mozilla.org/fxa/',
     metrics: {
       navTiming: { enabled: false, endpoint: '/check-your-metrics-config' },
-      webauthnCapabilitiesSampleRate: 0.1,
     },
     mfa: {
       otp: {

--- a/packages/fxa-settings/src/lib/glean/index.test.ts
+++ b/packages/fxa-settings/src/lib/glean/index.test.ts
@@ -28,6 +28,7 @@ import {
 } from 'fxa-shared/metrics/glean/web/session';
 import * as utm from 'fxa-shared/metrics/glean/web/utm';
 import * as entrypointQuery from 'fxa-shared/metrics/glean/web/entrypoint';
+import * as webauthn from 'fxa-shared/metrics/glean/web/webauthn';
 
 import { Config } from '../config';
 import { WebIntegration, useAccount, WebIntegrationData } from '../../models';
@@ -1131,6 +1132,30 @@ describe('lib/glean', () => {
           'delete_account_password_submit'
         );
         sinon.assert.calledOnce(spy);
+      });
+    });
+
+    describe('webauthn', () => {
+      it('stringifies extras to strings before recording', async () => {
+        const spy = sandbox.spy(webauthn.capabilities, 'record');
+        GleanMetrics.setEnabled(true);
+        GleanMetrics.webauthn.capabilities({
+          event: {
+            supported: true,
+            ppa: true,
+            cg: false,
+            error_reason: 'foo',
+            os_family: 'windows',
+          } as any,
+        });
+        await GleanMetrics.isDone();
+        sinon.assert.calledOnce(spy);
+        const arg = spy.getCall(0).args[0]!;
+        expect(arg.supported).toBe('true');
+        expect(arg.ppa).toBe('true');
+        expect(arg.cg).toBe('false');
+        expect(arg.error_reason).toBe('foo');
+        expect(arg.os_family).toBe('windows');
       });
     });
   });

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -659,25 +659,28 @@ const recordEventMetric = (
       break;
     case 'webauthn_capabilities': {
       const e = (gleanPingMetrics as any).event || {};
-      const extras: Record<string, any> = {};
-      if (typeof e['supported'] === 'boolean')
-        extras.supported = e['supported'];
-      if (typeof e['ppa'] === 'boolean') extras.ppa = e['ppa'];
-      if (typeof e['cg'] === 'boolean') extras.cg = e['cg'];
-      if (typeof e['rel'] === 'boolean') extras.rel = e['rel'];
-      if (typeof e['hyb'] === 'boolean') extras.hyb = e['hyb'];
-      if (typeof e['uvpa'] === 'boolean') extras.uvpa = e['uvpa'];
-      if (typeof e['prf'] === 'boolean') extras.prf = e['prf'];
-      if (typeof e['error_reason'] === 'string')
-        extras.error_reason = e['error_reason'];
-      if (typeof e['os_family'] === 'string') extras.os_family = e['os_family'];
-      if (typeof e['os_major'] === 'string') extras.os_major = e['os_major'];
-      if (typeof e['browser_family'] === 'string')
-        extras.browser_family = e['browser_family'];
-      if (typeof e['browser_major'] === 'string')
-        extras.browser_major = e['browser_major'];
-      if (typeof e['cpu_arm'] === 'boolean') extras.cpu_arm = e['cpu_arm'];
-      webauthn.capabilities.record(extras);
+      // Always coerce expected extras to strings to ensure they appear in Looker "Events Extras"
+      const extras: Record<string, string> = {};
+      const allKeys = [
+        'supported',
+        'ppa',
+        'cg',
+        'rel',
+        'hyb',
+        'uvpa',
+        'prf',
+        'error_reason',
+        'os_family',
+        'os_major',
+        'browser_family',
+        'browser_major',
+      ] as const;
+      for (const key of allKeys) {
+        if (e[key] !== undefined) {
+          extras[key] = String(e[key]);
+        }
+      }
+      webauthn.capabilities.record(extras as any);
       break;
     }
   }

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -2991,25 +2991,25 @@ webauthn:
     extra_keys:
       supported:
         description: Whether capability API was available and query succeeded
-        type: boolean
+        type: string
       ppa:
         description: passkeyPlatformAuthenticator support
-        type: boolean
+        type: string
       cg:
         description: conditionalGet support
-        type: boolean
+        type: string
       rel:
         description: relatedOrigins support
-        type: boolean
+        type: string
       hyb:
         description: hybridTransport support
-        type: boolean
+        type: string
       uvpa:
         description: userVerifyingPlatformAuthenticator support
-        type: boolean
+        type: string
       prf:
         description: WebAuthn PRF extension support
-        type: boolean
+        type: string
       error_reason:
         description: Error or fallback reason when supported=false (e.g., no_getClientCapabilities, error)
         type: string
@@ -3026,9 +3026,6 @@ webauthn:
       browser_major:
         description: Browser major version (e.g., '130', '127', '17', or 'other')
         type: string
-      cpu_arm:
-        description: CPU architecture boolean bucket (true if ARM/ARM64, else false)
-        type: boolean
 account_banner:
   create_recovery_key_view:
     type: event

--- a/packages/fxa-shared/metrics/glean/web/webauthn.ts
+++ b/packages/fxa-shared/metrics/glean/web/webauthn.ts
@@ -17,17 +17,16 @@ import EventMetricType from '@mozilla/glean/private/metrics/event';
 export const capabilities = new EventMetricType<{
   browser_family?: string;
   browser_major?: string;
-  cg?: boolean;
-  cpu_arm?: boolean;
+  cg?: string;
   error_reason?: string;
-  hyb?: boolean;
+  hyb?: string;
   os_family?: string;
   os_major?: string;
-  ppa?: boolean;
-  prf?: boolean;
-  rel?: boolean;
-  supported?: boolean;
-  uvpa?: boolean;
+  ppa?: string;
+  prf?: string;
+  rel?: string;
+  supported?: string;
+  uvpa?: string;
 }>(
   {
     category: 'webauthn',
@@ -40,7 +39,6 @@ export const capabilities = new EventMetricType<{
     'browser_family',
     'browser_major',
     'cg',
-    'cpu_arm',
     'error_reason',
     'hyb',
     'os_family',


### PR DESCRIPTION
## Because

Extra keys need to be strings otherwise they are not picked up by Looker

## This pull request

* Ensure extra keys are recorded as strings
* Update the version in local storage
* Some cleanup to simplify
* Remove sampling rate, event will only be emitted 1x/month/device

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
