### PR TITLE
feat(payments-next): Cancellation flow: Update Churn intervention logic

### DIFF
--- a/libs/payments/management/src/lib/churn-intervention.service.spec.ts
+++ b/libs/payments/management/src/lib/churn-intervention.service.spec.ts
@@ -4,18 +4,40 @@
 
 import { ChurnInterventionService } from './churn-intervention.service';
 import { ChurnInterventionManager, ChurnInterventionEntryFactory } from '@fxa/payments/cart';
-import { ChurnInterventionByProductIdResultFactory } from '@fxa/shared/cms';
-import { ProductConfigurationManager } from '@fxa/shared/cms';
+import {
+  ChurnInterventionByProductIdResultFactory,
+  ChurnInterventionByProductIdRawResultFactory,
+  ChurnInterventionByProductIdResultUtil
+} from '@fxa/shared/cms';
+import {
+  EligibilityService,
+  EligibilityStatus,
+} from '@fxa/payments/eligibility';
+import {
+  StripeSubscriptionFactory,
+  StripeResponseFactory,
+  StripePriceFactory,
+  StripePriceRecurringFactory,
+} from '@fxa/payments/stripe';
+import {
+  ProductConfigurationManager,
+  CancelInterstitialOfferTransformedFactory,
+  CancelInterstitialOfferResultFactory,
+  CancelInterstitialOfferUtil,
+} from '@fxa/shared/cms';
 import { SubscriptionManagementService } from './subscriptionManagement.service';
 import { Test } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
 import { Logger } from '@nestjs/common';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
+import { SubplatInterval } from '@fxa/payments/customer';
 
 describe('ChurnInterventionService', () => {
   let churnInterventionService: ChurnInterventionService;
   let churnInterventionManager: ChurnInterventionManager;
   let productConfigurationManager: ProductConfigurationManager;
   let subscriptionManagementService: SubscriptionManagementService;
+  let eligibilityService: EligibilityService;
 
   const mockEntry = ChurnInterventionEntryFactory();
   const mockLogger = {
@@ -40,6 +62,12 @@ describe('ChurnInterventionService', () => {
           useValue: mockLogger
         },
         {
+          provide: EligibilityService,
+          useValue: {
+            checkEligibility: jest.fn(),
+          }
+        },
+        {
           provide: ChurnInterventionManager,
           useValue: {
             getEntry: jest.fn(),
@@ -58,6 +86,9 @@ describe('ChurnInterventionService', () => {
           provide: ProductConfigurationManager,
           useValue: {
             getChurnInterventionBySubscription: jest.fn(),
+            getCancelInterstitialOffer: jest.fn(),
+            getSubplatIntervalBySubscription: jest.fn(),
+            retrieveStripePrice: jest.fn(),
           },
         },
         {
@@ -71,11 +102,13 @@ describe('ChurnInterventionService', () => {
     churnInterventionManager = moduleRef.get(ChurnInterventionManager);
     productConfigurationManager = moduleRef.get(ProductConfigurationManager);
     subscriptionManagementService = moduleRef.get(SubscriptionManagementService);
+    eligibilityService = moduleRef.get(EligibilityService);
   });
 
   describe('getChurnInterventionForCustomerId', () => {
     it('returns the churn intervention entry', async () => {
-      (churnInterventionManager.getEntry as jest.Mock).mockResolvedValue(mockEntry);
+      jest.spyOn(churnInterventionManager, 'getEntry')
+        .mockResolvedValue(mockEntry);
       const result = await churnInterventionService.getChurnInterventionForCustomerId(mockEntry.customerId, mockEntry.churnInterventionId);
 
       expect(churnInterventionManager.getEntry).toHaveBeenCalledWith(
@@ -90,17 +123,16 @@ describe('ChurnInterventionService', () => {
     const uid = 'uid_123';
     const subscriptionId = 'sub_123';
 
-    const cmsResult = (entries: any[]) => ({
-      getTransformedChurnInterventionByProductId: () => entries,
-    });
-
     afterEach(() => {
       jest.resetAllMocks();
     });
 
     it('returns ineligible when no churn intervention entries are found', async () => {
-      (productConfigurationManager.getChurnInterventionBySubscription as jest.Mock)
-        .mockResolvedValue(cmsResult([]));
+      const rawResult = ChurnInterventionByProductIdRawResultFactory();
+      const util = new ChurnInterventionByProductIdResultUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
+        .mockResolvedValue(util);
+      jest.spyOn(util, 'getTransformedChurnInterventionByProductId').mockReturnValue([]);
 
       const result = await churnInterventionService.determineStaySubscribedEligibility(
         uid,
@@ -115,13 +147,19 @@ describe('ChurnInterventionService', () => {
     });
 
     it('returns ineligible when redemption limit reached', async () => {
-      const entry = {
+      const rawResult = ChurnInterventionByProductIdRawResultFactory();
+      const util = new ChurnInterventionByProductIdResultUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
+        .mockResolvedValue(util);
+
+      const mockCmsChurnEntry = ChurnInterventionByProductIdResultFactory({
         churnInterventionId: 'churn_id',
         redemptionLimit: 1
-      };
-      (productConfigurationManager.getChurnInterventionBySubscription as jest.Mock)
-        .mockResolvedValue(cmsResult([entry]));
-      (churnInterventionManager.getRedemptionCountForUid as jest.Mock)
+      });
+      jest.spyOn(util, 'getTransformedChurnInterventionByProductId')
+        .mockReturnValue([mockCmsChurnEntry]);
+
+      jest.spyOn(churnInterventionManager, 'getRedemptionCountForUid')
         .mockResolvedValue(1);
 
       const result = await churnInterventionService.determineStaySubscribedEligibility(
@@ -137,15 +175,14 @@ describe('ChurnInterventionService', () => {
     });
 
     it('returns ineligible when subscription is not active', async () => {
-      const entry = {
-        churnInterventionId: 'churn_id',
-        redemptionLimit: null
-      };
-      (productConfigurationManager.getChurnInterventionBySubscription as jest.Mock)
-        .mockResolvedValue(cmsResult([entry]));
-      (churnInterventionManager.getRedemptionCountForUid as jest.Mock)
+      const rawResult = ChurnInterventionByProductIdRawResultFactory();
+      const util = new ChurnInterventionByProductIdResultUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
+        .mockResolvedValue(util);
+
+      jest.spyOn(churnInterventionManager, 'getRedemptionCountForUid')
         .mockResolvedValue(0);
-      (subscriptionManagementService.getSubscriptionStatus as jest.Mock)
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
         .mockResolvedValue({ active: false, cancelAtPeriodEnd: true });
 
       const result = await churnInterventionService.determineStaySubscribedEligibility(
@@ -161,15 +198,14 @@ describe('ChurnInterventionService', () => {
     });
 
     it('returns ineligible when subscription is still active', async () => {
-      const entry = {
-        churnInterventionId: 'churn_id',
-        redemptionLimit: null
-      };
-      (productConfigurationManager.getChurnInterventionBySubscription as jest.Mock)
-        .mockResolvedValue(cmsResult([entry]));
-      (churnInterventionManager.getRedemptionCountForUid as jest.Mock)
+      const rawResult = ChurnInterventionByProductIdRawResultFactory();
+      const util = new ChurnInterventionByProductIdResultUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
+        .mockResolvedValue(util);
+
+      jest.spyOn(churnInterventionManager, 'getRedemptionCountForUid')
         .mockResolvedValue(0);
-      (subscriptionManagementService.getSubscriptionStatus as jest.Mock)
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
         .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
 
       const result = await churnInterventionService.determineStaySubscribedEligibility(
@@ -185,15 +221,18 @@ describe('ChurnInterventionService', () => {
     });
 
     it('returns eligible on success', async () => {
-      const entry = {
-        churnInterventionId: 'churn_id',
-        redemptionLimit: null
-      };
-      (productConfigurationManager.getChurnInterventionBySubscription as jest.Mock)
-        .mockResolvedValue(cmsResult([entry]));
-      (churnInterventionManager.getRedemptionCountForUid as jest.Mock)
+      const rawResult = ChurnInterventionByProductIdRawResultFactory();
+      const util = new ChurnInterventionByProductIdResultUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
+        .mockResolvedValue(util);
+
+      const mockCmsChurnEntry = ChurnInterventionByProductIdResultFactory();
+      jest.spyOn(util, 'getTransformedChurnInterventionByProductId')
+        .mockReturnValue([mockCmsChurnEntry]);
+
+      jest.spyOn(churnInterventionManager, 'getRedemptionCountForUid')
         .mockResolvedValue(0);
-      (subscriptionManagementService.getSubscriptionStatus as jest.Mock)
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
         .mockResolvedValue({ active: true, cancelAtPeriodEnd: true });
 
       const result = await churnInterventionService.determineStaySubscribedEligibility(
@@ -204,12 +243,12 @@ describe('ChurnInterventionService', () => {
       expect(result).toEqual({
         isEligible: true,
         reason: 'eligible',
-        cmsChurnInterventionEntry: entry,
+        cmsChurnInterventionEntry: mockCmsChurnEntry,
       });
     });
 
     it('returns general_error for general errors', async () => {
-      (productConfigurationManager.getChurnInterventionBySubscription as jest.Mock)
+      jest.spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
         .mockRejectedValue(new Error('error'));
 
       const result = await churnInterventionService.determineStaySubscribedEligibility(
@@ -240,8 +279,15 @@ describe('ChurnInterventionService', () => {
           cmsChurnInterventionEntry: mockCmsChurnEntry,
         });
 
-      (subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
-        .mockResolvedValue({ id: subscriptionId, cancel_at_period_end: true });
+      const updatedSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          id: subscriptionId,
+          cancel_at_period_end: true,
+        })
+      );
+
+      jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription')
+        .mockResolvedValue(updatedSubscription);
 
       const prevCount = mockChurnInterventionEntry.redemptionCount || 0;
 
@@ -251,7 +297,7 @@ describe('ChurnInterventionService', () => {
         churnInterventionId: mockChurnInterventionEntry.churnInterventionId,
         redemptionCount: prevCount + 1,
       });
-      (churnInterventionManager.updateEntry as jest.Mock)
+      jest.spyOn(churnInterventionManager, 'updateEntry')
         .mockResolvedValue(updatedEntry);
 
       const result = await churnInterventionService.redeemChurnCoupon(
@@ -259,7 +305,7 @@ describe('ChurnInterventionService', () => {
         subscriptionId
       );
 
-      expect(subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
+      expect(jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription'))
         .toHaveBeenCalledWith({
           uid: mockChurnInterventionEntry.customerId,
           subscriptionId,
@@ -267,7 +313,7 @@ describe('ChurnInterventionService', () => {
           setCancelAtPeriodEnd: true,
         });
 
-      expect(churnInterventionManager.updateEntry as jest.Mock)
+      expect(jest.spyOn(churnInterventionManager, 'updateEntry'))
         .toHaveBeenCalledWith(
           mockChurnInterventionEntry.customerId,
           mockCmsChurnEntry.churnInterventionId,
@@ -292,7 +338,7 @@ describe('ChurnInterventionService', () => {
           cmsChurnInterventionEntry: mockCmsChurnEntry,
         });
 
-      (subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
+      jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription')
         .mockRejectedValue(new Error('Stripe error'));
 
       const result = await churnInterventionService.redeemChurnCoupon(
@@ -300,7 +346,7 @@ describe('ChurnInterventionService', () => {
         subscriptionId
       );
 
-      expect(subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
+      expect(jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription'))
         .toHaveBeenCalledWith({
           uid: mockChurnInterventionEntry.customerId,
           subscriptionId,
@@ -308,7 +354,7 @@ describe('ChurnInterventionService', () => {
           setCancelAtPeriodEnd: true,
         });
 
-      expect(churnInterventionManager.updateEntry as jest.Mock).not.toHaveBeenCalled();
+      expect(jest.spyOn(churnInterventionManager, 'updateEntry')).not.toHaveBeenCalled();
       expect(result).toEqual({
         redeemed: false,
         reason: 'failed_to_redeem_coupon',
@@ -331,10 +377,10 @@ describe('ChurnInterventionService', () => {
         subscriptionId
       );
 
-      expect(subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
+      expect(jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription'))
         .not.toHaveBeenCalled();
 
-      expect(churnInterventionManager.updateEntry as jest.Mock).not.toHaveBeenCalled();
+      expect(jest.spyOn(churnInterventionManager, 'updateEntry')).not.toHaveBeenCalled();
       expect(result).toEqual({
         redeemed: false,
         reason: 'discount_already_applied',
@@ -352,7 +398,7 @@ describe('ChurnInterventionService', () => {
           cmsChurnInterventionEntry: mockCmsChurnEntry,
         });
 
-      (subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
+      jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription')
         .mockResolvedValue(null);
 
       const result = await churnInterventionService.redeemChurnCoupon(
@@ -360,7 +406,7 @@ describe('ChurnInterventionService', () => {
         subscriptionId
       );
 
-      expect(subscriptionManagementService.applyStripeCouponToSubscription as jest.Mock)
+      expect(jest.spyOn(subscriptionManagementService, 'applyStripeCouponToSubscription'))
         .toHaveBeenCalledWith({
           uid: mockChurnInterventionEntry.customerId,
           subscriptionId,
@@ -368,12 +414,393 @@ describe('ChurnInterventionService', () => {
           setCancelAtPeriodEnd: true,
         });
 
-      expect(churnInterventionManager.updateEntry as jest.Mock).not.toHaveBeenCalled();
+      expect(jest.spyOn(churnInterventionManager, 'updateEntry')).not.toHaveBeenCalled();
       expect(result).toEqual({
         redeemed: false,
         reason: 'stripe_subscription_update_failed',
         updatedChurnInterventionEntryData: null,
         cmsChurnInterventionEntry: mockCmsChurnEntry,
+      });
+    });
+  });
+
+  describe('determineCancellationIntervention', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('returns cancel_interstitial_offer when one exists', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      const mockCancelInterstitialOffer = CancelInterstitialOfferTransformedFactory();
+
+      jest.spyOn(churnInterventionService, 'determineCancelInterstitialOfferEligibility')
+        .mockResolvedValue({
+          isEligible: true,
+          reason: 'eligible',
+          cmsCancelInterstitialOfferResult: mockCancelInterstitialOffer,
+        });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'cancel_interstitial_offer',
+        reason: 'eligible',
+        cmsOfferContent: mockCancelInterstitialOffer,
+      });
+    });
+
+    it('returns cancel_interstitial_offer when all checks pass', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      const rawResult = CancelInterstitialOfferResultFactory();
+      const util = new CancelInterstitialOfferUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getCancelInterstitialOffer')
+        .mockResolvedValue(util);
+      const mockCancelInterstitialOffer = CancelInterstitialOfferTransformedFactory();
+      jest.spyOn(util, 'getTransformedResult').mockReturnValue(mockCancelInterstitialOffer);
+
+      jest.spyOn(productConfigurationManager, 'getSubplatIntervalBySubscription')
+        .mockResolvedValue(SubplatInterval.Monthly);
+
+      const mockPrice = StripeResponseFactory(StripePriceFactory());
+      jest.spyOn(productConfigurationManager, 'retrieveStripePrice')
+        .mockResolvedValue(mockPrice);
+
+      const mockFromOfferingId = faker.string.uuid();
+      const mockFromPrice = StripePriceFactory({
+        recurring: StripePriceRecurringFactory({ interval: 'month' }),
+      });
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
+        subscriptionEligibilityResult: EligibilityStatus.UPGRADE,
+        fromOfferingConfigId: mockFromOfferingId,
+        fromPrice: mockFromPrice,
+      });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+      expect(productConfigurationManager.retrieveStripePrice)
+        .toHaveBeenCalledWith(args.offeringApiIdentifier, args.upgradeInterval);
+      expect(mockStatsD.increment).toHaveBeenCalledWith(
+        'cancel_intervention_decision', {
+          type: 'cancel_interstitial_offer',
+        });
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'cancel_interstitial_offer',
+        reason: 'eligible',
+        cmsOfferContent: mockCancelInterstitialOffer,
+      });
+    });
+
+    it('returns cancel_churn_intervention when one exists', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      jest.spyOn(churnInterventionService, 'determineCancelInterstitialOfferEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_cancel_interstitial_offer_found',
+          cmsCancelInterstitialOfferResult: null,
+        });
+
+      const mockCmsOffer = ChurnInterventionByProductIdResultFactory();
+      jest.spyOn(churnInterventionService, 'determineCancelChurnContentEligibility')
+        .mockResolvedValue({
+          isEligible: true,
+          reason: 'eligible',
+          cmsChurnInterventionEntry: mockCmsOffer,
+        });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'cancel_churn_intervention',
+        reason: 'eligible',
+        cmsOfferContent: mockCmsOffer,
+      });
+    });
+
+    it('returns none when no cancel offers exist', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      jest.spyOn(churnInterventionService, 'determineCancelInterstitialOfferEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_cancel_interstitial_offer_found',
+          cmsCancelInterstitialOfferResult: null,
+        });
+
+      jest.spyOn(churnInterventionService, 'determineCancelChurnContentEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_churn_intervention_found',
+          cmsChurnInterventionEntry: null,
+        });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+
+      expect(churnInterventionService.determineCancelInterstitialOfferEligibility)
+        .toHaveBeenCalledWith(args);
+      expect(churnInterventionService.determineCancelInterstitialOfferEligibility)
+        .toHaveBeenCalledTimes(1);
+
+        expect(churnInterventionService.determineCancelChurnContentEligibility)
+        .toHaveBeenCalledWith({
+          uid: args.uid,
+          subscriptionId: args.subscriptionId,
+          acceptLanguage: undefined,
+          selectedLanguage: undefined,
+        });
+      expect(churnInterventionService.determineCancelChurnContentEligibility)
+        .toHaveBeenCalledTimes(1);
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'none',
+        reason: 'no_churn_intervention_found',
+        cmsOfferContent: null,
+      });
+    });
+
+    it('returns none when currentInterval does not match current subscription plan interval', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      const raw = CancelInterstitialOfferResultFactory();
+      const util = new CancelInterstitialOfferUtil(raw);
+      jest.spyOn(productConfigurationManager, 'getCancelInterstitialOffer')
+        .mockResolvedValue(util);
+
+      jest.spyOn(productConfigurationManager, 'getSubplatIntervalBySubscription')
+        .mockResolvedValue(SubplatInterval.Yearly);
+
+      jest.spyOn(churnInterventionService, 'determineCancelChurnContentEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_churn_intervention_found',
+          cmsChurnInterventionEntry: null,
+        });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+      expect(productConfigurationManager.retrieveStripePrice).not.toHaveBeenCalled();
+
+      expect(mockStatsD.increment).toHaveBeenCalledWith(
+        'cancel_intervention_decision', {
+          type: 'none',
+          reason: 'current_interval_mismatch',
+      });
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'none',
+        reason: 'no_churn_intervention_found',
+        cmsOfferContent: null,
+      });
+    });
+
+    it('returns none when there is no upgrade plan', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      const rawResult = CancelInterstitialOfferResultFactory();
+      const util = new CancelInterstitialOfferUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getCancelInterstitialOffer')
+        .mockResolvedValue(util);
+
+      jest.spyOn(productConfigurationManager, 'getSubplatIntervalBySubscription')
+        .mockResolvedValue(SubplatInterval.Monthly);
+      jest.spyOn(productConfigurationManager, 'retrieveStripePrice')
+        .mockRejectedValue(new Error('error'));
+
+      jest.spyOn(churnInterventionService, 'determineCancelChurnContentEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_churn_intervention_found',
+          cmsChurnInterventionEntry: null,
+        });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+      expect(productConfigurationManager.retrieveStripePrice)
+        .toHaveBeenCalledWith(args.offeringApiIdentifier, args.upgradeInterval);
+      expect(mockStatsD.increment).toHaveBeenCalledWith(
+        'cancel_intervention_decision', {
+          type: 'none',
+          reason: 'no_upgrade_plan_found',
+      });
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'none',
+        reason: 'no_churn_intervention_found',
+        cmsOfferContent: null,
+      });
+    });
+
+    it('returns none when customer is not eligible for the upgrade interval plan', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Monthly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      const rawResult = CancelInterstitialOfferResultFactory();
+      const util = new CancelInterstitialOfferUtil(rawResult);
+      jest.spyOn(productConfigurationManager, 'getCancelInterstitialOffer')
+        .mockResolvedValue(util);
+
+      jest.spyOn(productConfigurationManager, 'getSubplatIntervalBySubscription')
+        .mockResolvedValue(SubplatInterval.Monthly);
+
+      const mockPrice = StripeResponseFactory(StripePriceFactory());
+      jest.spyOn(productConfigurationManager, 'retrieveStripePrice')
+        .mockResolvedValue(mockPrice);
+      jest.spyOn(eligibilityService, 'checkEligibility')
+        .mockResolvedValue({ subscriptionEligibilityResult: EligibilityStatus.SAME });
+
+      jest.spyOn(churnInterventionService, 'determineCancelChurnContentEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_churn_intervention_found',
+          cmsChurnInterventionEntry: null,
+        });
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(subscriptionManagementService.getSubscriptionStatus)
+        .toHaveBeenCalledWith(args.uid, args.subscriptionId);
+      expect(productConfigurationManager.retrieveStripePrice)
+        .toHaveBeenCalledWith(args.offeringApiIdentifier, args.upgradeInterval);
+      expect(mockStatsD.increment).toHaveBeenCalledWith(
+        'cancel_intervention_decision', {
+          type: 'none',
+          reason: 'not_eligible_for_upgrade_interval',
+        });
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'none',
+        reason: 'no_churn_intervention_found',
+        cmsOfferContent: null,
+      });
+    });
+
+    it('returns none with discount_already_applied when customer is not eligible to redeem', async () => {
+      const args = {
+        uid: 'uid_123',
+        subscriptionId: 'sub_123',
+        offeringApiIdentifier: 'offer_123',
+        currentInterval: SubplatInterval.Monthly,
+        upgradeInterval: SubplatInterval.Yearly,
+      };
+
+      jest.spyOn(subscriptionManagementService, 'getSubscriptionStatus')
+        .mockResolvedValue({ active: true, cancelAtPeriodEnd: false });
+
+      jest.spyOn(churnInterventionService, 'determineCancelInterstitialOfferEligibility')
+        .mockResolvedValue({
+          isEligible: false,
+          reason: 'no_cancel_interstitial_offer_found',
+          cmsCancelInterstitialOfferResult: null,
+        });
+
+      const raw = ChurnInterventionByProductIdRawResultFactory();
+      const util = new ChurnInterventionByProductIdResultUtil(raw);
+      const cmsEntry = ChurnInterventionByProductIdResultFactory({
+        redemptionLimit: 1,
+      });
+
+      jest
+        .spyOn(productConfigurationManager, 'getChurnInterventionBySubscription')
+        .mockResolvedValue(util);
+      jest
+        .spyOn(util, 'getTransformedChurnInterventionByProductId')
+        .mockReturnValue([cmsEntry]);
+      jest
+        .spyOn(churnInterventionManager, 'getRedemptionCountForUid')
+        .mockResolvedValue(1);
+
+      const result = await churnInterventionService.determineCancellationIntervention(args);
+
+      expect(mockStatsD.increment).toHaveBeenCalledWith(
+        'cancel_intervention_decision', {
+          type: 'none',
+          reason: 'discount_already_applied',
+        });
+
+      expect(result).toEqual({
+        cancelChurnInterventionType: 'none',
+        reason: 'discount_already_applied',
+        cmsOfferContent: null,
       });
     });
   });

--- a/libs/payments/management/src/lib/churn-intervention.service.ts
+++ b/libs/payments/management/src/lib/churn-intervention.service.ts
@@ -9,6 +9,10 @@ import {
   ProductConfigurationManager,
 } from '@fxa/shared/cms';
 import { SubscriptionManagementService } from './subscriptionManagement.service';
+import {
+  EligibilityService,
+  EligibilityStatus,
+} from '@fxa/payments/eligibility';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { StatsD } from 'hot-shots';
 import { SubplatInterval } from '@fxa/payments/customer';
@@ -20,6 +24,7 @@ export class ChurnInterventionService {
     private productConfigurationManager: ProductConfigurationManager,
     private churnInterventionManager: ChurnInterventionManager,
     private subscriptionManagementService: SubscriptionManagementService,
+    private eligibilityService: EligibilityService,
     @Inject(StatsDService) private statsd: StatsD,
     @Inject(Logger) private log: LoggerService
   ) {}
@@ -236,6 +241,229 @@ export class ChurnInterventionService {
         updatedChurnInterventionEntryData: null,
         cmsChurnInterventionEntry: eligibilityResult.cmsChurnInterventionEntry,
       };
+    }
+  }
+
+  async determineCancellationIntervention(args: {
+    uid: string,
+    subscriptionId: string,
+    offeringApiIdentifier: string,
+    currentInterval: SubplatInterval,
+    upgradeInterval: SubplatInterval,
+    acceptLanguage?: string | null,
+    selectedLanguage?: string,
+  }) {
+    try {
+      const subscriptionStatus = await this.subscriptionManagementService.getSubscriptionStatus(
+        args.uid,
+        args.subscriptionId
+      );
+      if (!subscriptionStatus.active) {
+        this.statsd.increment('cancel_intervention_decision', {
+          type: 'none',
+          reason: 'subscription_not_active',
+        });
+        return {
+          cancelChurnInterventionType: 'none',
+          reason: 'subscription_not_active',
+          cmsOfferContent: null,
+        }
+      }
+
+      if (subscriptionStatus.cancelAtPeriodEnd) {
+        this.statsd.increment('cancel_intervention_decision', {
+          type: 'none',
+          reason: 'subscription_already_cancelling',
+        });
+        return {
+          cancelChurnInterventionType: 'none',
+          reason: 'subscription_already_cancelling',
+          cmsOfferContent: null,
+        };
+      }
+
+      const cancelInterstitialOfferEligiblityResult = await this.determineCancelInterstitialOfferEligibility(args);
+      if (cancelInterstitialOfferEligiblityResult.isEligible) {
+        return {
+          cancelChurnInterventionType: 'cancel_interstitial_offer',
+          reason: 'eligible',
+          cmsOfferContent: cancelInterstitialOfferEligiblityResult.cmsCancelInterstitialOfferResult,
+        }
+      }
+
+      const cancelChurnContentEligiblityResult = await this.determineCancelChurnContentEligibility({
+        uid: args.uid,
+        subscriptionId: args.subscriptionId,
+        acceptLanguage: args.acceptLanguage,
+        selectedLanguage: args.selectedLanguage
+      });
+      if (cancelChurnContentEligiblityResult.isEligible) {
+        return {
+          cancelChurnInterventionType: 'cancel_churn_intervention',
+          reason: 'eligible',
+          cmsOfferContent: cancelChurnContentEligiblityResult.cmsChurnInterventionEntry,
+        }
+      }
+
+      return {
+        cancelChurnInterventionType: 'none',
+        reason: cancelChurnContentEligiblityResult.reason,
+        cmsOfferContent: null,
+      }
+    } catch (error) {
+      this.log.error(error);
+      return {
+        cancelChurnInterventionType: 'none',
+        reason: 'general_error',
+        cmsOfferContent: null,
+      }
+    }
+  }
+
+  async determineCancelInterstitialOfferEligibility(args: {
+    uid: string,
+    subscriptionId: string,
+    offeringApiIdentifier: string,
+    currentInterval: SubplatInterval,
+    upgradeInterval: SubplatInterval,
+    acceptLanguage?: string | null,
+    selectedLanguage?: string,
+  }) {
+      const cmsCancelInterstitialOffer =
+        await this.productConfigurationManager.getCancelInterstitialOffer(
+          args.offeringApiIdentifier,
+          args.currentInterval,
+          args.upgradeInterval,
+          args.acceptLanguage || undefined,
+          args.selectedLanguage
+        );
+
+      const cmsCancelInterstitialOfferResult = cmsCancelInterstitialOffer.getTransformedResult();
+      if (!cmsCancelInterstitialOfferResult) {
+        this.statsd.increment('cancel_intervention_decision', {
+          type: 'none',
+          reason: 'no_cancel_interstitial_offer_found',
+        });
+        return {
+          isEligible: false,
+          reason: 'no_cancel_interstitial_offer_found',
+          cmsCancelInterstitialOfferResult: null,
+        }
+      }
+
+      const currentStripeInterval = await this.productConfigurationManager.getSubplatIntervalBySubscription(
+        args.subscriptionId
+      );
+      if (!currentStripeInterval || currentStripeInterval !== args.currentInterval) {
+        this.statsd.increment('cancel_intervention_decision', {
+          type: 'none',
+          reason: 'current_interval_mismatch',
+        });
+        return {
+          isEligible: false,
+          reason: 'current_interval_mismatch',
+          cmsCancelInterstitialOfferResult: null,
+        }
+      }
+
+      try {
+        await this.productConfigurationManager.retrieveStripePrice(
+          args.offeringApiIdentifier,
+          args.upgradeInterval
+        );
+      } catch {
+        this.statsd.increment('cancel_intervention_decision', {
+          type: 'none',
+          reason: 'no_upgrade_plan_found',
+        });
+        return {
+          isEligible: false,
+          reason: 'no_upgrade_plan_found',
+          cmsCancelInterstitialOfferResult: null,
+        };
+      }
+
+      const eligibility = await this.eligibilityService.checkEligibility(
+        args.upgradeInterval,
+        args.offeringApiIdentifier,
+        args.uid,
+        args.subscriptionId
+      );
+
+      if (eligibility.subscriptionEligibilityResult !== EligibilityStatus.UPGRADE) {
+        this.statsd.increment('cancel_intervention_decision', {
+          type: 'none',
+          reason: 'not_eligible_for_upgrade_interval',
+        });
+        return {
+          isEligible: false,
+          reason: 'not_eligible_for_upgrade_interval',
+          cmsCancelInterstitialOfferResult: null,
+        }
+      }
+
+      this.statsd.increment('cancel_intervention_decision', {
+        type: 'cancel_interstitial_offer'
+      });
+      return {
+        isEligible: true,
+        reason: 'eligible',
+        cmsCancelInterstitialOfferResult,
+      }
+  }
+
+  async determineCancelChurnContentEligibility(args: {
+    uid: string,
+    subscriptionId: string,
+    acceptLanguage?: string | null,
+    selectedLanguage?: string,
+  }) {
+    const cmsChurnResult =
+      await this.productConfigurationManager.getChurnInterventionBySubscription(
+        args.subscriptionId,
+        'cancel',
+        args.acceptLanguage || undefined,
+        args.selectedLanguage
+      );
+
+    const cmsChurnInterventionEntries = cmsChurnResult.getTransformedChurnInterventionByProductId();
+    if (!cmsChurnInterventionEntries.length) {
+      this.statsd.increment('cancel_intervention_decision', {
+        type: 'none',
+        reason: 'no_churn_intervention_found',
+      });
+      return {
+        isEligible: false,
+        reason: 'no_churn_intervention_found',
+        cmsChurnInterventionEntry: null,
+      }
+    }
+
+    const cmsChurnInterventionEntry = cmsChurnInterventionEntries[0];
+    const redemptionCount = await this.churnInterventionManager.getRedemptionCountForUid(
+      args.uid,
+      cmsChurnInterventionEntry.churnInterventionId
+    );
+
+    if (cmsChurnInterventionEntry.redemptionLimit && redemptionCount >= cmsChurnInterventionEntry.redemptionLimit) {
+      this.statsd.increment('cancel_intervention_decision', {
+        type: 'none',
+        reason: 'discount_already_applied',
+      });
+      return {
+        isEligible: false,
+        reason: 'discount_already_applied',
+        cmsChurnInterventionEntry: null,
+      }
+    }
+
+    this.statsd.increment('cancel_intervention_decision', {
+      type: 'cancel_churn_intervention',
+    });
+    return {
+      isEligible: true,
+      reason: 'eligible',
+      cmsChurnInterventionEntry,
     }
   }
 }

--- a/libs/payments/ui/src/lib/actions/determineCancellationIntervention.ts
+++ b/libs/payments/ui/src/lib/actions/determineCancellationIntervention.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { getApp } from '../nestapp/app';
+import { SubplatInterval } from '@fxa/payments/customer';
+
+export const determineCancellationInterventionAction = async (args: {
+    uid: string,
+    subscriptionId: string,
+    offeringApiIdentifier: string,
+    currentInterval: SubplatInterval,
+    upgradeInterval: SubplatInterval,
+    acceptLanguage?: string | null,
+    selectedLanguage?: string,
+}) => {
+  return await getApp().getActionsService().determineCancellationIntervention({
+    uid: args.uid,
+    subscriptionId: args.subscriptionId,
+    offeringApiIdentifier: args.offeringApiIdentifier,
+    currentInterval: args.currentInterval,
+    upgradeInterval: args.upgradeInterval,
+    acceptLanguage: args.acceptLanguage,
+    selectedLanguage: args.selectedLanguage,
+  });
+};

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -54,6 +54,7 @@ import { GetNeedsInputActionArgs } from './validators/GetNeedsInputActionArgs';
 import { ValidatePostalCodeActionArgs } from './validators/ValidatePostalCodeActionArgs';
 import { DetermineCurrencyActionArgs } from './validators/DetermineCurrencyActionArgs';
 import { DetermineStaySubscribedEligibilityActionArgs } from './validators/DetermineStaySubscribedEligibilityActionArgs';
+import { DetermineCancellationInterventionActionArgs } from './validators/DetermineCancellationInterventionActionArgs';
 import { NextIOValidator } from './NextIOValidator';
 import type {
   CommonMetrics,
@@ -120,6 +121,7 @@ import { CreatePaypalBillingAgreementIdArgs } from './validators/CreatePaypalBil
 import { DetermineCurrencyForCustomerActionArgs } from './validators/DetermineCurrencyForCustomerActionArgs';
 import { DetermineCurrencyForCustomerActionResult } from './validators/DetermineCurrencyForCustomerActionResult';
 import { DetermineStaySubscribedEligibilityActionResult } from './validators/DetermineStaySubscribedEligibilityActionResult';
+import { DetermineCancellationInterventionActionResult } from './validators/DetermineCancellationInterventionActionResult';
 import { NimbusManager } from '@fxa/payments/experiments';
 import { GetExperimentsActionArgs } from './validators/GetExperimentsActionArgs';
 import { GetExperimentsActionResult } from './validators/GetExperimentsActionResult';
@@ -283,6 +285,33 @@ export class NextJSActionsService {
       args.acceptLanguage,
       args.selectedLanguage
     );
+  }
+
+  @SanitizeExceptions()
+  @NextIOValidator(
+    DetermineCancellationInterventionActionArgs,
+    DetermineCancellationInterventionActionResult
+  )
+  @WithTypeCachableAsyncLocalStorage()
+  @CaptureTimingWithStatsD()
+  async determineCancellationIntervention(args: {
+    uid: string,
+    subscriptionId: string,
+    offeringApiIdentifier: string,
+    currentInterval: SubplatInterval,
+    upgradeInterval: SubplatInterval,
+    acceptLanguage?: string | null,
+    selectedLanguage?: string,
+  }) {
+    return await this.churnInterventionService.determineCancellationIntervention({
+      uid: args.uid,
+      subscriptionId: args.subscriptionId,
+      offeringApiIdentifier: args.offeringApiIdentifier,
+      currentInterval: args.currentInterval,
+      upgradeInterval: args.upgradeInterval,
+      acceptLanguage: args.acceptLanguage,
+      selectedLanguage: args.selectedLanguage,
+    });
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/DetermineCancellationInterventionActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/DetermineCancellationInterventionActionArgs.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString, IsOptional } from 'class-validator';
+import { SubplatInterval } from '@fxa/payments/customer';
+
+export class DetermineCancellationInterventionActionArgs {
+  @IsString()
+  uid!: string;
+
+  @IsString()
+  subscriptionId!: string;
+
+  @IsString()
+  offeringApiIdentifier!: string;
+
+  @IsString()
+  currentInterval!: SubplatInterval;
+
+  @IsString()
+  upgradeInterval!: SubplatInterval;
+
+  @IsString()
+  @IsOptional()
+  acceptLanguage?: string;
+
+  @IsString()
+  @IsOptional()
+  selectedLanguage?: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/DetermineCancellationInterventionActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/DetermineCancellationInterventionActionResult.ts
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  IsArray,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  Enum_Cancelinterstitialoffer_Currentinterval,
+  Enum_Cancelinterstitialoffer_Upgradeinterval,
+} from '../../../../../../shared/cms/src/__generated__/graphql';
+
+export class CmsChurnInterventionEntryResult {
+  @IsString()
+  webIcon!: string;
+
+  @IsString()
+  churnInterventionId!: string;
+
+  @IsString()
+  churnType!: string;
+
+  @IsOptional()
+  @IsNumber()
+  redemptionLimit?: number | null;
+
+  @IsString()
+  stripeCouponId!: string;
+
+  @IsString()
+  interval!: string;
+
+  @IsNumber()
+  discountAmount!: number;
+
+  @IsString()
+  ctaMessage!: string;
+
+  @IsString()
+  modalHeading!: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  modalMessage!: string[];
+
+  @IsString()
+  productPageUrl!: string;
+
+  @IsString()
+  termsHeading!: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  termsDetails!: string[];
+
+  @IsString()
+  supportUrl!: string;
+}
+
+export class CmsPurchaseDetailsLocalizationObject {
+  @IsString()
+  webIcon!: string;
+}
+
+export class CmsPurchaseDetailsDataObject {
+  @IsString()
+  webIcon!: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CmsPurchaseDetailsLocalizationObject)
+  localizations!: CmsPurchaseDetailsLocalizationObject[]
+}
+
+export class CmsDefaultPurchaseDataObject {
+  @ValidateNested()
+  @Type(() => CmsPurchaseDetailsDataObject)
+  purchaseDetails!: CmsPurchaseDetailsDataObject;
+}
+
+export class CancelInterstitialOfferOfferingObject {
+  @IsString()
+  stripeProductId!: string;
+
+  @ValidateNested()
+  @Type(() => CmsDefaultPurchaseDataObject)
+  defaultPurchase!: CmsDefaultPurchaseDataObject;
+}
+
+export class CmsCancelInterstitialOfferPartialResult {
+  @IsString()
+  @IsOptional()
+  offeringApiIdentifier?: string;
+
+  @IsEnum(Enum_Cancelinterstitialoffer_Currentinterval)
+  @IsOptional()
+  currentInterval?: Enum_Cancelinterstitialoffer_Currentinterval;
+
+  @IsEnum(Enum_Cancelinterstitialoffer_Upgradeinterval)
+  @IsOptional()
+  upgradeInterval?: Enum_Cancelinterstitialoffer_Upgradeinterval;
+
+  @IsNumber()
+  @IsOptional()
+  advertisedSavings?: number;
+
+  @IsString()
+  @IsOptional()
+  ctaMessage?: string;
+
+  @IsString()
+  @IsOptional()
+  modalHeading1?: string;
+
+  @IsString()
+  @IsOptional()
+  modalHeading2?: string;
+
+  @IsString()
+  @IsOptional()
+  modalMessage?: string;
+
+  @IsString()
+  @IsOptional()
+  productPageUrl?: string;
+
+  @IsString()
+  @IsOptional()
+  upgradeButtonLabel?: string;
+
+  @IsString()
+  @IsOptional()
+  upgradeButtonUrl?: string;
+
+  @ValidateNested()
+  @IsOptional()
+  @Type(() => CancelInterstitialOfferOfferingObject)
+  offering?: CancelInterstitialOfferOfferingObject;
+}
+
+export class CmsCancelInterstitialOfferResult {
+  @IsString()
+  offeringApiIdentifier!: string;
+
+  @IsEnum(Enum_Cancelinterstitialoffer_Currentinterval)
+  currentInterval!: Enum_Cancelinterstitialoffer_Currentinterval;
+
+  @IsEnum(Enum_Cancelinterstitialoffer_Upgradeinterval)
+  upgradeInterval!: Enum_Cancelinterstitialoffer_Upgradeinterval;
+
+  @IsNumber()
+  advertisedSavings!: number;
+
+  @IsString()
+  ctaMessage!: string;
+
+  @IsString()
+  modalHeading1!: string;
+
+  @IsString()
+  modalHeading2!: string;
+
+  @IsString()
+  modalMessage!: string;
+
+  @IsString()
+  productPageUrl!: string;
+
+  @IsString()
+  upgradeButtonLabel!: string;
+
+  @IsString()
+  upgradeButtonUrl!: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CmsCancelInterstitialOfferPartialResult)
+  localizations!: CmsCancelInterstitialOfferPartialResult[];
+
+  @ValidateNested()
+  @Type(() => CancelInterstitialOfferOfferingObject)
+  offering!: CancelInterstitialOfferOfferingObject;
+}
+
+export class DetermineCancellationInterventionActionResult {
+  @IsString()
+  cancelChurnInterventionType!: string;
+
+  @IsString()
+  reason!: string;
+
+  @IsOptional()
+  cmsOfferContent!: CmsChurnInterventionEntryResult | CmsCancelInterstitialOfferResult | null;
+}


### PR DESCRIPTION
## Because

- Need to handle when customer clicks "cancel subscription" for an active subscription and give them a potential churn intervention offer.

## This pull request

Returns Cancel Interstitial offer content if:
* custom content exists
* currentInterval matches current subscription plan interval
* the current plan interval has an upgraded plan of toInterval
*  the customer is eligible for the upgraded plan of toInterval

Otherwise, returns Cancel churn content if:
* churn content exists for “cancel”
* customer is eligible to redeem

If neither exists, the customer will continue to Cancel Subscription page.

* Includes logging metrics to StatsD/BQ

## Issue that this pull request solves

Closes #[PAY-3370](https://mozilla-hub.atlassian.net/browse/PAY-3370)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3370]: https://mozilla-hub.atlassian.net/browse/PAY-3370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ