### PR TITLE
fix(service): Add AiWindow to isFirefoxService

### DIFF
--- a/packages/fxa-settings/src/models/integrations/utils.test.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.test.ts
@@ -16,6 +16,11 @@ describe('isFirefoxService', () => {
     expect(result).toBe(true);
   });
 
+  it('should return true for OAuthNativeServices.AiWindow', () => {
+    const result = isFirefoxService(OAuthNativeServices.AiWindow);
+    expect(result).toBe(true);
+  });
+
   it('should return false for a service that is not in OAuthNativeServices', () => {
     const result = isFirefoxService('testo');
     expect(result).toBe(false);

--- a/packages/fxa-settings/src/models/integrations/utils.ts
+++ b/packages/fxa-settings/src/models/integrations/utils.ts
@@ -7,7 +7,8 @@ import { OAuthNativeServices } from './oauth-native-integration';
 export function isFirefoxService(service?: string) {
   return (
     service === OAuthNativeServices.Sync ||
-    service === OAuthNativeServices.Relay
+    service === OAuthNativeServices.Relay ||
+    service === OAuthNativeServices.AiWindow
   );
 }
 


### PR DESCRIPTION
Because:
* We aren't checking for AiWindow in this helper which is referenced when sending 'service' up to auth-server

This commit:
* Adds 'AiWindow' to isFirefoxService