### PR TITLE
polish(payments): Revise conditional for Link

### DIFF
--- a/libs/payments/customer/src/lib/paymentMethod.manager.ts
+++ b/libs/payments/customer/src/lib/paymentMethod.manager.ts
@@ -142,7 +142,7 @@ export class PaymentMethodManager {
           type: SubPlatPaymentMethodType.GooglePay,
           paymentMethodId: customer.invoice_settings.default_payment_method,
         };
-      } else if (paymentMethod.type === 'link') {
+      } else if (paymentMethod.type === 'link' || paymentMethod.card?.wallet?.type === 'link') {
         return {
           type: SubPlatPaymentMethodType.Link,
           paymentMethodId: customer.invoice_settings.default_payment_method,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1696,7 +1696,7 @@ export class StripeHelper extends StripeHelperBase {
         return SubPlatPaymentMethodType.ApplePay;
       } else if (walletType === 'google_pay') {
         return SubPlatPaymentMethodType.GooglePay;
-      } else if (paymentMethod.type === 'link') {
+      } else if (paymentMethod.type === 'link' || walletType === 'link') {
         return SubPlatPaymentMethodType.Link;
       } else if (paymentMethod.type === 'card') {
         return SubPlatPaymentMethodType.Card;


### PR DESCRIPTION
## Because

For Link:
- In stage, the payment method object has the value of "link" for `type` and no card object
- In prod, the payment method object has the value of "card" for `type` with a card object - value of 'link' for wallet.type as well as card expiry month/year

## This pull request

- should display an error message for customers that have an expired Link account as their default payment method

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.