### PR TITLE
fix(settings): fix create_password redirecting to change_passsword on success

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.tsx
@@ -5,7 +5,7 @@
 import { Localized } from '@fluent/react';
 import { RouteComponentProps, useLocation } from '@reach/router';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { SETTINGS_PATH } from '../../../constants';
 import {
@@ -50,6 +50,13 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
   };
   const { wantsUnlinkProviderId } = location.state || {};
 
+  const passwordCreated = useRef(false);
+  useEffect(() => {
+    if (account.hasPassword && !passwordCreated.current) {
+      navigateWithQuery(SETTINGS_PATH + '/change_password', { replace: true });
+    }
+  }, [account.hasPassword, navigateWithQuery]);
+
   const alertSuccessAndGoHome = useCallback(() => {
     alertBar.success(
       ftlMsgResolver.getMsg('pw-create-success-alert-2', 'Password set')
@@ -67,10 +74,12 @@ export const PageCreatePassword = ({}: RouteComponentProps) => {
     async ({ newPassword }: FormData) => {
       try {
         logViewEvent(settingsViewName, 'create-password.submit');
+        passwordCreated.current = true;
         await account.createPassword(newPassword);
         logViewEvent(settingsViewName, 'create-password.success');
         alertSuccessAndGoHome();
       } catch (e) {
+        passwordCreated.current = false;
         logViewEvent(settingsViewName, 'create-password.fail');
         alertBar.error(
           ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -362,21 +362,6 @@ describe('Settings App', () => {
     expect(history.location.pathname).toBe('/settings/avatar');
   });
 
-  it('redirects to CreatePassword', async () => {
-    const {
-      history,
-      history: { navigate },
-    } = renderWithRouter(
-      <AppContext.Provider value={mockAppContext()}>
-        <Subject />
-      </AppContext.Provider>,
-      { route: SETTINGS_PATH }
-    );
-
-    await navigate(SETTINGS_PATH + '/create_password');
-    expect(history.location.pathname).toBe('/settings/change_password');
-  });
-
   describe('guarded routes render MFA guard', () => {
     // as new guards are added to pages we just add the page name and route here
     // hasPassword is used to pass needed context to `mockAppContext`

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -201,21 +201,17 @@ export const Settings = ({
           ) : (
             <Redirect from="/account_recovery" to="/settings" noThrow />
           )}
+          {/* PageCreatePassword internally redirects to /change_password if password exists */}
+          <PageCreatePassword path="/create_password" />
           {account.hasPassword ? (
             <>
               <MfaGuardedPageChangePassword path="/change_password" />
-              <Redirect
-                from="/create_password"
-                to="/settings/change_password"
-                noThrow
-              />
               <MfaGuardPage2faSetup path="/two_step_authentication" />
               <MfaGuardPage2faChange path="/two_step_authentication/change" />
               <MfaGuardPage2faReplaceBackupCodes path="/two_step_authentication/replace_codes" />
             </>
           ) : (
             <>
-              <PageCreatePassword path="/create_password" />
               <Redirect
                 from="/change_password"
                 to="/settings/create_password"


### PR DESCRIPTION
## Because

- create_password redirecting to change_passsword on success

## This pull request

- fixes this issue

## Issue that this pull request solves

Closes: FXA-12639

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This PR does NOT add MFA to `password/create`. If we decide we do need to do so, I'll make a separate PR.
