### PR TITLE
fix(auth): Roll back FXA-12531 changes to accountDevices

### DIFF
--- a/libs/shared/sentry-utils/src/lib/pii/filter-actions.spec.ts
+++ b/libs/shared/sentry-utils/src/lib/pii/filter-actions.spec.ts
@@ -357,9 +357,9 @@ describe('pii-filter-actions', () => {
 
     it('filters token value in db statement', () => {
       const result = CommonPiiActions.tokenValues.execute(
-        `Call accountDevices_18(X'cce22e4006d243c895c7596e2cad53d8',500)`
+        `Call accountDevices_17(X'cce22e4006d243c895c7596e2cad53d8',500)`
       );
-      expect(result.val).toEqual(`Call accountDevices_18(X'${FILTERED}',500)`);
+      expect(result.val).toEqual(`Call accountDevices_17(X'${FILTERED}',500)`);
     });
 
     it('filters token value in db query', () => {

--- a/libs/shared/sentry/src/lib/pii/filter-actions.spec.ts
+++ b/libs/shared/sentry/src/lib/pii/filter-actions.spec.ts
@@ -357,9 +357,9 @@ describe('pii-filter-actions', () => {
 
     it('filters token value in db statement', () => {
       const result = CommonPiiActions.tokenValues.execute(
-        `Call accountDevices_18(X'cce22e4006d243c895c7596e2cad53d8',500)`
+        `Call accountDevices_17(X'cce22e4006d243c895c7596e2cad53d8',500)`
       );
-      expect(result.val).toEqual(`Call accountDevices_18(X'${FILTERED}',500)`);
+      expect(result.val).toEqual(`Call accountDevices_17(X'${FILTERED}',500)`);
     });
 
     it('filters token value in db query', () => {

--- a/packages/fxa-shared/db/models/auth/base-auth.ts
+++ b/packages/fxa-shared/db/models/auth/base-auth.ts
@@ -9,7 +9,7 @@ import { Knex } from 'knex';
 export enum Proc {
   AccountRecord = 'accountRecord_10',
   AccountResetToken = 'accountResetToken_2',
-  AccountDevices = 'accountDevices_18',
+  AccountDevices = 'accountDevices_17',
   ConsumeRecoveryCode = 'consumeRecoveryCode_3',
   ConsumeSigninCode = 'consumeSigninCode_4',
   ConsumeUnblockCode = 'consumeUnblockCode_4',

--- a/packages/fxa-shared/test/sentry/pii-filter-actions.ts
+++ b/packages/fxa-shared/test/sentry/pii-filter-actions.ts
@@ -358,9 +358,9 @@ describe('pii-filter-actions', () => {
 
     it('filters token value in db statement', () => {
       const result = CommonPiiActions.tokenValues.execute(
-        `Call accountDevices_18(X'cce22e4006d243c895c7596e2cad53d8',500)`
+        `Call accountDevices_17(X'cce22e4006d243c895c7596e2cad53d8',500)`
       );
-      expect(result.val).to.equal(`Call accountDevices_18(X'${FILTERED}',500)`);
+      expect(result.val).to.equal(`Call accountDevices_17(X'${FILTERED}',500)`);
     });
 
     it('filters token value in db query', () => {


### PR DESCRIPTION
Because:
 - We saw a spike in cpu wait after latest changes which could be from this
 - And the query on average is slightly slower than prior

This Commit:
 - "Rolls back" the changes to accountDevices stored procedure. However, it does it by rolling forward. We can't revert the commit since it would drop the stored procedure before code is updated and cause errors until code deploys

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
