### PR TITLE
feat(payments-next): Add Action when customer redeems churn coupon

### DIFF
--- a/libs/payments/ui/src/lib/actions/redeemChurnCoupon.ts
+++ b/libs/payments/ui/src/lib/actions/redeemChurnCoupon.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+
+export const redeemChurnCouponAction = async (
+  uid: string,
+  subscriptionId: string,
+  acceptLanguage?: string | null,
+  selectedLanguage?: string,
+) => {
+  return await getApp().getActionsService().redeemChurnCoupon({
+    uid,
+    subscriptionId,
+    acceptLanguage,
+    selectedLanguage,
+  });
+};

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -45,6 +45,7 @@ import { GetCouponArgs } from './validators/GetCouponArgs';
 import { GetCouponResult } from './validators/GetCouponResult';
 import { PaymentsEmitterService } from '@fxa/payments/events';
 import { FinalizeProcessingCartActionArgs } from './validators/finalizeProcessingCartActionArgs';
+import { RedeemChurnCouponActionArgs } from './validators/RedeemChurnCouponActionArgs';
 import { SubmitNeedsInputActionArgs } from './validators/SubmitNeedsInputActionArgs';
 import { GetNeedsInputActionArgs } from './validators/GetNeedsInputActionArgs';
 import { ValidatePostalCodeActionArgs } from './validators/ValidatePostalCodeActionArgs';
@@ -104,6 +105,7 @@ import { UpdateStripePaymentDetailsResult } from './validators/UpdateStripePayme
 import { SetDefaultStripePaymentDetailsActionArgs } from './validators/SetDefaultStripePaymentDetailsActionArgs';
 import { CancelSubscriptionAtPeriodEndActionArgs } from './validators/CancelSubscriptionAtPeriodEndActionArgs';
 import { CancelSubscriptionAtPeriodEndActionResult } from './validators/CancelSubscriptionAtPeriodEndActionResult';
+import { RedeemChurnCouponActionResult } from './validators/RedeemChurnCouponActionResult';
 import { ResubscribeSubscriptionActionArgs } from './validators/ResubscribeSubscriptionActionArgs';
 import { ResubscribeSubscriptionActionResult } from './validators/ResubscribeSubscriptionActionResult';
 import { GetPaypalBillingAgreementActiveIdArgs } from './validators/GetPaypalBillingAgreementActiveIdArgs';
@@ -268,6 +270,27 @@ export class NextJSActionsService {
     selectedLanguage?: string;
   }) {
     return await this.churnInterventionService.determineStaySubscribedEligibility(
+      args.uid,
+      args.subscriptionId,
+      args.acceptLanguage,
+      args.selectedLanguage,
+    );
+  }
+
+  @SanitizeExceptions()
+  @NextIOValidator(
+    RedeemChurnCouponActionArgs,
+    RedeemChurnCouponActionResult
+  )
+  @WithTypeCachableAsyncLocalStorage()
+  @CaptureTimingWithStatsD()
+  async redeemChurnCoupon(args: {
+    uid: string;
+    subscriptionId: string;
+    acceptLanguage?: string | null;
+    selectedLanguage?: string;
+  }) {
+    return await this.churnInterventionService.redeemChurnCoupon(
       args.uid,
       args.subscriptionId,
       args.acceptLanguage,

--- a/libs/payments/ui/src/lib/nestapp/validators/RedeemChurnCouponActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RedeemChurnCouponActionArgs.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString, IsOptional } from 'class-validator';
+
+export class RedeemChurnCouponActionArgs {
+  @IsString()
+  uid!: string;
+
+  @IsString()
+  subscriptionId!: string;
+
+  @IsString()
+  @IsOptional()
+  acceptLanguage?: string;
+
+  @IsString()
+  @IsOptional()
+  selectedLanguage?: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/RedeemChurnCouponActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RedeemChurnCouponActionResult.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CmsChurnInterventionEntryResult {
+  @IsString()
+  webIcon!: string;
+
+  @IsString()
+  churnInterventionId!: string;
+
+  @IsString()
+  churnType!: string;
+
+  @IsOptional()
+  @IsNumber()
+  redemptionLimit?: number | null;
+
+  @IsString()
+  stripeCouponId!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsNumber()
+  discountAmount!: number;
+
+  @IsString()
+  ctaMessage!: string;
+
+  @IsString()
+  modalHeading!: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  modalMessage!: string[];
+
+  @IsString()
+  productPageUrl!: string;
+
+  @IsString()
+  termsHeading!: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  termsDetails!: string[];
+
+  @IsString()
+  supportUrl!: string;
+}
+
+export class ChurnInterventionEntryDataResult {
+  @IsString()
+  customerId!: string;
+
+  @IsString()
+  churnInterventionId!: string;
+
+  @IsNumber()
+  redemptionCount!: number;
+}
+
+export class RedeemChurnCouponActionResult {
+  @IsBoolean()
+  redeemed!: boolean;
+
+  @IsString()
+  reason!: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => ChurnInterventionEntryDataResult)
+  updatedChurnInterventionEntryData!: ChurnInterventionEntryDataResult | null;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CmsChurnInterventionEntryResult)
+  cmsChurnInterventionEntry!: CmsChurnInterventionEntryResult | null;
+}


### PR DESCRIPTION
## Because

- Need to add an action when a customer redeems a churn coupon.

## This pull request

- Updates payments-ui to add Action to update customer’s subscription when redeeming churn coupon.
- If the customer is eligible and redeems the churn coupon, increments the customer’s redemption count.
- Makes sure the subscription's auto renew is set to false

## Issue that this pull request solves

Closes: #[PAY-3362](https://mozilla-hub.atlassian.net/browse/PAY-3362)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3362]: https://mozilla-hub.atlassian.net/browse/PAY-3362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ