### PR TITLE
fix(sync): Only send fxaStatus if UA is likely Fx, update unsupported context list

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -30,6 +30,7 @@ import {
   useIntegration,
   useLocalSignedInQueryState,
   useSession,
+  isProbablyFirefox,
 } from '../../models';
 import {
   initializeSettingsContext,
@@ -216,12 +217,8 @@ export const App = ({
       // Request and update account data/state to match the browser state.
       // If there is a user actively signed into the browser,
       // we should try to use that user's account when possible.
-      const ua = navigator.userAgent.toLowerCase();
-      // This may not catch all Firefox browsers notably iOS devices, see FXA-11520 for alternate approach
-      const isProbablyFirefox = ua.includes('firefox') || ua.includes('fxios');
-
       let userFromBrowser;
-      if (isProbablyFirefox) {
+      if (isProbablyFirefox()) {
         userFromBrowser = await firefox.requestSignedInUser(
           integration.data.context || '',
           // TODO with React pairing flow, update this if pairing flow

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -8,6 +8,7 @@ import {
   isOAuthIntegration,
   isSyncDesktopV3Integration,
   isOAuthNativeIntegration,
+  isProbablyFirefox,
 } from '../../../models';
 import {
   defaultDesktopV3SyncEngineConfigs,
@@ -45,7 +46,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   useEffect(() => {
     // This sends a web channel message to the browser to prompt a response
     // that we listen for.
-    if (isSync || isOAuthNative) {
+    if ((isSync || isOAuthNative) && isProbablyFirefox()) {
       (async () => {
         const status = await firefox.fxaStatus({
           // TODO: Improve getting 'context', probably set this on the integration

--- a/packages/fxa-settings/src/models/integrations/index.ts
+++ b/packages/fxa-settings/src/models/integrations/index.ts
@@ -14,3 +14,4 @@ export * from './sync-desktop-v3-integration';
 export * from './web-integration';
 export * from './third-party-auth-callback-integration';
 export * from './relier-interfaces';
+export * from './utils';

--- a/packages/fxa-settings/src/models/integrations/utils.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.ts
@@ -12,6 +12,7 @@ export function isFirefoxService(service?: string) {
 }
 
 const NO_LONGER_SUPPORTED_CONTEXTS = new Set([
+  'fx_ios_v1',
   'fx_desktop_v1',
   'fx_desktop_v2',
   'fx_firstrun_v2',
@@ -19,4 +20,14 @@ const NO_LONGER_SUPPORTED_CONTEXTS = new Set([
 ]);
 export function isUnsupportedContext(context?: string): boolean {
   return !!context && NO_LONGER_SUPPORTED_CONTEXTS.has(context);
+}
+
+/**
+ * Checks if the browser is probably Firefox based on the user agent string.
+ * This may not catch all Firefox browsers, notably iOS devices.
+ * See FXA-11520 for alternate approach.
+ */
+export function isProbablyFirefox(): boolean {
+  const ua = navigator.userAgent.toLowerCase();
+  return ua.includes('firefox') || ua.includes('fxios');
 }


### PR DESCRIPTION
Because:
* We have some Sentry events showing users not using Firefox but with valid Sync query params. We should not send fxaStatus in this case. Other events show some users on fx_ios_v1 context, which is unsupported

This commit:
* Moves the existing isProbablyFirefox check into a helper to reference also in the useFxaStatus hook
* Adds fx_ios_v1 to unsupported contexts

closes FXA-12760