### PR TITLE
fix(mfa): fix UI issue with MFA modal on mobile

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Modal/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.stories.tsx
@@ -22,7 +22,7 @@ const ModalToggle = ({ children }: ModalToggleProps) => {
   const [modalRevealed, showModal, hideModal] = useBooleanState(true);
   const onClick = useCallback(
     (ev: React.MouseEvent) => {
-      ev.preventDefault();
+      ev.stopPropagation();
       showModal();
     },
     [showModal]
@@ -79,6 +79,26 @@ export const WithConfirmButton = () => (
         >
           <h2>Header goes here.</h2>
           <p>This is a modal with cancel and confirm buttons.</p>
+        </Modal>
+      )
+    }
+  </ModalToggle>
+);
+
+export const WithLongContent = () => (
+  <ModalToggle>
+    {({ modalRevealed, hideModal }) =>
+      modalRevealed && (
+        <Modal
+          headerId="some-id"
+          descId="some-description"
+          onConfirm={hideModal as () => void}
+          onDismiss={hideModal}
+        >
+          <h2>This is a modal with long content.</h2>
+          {Array.from({ length: 42 }, (_, i) => (
+            <p key={i}>Scroll down to see more</p>
+          ))}
         </Modal>
       )
     }

--- a/packages/fxa-settings/src/components/Settings/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Modal/index.tsx
@@ -61,12 +61,12 @@ export const Modal = ({
     <Portal id="modal">
       <div
         data-testid={testid}
-        className="flex flex-col justify-center fixed inset-0 z-50 w-full p-2 h-full bg-black/75"
+        className="flex fixed inset-0 z-50 w-full p-2 bg-black/75 h-dvh overflow-y-auto overscroll-contain"
       >
         <div
           data-testid="modal-content-container"
           className={classNames(
-            'max-w-120 bg-white mx-auto rounded-xl border border-transparent overflow-y-auto',
+            'max-w-120 bg-white m-auto rounded-xl border border-transparent',
             className
           )}
           ref={modalInsideRef}


### PR DESCRIPTION
## Because

- The modal jumps on scroll

## This pull request

- prevents the background from scrolling with overscroll-contain and makes scrolling work nicer
- adds a story for modal to test out scrolling

## Issue that this pull request solves

Closes: FXA-12473

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

(I had to make it longer to make it scrollable; this screenshot alone doesn't tell much, since you need to scroll to see the problem)

<img width="333" height="719" alt="image" src="https://github.com/user-attachments/assets/4dc43d4a-25e0-4356-a523-17c55c2eb65b" />

## Other information (Optional)

You might need this to actually out the changes (responsive mode in desktop firefox doesn't have that taskbar, and the taskbar doesn't hide on scroll in storybook): https://mozilla.github.io/ecosystem-platform/reference/mobile-specifics#android-debugging
