### PR TITLE
enqueue inactive account for deletion if one or more bounce recorded

### DIFF
--- a/packages/fxa-auth-server/test/local/inactive-accounts/index.js
+++ b/packages/fxa-auth-server/test/local/inactive-accounts/index.js
@@ -71,7 +71,7 @@ const mockEmailTasks = {
 };
 
 const getAccountCustomerByUid = sandbox.stub();
-const emailBounceSelect = sandbox.stub().resolves([]);
+const emailBounceDistinct = sandbox.stub().resolves([]);
 const emailBounceWhere = sandbox.stub();
 const emailBounceJoin = sandbox.stub();
 const emailBounceQuery = sandbox.stub();
@@ -96,8 +96,8 @@ const EmailBounce = new (class {
     emailBounceJoin.apply(this, arguments);
     return this;
   }
-  select() {
-    return emailBounceSelect.apply(this, arguments);
+  distinct() {
+    return emailBounceDistinct.apply(this, arguments);
   }
 })();
 
@@ -139,7 +139,7 @@ describe('InactiveAccountsManager', () => {
     mockGlean.inactiveAccountDeletion.secondEmailSkipped.resetHistory();
     mockGlean.inactiveAccountDeletion.finalEmailSkipped.resetHistory();
     Object.values(mockEmailTasks).forEach((stub) => stub.resetHistory());
-    emailBounceSelect.resetHistory();
+    emailBounceDistinct.resetHistory();
     mockDeleteAccountTasks.deleteAccount.resetHistory();
     sandbox.resetHistory();
     sinon.resetHistory();
@@ -307,14 +307,14 @@ describe('InactiveAccountsManager', () => {
 
     it('should delete the account if the first email bounced', async () => {
       sandbox.stub(inactiveAccountManager, 'isActive').resolves(false);
-      emailBounceSelect.resolves([mockAccount]);
+      emailBounceDistinct.resolves([mockAccount]);
       sandbox.stub(inactiveAccountManager, 'scheduleNextEmail').resolves();
 
       await inactiveAccountManager.handleNotificationTask(
         mockSecondTaskPayload
       );
 
-      sinon.assert.calledOnceWithExactly(emailBounceSelect, ['email']);
+      sinon.assert.calledOnceWithExactly(emailBounceDistinct, 'email');
       sinon.assert.calledWithExactly(
         mockStatsd.increment,
         'account.inactive.second-email.skipped.bounce'
@@ -338,7 +338,7 @@ describe('InactiveAccountsManager', () => {
     it('should send the second email and enqueue the final', async () => {
       sandbox.stub(accountEventsManager, 'findEmailEvents').resolves([]);
       sandbox.stub(inactiveAccountManager, 'isActive').resolves(false);
-      emailBounceSelect.resolves([]);
+      emailBounceDistinct.resolves([]);
 
       await inactiveAccountManager.handleNotificationTask(
         mockSecondTaskPayload


### PR DESCRIPTION
## Because

- The bounce check was checking if length matched exactly, but this can fail in the odd case where >1 bounce recorded

## This pull request

- Add `distinct()`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
