### PR TITLE
feat(libs/emails): Add retry with backoff for email-sender

### DIFF
--- a/libs/accounts/email-sender/src/email-sender.spec.ts
+++ b/libs/accounts/email-sender/src/email-sender.spec.ts
@@ -55,6 +55,13 @@ describe('EmailSender', () => {
   let config: MailerConfig;
   let mockSentryCaptureException: jest.SpyInstance;
 
+  const defaultResponse = {
+    sent: true,
+    message: 'Email sent',
+    messageId: 'test-message-id',
+    response: '250 OK',
+  };
+
   beforeEach(() => {
     mockNodemailer = nodemailer as jest.Mocked<typeof nodemailer>;
 
@@ -98,6 +105,12 @@ describe('EmailSender', () => {
       user: 'test',
       password: 'test',
       sender: 'test@example.com',
+      retry: {
+        maxAttempts: 1,
+        backOffMs: 1,
+        jitter: 0.0,
+        maxDelayMs: 10_000,
+      },
     };
 
     emailSender = new EmailSender(config, mockBounces, mockStatsd, mockLogger);
@@ -113,13 +126,12 @@ describe('EmailSender', () => {
         cc: ['cc@mozilla.com'],
       });
 
-      expect(result.sent).toBe(true);
-      expect(result.messageId).toBe('test-message-id');
       expect(mockBounces.check).toHaveBeenCalledWith(
         defaultMockEmail.to,
         defaultMockEmail.template
       );
       expect(mockTransport.sendMail).toHaveBeenCalled();
+      expect(result).toEqual(defaultResponse);
     });
 
     it('handles when bounce check fails', async () => {
@@ -173,9 +185,10 @@ describe('EmailSender', () => {
       );
 
       const result = await emailSender.send(defaultMockEmail);
-      expect(result.sent).toBe(true);
+      expect(result).toEqual(defaultResponse);
       expect(mockTransport.sendMail).toHaveBeenCalled();
     });
+
     it('sets X-Mailer header to empty string', async () => {
       await emailSender.send(defaultMockEmail);
 
@@ -187,9 +200,94 @@ describe('EmailSender', () => {
         })
       );
     });
+
+    it('does not retry if maxAttempts is 0', async () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 0,
+          backOffMs: 100,
+          jitter: 0,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      mockTransport.sendMail.mockRejectedValueOnce(
+        new Error('Temporary error')
+      );
+
+      await expect(emailSender.send(defaultMockEmail)).rejects.toThrow(
+        'Temporary error'
+      );
+
+      // Should only attempt once (no retries)
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(1);
+      expect(mockStatsd.increment).not.toHaveBeenCalledWith(
+        'email.send.retry',
+        expect.anything()
+      );
+    });
+
+    it('does not retry if backOffMs is 0', async () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 3,
+          backOffMs: 0,
+          jitter: 0,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      mockTransport.sendMail.mockRejectedValueOnce(
+        new Error('Temporary error')
+      );
+
+      await expect(emailSender.send(defaultMockEmail)).rejects.toThrow(
+        'Temporary error'
+      );
+
+      // Should only attempt once (no retries)
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(1);
+      expect(mockStatsd.increment).not.toHaveBeenCalledWith(
+        'email.send.retry',
+        expect.anything()
+      );
+    });
   });
   describe('sendMail error handling', () => {
-    it('throws error when sendMail fails', async () => {
+    it('throws error when sendMail fails without retry', async () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 0,
+          backOffMs: 100,
+          jitter: 0,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
       const error = new Error('SMTP connection failed');
       mockTransport.sendMail.mockRejectedValueOnce(error);
 
@@ -197,6 +295,7 @@ describe('EmailSender', () => {
         'SMTP connection failed'
       );
 
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(
         'mailer.send.error',
         expect.objectContaining({
@@ -209,11 +308,29 @@ describe('EmailSender', () => {
     });
 
     it('logs app error with errno when sendMail fails with AppError', async () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 0,
+          backOffMs: 100,
+          jitter: 0,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
       const appError = AppError.emailBouncedHard(100_000_000_000);
       mockTransport.sendMail.mockRejectedValueOnce(appError);
 
       await expect(emailSender.send(defaultMockEmail)).rejects.toThrow();
 
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(1);
       expect(mockLogger.error).toHaveBeenCalledWith(
         'mailer.send.error',
         expect.objectContaining({
@@ -345,6 +462,248 @@ describe('EmailSender', () => {
       expect(headers['X-SES-MESSAGE-TAGS']).toContain(
         'cmsRp=cms-client-123-entrypoint-abc'
       );
+    });
+  });
+  describe('retry with recursive sendMail', () => {
+    let configWithRetry: MailerConfig;
+
+    beforeEach(() => {
+      configWithRetry = {
+        ...config,
+        retry: {
+          maxAttempts: 3,
+          backOffMs: 100,
+          jitter: 0.0,
+          maxDelayMs: 10_000,
+        },
+      };
+    });
+
+    it('retries twice before succeeding', async () => {
+      const mockTransportResponse = {
+        messageId: 'test-message-id',
+        message: 'It worked!',
+        response: '250 OK',
+      };
+
+      mockTransport.sendMail
+        .mockRejectedValueOnce(new Error('Temporary SMTP error 1'))
+        .mockRejectedValueOnce(new Error('Temporary SMTP error 2'))
+        .mockResolvedValueOnce(mockTransportResponse);
+
+      emailSender = new EmailSender(
+        configWithRetry,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      const result = await emailSender.send(defaultMockEmail);
+
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(3);
+      expect(result).toEqual({
+        sent: true,
+        message: mockTransportResponse.message,
+        messageId: mockTransportResponse.messageId,
+        response: mockTransportResponse.response,
+      });
+    });
+    it('retries with exponential backoff', async () => {
+      const sleepDurations: number[] = [];
+      const mockTransportResponse = {
+        messageId: 'test-message-id',
+        message: 'It worked!',
+        response: '250 OK',
+      };
+
+      jest.spyOn(global, 'setTimeout').mockImplementation((fn, delay) => {
+        sleepDurations.push(delay as number);
+        (fn as () => void)();
+        return null as any;
+      });
+
+      // new config for larger dataset to fully see exponential backoff
+      configWithRetry = {
+        ...configWithRetry,
+        retry: {
+          maxAttempts: 5,
+          backOffMs: 10,
+          jitter: 0.0,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      mockTransport.sendMail
+        .mockRejectedValueOnce(new Error('Temporary SMTP error 1'))
+        .mockRejectedValueOnce(new Error('Temporary SMTP error 2'))
+        .mockRejectedValueOnce(new Error('Temporary SMTP error 3'))
+        .mockRejectedValueOnce(new Error('Temporary SMTP error 4'))
+        .mockResolvedValueOnce(mockTransportResponse);
+
+      emailSender = new EmailSender(
+        configWithRetry,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      const result = await emailSender.send(defaultMockEmail);
+
+      expect(result).toEqual({
+        sent: true,
+        message: mockTransportResponse.message,
+        messageId: mockTransportResponse.messageId,
+        response: mockTransportResponse.response,
+      });
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(5);
+      // this is the part we care about since we're spying on setTimeout above.
+      // and so, the first 4 loops will set a delay, but our 5th attempt will succeed without a delay.
+      expect(sleepDurations).toEqual([10, 20, 40, 80]);
+    });
+    it('throws error if all attempts fail', async () => {
+      const error = new Error('Temporary SMTP error');
+
+      mockTransport.sendMail.mockRejectedValue(error);
+
+      emailSender = new EmailSender(
+        configWithRetry,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      await expect(emailSender.send(defaultMockEmail)).rejects.toThrow(
+        'Temporary SMTP error'
+      );
+
+      expect(mockTransport.sendMail).toHaveBeenCalledTimes(4);
+
+      // statsd for retries
+      expect(mockStatsd.increment).toHaveBeenCalledWith('email.send.retry', {
+        template: defaultMockEmail.template,
+      });
+
+      // statsd for final failure
+      expect(mockStatsd.increment).toHaveBeenCalledWith(
+        'email.send.retry.failure',
+        {
+          template: defaultMockEmail.template,
+        }
+      );
+      expect(mockStatsd.increment).toHaveBeenCalledTimes(4);
+    });
+  });
+  describe('calculateBackoffDelay', () => {
+    it('calculates exponential backoff without jitter', () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 3,
+          backOffMs: 100,
+          jitter: 0,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      // attempt 0: 100 * 2^0 = 100
+      expect(emailSender.calculateBackoffDelay(0)).toBe(100);
+      // attempt 1: 100 * 2^1 = 200
+      expect(emailSender.calculateBackoffDelay(1)).toBe(200);
+      // attempt 2: 100 * 2^2 = 400
+      expect(emailSender.calculateBackoffDelay(2)).toBe(400);
+      // attempt 3: 100 * 2^3 = 800
+      expect(emailSender.calculateBackoffDelay(3)).toBe(800);
+    });
+
+    it('calculates exponential backoff with jitter', () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 3,
+          backOffMs: 100,
+          jitter: 0.5,
+          maxDelayMs: 10_000,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      // Mock Math.random to return 0.5 for deterministic testing
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      // With jitter 0.5 and random() = 0.5:
+      // attempt 0: 100 * (1 + 0.5 * 0.5) = 100 * 1.25 = 125
+      expect(emailSender.calculateBackoffDelay(0)).toBe(125);
+      // attempt 1: 200 * (1 + 0.5 * 0.5) = 200 * 1.25 = 250
+      expect(emailSender.calculateBackoffDelay(1)).toBe(250);
+
+      (Math.random as jest.Mock).mockRestore();
+    });
+
+    it('caps backoff at maxDelayMs', () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 10,
+          backOffMs: 100,
+          jitter: 0,
+          maxDelayMs: 500,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      // attempt 0: 100 * 2^0 = 100 (under cap)
+      expect(emailSender.calculateBackoffDelay(0)).toBe(100);
+      // attempt 3: 100 * 2^3 = 800, but capped at 500
+      expect(emailSender.calculateBackoffDelay(3)).toBe(500);
+      // attempt 5: 100 * 2^5 = 3200, but capped at 500
+      expect(emailSender.calculateBackoffDelay(5)).toBe(500);
+    });
+
+    it('applies jitter after capping at maxDelayMs', () => {
+      config = {
+        ...config,
+        retry: {
+          maxAttempts: 10,
+          backOffMs: 100,
+          jitter: 0.2,
+          maxDelayMs: 300,
+        },
+      };
+
+      emailSender = new EmailSender(
+        config,
+        mockBounces,
+        mockStatsd,
+        mockLogger
+      );
+
+      // Mock Math.random to return 0.75 for deterministic testing
+      jest.spyOn(Math, 'random').mockReturnValue(0.75);
+
+      // attempt 5: 100 * 2^5 = 3200, capped at 300, then jitter applied
+      // 300 * (1 + 0.2 * 0.75) = 300 * 1.15 = 345
+      expect(emailSender.calculateBackoffDelay(5)).toBe(300);
+
+      (Math.random as jest.Mock).mockRestore();
     });
   });
 });

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -854,6 +854,32 @@ const conf = convict({
       default: 30000,
       env: 'SMTP_DNS_TIMEOUT',
     },
+    retry: {
+      maxAttempts: {
+        doc: 'Maximum number of attempts for sending an email IF it fails. 1 means 1 additional attempt after the initial failure.',
+        format: 'int',
+        default: 3,
+        env: 'SMTP_RETRY_MAX_RETRIES',
+      },
+      backOffMs: {
+        doc: `Number of milliseconds to exponentially back off when retrying sending an email.`,
+        format: 'int',
+        default: 200,
+        env: 'SMTP_RETRY_BACKOFF_MS',
+      },
+      jitter: {
+        doc: 'Jitter factor (0-1) to add randomness to backoff timing. 0 = no jitter, 1 = up to 100% jitter.',
+        format: Number,
+        default: 0.3,
+        env: 'SMTP_RETRY_JITTER',
+      },
+      maxDelayMs: {
+        doc: 'Maximum delay in milliseconds to cap the backoff at.',
+        format: 'int',
+        default: 1000 * 10, // 10 seconds maximum delay
+        env: 'SMTP_RETRY_MAX_DELAY_MS',
+      },
+    },
   },
   bounces: {
     enabled: {


### PR DESCRIPTION
Because:
- We want to enable retrying an email send if the send fails
    
This Commit:
- Adds a recursive retry if sending fails
- Adds configuration to change maxRetries, backOffMs, jitter and maxDelayMs
- Adds tests for new functionality
    
Closes: FXA-12591

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-12579]: https://mozilla-hub.atlassian.net/browse/FXA-12579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ