### PR TITLE
fix(payments-management): Display Subscription Not Found if subscription is expired or does not belong to logged in customer

### DIFF
--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -1927,6 +1927,60 @@ describe('SubscriptionManagementService', () => {
         SubscriptionManagementCouldNotRetrieveProductNamesFromCMSError
       );
     });
+
+    it('returns not_found when subscription customer does not match', async () => {
+      const mockStripeCustomer1 = StripeCustomerFactory();
+      const mockStripeCustomer2 = StripeCustomerFactory();
+      const mockAccountCustomer1 = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer1.id,
+      });
+      const mockSubscription2 = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer2.id,
+        })
+      );
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer1);
+
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription2);
+
+      const result = await subscriptionManagementService.getCancelFlowContent(
+        mockAccountCustomer1.uid,
+        mockSubscription2.id
+      );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+
+    it('returns not_found when subscription is not active', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          status: 'canceled',
+        })
+      );
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+
+      const result = await subscriptionManagementService.getCancelFlowContent(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
   });
 
   describe('getStaySubscribedFlowContent', () => {


### PR DESCRIPTION
## Because

- Subscription Not Found should be displayed if subscription is not logged in customers
- Subscription Not Found should be displayed for expired subscription

## This pull request

- Updates SubscriptionManagementService to return flowType not_found for expired subscription and subscription that does not belong to logged in customer

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
Any other information that is important to this pull request.
