### PR TITLE
feat(payments-next): Add expanded payment method metrics in statsd/yardstick

### DIFF
--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -36,6 +36,7 @@ import {
   SubplatInterval,
   SubscriptionManager,
   TaxAddressFactory,
+  SubPlatPaymentMethodType,
 } from '@fxa/payments/customer';
 import {
   ResultAccountCustomerFactory,
@@ -1131,6 +1132,16 @@ describe('CartService', () => {
   });
 
   describe('finalizeProcessingCart', () => {
+    const mockPaymentMethod = StripeResponseFactory(
+      StripePaymentMethodFactory({})
+    );
+
+    beforeEach(() => {
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+    });
+
     it('throws an error for a cart that has no uid', async () => {
       const mockCart = ResultCartFactory();
 
@@ -1186,6 +1197,7 @@ describe('CartService', () => {
         subscription: mockSubscription,
         uid: mockCart.uid,
         paymentProvider: 'stripe',
+        paymentForm: SubPlatPaymentMethodType.Card,
       });
     });
   });
@@ -2222,6 +2234,9 @@ describe('CartService', () => {
       jest
         .spyOn(subscriptionManager, 'retrieve')
         .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
       jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
       jest.spyOn(cartService, 'finalizeCartWithError').mockResolvedValue();
       jest.spyOn(cartManager, 'finishErrorCart').mockResolvedValue();
@@ -2247,6 +2262,7 @@ describe('CartService', () => {
         subscription: mockSubscription,
         uid: mockCart.uid,
         paymentProvider: 'stripe',
+        paymentForm: SubPlatPaymentMethodType.Card,
       });
       expect(cartManager.finishErrorCart).not.toHaveBeenCalled();
     });
@@ -2279,6 +2295,7 @@ describe('CartService', () => {
         subscription: mockSubscription,
         uid: mockCartWithSetupIntent.uid,
         paymentProvider: 'stripe',
+        paymentForm: SubPlatPaymentMethodType.Card,
       });
       expect(cartManager.finishErrorCart).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Because

- We currently report stripe vs paypal subscription payments, but with the introduction of expanded payment methods, we should capture that breakdown in statsd/yardstick


## This pull request

- Differentiates between different SubPlatPaymentMethodType when reporting the payment provider.

## Issue that this pull request solves

Closes: #[PAY-3349](https://mozilla-hub.atlassian.net/browse/PAY-3349)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3349]: https://mozilla-hub.atlassian.net/browse/PAY-3349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ