### PR TITLE
bug(auth): Fix typo in error name

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/client/get.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/client/get.js
@@ -46,7 +46,7 @@ module.exports = ({ log, oauthDB }) => ({
         .then(function (client) {
           if (!client) {
             log.debug('notFound', { id: params.client_id });
-            throw AppError.unknownClient(params.client_id);
+            throw AppError.unknownClientId(params.client_id);
           } else {
             return {
               id: client.id.toString('hex'),


### PR DESCRIPTION
## Because

- We refactored app errors

## This pull request

- Changes `AppError.unknownClient` to `AppError.unknownClientId`

## Issue that this pull request solves

Closes: FXA-12784

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
