### PR TITLE
task(email-renderer): Add types to email template partials

### DIFF
--- a/libs/accounts/email-renderer/src/partials/accountDeletionInfoBlock/index.ts
+++ b/libs/accounts/email-renderer/src/partials/accountDeletionInfoBlock/index.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  supportUrl: string;
+  unsubscribeUrl: string;
+};
+export const template = 'accountDeletionInfoBlock';
+export const version = 1;

--- a/libs/accounts/email-renderer/src/partials/appBadges/index.ts
+++ b/libs/accounts/email-renderer/src/partials/appBadges/index.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cssPath: string;
+  productName: string;
+  hideDeviceLink: boolean;
+  onDesktopOrTabletDevice: boolean;
+  iosUrl?: string;
+  androidUrl?: string;
+  desktopLink?: string;
+  link?: string;
+  supportUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/automatedEmailChangePassword/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailChangePassword/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  passwordChangeLink: string;
+  supportUrl: string;
+};

--- a/libs/accounts/email-renderer/src/partials/automatedEmailInactiveAccount/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailInactiveAccount/index.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = unknown;

--- a/libs/accounts/email-renderer/src/partials/automatedEmailNoAction/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailNoAction/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  supportUrl: string;
+};

--- a/libs/accounts/email-renderer/src/partials/automatedEmailNotAuthorized/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailNotAuthorized/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  passwordChangeLink: string;
+};

--- a/libs/accounts/email-renderer/src/partials/automatedEmailRecoveryKey/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailRecoveryKey/index.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  device?: {
+    uaBrowser?: string;
+    uaOS?: string;
+    uaOSVersion?: string;
+  };
+  keyExists: boolean;
+  revokeAccountRecoveryLink: string;
+  supportUrl: string;
+  passwordChangeLink: string;
+};

--- a/libs/accounts/email-renderer/src/partials/automatedEmailResetPassword/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailResetPassword/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  resetLink: string;
+  supportUrl: string;
+};

--- a/libs/accounts/email-renderer/src/partials/automatedEmailResetPasswordTwoFactor/index.ts
+++ b/libs/accounts/email-renderer/src/partials/automatedEmailResetPasswordTwoFactor/index.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  resetLink: string;
+  twoFactorSettingsLink: string;
+  supportUrl: string;
+};

--- a/libs/accounts/email-renderer/src/partials/bannerWarning/index.ts
+++ b/libs/accounts/email-renderer/src/partials/bannerWarning/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cssPath: string;
+};

--- a/libs/accounts/email-renderer/src/partials/brandMessaging/index.ts
+++ b/libs/accounts/email-renderer/src/partials/brandMessaging/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  brandMessagingMode: string;
+  cssPath: string;
+};

--- a/libs/accounts/email-renderer/src/partials/button/index.ts
+++ b/libs/accounts/email-renderer/src/partials/button/index.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cssPath?: string;
+  cssClass?: string;
+  link?: string;
+  buttonL10nId?: string;
+  buttonText?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/cancellationSurvey/index.ts
+++ b/libs/accounts/email-renderer/src/partials/cancellationSurvey/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cancellationSurveyUrl: string;
+};

--- a/libs/accounts/email-renderer/src/partials/changePassword/index.ts
+++ b/libs/accounts/email-renderer/src/partials/changePassword/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  passwordChangeLink: string;
+};

--- a/libs/accounts/email-renderer/src/partials/icon/index.ts
+++ b/libs/accounts/email-renderer/src/partials/icon/index.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  icon: string;
+  productName: string;
+  productIconURLNew?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/images.ts
+++ b/libs/accounts/email-renderer/src/partials/images.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  productName?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/manageAccount/index.ts
+++ b/libs/accounts/email-renderer/src/partials/manageAccount/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  link: string;
+};

--- a/libs/accounts/email-renderer/src/partials/metadata.ts
+++ b/libs/accounts/email-renderer/src/partials/metadata.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  oneClickLink?: string;
+  subject?: string;
+  action?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/paymentPlanDetails/index.ts
+++ b/libs/accounts/email-renderer/src/partials/paymentPlanDetails/index.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  productName?: string;
+  invoiceNumber?: string;
+  invoiceDateOnly?: string;
+  invoiceTotal?: string;
+  nextInvoiceDateOnly?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/paymentProvider/index.ts
+++ b/libs/accounts/email-renderer/src/partials/paymentProvider/index.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  invoiceAmountDueInCents: number;
+  paymentProviderName?: string;
+  cardName?: string;
+  lastFour?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionCharges/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionCharges/index.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This template invokes the paymentProviderTemplate;
+import { TemplateData as PaymentProviderTemplateData } from '../paymentProvider';
+
+export type TemplateData = PaymentProviderTemplateData & {
+  invoiceNumber: string;
+  invoiceDateOnly: string;
+
+  remainingAmountTotalInCents?: number;
+  offeringPriceInCents?: number;
+  remainingAmountTotal?: string;
+  offeringPrice?: string;
+  unusedAmountTotalInCents?: number;
+  unusedAmountTotal?: string;
+
+  invoiceSubtotalInCents?: number;
+  invoiceSubtotal?: string;
+  discountType?: string;
+  discountDuration?: string;
+  invoiceDiscountAmount?: string;
+
+  showTaxAmount?: boolean;
+  invoiceTaxAmountInCents?: number;
+  invoiceTaxAmount?: string;
+
+  invoiceAmountDueInCents?: number;
+  invoiceTotal?: string;
+
+  creditAppliedInCents?: number;
+  invoiceStartingBalance?: string;
+  creditApplied?: string;
+
+  invoiceAmountDue: string;
+  invoiceTotalInCents: number;
+  creditReceived: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionSupport/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionSupport/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cssClass?: string;
+  subscriptionSupportUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionSupportContact/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionSupportContact/index.ts
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  productName?: string;
+  subscriptionSupportUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionSupportGetHelp/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionSupportGetHelp/index.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cssClass?: string;
+  manageSubscriptionUrl?: string;
+  subscriptionSupportUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionUpdateBillingEnsure/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionUpdateBillingEnsure/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  updateBillingUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionUpdateBillingTry/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionUpdateBillingTry/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  updateBillingUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/subscriptionUpdatePayment/index.ts
+++ b/libs/accounts/email-renderer/src/partials/subscriptionUpdatePayment/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  updateBillingUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/support/index.mjml
+++ b/libs/accounts/email-renderer/src/partials/support/index.mjml
@@ -1,3 +1,7 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
 <mj-section>
   <mj-column>
     <mj-text css-class="text-footer-automatedEmail">

--- a/libs/accounts/email-renderer/src/partials/support/index.ts
+++ b/libs/accounts/email-renderer/src/partials/support/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  supportUrl?: string;
+};

--- a/libs/accounts/email-renderer/src/partials/userDevice/index.ts
+++ b/libs/accounts/email-renderer/src/partials/userDevice/index.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  device?: {
+    uaBrowser?: string;
+    uaOS?: string;
+    uaOSVersion?: string;
+  };
+};

--- a/libs/accounts/email-renderer/src/partials/userInfo/index.ts
+++ b/libs/accounts/email-renderer/src/partials/userInfo/index.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { TemplateData as UserDeviceTemplateData } from '../userDevice';
+import { TemplateData as UserLocationTemplateData } from '../userLocation';
+
+export type TemplateData = UserDeviceTemplateData &
+  UserLocationTemplateData & {
+    cssPath?: string;
+    primaryEmail?: string;
+    date?: string;
+    time?: string;
+  };

--- a/libs/accounts/email-renderer/src/partials/userLocation/index.ts
+++ b/libs/accounts/email-renderer/src/partials/userLocation/index.ts
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  location?: {
+    city?: string;
+    stateCode?: string;
+    country?: string;
+  };
+};

--- a/libs/accounts/email-renderer/src/partials/viewInvoice/index.ts
+++ b/libs/accounts/email-renderer/src/partials/viewInvoice/index.ts
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  invoiceLink?: string;
+};

--- a/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
@@ -51,11 +51,13 @@ const renderAndSnapshotEmail = async <
 const mockLink = 'http://localhost:3030/mock-link';
 const mockLinkOneClick = 'http://localhost:3030/mock-one-click-link';
 const mockLinkSupport = 'http://localhost:3030/mock-support-link';
+const mockLinkUnsubscribe = 'http://localhost:3030/mock-unsubscribe';
 const mockLinkReset = 'http://localhost:3030/mock-reset-link';
 const mockLinkPasswordChange =
   'http://localhost:3030/mock-password-change-link';
 const mockLinkRevokeAccountRecovery =
   'http://localhost:3030/mock-revoke-account-recovery-link';
+const mockCssPath = '';
 
 const mockEmail = 'mock-email@mozilla.com';
 
@@ -98,6 +100,10 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           oneClickLink: mockLinkOneClick,
           productName: 'Firefox',
+          cssPath: mockCssPath,
+          hideDeviceLink: false,
+          onDesktopOrTabletDevice: false,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -112,6 +118,10 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           oneClickLink: mockLinkOneClick,
           productName: 'Firefox',
+          supportUrl: mockLinkSupport,
+          cssPath: mockCssPath,
+          hideDeviceLink: false,
+          onDesktopOrTabletDevice: false,
         },
         defaultLayoutTemplateValues
       );
@@ -122,7 +132,12 @@ describe('FxA Email Renderer', () => {
     it('should render and snapshot email', async () => {
       await renderAndSnapshotEmail(
         'renderInactiveAccountFinalWarning',
-        { deletionDate: 'January 1, 2025', link: mockLink },
+        {
+          deletionDate: 'January 1, 2025',
+          link: mockLink,
+          supportUrl: mockLinkSupport,
+          unsubscribeUrl: mockLinkUnsubscribe,
+        },
         defaultLayoutTemplateValues
       );
     });
@@ -132,7 +147,12 @@ describe('FxA Email Renderer', () => {
     it('should render and snapshot email', async () => {
       await renderAndSnapshotEmail(
         'renderInactiveAccountFirstWarning',
-        { deletionDate: 'January 1, 2025', link: mockLink },
+        {
+          deletionDate: 'January 1, 2025',
+          link: mockLink,
+          unsubscribeUrl: mockLinkUnsubscribe,
+          supportUrl: mockLinkSupport,
+        },
         defaultLayoutTemplateValues
       );
     });
@@ -142,7 +162,12 @@ describe('FxA Email Renderer', () => {
     it('should render and snapshot email', async () => {
       await renderAndSnapshotEmail(
         'renderInactiveAccountSecondWarning',
-        { deletionDate: 'January 1, 2025', link: mockLink },
+        {
+          deletionDate: 'January 1, 2025',
+          link: mockLink,
+          unsubscribeUrl: mockLinkUnsubscribe,
+          supportUrl: mockLinkSupport,
+        },
         defaultLayoutTemplateValues
       );
     });
@@ -152,7 +177,7 @@ describe('FxA Email Renderer', () => {
     it('should render and snapshot email', async () => {
       await renderAndSnapshotEmail(
         'renderLowRecoveryCodes',
-        { link: mockLink, numberRemaining: 3 },
+        { link: mockLink, numberRemaining: 3, supportUrl: mockLinkSupport },
         defaultLayoutTemplateValues
       );
     });
@@ -171,6 +196,8 @@ describe('FxA Email Renderer', () => {
           device: mockDevice,
           passwordChangeLink: mockLinkSupport,
           mozillaSupportUrl: mockLinkSupport,
+          supportUrl: mockLinkSupport,
+          showBannerWarning: false,
         },
         defaultLayoutTemplateValues
       );
@@ -190,6 +217,8 @@ describe('FxA Email Renderer', () => {
           device: mockDevice,
           passwordChangeLink: mockLinkSupport,
           mozillaSupportUrl: mockLinkSupport,
+          supportUrl: mockLinkSupport,
+          showBannerWarning: false,
         },
         defaultLayoutTemplateValues
       );
@@ -206,6 +235,7 @@ describe('FxA Email Renderer', () => {
           device: mockDevice,
           location: mockLocation,
           resetLink: mockLinkReset,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -232,6 +262,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           device: mockDevice,
           location: mockLocation,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -248,6 +279,7 @@ describe('FxA Email Renderer', () => {
           resetLink: mockLinkReset,
           device: mockDevice,
           location: mockLocation,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -266,6 +298,10 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           passwordChangeLink: mockLinkPasswordChange,
           productName: 'Sync',
+          supportUrl: mockLinkSupport,
+          cssPath: mockCssPath,
+          hideDeviceLink: false,
+          onDesktopOrTabletDevice: false,
         },
         defaultLayoutTemplateValues
       );
@@ -284,6 +320,7 @@ describe('FxA Email Renderer', () => {
           resetLink: mockLinkReset,
           twoFactorSettingsLink: mockLinkSupport,
           time: '12:00 PM',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -302,6 +339,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
           productName: 'Sync',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -320,6 +358,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
           revokeAccountRecoveryLink: mockLinkRevokeAccountRecovery,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -338,6 +377,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
           providerName: 'Google',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -357,6 +397,7 @@ describe('FxA Email Renderer', () => {
           maskedLastFourPhoneNumber: '•••• •••• 1234',
           resetLink: mockLinkReset,
           twoFactorSupportLink: mockLinkSupport,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -375,6 +416,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           twoFactorSupportLink: mockLinkSupport,
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -393,7 +435,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
           revokeAccountRecoveryLink: mockLinkRevokeAccountRecovery,
-          supportLink: mockLinkSupport,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -408,6 +450,7 @@ describe('FxA Email Renderer', () => {
           email: mockEmail,
           link: mockLink,
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -424,6 +467,7 @@ describe('FxA Email Renderer', () => {
           location: mockLocation,
           resetLink: mockLinkReset,
           time: '12:00 PM',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -442,6 +486,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
           twoFactorSupportLink: mockLinkSupport,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -460,6 +505,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           resetLink: mockLinkReset,
           twoFactorSettingsLink: mockLinkSupport,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -477,6 +523,7 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -494,6 +541,8 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
+          revokeAccountRecoveryLink: mockLinkRevokeAccountRecovery,
         },
         defaultLayoutTemplateValues
       );
@@ -510,6 +559,7 @@ describe('FxA Email Renderer', () => {
           location: mockLocation,
           resetLink: mockLinkReset,
           time: '12:00 PM',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -523,6 +573,7 @@ describe('FxA Email Renderer', () => {
         {
           link: mockLink,
           secondaryEmail: mockEmail,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -540,6 +591,7 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           time: '12:00 PM',
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -557,6 +609,7 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           time: '12:00 PM',
           resetLink: mockLinkReset,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -574,6 +627,7 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           time: '12:00 PM',
           resetLink: mockLinkReset,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -589,6 +643,9 @@ describe('FxA Email Renderer', () => {
           desktopLink: mockLink,
           onDesktopOrTabletDevice: true,
           productName: 'Firefox',
+          supportUrl: mockLinkSupport,
+          cssPath: mockCssPath,
+          hideDeviceLink: false,
         },
         defaultLayoutTemplateValues
       );
@@ -603,6 +660,7 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           secondaryEmail: mockEmail,
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -619,6 +677,7 @@ describe('FxA Email Renderer', () => {
           location: mockLocation,
           link: mockLink,
           time: '12:00 PM',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -648,6 +707,7 @@ describe('FxA Email Renderer', () => {
         'renderVerificationReminderFinal',
         {
           link: mockLink,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -660,6 +720,7 @@ describe('FxA Email Renderer', () => {
         'renderVerificationReminderFirst',
         {
           link: mockLink,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -672,6 +733,7 @@ describe('FxA Email Renderer', () => {
         'renderVerificationReminderSecond',
         {
           link: mockLink,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -689,6 +751,7 @@ describe('FxA Email Renderer', () => {
           link: mockLink,
           time: '12:00 PM',
           sync: false,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -707,6 +770,7 @@ describe('FxA Email Renderer', () => {
           code: '123456',
           expirationTime: 15,
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -725,6 +789,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           clientName: 'Firefox Sync',
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -742,6 +807,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           code: '654321',
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
           serviceName: 'Firefox Sync',
         },
         defaultLayoutTemplateValues
@@ -761,6 +827,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           sync: true,
           passwordChangeLink: mockLinkPasswordChange,
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );
@@ -778,6 +845,7 @@ describe('FxA Email Renderer', () => {
           time: '12:00 PM',
           email: mockEmail,
           code: '789012',
+          supportUrl: 'http://localhost:3030/support',
         },
         defaultLayoutTemplateValues
       );
@@ -793,6 +861,7 @@ describe('FxA Email Renderer', () => {
           device: mockDevice,
           location: mockLocation,
           code: '345678',
+          supportUrl: mockLinkSupport,
         },
         defaultLayoutTemplateValues
       );

--- a/libs/accounts/email-renderer/src/templates/cadReminderFirst/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/cadReminderFirst/index.stories.ts
@@ -14,6 +14,10 @@ const data = {
   oneClickLink: 'http://localhost:3030/connect_another_device?one_click=true',
   link: 'http://localhost:3030/connect_another_device',
   productName: 'Firefox',
+  supportUrl: 'https://support.mozilla.org',
+  cssPath: '',
+  hideDeviceLink: true,
+  onDesktopOrTabletDevice: true,
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/cadReminderFirst/index.ts
+++ b/libs/accounts/email-renderer/src/templates/cadReminderFirst/index.ts
@@ -2,12 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  oneClickLink: string;
-  link: string;
-  productName: string;
-};
+import { TemplateData as AppBadgesTemplateData } from '../../partials/appBadges';
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
 
+export type TemplateData = AppBadgesTemplateData &
+  AutomatedEmailNoActionTemplateData & {
+    oneClickLink: string;
+    link: string;
+    productName: string;
+  };
 export const template = 'cadReminderFirst';
 export const version = 3;
 export const layout = 'fxa';

--- a/libs/accounts/email-renderer/src/templates/cadReminderSecond/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/cadReminderSecond/index.stories.ts
@@ -14,6 +14,10 @@ const data = {
   oneClickLink: 'http://localhost:3030/connect_another_device?one_click=true',
   link: 'http://localhost:3030/connect_another_device',
   productName: 'Firefox',
+  supportUrl: 'https://support.mozilla.org',
+  cssPath: '',
+  hideDeviceLink: true,
+  onDesktopOrTabletDevice: true,
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/cadReminderSecond/index.ts
+++ b/libs/accounts/email-renderer/src/templates/cadReminderSecond/index.ts
@@ -2,11 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  oneClickLink: string;
-  link: string;
-  productName: string;
-};
+import { TemplateData as AppBadgesTemplateData } from '../../partials/appBadges';
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AppBadgesTemplateData &
+  AutomatedEmailNoActionTemplateData & {
+    oneClickLink: string;
+    link: string;
+    productName: string;
+  };
 
 export const template = 'cadReminderSecond';
 export const version = 3;

--- a/libs/accounts/email-renderer/src/templates/downloadSubscription/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/downloadSubscription/index.stories.ts
@@ -22,6 +22,9 @@ const data = {
   // Forces fallbacks to be used in appBadges partial
   iosUrl: undefined,
   androidUrl: undefined,
+  cssPath: '',
+  hideDeviceLink: true,
+  onDesktopOrTabletDevice: true,
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/downloadSubscription/index.ts
+++ b/libs/accounts/email-renderer/src/templates/downloadSubscription/index.ts
@@ -2,16 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  icon: string;
-  link: string;
-  productName: string;
-  subscriptionSupportUrl: string;
-  playStoreLink: string;
-  appStoreLink: string;
-  iosUrl: undefined;
-  androidUrl: undefined;
-};
+import { TemplateData as AppBadgesTemplateData } from '../../partials/appBadges';
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = AppBadgesTemplateData &
+  IconTemplateData &
+  SubscriptionSupportTemplateData & {
+    icon: string;
+    link: string;
+    productName: string;
+    subscriptionSupportUrl: string;
+    playStoreLink: string;
+    appStoreLink: string;
+    iosUrl: undefined;
+    androidUrl: undefined;
+  };
 
 export const template = 'downloadSubscription';
 export const version = 2;

--- a/libs/accounts/email-renderer/src/templates/fraudulentAccountDeletion/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/fraudulentAccountDeletion/index.stories.ts
@@ -12,6 +12,7 @@ export default {
 
 const data = {
   mozillaSupportUrl: 'https://support.mozilla.org',
+  supportUrl: 'https://support.mozilla.org',
   wasDeleted: true,
 };
 

--- a/libs/accounts/email-renderer/src/templates/fraudulentAccountDeletion/index.ts
+++ b/libs/accounts/email-renderer/src/templates/fraudulentAccountDeletion/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData & {
   mozillaSupportUrl: string;
   wasDeleted: boolean;
 };

--- a/libs/accounts/email-renderer/src/templates/inactiveAccountFinalWarning/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/inactiveAccountFinalWarning/index.stories.ts
@@ -14,6 +14,8 @@ const data = {
   // dates will be passed in to the template already localized and formatted by the email handler
   deletionDate: 'Thursday, Jan 9, 2025',
   link: 'http://localhost:3030/signin',
+  supportUrl: 'https://support.mozilla.org',
+  unsubscribeUrl: 'https://accounts.firefox.com/unsubscribe',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/inactiveAccountFinalWarning/index.ts
+++ b/libs/accounts/email-renderer/src/templates/inactiveAccountFinalWarning/index.ts
@@ -2,10 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  deletionDate: string;
-  link: string;
-};
+import { TemplateData as AccountDeletionInfoBlockTemplateData } from '../../partials/accountDeletionInfoBlock';
+import { TemplateData as AutomatedEmailInactiveAccountTemplateData } from '../../partials/automatedEmailInactiveAccount';
+
+export type TemplateData = AccountDeletionInfoBlockTemplateData &
+  AutomatedEmailInactiveAccountTemplateData & {
+    deletionDate: string;
+    link: string;
+  };
 
 export const template = 'inactiveAccountFinalWarning';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/inactiveAccountFirstWarning/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/inactiveAccountFirstWarning/index.stories.ts
@@ -14,6 +14,8 @@ const data = {
   // dates will be passed in to the template already localized and formatted by the email handler
   deletionDate: 'Thursday, Jan 9, 2025',
   link: 'http://localhost:3030/signin',
+  supportUrl: 'https://support.mozilla.org',
+  unsubscribeUrl: 'https://accounts.firefox.com/unsubscribe',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/inactiveAccountFirstWarning/index.ts
+++ b/libs/accounts/email-renderer/src/templates/inactiveAccountFirstWarning/index.ts
@@ -2,10 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  deletionDate: string;
-  link: string;
-};
+import { TemplateData as AccountDeletionInfoBlockTemplateData } from '../../partials/accountDeletionInfoBlock';
+import { TemplateData as AutomatedEmailInactiveAccountTemplateData } from '../../partials/automatedEmailInactiveAccount';
+
+export type TemplateData = AccountDeletionInfoBlockTemplateData &
+  AutomatedEmailInactiveAccountTemplateData & {
+    deletionDate: string;
+    link: string;
+  };
 
 export const template = 'inactiveAccountFirstWarning';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/inactiveAccountSecondWarning/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/inactiveAccountSecondWarning/index.stories.ts
@@ -13,6 +13,8 @@ export default {
 const data = {
   deletionDate: 'Thursday, Jan 9, 2025',
   link: 'http://localhost:3030/signin',
+  supportUrl: 'https://support.mozilla.org',
+  unsubscribeUrl: 'https://accounts.firefox.com/unsubscribe',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/inactiveAccountSecondWarning/index.ts
+++ b/libs/accounts/email-renderer/src/templates/inactiveAccountSecondWarning/index.ts
@@ -2,10 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  deletionDate: string;
-  link: string;
-};
+import { TemplateData as AccountDeletionInfoBlockTemplateData } from '../../partials/accountDeletionInfoBlock';
+import { TemplateData as AutomatedEmailInactiveAccountTemplateData } from '../../partials/automatedEmailInactiveAccount';
+
+export type TemplateData = AccountDeletionInfoBlockTemplateData &
+  AutomatedEmailInactiveAccountTemplateData & {
+    deletionDate: string;
+    link: string;
+  };
 
 export const template = 'inactiveAccountSecondWarning';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/lowRecoveryCodes/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/lowRecoveryCodes/index.stories.ts
@@ -12,6 +12,7 @@ export default {
 
 const data = {
   link: 'http://localhost:3030/settings/two_step_authentication/replace_codes?low_recovery_codes=true',
+  supportUrl: 'https://support.mozilla.org',
   numberRemaining: 1,
 };
 

--- a/libs/accounts/email-renderer/src/templates/lowRecoveryCodes/index.ts
+++ b/libs/accounts/email-renderer/src/templates/lowRecoveryCodes/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData & {
   link: string;
   numberRemaining: number;
 };

--- a/libs/accounts/email-renderer/src/templates/newDeviceLogin/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/newDeviceLogin/index.stories.ts
@@ -17,6 +17,8 @@ const data = {
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   link: 'http://localhost:3030/settings',
   mozillaSupportUrl: 'https://support.mozilla.org',
+  showBannerWarning: false,
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/newDeviceLogin/index.ts
+++ b/libs/accounts/email-renderer/src/templates/newDeviceLogin/index.ts
@@ -2,30 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    date: string;
+    time: string;
+    clientName: string;
+    passwordChangeLink: string;
+    link: string;
+    mozillaSupportUrl: string;
+    showBannerWarning: boolean;
+    cmsRpClientId?: string;
+    cmsRpFromName?: string;
+    entrypoint?: string;
+    subject?: string;
+    headline?: string;
+    description?: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-  time: string;
-  clientName: string;
-  passwordChangeLink: string;
-  link: string;
-  mozillaSupportUrl: string;
-  cmsRpClientId?: string;
-  cmsRpFromName?: string;
-  entrypoint?: string;
-  subject?: string;
-  headline?: string;
-  description?: string;
-};
 
 export const template = 'newDeviceLogin';
 export const version = 7;

--- a/libs/accounts/email-renderer/src/templates/newDeviceLogin/strapi.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/newDeviceLogin/strapi.stories.ts
@@ -23,6 +23,8 @@ const data = {
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   link: 'http://localhost:3030/settings',
   mozillaSupportUrl: 'https://support.mozilla.org',
+  supportUrl: 'https://support.mozilla.org',
+  showBannerWarning: false,
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/passwordChangeRequired/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordChangeRequired/index.ts
@@ -1,7 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-export type TemplateData = {
+import { TemplateData as SupportTemplateData } from '../../partials/support';
+
+export type TemplateData = SupportTemplateData & {
   link: string;
 };
 

--- a/libs/accounts/email-renderer/src/templates/passwordChanged/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordChanged/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   resetLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/passwordChanged/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordChanged/index.ts
@@ -2,21 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    time: string;
+    date: string;
+    resetLink: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-  resetLink: string;
-};
 
 export const template = 'passwordChanged';
 export const version = 5;

--- a/libs/accounts/email-renderer/src/templates/passwordForgotOtp/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordForgotOtp/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   code: '96318398',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/passwordForgotOtp/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordForgotOtp/index.ts
@@ -2,21 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  code: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    code: string;
+    time: string;
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'passwordForgotOtp';
 export const version = 2;

--- a/libs/accounts/email-renderer/src/templates/passwordReset/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordReset/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   resetLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/passwordReset/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordReset/index.ts
@@ -2,21 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  resetLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    resetLink: string;
+    time: string;
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'passwordReset';
 export const version = 6;

--- a/libs/accounts/email-renderer/src/templates/passwordResetAccountRecovery/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetAccountRecovery/index.stories.ts
@@ -16,6 +16,10 @@ const data = {
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   productName: 'Firefox',
+  supportUrl: 'https://support.mozilla.org',
+  cssPath: '',
+  hideDeviceLink: true,
+  onDesktopOrTabletDevice: true,
 };
 const createStory = storyWithProps<TemplateData>(
   'passwordResetAccountRecovery',

--- a/libs/accounts/email-renderer/src/templates/passwordResetAccountRecovery/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetAccountRecovery/index.ts
@@ -2,23 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  productName: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AppBadgesTemplateData } from '../../partials/appBadges';
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AppBadgesTemplateData &
+  AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    productName: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'passwordResetAccountRecovery';
 export const version = 9;

--- a/libs/accounts/email-renderer/src/templates/passwordResetRecoveryPhone/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetRecoveryPhone/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  resetLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTwoFactorTemplateData } from '../../partials/automatedEmailResetPasswordTwoFactor';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTwoFactorTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    resetLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
+    twoFactorSettingsLink: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-  twoFactorSettingsLink: string;
-};
 
 export const template = 'passwordResetRecoveryPhone';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/passwordResetWithRecoveryKeyPrompt/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetWithRecoveryKeyPrompt/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   link: 'http://localhost:3030/settings/account_recovery',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   productName: 'Firefox',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/passwordResetWithRecoveryKeyPrompt/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetWithRecoveryKeyPrompt/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  productName: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    productName: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'passwordResetWithRecoveryKeyPrompt';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postAddAccountRecovery/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddAccountRecovery/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   revokeAccountRecoveryLink: 'http://localhost:3030/settings/#recovery-key',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postAddAccountRecovery/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddAccountRecovery/index.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailRecoveryKeyTemplateData } from '../../partials/automatedEmailRecoveryKey';
+
+export type TemplateData = Omit<
+  AutomatedEmailRecoveryKeyTemplateData,
+  'keyExists'
+> & {
   link: string;
   passwordChangeLink: string;
   revokeAccountRecoveryLink: string;

--- a/libs/accounts/email-renderer/src/templates/postAddLinkedAccount/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddLinkedAccount/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   providerName: 'Apple',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postAddLinkedAccount/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddLinkedAccount/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
+    providerName: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-  providerName: string;
-};
 
 export const template = 'postAddLinkedAccount';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postAddRecoveryPhone/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddRecoveryPhone/index.stories.ts
@@ -18,6 +18,7 @@ const data = {
   resetLink: 'http://localhost:3030/reset_password',
   twoFactorSupportLink:
     'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postAddRecoveryPhone/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddRecoveryPhone/index.ts
@@ -2,24 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  maskedLastFourPhoneNumber: string;
-  link: string;
-  resetLink: string;
-  twoFactorSupportLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    maskedLastFourPhoneNumber: string;
+    link: string;
+    resetLink: string;
+    twoFactorSupportLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postAddRecoveryPhone';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.stories.ts
@@ -17,6 +17,7 @@ const data = {
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   twoFactorSupportLink:
     'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  twoFactorSupportLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    twoFactorSupportLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postAddTwoStepAuthentication';
 export const version = 11;

--- a/libs/accounts/email-renderer/src/templates/postChangeAccountRecovery/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangeAccountRecovery/index.stories.ts
@@ -16,7 +16,7 @@ const data = {
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   revokeAccountRecoveryLink: 'http://localhost:3030/settings/#recovery-key',
-  supportLink: '',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postChangeAccountRecovery/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangeAccountRecovery/index.ts
@@ -2,11 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailRecoveryKeyTemplateData } from '../../partials/automatedEmailRecoveryKey';
+
+export type TemplateData = Omit<
+  AutomatedEmailRecoveryKeyTemplateData,
+  'keyExists'
+> & {
   link: string;
-  passwordChangeLink: string;
-  revokeAccountRecoveryLink: string;
-  supportLink: string;
   time: string;
   device: {
     uaBrowser: string;

--- a/libs/accounts/email-renderer/src/templates/postChangePrimary/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangePrimary/index.stories.ts
@@ -14,6 +14,7 @@ const data = {
   email: 'foo@bar.com',
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postChangePrimary/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangePrimary/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData & {
   email: string;
   link: string;
   passwordChangeLink: string;

--- a/libs/accounts/email-renderer/src/templates/postChangeRecoveryPhone/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangeRecoveryPhone/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   resetLink: 'http://localhost:3030/reset_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postChangeRecoveryPhone/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangeRecoveryPhone/index.ts
@@ -2,21 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  resetLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    resetLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postChangeRecoveryPhone';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.stories.ts
@@ -17,6 +17,7 @@ const data = {
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   twoFactorSupportLink:
     'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  twoFactorSupportLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    twoFactorSupportLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postChangeTwoStepAuthentication';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postConsumeRecoveryCode/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postConsumeRecoveryCode/index.stories.ts
@@ -17,6 +17,7 @@ const data = {
   resetLink: 'http://localhost:3030/reset_password',
   twoFactorSettingsLink:
     'http://localhost:3030/settings#two-step-authentication',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postConsumeRecoveryCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postConsumeRecoveryCode/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  resetLink: string;
-  twoFactorSettingsLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTwoFactorTemplateData } from '../../partials/automatedEmailResetPasswordTwoFactor';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTwoFactorTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    resetLink: string;
+    twoFactorSettingsLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postConsumeRecoveryCode';
 export const version = 8;

--- a/libs/accounts/email-renderer/src/templates/postNewRecoveryCodes/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postNewRecoveryCodes/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postNewRecoveryCodes/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postNewRecoveryCodes/index.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postNewRecoveryCodes';
 export const version = 7;

--- a/libs/accounts/email-renderer/src/templates/postRemoveAccountRecovery/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveAccountRecovery/index.stories.ts
@@ -15,6 +15,8 @@ const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  revokeAccountRecoveryLink: '', // Not used but partial requires type presence? No, Omit handles keyExists, but revokeAccountRecoveryLink is in partial required list. Wait.
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postRemoveAccountRecovery/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveAccountRecovery/index.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailRecoveryKeyTemplateData } from '../../partials/automatedEmailRecoveryKey';
+
+export type TemplateData = Omit<
+  AutomatedEmailRecoveryKeyTemplateData,
+  'keyExists'
+> & {
   link: string;
   passwordChangeLink: string;
   time: string;

--- a/libs/accounts/email-renderer/src/templates/postRemoveRecoveryPhone/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveRecoveryPhone/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   resetLink: 'http://localhost:3030/reset_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postRemoveRecoveryPhone/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveRecoveryPhone/index.ts
@@ -1,21 +1,25 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-export type TemplateData = {
-  resetLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    resetLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postRemoveRecoveryPhone';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postRemoveSecondary/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveSecondary/index.stories.ts
@@ -13,6 +13,7 @@ export default {
 const data = {
   link: 'http://localhost:3030/settings',
   secondaryEmail: 'secondary@email.com',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postRemoveSecondary/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveSecondary/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData & {
   link: string;
   secondaryEmail: string;
 };

--- a/libs/accounts/email-renderer/src/templates/postRemoveTwoStepAuthentication/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveTwoStepAuthentication/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/settings',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postRemoveTwoStepAuthentication/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postRemoveTwoStepAuthentication/index.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  passwordChangeLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    passwordChangeLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postRemoveTwoStepAuthentication';
 export const version = 9;

--- a/libs/accounts/email-renderer/src/templates/postSigninRecoveryCode/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postSigninRecoveryCode/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/settings',
   resetLink: 'http://localhost:3030/reset_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postSigninRecoveryCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postSigninRecoveryCode/index.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  resetLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    resetLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postSigninRecoveryCode';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postSigninRecoveryPhone/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postSigninRecoveryPhone/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/settings',
   resetLink: 'http://localhost:3030/reset_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postSigninRecoveryPhone/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postSigninRecoveryPhone/index.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  resetLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    resetLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'postSigninRecoveryPhone';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/postVerify/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postVerify/index.stories.ts
@@ -15,6 +15,13 @@ const data = {
   desktopLink: 'https://firefox.com',
   onDesktopOrTabletDevice: true,
   productName: 'Firefox',
+  playStoreLink:
+    'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
+  appStoreLink:
+    'https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926',
+  supportUrl: 'https://support.mozilla.org',
+  cssPath: '',
+  hideDeviceLink: true,
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postVerify/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postVerify/index.ts
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  desktopLink: string;
-  onDesktopOrTabletDevice: boolean;
-  productName: string;
-};
+import { TemplateData as AppBadgesTemplateData } from '../../partials/appBadges';
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AppBadgesTemplateData &
+  AutomatedEmailNoActionTemplateData & {
+    link: string;
+    desktopLink: string;
+    onDesktopOrTabletDevice: boolean;
+    productName: string;
+  };
 
 export const template = 'postVerify';
 export const version = 8;

--- a/libs/accounts/email-renderer/src/templates/postVerifySecondary/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postVerifySecondary/index.stories.ts
@@ -14,6 +14,7 @@ const data = {
   link: 'http://localhost:3030/settings',
   secondaryEmail: 'secondary@email.com',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postVerifySecondary/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postVerifySecondary/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData & {
   link: string;
   secondaryEmail: string;
   passwordChangeLink: string;

--- a/libs/accounts/email-renderer/src/templates/recovery/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/recovery/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/complete_reset_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/recovery/index.ts
+++ b/libs/accounts/email-renderer/src/templates/recovery/index.ts
@@ -2,21 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 export const template = 'recovery';
 export const version = 6;
 export const layout = 'fxa';

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountDeletion/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountDeletion/index.stories.ts
@@ -15,7 +15,7 @@ const data = {
   isCancellationEmail: true,
   invoiceTotal: '$20',
   invoiceDateOnly: '11/13/2021',
-  cancellationSurveryUrl:
+  cancellationSurveyUrl:
     'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
 };
 

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountDeletion/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountDeletion/index.ts
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as CancellationSurveyTemplateData } from '../../partials/cancellationSurvey';
+
+export type TemplateData = CancellationSurveyTemplateData & {
   productName: string;
   isCancellationEmail: boolean;
   invoiceTotal: string;
   invoiceDateOnly: string;
-  cancellationSurveryUrl: string;
+  cancellationSurveryUrl?: string;
 };
 
 export const template = 'subscriptionAccountDeletion';

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountFinishSetup/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountFinishSetup/index.stories.ts
@@ -16,6 +16,10 @@ const data = {
   link: 'http://localhost:3030/post_verify/finish_account_setup/set_password',
   subscriptionSupportUrl: 'http://localhost:3030/support',
   isFinishSetup: true,
+  invoiceDateOnly: '10/13/2021',
+  invoiceNumber: '8675309',
+  invoiceTotal: '$20.00',
+  nextInvoiceDateOnly: '11/13/2021',
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountFinishSetup/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountFinishSetup/index.ts
@@ -2,13 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  productName: string;
-  icon: string;
-  link: string;
-  subscriptionSupportUrl: string;
-  isFinishSetup: boolean;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as PaymentPlanDetailsTemplateData } from '../../partials/paymentPlanDetails';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = IconTemplateData &
+  PaymentPlanDetailsTemplateData &
+  SubscriptionSupportTemplateData & {
+    productName: string;
+    icon: string;
+    link: string;
+    subscriptionSupportUrl: string;
+    isFinishSetup: boolean;
+  };
 
 export const template = 'subscriptionAccountFinishSetup';
 export const version = 2;

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderFirst/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderFirst/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   reminderShortForm: true,
   resetLink: 'http://localhost:3030/settings/change_password',
   subscriptionSupportUrl: 'http://localhost:3030/support',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderFirst/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderFirst/index.ts
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  reminderShortForm: boolean;
-  resetLink: string;
-  subscriptionSupportUrl: string;
-};
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  SubscriptionSupportTemplateData & {
+    link: string;
+    reminderShortForm: boolean;
+    resetLink: string;
+    subscriptionSupportUrl: string;
+  };
 
 export const template = 'subscriptionAccountReminderFirst';
 export const version = 3;

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderSecond/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderSecond/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   reminderShortForm: true,
   resetLink: 'http://localhost:3030/settings/change_password',
   subscriptionSupportUrl: 'http://localhost:3030/support',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderSecond/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionAccountReminderSecond/index.ts
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  reminderShortForm: boolean;
-  resetLink: string;
-  subscriptionSupportUrl: string;
-};
+import { TemplateData as AutomatedEmailResetPasswordTemplateData } from '../../partials/automatedEmailResetPassword';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = AutomatedEmailResetPasswordTemplateData &
+  SubscriptionSupportTemplateData & {
+    link: string;
+    reminderShortForm: boolean;
+    resetLink: string;
+    subscriptionSupportUrl: string;
+  };
 
 export const template = 'subscriptionAccountReminderSecond';
 export const version = 3;

--- a/libs/accounts/email-renderer/src/templates/subscriptionCancellation/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionCancellation/index.stories.ts
@@ -16,7 +16,7 @@ const data = {
   invoiceTotal: '$2,000.00',
   invoiceDateOnly: '11/13/2021',
   serviceLastActiveDateOnly: '12/13/2021',
-  cancellationSurveryUrl:
+  cancellationSurveyUrl:
     'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
   showOutstandingBalance: true,
   cancelAtEnd: false,

--- a/libs/accounts/email-renderer/src/templates/subscriptionCancellation/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionCancellation/index.ts
@@ -2,13 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as CancellationSurveyTemplateData } from '../../partials/cancellationSurvey';
+
+export type TemplateData = CancellationSurveyTemplateData & {
   productName: string;
   isCancellationEmail: boolean;
   invoiceTotal: string;
   invoiceDateOnly: string;
   serviceLastActiveDateOnly: string;
-  cancellationSurveryUrl: string;
+  cancellationSurveryUrl?: string;
   showOutstandingBalance: boolean;
   cancelAtEnd: boolean;
 };

--- a/libs/accounts/email-renderer/src/templates/subscriptionDowngrade/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionDowngrade/index.stories.ts
@@ -18,6 +18,7 @@ const data = {
     'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
   productIconURLOld:
     'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
+  icon: 'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
   productName: 'Product Name B',
   productNameOld: 'Product Name A',
   productPaymentCycleNew: 'month',

--- a/libs/accounts/email-renderer/src/templates/subscriptionDowngrade/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionDowngrade/index.ts
@@ -2,18 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  paymentAmountNew: string;
-  paymentAmountOld: string;
-  paymentProrated: string;
-  productIconURLNew: string;
-  productIconURLOld: string;
-  productName: string;
-  productNameOld: string;
-  productPaymentCycleNew: string;
-  productPaymentCycleOld: string;
-  subscriptionSupportUrl: string;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = IconTemplateData &
+  SubscriptionSupportTemplateData & {
+    paymentAmountNew: string;
+    paymentAmountOld: string;
+    paymentProrated: string;
+    productIconURLNew: string;
+    productIconURLOld: string;
+    productName: string;
+    productNameOld: string;
+    productPaymentCycleNew: string;
+    productPaymentCycleOld: string;
+    subscriptionSupportUrl: string;
+  };
 
 export const template = 'subscriptionDowngrade';
 export const version = 2;

--- a/libs/accounts/email-renderer/src/templates/subscriptionFailedPaymentsCancellation/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionFailedPaymentsCancellation/index.stories.ts
@@ -13,7 +13,7 @@ export default {
 const data = {
   productName: 'Firefox Fortress',
   isCancellationEmail: true,
-  cancellationSurveryUrl:
+  cancellationSurveyUrl:
     'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
 };
 

--- a/libs/accounts/email-renderer/src/templates/subscriptionFailedPaymentsCancellation/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionFailedPaymentsCancellation/index.ts
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as CancellationSurveyTemplateData } from '../../partials/cancellationSurvey';
+
+export type TemplateData = CancellationSurveyTemplateData & {
   productName: string;
   isCancellationEmail: boolean;
-  cancellationSurveryUrl: string;
+  cancellationSurveryUrl?: string;
 };
 
 export const template = 'subscriptionFailedPaymentsCancellation';

--- a/libs/accounts/email-renderer/src/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionFirstInvoice/index.stories.ts
@@ -21,14 +21,14 @@ const data = {
   invoiceNumber: '8675309',
   invoiceTotal: '$20.00',
   invoiceTotalInCents: 2000,
-  invoiceSubtotal: null,
-  invoiceTaxAmount: null,
-  invoiceDiscountAmount: null,
-  discountType: null,
-  discountDuration: null,
+  invoiceSubtotal: undefined,
+  invoiceTaxAmount: undefined,
+  invoiceDiscountAmount: undefined,
+  discountType: undefined,
+  discountDuration: undefined,
   nextInvoiceDateOnly: '11/13/2021',
   subscriptionSupportUrl: 'http://localhost:3030/support',
-  paymentProrated: null,
+  paymentProrated: undefined,
   showPaymentMethod: true,
   showProratedAmount: false,
   showTaxAmount: false,
@@ -47,6 +47,7 @@ const data = {
   invoiceStartingBalance: '$10.00',
   manageSubscriptionUrl: 'https://payments.firefox.com/', // Does this need UTM params?
   invoiceTaxAmountInCents: 1000,
+  creditReceived: '$10.00',
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/subscriptionFirstInvoice/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionFirstInvoice/index.ts
@@ -2,40 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  invoiceAmountDue: string;
-  invoiceAmountDueInCents: number;
-  icon: string;
-  invoiceDateOnly: string;
-  invoiceLink: string;
-  invoiceNumber: string;
-  invoiceTotal: string;
-  invoiceTotalInCents: number;
-  invoiceSubtotal: string | null;
-  invoiceTaxAmount: string | null;
-  invoiceDiscountAmount: string | null;
-  discountType: string | null;
-  discountDuration: string | null;
-  nextInvoiceDateOnly: string;
-  subscriptionSupportUrl: string;
-  paymentProrated: string | null;
-  showPaymentMethod: boolean;
-  showProratedAmount: boolean;
-  showTaxAmount: boolean;
-  cardName: string;
-  paymentProviderName: string;
-  lastFour: string;
-  remainingAmountTotalInCents: number;
-  offeringPrice: string;
-  offeringPriceInCents: number;
-  unusedAmountTotal: string;
-  unusedAmountTotalInCents: number;
-  invoiceSubtotalInCents: number;
-  creditAppliedInCents: number;
-  invoiceStartingBalance: string;
-  manageSubscriptionUrl: string;
-  invoiceTaxAmountInCents: number;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionChargesTemplateData } from '../../partials/subscriptionCharges';
+import { TemplateData as SubscriptionSupportGetHelpTemplateData } from '../../partials/subscriptionSupportGetHelp';
+import { TemplateData as ViewInvoiceTemplateData } from '../../partials/viewInvoice';
+
+export type TemplateData = IconTemplateData &
+  SubscriptionChargesTemplateData &
+  SubscriptionSupportGetHelpTemplateData &
+  ViewInvoiceTemplateData & {
+    nextInvoiceDateOnly: string;
+    productName: string;
+  };
 
 export const template = 'subscriptionFirstInvoice';
 export const version = 4;

--- a/libs/accounts/email-renderer/src/templates/subscriptionPaymentExpired/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionPaymentExpired/index.ts
@@ -2,11 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  productName: string;
-  updateBillingUrl: string;
-  subscriptionSupportUrl: string;
-};
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+import { TemplateData as SubscriptionUpdatePaymentTemplateData } from '../../partials/subscriptionUpdatePayment';
+
+export type TemplateData = SubscriptionSupportTemplateData &
+  SubscriptionUpdatePaymentTemplateData & {
+    productName: string;
+    updateBillingUrl: string;
+    subscriptionSupportUrl: string;
+  };
 
 export const template = 'subscriptionPaymentExpired';
 export const version = 4;

--- a/libs/accounts/email-renderer/src/templates/subscriptionPaymentFailed/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionPaymentFailed/index.ts
@@ -2,12 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  icon: string;
-  productName: string;
-  subscriptionSupportUrl: string;
-  updateBillingUrl: string;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+import { TemplateData as SubscriptionUpdateBillingTryTemplateData } from '../../partials/subscriptionUpdateBillingTry';
+
+export type TemplateData = IconTemplateData &
+  SubscriptionSupportTemplateData &
+  SubscriptionUpdateBillingTryTemplateData & {
+    icon: string;
+    productName: string;
+    subscriptionSupportUrl: string;
+    updateBillingUrl: string;
+  };
 
 export const template = 'subscriptionPaymentFailed';
 export const version = 3;

--- a/libs/accounts/email-renderer/src/templates/subscriptionPaymentProviderCancelled/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionPaymentProviderCancelled/index.ts
@@ -2,11 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  productName: string;
-  subscriptionSupportUrl: string;
-  updateBillingUrl: string;
-};
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+import { TemplateData as SubscriptionUpdatePaymentTemplateData } from '../../partials/subscriptionUpdatePayment';
+
+export type TemplateData = SubscriptionSupportTemplateData &
+  SubscriptionUpdatePaymentTemplateData & {
+    productName: string;
+    subscriptionSupportUrl: string;
+    updateBillingUrl: string;
+  };
 
 export const template = 'subscriptionPaymentProviderCancelled';
 export const version = 3;

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.ts
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  productName: string;
-  invoiceTotal: string;
-  nextInvoiceDateOnly: string;
-  icon: string;
-  subscriptionSupportUrl: string;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = IconTemplateData &
+  SubscriptionSupportTemplateData & {
+    productName: string;
+    invoiceTotal: string;
+    nextInvoiceDateOnly: string;
+    icon: string;
+    subscriptionSupportUrl: string;
+  };
 
 export const template = 'subscriptionReactivation';
 export const version = 2;

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.ts
@@ -2,15 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  productName: string;
-  invoiceTotal: string;
-  planInterval: string;
-  planIntervalCount: string;
-  reminderLength: string;
-  subscriptionSupportUrl: string;
-  updateBillingUrl: string;
-};
+import { TemplateData as SubscriptionSupportContactTemplateData } from '../../partials/subscriptionSupportContact';
+import { TemplateData as SubscriptionUpdateBillingEnsureTemplateData } from '../../partials/subscriptionUpdateBillingEnsure';
+
+export type TemplateData = SubscriptionSupportContactTemplateData &
+  SubscriptionUpdateBillingEnsureTemplateData & {
+    productName: string;
+    invoiceTotal: string;
+    planInterval: string;
+    planIntervalCount: string;
+    reminderLength: string;
+    subscriptionSupportUrl: string;
+    updateBillingUrl: string;
+  };
 
 export const template = 'subscriptionRenewalReminder';
 export const version = 2;

--- a/libs/accounts/email-renderer/src/templates/subscriptionSubsequentInvoice/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionSubsequentInvoice/index.stories.ts
@@ -17,17 +17,17 @@ const data = {
   invoiceNumber: '8675309',
   invoiceTotalInCents: 2000,
   invoiceTotal: '$20.00',
-  invoiceSubtotal: null,
-  invoiceTaxAmount: null,
-  invoiceDiscountAmount: null,
-  discountType: null,
-  discountDuration: null,
+  invoiceSubtotal: undefined,
+  invoiceTaxAmount: undefined,
+  invoiceDiscountAmount: undefined,
+  discountType: undefined,
+  discountDuration: undefined,
   icon: 'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
   invoiceLink:
     'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
   nextInvoiceDateOnly: '1/14/2022',
   subscriptionSupportUrl: 'http://localhost:3030/support',
-  paymentProrated: null,
+  paymentProrated: undefined,
   showPaymentMethod: true,
   showProratedAmount: false,
   showTaxAmount: false,
@@ -45,6 +45,7 @@ const data = {
   invoiceStartingBalance: '$10.00',
   manageSubscriptionUrl: 'https://payments.firefox.com/', // Does this need UTM params?
   invoiceTaxAmountInCents: 1000,
+  creditReceived: '$10.00',
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/subscriptionSubsequentInvoice/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionSubsequentInvoice/index.ts
@@ -2,32 +2,40 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  productName: string;
-  invoiceAmountDue: string;
-  invoiceDateOnly: string;
-  invoiceNumber: string;
-  invoiceTotalInCents: number;
-  invoiceTotal: string;
-  invoiceSubtotal: number | null;
-  invoiceTaxAmount: number | null;
-  invoiceDiscountAmount: number | null;
-  discountType: string | null;
-  discountDuration: string | null;
-  productPaymentCycle: string;
-  invoiceAmountDueInCents: number;
-  paymentProviderName: string;
-  remainingAmountTotalInCents: number;
-  offeringPriceInCents: number;
-  offeringPrice: string;
-  unusedAmountTotalInCents: number;
-  unusedAmountTotal: string;
-  invoiceSubtotalInCents: number;
-  creditAppliedInCents: number;
-  invoiceStartingBalance: string;
-  manageSubscriptionUrl: string;
-  invoiceTaxAmountInCents: number;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionChargesTemplateData } from '../../partials/subscriptionCharges';
+import { TemplateData as SubscriptionSupportGetHelpTemplateData } from '../../partials/subscriptionSupportGetHelp';
+import { TemplateData as ViewInvoiceTemplateData } from '../../partials/viewInvoice';
+
+export type TemplateData = IconTemplateData &
+  SubscriptionChargesTemplateData &
+  SubscriptionSupportGetHelpTemplateData &
+  ViewInvoiceTemplateData & {
+    productName: string;
+    nextInvoiceDateOnly: string;
+    // invoiceAmountDue: string;
+    // invoiceDateOnly: string;
+    // invoiceTotalInCents: number;
+    // invoiceTotal: string;
+    // invoiceSubtotal: number | null;
+    // invoiceTaxAmount: number | null;
+    // invoiceDiscountAmount: number | null;
+    // discountType: string | null;
+    // discountDuration: string | null;
+    // productPaymentCycle: string;
+    // invoiceAmountDueInCents: number;
+    // paymentProviderName: string;
+    // remainingAmountTotalInCents: number;
+    // offeringPriceInCents: number;
+    // offeringPrice: string;
+    // unusedAmountTotalInCents: number;
+    // unusedAmountTotal: string;
+    // invoiceSubtotalInCents: number;
+    // creditAppliedInCents: number;
+    // invoiceStartingBalance: string;
+    // manageSubscriptionUrl: string;
+    // invoiceTaxAmountInCents: number;
+  };
 
 export const template = 'subscriptionSubsequentInvoice';
 export const version = 5;

--- a/libs/accounts/email-renderer/src/templates/subscriptionUpgrade/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionUpgrade/index.stories.ts
@@ -22,6 +22,7 @@ const data = {
   productPaymentCycleOld: 'month',
   paymentProrated: '$60.00',
   subscriptionSupportUrl: 'http://localhost:3030/support',
+  icon: 'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/subscriptionUpgrade/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionUpgrade/index.ts
@@ -2,18 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  invoiceAmountDue: string;
-  paymentAmountNew: string;
-  paymentAmountOld: string;
-  productIconURLNew: string;
-  productName: string;
-  productNameOld: string;
-  productPaymentCycleNew: string;
-  productPaymentCycleOld: string;
-  paymentProrated: string;
-  subscriptionSupportUrl: string;
-};
+import { TemplateData as IconTemplateData } from '../../partials/icon';
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+
+export type TemplateData = IconTemplateData &
+  SubscriptionSupportTemplateData & {
+    invoiceAmountDue: string;
+    paymentAmountNew: string;
+    paymentAmountOld: string;
+    productIconURLNew: string;
+    productName: string;
+    productNameOld: string;
+    productPaymentCycleNew: string;
+    productPaymentCycleOld: string;
+    paymentProrated: string;
+    subscriptionSupportUrl: string;
+  };
 
 export const template = 'subscriptionUpgrade';
 export const version = 7;

--- a/libs/accounts/email-renderer/src/templates/subscriptionsPaymentExpired/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionsPaymentExpired/index.ts
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  subscriptions: Array<{ productName: string }>;
-  updateBillingUrl: string;
-  subscriptionSupportUrl: string;
-  productName: string;
-};
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+import { TemplateData as SubscriptionUpdatePaymentTemplateData } from '../../partials/subscriptionUpdatePayment';
+
+export type TemplateData = SubscriptionSupportTemplateData &
+  SubscriptionUpdatePaymentTemplateData & {
+    subscriptions: Array<{ productName: string }>;
+    updateBillingUrl: string;
+    subscriptionSupportUrl: string;
+    productName: string;
+  };
 
 export const template = 'subscriptionsPaymentExpired';
 export const version = 4;

--- a/libs/accounts/email-renderer/src/templates/subscriptionsPaymentProviderCancelled/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionsPaymentProviderCancelled/index.ts
@@ -2,12 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  subscriptions: Array<{ productName: string }>;
-  subscriptionSupportUrl: string;
-  updateBillingUrl: string;
-  productName: string;
-};
+import { TemplateData as SubscriptionSupportTemplateData } from '../../partials/subscriptionSupport';
+import { TemplateData as SubscriptionUpdatePaymentTemplateData } from '../../partials/subscriptionUpdatePayment';
+
+export type TemplateData = SubscriptionSupportTemplateData &
+  SubscriptionUpdatePaymentTemplateData & {
+    subscriptions: Array<{ productName: string }>;
+    subscriptionSupportUrl: string;
+    updateBillingUrl: string;
+    productName: string;
+  };
 
 export const template = 'subscriptionsPaymentProviderCancelled';
 export const version = 3;

--- a/libs/accounts/email-renderer/src/templates/unblockCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/unblockCode/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = UserInfoTemplateData & {
   unblockCode: string;
   reportSignInLink: string;
   time: string;

--- a/libs/accounts/email-renderer/src/templates/verificationReminderFinal/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verificationReminderFinal/index.stories.ts
@@ -12,6 +12,7 @@ export default {
 
 const data = {
   link: 'http://localhost:3030/verify_email',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verificationReminderFinal/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verificationReminderFinal/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData & {
   link: string;
 };
 

--- a/libs/accounts/email-renderer/src/templates/verificationReminderFirst/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verificationReminderFirst/index.stories.ts
@@ -12,6 +12,7 @@ export default {
 
 const data = {
   link: 'http://localhost:3030/verify_email',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verificationReminderFirst/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verificationReminderFirst/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData & {
   link: string;
 };
 

--- a/libs/accounts/email-renderer/src/templates/verificationReminderSecond/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verificationReminderSecond/index.stories.ts
@@ -12,6 +12,7 @@ export default {
 
 const data = {
   link: 'http://localhost:3030/verify_email',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verificationReminderSecond/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verificationReminderSecond/index.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData & {
   link: string;
 };
 

--- a/libs/accounts/email-renderer/src/templates/verify/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verify/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   ...MOCK_USER_INFO,
   link: 'http://localhost:3030/verify_email',
   sync: true,
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verify/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verify/index.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  sync: boolean;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    sync: boolean;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'verify';
 export const version = 7;

--- a/libs/accounts/email-renderer/src/templates/verifyAccountChange/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyAccountChange/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   code: '918398',
   expirationTime: 5,
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifyAccountChange/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyAccountChange/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  code: string;
-  expirationTime: number;
-  passwordChangeLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    code: string;
+    expirationTime: number;
+    passwordChangeLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'verifyAccountChange';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/verifyLogin/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyLogin/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   link: 'http://localhost:3030/complete_signin',
   clientName: 'Firefox',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifyLogin/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyLogin/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  clientName: string;
-  passwordChangeLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    clientName: string;
+    passwordChangeLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'verifyLogin';
 export const version = 6;

--- a/libs/accounts/email-renderer/src/templates/verifyLoginCode/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyLoginCode/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   code: '918398',
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
   serviceName: 'Firefox',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifyLoginCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyLoginCode/index.ts
@@ -2,30 +2,34 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  code: string;
-  passwordChangeLink: string;
-  serviceName: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
-  };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
 
-  cmsRpClientId?: string;
-  cmsRpFromName?: string;
-  entrypoint?: string;
-  subject?: string;
-  headline?: string;
-  description?: string;
-};
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    code: string;
+    passwordChangeLink: string;
+    serviceName: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
+
+    cmsRpClientId?: string;
+    cmsRpFromName?: string;
+    entrypoint?: string;
+    subject?: string;
+    headline?: string;
+    description?: string;
+  };
 
 export const template = 'verifyLoginCode';
 export const version = 9;

--- a/libs/accounts/email-renderer/src/templates/verifyLoginCode/strapi.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyLoginCode/strapi.stories.ts
@@ -22,6 +22,7 @@ const data = {
   subject: 'Confirm Your Login',
   headline: 'Are you signing in to use Product?',
   description: 'Use the code below to verify your signin.',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifyPrimary/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyPrimary/index.stories.ts
@@ -16,6 +16,7 @@ const data = {
   link: 'http://localhost:3030/verify_primary_email',
   sync: false,
   passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifyPrimary/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyPrimary/index.ts
@@ -2,23 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  link: string;
-  sync: boolean;
-  passwordChangeLink: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  UserInfoTemplateData & {
+    link: string;
+    sync: boolean;
+    passwordChangeLink: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'verifyPrimary';
 export const version = 8;

--- a/libs/accounts/email-renderer/src/templates/verifySecondaryCode/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifySecondaryCode/index.stories.ts
@@ -15,6 +15,7 @@ const data = {
   ...MOCK_USER_INFO,
   email: 'foo@bar.com',
   code: '918398',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifySecondaryCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifySecondaryCode/index.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  email: string;
-  code: string;
-  time: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    email: string;
+    code: string;
+    time: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-};
 
 export const template = 'verifySecondaryCode';
 export const version = 1;

--- a/libs/accounts/email-renderer/src/templates/verifyShortCode/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyShortCode/index.stories.ts
@@ -14,6 +14,7 @@ export default {
 const data = {
   ...MOCK_USER_INFO,
   code: '918398',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/verifyShortCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyShortCode/index.ts
@@ -2,27 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export type TemplateData = {
-  code: string;
-  device: {
-    uaBrowser: string;
-    uaOSVersion: string;
-    uaOS: string;
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    code: string;
+    device: {
+      uaBrowser: string;
+      uaOSVersion: string;
+      uaOS: string;
+    };
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+    date: string;
+    cmsRpClientId?: string;
+    cmsRpFromName?: string;
+    entrypoint?: string;
+    subject?: string;
+    headline?: string;
+    description?: string;
+    time?: string;
   };
-  location: {
-    stateCode: string;
-    country: string;
-    city: string;
-  };
-  date: string;
-  cmsRpClientId?: string;
-  cmsRpFromName?: string;
-  entrypoint?: string;
-  subject?: string;
-  headline?: string;
-  description?: string;
-  time?: string;
-};
 
 export const template = 'verifyShortCode';
 export const version = 4;

--- a/libs/accounts/email-renderer/src/templates/verifyShortCode/strapi.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyShortCode/strapi.stories.ts
@@ -20,6 +20,7 @@ const data = {
   subject: 'Confirm Your Account',
   headline: 'Verify you account to start using Product!',
   description: 'Use the code below to verify your account and gogogo',
+  supportUrl: 'https://support.mozilla.org',
 };
 
 const createStory = storyWithProps<TemplateData>(


### PR DESCRIPTION
## Because

- We can also declare types for partial templates

## This pull request

- Declares types for partial templates
- Updates current templates to union types defined by partial templates

## Issue that this pull request solves

Closes: FXA-12613

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
