### PR TITLE
fix(settings): fix confetti placement

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -122,7 +122,7 @@ export const AppLayout = ({
 
         {!splitLayout ? (
           <main className="flex mobileLandscape:items-center flex-1">
-            <section className="relative">
+            <section>
               {loading ? (
                 <>
                   <CardLoadingSpinner />

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
@@ -48,7 +48,7 @@ const SignupConfirmedSync = ({
 
   return (
     <AppLayout {...{ cmsInfo, title }}>
-      <FallingConfettiImage />
+      <FallingConfettiImage ariaHidden />
 
       {originPostVerifySetPassword ? (
         <Banner


### PR DESCRIPTION
## Because

- The confetti animation on the signup confirmed sync page is not centered.

## This pull request

- makes the confetti animation centered by fixing a regression in AppLayout
- marks confetti animation as aria-hidden for accessibility.

## Issue that this pull request solves

Closes: FXA-12713

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1134" height="942" alt="image" src="https://github.com/user-attachments/assets/1564c315-7b8c-41f3-9afd-5cf32bbbc4e5" />

## Other information (Optional)

Any other information that is important to this pull request.
