### PR TITLE
task(auth): Make account deletion on email bounce configurable

### DIFF
--- a/packages/fxa-auth-server/bin/email_notifications.js
+++ b/packages/fxa-auth-server/bin/email_notifications.js
@@ -62,7 +62,7 @@ if (config.subscriptions && config.subscriptions.stripeApiKey) {
 const error = require('../lib/error');
 const Token = require('../lib/tokens')(log, config);
 const SQSReceiver = require('../lib/sqs')(log, statsd);
-const bounces = require('../lib/email/bounces')(log, error);
+const bounces = require('../lib/email/bounces')(log, error, config);
 const delivery = require('../lib/email/delivery')(log, glean);
 const notifications = require('../lib/email/notifications')(log, error);
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -600,6 +600,12 @@ const convictConf = convict({
         ],
         env: 'BOUNCES_IGNORE_TEMPLATES',
       },
+      deleteAccount: {
+        doc: 'Flag to enable deleting account on email bounce.',
+        format: Boolean,
+        default: false,
+        env: 'BOUNCES_DELETE_ACCOUNT',
+      },
     },
     connectionTimeout: {
       doc: 'Milliseconds to wait for the connection to establish (default is 2 minutes)',


### PR DESCRIPTION
## Because
- We have some reports of emails being reported as bounced when they actually go through
- We want to experiment with account deletion on email bounces

## This pull request

- Adds config to enable / disable account deletion on email bounce
- Logs raw email bounce message for more detailed insight
- Logs info about current context when account isn't deleted

## Issue that this pull request solves

Closes: FXA-12701

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

