### PR TITLE
task(auth): Restore session verified flag

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/session-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/session-api.ts
@@ -43,10 +43,15 @@ const SESSION_REAUTH_POST = {
       Re-authenticate an existing session token. This is equivalent to calling \`/account/login\`, but it re-uses an existing session token rather than generating a new one, allowing the caller to maintain session state such as verification and device registration.
 
       The response includes:
-      - \`emailVerified\`: Whether the account's primary email address has been verified
-      - \`sessionVerified\`: Whether the current session token has been verified
+      - \`uid\`: Account id
+      - \`keyFetchToken\`: Present if keys were requested.
       - \`verificationMethod\`: Present if verification is incomplete, e.g. \`email\`, \`email-2fa\`, \`email-otp\`, \`totp-2fa\`
       - \`verificationReason\`: Present if verification is incomplete, e.g. \`login\`, \`signup\`
+      - \`emailVerified\`: Whether the account's primary email address has been verified
+      - \`sessionVerified\`: Whether the current session token has been verified
+      - \`authAt\`: Timestamp of authentication
+      - \`metricsEnabled\`: Flag indicating if metrics are enabled on the session
+      - \`verified\`: Deprecated! Use emailVerified and sessionVerified instead.
     `,
   ],
   plugins: {
@@ -78,11 +83,15 @@ const SESSION_STATUS_GET = {
 
       Returns a success response if the session token is valid. The response includes detailed information about the session and account state.
 
-      **Response details object:**
-      - \`accountEmailVerified\`: Whether the account's primary email is verified
-      - \`sessionVerificationMethod\`: The verification method used for the session (e.g., 'email-2fa', 'totp-2fa'), or null if not verified
-      - \`sessionVerified\`: Whether the session token itself is verified (no pending token verification)
-      - \`sessionVerificationMeetsMinimumAAL\`: Whether the session's Authentication Assurance Level (AAL) meets or exceeds the account's maximum AAL
+
+      **Response object:**
+      - \`state\`: Describes the session's verification state.
+      - \`uid\`: Account id
+      - \`details.accountEmailVerified\`: Whether the account's primary email is verified
+      - \`details.sessionVerificationMethod\`: The verification method used for the session (e.g., 'email-2fa', 'totp-2fa'), or null if not verified
+      - \`details.sessionVerified\`: Whether the session token itself is verified (no pending token verification)
+      - \`details.sessionVerificationMeetsMinimumAAL\`: Whether the session's Authentication Assurance Level (AAL) meets or exceeds the account's maximum AAL
+      - \`details.verified\`: Deprecated! Use accountEmailVerified and sessionVerified instead.
     `,
   ],
 };
@@ -95,6 +104,16 @@ const SESSION_DUPLICATE_POST = {
       🔒 Authenticated with session token
 
       Create a new \`sessionToken\` that duplicates the current session. It will have the same verification status as the current session, but will have a distinct verification code.
+
+      **Response object:**
+      - \`uid\`: Account id
+      - \`sessionToken\`: Session Token
+      - \`authAt\`: Authentication timestamp
+      - \`emailVerified\`: Whether the account's primary email is verified
+      - \`sessionVerified\`: Whether the session token itself is verified (no pending token verification)
+      - \`verificationMethod\`: Present if verification is incomplete, e.g. \`email\`, \`email-2fa\`, \`email-otp\`, \`totp-2fa\`
+      - \`verificationReason\`: Present if verification is incomplete, e.g. \`login\`, \`signup\`
+      - \`verified\`: Deprecated! Use emailVerified and sessionVerified instead.
     `,
   ],
 };
@@ -129,7 +148,7 @@ const SESSION_VERIFY_PUSH_POST = {
   notes: [
     dedent`
     🔒 Authenticated with session token
-    
+
     Endpoint that accepts a code and tokenVerificationId to verify a session.
     `,
   ],

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -210,6 +210,7 @@ describe('/session/status', () => {
           sessionVerificationMeetsMinimumAAL: false,
           sessionVerificationMethod: 'totp-2fa',
           sessionVerified: false,
+          verified: false,
         },
       });
     });
@@ -246,6 +247,7 @@ describe('/session/status', () => {
         accountEmailVerified: false,
         sessionVerificationMethod: 'email',
         sessionVerified: false,
+        verified: false,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -281,6 +283,7 @@ describe('/session/status', () => {
         accountEmailVerified: false,
         sessionVerificationMethod: 'email',
         sessionVerified: false,
+        verified: false,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -316,6 +319,7 @@ describe('/session/status', () => {
         accountEmailVerified: true,
         sessionVerificationMethod: 'email',
         sessionVerified: false,
+        verified: false,
         sessionVerificationMeetsMinimumAAL: false,
       },
     });
@@ -351,6 +355,7 @@ describe('/session/status', () => {
         accountEmailVerified: true,
         sessionVerificationMethod: 'totp-2fa',
         sessionVerified: true,
+        verified: true,
         sessionVerificationMeetsMinimumAAL: false,
       },
     });
@@ -385,6 +390,7 @@ describe('/session/status', () => {
         accountEmailVerified: true,
         sessionVerificationMethod: 'email',
         sessionVerified: true,
+        verified: true,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -420,6 +426,7 @@ describe('/session/status', () => {
         accountEmailVerified: true,
         sessionVerificationMethod: 'totp-2fa',
         sessionVerified: true,
+        verified: true,
         sessionVerificationMeetsMinimumAAL: true,
       },
     });
@@ -519,6 +526,7 @@ describe('/session/reauth', () => {
     );
     signinUtils.getSessionVerificationStatus = sinon.spy(() => ({
       sessionVerified: true,
+      verified: true,
     }));
     const testNow = Math.floor(Date.now() / 1000);
     return runTest(route, request).then((res) => {
@@ -720,7 +728,7 @@ describe('/session/reauth', () => {
 
       assert.equal(
         Object.keys(res).length,
-        6,
+        7,
         'response object had correct number of keys'
       );
       assert.equal(res.uid, TEST_UID, 'response object contained correct uid');
@@ -742,6 +750,11 @@ describe('/session/reauth', () => {
         res.sessionVerified,
         true,
         'response object indicated correct session verification status'
+      );
+      assert.equal(
+        res.verified,
+        true,
+        'response object indicated correct legacy session verified status'
       );
     });
   });
@@ -1165,7 +1178,7 @@ describe('/session/duplicate', () => {
     return runTest(route, request).then((res) => {
       assert.equal(
         Object.keys(res).length,
-        5,
+        6,
         'response has correct number of keys'
       );
       assert.equal(
@@ -1188,6 +1201,11 @@ describe('/session/duplicate', () => {
         res.sessionVerified,
         true,
         'response includes correctly-copied session verification flag'
+      );
+      assert.equal(
+        res.verified,
+        true,
+        'response includes correctly-copied leagacy session verified flag'
       );
 
       assert.equal(
@@ -1283,7 +1301,7 @@ describe('/session/duplicate', () => {
     return runTest(route, request).then((res) => {
       assert.equal(
         Object.keys(res).length,
-        7,
+        8,
         'response has correct number of keys'
       );
       assert.equal(
@@ -1306,6 +1324,11 @@ describe('/session/duplicate', () => {
         res.sessionVerified,
         false,
         'response includes correctly-copied session verification flag'
+      );
+      assert.equal(
+        res.verified,
+        false,
+        'response includes correctly-copied legacy session verified flag'
       );
       assert.equal(
         res.verificationMethod,
@@ -1414,7 +1437,7 @@ describe('/session/duplicate', () => {
     return runTest(route, request).then((res) => {
       assert.equal(
         Object.keys(res).length,
-        7,
+        8,
         'response has correct number of keys'
       );
       assert.equal(
@@ -1437,6 +1460,11 @@ describe('/session/duplicate', () => {
         res.sessionVerified,
         true,
         'response includes correctly-copied session verification flag'
+      );
+      assert.equal(
+        res.verified,
+        false,
+        'response includes correctly-copied legacy session verified flag'
       );
       assert.equal(
         res.verificationMethod,

--- a/packages/fxa-auth-server/test/remote/session_tests.js
+++ b/packages/fxa-auth-server/test/remote/session_tests.js
@@ -543,6 +543,7 @@ const config = require('../../config').default.getProperties();
                 sessionVerificationMeetsMinimumAAL: true,
                 sessionVerificationMethod: null,
                 sessionVerified: false,
+                verified: false,
               },
             });
           });


### PR DESCRIPTION
## Because

- We need it for backwards compatibility

## This pull request

- Restores the `verified` flag that was removed when `emailVerifed` and `sessionVerified` flags were added.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
