### PR TITLE
feat(auth): New stored procedure for deviceCount to support recovery-key route

### DIFF
--- a/packages/db-migrations/databases/fxa/patches/patch-178-179.sql
+++ b/packages/db-migrations/databases/fxa/patches/patch-178-179.sql
@@ -2,9 +2,14 @@ SET NAMES utf8mb4 COLLATE utf8mb4_bin;
 
 CALL assertPatchLevel('178');
 
+-- In practice, this stored procedure ended up being slower than the original despite
+-- the optimizer hints, and fewer rows from the CTE filtering first. Code should still
+-- reference accountDevices_17, but this will be left so we don't have to drop the procedure.
+
 -- This migration updates the attachedDevices sproc to optimize performance
 -- using CTE and MySQL 8 optimizer hints, limiting fan-out during joins to
 -- deviceCommands and deviceCommandIdentifiers.
+
 
 CREATE PROCEDURE `accountDevices_18` (
   IN `uidArg` BINARY(16),

--- a/packages/db-migrations/databases/fxa/patches/patch-179-180.sql
+++ b/packages/db-migrations/databases/fxa/patches/patch-179-180.sql
@@ -1,0 +1,18 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('179');
+
+-- Creates a new stored procedure to just get the count of devices for a given uid.
+CREATE PROCEDURE `deviceCount_1` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT COUNT(*) AS deviceCount
+  FROM devices AS d
+  LEFT JOIN sessionTokens AS s ON d.sessionTokenId = s.tokenId
+  WHERE d.uid = uidArg
+  -- Similar to accountDevices_17, we need to filter out zombie devices.
+  AND (s.tokenId IS NOT NULL OR d.refreshTokenId IS NOT NULL);
+END;
+
+UPDATE dbMetadata SET value = '180' WHERE name = 'schema-patch-level';

--- a/packages/db-migrations/databases/fxa/patches/patch-180-179.sql
+++ b/packages/db-migrations/databases/fxa/patches/patch-180-179.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `deviceCount_1`;
+
+-- UPDATE dbMetadata SET value = '179' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/db.ts
+++ b/packages/fxa-auth-server/lib/db.ts
@@ -442,6 +442,21 @@ export const createDB = (
       }
     }
 
+    /**
+     * Get a count of all devices for a given UID.
+     * @param uid
+     * @returns
+     */
+    async deviceCount(uid: string) {
+      log.trace('DB.deviceCount', { uid });
+      const count = await Device.countByUid(uid);
+      this.metrics?.increment('db.deviceCount.retrieve', {
+        result: 'success',
+        count,
+      });
+      return count;
+    }
+
     async sessionToken(id: string) {
       log.trace('DB.sessionToken', { id });
       const data = await RawSessionToken.findByTokenId(id);
@@ -1064,15 +1079,15 @@ export const createDB = (
       );
     }
 
-    async verifiedLoginSecurityEventsByUid(params: { uid: string; skipTimeframeMs: number}) {
+    async verifiedLoginSecurityEventsByUid(params: {
+      uid: string;
+      skipTimeframeMs: number;
+    }) {
       log.trace('DB.verifiedLoginSecurityEventsByUid', {
         params: params,
       });
       const { uid, skipTimeframeMs } = params;
-      return SecurityEvent.findByUidAndVerifiedLogin(
-        uid,
-        skipTimeframeMs
-      );
+      return SecurityEvent.findByUidAndVerifiedLogin(uid, skipTimeframeMs);
     }
 
     async securityEventsByUid(params: { uid: string }) {

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -362,9 +362,12 @@ module.exports = (
         // We try our best to estimate the number of Sync devices that could be impacted by using a recovery key.
         // It is an estimate because we currently can't query the Sync service to get the actual number of items
         // until https://mozilla-hub.atlassian.net/browse/SYNC-4240 is implemented.
-        const services = await list(uid);
+        const [services, deviceCount] = await Promise.all([
+          list(uid),
+          db.deviceCount(uid),
+        ]);
         const estimatedSyncDeviceCount = Math.max(
-          (await db.devices(uid)).length,
+          deviceCount,
           services.filter((service) =>
             service.scope.includes(OAUTH_SCOPE_OLD_SYNC)
           ).length

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -637,7 +637,7 @@ describe('POST /recoveryKey/exists', () => {
         {
           db: {
             recoveryData,
-            devices: [],
+            deviceCount: 0,
           },
         },
         {},
@@ -662,14 +662,7 @@ describe('POST /recoveryKey/exists', () => {
         {
           db: {
             recoveryData,
-            devices: [
-              {
-                type: 'desktop',
-                id: 'desktop1',
-                lastAccess: new Date(),
-                lastAccessVersion: '1.0',
-              },
-            ],
+            deviceCount: 1,
           },
         },
         {},
@@ -705,7 +698,7 @@ describe('POST /recoveryKey/exists', () => {
           },
           db: {
             recoveryData,
-            devices: [],
+            deviceCount: 0,
           },
         },
         {},

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -74,6 +74,7 @@ const DB_METHOD_NAMES = [
   'deleteTotpToken',
   'devices',
   'device',
+  'deviceCount',
   'emailBounces',
   'emailRecord',
   'forgotPasswordVerified',
@@ -577,6 +578,13 @@ function mockDB(data, errors) {
       const device = data.devices.find((d) => d.id === deviceId);
       assert.ok(device);
       return Promise.resolve(device);
+    }),
+    deviceCount: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string');
+      return Promise.resolve(
+        // default to 0 if not set
+        typeof data.deviceCount !== 'undefined' ? data.deviceCount : 0
+      );
     }),
     deleteSessionToken: sinon.spy(() => {
       return Promise.resolve();

--- a/packages/fxa-shared/db/models/auth/base-auth.ts
+++ b/packages/fxa-shared/db/models/auth/base-auth.ts
@@ -39,6 +39,7 @@ export enum Proc {
   DeleteSessionToken = 'deleteSessionToken_4',
   DeleteTotpToken = 'deleteTotpToken_4',
   Device = 'device_3',
+  DeviceCount = 'deviceCount_1',
   DeviceFromTokenVerificationId = 'deviceFromTokenVerificationId_6',
   EmailBounces = 'fetchEmailBounces_3',
   FindLargeAccounts = 'findLargeAccounts_1',

--- a/packages/fxa-shared/db/models/auth/device.ts
+++ b/packages/fxa-shared/db/models/auth/device.ts
@@ -238,4 +238,11 @@ export class Device extends BaseAuthModel {
     );
     return this.fromRows(rows).shift() || null;
   }
+
+  static async countByUid(uid: string) {
+    const {
+      rows: [{ deviceCount }], // deviceCount comes from COUNT(*) in the stored procedure
+    } = await this.callProcedure(Proc.DeviceCount, uuidTransformer.to(uid));
+    return deviceCount;
+  }
 }

--- a/packages/fxa-shared/test/db/models/auth/helpers.ts
+++ b/packages/fxa-shared/test/db/models/auth/helpers.ts
@@ -218,7 +218,7 @@ export async function testAuthDatabaseSetup(instance: Knex): Promise<void> {
     './recovery-phones.sql',
     './key-fetch-tokens.sql',
     './security-event-names.sql',
-    './security-events.sql'
+    './security-events.sql',
   ]);
   // The order matters for inserts or foreign key refs
   await runSql([
@@ -226,11 +226,12 @@ export async function testAuthDatabaseSetup(instance: Knex): Promise<void> {
     './sent-emails.sql',
     './deviceCommands.sql',
     './sp_accountDevices.sql',
+    './sp_deviceCount.sql',
     './sp_prune.sql',
     './sp_limitSessions.sql',
     './sp_findLargeAccounts.sql',
     './sp_resetAccount.sql',
-    './sp_createSecurityEvent.sql'
+    './sp_createSecurityEvent.sql',
   ]);
 
   /*/ Debugging Assistance

--- a/packages/fxa-shared/test/db/models/auth/sp_deviceCount.sql
+++ b/packages/fxa-shared/test/db/models/auth/sp_deviceCount.sql
@@ -1,0 +1,11 @@
+CREATE PROCEDURE `deviceCount_1` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  SELECT COUNT(*) AS deviceCount
+  FROM devices AS d
+  LEFT JOIN sessionTokens AS s ON d.sessionTokenId = s.tokenId
+  WHERE d.uid = uidArg
+  -- Similar to accountDevices_17, we need to filter out zombie devices.
+  AND (s.tokenId IS NOT NULL OR d.refreshTokenId IS NOT NULL);
+END;


### PR DESCRIPTION
## Because

- We currently call to `accountDevices` stored procedure for any calls to `recoveryKey/exists`, and that is a larger query for just a device count than it needs to be

## This pull request

- Creates a new stored procedure for just the count of devices for an account, ignoring records without sessionToken or refreshToken
- Updates `recoveryKey/exists` to handle use the new count method
- Updates tests

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
