### PR TITLE
fix(auth): device login email sent at same time as verify login email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1267,11 +1267,14 @@ export class AccountHandler {
       // If the request wants keys , user *must* confirm their login session before they can actually
       // use it. Otherwise, they don't *have* to verify their session. All sessions are created
       // unverified because it prevents them from being used for sync.
+      // Also require verification if the service is in the servicesWithEmailVerification list.
       let mustVerifySession =
         needsVerificationId &&
         (verificationForced === 'suspect' ||
           verificationForced === 'global' ||
-          requestHelper.wantsKeys(request));
+          requestHelper.wantsKeys(request) ||
+          (service &&
+            this.config.servicesWithEmailVerification.includes(service)));
 
       // For accounts with TOTP, we always force verifying a session.
       if (verificationMethod === 'totp-2fa') {


### PR DESCRIPTION
## Because

- New device login email sent at same time as verify login email with code

## This pull request

- prevents the "new device" email from being sent because `mustVerifySession` will be true for `servicesWithEmailVerification`

## Issue that this pull request solves

Closes: FXA-12728