### PR TITLE
fix(payments-next): Broken privacyNoticeDownloadUrl and termsOfServiceDownloadUrl in “subscriptionReactivation” email template

### DIFF
--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -704,7 +704,7 @@ const conf = convict({
     },
     subscriptionTermsUrl: {
       default:
-        'https://www.mozilla.org/about/legal/terms/firefox-private-network/',
+        'https://www.mozilla.org/about/legal/terms/subscription-services',
       doc: 'Subscription terms and cancellation policy URL',
       env: 'SUBSCRIPTION_TERMS_URL',
       format: String,

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -19,7 +19,7 @@
     "port": 9999,
     "secure": false,
     "redirectDomain": "localhost",
-    "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/firefox-private-network/",
+    "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/subscription-services",
     "subscriptionSettingsUrl": "http://localhost:3035/",
     "user": "local",
     "password": "local"

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -525,7 +525,7 @@ const convictConf = convict({
     },
     subscriptionTermsUrl: {
       default:
-        'https://www.mozilla.org/about/legal/terms/firefox-private-network/',
+        'https://www.mozilla.org/about/legal/terms/subscription-services',
       doc: 'Subscription terms and cancellation policy URL',
       env: 'SUBSCRIPTION_TERMS_URL',
       format: String,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3703,9 +3703,9 @@ describe('#integration - StripeHelper', () => {
       name: productName,
       metadata: {
         'product:termsOfServiceURL':
-          'https://www.mozilla.org/about/legal/terms/firefox-private-network',
+          'https://www.mozilla.org/about/legal/terms/subscription-services',
         'product:privacyNoticeURL':
-          'https://www.mozilla.org/privacy/firefox-private-network',
+          'https://www.mozilla.org/privacy/subscription-services',
       },
     };
     beforeEach(() => {
@@ -5378,9 +5378,9 @@ describe('#integration - StripeHelper', () => {
     const sourceId = eventCustomerSourceExpiring.data.object.id;
     const chargeId = 'ch_1GVm24BVqmGyQTMaUhRAfUmA';
     const privacyNoticeURL =
-      'https://www.mozilla.org/privacy/firefox-private-network';
+      'https://www.mozilla.org/privacy/subscription-services';
     const termsOfServiceURL =
-      'https://www.mozilla.org/about/legal/terms/firefox-private-network';
+      'https://www.mozilla.org/about/legal/terms/subscription-services';
     const cancellationSurveyURL =
       'https://www.mozilla.org/legal/mozilla_cancellation_survey_url';
 

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -164,14 +164,14 @@ const conf = convict({
   },
   legalDocLinks: {
     privacyNotice: {
-      default: 'https://www.mozilla.org/privacy/firefox-private-network',
+      default: 'https://www.mozilla.org/privacy/subscription-services',
       doc: 'Link to Privacy Notice',
       env: 'PAYMENT_PRIVACY_NOTICE',
       format: 'url',
     },
     termsOfService: {
       default:
-        'https://www.mozilla.org/about/legal/terms/firefox-private-network',
+        'https://www.mozilla.org/about/legal/terms/subscription-services',
       doc: 'Link to Terms of Service',
       env: 'PAYMENT_TERMS_OF_SERVCIE',
       format: 'url',

--- a/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConsentCheckbox/index.test.tsx
@@ -89,7 +89,7 @@ describe('components/PaymentConsentCheckbox', () => {
         );
         expect(legalCheckbox.props.children.props.children[1]).toBe(' ');
         expect(legalCheckbox.props.children.props.children[2].props.href).toBe(
-          'https://www.mozilla.org/about/legal/terms/firefox-private-network'
+          'https://www.mozilla.org/about/legal/terms/subscription-services'
         );
         expect(
           legalCheckbox.props.children.props.children[2].props.children
@@ -97,7 +97,7 @@ describe('components/PaymentConsentCheckbox', () => {
         expect(legalCheckbox.props.children.props.children[3]).toBe(' and');
         expect(legalCheckbox.props.children.props.children[4]).toBe(' ');
         expect(legalCheckbox.props.children.props.children[5].props.href).toBe(
-          'https://www.mozilla.org/privacy/firefox-private-network'
+          'https://www.mozilla.org/privacy/subscription-services'
         );
         expect(
           legalCheckbox.props.children.props.children[5].props.children

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -26,12 +26,12 @@ export const DEFAULT_PRODUCT_DETAILS: ProductDetails = {
     'Available for Windows, iOS and Android',
   ],
   termsOfServiceURL:
-    'https://www.mozilla.org/about/legal/terms/firefox-private-network',
+    'https://www.mozilla.org/about/legal/terms/subscription-services',
   termsOfServiceDownloadURL:
-    'https://cdn.accounts.firefox.com/legal/Mozilla_VPN_ToS/en-US.pdf',
-  privacyNoticeURL: 'https://www.mozilla.org/privacy/firefox-private-network',
+    'https://cdn.accounts.firefox.com/legal/subscription_services_tos.en.pdf',
+  privacyNoticeURL: 'https://www.mozilla.org/privacy/subscription-services',
   privacyNoticeDownloadURL:
-    'https://cdn.accounts.firefox.com/legal/mozilla_vpn_privacy_notice/en-US.pdf',
+    'https://cdn.accounts.firefox.com/legal/subscription_services_privacy_notice.en.pdf',
 };
 
 // Support some default null values for product / plan metadata and


### PR DESCRIPTION
## Because

- A couple urls are wrong and broken in emails being sent to users.

## This pull request

- Fixes the urls.

## Issue that this pull request solves

Closes: (issue number) #PAY-3379, PAY-3418

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
* Also updated Stripe Metadata fields with Strapi links.
