### PR TITLE
fix(settings): clear AAL error alert after AAL upgrade

### DIFF
--- a/packages/functional-tests/tests/settings/redirect.spec.ts
+++ b/packages/functional-tests/tests/settings/redirect.spec.ts
@@ -58,6 +58,8 @@ test.describe('severity-2 #smoke', () => {
       await signinTotpCode.fillOutCodeForm(code);
 
       await expect(page).toHaveURL(/settings/);
+      // Error alert caused by insufficient AAL error should not linger (see FXA-12707)
+      await expect(page.getByText(/Insufficient AAL/)).toBeHidden();
       await settings.disconnectTotp();
       await secondContext.close();
     });

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link, RouteComponentProps, useLocation } from '@reach/router';
 import { FtlMsg } from 'fxa-react/lib/utils';
-import { useFtlMsgResolver, useSession } from '../../../models';
+import { useAlertBar, useFtlMsgResolver, useSession } from '../../../models';
 import { logViewEvent } from '../../../lib/metrics';
 import { MozServices } from '../../../lib/types';
 import firefox from '../../../lib/channels/firefox';
@@ -56,6 +56,7 @@ export const SigninTotpCode = ({
   const navigateWithQuery = useNavigateWithQuery();
   const session = useSession();
   const isSessionAALUpgrade = signinState.isSessionAALUpgrade;
+  const alertBar = useAlertBar();
 
   const [bannerError, setBannerError] = useState<string>('');
 
@@ -107,6 +108,11 @@ export const SigninTotpCode = ({
       setBannerError(getLocalizedErrorMessage(ftlMsgResolver, error));
       return;
     } else {
+      // Clear lingering error alert caused by insufficient AAL error (see FXA-12707)
+      if (isSessionAALUpgrade) {
+        alertBar.hide();
+      }
+
       GleanMetrics.totpForm.success();
 
       const {


### PR DESCRIPTION
## Because

- AAL error alert lingers after AAL upgrade

This commit:

## This pull request

- clears AAL error alert after AAL upgrade

## Issue that this pull request solves

Closes: FXA-12707

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
