### PR TITLE
Fix get cms info mock

### DIFF
--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -144,6 +144,7 @@ describe('IndexContainer', () => {
       isFirefoxClientServiceRelay: () => false,
       isFirefoxClientServiceAiMode: () => false,
       wantsKeys: () => true,
+      getCmsInfo: () => undefined,
       data: { clientId: 'abc123' },
     } as Integration;
   }


### PR DESCRIPTION
## Because

- We missed mock, likely due to commit order.

## This pull request

- Makes sure `getCmsInfo()` is mocked

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
