### PR TITLE
feat(settings): Enable split layout option on more pages

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/AppLayout/__snapshots__/index.test.tsx.snap
@@ -4,14 +4,14 @@ exports[`<AppLayout /> snapshots renders correctly with CMS: background wrapper 
 <div
   class="flex min-h-screen flex-col items-center tablet:[background:var(--cms-bg)]"
   data-testid="app"
-  style="--cms-bg: linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%);"
+  style="--cms-bg: linear-gradient(135deg, #F5E9FF 0%, #E8D7FF 40%, #DCC2FF 70%, #C4A5FF 100%);"
 />
 `;
 
 exports[`<AppLayout /> snapshots renders correctly with CMS: header background 1`] = `
 <header
   class="w-full px-6 py-4 mobileLandscape:py-6 tablet:[background:var(--cms-header-bg)]"
-  style="--cms-header-bg: linear-gradient(135deg, #764ba2 0%, #667eea 100%);"
+  style="--cms-header-bg: linear-gradient(135deg, #6B4DFB 0%, #3A1A78 100%);"
 />
 `;
 

--- a/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/InlineRecoveryKeySetupCreate/__snapshots__/index.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`InlineRecoveryKeySetupCreate renders button with CMS passthrough 1`] = 
 <button
   class="cta-primary-cms cta-xl flex justify-center items-center"
   data-glean-id="inline_recovery_key_cta_submit"
-  style="--cta-bg: #D41C1C; --cta-border: #D41C1C; --cta-active: #D41C1C; --cta-disabled: #D41C1C60;"
+  style="--cta-bg: #6B4DFB; --cta-border: #6B4DFB; --cta-active: #6B4DFB; --cta-disabled: #6B4DFB60;"
   type="submit"
 >
   <span

--- a/packages/fxa-settings/src/components/LocaleToggle/index.tsx
+++ b/packages/fxa-settings/src/components/LocaleToggle/index.tsx
@@ -10,15 +10,24 @@ import { getBrowserDefaultLocaleInfo } from '../../lib/locales';
 const BROWSER_DEFAULT_VALUE = 'browser-default';
 
 /**
-* Locale selection dropdown component with browser default support
-* Handles locale switching and preference clearing
-*/
+ * Locale selection dropdown component with browser default support
+ * Handles locale switching and preference clearing
+ */
 export const LocaleToggle: React.FC = () => {
   const ftlMsgResolver = useFtlMsgResolver();
-  const { currentLocale, availableLocales, switchLocale, clearLocalePreference, isUsingBrowserDefault, isLoading } = useLocaleManager();
+  const {
+    currentLocale,
+    availableLocales,
+    switchLocale,
+    clearLocalePreference,
+    isUsingBrowserDefault,
+    isLoading,
+  } = useLocaleManager();
 
   // Handle locale selection
-  const handleLocaleChange = async (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleLocaleChange = async (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ) => {
     const newLocale = event.target.value;
 
     if (newLocale === BROWSER_DEFAULT_VALUE) {
@@ -46,7 +55,7 @@ export const LocaleToggle: React.FC = () => {
   // Determine the current value for the select
   // If using browser default, show the actual browser locale in the dropdown
   const currentValue = isUsingBrowserDefault
-    ? (browserDefaultLocale?.code || currentLocale)
+    ? browserDefaultLocale?.code || currentLocale
     : currentLocale;
 
   return (
@@ -59,7 +68,7 @@ export const LocaleToggle: React.FC = () => {
         value={currentValue}
         onChange={handleLocaleChange}
         disabled={isLoading}
-        className="text-xs text-grey-500 hover:text-grey-600 focus:outline-none focus:text-grey-600 disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-0 cursor-pointer appearance-none min-w-[8ch] w-auto"
+        className="text-xs text-grey-500 hover:text-grey-600 p-1 focus:outline-2 focus:outline-offset-1 focus:outline-blue-500 focus:text-grey-600 disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-0 cursor-pointer appearance-none min-w-[8ch] w-auto"
         data-testid="locale-select"
         aria-label={selectLabel}
       >

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`RecoveryKeySetupDownload renders button with CMS passthrough 1`] = `
 <button
   class="cta-primary-cms cta-xl w-full mt-4"
-  style="--cta-bg: #D41C1C; --cta-border: #D41C1C; --cta-active: #D41C1C; --cta-disabled: #D41C1C60;"
+  style="--cta-bg: #6B4DFB; --cta-border: #6B4DFB; --cta-active: #6B4DFB; --cta-disabled: #6B4DFB60;"
 >
   Download and continue
 </button>

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -82,9 +82,7 @@ try {
 
   render(
     <React.StrictMode>
-      <DynamicLocalizationProvider
-        baseDir={config.l10n.baseUrl}
-      >
+      <DynamicLocalizationProvider baseDir={config.l10n.baseUrl}>
         <AppErrorBoundary>
           <AppContext.Provider value={appContext}>
             <NimbusProvider>

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -42,6 +42,7 @@ const IndexContainer = ({
   serviceName,
   flowQueryParams,
   useFxAStatusResult,
+  setCurrentSplitLayout,
 }: IndexContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -317,10 +318,15 @@ const IndexContainer = ({
   const deeplink = queryParamModel.deeplink;
   const isMobile = isMobileDevice();
 
+  const cmsInfo = integration.getCmsInfo();
+  const splitLayout = cmsInfo?.EmailFirstPage?.splitLayout;
+
   // WebAuthn capability probe is fired at app-level (components/App/index.tsx)
 
   return isLoading ? (
-    <AppLayout cmsInfo={integration.getCmsInfo()} loading />
+    <AppLayout
+      {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+    />
   ) : (
     <Index
       {...{
@@ -337,6 +343,7 @@ const IndexContainer = ({
         flowQueryParams,
         isMobile,
         useFxAStatusResult,
+        setCurrentSplitLayout,
       }}
       prefillEmail={initialPrefill}
     />

--- a/packages/fxa-settings/src/pages/Index/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.stories.tsx
@@ -91,6 +91,20 @@ export const WithCmsOnMobile = storyWithProps({
   isMobile: true,
 });
 
+export const WithCmsSplitLayout = storyWithProps({
+  integration: createMockIndexOAuthNativeIntegration({
+    isFirefoxClientServiceRelay: true,
+    isSync: false,
+    cmsInfo: {
+      ...MOCK_CMS_INFO,
+      EmailFirstPage: {
+        ...MOCK_CMS_INFO.EmailFirstPage,
+        splitLayout: true,
+      },
+    },
+  }),
+});
+
 export const WithCmsWithSharedFallback = storyWithProps({
   integration: createMockIndexOAuthNativeIntegration({
     isFirefoxClientServiceRelay: true,

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -36,6 +36,7 @@ export const Index = ({
   flowQueryParams,
   isMobile,
   useFxAStatusResult,
+  setCurrentSplitLayout,
 }: IndexProps) => {
   const clientId = integration.getClientId();
   const isSync = integration.isSync();
@@ -103,7 +104,7 @@ export const Index = ({
   const splitLayout = cmsInfo?.EmailFirstPage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title, splitLayout }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       {cmsInfo ? (
         <>
           <CmsLogo

--- a/packages/fxa-settings/src/pages/Index/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Index/interfaces.ts
@@ -24,6 +24,7 @@ export interface IndexContainerProps {
   serviceName: MozServices;
   flowQueryParams?: QueryParams;
   useFxAStatusResult: UseFxAStatusResult;
+  setCurrentSplitLayout?: (value: boolean) => void;
 }
 
 export interface LocationState {
@@ -47,6 +48,7 @@ export interface IndexProps extends LocationState {
   flowQueryParams?: QueryParams;
   isMobile: boolean;
   useFxAStatusResult: UseFxAStatusResult;
+  setCurrentSplitLayout?: (value: boolean) => void;
 }
 
 export interface IndexFormData {

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -40,8 +40,10 @@ import {
 
 const SigninTokenCodeContainer = ({
   integration,
+  setCurrentSplitLayout,
 }: {
   integration: Integration;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & RouteComponentProps) => {
   const navigateWithQuery = useNavigateWithQuery();
   const location = useLocation() as ReturnType<typeof useLocation> & {
@@ -96,9 +98,16 @@ const SigninTokenCodeContainer = ({
     getTotpStatus();
   }, [authClient, signinState]);
 
+  const cmsInfo = integration.getCmsInfo();
+  const splitLayout = cmsInfo?.SigninTokenCodePage?.splitLayout;
+
   if (!signinState || !signinState.sessionToken) {
     navigateWithQuery('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   // redirect if there is 2FA is set up for the account,
@@ -107,7 +116,11 @@ const SigninTokenCodeContainer = ({
     navigateWithQuery('/signin_totp_code', {
       state: signinState,
     });
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   if (oAuthDataError) {
@@ -139,6 +152,7 @@ const SigninTokenCodeContainer = ({
         keyFetchToken,
         unwrapBKey,
         onSessionVerified,
+        setCurrentSplitLayout,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.stories.tsx
@@ -21,6 +21,18 @@ export const DefaultWithCms = () => (
   <Subject integration={createOAuthNativeIntegration(true, MOCK_CMS_INFO)} />
 );
 
+export const SplitLayoutWithCms = () => (
+  <Subject
+    integration={createOAuthNativeIntegration(true, {
+      ...MOCK_CMS_INFO,
+      SigninTokenCodePage: {
+        ...MOCK_CMS_INFO.SigninTokenCodePage!,
+        splitLayout: true,
+      },
+    })}
+  />
+);
+
 export const OAuthDesktopServiceRelay = () => (
   <Subject integration={createOAuthNativeIntegration(false)} />
 );

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/index.tsx
@@ -37,6 +37,7 @@ const SigninTokenCode = ({
   keyFetchToken,
   unwrapBKey,
   onSessionVerified,
+  setCurrentSplitLayout,
 }: SigninTokenCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
   const session = useSession();
@@ -208,9 +209,10 @@ const SigninTokenCode = ({
 
   const cmsInfo = integration?.getCmsInfo();
   const title = cmsInfo?.SigninTokenCodePage?.pageTitle;
+  const splitLayout = cmsInfo?.SigninTokenCodePage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       <CardHeader
         headingText="Enter confirmation code"
         headingAndSubheadingFtlId="signin-token-code-heading-2"

--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/interfaces.ts
@@ -12,6 +12,7 @@ export type SigninTokenCodeProps = {
   integration: SigninIntegration;
   signinState: SigninLocationState;
   onSessionVerified: (sessionId: string) => Promise<void>;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & SensitiveData.AuthData;
 
 export interface TotpStatusResponse {

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/container.tsx
@@ -48,11 +48,13 @@ import AppLayout from '../../../components/AppLayout';
 export type SigninTotpCodeContainerProps = {
   integration: Integration;
   serviceName: MozServices;
+  setCurrentSplitLayout?: (value: boolean) => void;
 };
 
 export const SigninTotpCodeContainer = ({
   integration,
   serviceName,
+  setCurrentSplitLayout,
 }: SigninTotpCodeContainerProps & RouteComponentProps) => {
   const authClient = useAuthClient();
   const session = useSession();
@@ -169,6 +171,9 @@ export const SigninTotpCodeContainer = ({
     return <OAuthDataError error={oAuthKeysCheckError} />;
   }
 
+  const cmsInfo = integration.getCmsInfo();
+  const splitLayout = cmsInfo?.SigninTotpCodePage?.splitLayout;
+
   if (
     !signinState ||
     (signinState.isSessionAALUpgrade !== true &&
@@ -176,7 +181,11 @@ export const SigninTotpCodeContainer = ({
       signinState.verificationMethod !== VerificationMethods.TOTP_2FA)
   ) {
     navigateWithQuery('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   return (
@@ -190,6 +199,7 @@ export const SigninTotpCodeContainer = ({
         serviceName,
         keyFetchToken,
         unwrapBKey,
+        setCurrentSplitLayout,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.stories.tsx
@@ -79,3 +79,15 @@ export const DefaultWithCms = storyWithProps({
   serviceName: MozServices.Default,
   integration: mockOAuthNativeSigninIntegration(true, MOCK_CMS_INFO),
 });
+
+export const SplitLayoutWithCms = storyWithProps({
+  submitTotpCode: async () => ({}),
+  serviceName: MozServices.Default,
+  integration: mockOAuthNativeSigninIntegration(true, {
+    ...MOCK_CMS_INFO,
+    SigninTotpCodePage: {
+      ...MOCK_CMS_INFO.SigninTotpCodePage!,
+      splitLayout: true,
+    },
+  }),
+});

--- a/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTotpCode/index.tsx
@@ -38,6 +38,7 @@ export type SigninTotpCodeProps = {
   // TODO: Switch to gql error shaped object
   submitTotpCode: (totpCode: string) => Promise<{ error?: HandledError }>;
   serviceName?: MozServices;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & SensitiveData.AuthData;
 
 export const viewName = 'signin-totp-code';
@@ -50,6 +51,7 @@ export const SigninTotpCode = ({
   submitTotpCode,
   keyFetchToken,
   unwrapBKey,
+  setCurrentSplitLayout,
 }: SigninTotpCodeProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
@@ -164,9 +166,10 @@ export const SigninTotpCode = ({
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.SigninTotpCodePage?.pageTitle;
+  const splitLayout = cmsInfo?.SigninTotpCodePage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       {cmsInfo ? (
         <>
           {cmsInfo.shared.logoUrl && cmsInfo.shared.logoAltText && (

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.tsx
@@ -55,9 +55,11 @@ import AppLayout from '../../../components/AppLayout';
 export const SigninUnblockContainer = ({
   integration,
   flowQueryParams,
+  setCurrentSplitLayout,
 }: {
   integration: SigninUnblockIntegration;
   flowQueryParams: QueryParams;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const ftlMsgResolver = useFtlMsgResolver();
@@ -226,9 +228,16 @@ export const SigninUnblockContainer = ({
     return <OAuthDataError error={oAuthDataError} />;
   }
 
+  const cmsInfo = integration.getCmsInfo();
+  const splitLayout = cmsInfo?.SigninUnblockCodePage?.splitLayout;
+
   if (!email || !password) {
     navigateWithQuery('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
   return (
     <SigninUnblock
@@ -241,6 +250,7 @@ export const SigninUnblockContainer = ({
         resendUnblockCodeHandler,
         wantsTwoStepAuthentication,
         finishOAuthFlowHandler,
+        setCurrentSplitLayout,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.stories.tsx
@@ -8,7 +8,8 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import {
-  MOCK_AUTH_AT, MOCK_CMS_INFO,
+  MOCK_AUTH_AT,
+  MOCK_CMS_INFO,
   MOCK_EMAIL,
   MOCK_SESSION_TOKEN,
   MOCK_UID,
@@ -72,7 +73,29 @@ export const DefaultWithCms = () => (
       hasPassword={true}
       finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
       integration={createMockSigninOAuthIntegration({
-        cmsInfo: MOCK_CMS_INFO
+        cmsInfo: MOCK_CMS_INFO,
+      })}
+      signinWithUnblockCode={mockSuccessResponse}
+      resendUnblockCodeHandler={mockResendSuccessResponse}
+    />
+  </LocationProvider>
+);
+
+export const SplitLayoutWithCms = () => (
+  <LocationProvider>
+    <SigninUnblock
+      email={MOCK_EMAIL}
+      hasLinkedAccount={false}
+      hasPassword={true}
+      finishOAuthFlowHandler={mockFinishOAuthFlowHandler}
+      integration={createMockSigninOAuthIntegration({
+        cmsInfo: {
+          ...MOCK_CMS_INFO,
+          SigninUnblockCodePage: {
+            ...MOCK_CMS_INFO.SigninUnblockCodePage!,
+            splitLayout: true,
+          },
+        },
       })}
       signinWithUnblockCode={mockSuccessResponse}
       resendUnblockCodeHandler={mockResendSuccessResponse}

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/index.tsx
@@ -44,6 +44,7 @@ export const SigninUnblock = ({
   resendUnblockCodeHandler,
   integration,
   finishOAuthFlowHandler,
+  setCurrentSplitLayout,
 }: SigninUnblockProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -209,9 +210,10 @@ export const SigninUnblock = ({
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.SigninUnblockCodePage?.pageTitle;
+  const splitLayout = cmsInfo?.SigninUnblockCodePage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       <CardHeader
         headingText="Authorize this sign-in"
         headingTextFtlId="signin-unblock-header"

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/interfaces.ts
@@ -21,6 +21,7 @@ export interface SigninUnblockProps {
   signinWithUnblockCode: (code: string) => Promise<BeginSigninResult>;
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   integration: SigninIntegration;
+  setCurrentSplitLayout?: (value: boolean) => void;
 }
 
 export type BeginSigninWithUnblockCodeHandler = (

--- a/packages/fxa-settings/src/pages/Signin/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/pages/Signin/__snapshots__/index.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Signin component snapshots - CMS renders CardHeader with CMS content wh
 exports[`Signin component snapshots - CMS renders the CMS-styled submit button 1`] = `
 <button
   class="cta-primary-cms cta-xl cta-primary cta-xl"
-  style="--cta-bg: #D41C1C; --cta-border: #D41C1C; --cta-active: #D41C1C; --cta-disabled: #D41C1C60;"
+  style="--cta-bg: #6B4DFB; --cta-border: #6B4DFB; --cta-active: #6B4DFB; --cta-disabled: #6B4DFB60;"
   type="submit"
 >
   Sign in

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -155,11 +155,13 @@ const SigninContainer = ({
   serviceName,
   flowQueryParams,
   useFxAStatusResult,
+  setCurrentSplitLayout,
 }: {
   integration: Integration;
   serviceName: MozServices;
   flowQueryParams?: QueryParams;
   useFxAStatusResult: UseFxAStatusResult;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & RouteComponentProps) => {
   const config = useConfig();
   const authClient = useAuthClient();
@@ -530,21 +532,34 @@ const SigninContainer = ({
     return <OAuthDataError error={oAuthDataError} />;
   }
 
+  const cmsInfo = integration.getCmsInfo();
+  const splitLayout = cmsInfo?.SigninPage?.splitLayout;
+
   // TODO: if validationError is 'email', in content-server we show "Bad request email param"
   // For now, just redirect to index-first, until FXA-8289 is done
   if (!email || validationError) {
     navigateWithQuery('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   // Wait for async call (if needed) to complete
   if (hasLinkedAccount === undefined || hasPassword === undefined) {
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   if (isUnsupportedContext(integration.data.context)) {
     hardNavigate('/update_firefox', {}, true);
-    return <AppLayout loading />;
+    return (
+      <AppLayout {...{ loading: true, splitLayout, setCurrentSplitLayout }} />
+    );
   }
 
   const deeplink = queryParamModel.deeplink;
@@ -570,6 +585,7 @@ const SigninContainer = ({
         deeplink,
         flowQueryParams,
         useFxAStatusResult,
+        setCurrentSplitLayout,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -89,11 +89,37 @@ export const SignInWithCms = storyWithProps({
   }),
 });
 
+export const SignInWithCmsSplitLayout = storyWithProps({
+  integration: createMockSigninOAuthIntegration({
+    cmsInfo: {
+      ...MOCK_CMS_INFO,
+      SigninPage: {
+        ...MOCK_CMS_INFO.SigninPage!,
+        splitLayout: true,
+      },
+    },
+  }),
+});
+
 export const SignInWithCmsCachedCredentials = storyWithProps({
   sessionToken: MOCK_SESSION_TOKEN,
   integration: createMockSigninOAuthIntegration({
     wantsKeys: false,
     cmsInfo: MOCK_CMS_INFO,
+  }),
+});
+
+export const SignInWithCmsCachedCredentialsSplitLayout = storyWithProps({
+  sessionToken: MOCK_SESSION_TOKEN,
+  integration: createMockSigninOAuthIntegration({
+    wantsKeys: false,
+    cmsInfo: {
+      ...MOCK_CMS_INFO,
+      SigninPage: {
+        ...MOCK_CMS_INFO.SigninPage!,
+        splitLayout: true,
+      },
+    },
   }),
 });
 

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -63,6 +63,7 @@ const Signin = ({
   deeplink,
   flowQueryParams,
   useFxAStatusResult: { supportsKeysOptionalLogin },
+  setCurrentSplitLayout,
 }: SigninProps & RouteComponentProps) => {
   const config = useConfig();
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
@@ -376,9 +377,10 @@ const Signin = ({
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.SigninPage.pageTitle;
+  const splitLayout = cmsInfo?.SigninPage.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       {(localizedSuccessBannerHeading || localizedSuccessBannerDescription) && (
         <Banner
           type="success"

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -108,6 +108,7 @@ export interface SigninProps {
   deeplink?: string;
   flowQueryParams?: QueryParams;
   useFxAStatusResult: UseFxAStatusResult;
+  setCurrentSplitLayout?: (value: boolean) => void;
 }
 
 export type BeginSigninHandler = (

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -49,9 +49,11 @@ function getAccountInfo(
 const SignupConfirmCodeContainer = ({
   integration,
   flowQueryParams,
+  setCurrentSplitLayout,
 }: {
   integration: Integration;
   flowQueryParams: QueryParams;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const sensitiveDataClient = useSensitiveDataClient();
@@ -122,15 +124,24 @@ const SignupConfirmCodeContainer = ({
     }
   }, [data, origin, navigateWithQuery, email]);
 
+  const cmsInfo = integration?.getCmsInfo();
+  const splitLayout = cmsInfo?.SignupConfirmCodePage?.splitLayout;
+
   // TODO: This check and related test can be moved up the tree to the App component,
   // where a missing integration should be caught and handled.
   if (!integration) {
-    return <AppLayout loading />;
+    return (
+      <AppLayout {...{ loading: true, splitLayout, setCurrentSplitLayout }} />
+    );
   }
 
   if (!uid || !sessionToken || !email) {
     navigateWithQuery('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   if (oAuthDataError) {
@@ -152,7 +163,11 @@ const SignupConfirmCodeContainer = ({
           localizedErrorMessage,
         },
       });
-      return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+      return (
+        <AppLayout
+          {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+        />
+      );
     }
     return (
       <OAuthDataError
@@ -177,6 +192,7 @@ const SignupConfirmCodeContainer = ({
         unwrapBKey,
         flowQueryParams,
         origin,
+        setCurrentSplitLayout,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.stories.tsx
@@ -6,11 +6,15 @@ import React from 'react';
 import ConfirmSignupCode from '.';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { createMockOAuthNativeIntegration, Subject } from './mocks';
+import {
+  createMockOAuthNativeIntegration,
+  createMockOAuthWebIntegration,
+  Subject,
+} from './mocks';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
-import { createMockIntegrationWithCms } from '../../mocks';
+import { MOCK_CMS_INFO } from '../../mocks';
 
 export default {
   title: 'Pages/Signup/ConfirmSignupCode',
@@ -53,6 +57,22 @@ export const OAuthDesktopServiceRelay = () => (
 
 export const WithSuccessCms = () => (
   <AppContext.Provider value={mockAppContext({ account: accountWithSuccess })}>
-    <Subject integration={createMockIntegrationWithCms()} />
+    <Subject
+      integration={createMockOAuthWebIntegration(undefined, MOCK_CMS_INFO)}
+    />
+  </AppContext.Provider>
+);
+
+export const WithSuccessCmsSplitLayout = () => (
+  <AppContext.Provider value={mockAppContext({ account: accountWithSuccess })}>
+    <Subject
+      integration={createMockOAuthWebIntegration(undefined, {
+        ...MOCK_CMS_INFO,
+        SignupConfirmCodePage: {
+          ...MOCK_CMS_INFO.SignupConfirmCodePage!,
+          splitLayout: true,
+        },
+      })}
+    />
   </AppContext.Provider>
 );

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/index.tsx
@@ -55,6 +55,7 @@ const ConfirmSignupCode = ({
   unwrapBKey,
   flowQueryParams,
   origin,
+  setCurrentSplitLayout,
 }: ConfirmSignupCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
 
@@ -316,9 +317,10 @@ const ConfirmSignupCode = ({
         'confirm-signup-code-page-title',
         'Enter confirmation code'
       );
+  const splitLayout = cmsInfo?.SignupConfirmCodePage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       {cmsInfo ? (
         <>
           {cmsInfo.shared.logoUrl && cmsInfo.shared.logoAltText && (

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/interfaces.ts
@@ -31,6 +31,7 @@ export type ConfirmSignupCodeProps = {
   declinedSyncEngines?: string[];
   flowQueryParams: QueryParams;
   origin?: string;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & SensitiveData.AuthData &
   RouteComponentProps;
 

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/mocks.tsx
@@ -12,6 +12,7 @@ import {
   OAuthNativeServices,
   OAuthWebIntegration,
   RelierClientInfo,
+  RelierCmsInfo,
   WebIntegration,
 } from '../../../models';
 import {
@@ -95,7 +96,8 @@ export function createMockWebIntegration({
 }
 
 export function createMockOAuthWebIntegration(
-  serviceName = MOCK_SERVICE
+  serviceName = MOCK_SERVICE,
+  cmsInfo: RelierCmsInfo | undefined = MOCK_CMS_INFO
 ): ConfirmSignupCodeOAuthIntegration {
   // Keeping previous mock for reference... Now we mock the data and use the actual integration.
   // return {
@@ -132,7 +134,7 @@ export function createMockOAuthWebIntegration(
     redirectUri: MOCK_REDIRECT_URI,
   } as RelierClientInfo;
 
-  integration.cmsInfo = MOCK_CMS_INFO;
+  integration.getCmsInfo = () => cmsInfo;
 
   if (typeof expect !== 'undefined') {
     expect(integration.type).toEqual(IntegrationType.OAuthWeb);

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.stories.tsx
@@ -18,7 +18,19 @@ export default {
 export const Desktop = () => <Subject />;
 
 export const DesktopWithCms = () => (
-  <Subject integration={createMockIntegration({ cmsInfo: MOCK_CMS_INFO })} />
+  <Subject integration={createMockIntegration(true, MOCK_CMS_INFO)} />
+);
+
+export const DesktopWithCmsSplitLayout = () => (
+  <Subject
+    integration={createMockIntegration(true, {
+      ...MOCK_CMS_INFO,
+      SignupConfirmedSyncPage: {
+        ...MOCK_CMS_INFO.SignupConfirmedSyncPage,
+        splitLayout: true,
+      },
+    })}
+  />
 );
 
 export const FromThirdPartyAuthSetPassword = () => (
@@ -30,5 +42,5 @@ export const DesktopWithoutPaymentMethodsSync = () => (
 );
 
 export const MobileNotCurrentlyUsed = () => (
-  <Subject integration={createMockIntegration({ isDesktopSync: false })} />
+  <Subject integration={createMockIntegration(false)} />
 );

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.test.tsx
@@ -82,7 +82,7 @@ describe('SignupConfirmedSync', () => {
 
   it('on mobile, shows only "Manage sync"', () => {
     renderWithLocalizationProvider(
-      <Subject integration={createMockIntegration({ isDesktopSync: false })} />
+      <Subject integration={createMockIntegration(false)} />
     );
 
     expect(screen.queryByText('Add another device')).not.toBeInTheDocument();
@@ -112,7 +112,7 @@ describe('SignupConfirmedSync', () => {
     } as unknown as RelierCmsInfo;
 
     renderWithLocalizationProvider(
-      <Subject integration={createMockIntegration({ cmsInfo })} />
+      <Subject integration={createMockIntegration(false, cmsInfo)} />
     );
 
     const cmsImg = screen.getByRole('img', { name: 'sync is on' });

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/index.tsx
@@ -21,6 +21,7 @@ import CmsButtonWithFallback from '../../../components/CmsButtonWithFallback';
 const SignupConfirmedSync = ({
   integration,
   offeredSyncEngines,
+  setCurrentSplitLayout,
 }: SignupConfirmedSyncProps & RouteComponentProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
   const paymentMethodsSynced = checkPaymentMethodsWillSync(offeredSyncEngines);
@@ -45,9 +46,10 @@ const SignupConfirmedSync = ({
   const cmsHideCTA = !!cmsInfo?.shared.featureFlags?.syncConfirmedPageHideCTA;
   const title = cmsInfo?.SignupConfirmedSyncPage?.pageTitle;
   const cmsSyncEnabledImage = cmsInfo?.SignupConfirmedSyncPage?.primaryImage;
+  const splitLayout = cmsInfo?.SignupConfirmedSyncPage?.splitLayout;
 
   return (
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       <FallingConfettiImage ariaHidden />
 
       {originPostVerifySetPassword ? (

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/interfaces.ts
@@ -14,6 +14,7 @@ export type SignupConfirmedSyncIntegration = Pick<
 export interface SignupConfirmedSyncProps {
   integration: SignupConfirmedSyncIntegration;
   offeredSyncEngines: UseFxAStatusResult['offeredSyncEngines'];
+  setCurrentSplitLayout?: (value: boolean) => void;
 }
 
 export interface LocationState {

--- a/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signup/SignupConfirmedSync/mocks.tsx
@@ -13,15 +13,12 @@ import {
   LocationProvider,
 } from '@reach/router';
 import SignupConfirmedSync from '.';
-import { RelierCmsInfo } from '../../../models';
+import { RelierCmsInfo } from '../../../models/integrations';
 
-export function createMockIntegration({
+export function createMockIntegration(
   isDesktopSync = true,
-  cmsInfo,
-}: {
-  isDesktopSync?: boolean;
-  cmsInfo?: RelierCmsInfo;
-} = {}): SignupConfirmedSyncIntegration {
+  cmsInfo?: RelierCmsInfo
+): SignupConfirmedSyncIntegration {
   return {
     isDesktopSync: () => isDesktopSync,
     getCmsInfo: () => cmsInfo,

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -64,10 +64,12 @@ const SignupContainer = ({
   integration,
   flowQueryParams,
   useFxAStatusResult,
+  setCurrentSplitLayout,
 }: {
   integration: SignupIntegration;
   flowQueryParams: QueryParams;
   useFxAStatusResult: UseFxAStatusResult;
+  setCurrentSplitLayout?: (value: boolean) => void;
 } & RouteComponentProps) => {
   const authClient = useAuthClient();
   const keyStretchExp = useValidatedQueryParams(KeyStretchExperiment);
@@ -205,9 +207,16 @@ const SignupContainer = ({
     ]
   );
 
+  const cmsInfo = integration.getCmsInfo();
+  const splitLayout = cmsInfo?.SignupSetPasswordPage?.splitLayout;
+
   if (validationError || !email) {
     navigateWithQuery('/');
-    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+    return (
+      <AppLayout
+        {...{ cmsInfo, loading: true, splitLayout, setCurrentSplitLayout }}
+      />
+    );
   }
 
   const deeplink = queryParamModel.deeplink;
@@ -223,6 +232,7 @@ const SignupContainer = ({
         deeplink,
         flowQueryParams,
         isMobile,
+        setCurrentSplitLayout,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signup/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.stories.tsx
@@ -120,6 +120,22 @@ export const WithCms = () => (
   />
 );
 
+export const WithCmsSplitLayout = () => (
+  <StoryWithProps
+    integration={createMockSignupOAuthWebIntegration(
+      MONITOR_CLIENTIDS[0],
+      undefined,
+      {
+        ...MOCK_CMS_INFO,
+        SignupSetPasswordPage: {
+          ...MOCK_CMS_INFO.SignupSetPasswordPage,
+          splitLayout: true,
+        },
+      }
+    )}
+  />
+);
+
 export const WithCmsUsingSharedFallback = () => (
   <StoryWithProps
     integration={createMockSignupOAuthWebIntegration(

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -58,6 +58,7 @@ export const Signup = ({
   deeplink,
   flowQueryParams,
   isMobile,
+  setCurrentSplitLayout,
 }: SignupProps) => {
   const sensitiveDataClient = useSensitiveDataClient();
 
@@ -272,11 +273,12 @@ export const Signup = ({
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.SignupSetPasswordPage?.pageTitle;
+  const splitLayout = cmsInfo?.SignupSetPasswordPage?.splitLayout;
 
   return (
     // TODO: FXA-8268, if force_auth && AuthErrors.is(error, 'DELETED_ACCOUNT'):
     //       - forceMessage('Account no longer exists. Recreate it?')
-    <AppLayout {...{ cmsInfo, title }}>
+    <AppLayout {...{ cmsInfo, title, splitLayout, setCurrentSplitLayout }}>
       {cmsInfo ? (
         <>
           <CmsLogo

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -45,6 +45,7 @@ export interface SignupProps {
   deeplink?: string;
   flowQueryParams?: QueryParams;
   isMobile: boolean;
+  setCurrentSplitLayout?: (value: boolean) => void;
 }
 
 export type SignupIntegration = SignupOAuthIntegration | SignupBaseIntegration;

--- a/packages/fxa-settings/src/pages/mocks.tsx
+++ b/packages/fxa-settings/src/pages/mocks.tsx
@@ -97,7 +97,7 @@ export const MOCK_CMS_INFO = {
   entrypoint: 'app',
   name: '123Done - app',
   shared: {
-    buttonColor: '#D41C1C',
+    buttonColor: '#6B4DFB',
     logoUrl: 'https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg',
     headerLogoUrl:
       'https://cdn.accounts.firefox.com/other/firefox-browser-logo.svg',
@@ -110,10 +110,10 @@ export const MOCK_CMS_INFO = {
     },
     favicon: '',
     backgrounds: {
-      header: 'linear-gradient(135deg, #764ba2 0%, #667eea 100%)',
+      header: 'linear-gradient(135deg, #6B4DFB 0%, #3A1A78 100%)',
       defaultLayout:
-        'linear-gradient(135deg, rgba(255, 255, 255, 0.7) 0%, rgba(255, 26, 26, 0.25) 40%, rgba(230, 0, 0, 0.3) 70%, rgba(179, 0, 0, 0.45) 100%)',
-      splitLayout: 'linear-gradient(135deg, #667eea 0%, #FF69B4 100%)',
+        'linear-gradient(135deg, #F5E9FF 0%, #E8D7FF 40%, #DCC2FF 70%, #C4A5FF 100%)',
+      splitLayout: 'linear-gradient(135deg, #6B4DFB 0%, #c230ccff 100%)',
     },
   },
   EmailFirstPage: {


### PR DESCRIPTION
## Because

* The split layout option was only rendering on the index page, and we want to enable it for all pages that support customization

## This pull request

* Pass the split layout property to all cms-enabled pages
* Add split layout stories for all these pages
* Update the mock cms colour scheme to Kit branding, just for funsies + update snapshots

## Issue that this pull request solves

Closes: FXA-12740

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This PR also includes a commit to improve the loading spinner behaviour when navigating between pages. Previously, there would be a flash of full page with spinner when navigating between split layout pages.
