### PR TITLE
feat(mfa): add MFA to create_password page

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1687,6 +1687,45 @@ export default class AuthClient {
     };
   }
 
+  /**
+   * Create password using JWT authentication (for MFA-protected operations).
+   * This uses the /mfa/password/create endpoint that requires JWT authentication.
+   *
+   * @param jwt - Required scope: 'mfa:password'.
+   * @param email - The email of the user.
+   * @param newPassword - The new password to create.
+   * @param headers - The headers for the request.
+   * @returns Response
+   */
+  async createPasswordWithJwt(
+    jwt: string,
+    email: string,
+    newPassword: string,
+    headers?: Headers
+  ): Promise<{ passwordCreated: number; authPW: string; unwrapBKey: string }> {
+    const { authPW, unwrapBKey } = await crypto.getCredentials(
+      email,
+      newPassword
+    );
+
+    const payload = {
+      authPW,
+    };
+
+    const passwordCreated = await this.jwtPost(
+      '/mfa/password/create',
+      jwt,
+      payload,
+      headers
+    );
+
+    return {
+      passwordCreated,
+      authPW,
+      unwrapBKey,
+    };
+  }
+
   async getRandomBytes(headers?: Headers) {
     return this.request('POST', '/get_random_bytes', null, headers);
   }

--- a/packages/fxa-auth-server/docs/swagger/password-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/password-api.ts
@@ -165,9 +165,21 @@ const PASSWORD_CREATE_POST = {
   ],
 };
 
-const PASSWORD_CHANGE_JWT_POST = {
+const MFA_PASSWORD_CREATE_POST = {
   ...TAGS_PASSWORD,
-  description: '/password/change/jwt',
+  description: '/mfa/password/create',
+  notes: [
+    dedent`
+      🔒 Authenticated with MFA JWT (scope: mfa:password)
+
+      Creates a new password for the user associated with the session token. Creating a new password will generate new encryption key.
+    `,
+  ],
+};
+
+const MFA_PASSWORD_CHANGE_POST = {
+  ...TAGS_PASSWORD,
+  description: '/mfa/password/change',
   notes: [
     dedent`
     🔒 Authenticated with MFA JWT (scope: mfa:password)
@@ -187,7 +199,8 @@ const API_DOCS = {
   PASSWORD_FORGOT_STATUS_GET,
   PASSWORD_FORGOT_VERIFY_CODE_POST,
   PASSWORD_CREATE_POST,
-  PASSWORD_CHANGE_JWT_POST,
+  MFA_PASSWORD_CREATE_POST,
+  MFA_PASSWORD_CHANGE_POST,
 };
 
 export default API_DOCS;

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -583,7 +583,7 @@ module.exports = function (
       method: 'POST',
       path: '/mfa/password/change',
       options: {
-        ...PASSWORD_DOCS.PASSWORD_CHANGE_JWT_POST,
+        ...PASSWORD_DOCS.MFA_PASSWORD_CHANGE_POST,
         auth: {
           strategy: 'mfa',
           scope: ['mfa:password'],
@@ -1611,6 +1611,45 @@ module.exports = function (
         }
 
         return passwordCreated;
+      },
+    },
+    {
+      method: 'POST',
+      path: '/mfa/password/create',
+      options: {
+        ...PASSWORD_DOCS.MFA_PASSWORD_CREATE_POST,
+        auth: {
+          strategy: 'mfa',
+          scope: ['mfa:password'],
+          payload: false,
+        },
+        validate: {
+          payload: isA
+            .object({
+              authPW: validators.authPW.description(DESCRIPTION.authPW),
+              authPWVersion2: validators.authPWVersion2
+                .optional()
+                .description(DESCRIPTION.authPWVersion2),
+              wrapKb: validators.wrapKb
+                .optional()
+                .description(DESCRIPTION.wrapKb),
+              wrapKbVersion2: validators.wrapKb
+                .optional()
+                .description(DESCRIPTION.wrapKbVersion2),
+              clientSalt: validators.clientSalt
+                .optional()
+                .description(DESCRIPTION.clientSalt),
+            })
+            .and('authPWVersion2', 'wrapKb', 'wrapKbVersion2', 'clientSalt'),
+        },
+      },
+      handler: async function (request) {
+        return routes
+          .find(
+            (route) =>
+              route.path === '/v1/password/create' && route.method === 'POST'
+          )
+          ?.handler(request);
       },
     },
     {

--- a/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageCreatePassword/index.stories.tsx
@@ -2,12 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import PageCreatePassword from '.';
+import { PageCreatePassword } from '.';
 import React from 'react';
 import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
+import { MfaContext } from '../MfaGuard';
+import { Account, AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
 
 export default {
   title: 'Pages/Settings/CreatePassword',
@@ -16,9 +19,22 @@ export default {
 } as Meta;
 
 export const Default = () => (
-  <LocationProvider>
-    <SettingsLayout>
-      <PageCreatePassword />
-    </SettingsLayout>
-  </LocationProvider>
+  <AppContext.Provider
+    value={mockAppContext({
+      account: {
+        primaryEmail: {
+          email: 'test@example.com',
+        },
+        hasPassword: false,
+      } as unknown as Account,
+    })}
+  >
+    <LocationProvider>
+      <SettingsLayout>
+        <MfaContext.Provider value="password">
+          <PageCreatePassword />
+        </MfaContext.Provider>
+      </SettingsLayout>
+    </LocationProvider>
+  </AppContext.Provider>
 );

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -21,7 +21,7 @@ import {
 } from '@reach/router';
 import PageSettings from './PageSettings';
 import MfaGuardedPageChangePassword from './PageChangePassword';
-import PageCreatePassword from './PageCreatePassword';
+import MfaPageCreatePassword from './PageCreatePassword';
 import { MfaGuardPageSecondaryEmailAdd } from './PageSecondaryEmailAdd';
 import { MfaGuardPageSecondaryEmailVerify } from './PageSecondaryEmailVerify';
 import { PageDisplayName } from './PageDisplayName';
@@ -201,8 +201,8 @@ export const Settings = ({
           ) : (
             <Redirect from="/account_recovery" to="/settings" noThrow />
           )}
-          {/* PageCreatePassword internally redirects to /change_password if password exists */}
-          <PageCreatePassword path="/create_password" />
+          {/* MfaPageCreatePassword internally redirects to /change_password if password exists */}
+          <MfaPageCreatePassword path="/create_password" />
           {account.hasPassword ? (
             <>
               <MfaGuardedPageChangePassword path="/change_password" />

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -25,6 +25,7 @@ export enum MfaReason {
   verifySecondaryEmail = 'verify secondary email',
   removeSecondaryEmail = 'remove secondary email',
   changePrimaryEmail = 'change primary email',
+  createPassword = 'create password',
   changePassword = 'change password',
   createRecoveryPhone = 'create recovery phone',
   changeRecoveryPhone = 'change recovery phone',

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -672,6 +672,26 @@ export class Account implements AccountData {
     });
   }
 
+  async createPasswordWithJwt(newPassword: string) {
+    const jwt = this.getCachedJwtByScope('password');
+    const passwordCreatedResult = await this.withLoadingStatus(
+      this.authClient.createPasswordWithJwt(
+        jwt,
+        this.primaryEmail.email,
+        newPassword
+      )
+    );
+    const cache = this.apolloClient.cache;
+    cache.modify({
+      id: cache.identify({ __typename: 'Account' }),
+      fields: {
+        passwordCreated() {
+          return passwordCreatedResult.passwordCreated;
+        },
+      },
+    });
+  }
+
   async resetPassword(
     email: string,
     service?: string,


### PR DESCRIPTION
## Because

- create_password page does not have MFA

## This pull request

- adds MFA to create_password page

## Issue that this pull request solves

Closes: FXA-12741

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
