### PR TITLE
bug(auth): Fix reference to bounce config

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -603,7 +603,7 @@ const convictConf = convict({
       deleteAccount: {
         doc: 'Flag to enable deleting account on email bounce.',
         format: Boolean,
-        default: false,
+        default: true,
         env: 'BOUNCES_DELETE_ACCOUNT',
       },
     },

--- a/packages/fxa-auth-server/lib/email/bounces.js
+++ b/packages/fxa-auth-server/lib/email/bounces.js
@@ -44,7 +44,7 @@ module.exports = function (log, error, config) {
       let error = null;
 
       // Checks
-      const accountDeleteEnabled = config.bounces.deleteAccount === true;
+      const accountDeleteEnabled = config.smtp.bounces.deleteAccount;
       const emailUnverified = !record.emailVerified;
       const isRecentAccount =
         record.createdAt && record.createdAt > Date.now() - SIX_HOURS;

--- a/packages/fxa-auth-server/test/local/email/bounce.js
+++ b/packages/fxa-auth-server/test/local/email/bounce.js
@@ -35,8 +35,10 @@ describe('bounce messages', () => {
   beforeEach(() => {
     log = mockLog();
     mockConfig = {
-      bounces: {
-        deleteAccount: true,
+      smtp: {
+        bounces: {
+          deleteAccount: true,
+        },
       },
     };
     mockDB = {
@@ -116,7 +118,7 @@ describe('bounce messages', () => {
   });
 
   it('should not delete account when account delete is disabled', () => {
-    mockConfig.bounces.deleteAccount = false;
+    mockConfig.smtp.bounces.deleteAccount = false;
     const bounceType = 'Transient';
     const mockMsg = mockMessage({
       bounce: {


### PR DESCRIPTION
## Because

- We had a bad reference to `config.bounce.deleteAccount`

## This pull request

- Fixes reference to be `config.smtp.bounce.deleteAccount`
- Defaults the config value for `config.smtp.bounce.deleteAccount` to true, since that was the previous default behavior.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
