### PR TITLE
fix(payments-ui): improve paypal sdk error handling

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
@@ -20,10 +20,8 @@ import errorIcon from '@fxa/shared/assets/images/error.svg';
 
 export default async function PaypalPaymentManagementPage({
   params,
-  searchParams,
 }: {
   params: ManageParams;
-  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const acceptLanguage = headers().get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage);

--- a/libs/payments/ui/src/lib/client/en.ftl
+++ b/libs/payments/ui/src/lib/client/en.ftl
@@ -2,3 +2,5 @@ dialog-close = Close dialog
 
 button-back-to-subscriptions = Back to subscriptions
 subscription-content-cancel-action-error = An unexpected error occurred. Please try again.
+
+paypal-unavailable-error = { -brand-paypal } is currently unavailable. Please use another payment option or try again later.


### PR DESCRIPTION
## Because

- If the PayPal SDK fails to load, the page crashes and navigates the user to an error page.

## This pull request

- More gracefully handle PayPal SDK load failure, by showing the customer a message letting them know PayPal isn't currently available and to try a different payment method or try again later.

## Issue that this pull request solves

Closes: #PAY-3323

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="600" height="990" alt="image" src="https://github.com/user-attachments/assets/8f099bba-6fb1-4ae7-b807-8ededf7e555c" />
