### PR TITLE
fix(nimbus): Use uid if available for nimbus user id

### DIFF
--- a/packages/fxa-settings/src/models/contexts/NimbusContext.ts
+++ b/packages/fxa-settings/src/models/contexts/NimbusContext.ts
@@ -86,7 +86,9 @@ export function NimbusProvider({ children }: NimbusProviderProps) {
       return;
     }
 
-    if (!config?.nimbus.enabled || !uniqueUserId) {
+    const nimbusUserId = legacyLocalStorageAccount?.uid || uniqueUserId;
+
+    if (!config?.nimbus.enabled || !nimbusUserId) {
       setExperiments(null);
       setLoading(false);
       setError(undefined);
@@ -111,7 +113,7 @@ export function NimbusProvider({ children }: NimbusProviderProps) {
           : searchParams(window.location.search)[NIMBUS_PREVIEW_PARAM] === 'true';
 
         const nimbusResult = await initializeNimbus(
-          uniqueUserId,
+          nimbusUserId,
           nimbusPreview,
           {
             language,
@@ -154,7 +156,12 @@ export function NimbusProvider({ children }: NimbusProviderProps) {
     return () => {
       mounted = false;
     };
-  }, [config?.nimbus.enabled, config?.nimbus.preview, uniqueUserId, currentLocale]);
+  }, [
+    config?.nimbus.enabled,
+    config?.nimbus.preview,
+    uniqueUserId,
+    currentLocale
+  ]);
 
   const value: NimbusContextValue = useMemo(() => ({
     experiments,


### PR DESCRIPTION
## Because

- We want to use the FxA uid if the user is signed in

## This pull request

- Uses the FxA uid for local account

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12697

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Any other information that is important to this pull request.
