### PR TITLE
polish(payments-ui): Revise mobile layout for Cancel/Stay subscribed pages

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CancelSubscription/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CancelSubscription/index.tsx
@@ -89,11 +89,11 @@ export function CancelSubscription({
 
   return (
     <section
-      className="flex items-center justify-center min-h-[calc(100vh_-_4rem)] tablet:min-h-[calc(100vh_-_5rem)]"
+      className="flex justify-center min-h-[calc(100vh_-_4rem)] tablet:items-center tablet:min-h-[calc(100vh_-_5rem)]"
       aria-labelledby="cancel-subscription-heading"
     >
       {cancelAtPeriodEnd && active ? (
-        <Form.Root className="max-w-[480px] p-10 text-grey-600 bg-white rounded-xl border border-grey-200 shadow-[0_0_16px_0_rgba(0,0,0,0.08)]">
+        <Form.Root className="max-w-[480px] p-10 text-grey-600 tablet:bg-white tablet:rounded-xl tablet:border tablet:border-grey-200 tablet:shadow-[0_0_16px_0_rgba(0,0,0,0.08)]">
           <div className="flex flex-col items-center justify-center gap-6 text-center">
             <Image src={webIcon} alt={productName} height={64} width={64} />
             <Localized id="subscription-cancellation-dialog-title">
@@ -167,7 +167,8 @@ export function CancelSubscription({
       ) : (
         <Form.Root
           action={cancelSubscriptionAtPeriodEnd}
-          className="max-w-[480px] p-10 text-grey-600 bg-white rounded-xl border border-grey-200 shadow-[0_0_16px_0_rgba(0,0,0,0.08)]"
+          className="max-w-[480px] p-10 tablet:bg-white tablet:rounded-xl tablet:border tablet:border-grey-200 tablet:shadow-[0_0_16px_0_rgba(0,0,0,0.08)]
+          "
         >
           <div className="flex flex-col items-center justify-center gap-6 text-center">
             <Image src={webIcon} alt={productName} height={64} width={64} />
@@ -194,6 +195,11 @@ export function CancelSubscription({
                 cycle.
               </p>
             </Localized>
+            <div
+              className="border-none h-px bg-grey-100 my-6"
+              role="separator"
+              aria-hidden="true"
+            ></div>
             <Form.Label asChild className="cursor-pointer my-3">
               <label htmlFor="cancelAccess" className="flex items-start gap-4">
                 <Form.Control asChild>

--- a/libs/payments/ui/src/lib/client/components/StaySubscribed/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/StaySubscribed/index.tsx
@@ -90,13 +90,13 @@ export function StaySubscribed({
 
   return (
     <section
-      className="flex items-center justify-center min-h-[calc(100vh_-_4rem)] tablet:min-h-[calc(100vh_-_5rem)]"
+      className="flex justify-center min-h-[calc(100vh_-_4rem)] tablet:items-center tablet:min-h-[calc(100vh_-_5rem)]"
       aria-labelledby="stay-subscribed-heading"
     >
       {cancelAtPeriodEnd && active ? (
         <Form.Root
           action={resubscribe}
-          className="max-w-[480px] p-10 text-grey-600 bg-white rounded-xl border border-grey-200 shadow-[0_0_16px_0_rgba(0,0,0,0.08)]"
+          className="max-w-[480px] p-10 text-grey-600 tablet:bg-white tablet:rounded-xl tablet:border tablet:border-grey-200 tablet:shadow-[0_0_16px_0_rgba(0,0,0,0.08)]"
         >
           <div className="flex flex-col items-center justify-center gap-4 text-center">
             <Image src={webIcon} alt={productName} height={64} width={64} />
@@ -201,7 +201,7 @@ export function StaySubscribed({
           </div>
         </Form.Root>
       ) : (
-        <Form.Root className="w-[480px] max-w-[480px] p-10 text-grey-600 bg-white rounded-xl border border-grey-200 shadow-[0_0_16px_0_rgba(0,0,0,0.08)]">
+        <Form.Root className="w-[480px] max-w-[480px] p-10 text-grey-600 tablet:bg-white tablet:rounded-xl tablet:border tablet:border-grey-200 tablet:shadow-[0_0_16px_0_rgba(0,0,0,0.08)]">
           <div className="flex flex-col items-center justify-center gap-4 text-center">
             <Image src={webIcon} alt={productName} height={64} width={64} />
             <Localized id="resubscribe-success-dialog-title">


### PR DESCRIPTION
## This pull request

- Updates mobile layout

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)
Cancel subscription

Mobile
<img width="373" height="814" alt="Screenshot 2025-12-05 at 1 08 57 PM" src="https://github.com/user-attachments/assets/8a637b7b-17c3-4edf-b8fb-00f23d92ed20" />

Tablet
<img width="649" height="856" alt="Screenshot 2025-12-05 at 1 09 12 PM" src="https://github.com/user-attachments/assets/d28277f2-30d9-4141-912b-b56ec41b9170" />

Mobile
<img width="301" height="653" alt="Screenshot 2025-12-05 at 1 09 50 PM" src="https://github.com/user-attachments/assets/70f9e1f0-8953-4191-816a-c80ee2acb710" />

Tablet
<img width="650" height="847" alt="Screenshot 2025-12-05 at 1 09 35 PM" src="https://github.com/user-attachments/assets/dc1178dc-5e9c-4d12-8160-40e97b18dd75" />

Stay subscribed
Mobile
<img width="299" height="646" alt="Screenshot 2025-12-05 at 1 10 29 PM" src="https://github.com/user-attachments/assets/e0742036-61fc-472b-9195-d8f64188dbb3" />

Tablet
<img width="649" height="863" alt="Screenshot 2025-12-05 at 1 10 42 PM" src="https://github.com/user-attachments/assets/ceb616fe-190e-4169-967a-56896c5011f8" />

Mobile
<img width="301" height="637" alt="Screenshot 2025-12-05 at 1 11 12 PM" src="https://github.com/user-attachments/assets/ef916605-d60e-4c87-9ec7-ace1cfb4f591" />

Tablet
<img width="650" height="866" alt="Screenshot 2025-12-05 at 1 11 00 PM" src="https://github.com/user-attachments/assets/9e0889db-d16d-401a-9c83-2ef45705e065" />
