### PR TITLE
task(admin): Fix bug when diagnosticCode is null

### DIFF
--- a/packages/fxa-admin-server/src/gql/model/email-bounces.model.ts
+++ b/packages/fxa-admin-server/src/gql/model/email-bounces.model.ts
@@ -54,6 +54,6 @@ export class EmailBounce {
   @Field()
   public createdAt!: number;
 
-  @Field()
+  @Field({ nullable: true })
   public diagnosticCode?: string;
 }

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -86,7 +86,7 @@ export interface EmailBounce {
     bounceType: BounceType;
     bounceSubType: BounceSubType;
     createdAt: number;
-    diagnosticCode: string;
+    diagnosticCode?: Nullable<string>;
 }
 
 export interface Email {

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -36,7 +36,7 @@ type EmailBounce {
   bounceType: BounceType!
   bounceSubType: BounceSubType!
   createdAt: Float!
-  diagnosticCode: String!
+  diagnosticCode: String
 }
 
 enum BounceType {


### PR DESCRIPTION
## Because

- Diagnostic code can be null in the database
- We recently fixed a different bug, where inserts were failing because were providing `undefined` instead `null`, hence `null` values are now being written.

## This pull request

- Fixes the schema to support nullable values.

## Issue that this pull request solves

Closes: FXA-127896

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="942" height="186" alt="image" src="https://github.com/user-attachments/assets/2a52417a-e88f-4720-88f3-9a4f5a36fa3c" />

After:
<img width="944" height="338" alt="image" src="https://github.com/user-attachments/assets/a34b870d-b6ee-49c0-afa6-aa0fcf7797b5" />

## Other information (Optional)

Any other information that is important to this pull request.
