### PR TITLE
fix(payments-next): Fix redirect loops

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
+++ b/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
@@ -14,6 +14,7 @@ export async function GET(
   request: NextRequest,
   { params }: { params: ManageParams }
 ) {
+  const currentUrl = request.nextUrl;
   const requestSearchParams = request.nextUrl.searchParams;
   const { locale } = params;
 
@@ -53,5 +54,12 @@ export async function GET(
     console.error(error);
   }
 
-  redirect(redirectUrl ?? redirectToUrl.href);
+  let finalRedirectUrl = redirectUrl ?? redirectToUrl.href;
+  // Avoid redirecting back to this same landing URL
+  if (finalRedirectUrl === currentUrl.href) {
+    // Prefer the manage URL instead of looping
+    finalRedirectUrl = redirectToUrl.href;
+  }
+
+  redirect(finalRedirectUrl);
 }

--- a/apps/payments/next/middleware.ts
+++ b/apps/payments/next/middleware.ts
@@ -10,7 +10,9 @@ export function middleware(request: NextRequest) {
     request.nextUrl.pathname,
     request.headers.get('accept-language')
   );
-  if (result.redirect) {
+
+  // Redirect only if the pathname has changed to avoid an infinite redirect loop
+  if (result.redirect && result.pathname !== request.nextUrl.pathname) {
     return NextResponse.redirect(
       new URL(`${result.pathname}${request.nextUrl.search}`, request.url)
     );


### PR DESCRIPTION
## Because

- Sentry events
  - [RangeError: Maximum call stack size exceeded](https://mozilla.sentry.io/issues/7095360494/?project=4509311130861568&query=is%3Aunresolved&referrer=issue-stream)
  - [Error/incomplete-app-router-transaction](https://mozilla.sentry.io/issues/7095360494/?project=4509311130861568&query=is%3Aunresolved&referrer=issue-stream)

## This pull request

- fixes redirect loops on /subscriptions/landing and locale middleware
  - prevent redirecting when locale pathname already matches/avoid redirecting back to the current URL
  - resolves loops causing RSC payload fetch failures and incomplete router transactions

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.