### PR TITLE
fix(payments-iap): handle empty iap data response

### DIFF
--- a/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
+++ b/libs/payments/iap/src/lib/apple/apple-iap-purchase.manager.ts
@@ -136,9 +136,11 @@ export class AppleIapPurchaseManager {
       originalTransactionId
     );
     // Find the latest transaction for the subscription
-    const item = apiResponse.data[0].lastTransactions.find(
-      (item) => item.originalTransactionId === originalTransactionId
-    );
+    const item = apiResponse.data
+      .at(0)
+      ?.lastTransactions.find(
+        (item) => item.originalTransactionId === originalTransactionId
+      );
     if (!item) {
       throw new AppleIapNoTransactionsFoundError(
         bundleId,


### PR DESCRIPTION
## Because

- Apple IAP reponse where data response is an empty array results in a unexpected TypeError.

## This pull request

- Update logic to support empty IAP data array.

## Issue that this pull request solves

Closes: #PAY-3284

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
