### PR TITLE
fix(payments-management): Display Subscription Not Found if subscription is expired for StaySubscribed

### DIFF
--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -2062,6 +2062,62 @@ describe('SubscriptionManagementService', () => {
       expect(result.flowType).toEqual('not_found');
     });
 
+    it('returns not_found when subscription customer does not match', async () => {
+      const mockStripeCustomer1 = StripeCustomerFactory();
+      const mockStripeCustomer2 = StripeCustomerFactory();
+      const mockAccountCustomer1 = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer1.id,
+      });
+      const mockSubscription2 = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer2.id,
+        })
+      );
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer1);
+
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription2);
+
+      const result =
+        await subscriptionManagementService.getStaySubscribedFlowContent(
+          mockAccountCustomer1.uid,
+          mockSubscription2.id
+        );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+
+    it('returns not_found when subscription is not active', async () => {
+      const mockStripeCustomer = StripeCustomerFactory();
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockStripeCustomer.id,
+      });
+      const mockSubscription = StripeResponseFactory(
+        StripeSubscriptionFactory({
+          customer: mockStripeCustomer.id,
+          status: 'canceled',
+        })
+      );
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+
+      const result =
+        await subscriptionManagementService.getStaySubscribedFlowContent(
+          mockAccountCustomer.uid,
+          mockSubscription.id
+        );
+
+      expect(result).toEqual({ flowType: 'not_found' });
+    });
+
     it('throws error - SubscriptionManagementNoStripeCustomerFoundError', async () => {
       const mockUid = faker.string.uuid();
       const mockSubscription = StripeResponseFactory(

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -629,7 +629,7 @@ export class SubscriptionManagementService {
       subscriptionId
     );
 
-    if (!subscription) {
+    if (!subscription || subscription.status !== 'active') {
       return {
         flowType: 'not_found',
       };


### PR DESCRIPTION
## This pull request

- displays the Subscription Not Found page if a customer navigates to the /stay-subscribed page with an expired email

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).