### PR TITLE
task(admin): Support secret rotation for RPs

### DIFF
--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/index.gql.ts
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/index.gql.ts
@@ -17,18 +17,26 @@ export const GET_RELYING_PARTIES = gql`
       trusted
       allowedScopes
       notes
+      hasSecret
+      hasPreviousSecret
     }
   }
 `;
 
 export const CREATE_RELYING_PARTY = gql`
   mutation createRelyingParty($relyingParty: RelyingPartyUpdateDto!) {
-    createRelyingParty(relyingParty: $relyingParty)
+    createRelyingParty(relyingParty: $relyingParty) {
+      id
+      secret
+    }
   }
 `;
 
 export const UPDATE_RELYING_PARTY = gql`
-  mutation updateRelyingParty($id: String!, $relyingParty: RelyingPartyUpdateDto!) {
+  mutation updateRelyingParty(
+    $id: String!
+    $relyingParty: RelyingPartyUpdateDto!
+  ) {
     updateRelyingParty(id: $id, relyingParty: $relyingParty)
   }
 `;
@@ -36,5 +44,19 @@ export const UPDATE_RELYING_PARTY = gql`
 export const DELETE_RELYING_PARTY = gql`
   mutation deleteRelyingParty($id: String!) {
     deleteRelyingParty(id: $id)
+  }
+`;
+
+export const ROTATE_RELYING_PARTY_SECRET = gql`
+  mutation rotateRelyingPartySecret($id: String!) {
+    rotateRelyingPartySecret(id: $id) {
+      secret
+    }
+  }
+`;
+
+export const DELETE_RELYING_PARTY_PREVIOUS_SECRET = gql`
+  mutation deletePreviousRelyingPartySecret($id: String!) {
+    deletePreviousRelyingPartySecret(id: $id)
   }
 `;

--- a/packages/fxa-admin-panel/src/components/PageRelyingParties/mocks.tsx
+++ b/packages/fxa-admin-panel/src/components/PageRelyingParties/mocks.tsx
@@ -18,7 +18,9 @@ export const MOCK_RP_ALL_FIELDS = {
   imageUri:
     'https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png',
   allowedScopes: 'https://identity.mozilla.com/apps/send',
-  notes: null,
+  notes: '',
+  hasSecret: true,
+  hasPreviousSecret: false,
 } as RelyingPartyDto;
 
 export const MOCK_RP_FALSY_FIELDS = {
@@ -30,8 +32,10 @@ export const MOCK_RP_FALSY_FIELDS = {
   createdAt: 1583259953,
   trusted: false,
   imageUri: '',
-  allowedScopes: null,
-  notes: null,
+  allowedScopes: '',
+  notes: '',
+  hasSecret: true,
+  hasPreviousSecret: false,
 } as RelyingPartyDto;
 
 // Apollo mocks

--- a/packages/fxa-admin-server/src/auth/audit-log.interceptor.ts
+++ b/packages/fxa-admin-server/src/auth/audit-log.interceptor.ts
@@ -89,7 +89,7 @@ export class AuditLogInterceptor implements NestInterceptor {
         next: (result) => {
           this.safeLogInfo({
             ...baseLogData('success'),
-            result, // we could sanitize this, but there shouldn't be any sensitive data in the result
+            result: sanitizeObject(result, this.sensitiveKeys),
           });
         },
         error: (error) => {

--- a/packages/fxa-admin-server/src/backend/email.service.ts
+++ b/packages/fxa-admin-server/src/backend/email.service.ts
@@ -42,18 +42,6 @@ export class EmailService {
       this.getLayoutData()
     );
 
-    console.log('!!! headers', {
-      template: {
-        name: emailContent.template,
-        version: emailContent.version,
-      },
-      context: {
-        language: 'en',
-        serverName: 'fxa-admin-server',
-      },
-      headers: {},
-    });
-
     const headers = await this.mailer.buildHeaders({
       template: {
         name: emailContent.template,

--- a/packages/fxa-admin-server/src/gql/model/relying-party.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/relying-party.model.ts
@@ -23,10 +23,10 @@ export class RelyingPartyUpdateDto {
   @Field()
   trusted!: boolean;
 
-  @Field({ nullable: true })
+  @Field()
   allowedScopes!: string;
 
-  @Field({ nullable: true })
+  @Field()
   notes!: string;
 }
 
@@ -56,9 +56,30 @@ export class RelyingPartyDto {
   @Field()
   trusted!: boolean;
 
-  @Field({ nullable: true })
+  @Field()
   allowedScopes!: string;
 
-  @Field({ nullable: true })
+  @Field()
   notes!: string;
+
+  @Field()
+  hasSecret!: boolean;
+
+  @Field()
+  hasPreviousSecret!: boolean;
+}
+
+@ObjectType()
+export class RelyingPartyCreatedDto {
+  @Field()
+  id!: string;
+
+  @Field()
+  secret!: string;
+}
+
+@ObjectType()
+export class RotateSecretDto {
+  @Field()
+  secret!: string;
 }

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -48,8 +48,8 @@ export interface RelyingPartyUpdateDto {
     canGrant: boolean;
     publicClient: boolean;
     trusted: boolean;
-    allowedScopes?: Nullable<string>;
-    notes?: Nullable<string>;
+    allowedScopes: string;
+    notes: string;
 }
 
 export interface Location {
@@ -236,8 +236,19 @@ export interface RelyingPartyDto {
     canGrant: boolean;
     publicClient: boolean;
     trusted: boolean;
-    allowedScopes?: Nullable<string>;
-    notes?: Nullable<string>;
+    allowedScopes: string;
+    notes: string;
+    hasSecret: boolean;
+    hasPreviousSecret: boolean;
+}
+
+export interface RelyingPartyCreatedDto {
+    id: string;
+    secret: string;
+}
+
+export interface RotateSecretDto {
+    secret: string;
 }
 
 export interface BlockStatus {
@@ -276,9 +287,11 @@ export interface IMutation {
     resetAccounts(locators: string[], notificationEmail: string): AccountResetResponse[] | Promise<AccountResetResponse[]>;
     clearEmailBounce(email: string): boolean | Promise<boolean>;
     clearRateLimits(ip?: Nullable<string>, email?: Nullable<string>, uid?: Nullable<string>): number | Promise<number>;
-    createRelyingParty(relyingParty: RelyingPartyUpdateDto): string | Promise<string>;
+    createRelyingParty(relyingParty: RelyingPartyUpdateDto): RelyingPartyCreatedDto | Promise<RelyingPartyCreatedDto>;
     updateRelyingParty(id: string, relyingParty: RelyingPartyUpdateDto): boolean | Promise<boolean>;
     deleteRelyingParty(id: string): boolean | Promise<boolean>;
+    rotateRelyingPartySecret(id: string): RotateSecretDto | Promise<RotateSecretDto>;
+    deletePreviousRelyingPartySecret(id: string): boolean | Promise<boolean>;
 }
 
 export type DateTime = any;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -221,14 +221,25 @@ type RelyingPartyDto {
   canGrant: Boolean!
   publicClient: Boolean!
   trusted: Boolean!
-  allowedScopes: String
-  notes: String
+  allowedScopes: String!
+  notes: String!
+  hasSecret: Boolean!
+  hasPreviousSecret: Boolean!
 }
 
 """
 A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
 """
 scalar DateTime
+
+type RelyingPartyCreatedDto {
+  id: String!
+  secret: String!
+}
+
+type RotateSecretDto {
+  secret: String!
+}
 
 type BlockStatus {
   retryAfter: Float!
@@ -266,9 +277,11 @@ type Mutation {
   resetAccounts(locators: [String!]!, notificationEmail: String!): [AccountResetResponse!]!
   clearEmailBounce(email: String!): Boolean!
   clearRateLimits(ip: String, email: String, uid: String): Float!
-  createRelyingParty(relyingParty: RelyingPartyUpdateDto!): String!
+  createRelyingParty(relyingParty: RelyingPartyUpdateDto!): RelyingPartyCreatedDto!
   updateRelyingParty(id: String!, relyingParty: RelyingPartyUpdateDto!): Boolean!
   deleteRelyingParty(id: String!): Boolean!
+  rotateRelyingPartySecret(id: String!): RotateSecretDto!
+  deletePreviousRelyingPartySecret(id: String!): Boolean!
 }
 
 input RelyingPartyUpdateDto {
@@ -278,6 +291,6 @@ input RelyingPartyUpdateDto {
   canGrant: Boolean!
   publicClient: Boolean!
   trusted: Boolean!
-  allowedScopes: String
-  notes: String
+  allowedScopes: String!
+  notes: String!
 }

--- a/packages/fxa-shared/db/models/auth/relying-party.ts
+++ b/packages/fxa-shared/db/models/auth/relying-party.ts
@@ -18,4 +18,6 @@ export class RelyingParty extends BaseAuthModel {
   trusted!: boolean;
   allowedScopes!: string | null;
   notes!: string | null;
+  hashedSecret!: Buffer | null;
+  hashedSecretPrevious!: Buffer | null;
 }


### PR DESCRIPTION
## Because

- We want to support management of RP's client secrets

## This pull request

- Allows us to rotate a client secret
- Preserves the previous secret, so that rotation is not disruptive
- Let's us revoke the previous secret, once the new secret has been validated
- Warns user if they are about to rotate over an existing previous secret

## Issue that this pull request solves

Closes: FXA-12703

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="957" height="447" alt="image" src="https://github.com/user-attachments/assets/f7b128ed-2495-4ea4-810d-f230e3952577" />
<img width="958" height="272" alt="image" src="https://github.com/user-attachments/assets/35d91fbd-4c21-4ed5-9816-a087e0b72240" />
<img width="976" height="544" alt="image" src="https://github.com/user-attachments/assets/ac435b0b-e88e-4ea5-8a80-a4e7a878d107" />
<img width="967" height="441" alt="image" src="https://github.com/user-attachments/assets/6b9ecd42-aa3d-4374-944c-2749fea2e787" />
<img width="968" height="278" alt="image" src="https://github.com/user-attachments/assets/accdf335-629c-46fa-9f0e-cce9e955b526" />
<img width="957" height="214" alt="image" src="https://github.com/user-attachments/assets/0a0f32a9-d092-4c4d-b88c-6b00e6cd8946" />

## Other information (Optional)

Any other information that is important to this pull request.
