### PR TITLE
chore(settings): remove sendFxAStatusOnSettings feature flag

### DIFF
--- a/packages/functional-tests/tests/settings/fxaStatus.spec.ts
+++ b/packages/functional-tests/tests/settings/fxaStatus.spec.ts
@@ -8,12 +8,6 @@ import { SigninPage } from '../../pages/signin';
 import { Credentials } from '../../lib/targets';
 
 test.describe('fxa_status web channel message in Settings', () => {
-  test.beforeEach(async ({ pages: { configPage } }) => {
-    // Ensure that the feature flag is enabled
-    const config = await configPage.getConfig();
-    test.skip(config.featureFlags.sendFxAStatusOnSettings !== true);
-  });
-
   test('message is sent when loading with context = oauth_webchannel_v1', async ({
     target,
     syncBrowserPages: { connectAnotherDevice, page, settings, signin },
@@ -63,7 +57,10 @@ test.describe('fxa_status web channel message in Settings', () => {
   });
 });
 
-async function signInAccount(signin: SigninPage, credentials: Credentials):Promise<void> {
+async function signInAccount(
+  signin: SigninPage,
+  credentials: Credentials
+): Promise<void> {
   await signin.fillOutEmailFirstForm(credentials.email);
   await signin.page.waitForURL(/signin/);
   await signin.fillOutPasswordForm(credentials.password);

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -72,7 +72,6 @@
     "postVerifyThirdPartyAuthRoutes": true
   },
   "featureFlags": {
-    "sendFxAStatusOnSettings": true,
     "recoveryCodeSetupOnSyncSignIn": true,
     "showLocaleToggle": true,
     "paymentsNextSubscriptionManagement": true

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -103,7 +103,6 @@ const settingsConfig = {
   brandMessagingMode: config.get('brandMessagingMode'),
   glean: { ...config.get('glean'), appDisplayVersion: config.get('version') },
   redirectAllowlist: config.get('redirect_check.allow_list'),
-  sendFxAStatusOnSettings: config.get('featureFlags.sendFxAStatusOnSettings'),
   showReactApp: {
     signUpRoutes: config.get('showReactApp.signUpRoutes'),
     signInRoutes: config.get('showReactApp.signInRoutes'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -223,12 +223,6 @@ const conf = (module.exports = convict({
         format: 'int',
       },
     },
-    sendFxAStatusOnSettings: {
-      default: false,
-      doc: 'Sends a webchannel message on the settings page to request auth data from the browser',
-      format: Boolean,
-      env: 'FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS',
-    },
     keyStretchV2: {
       default: true,
       doc: 'Enables V2 key stretching',

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -49,9 +49,6 @@ function getIndexRouteDefinition(config) {
   const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
   const SHOW_REACT_APP = config.get('showReactApp');
   const BRAND_MESSAGING_MODE = config.get('brandMessagingMode');
-  const FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS = config.get(
-    'featureFlags.sendFxAStatusOnSettings'
-  );
   const FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN = config.get(
     'featureFlags.recoveryCodeSetupOnSyncSignIn'
   );
@@ -121,7 +118,6 @@ function getIndexRouteDefinition(config) {
     showReactApp: SHOW_REACT_APP,
     brandMessagingMode: BRAND_MESSAGING_MODE,
     featureFlags: {
-      sendFxAStatusOnSettings: FEATURE_FLAGS_FXA_STATUS_ON_SETTINGS,
       recoveryCodeSetupOnSyncSignIn:
         FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
       showLocaleToggle: FEATURE_FLAGS_SHOW_LOCALE_TOGGLE,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -87,7 +87,6 @@ export interface Config {
     debugViewTag: string;
   };
   redirectAllowlist: string[];
-  sendFxAStatusOnSettings: boolean;
   showReactApp: {
     signUpRoutes: boolean;
     signInRoutes: boolean;
@@ -189,7 +188,6 @@ export function getDefault() {
       debugViewTag: '',
     },
     redirectAllowlist: ['localhost'],
-    sendFxAStatusOnSettings: false,
     showReactApp: {
       signUpRoutes: false,
       signInRoutes: false,


### PR DESCRIPTION
## Because

- the sendFxAStatusOnSettings feature flag is no longer needed

## This pull request

- removes the sendFxAStatusOnSettings feature flag and code referencing it

## Issue that this pull request solves

Closes: FXA-9013

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
