### PR TITLE
bug(shared): Make sure 'undefined' isn't passed to the CreateEmailBounce sproc

### DIFF
--- a/packages/fxa-shared/db/models/auth/email-bounce.ts
+++ b/packages/fxa-shared/db/models/auth/email-bounce.ts
@@ -66,7 +66,7 @@ export class EmailBounce extends BaseAuthModel {
         BOUNCE_TYPES[bounceType],
         BOUNCE_SUB_TYPES[bounceSubType],
         Date.now(),
-        diagnosticCode
+        diagnosticCode ?? null
       );
     } catch (e: any) {
       throw convertError(e);


### PR DESCRIPTION
## Because

- We noticed failures creating new email bounce records

## This pull request

- Makes sure the `diagnosticCode` falls back to `null`

## Issue that this pull request solves

Closes: FXA-12704

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
