### PR TITLE
feat(sync): Send UID in can_link_account for secondary email sign-in when capability is true

### DIFF
--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -72,6 +72,7 @@ export type FxAStatusResponse = {
     pairing: boolean;
     choose_what_to_sync?: boolean;
     keys_optional?: boolean;
+    can_link_account_uid?: boolean;
   };
   clientId?: string;
   signedInUser?: SignedInUser;
@@ -134,7 +135,11 @@ export type FxAOAuthLogin = {
 // ref: https://searchfox.org/mozilla-central/rev/82828dba9e290914eddd294a0871533875b3a0b5/services/fxaccounts/FxAccountsWebChannel.sys.mjs#230
 export type FxACanLinkAccount = {
   email: string;
+  // To allow secondary email sign-ins, we send the UID up to the browser when
+  // the UID is available and the 'can_link_account_uid' capability is true.
+  uid?: string;
 };
+
 type FxACanLinkAccountResponse = {
   ok: boolean;
 };

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -39,6 +39,8 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   const [declinedSyncEngines, setDeclinedSyncEngines] = useState<string[]>([]);
   const [supportsKeysOptionalLogin, setSupportsKeysOptionalLogin] =
     useState<boolean>(false);
+  const [supportsCanLinkAccountUid, setSupportsCanLinkAccountUid] =
+    useState<boolean>(false);
 
   useEffect(() => {
     // This sends a web channel message to the browser to prompt a response
@@ -75,6 +77,11 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
           setSupportsKeysOptionalLogin(true);
         } else {
           setSupportsKeysOptionalLogin(false);
+        }
+        if (status.capabilities.can_link_account_uid) {
+          setSupportsCanLinkAccountUid(true);
+        } else {
+          setSupportsCanLinkAccountUid(false);
         }
       })();
     }
@@ -138,6 +145,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
     declinedSyncEngines,
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
+    supportsCanLinkAccountUid,
   };
 }
 

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
@@ -7,9 +7,11 @@ import { getSyncEngineIds, syncEngineConfigs } from '../../sync-engines';
 export function mockUseFxAStatus({
   offeredSyncEnginesOverride,
   supportsKeysOptionalLogin = false,
+  supportsCanLinkAccountUid = false,
 }: {
   offeredSyncEnginesOverride?: ReturnType<typeof getSyncEngineIds>;
   supportsKeysOptionalLogin?: boolean;
+  supportsCanLinkAccountUid?: boolean;
 } = {}) {
   const offeredSyncEngineConfigs = syncEngineConfigs;
   const offeredSyncEngines =
@@ -33,6 +35,7 @@ export function mockUseFxAStatus({
     declinedSyncEngines,
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
+    supportsCanLinkAccountUid,
   };
 }
 

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -10,7 +10,7 @@ import { isEmail } from 'class-validator';
 
 import { isEmailMask } from 'fxa-shared/email/helpers';
 
-import firefox from '../../lib/channels/firefox';
+import { firefox } from '../../lib/channels/firefox';
 import { AuthUiError, AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { currentAccount, lastStoredAccount } from '../../lib/cache';
 import { checkEmailDomain } from '../../lib/email-domain-validator';
@@ -20,7 +20,11 @@ import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
 import { ModelValidationErrors } from '../../lib/model-data';
 import { AuthError } from '../../lib/oauth';
 
-import { useAuthClient, useFtlMsgResolver } from '../../models';
+import {
+  isOAuthNativeIntegration,
+  useAuthClient,
+  useFtlMsgResolver,
+} from '../../models';
 import { isOAuthWebIntegration } from '../../models/integrations/oauth-web-integration';
 import { isUnsupportedContext } from '../../models/integrations/utils';
 import { IndexQueryParams } from '../../models/pages/index';
@@ -173,12 +177,32 @@ const IndexContainer = ({
           }
           // DNS lookup for MX record
           await checkEmailDomain(email);
+
+          if (
+            isOAuthNativeIntegration(integration) &&
+            useFxAStatusResult.supportsCanLinkAccountUid
+          ) {
+            // For newer Firefox versions allowing secondary email sign-in.
+            // The merge warning will be unconditionally shown if anyone was previously
+            // logged in to the existing Profile since the account does not exist. The
+            // 'email' we pass will only be used to display the email in the alert.
+            const { ok } = await firefox.fxaCanLinkAccount({
+              email,
+              uid: undefined,
+            });
+            if (!ok) {
+              throw AuthUiErrors.USER_CANCELED_LOGIN;
+            }
+          }
         }
 
+        // For older versions of Fx, send can_link_account with email regardless of
+        // if the account exists or not
         if (
-          integration.isSync() ||
-          integration.isFirefoxClientServiceRelay() ||
-          integration.isFirefoxClientServiceAiMode()
+          (integration.isSync() ||
+            integration.isFirefoxClientServiceRelay() ||
+            integration.isFirefoxClientServiceAiMode()) &&
+          !useFxAStatusResult.supportsCanLinkAccountUid
         ) {
           const { ok } = await firefox.fxaCanLinkAccount({ email });
           if (!ok) {
@@ -210,6 +234,7 @@ const IndexContainer = ({
       handleEmailSubmissionError,
       handleSuccessNavigation,
       integration,
+      useFxAStatusResult.supportsCanLinkAccountUid,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -13,7 +13,10 @@ import {
   isWebIntegration,
   useFtlMsgResolver,
 } from '../../../models';
-import { handleNavigation } from '../../Signin/utils';
+import {
+  handleNavigation,
+  fxaCanLinkAccountAndNavigate,
+} from '../../Signin/utils';
 import { useFinishOAuthFlowHandler } from '../../../lib/oauth/hooks';
 import {
   StoredAccountData,
@@ -28,7 +31,6 @@ import VerificationReasons from '../../../constants/verification-reasons';
 import { currentAccount } from '../../../lib/cache';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
-import firefox from '../../../lib/channels/firefox';
 
 type LinkedAccountData = {
   uid: hexstring;
@@ -84,26 +86,17 @@ const ThirdPartyAuthCallback = ({
     async (linkedAccount: LinkedAccountData, needsVerification = false) => {
       const shouldSendWebChannelMessages =
         integration.isFirefoxClientServiceRelay() ||
-        integration.isFirefoxClientServiceAiMode();
+        integration.isFirefoxClientServiceAiMode() ||
+        integration.isSync();
 
       if (shouldSendWebChannelMessages) {
-        const { ok } = await firefox.fxaCanLinkAccount({
+        const ok = await fxaCanLinkAccountAndNavigate({
           email: linkedAccount.email,
+          uid: linkedAccount.uid,
+          ftlMsgResolver,
+          navigateWithQuery,
         });
         if (!ok) {
-          // User cancelled the login, redirect back to Index with error banner.
-          // Prefill the email with this account to prevent a redirect to '/signin'
-          // so they can see the error and decide what to do.
-          navigateWithQuery('/', {
-            replace: true,
-            state: {
-              localizedErrorFromLocationState: ftlMsgResolver.getMsg(
-                'auth-error-1001',
-                'Login attempt cancelled'
-              ),
-              prefillEmail: linkedAccount.email,
-            },
-          });
           return;
         }
       }

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -84,6 +84,7 @@ const Signin = ({
   const [hasEngaged, setHasEngaged] = useState<boolean>(false);
 
   const isOAuth = isOAuthIntegration(integration);
+  const isOAuthNative = isOAuthNativeIntegration(integration);
   const isFirefoxClientServiceRelay = integration.isFirefoxClientServiceRelay();
   const clientId = integration.getClientId();
   const isMonitorClient = isOAuth && isClientMonitor(clientId);
@@ -124,7 +125,7 @@ const Signin = ({
   // Show for all other cases.
   const hideThirdPartyAuth = integration.isSync()
     ? hasPassword
-    : isOAuthNativeIntegration(integration) && !supportsKeysOptionalLogin;
+    : isOAuthNative && !supportsKeysOptionalLogin;
 
   useEffect(() => {
     if (!isPasswordNeededRef.current) {

--- a/packages/fxa-settings/src/pages/Signup/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.test.tsx
@@ -217,6 +217,7 @@ async function render(text?: string) {
           selectedEnginesForGlean: {},
           declinedSyncEngines: [],
           supportsKeysOptionalLogin: false,
+          supportsCanLinkAccountUid: false,
         }}
         flowQueryParams={{ flowId: MOCK_FLOW_ID }}
       />


### PR DESCRIPTION
Because:
* We want to enable secondary email sign-ins to Sync

This commit:
* Checks for a new capability, can_link_account_uid, and references it to send uid + email at agreed upon times, or to send fxaCanLinkAccount with email (existing functionality) if not present or false

closes FXA-12653

---

See doc linked in the ticket for when to send these.

You can test this by changing `if (status.capabilities.can_link_account_uid) {` in `useFxaStatus` to `if (!status.capabilities.can_link_account_uid) {`. Then, you can see the merge warning at the expected new time. Note that Sync is still working on this on their side and need this piece to test, so sign-in with secondary email doesn't actually _work_ and the same UID but different email will still trigger the warning. This just fires the warning at the new time.

So, e.g. create an account A through the web. Start `yarn firefox` and sign in with a new account B through Sync. Sign out. Try to sign up with a new email C. The merge warning will fire on email-first. Try to sign in with account A. Once you enter the correct password the merge warning will show.