### PR TITLE
fix(payments): Fix validation for paymentProvider 

### DIFF
--- a/libs/payments/events/src/lib/emitter.service.spec.ts
+++ b/libs/payments/events/src/lib/emitter.service.spec.ts
@@ -39,7 +39,6 @@ import {
   CommonMetricsFactory,
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
-  PaymentProvidersType,
   PaymentsGleanManager,
 } from '@fxa/payments/metrics';
 import { CartManager } from '@fxa/payments/cart';
@@ -105,7 +104,7 @@ describe('PaymentsEmitterService', () => {
   });
   const mockCheckoutPaymentEvents = {
     ...mockCommonMetricsData,
-    paymentProvider: 'stripe' as PaymentProvidersType,
+    paymentProvider: SubPlatPaymentMethodType.Stripe,
   };
   let retrieveOptOutMock: jest.SpyInstance<any, unknown[], any>;
   const mockLogger = {

--- a/libs/payments/events/src/lib/emitter.types.ts
+++ b/libs/payments/events/src/lib/emitter.types.ts
@@ -6,7 +6,6 @@ import {
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
-  PaymentProvidersType,
 } from '@fxa/payments/metrics';
 import { LocationStatus } from '@fxa/payments/eligibility';
 import { TaxChangeAllowedStatus } from '@fxa/payments/cart';
@@ -14,7 +13,7 @@ import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 
 export type CheckoutEvents = CommonMetrics;
 export type CheckoutPaymentEvents = CommonMetrics & {
-  paymentProvider?: PaymentProvidersType;
+  paymentProvider?: SubPlatPaymentMethodType;
 };
 
 export type SubscriptionEndedEvents = {

--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -7,7 +7,6 @@ import {
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
-  PaymentProvidersType,
   PaymentsGleanProvider,
   SubscriptionCancellationData,
   type ExperimentationData,
@@ -64,7 +63,7 @@ export class PaymentsGleanManager {
       cmsMetricsData: CmsMetricsData;
       experimentationData: ExperimentationData;
     },
-    paymentProvider?: PaymentProvidersType
+    paymentProvider?: SubPlatPaymentMethodType
   ) {
     if (this.isEnabled) {
       this.paymentsGleanServerEventsLogger.recordPaySetupSubmit({
@@ -102,7 +101,7 @@ export class PaymentsGleanManager {
       cmsMetricsData: CmsMetricsData;
       experimentationData: ExperimentationData;
     },
-    paymentProvider?: PaymentProvidersType
+    paymentProvider?: SubPlatPaymentMethodType
   ) {
     const commonMetrics = this.populateCommonMetrics(metrics);
 
@@ -120,7 +119,7 @@ export class PaymentsGleanManager {
       cmsMetricsData: CmsMetricsData;
       subscriptionCancellationData: SubscriptionCancellationData;
     },
-    paymentProvider?: PaymentProvidersType
+    paymentProvider?: SubPlatPaymentMethodType
   ) {
     const commonMetrics = this.populateCommonMetrics(metrics);
 

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -2,26 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ResultCart } from '@fxa/payments/cart';
-import Stripe from 'stripe';
 
 export const CheckoutTypes = ['with-accounts', 'without-accounts'] as const;
 export type CheckoutTypesType = (typeof CheckoutTypes)[number];
-import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
-
-export const PaymentProvidersTypePartial = [
-  'card',
-  'google_iap',
-  'apple_iap',
-  'external_paypal',
-  'link',
-] as const;
-export type PaymentProvidersType =
-  | Stripe.PaymentMethod.Type
-  | SubPlatPaymentMethodType
-  | 'google_iap'
-  | 'apple_iap'
-  | 'external_paypal';
-
 export type CommonMetrics = {
   ipAddress: string;
   deviceType: string;

--- a/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/actions/recordEmitterEvent.ts
@@ -6,14 +6,14 @@
 import { getApp } from '../nestapp/app';
 import { flattenRouteParams } from '../utils/flatParam';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
-import { PaymentProvidersType } from '@fxa/payments/cart';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 import { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
 
 async function recordEmitterEventAction(
   eventName: 'checkoutSubmit',
   params: Record<string, string | string[]>,
   searchParams: Record<string, string | string[]>,
-  paymentProvider: PaymentProvidersType
+  paymentProvider: SubPlatPaymentMethodType
 ): Promise<void>;
 async function recordEmitterEventAction(
   eventName:
@@ -28,7 +28,7 @@ async function recordEmitterEventAction(
   eventName: PaymentsEmitterEventsKeysType,
   params: Record<string, string | string[]>,
   searchParams: Record<string, string | string[]>,
-  paymentProvider?: PaymentProvidersType
+  paymentProvider?: SubPlatPaymentMethodType | undefined
 ) {
   const requestArgs = {
     ...getAdditionalRequestArgs(),

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -6,7 +6,7 @@
 import { Localized, useLocalization } from '@fluent/react';
 import { PayPalButtons } from '@paypal/react-paypal-js';
 import * as Form from '@radix-ui/react-form';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 import {
   PaymentElement,
   useStripe,
@@ -29,6 +29,7 @@ import { useEffect, useState } from 'react';
 import { BaseButton, ButtonVariant, CheckoutCheckbox } from '@fxa/payments/ui';
 import LockImage from '@fxa/shared/assets/images/lock.svg';
 import { useCallbackOnce } from '../../hooks/useCallbackOnce';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 import {
   handleStripeErrorAction,
   recordEmitterEventAction,
@@ -38,7 +39,6 @@ import {
   checkoutCartWithPaypal,
 } from '@fxa/payments/ui/actions';
 import { CartErrorReasonId } from '@fxa/shared/db/mysql/account/kysely-types';
-import { PaymentProvidersType } from '@fxa/payments/cart';
 import PaypalIcon from '@fxa/shared/assets/images/payment-methods/paypal.svg';
 import spinnerWhiteImage from '@fxa/shared/assets/images/spinnerwhite.svg';
 
@@ -198,7 +198,7 @@ export function CheckoutForm({
         'checkoutSubmit',
         { ...params },
         Object.fromEntries(searchParams),
-        'external_paypal'
+        SubPlatPaymentMethodType.PayPal
       );
 
       await checkoutCartWithPaypal(
@@ -282,7 +282,7 @@ export function CheckoutForm({
       'checkoutSubmit',
       { ...params },
       Object.fromEntries(searchParams),
-      selectedPaymentMethod as PaymentProvidersType
+      selectedPaymentMethod as SubPlatPaymentMethodType
     );
 
     await checkoutCartWithStripe(

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -55,16 +55,14 @@ import { ValidatePostalCodeActionArgs } from './validators/ValidatePostalCodeAct
 import { DetermineCurrencyActionArgs } from './validators/DetermineCurrencyActionArgs';
 import { DetermineStaySubscribedEligibilityActionArgs } from './validators/DetermineStaySubscribedEligibilityActionArgs';
 import { NextIOValidator } from './NextIOValidator';
-import type {
-  CommonMetrics,
-  PaymentProvidersType,
-} from '@fxa/payments/metrics';
+import type { CommonMetrics } from '@fxa/payments/metrics';
 import { GetCartActionResult } from './validators/GetCartActionResult';
 import { GetChurnInterventionDataActionResult } from './validators/GetChurnInterventionDataActionResult';
 import { GetSuccessCartActionResult } from './validators/GetSuccessCartActionResult';
 import {
   CouponErrorCannotRedeem,
   PromotionCodeSanitizedError,
+  SubPlatPaymentMethodType,
   TaxAddress,
   type SubplatInterval,
 } from '@fxa/payments/customer';
@@ -257,10 +255,11 @@ export class NextJSActionsService {
     customerId: string;
     churnInterventionId: string;
   }) {
-    const data = await this.churnInterventionService.getChurnInterventionForCustomerId(
-      args.customerId,
-      args.churnInterventionId
-    );
+    const data =
+      await this.churnInterventionService.getChurnInterventionForCustomerId(
+        args.customerId,
+        args.churnInterventionId
+      );
     return data;
   }
 
@@ -540,7 +539,7 @@ export class NextJSActionsService {
   async recordEmitterEvent(args: {
     eventName: string;
     requestArgs: CommonMetrics;
-    paymentProvider: PaymentProvidersType | undefined;
+    paymentProvider: SubPlatPaymentMethodType | undefined;
   }) {
     const { eventName, requestArgs, paymentProvider } = args;
 

--- a/libs/payments/ui/src/lib/nestapp/validators/RecordEmitterEvent.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/RecordEmitterEvent.ts
@@ -10,12 +10,9 @@ import {
   IsString,
   ValidateNested,
 } from 'class-validator';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 import { PaymentsEmitterEventsKeys } from '@fxa/payments/events';
 import type { PaymentsEmitterEventsKeysType } from '@fxa/payments/events';
-import {
-  PaymentProvidersTypePartial,
-  type PaymentProvidersType,
-} from '@fxa/payments/metrics';
 
 /**
  * Common metrics that can be found on all events
@@ -49,6 +46,6 @@ export class RecordEmitterEventArgs {
   requestArgs!: RequestArgs;
 
   @IsOptional()
-  @IsEnum(PaymentProvidersTypePartial)
-  paymentProvider?: PaymentProvidersType;
+  @IsEnum(SubPlatPaymentMethodType)
+  paymentProvider?: SubPlatPaymentMethodType;
 }

--- a/libs/payments/webhooks/src/lib/util/determineCancellation.spec.ts
+++ b/libs/payments/webhooks/src/lib/util/determineCancellation.spec.ts
@@ -10,12 +10,13 @@ import {
   CancellationReason,
   determineCancellation,
 } from './determineCancellation';
+import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 
 describe('determineCancellation', () => {
   const mockSubscription = StripeSubscriptionFactory();
 
   describe('external_paypal', () => {
-    const paymentProvider = 'external_paypal';
+    const paymentProvider = SubPlatPaymentMethodType.PayPal;
     it('returns customer initiated if status is not uncollectible', () => {
       const mockLatestInvoice = StripeInvoiceFactory({ status: 'paid' });
       expect(
@@ -48,7 +49,7 @@ describe('determineCancellation', () => {
   });
 
   describe('card', () => {
-    const paymentProvider = 'card';
+    const paymentProvider = SubPlatPaymentMethodType.Card;
     it('returns customer initiated if reason is cancellation_requested', () => {
       const mockSubscription = StripeSubscriptionFactory({
         cancellation_details: {
@@ -86,7 +87,7 @@ describe('determineCancellation', () => {
   });
 
   describe('redundantCancellation', () => {
-    const paymentProvider = 'card';
+    const paymentProvider = SubPlatPaymentMethodType.Card;
     it('returns redundant if metadata contains redundantCancellation', () => {
       const mockSubscription = StripeSubscriptionFactory({
         metadata: {
@@ -100,7 +101,7 @@ describe('determineCancellation', () => {
   });
 
   describe('other', () => {
-    const paymentProvider = 'google_iap';
+    const paymentProvider = SubPlatPaymentMethodType.GooglePay;
     it('returns undefined if payment provider is not supported', () => {
       expect(determineCancellation(paymentProvider, mockSubscription)).toBe(
         undefined


### PR DESCRIPTION
## Because

- Sentry events frequently stating the "Server Components render" error occur for the CheckoutForm component
  - CheckoutForm is a client component, but it is importing the Node server SDK for Stripe causing Next to try to bundle Stripe Node SDK into the client build and surfacing the Server Components render error
  - Validation for paymentProvider was expecting an enum

## This pull request

- Updates import for Stripe to type-only since we are only using Stripe for `Stripe.PaymentMethod.Type`
- Maps SubPlatPaymentMethodType to PaymentProvidersType

## Issue that this pull request solves

Closes: PAY-3439

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.