### PR TITLE
fix(settings): Clear apollo cache on account deletion

### DIFF
--- a/packages/functional-tests/tests/settings/deleteAccount.spec.ts
+++ b/packages/functional-tests/tests/settings/deleteAccount.spec.ts
@@ -59,13 +59,7 @@ test.describe('severity-1 #smoke', () => {
     testAccountTracker,
   }) => {
     const credentials = await testAccountTracker.signUp();
-    await signInAccount(
-      target,
-      page,
-      settings,
-      signin,
-      credentials
-    );
+    await signInAccount(target, page, settings, signin, credentials);
 
     await settings.goto();
 
@@ -99,6 +93,25 @@ test.describe('severity-1 #smoke', () => {
     await deleteAccount.deleteButton.click();
 
     await expect(deleteAccount.tooltip).toHaveText('Incorrect password');
+  });
+
+  test('delete account A then sign in with account B, no apollo cache pollution', async ({
+    target,
+    pages: { page, deleteAccount, settings, signin },
+    testAccountTracker,
+  }) => {
+    const credentialsA = await testAccountTracker.signUp();
+    const credentialsB = await testAccountTracker.signUp();
+
+    await signInAccount(target, page, settings, signin, credentialsA);
+    await settings.deleteAccountButton.click();
+    await deleteAccount.deleteAccount(credentialsA.password);
+
+    await expect(page.getByText('Account deleted successfully')).toBeVisible();
+    await signin.fillOutEmailFirstForm(credentialsB.email);
+    await signin.fillOutPasswordForm(credentialsB.password);
+    await expect(settings.settingsHeading).toBeVisible();
+    await expect(settings.primaryEmail.status).toHaveText(credentialsB.email);
   });
 });
 

--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.tsx
@@ -19,6 +19,7 @@ import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { getLocalizedErrorMessage } from '../../../lib/error-utils';
 import GleanMetrics from '../../../lib/glean';
 import { useFtlMsgResolver } from '../../../models/hooks';
+import { useApolloClient } from '@apollo/client';
 
 type FormData = {
   password: string;
@@ -102,6 +103,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const goHome = useCallback(() => window.history.back(), []);
 
   const account = useAccount();
+  const apolloClient = useApolloClient();
 
   useEffect(() => {
     GleanMetrics.deleteAccount.view();
@@ -136,6 +138,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
           'flow.settings.account-delete',
           'confirm-password.success'
         );
+        await apolloClient.clearStore();
 
         navigateWithQuery('/', {
           state: {
@@ -160,6 +163,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
       alertBar,
       ftlMsgResolver,
       navigateWithQuery,
+      apolloClient,
     ]
   );
 

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -17,6 +17,16 @@ import { SETTINGS_PATH } from '../../constants';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import { Subject } from './mocks';
 
+jest.mock('@apollo/client', () => {
+  const actual = jest.requireActual('@apollo/client');
+  return {
+    ...actual,
+    useApolloClient: () => ({
+      clearStore: jest.fn().mockResolvedValue(undefined),
+    }),
+  };
+});
+
 const mockSessionStatus = jest.fn();
 jest.mock('../../models', () => ({
   ...jest.requireActual('../../models'),


### PR DESCRIPTION
## Because

* Cache may linger after account deletion

## This pull request

* Clear cache when account is destroyed
* Add functional test for this case

## Issue that this pull request solves

Closes: #FXA-12717

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

To reproduce, follow the steps in the new functional-test (or copy the test into main and observe it fails)
