### PR TITLE
feat(next): populate nimbus_user_id for all pay_setup

### DIFF
--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -48,6 +48,7 @@ export class PaymentsGleanManager {
     commonMetricsData: CommonMetrics;
     cartMetricsData: CartMetrics;
     cmsMetricsData: CmsMetricsData;
+    experimentationData: ExperimentationData;
   }) {
     if (this.isEnabled) {
       this.paymentsGleanServerEventsLogger.recordPaySetupEngage(
@@ -61,6 +62,7 @@ export class PaymentsGleanManager {
       commonMetricsData: CommonMetrics;
       cartMetricsData: CartMetrics;
       cmsMetricsData: CmsMetricsData;
+      experimentationData: ExperimentationData;
     },
     paymentProvider?: PaymentProvidersType
   ) {
@@ -78,6 +80,7 @@ export class PaymentsGleanManager {
       commonMetricsData: CommonMetrics;
       cartMetricsData: CartMetrics;
       cmsMetricsData: CmsMetricsData;
+      experimentationData: ExperimentationData;
     },
     paymentProvider?: SubPlatPaymentMethodType
   ) {
@@ -97,6 +100,7 @@ export class PaymentsGleanManager {
       commonMetricsData: CommonMetrics;
       cartMetricsData: CartMetrics;
       cmsMetricsData: CmsMetricsData;
+      experimentationData: ExperimentationData;
     },
     paymentProvider?: PaymentProvidersType
   ) {


### PR DESCRIPTION
## Because

- `nimbus_user_id` needs to be populated for all pay_setup events.

## This pull request

- Updates emitter and glean manager to populate `nimbus_user_id` for all pay_setup events.

## Issue that this pull request solves

Closes: #PAY-3411

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).