### PR TITLE
task(auth): Add flag for account destroy operation on account create

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2079,6 +2079,12 @@ const convictConf = convict({
       format: Boolean,
       env: 'ACCOUNT_DESTROY__REQUIRE_VERIFIED_SESSION',
     },
+    onCreateIfUnverified: {
+      doc: 'Whether or not the account record should be deleted during account creation if the email has not yet been verified..',
+      default: true,
+      format: Boolean,
+      env: 'ACCOUNT_DESTROY__ON_CREATE_IF_UNVERIFIED',
+    },
   },
   passwordForgotOtp: {
     digits: {

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -563,13 +563,18 @@ export class AccountHandler {
     }
 
     await this.customs.check(request, email, 'accountCreate');
-    await deleteAccountIfUnverified(
-      this.db,
-      this.stripeHelper,
-      this.log,
-      request,
-      email
-    );
+
+    if (this.config.accountDestroy.onCreateIfUnverified) {
+      await deleteAccountIfUnverified(
+        this.db,
+        this.stripeHelper,
+        this.log,
+        request,
+        email
+      );
+    } else if (await this.db.accountExists(email)) {
+      throw error.accountExists(email);
+    }
 
     // Block creation if email is reserved for secondary email registration
     const normalizedEmail = normalizeEmail(email);
@@ -670,13 +675,17 @@ export class AccountHandler {
 
     const client = await getClientById(clientId);
 
-    await deleteAccountIfUnverified(
-      this.db,
-      this.stripeHelper,
-      this.log,
-      request,
-      email
-    );
+    if (this.config.accountDestroy.onCreateIfUnverified) {
+      await deleteAccountIfUnverified(
+        this.db,
+        this.stripeHelper,
+        this.log,
+        request,
+        email
+      );
+    } else if (await this.db.accountExists(email)) {
+      throw error.accountExists(email);
+    }
 
     const { hex16: emailCode, hex32: authSalt } =
       await this.generateRandomValues();

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -94,6 +94,7 @@ const makeRoutes = function (options = {}, requireMocks = {}) {
   config.securityHistory = config.securityHistory || {};
   config.gleanMetrics = config.gleanMetrics || defaultConfig.gleanMetrics;
   config.cloudTasks = mocks.mockCloudTasksConfig;
+  config.accountDestroy = defaultConfig.accountDestroy;
 
   const log = options.log || mocks.mockLog();
   Container.set(AuthLogger, log);


### PR DESCRIPTION
## Because

- We want to be able to toggle the account delete operation that can happen during account create.

## This pull request

- Adds config to toggle deleting on an unverified account on account creation.

## Issue that this pull request solves

Closes: [FXA-12798](https://mozilla-hub.atlassian.net/browse/FXA-12798)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[FXA-12798]: https://mozilla-hub.atlassian.net/browse/FXA-12798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ