### PR TITLE
feat(admin-server): Audit logging for admin server routes

### DIFF
--- a/packages/fxa-admin-server/src/auth/audit-log.decorator.ts
+++ b/packages/fxa-admin-server/src/auth/audit-log.decorator.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { UseInterceptors } from '@nestjs/common';
+import { AuditLogInterceptor } from './audit-log.interceptor';
+
+/**
+ * Decorator to automatically log admin actions.
+ *
+ * Usage:
+ * @AuditLog()
+ * @Mutation((returns) => Boolean)
+ * public async someAction(@Args('uid') uid: string, @CurrentUser() user: string) {
+ *   // ...
+ * }
+ *
+ * This will automatically log:
+ * - User (admin who performed the action - from request.user set by GqlAuthHeaderGuard)
+ * - Action (function/mutation name)
+ * - Timestamp (ISO string)
+ * - Payload (arguments passed to the mutation, with sensitive data redacted)
+ * - Result status (success/error)
+ *
+ * The interceptor will log:
+ * 1. When the action is initiated (before execution)
+ * 2. When the action completes successfully (with result)
+ * 3. When the action fails (with error details)
+ */
+export const AuditLog = () => UseInterceptors(AuditLogInterceptor);

--- a/packages/fxa-admin-server/src/auth/audit-log.interceptor.spec.ts
+++ b/packages/fxa-admin-server/src/auth/audit-log.interceptor.spec.ts
@@ -1,0 +1,535 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { of, throwError } from 'rxjs';
+import { createMock } from '@golevelup/ts-jest';
+import { AuditLogInterceptor, sanitizeObject } from './audit-log.interceptor';
+import { MozLoggerService } from '@fxa/shared/mozlog';
+import { AppConfig } from '../config';
+import * as Sentry from '@sentry/node';
+
+jest.mock('@nestjs/graphql', () => ({
+  GqlExecutionContext: {
+    create: jest.fn(),
+  },
+}));
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+}));
+
+describe('AuditLogInterceptor', () => {
+  let interceptor: AuditLogInterceptor;
+  let logger: jest.Mocked<MozLoggerService>;
+  let configService: jest.Mocked<ConfigService<AppConfig>>;
+  let mockContext: jest.Mocked<ExecutionContext>;
+  let mockCallHandler: jest.Mocked<CallHandler>;
+  let mockGqlContext: any;
+
+  beforeEach(() => {
+    logger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+    } as any;
+
+    // Default config with standard sanitizeProperties
+    configService = {
+      get: jest.fn().mockReturnValue({
+        auditSanitizeProperties: [
+          'password',
+          'sessionToken',
+          'token',
+          'secret',
+          'key',
+          'auth',
+        ],
+      }),
+    } as any;
+
+    mockGqlContext = {
+      getContext: jest.fn().mockReturnValue({
+        req: {
+          user: 'admin@example.com',
+        },
+      }),
+      getArgs: jest.fn().mockReturnValue({
+        uid: 'test-uid-123',
+        locale: 'en-US',
+      }),
+    };
+
+    (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
+
+    mockContext = createMock<ExecutionContext>();
+    mockContext.getHandler.mockReturnValue({
+      name: 'testMutation',
+    } as any);
+
+    mockCallHandler = createMock<CallHandler>();
+    mockCallHandler.handle.mockReturnValue(of({ success: true }));
+
+    interceptor = new AuditLogInterceptor(logger, configService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    (Sentry.captureException as jest.Mock).mockClear();
+    // Reset config to default
+    configService.get.mockReturnValue({
+      auditSanitizeProperties: [
+        'password',
+        'sessionToken',
+        'token',
+        'secret',
+        'key',
+        'auth',
+      ],
+    });
+  });
+
+  it('should be defined', () => {
+    expect(interceptor).toBeDefined();
+  });
+
+  it('should log initiated status before execution', (done) => {
+    // The initiated log happens synchronously before next.handle() is called
+    // So we can check it was called, and verify it happened before the handler executes
+    const observable = interceptor.intercept(mockContext, mockCallHandler);
+
+    expect(logger.info).toHaveBeenCalledWith('admin-audit', {
+      user: 'admin@example.com',
+      action: 'testMutation',
+      timestamp: expect.any(String),
+      payload: {
+        uid: 'test-uid-123',
+        locale: 'en-US',
+      },
+      status: 'initiated',
+    });
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+
+    // Now, subscribe and verify we have two calls (initiated + success)
+    observable.subscribe({
+      next: () => {
+        expect(logger.info).toHaveBeenCalledTimes(2);
+        done();
+      },
+    });
+  });
+
+  it('should log success status after successful execution', (done) => {
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: () => {
+        const calls = logger.info.mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+
+        const successCall = calls.find((call) => call[1]?.status === 'success');
+        expect(successCall).toBeDefined();
+        expect(successCall?.[1]).toMatchObject({
+          user: 'admin@example.com',
+          action: 'testMutation',
+          status: 'success',
+          result: { success: true },
+        });
+        done();
+      },
+    });
+  });
+
+  it('should log error status when execution fails', (done) => {
+    const testError = new Error('Test error');
+    mockCallHandler.handle.mockReturnValue(throwError(() => testError));
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      error: () => {
+        const errorCall = logger.error.mock.calls[0];
+        expect(errorCall).toBeDefined();
+        expect(errorCall?.[0]).toBe('admin-audit');
+        expect(errorCall?.[1]).toMatchObject({
+          user: 'admin@example.com',
+          action: 'testMutation',
+          status: 'error',
+          error: 'Test error',
+          errorName: 'Error',
+        });
+        done();
+      },
+    });
+  });
+
+  it('should sanitize sensitive data in payload', (done) => {
+    mockGqlContext.getArgs.mockReturnValue({
+      uid: 'test-uid-123',
+      password: 'secret123',
+      token: 'abc123',
+      secretKey: 'my-secret',
+    });
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: () => {
+        const initiatedCall = logger.info.mock.calls.find(
+          (call) => call[1]?.status === 'initiated'
+        );
+        expect(initiatedCall?.[1]?.payload).toEqual({
+          uid: 'test-uid-123',
+          password: '[REDACTED]',
+          token: '[REDACTED]',
+          secretKey: '[REDACTED]',
+        });
+        done();
+      },
+    });
+  });
+
+  it('should handle unknown user when request.user is not set', (done) => {
+    mockGqlContext.getContext.mockReturnValue({
+      req: {},
+    });
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: () => {
+        const initiatedCall = logger.info.mock.calls.find(
+          (call) => call[1]?.status === 'initiated'
+        );
+        expect(initiatedCall?.[1]?.user).toBe('unknown');
+        done();
+      },
+    });
+  });
+
+  it('should handle boolean results correctly', (done) => {
+    mockCallHandler.handle.mockReturnValue(of(true));
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: () => {
+        const successCall = logger.info.mock.calls.find(
+          (call) => call[1]?.status === 'success'
+        );
+        expect(successCall?.[1]?.result).toBe(true);
+        done();
+      },
+    });
+  });
+
+  it('should handle null results correctly', (done) => {
+    mockCallHandler.handle.mockReturnValue(of(null));
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: () => {
+        const successCall = logger.info.mock.calls.find(
+          (call) => call[1]?.status === 'success'
+        );
+        expect(successCall?.[1].result).toBeNull();
+        done();
+      },
+    });
+  });
+
+  it('should handle undefined results correctly', (done) => {
+    mockCallHandler.handle.mockReturnValue(of(undefined));
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: () => {
+        const successCall = logger.info.mock.calls.find(
+          (call) => call[1]?.status === 'success'
+        );
+        expect(successCall?.[1].result).toBeUndefined();
+        done();
+      },
+    });
+  });
+
+  it('should not block the request if logging throws an error', (done) => {
+    const loggingError = new Error('Logging service error');
+    logger.info.mockImplementation(() => {
+      throw loggingError;
+    });
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        // Request should complete successfully despite logging error
+        expect(result).toEqual({ success: true });
+        expect(logger.info).toHaveBeenCalled();
+        // Verify Sentry was called with the logging error
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          loggingError,
+          expect.objectContaining({
+            tags: expect.objectContaining({
+              source: 'AuditLogInterceptor',
+              logType: 'info',
+            }),
+            extra: expect.objectContaining({
+              logData: expect.objectContaining({
+                status: 'initiated',
+              }),
+            }),
+          })
+        );
+        done();
+      },
+      error: () => {
+        done.fail('Request should not fail when logging throws an error');
+      },
+    });
+  });
+
+  it('should not block the request if logging throws an error during success logging', (done) => {
+    // Make logger.info throw an error only on the second call (success logging)
+    let callCount = 0;
+    const loggingError = new Error('Logging service error');
+    logger.info.mockImplementation(() => {
+      callCount++;
+      if (callCount === 2) {
+        throw loggingError;
+      }
+    });
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      next: (result) => {
+        expect(result).toEqual({ success: true });
+        expect(logger.info).toHaveBeenCalledTimes(2);
+        // Verify Sentry was called with the logging error
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          loggingError,
+          expect.objectContaining({
+            tags: expect.objectContaining({
+              source: 'AuditLogInterceptor',
+              logType: 'info',
+            }),
+            extra: expect.objectContaining({
+              logData: expect.objectContaining({
+                status: 'success',
+              }),
+            }),
+          })
+        );
+        done();
+      },
+      error: () => {
+        done.fail('Request should not fail when logging throws an error');
+      },
+    });
+  });
+
+  it('should not block the request if logging throws an error during error logging', (done) => {
+    const testError = new Error('Test handler error');
+    mockCallHandler.handle.mockReturnValue(throwError(() => testError));
+
+    const loggingError = new Error('Logging service error');
+    logger.error.mockImplementation(() => {
+      throw loggingError;
+    });
+
+    interceptor.intercept(mockContext, mockCallHandler).subscribe({
+      error: (error) => {
+        // Original error should propagate, not the logging error
+        expect(error).toBe(testError);
+        expect(logger.error).toHaveBeenCalled();
+        // Verify Sentry was called with the logging error (not the handler error)
+        expect(Sentry.captureException).toHaveBeenCalledWith(
+          loggingError,
+          expect.objectContaining({
+            tags: expect.objectContaining({
+              source: 'AuditLogInterceptor',
+              logType: 'error',
+            }),
+            extra: expect.objectContaining({
+              logData: expect.objectContaining({
+                status: 'error',
+              }),
+            }),
+          })
+        );
+        done();
+      },
+    });
+  });
+
+  describe('config-based sanitization', () => {
+    it('should use custom sanitizeProperties from config', (done) => {
+      configService.get.mockReturnValue({
+        auditSanitizeProperties: ['jedi', 'password', 'token'],
+      });
+
+      const customInterceptor = new AuditLogInterceptor(logger, configService);
+
+      mockGqlContext.getArgs.mockReturnValue({
+        uid: 'test-uid-123',
+        password: 'secret123',
+        jedi: 'luke-skywalker',
+        token: 'abc123',
+        email: 'test@example.com', // Should not be redacted, it's not in the config mock above
+      });
+
+      customInterceptor.intercept(mockContext, mockCallHandler).subscribe({
+        next: () => {
+          const initiatedCall = logger.info.mock.calls.find(
+            (call) => call[1]?.status === 'initiated'
+          );
+          expect(initiatedCall?.[1]?.payload).toEqual({
+            uid: 'test-uid-123',
+            password: '[REDACTED]',
+            jedi: '[REDACTED]', // Custom property should be redacted
+            token: '[REDACTED]',
+            email: 'test@example.com', // Should remain unchanged
+          });
+          done();
+        },
+      });
+    });
+  });
+});
+
+describe('sanitizePayload', () => {
+  const sensitiveKeys = ['password', 'sessionToken', 'secret'];
+
+  it('should return object unchanged if it is not an object', () => {
+    const payload = 'test-string';
+    const sanitized = sanitizeObject(payload, sensitiveKeys);
+    expect(sanitized).toBe(payload); // .toBe to ensure we get back the same object reference
+  });
+
+  it('should return object unchanged if it is null or undefined', () => {
+    const payload = null;
+    const sanitized = sanitizeObject(payload, sensitiveKeys);
+    expect(sanitized).toBe(payload);
+  });
+
+  it('should return matching object if no sensitive keys are found', () => {
+    const payload = {
+      uid: 'test-uid-123',
+      password: 'secret123',
+      token: 'abc123',
+      secretKey: 'my-secret',
+    };
+    const sanitized = sanitizeObject(payload, ['not-a-sensitive-key']);
+    expect(sanitized).toEqual(payload);
+  });
+
+  it('should return object unchanged if sensitiveKeys is an empty array', () => {
+    const payload = {
+      uid: 'test-uid-123',
+      password: 'secret123',
+      token: 'abc123',
+      secretKey: 'my-secret',
+    };
+    const sanitized = sanitizeObject(payload, []);
+    expect(sanitized).toBe(payload);
+  });
+  it('should sanitize sensitive data in payload', () => {
+    const payload = {
+      uid: 'test-uid-123',
+      password: 'secret123',
+      token: 'abc123',
+      secretKey: 'my-secret',
+    };
+    const sanitized = sanitizeObject(payload, sensitiveKeys);
+    expect(sanitized).toEqual({
+      uid: 'test-uid-123',
+      password: '[REDACTED]',
+      token: 'abc123', // not in sensitive keys, should not be redacted
+      secretKey: '[REDACTED]',
+    });
+  });
+
+  it('should sanitize nested objects', () => {
+    const payload = {
+      uid: 'test-uid-123',
+      nested: {
+        password: 'secret123',
+        token: 'abc123',
+        secretKey: 'my-secret',
+      },
+      password: 'secret123',
+      token: 'abc123',
+      secretKey: 'my-secret',
+    };
+    const sanitized = sanitizeObject(payload, sensitiveKeys);
+    expect(sanitized).toEqual({
+      uid: 'test-uid-123',
+      nested: {
+        password: '[REDACTED]',
+        token: 'abc123', // not in sensitive keys, should not be redacted
+        secretKey: '[REDACTED]',
+      },
+      password: '[REDACTED]',
+      token: 'abc123', // not in sensitive keys, should not be redacted
+      secretKey: '[REDACTED]',
+    });
+  });
+  it('should sanitize array of objects', () => {
+    const payload = [
+      {
+        uid: 'test-uid-123',
+        password: 'secret123',
+        token: 'abc123',
+        secretKey: 'my-secret',
+      },
+    ];
+    const sanitized = sanitizeObject(payload, sensitiveKeys);
+    expect(sanitized).toEqual([
+      {
+        uid: 'test-uid-123',
+        password: '[REDACTED]',
+        token: 'abc123', // not in sensitive keys, should not be redacted
+        secretKey: '[REDACTED]',
+      },
+    ]);
+  });
+  it('should sanitize a nested array of objects with nested objects', () => {
+    const payload = {
+      uid: 'test-uid-123',
+      nestedArray: [
+        {
+          password: 'secret123',
+          token: 'abc123',
+          secretKey: 'my-secret',
+          nestedObject: {
+            password: 'secret123',
+            token: 'abc123',
+            secretKey: 'my-secret',
+          },
+        },
+      ],
+    };
+    const sanitized = sanitizeObject(payload, sensitiveKeys);
+    expect(sanitized).toEqual({
+      uid: 'test-uid-123',
+      nestedArray: [
+        {
+          password: '[REDACTED]',
+          token: 'abc123', // not in sensitive keys, should not be redacted
+          secretKey: '[REDACTED]',
+          nestedObject: {
+            password: '[REDACTED]',
+            token: 'abc123', // not in sensitive keys, should not be redacted
+            secretKey: '[REDACTED]',
+          },
+        },
+      ],
+    });
+  });
+
+  it('should sanitize keys regardless of case', () => {
+    const payload = {
+      uid: 'test-uid-123',
+      password: 'secret123',
+      token: 'abc123',
+      secretKey: 'my-secret',
+    };
+    const sanitized = sanitizeObject(payload, ['Password']);
+    expect(sanitized).toEqual({
+      uid: 'test-uid-123',
+      password: '[REDACTED]', // should be redacted because of case insensitive match
+      token: 'abc123',
+      secretKey: 'my-secret',
+    });
+  });
+});

--- a/packages/fxa-admin-server/src/auth/audit-log.interceptor.ts
+++ b/packages/fxa-admin-server/src/auth/audit-log.interceptor.ts
@@ -1,0 +1,143 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { Request } from 'express';
+import * as Sentry from '@sentry/node';
+import { MozLoggerService } from '@fxa/shared/mozlog';
+import { AppConfig } from '../config';
+
+/**
+ * Interceptor that automatically logs admin actions with:
+ * - User (admin who performed the action)
+ * - Action (function/mutation name)
+ * - Date (timestamp)
+ * - Payload (arguments passed to the mutation)
+ */
+@Injectable()
+export class AuditLogInterceptor implements NestInterceptor {
+  private readonly logType = 'admin-audit';
+  private readonly sensitiveKeys: string[];
+
+  constructor(
+    private readonly log: MozLoggerService,
+    private readonly configService: ConfigService<AppConfig>
+  ) {
+    const logConfig = this.configService.get('log') as AppConfig['log'];
+    this.sensitiveKeys = logConfig.auditSanitizeProperties;
+  }
+
+  private safeLogInfo(data: Record<string, any>): void {
+    this.safeLog('info', data);
+  }
+
+  private safeLogError(data: Record<string, any>): void {
+    this.safeLog('error', data);
+  }
+
+  private safeLog(
+    logType: 'info' | 'error' | 'debug' | 'warn' | 'trace',
+    data: Record<string, any>
+  ): void {
+    try {
+      this.log[logType](this.logType, data);
+    } catch (error) {
+      Sentry.captureException(error, {
+        tags: { source: 'AuditLogInterceptor', logType },
+        extra: { logData: data },
+      });
+    }
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const gqlContext = GqlExecutionContext.create(context);
+    const gqlContextValue = gqlContext.getContext();
+    const request = gqlContextValue.req as Request;
+    const handler = context.getHandler();
+    const args = gqlContext.getArgs();
+
+    const user = (request as any).user || 'unknown';
+    const actionName = handler.name;
+    const timestamp = new Date().toISOString();
+    const payload = sanitizeObject(args, this.sensitiveKeys);
+
+    const baseLogData = (status: 'initiated' | 'success' | 'error') => ({
+      user,
+      action: actionName,
+      timestamp,
+      payload,
+      status,
+    });
+
+    // Log before execution - don't let logging errors block the request
+    this.safeLogInfo({
+      ...baseLogData('initiated'),
+    });
+
+    return next.handle().pipe(
+      tap({
+        next: (result) => {
+          this.safeLogInfo({
+            ...baseLogData('success'),
+            result, // we could sanitize this, but there shouldn't be any sensitive data in the result
+          });
+        },
+        error: (error) => {
+          this.safeLogError({
+            ...baseLogData('error'),
+            error: error.message,
+            errorName: error.name,
+          });
+        },
+      })
+    );
+  }
+}
+
+/**
+ * Redacts sensitive data from an object, recursively.
+ *
+ * Fields remain, but values are replaced with '[REDACTED]'.
+ */
+export function sanitizeObject(
+  args: any,
+  sensitiveKeys: string[]
+): Record<string, any> {
+  if (sensitiveKeys.length === 0 || !args) {
+    return args;
+  }
+  if (typeof args !== 'object') {
+    return args;
+  }
+  // check if args is an array of objects, then sanitize each object
+  if (Array.isArray(args)) {
+    return args.map((item) => sanitizeObject(item, sensitiveKeys));
+  }
+
+  const sanitized = { ...args };
+
+  for (const key in sanitized) {
+    if (typeof sanitized[key] === 'object') {
+      // recursive into nested objects
+      sanitized[key] = sanitizeObject(sanitized[key], sensitiveKeys);
+      continue;
+    }
+    if (
+      sensitiveKeys.some((sk) => key.toLowerCase().includes(sk.toLowerCase()))
+    ) {
+      sanitized[key] = '[REDACTED]';
+    }
+  }
+
+  return sanitized;
+}

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -115,6 +115,12 @@ const conf = convict({
       default: 'info',
       env: 'LOG_LEVEL',
     },
+    auditSanitizeProperties: {
+      default: ['password', 'sessionToken', 'token', 'secret', 'key', 'auth'],
+      doc: 'Properties to sanitize in the audit log',
+      env: 'LOGGING_AUDIT_SANITIZE_PROPERTIES',
+      format: Array,
+    },
   },
   port: {
     default: 8095,

--- a/packages/fxa-admin-server/src/gql/account/account.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/account/account.resolver.ts
@@ -37,6 +37,7 @@ import { ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 import { CurrentUser } from '../../auth/auth-header.decorator';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
 import { Features } from '../../auth/user-group-header.decorator';
+import { AuditLog } from '../../auth/audit-log.decorator';
 import { EmailService } from '../../backend/email.service';
 import {
   CloudTasks,
@@ -240,6 +241,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.Remove2FA)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async remove2FA(@Args('uid') uid: string) {
     this.eventLogging.onEvent(EventNames.Remove2FA);
@@ -281,6 +283,7 @@ export class AccountResolver {
 
   // unverifies the user's email. will have to verify again on next login
   @Features(AdminPanelFeature.UnverifyEmail)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async unverifyEmail(@Args('email') email: string) {
     this.eventLogging.onEvent(EventNames.UnverifyEmail);
@@ -295,6 +298,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.DisableAccount)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async disableAccount(@Args('uid') uid: string) {
     this.eventLogging.onEvent(EventNames.DisableLogin);
@@ -315,6 +319,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.EditLocale)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async editLocale(
     @Args('uid') uid: string,
@@ -340,6 +345,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.DeleteRecoveryPhone)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async deleteRecoveryPhone(@Args('uid') uid: string): Promise<Boolean> {
     this.eventLogging.onEvent(EventNames.DeleteRecoveryPhone);
@@ -363,6 +369,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.EnableAccount)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async enableAccount(@Args('uid') uid: string) {
     const uidBuffer = uuidTransformer.to(uid);
@@ -593,6 +600,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.UnlinkAccount)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async unlinkAccount(
     @Args('uid') uid: string,
@@ -609,6 +617,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.UnsubscribeFromMailingLists)
+  @AuditLog()
   @Mutation((returns) => Boolean)
   public async unsubscribeFromMailingLists(@Args('uid') uid: string) {
     // Look up email. This end point is protected, but using a uid would makes it harder
@@ -681,6 +690,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.DeleteAccount)
+  @AuditLog()
   @Mutation((returns) => [AccountDeleteResponse])
   public async deleteAccounts(
     @Args('locators', { type: () => [String] }) locators: string[],
@@ -766,6 +776,7 @@ export class AccountResolver {
   }
 
   @Features(AdminPanelFeature.AccountReset)
+  @AuditLog()
   @Mutation((returns) => [AccountResetResponse])
   public async resetAccounts(
     @Args('locators', { type: () => [String] }) locators: string[],

--- a/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.spec.ts
+++ b/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.spec.ts
@@ -8,6 +8,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MozLoggerService } from '@fxa/shared/mozlog';
 import { RateLimitClient } from '@fxa/accounts/rate-limit';
 import { EventLoggingService } from '../../event-logging/event-logging.service';
+import { AuditLogInterceptor } from '../../auth/audit-log.interceptor';
 import { RateLimitingResolver } from './rate-limiting.resolver';
 import { BlockStatus } from '../model/block-status.model';
 
@@ -60,6 +61,7 @@ describe('RateLimitingResolver', () => {
       providers: [
         RateLimitingResolver,
         EventLoggingService,
+        AuditLogInterceptor,
         MockMozLoggerService,
         MockConfig,
         MockMetricsFactory,

--- a/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/rate-limiting/rate-limiting.resolver.ts
@@ -6,6 +6,7 @@ import { UseGuards, Inject } from '@nestjs/common';
 import { Args, Query, Resolver, Mutation } from '@nestjs/graphql';
 import { AdminPanelFeature } from '@fxa/shared/guards';
 import { MozLoggerService } from '@fxa/shared/mozlog';
+import { AuditLog } from '../../auth/audit-log.decorator';
 
 import { RateLimit, RateLimitClient } from '@fxa/accounts/rate-limit';
 import { CurrentUser } from '../../auth/auth-header.decorator';
@@ -35,6 +36,7 @@ export class RateLimitingResolver {
 
   @Mutation(() => Number)
   @Features(AdminPanelFeature.RateLimiting)
+  @AuditLog()
   public async clearRateLimits(
     @CurrentUser() user: string,
     @Args('ip', { type: () => String, nullable: true }) ip?: string,

--- a/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
+++ b/packages/fxa-admin-server/src/gql/relying-party/relying-party.resolver.ts
@@ -8,6 +8,7 @@ import { uuidTransformer } from '../../database/transformers';
 
 import { AdminPanelFeature } from '@fxa/shared/guards';
 import { GqlAuthHeaderGuard } from '../../auth/auth-header.guard';
+import { AuditLog } from '../../auth/audit-log.decorator';
 import { Features } from '../../auth/user-group-header.decorator';
 import { DatabaseService } from '../../database/database.service';
 import {
@@ -48,6 +49,7 @@ export class RelyingPartyResolver {
   }
 
   @Features(AdminPanelFeature.CreateRelyingParty)
+  @AuditLog()
   @Mutation(() => String)
   public async createRelyingParty(
     @Args('relyingParty') relyingParty: RelyingPartyUpdateDto
@@ -60,7 +62,6 @@ export class RelyingPartyResolver {
       ...relyingParty,
     });
 
-
     if (result.id) {
       // Ping FxA channel, so devs know to setup a new queue
       // TODO: Create the event broker queue
@@ -70,6 +71,7 @@ export class RelyingPartyResolver {
   }
 
   @Features(AdminPanelFeature.UpdateRelyingParty)
+  @AuditLog()
   @Mutation(() => Boolean)
   public async updateRelyingParty(
     @Args('id') id: string,
@@ -88,6 +90,7 @@ export class RelyingPartyResolver {
   }
 
   @Features(AdminPanelFeature.DeleteRelyingParty)
+  @AuditLog()
   @Mutation(() => Boolean)
   public async deleteRelyingParty(@Args('id') id: string) {
     const result = await this.db.relyingParty


### PR DESCRIPTION
Because:
 - We need visibility and an audit trail of changes made in admin-panel
 - And the audit needs to include who, what, when

This Commit:
 - Adds a new decorator to admin-server that extracts who performs actions
 - Adds tests for the decorator
 - Adds the decorator to various admin-server resolvers to start capturing aduit trails

Closes: FXA-12603

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Here's an example of the logs from a few of the functions decorated. (logs are doubled up for me for some reason, I logged a ticket [here](https://mozilla-hub.atlassian.net/browse/FXA-12683))
```
// incoming request log
22|admin-server  | 2025-11-18T14:07:44: {"Timestamp":1763500064238000000,"Logger":"fxa-user-admin-server","Type":"AuditLogInterceptor.admin-audit","Severity":6,"Pid":26755,"EnvVersion":"2.0","Fields":{"user":"hello@mozilla.com","action":"disableAccount","timestamp":"2025-11-18T21:07:44.237Z","payload":"{\"uid\":\"cc65b605d64447ada62aafd682fe87fe\"}","status":"initiated"}}
22|admin-server  | 2025-11-18T14:07:44: {"Timestamp":1763500064238000000,"Logger":"fxa-user-admin-server","Type":"AuditLogInterceptor.admin-audit","Severity":6,"Pid":26755,"EnvVersion":"2.0","Fields":{"user":"hello@mozilla.com","action":"disableAccount","timestamp":"2025-11-18T21:07:44.237Z","payload":"{\"uid\":\"cc65b605d64447ada62aafd682fe87fe\"}","status":"initiated"}}

// success log
22|admin-server  | 2025-11-18T14:00:23: {"Timestamp":1763499623386000000,"Logger":"fxa-user-admin-server","Type":"AuditLogInterceptor.admin-audit","Severity":6,"Pid":26755,"EnvVersion":"2.0","Fields":{"user":"hello@mozilla.com","action":"disableAccount","timestamp":"2025-11-18T21:00:23.372Z","payload":"{\"uid\":\"cc65b605d64447ada62aafd682fe87fe\"}","status":"success","result":true}}
22|admin-server  | 2025-11-18T14:00:23: {"Timestamp":1763499623386000000,"Logger":"fxa-user-admin-server","Type":"AuditLogInterceptor.admin-audit","Severity":6,"Pid":26755,"EnvVersion":"2.0","Fields":{"user":"hello@mozilla.com","action":"disableAccount","timestamp":"2025-11-18T21:00:23.372Z","payload":"{\"uid\":\"cc65b605d64447ada62aafd682fe87fe\"}","status":"success","result":true}}

// error log for when the handler fails to resolve
22|admin-server  | 2025-11-18T14:11:00: {"Timestamp":1763500260687000000,"Logger":"fxa-user-admin-server","Type":"AuditLogInterceptor.admin-audit","Severity":2,"Pid":28584,"EnvVersion":"2.0","Fields":{"user":"hello@mozilla.com","action":"enableAccount","timestamp":"2025-11-18T21:11:00.568Z","payload":"{\"uid\":\"cc65b605d64447ada62aafd682fe87fe\"}","status":"error","error":"Not Found","errorName":"Error"}}
22|admin-server  | 2025-11-18T14:11:00: {"Timestamp":1763500260687000000,"Logger":"fxa-user-admin-server","Type":"AuditLogInterceptor.admin-audit","Severity":2,"Pid":28584,"EnvVersion":"2.0","Fields":{"user":"hello@mozilla.com","action":"enableAccount","timestamp":"2025-11-18T21:11:00.568Z","payload":"{\"uid\":\"cc65b605d64447ada62aafd682fe87fe\"}","status":"error","error":"Not Found","errorName":"Error"}}
```
