### PR TITLE
fix(settings): Sync signin error after setting password

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -8,7 +8,7 @@ import { currentAccount } from '../../../lib/cache';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { Integration, useAuthClient } from '../../../models';
 import { cache } from '../../../lib/cache';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { CreatePasswordHandler } from './interfaces';
 import { HandledError } from '../../../lib/error-utils';
 import {
@@ -51,7 +51,10 @@ const SetPasswordContainer = ({
     flowQueryParams as unknown as Record<string, string>
   );
 
+  const didRunPasswordStatusCheckRef = useRef(false);
   useEffect(() => {
+    if (didRunPasswordStatusCheckRef.current) return;
+    didRunPasswordStatusCheckRef.current = true;
     const checkPasswordStatus = async () => {
       if (sessionToken) {
         try {
@@ -72,9 +75,8 @@ const SetPasswordContainer = ({
         }
       }
     };
-
     checkPasswordStatus();
-  }, [sessionToken, authClient, navigateWithQuery]);
+  }, [authClient, sessionToken, navigateWithQuery]);
 
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -54,7 +54,7 @@ import VerificationMethods from '../../constants/verification-methods';
 import VerificationReasons from '../../constants/verification-reasons';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 
-import { fxaCanLinkAccountAndNavigate } from './utils';
+import { ensureCanLinkAcountOrRedirect } from './utils';
 import { mockSensitiveDataClient as createMockSensitiveDataClient } from '../../models/mocks';
 import { SensitiveData } from '../../lib/sensitive-data-client';
 import { Constants } from '../../lib/constants';
@@ -80,7 +80,7 @@ jest.mock('../../lib/storage-utils', () => ({
 
 jest.mock('./utils', () => ({
   ...jest.requireActual('./utils'),
-  fxaCanLinkAccountAndNavigate: jest.fn(),
+  ensureCanLinkAcountOrRedirect: jest.fn(),
 }));
 
 jest.mock('../../lib/oauth/hooks', () => ({
@@ -754,10 +754,10 @@ describe('signin container', () => {
     describe('fxaCanLinkAccount', () => {
       beforeEach(() => {
         mockSyncDesktopV3Integration();
-        (fxaCanLinkAccountAndNavigate as jest.Mock).mockResolvedValue(true);
+        (ensureCanLinkAcountOrRedirect as jest.Mock).mockResolvedValue(true);
       });
       afterEach(() => {
-        (fxaCanLinkAccountAndNavigate as jest.Mock).mockRestore();
+        (ensureCanLinkAcountOrRedirect as jest.Mock).mockRestore();
       });
       it('is not called when conditions are not met (query param)', async () => {
         // this puts hasLinkedAccount=false in the query params
@@ -781,11 +781,11 @@ describe('signin container', () => {
             MOCK_EMAIL,
             MOCK_PASSWORD
           );
-          expect(fxaCanLinkAccountAndNavigate).not.toHaveBeenCalled();
+          expect(ensureCanLinkAcountOrRedirect).not.toHaveBeenCalled();
         });
       });
 
-      it('calls fxaCanLinkAccountAndNavigate early without UID when conditions are met', async () => {
+      it('calls ensureCanLinkAcountOrRedirect early without UID when conditions are met', async () => {
         mockLocationState = {
           hasLinkedAccount: undefined,
           email: MOCK_ROUTER_STATE_EMAIL,
@@ -811,13 +811,13 @@ describe('signin container', () => {
 
           expect(handlerResult?.data).toBeDefined();
         });
-        expect(fxaCanLinkAccountAndNavigate).toHaveBeenCalledTimes(1);
-        expect(fxaCanLinkAccountAndNavigate).toHaveBeenCalledWith(
+        expect(ensureCanLinkAcountOrRedirect).toHaveBeenCalledTimes(1);
+        expect(ensureCanLinkAcountOrRedirect).toHaveBeenCalledWith(
           expect.objectContaining({
             email: MOCK_EMAIL,
           })
         );
-        expect(fxaCanLinkAccountAndNavigate).toHaveBeenCalledWith(
+        expect(ensureCanLinkAcountOrRedirect).toHaveBeenCalledWith(
           expect.not.objectContaining({
             uid: expect.anything(),
           })
@@ -829,7 +829,7 @@ describe('signin container', () => {
           hasLinkedAccount: undefined,
           email: MOCK_ROUTER_STATE_EMAIL,
         };
-        (fxaCanLinkAccountAndNavigate as jest.Mock).mockResolvedValue(false);
+        (ensureCanLinkAcountOrRedirect as jest.Mock).mockResolvedValue(false);
         render([mockGqlAvatarUseQuery()]);
 
         await waitFor(async () => {
@@ -846,7 +846,7 @@ describe('signin container', () => {
           mockOAuthNativeIntegration();
         });
 
-        it('calls fxaCanLinkAccountAndNavigate with UID after successful signin', async () => {
+        it('calls ensureCanLinkAcountOrRedirect with UID after successful signin', async () => {
           const useFxAStatusResult = mockUseFxAStatus({
             supportsCanLinkAccountUid: true,
           });
@@ -876,8 +876,8 @@ describe('signin container', () => {
             expect(handlerResult?.data).toBeDefined();
             expect(handlerResult?.data?.signIn?.uid).toBe(MOCK_UID);
           });
-          expect(fxaCanLinkAccountAndNavigate).toHaveBeenCalledTimes(1);
-          expect(fxaCanLinkAccountAndNavigate).toHaveBeenCalledWith(
+          expect(ensureCanLinkAcountOrRedirect).toHaveBeenCalledTimes(1);
+          expect(ensureCanLinkAcountOrRedirect).toHaveBeenCalledWith(
             expect.objectContaining({
               email: MOCK_EMAIL,
               uid: MOCK_UID,

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -80,7 +80,7 @@ import {
   storeAccountData,
   StoredAccountData,
 } from '../../lib/storage-utils';
-import { cachedSignIn, fxaCanLinkAccountAndNavigate } from './utils';
+import { cachedSignIn, ensureCanLinkAcountOrRedirect } from './utils';
 import OAuthDataError from '../../components/OAuthDataError';
 import { AppLayout } from '../../components/AppLayout';
 
@@ -321,7 +321,7 @@ const SigninContainer = ({
         !originFromEmailFirst &&
         !useFxAStatusResult.supportsCanLinkAccountUid
       ) {
-        const ok = await fxaCanLinkAccountAndNavigate({
+        const ok = await ensureCanLinkAcountOrRedirect({
           email,
           ftlMsgResolver,
           navigateWithQuery,
@@ -391,7 +391,7 @@ const SigninContainer = ({
           isOAuthNativeIntegration(integration) &&
           useFxAStatusResult.supportsCanLinkAccountUid
         ) {
-          const ok = await fxaCanLinkAccountAndNavigate({
+          const ok = await ensureCanLinkAcountOrRedirect({
             email,
             uid: result.data.signIn.uid,
             ftlMsgResolver,

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -17,7 +17,7 @@ import {
   createMockSigninOAuthNativeIntegration,
   createMockSigninOAuthIntegration,
 } from './mocks';
-import { handleNavigation, fxaCanLinkAccountAndNavigate } from './utils';
+import { handleNavigation, ensureCanLinkAcountOrRedirect } from './utils';
 import * as ReachRouter from '@reach/router';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import firefox from '../../lib/channels/firefox';
@@ -246,7 +246,7 @@ describe('Signin utils', () => {
         );
       });
 
-      it('does not send fxaLogin for TOTP verification', async () => {
+      it('does not send fxaLogin if TOTP verification required', async () => {
         const navigationOptions = createBaseNavigationOptions({
           signinData: {
             ...createBaseNavigationOptions().signinData,
@@ -298,7 +298,7 @@ describe('Signin utils', () => {
     });
   });
 
-  describe('fxaCanLinkAccountAndNavigate', () => {
+  describe('ensureCanLinkAcountOrRedirect', () => {
     const mockFtlMsgResolver = {
       getMsg: jest.fn().mockReturnValue('Login attempt cancelled'),
     };
@@ -311,7 +311,7 @@ describe('Signin utils', () => {
     it('returns true when user accepts', async () => {
       fxaCanLinkAccountSpy.mockResolvedValue({ ok: true });
 
-      const result = await fxaCanLinkAccountAndNavigate({
+      const result = await ensureCanLinkAcountOrRedirect({
         email: MOCK_EMAIL,
         uid: MOCK_UID,
         ftlMsgResolver: mockFtlMsgResolver as any,
@@ -331,7 +331,7 @@ describe('Signin utils', () => {
       const linkedAccountUid = '123';
       fxaCanLinkAccountSpy.mockResolvedValue({ ok: false });
 
-      const result = await fxaCanLinkAccountAndNavigate({
+      const result = await ensureCanLinkAcountOrRedirect({
         email: linkedAccountEmail,
         uid: linkedAccountUid,
         ftlMsgResolver: mockFtlMsgResolver as any,

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -338,8 +338,9 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
       oauthData
     ) {
       // If this is a Sync (with password) sign-in, the scoped keys will be bundled
-      // with the 'code'. If this is a third party auth sign-in, oauth data is still
-      // needed but the keys will not be bundled.
+      // with the 'code'.
+      // If this is a third party auth sign-in prior to setting a password,
+      // the oauthLogin will be deferred until after the password is set.
       firefox.fxaOAuthLogin({
         action: 'signin',
         code: oauthData.code,
@@ -598,7 +599,7 @@ function getStoredAccountInfo(): SigninLocationState | null {
 /**
  * Sends `can_link_account` with email and UID and handles navigation if cancelled.
  */
-export async function fxaCanLinkAccountAndNavigate({
+export async function ensureCanLinkAcountOrRedirect({
   email,
   uid,
   ftlMsgResolver,


### PR DESCRIPTION
## Because

* Sync sign in was failing after setting a password for third party auth accounts

## This pull request

* Fixing issue with fxaLogin, fxaOauthLogin being sent prematurely before keys are available
* Sending the webchannel messages early and without keys causes the browser to respond by disconnecting ("account disconnected" state in the browser) and destroying the session

## Issue that this pull request solves

Closes: FXA-12694

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Steps to test:
- Create an account with Google/Apple auth
- Sign in to Sync with that account

Expected result:
Prompted to set a password then signed in to sync on success
No regression for other sign ins (sign in to browser with non-sync integration, sign in to sync with password)
