### PR TITLE
task(auth): Better metrics on bounce types

### DIFF
--- a/packages/fxa-auth-server/bin/email_notifications.js
+++ b/packages/fxa-auth-server/bin/email_notifications.js
@@ -62,7 +62,7 @@ if (config.subscriptions && config.subscriptions.stripeApiKey) {
 const { AppError: error } = require('@fxa/accounts/errors');
 const Token = require('../lib/tokens')(log, config);
 const SQSReceiver = require('../lib/sqs')(log, statsd);
-const bounces = require('../lib/email/bounces')(log, error, config);
+const bounces = require('../lib/email/bounces')(log, error, config, statsd);
 const delivery = require('../lib/email/delivery')(log, glean);
 const notifications = require('../lib/email/notifications')(log, error);
 

--- a/packages/fxa-auth-server/lib/email/bounces.js
+++ b/packages/fxa-auth-server/lib/email/bounces.js
@@ -13,7 +13,7 @@ const isValidEmailAddress =
   require('./../routes/validators').isValidEmailAddress;
 const SIX_HOURS = 1000 * 60 * 60 * 6;
 
-module.exports = function (log, error, config) {
+module.exports = function (log, error, config, statsd) {
   const stripeHelper = Container.get(StripeHelper);
 
   return function start(bounceQueue, db) {
@@ -85,6 +85,13 @@ module.exports = function (log, error, config) {
 
     async function handleBounce(message) {
       logBounceMessage(message);
+
+      statsd.increment('email.bounce.message', {
+        bounceType: message?.bounce?.bounceType || 'none',
+        bounceSubType: message?.bounce?.bounceSubType || 'none',
+        hasDiagnosticCode: !!message?.diagnosticCode,
+        hasComplaint: !!message?.complaint,
+      });
 
       utils.logErrorIfHeadersAreWeirdOrMissing(log, message, 'bounce');
 

--- a/packages/fxa-auth-server/test/local/email/bounce.js
+++ b/packages/fxa-auth-server/test/local/email/bounce.js
@@ -10,7 +10,7 @@ const { assert } = require('chai');
 const bounces = require(`${ROOT_DIR}/lib/email/bounces`);
 const { AppError: error } = require('@fxa/accounts/errors');
 const { EventEmitter } = require('events');
-const { mockLog } = require('../../mocks');
+const { mockLog, mockStatsd } = require('../../mocks');
 const sinon = require('sinon');
 const { default: Container } = require('typedi');
 const { StripeHelper } = require('../../../lib/payments/stripe');
@@ -20,7 +20,7 @@ const mockBounceQueue = new EventEmitter();
 mockBounceQueue.start = function start() {};
 
 describe('bounce messages', () => {
-  let log, mockConfig, mockDB, mockStripeHelper;
+  let log, mockConfig, mockDB, mockStripeHelper, statsd;
 
   function mockMessage(msg) {
     msg.del = sinon.spy();
@@ -29,11 +29,12 @@ describe('bounce messages', () => {
   }
 
   function mockedBounces(log, db) {
-    return bounces(log, error, mockConfig)(mockBounceQueue, db);
+    return bounces(log, error, mockConfig, statsd)(mockBounceQueue, db);
   }
 
   beforeEach(() => {
     log = mockLog();
+    statsd = mockStatsd();
     mockConfig = {
       bounces: {
         deleteAccount: true,
@@ -89,6 +90,31 @@ describe('bounce messages', () => {
         assert.equal(log.error.callCount, 0);
         assert.equal(log.warn.callCount, 1);
         assert.equal(log.warn.args[0][0], 'emailHeaders.keys');
+      });
+  });
+
+  it('should record metrics about bounce type', () => {
+    const bounceType = 'Transient';
+    return mockedBounces(log, mockDB)
+      .handleBounce(
+        mockMessage({
+          bounce: {
+            bounceType: bounceType,
+            bouncedRecipients: [
+              { emailAddress: 'test@example.com' },
+              { emailAddress: 'foobar@example.com' },
+            ],
+          },
+        })
+      )
+      .then(() => {
+        assert.equal(statsd.increment.callCount, 1);
+        sinon.assert.calledWith(statsd.increment, 'email.bounce.message', {
+          bounceType: bounceType,
+          bounceSubType: 'none',
+          hasDiagnosticCode: false,
+          hasComplaint: false,
+        });
       });
   });
 


### PR DESCRIPTION
## Because

- We want to chart the specific bounce types we see

## This pull request

- Adds metric about email bounce type, sub type, and if there is a complaint or diagnostic code

## Issue that this pull request solves

Closes: FXA-12718

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
