### PR TITLE
fix(profile): Use parallel auth-server request instead of sequential, add auth-server timeout

### DIFF
--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -27,6 +27,12 @@ const conf = convict({
       env: 'AUTH_SERVER_URL',
       default: 'http://localhost:9000/v1',
     },
+    timeoutMs: {
+      doc: 'Timeout in milliseconds for requests to fxa-auth-server',
+      format: 'duration',
+      default: '5 seconds',
+      env: 'AUTH_SERVER_TIMEOUT_MS',
+    },
   },
   clientAddressDepth: {
     doc: 'location of the client ip address in the remote address chain',

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -10,6 +10,7 @@ const logger = require('../logging')('routes._core_profile');
 const request = require('../request');
 
 const AUTH_SERVER_URL = config.get('authServer.url') + '/account/profile';
+const AUTH_SERVER_TIMEOUT_MS = config.get('authServer.timeoutMs') || 5000;
 
 /**
  * This is an internal-use route that retrieves all the user
@@ -54,6 +55,7 @@ module.exports = {
               Authorization: 'Bearer ' + req.auth.credentials.token,
             },
             json: true,
+            timeout: AUTH_SERVER_TIMEOUT_MS
           },
           (err, res, body) => {
             if (err) {


### PR DESCRIPTION
## Because

- The profile server makes requests serially to auth-server to get different profile data, this can be done in parallel
- There is no max timeout on auth-server requests

## This pull request

- Uses `P.all` for the batch request
- Adds a max timeout of 5seconds to auth-server

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12735

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

We would still need these changes even if we merge the profile server into the auth-server.
