### PR TITLE
fix(nimbus): Update nimbus timeout to 400ms

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -718,8 +718,8 @@ const conf = (module.exports = convict({
       format: String,
     },
     timeout: {
-      default: 200,
-      doc: 'Amount of time in milliseconds to wait for a response from cirrus',
+      default: 400,
+      doc: 'Amount of time in milliseconds to wait for a response from cirrus.',
       env: 'NIMBUS_CIRRUS_TIMEOUT',
       format: Number,
     },


### PR DESCRIPTION
## Because

- We were getting timeout errors when calling nimbus experiments

## This pull request

- Updates timeout to 400ms (it should take on avg 50ms)
- Only captures sentry event if its an exception
- Emits a statsd metric instead to track timeouts

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12711

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
