### PR TITLE
fix(oauth): fix signing into VPN does not show code input

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -131,6 +131,7 @@ const settingsConfig = {
     enabled: config.get('cms.enabled'),
     l10nEnabled: config.get('cms.l10nEnabled'),
   },
+  servicesWithEmailVerification: config.get('servicesWithEmailVerification'),
 };
 
 // Inject Settings content into the index HTML

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -907,6 +907,12 @@ const conf = (module.exports = convict({
       env: 'SENTRY_TRACES_SAMPLE_RATE',
     },
   },
+  servicesWithEmailVerification: {
+    doc: 'Services that will alwasy send a session verification email on sign in',
+    default: ['e6eb0d1e856335fc'],
+    format: Array,
+    env: 'SERVICES_WITH_EMAIL_VERIFICATION',
+  },
   sourceMapType: {
     default: 'source-map',
     doc: 'Type of source maps created. See https://webpack.js.org/configuration/devtool/',

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -111,6 +111,7 @@ export interface Config {
     enabled: boolean;
     l10nEnabled: boolean;
   };
+  servicesWithEmailVerification: string[];
 }
 
 export function getDefault() {
@@ -206,6 +207,7 @@ export function getDefault() {
       enabled: true,
       preview: true,
     },
+    servicesWithEmailVerification: ['e6eb0d1e856335fc'],
   } as Config;
 }
 

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -111,6 +111,9 @@ jest.mock('../../models', () => {
     useSession: () => ({
       sendVerificationCode: mockSendVerificationCode,
     }),
+    useConfig: () => ({
+      servicesWithEmailVerification: ['123456'],
+    }),
   };
 });
 
@@ -1193,6 +1196,72 @@ describe('Signin component', () => {
               })
             );
           });
+          handleNavigationSpy.mockRestore();
+        });
+
+        it('correctly provides isServiceWithEmailVerification to handleNavigation when client is in servicesWithEmailVerification', async () => {
+          const handleNavigationSpy = jest.spyOn(
+            SigninUtils,
+            'handleNavigation'
+          );
+          const finishOAuthFlowHandler = jest
+            .fn()
+            .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+          const integration = createMockSigninOAuthIntegration({
+            clientId: '123456',
+          });
+          render({
+            beginSigninHandler: jest.fn().mockReturnValue(
+              createBeginSigninResponse({
+                emailVerified: true,
+                sessionVerified: false,
+              })
+            ),
+            integration,
+            finishOAuthFlowHandler,
+            sessionToken: MOCK_SESSION_TOKEN,
+          });
+
+          await enterPasswordAndSubmit();
+          expect(handleNavigationSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              isServiceWithEmailVerification: true,
+            })
+          );
+
+          handleNavigationSpy.mockRestore();
+        });
+
+        it('correctly provides isServiceWithEmailVerification to handleNavigation when client is not in servicesWithEmailVerification', async () => {
+          const handleNavigationSpy = jest.spyOn(
+            SigninUtils,
+            'handleNavigation'
+          );
+          const finishOAuthFlowHandler = jest
+            .fn()
+            .mockReturnValueOnce(MOCK_OAUTH_FLOW_HANDLER_RESPONSE);
+          const integration = createMockSigninOAuthIntegration({
+            clientId: '654321',
+          });
+          render({
+            beginSigninHandler: jest.fn().mockReturnValue(
+              createBeginSigninResponse({
+                emailVerified: true,
+                sessionVerified: false,
+              })
+            ),
+            integration,
+            finishOAuthFlowHandler,
+            sessionToken: MOCK_SESSION_TOKEN,
+          });
+
+          await enterPasswordAndSubmit();
+          expect(handleNavigationSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              isServiceWithEmailVerification: false,
+            })
+          );
+
           handleNavigationSpy.mockRestore();
         });
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -25,6 +25,7 @@ import {
   isWebIntegration,
   isOAuthIntegration,
   isOAuthNativeIntegration,
+  useConfig,
 } from '../../models';
 import {
   isClientMonitor,
@@ -63,6 +64,7 @@ const Signin = ({
   flowQueryParams,
   useFxAStatusResult: { supportsKeysOptionalLogin },
 }: SigninProps & RouteComponentProps) => {
+  const config = useConfig();
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const location = useLocation();
   const navigateWithQuery = useNavigateWithQuery();
@@ -92,6 +94,8 @@ const Signin = ({
   const hasLinkedAccountAndNoPassword = hasLinkedAccount && !hasPassword;
 
   const isDeeplinking = !!deeplink;
+  const isServiceWithEmailVerification =
+    !!clientId && config.servicesWithEmailVerification.includes(clientId);
 
   // We must use a ref because we may update this value in a callback
   let isPasswordNeededRef = useRef(
@@ -167,6 +171,7 @@ const Signin = ({
           finishOAuthFlowHandler,
           queryParams: location.search,
           performNavigation: !integration.isFirefoxMobileClient(),
+          isServiceWithEmailVerification,
         };
 
         const { error: navError } = await handleNavigation(navigationOptions);
@@ -195,6 +200,7 @@ const Signin = ({
       finishOAuthFlowHandler,
       location.search,
       webRedirectCheck,
+      isServiceWithEmailVerification,
     ]
   );
 
@@ -227,6 +233,7 @@ const Signin = ({
           performNavigation: !(
             integration.isFirefoxMobileClient() && isFullyVerified
           ),
+          isServiceWithEmailVerification,
         };
 
         const { error: navError } = await handleNavigation(navigationOptions);
@@ -331,6 +338,7 @@ const Signin = ({
       location.search,
       webRedirectCheck,
       sensitiveDataClient,
+      isServiceWithEmailVerification,
     ]
   );
 

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -232,6 +232,7 @@ export interface NavigationOptions {
   };
   // If false, skip actually navigating. Still sends web channel messages etc.
   performNavigation?: boolean;
+  isServiceWithEmailVerification?: boolean;
 }
 
 export interface OAuthSigninResult {

--- a/packages/fxa-settings/src/pages/Signin/utils.test.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.test.ts
@@ -220,6 +220,30 @@ describe('Signin utils', () => {
         );
       });
 
+      it('returns early for OAuth integration that isServiceWithEmailVerification', async () => {
+        const mockOAuthIntegration = createMockSigninOAuthIntegration();
+
+        const navigationOptions = createBaseNavigationOptions({
+          signinData: {
+            ...createBaseNavigationOptions().signinData,
+            emailVerified: true,
+            sessionVerified: false,
+            verificationMethod: VerificationMethods.EMAIL,
+            verificationReason: VerificationReasons.SIGN_IN,
+          },
+          isServiceWithEmailVerification: true,
+          integration: mockOAuthIntegration,
+        });
+
+        const result = await handleNavigation(navigationOptions);
+
+        expect(result.error).toBeUndefined();
+        expect(navigateSpy).toHaveBeenCalledWith(
+          '/signin_token_code',
+          expect.any(Object)
+        );
+      });
+
       it('returns early for OAuth integration with wantsKeys', async () => {
         const mockOAuthIntegration = createMockSigninOAuthIntegration();
         (mockOAuthIntegration as any).wantsKeys = jest

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -235,8 +235,8 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
   // 4. Users with type C session going through an RP flow that requires two-step authentication
   //    always get redirected to confirm email, before setting up TOTP
   // 5. Users with type C session going through a normal RP redirect flow will be allowed to
-  //    continue onward without getting prompted for a code. If they try to use Settings with
-  //    this session later, they will be prompted then.
+  //    continue onward without getting prompted for a code, unless the RP is in `servicesWithEmailVerification`.
+  //    If they try to use Settings with this session later, they will be prompted then.
   // 6. WebIntegrations (ie Settings) are always redirected to confirm email
   // 7. Users that are forced to change their password always get redirected to confirm email
   const isFullyVerified =
@@ -265,6 +265,7 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
         VerificationMethods.TOTP_2FA ||
       navigationOptions.signinData.verificationReason ===
         VerificationReasons.CHANGE_PASSWORD ||
+      navigationOptions.isServiceWithEmailVerification ||
       wantsTwoStepAuthentication ||
       wantsKeys
     ) {


### PR DESCRIPTION
## Because

- Verification code is received, but user is not redirected to the “Enter confirmation code” page, when signing in from Mozilla VPN

## This pull request

- fixes this problem by adding `servicesWithEmailVerification` to frontend config

## Issue that this pull request solves

Closes: FXA-12712

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
