### PR TITLE
task(gql): Record metrics for 403s from GqlAllowList

### DIFF
--- a/packages/fxa-graphql-api/src/main.ts
+++ b/packages/fxa-graphql-api/src/main.ts
@@ -10,6 +10,7 @@ import bodyParser from 'body-parser';
 import { Request, Response } from 'express';
 import { allowlistGqlQueries } from 'fxa-shared/nestjs/gql/gql-allowlist';
 import { SentryInterceptor } from '@fxa/shared/sentry';
+import { StatsDService } from '@fxa/shared/metrics/statsd';
 import helmet from 'helmet';
 
 import { NestApplicationOptions } from '@nestjs/common';
@@ -33,7 +34,7 @@ async function bootstrap() {
 
   // Configure allowlisting of gql queries
   app.use(bodyParser.json());
-  app.use(allowlistGqlQueries(appConfig.gql));
+  app.use(allowlistGqlQueries(appConfig.gql, app.get(StatsDService)));
 
   if (appConfig.hstsEnabled) {
     const maxAge = appConfig.hstsMaxAge;

--- a/packages/fxa-shared/nestjs/gql/gql-allowlist.ts
+++ b/packages/fxa-shared/nestjs/gql/gql-allowlist.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { readFileSync } from 'fs';
 import { Request, Response, NextFunction } from 'express';
+import { StatsD } from 'hot-shots';
 
 /**
  * Configuration options for GqlGuard
@@ -64,12 +65,13 @@ export class GqlAllowlist {
  * @param config
  * @returns
  */
-export function allowlistGqlQueries(config: Config) {
+export function allowlistGqlQueries(config: Config, statsd?: StatsD) {
   const guard = new GqlAllowlist(config);
   return (req: Request, res: Response, next: NextFunction) => {
     if (guard.allowed(req)) {
       next();
     } else {
+      statsd?.increment('gql.unsanctioned_query');
       res
         .status(403)
         .send({ statusCode: 403, message: 'Unsanctioned Graphql Query' });


### PR DESCRIPTION
## Because

- We want to monitor queries rejected by the GqlAllowlist check

## This pull request

- Adds new metric, `gql.unsanctioned_query`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
