### PR TITLE
polish(payments-ui): Prevent Stripe IntegrationError

### DIFF
--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -75,10 +75,10 @@ interface CheckoutFormProps {
     };
     paymentInfo?: {
       type:
-      | Stripe.PaymentMethod.Type
-      | 'google_iap'
-      | 'apple_iap'
-      | 'external_paypal';
+        | Stripe.PaymentMethod.Type
+        | 'google_iap'
+        | 'apple_iap'
+        | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -237,16 +237,22 @@ export function CheckoutForm({
       return;
     }
 
+    const paymentElement = elements.getElement(PaymentElement);
+    if (!paymentElement) {
+      setLoading(false);
+      return;
+    }
+
     const confirmationTokenParams: ConfirmationTokenCreateParams | undefined =
       !isSavedPaymentMethod
         ? {
-          payment_method_data: {
-            billing_details: {
-              name: fullName,
-              email: sessionEmail || undefined,
+            payment_method_data: {
+              billing_details: {
+                name: fullName,
+                email: sessionEmail || undefined,
+              },
             },
-          },
-        }
+          }
         : undefined;
 
     // Create the ConfirmationToken using the details collected by the Payment Element
@@ -259,6 +265,7 @@ export function CheckoutForm({
 
     if (confirmationTokenError) {
       if (confirmationTokenError.type === 'validation_error') {
+        setLoading(false);
         return;
       } else {
         await handleStripeErrorAction(
@@ -266,6 +273,7 @@ export function CheckoutForm({
           confirmationTokenError,
           searchParamsRecord
         );
+        setLoading(false);
         return;
       }
     }


### PR DESCRIPTION
## Because

- Stripe IntegrationError occurs as PaymentElement is missing when createConfirmationToken is called


## This pull request

- Checks that PaymentElement is on the page before calling createConfirmationToken

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.