### PR TITLE
feat(payments-next): Capture error presence in CaptureTimingWithStatsD

### DIFF
--- a/libs/shared/metrics/statsd/src/lib/statsd.decorator.ts
+++ b/libs/shared/metrics/statsd/src/lib/statsd.decorator.ts
@@ -22,39 +22,49 @@ export function CaptureTimingWithStatsD<
     const originalDef = descriptor.value;
 
     descriptor.value = function (this: T, ...args: any[]) {
-      const defaultHandler = function (this: T, elapsed: number) {
+      const defaultHandler = function (this: T, elapsed: number, error = false) {
         this.statsd.timing(`${this.constructor.name}_${key}`, elapsed, {
           sourceClass: this.constructor.name,
+          error: error.toString(),
           ...options?.tags,
         });
         this.statsd.timing(this.constructor.name, elapsed, {
           methodName: key,
+          error: error.toString(),
           ...options?.tags,
         });
       };
       const handler = options?.handle || defaultHandler;
 
       const start = performance.now();
-      const originalReturnValue = originalDef.apply(this, args);
+      let originalReturnValue;
+
+      try {
+        originalReturnValue = originalDef.apply(this, args);
+      } catch (err) {
+        const end = performance.now();
+        handler.apply(this, [end - start, true]);
+        throw err;
+      }
 
       if (originalReturnValue instanceof Promise) {
         return originalReturnValue
           .then((value) => {
             const end = performance.now();
-            handler.apply(this, [end - start]);
+            handler.apply(this, [end - start, false]);
 
             return value;
           })
           .catch((err) => {
             const end = performance.now();
-            handler.apply(this, [end - start]);
+            handler.apply(this, [end - start, true]);
 
             throw err;
           });
       }
 
       const end = performance.now();
-      handler.apply(this, [end - start]);
+      handler.apply(this, [end - start, false]);
 
       return originalReturnValue;
     };


### PR DESCRIPTION
Because:

* Currently failing methods and successful methods are in the same bucket, and separating out the timing of the two distribution populations is not trivial

This commit:

* Adds in `error: 'true' | 'false'` to the StatsD call depending on whether the wrapped method throws an error

Closes #PAY-3201

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
