### PR TITLE
fix(settings): fix redirection to email first resulting in infinite loading

### DIFF
--- a/packages/functional-tests/tests/settings/redirect.spec.ts
+++ b/packages/functional-tests/tests/settings/redirect.spec.ts
@@ -112,7 +112,15 @@ test.describe('severity-2 #smoke', () => {
       await secondContext.close();
     });
 
-    test('redirects to email first when session token is invalid', async ({
+    test('redirects to email first when not signed in', async ({
+      page,
+      pages: { signup, settings },
+    }) => {
+      page.goto(settings.url);
+      await expect(signup.emailFormHeading).toBeVisible();
+    });
+
+    test('redirects to sign in when session token is invalid', async ({
       target,
       page,
       pages: { signin, settings },

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -5,7 +5,7 @@
 import React, { ReactNode } from 'react';
 import { act, screen, waitFor } from '@testing-library/react';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
-import { navigate } from '@reach/router';
+import * as ReactUtils from 'fxa-react/lib/utils';
 import App from '.';
 import * as Metrics from '../../lib/metrics';
 import {
@@ -36,13 +36,6 @@ import mockUseFxAStatus from '../../lib/hooks/useFxAStatus/mocks';
 import useFxAStatus from '../../lib/hooks/useFxAStatus';
 import sentryMetrics from 'fxa-shared/sentry/browser';
 import { OAuthError } from '../../lib/oauth';
-
-jest.mock('@reach/router', () => {
-  return {
-    ...jest.requireActual('@reach/router'),
-    navigate: jest.fn(),
-  };
-});
 
 jest.mock('../../lib/hooks/useFxAStatus', () => ({
   __esModule: true,
@@ -395,7 +388,8 @@ describe('SettingsRoutes', () => {
   const settingsPath = '/settings';
 
   beforeEach(() => {
-    (navigate as jest.Mock).mockClear();
+    jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
+    jest.clearAllMocks();
     (useInitialMetricsQueryState as jest.Mock).mockReturnValue({
       loading: false,
     });
@@ -430,7 +424,6 @@ describe('SettingsRoutes', () => {
   });
 
   afterEach(() => {
-    (navigate as jest.Mock).mockRestore();
     (useIntegration as jest.Mock).mockRestore();
     (useInitialMetricsQueryState as jest.Mock).mockRestore();
     (useLocalSignedInQueryState as jest.Mock).mockRestore();
@@ -472,7 +465,7 @@ describe('SettingsRoutes', () => {
     await act(() => navigateResult);
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(
+      expect(ReactUtils.hardNavigate).toHaveBeenCalledWith(
         `/?redirect_to=${encodeURIComponent(settingsPath)}`
       );
     });
@@ -517,7 +510,7 @@ describe('SettingsRoutes', () => {
     await act(() => navigateResult);
 
     await waitFor(() => {
-      expect(navigate).not.toHaveBeenCalled();
+      expect(ReactUtils.hardNavigate).not.toHaveBeenCalled();
     });
 
     expect(screen.getByText('Session Expired')).toBeInTheDocument();
@@ -582,7 +575,7 @@ describe('SettingsRoutes', () => {
     await act(() => navigateResult);
 
     await waitFor(() => {
-      expect(navigate).not.toHaveBeenCalled();
+      expect(ReactUtils.hardNavigate).not.toHaveBeenCalled();
     });
     expect(screen.getByTestId('settings-profile')).toBeInTheDocument();
   });
@@ -614,7 +607,7 @@ describe('SettingsRoutes', () => {
     await act(() => navigateResult);
 
     await waitFor(() => {
-      expect(navigate).not.toHaveBeenCalled();
+      expect(ReactUtils.hardNavigate).not.toHaveBeenCalled();
     });
     expect(screen.getByTestId('settings-profile')).toBeInTheDocument();
   });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -2,12 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  navigate,
-  RouteComponentProps,
-  Router,
-  useLocation,
-} from '@reach/router';
+import { RouteComponentProps, Router, useLocation } from '@reach/router';
 import {
   lazy,
   Suspense,
@@ -50,6 +45,7 @@ import { ScrollToTop } from '../Settings/ScrollToTop';
 import SignupConfirmedSync from '../../pages/Signup/SignupConfirmedSync';
 import useFxAStatus from '../../lib/hooks/useFxAStatus';
 import AppLayout from '../AppLayout';
+import { hardNavigate } from 'fxa-react/lib/utils';
 
 // Pages
 const IndexContainer = lazy(() => import('../../pages/Index/container'));
@@ -357,12 +353,6 @@ export const App = ({
     );
   }
 
-  // If we're on settings route but user is not signed in, redirect immediately
-  if (window.location.pathname?.includes('/settings') && !isSignedIn) {
-    navigate('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
-  }
-
   return (
     <Router basepath="/">
       <AuthAndAccountSetupRoutes
@@ -398,10 +388,10 @@ const SettingsRoutes = ({
       // For regular RP / web logins, maybe the session token expired. In this
       // case we just send them to the root.
       params.set('redirect_to', location.pathname);
-      navigate(`/?${params.toString()}`);
+      hardNavigate(`/?${params.toString()}`);
     }
 
-    return <LoadingSpinner fullScreen />;
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
   }
 
   const settingsContext = initializeSettingsContext();


### PR DESCRIPTION
## Because

- redirection from /settings routes to email first due to signed out state results in infinite loading

## This pull request

- fixes infinite loading by forcing a refresh with hard navigation

## Issue that this pull request solves

Closes: FXA-12693

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
