### PR TITLE
fix(sentry): Init sentry in profile server

### DIFF
--- a/packages/fxa-profile-server/lib/monitoring.js
+++ b/packages/fxa-profile-server/lib/monitoring.js
@@ -4,7 +4,7 @@
 
 const Sentry = require('@sentry/node');
 const { initMonitoring } = require('fxa-shared/monitoring');
-const { config } = require('./config');
+const config = require('./config').getProperties();
 const log = require('./logging')('configure-sentry');
 const { version } = require('../package.json');
 

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -92,6 +92,7 @@ exports.create = async function createServer() {
 
   // configure Sentry
   if (config.sentry && config.sentry.dsn) {
+
     // Attach a new Sentry scope to the request for breadcrumbs/tags/extras
     server.ext({
       type: 'onRequest',

--- a/packages/fxa-shared/sentry/browser.ts
+++ b/packages/fxa-shared/sentry/browser.ts
@@ -158,7 +158,7 @@ function configure(config: SentryConfigOpts, log?: ILogger) {
   }
 
   if (!config?.sentry?.dsn) {
-    log.error('No Sentry dsn provided');
+    log.error('sentry.dsn.missing', 'No Sentry dsn provided');
     return;
   }
 

--- a/packages/fxa-shared/sentry/node.ts
+++ b/packages/fxa-shared/sentry/node.ts
@@ -18,7 +18,7 @@ export type InitSentryOpts = SentryConfigOpts & ExtraOpts;
 
 export function initSentry(config: InitSentryOpts, log: ILogger) {
   if (!config?.sentry?.dsn) {
-    log.error('No Sentry dsn provided. Cannot start sentry');
+    log.error('sentry.dsn.missing', 'No Sentry dsn provided. Cannot start sentry');
     return;
   }
 


### PR DESCRIPTION
## Because

- We were not initalizing Sentry in the profile server

## This pull request

- Initalizes Sentry before using it

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-11811

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

I verified this with my personal Sentry account

<img width="1161" height="283" alt="Screenshot 2025-12-01 at 12 05 01 PM" src="https://github.com/user-attachments/assets/d1bca4de-9b42-45c2-b7b4-e40406e4aa65" />

