### PR TITLE
task(admin): Fix bug if x-forward-for has multiple values

### DIFF
--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -26,6 +26,7 @@ import {
 } from '../../../../db/models/auth';
 import { defaultOpts, testDatabaseSetup } from '../../../../test/db/helpers';
 import { chance, randomAccount, randomEmail } from './helpers';
+import { sanitizeIp } from '../../../../db/models/auth/security-event';
 
 const USER_1 = randomAccount();
 const EMAIL_1 = randomEmail(USER_1);
@@ -557,6 +558,34 @@ describe('#integration - auth', () => {
         endCreatedAtDate: Date.now(),
       });
       assert.equal(unverifiedAccounts.length, 3);
+    });
+  });
+});
+
+describe('security-event', async () => {
+  describe('sanitizes ip address', () => {
+    it('handles multiple ips', () => {
+      const ip = sanitizeIp(' 127.0.0.1, 127.0.0.2');
+      assert.equal(ip, '::127.0.0.1');
+    });
+    it('handles ip v4', () => {
+      const ip = sanitizeIp('127.0.0.1');
+      assert(ip, '::127.0.0.1');
+    });
+
+    it('handles ip v4 with spaces', () => {
+      const ip = sanitizeIp('127.0.0.1  ');
+      assert.equal(ip, '::127.0.0.1');
+    });
+
+    it('handles multiple ip v6', () => {
+      const ip = sanitizeIp('2001:db8::1111, 2001:db8::2222');
+      assert.equal(ip, '2001:db8::1111');
+    });
+
+    it('handles multiple ip v6 with spaces', () => {
+      const ip = sanitizeIp(' 2001:db8::1111 ');
+      assert.equal(ip, '2001:db8::1111');
     });
   });
 });


### PR DESCRIPTION
## Because

- X-forward-for address can contain multiple ips

## This pull request

- Handles a multi ip scenario
- Picks the first IP in the list, which belongs to the client

## Issue that this pull request solves

Closes: FXA-12755

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
