### PR TITLE
feat(auth): add subplatNimbusUserId to account delete log

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1062,6 +1062,12 @@ const convictConf = convict({
       env: 'SUBSCRIPTIONS_BILLING_PRICE_INFO_FEATURE',
       default: false,
     },
+    nimbusUserIdNamespace: {
+      doc: 'Namespace used to generate the SubPlat nimbus_user_id. This needs to be the same value used in payments-next',
+      format: String,
+      env: 'SUBSCRIPTIONS_NIMBUS_USER_ID_NAMESPACE',
+      default: 'e0066f05-3967-4f6e-8492-03933512611a',
+    },
   },
   currenciesToCountries: {
     doc: 'Mapping from ISO 4217 three-letter currency codes to list of ISO 3166-1 alpha-2 two-letter country codes: {"EUR": ["DE", "FR"], "USD": ["CA", "GB", "US" ]}  Requirement for only one currency per country. Tested at runtime. Must be uppercased.',


### PR DESCRIPTION
## Because

- SubPlats nimbus_user_id needs to be made available as part of deletion requests for Glean. An existing process for FxA metrics already exists and adding the subplatNimbusUserId to this log statement would allow Glean to follow a similar process to FxA metrics.

## This pull request

- Adds calculates and adds subplatNimbusUserId to DB.deleteAccount logs

## Issue that this pull request solves

Closes: #PAY-3412

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
