### PR TITLE
Fix nest container dependency injections

### DIFF
--- a/apps/payments/api/src/app/app.module.ts
+++ b/apps/payments/api/src/app/app.module.ts
@@ -36,6 +36,8 @@ import {
 } from '@fxa/payments/metrics';
 import { PaymentsGleanFactory } from '@fxa/payments/metrics/provider';
 import { PaymentsEmitterService } from '@fxa/payments/events';
+import { NimbusManager, NimbusManagerConfig } from '@fxa/payments/experiments';
+import { NimbusClient, NimbusClientConfig } from '@fxa/shared/experiments';
 
 @Module({
   imports: [
@@ -79,6 +81,10 @@ import { PaymentsEmitterService } from '@fxa/payments/events';
     PaypalBillingAgreementManager,
     PaypalCustomerManager,
     StrapiClient,
+    NimbusManager,
+    NimbusManagerConfig,
+    NimbusClient,
+    NimbusClientConfig,
     MockPaymentsGleanFactory,
   ],
 })

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -182,6 +182,7 @@ async function run(config) {
       const productConfigurationManager = new ProductConfigurationManager(
         strapiClient,
         priceManager,
+        stripeClient,
         statsd
       );
       Container.set(ProductConfigurationManager, productConfigurationManager);


### PR DESCRIPTION
## Because

- The key server is attempting to instantiate the product configuration manager without the stripe client
- The AppModule requires the Nimbus containers to properly instantiate payments-api

## This pull request

- Adds the stripe client to the args for instantiating the product configuration manager class to the key server
- Adds the nimbus containers for starting up payments-api

## Issue that this pull request solves

Closes: N/A

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
