### PR TITLE
fix(settings): Prevent duplicate sync merge warnings

### DIFF
--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -391,6 +391,8 @@ describe('IndexContainer', () => {
           email: 'test@example.com',
           hasLinkedAccount: false,
           hasPassword: true,
+          // no can_link_account check performed for non-browser services
+          canLinkAccountOk: undefined,
         },
       });
     });
@@ -433,6 +435,8 @@ describe('IndexContainer', () => {
         state: {
           email: 'test@example.com',
           emailStatusChecked: true,
+          // no can_link_account check performed for non-browser services
+          canLinkAccountOk: undefined,
         },
       });
     });
@@ -519,6 +523,8 @@ describe('IndexContainer', () => {
           email: 'current@example.com',
           hasLinkedAccount: false,
           hasPassword: true,
+          // no can_link_account check performed for non-browser services
+          canLinkAccountOk: undefined,
         },
       });
     });
@@ -570,6 +576,8 @@ describe('IndexContainer', () => {
           email: 'stored@example.com',
           hasLinkedAccount: false,
           hasPassword: true,
+          // no can_link_account check performed for non-browser services
+          canLinkAccountOk: undefined,
         },
       });
     });
@@ -878,7 +886,7 @@ describe('IndexContainer', () => {
           <IndexContainer
             {...{
               integration,
-              serviceName: MozServices.Default,
+              serviceName: MozServices.Relay,
               useFxAStatusResult: mockUseFxAStatusResult,
             }}
           />

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -305,6 +305,13 @@ const MOCK_LOCATION_STATE_COMPLETE = {
   email: MOCK_ROUTER_STATE_EMAIL,
   hasPassword: true,
   hasLinkedAccount: false,
+  canLinkAccountOk: undefined,
+};
+const MOCK_LOCATION_STATE_CAN_LINK_ACCOUNT_OK = {
+  email: MOCK_ROUTER_STATE_EMAIL,
+  hasPassword: true,
+  hasLinkedAccount: false,
+  canLinkAccountOk: true,
 };
 // Set this when testing location state
 let mockLocationState = {};
@@ -619,8 +626,9 @@ describe('signin container', () => {
     describe('showInlineRecoveryKeySetup', () => {
       beforeEach(() => {
         mockSyncDesktopV3Integration();
-        // this puts hasLinkedAccount=false in the query params to avoid more canLinkAccount mocking
-        mockUseValidateModule();
+        // Ensure early can_link_account check does not short‑circuit beginSigninHandler
+        (ensureCanLinkAcountOrRedirect as jest.Mock).mockResolvedValue(true);
+        mockLocationState = MOCK_LOCATION_STATE_CAN_LINK_ACCOUNT_OK;
         render([
           mockGqlAvatarUseQuery(),
           mockGqlCredentialStatusMutation({
@@ -760,9 +768,9 @@ describe('signin container', () => {
         (ensureCanLinkAcountOrRedirect as jest.Mock).mockRestore();
       });
       it('is not called when conditions are not met (query param)', async () => {
-        // this puts hasLinkedAccount=false in the query params
-        // We don't want this called when the user was prompted on email-first
-        mockUseValidateModule();
+        // Simulate Index already accepted/auto-OKed the merge warning
+        // avoids mocking ensureCanLinkAcountOrRedirect
+        mockLocationState = { canLinkAccountOk: true };
         render([
           mockGqlAvatarUseQuery(),
           mockGqlCredentialStatusMutation({

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -78,6 +78,7 @@ export interface LocationState {
   email?: string;
   hasLinkedAccount?: boolean;
   hasPassword?: boolean;
+  canLinkAccountOk?: boolean;
   localizedErrorMessage?: string;
   successBanner?: {
     localizedSuccessBannerHeading?: string;


### PR DESCRIPTION
## Because

* Users signing in with third party auth might see 2 merge warnings
* ThirdPartyAuth flows (Google/Apple) may switch the email, making early prompts at Index unsafe and causing duplicates.
* Signin previously skipped prompting after email‑first, relying on Index.

## This pull request

* Defers can_link_account at Index for accounts that exist and have a linked third‑party provider
* Ensures Signin prompts when not coming from email‑first OR when a linked third‑party account is present
* Clarifies inline comments in Index and Signin to document the deferral logic and legacy behaviour

## Issue that this pull request solves

Closes: FXA-12714

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
