### PR TITLE
fix(locale): Update locale switcher to use footer correctly

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -172,14 +172,18 @@ export const AppLayout = ({
             </main>
           </div>
         )}
-      </div>
+
       {showLocaleToggle && (
-        <footer>
-          <div className="fixed bottom-6 left-6 z-10">
+          <footer
+            className="w-full py-4 px-4 flex-wrap mobileLandscape:flex-nowrap mobileLandscape:mx-8 mobileLandscape:pb-6 flex text-grey-400"
+          >
+        <div className="w-full mobileLandscape:w-auto flex items-center mt-3 mobileLandscape:mt-0 mobileLandscape:ms-10">
             <LocaleToggle />
-          </div>
+        </div>
         </footer>
       )}
+
+      </div>
       <div id="body-bottom" className="w-full block mobileLandscape:hidden" />
     </>
   );


### PR DESCRIPTION
## Because

- We don't wnt the locale switcher to overlap other components

## This pull request

- Updates the footer css to not overlap, matches what we have in settings footer

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12734
Closes: https://mozilla-hub.atlassian.net/browse/FXA-12757

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="797" height="802" alt="Screenshot 2025-12-10 at 2 18 49 PM" src="https://github.com/user-attachments/assets/231252fe-7275-4b5f-92b6-9879d4ad56e9" />

