### PR TITLE
feat(payments-next): Add redirects on mismatched cart uids

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
@@ -7,6 +7,7 @@ import {
   LoadingSpinner,
   StripeWrapper,
   PaymentInputHandler,
+  buildRedirectUrl,
 } from '@fxa/payments/ui';
 import {
   getApp,
@@ -17,6 +18,8 @@ import { headers } from 'next/headers';
 import { getCartOrRedirectAction } from '@fxa/payments/ui/actions';
 import type { Metadata } from 'next';
 import { config } from 'apps/payments/next/config';
+import { auth } from 'apps/payments/next/auth';
+import { redirect } from 'next/navigation';
 
 export async function generateMetadata({
   params,
@@ -45,14 +48,38 @@ export default async function NeedsInputPage({
   const { locale } = params;
   const acceptLanguage = headers().get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, locale);
-  const cart = await getCartOrRedirectAction(
+
+  const sessionPromise = auth();
+  const cartPromise = getCartOrRedirectAction(
     params.cartId,
     SupportedPages.NEEDS_INPUT,
     searchParams
   );
+  const [session, cart] = await Promise.all([sessionPromise, cartPromise]);
+
   if (!cart.currency) {
     throw new Error('Currency is missing from the cart');
   }
+
+  if (!session?.user?.id ||cart.uid !== session.user.id) {
+    const redirectSearchParams: Record<string, string | string[]> =
+      searchParams || {};
+    delete redirectSearchParams.cartId;
+    delete redirectSearchParams.cartVersion;
+    const redirectTo = buildRedirectUrl(
+      params.offeringId,
+      params.interval,
+      'new',
+      'checkout',
+      {
+        baseUrl: config.paymentsNextHostedUrl,
+        locale,
+        searchParams: redirectSearchParams,
+      }
+    );
+    redirect(redirectTo);
+  }
+
   return (
     <section
       className="flex flex-col text-center text-sm"

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -8,7 +8,7 @@ import Image from 'next/image';
 import { auth } from 'apps/payments/next/auth';
 
 import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
-import { getCardIcon } from '@fxa/payments/ui';
+import { buildRedirectUrl, getCardIcon } from '@fxa/payments/ui';
 import {
   fetchCMSData,
   getCartOrRedirectAction,
@@ -20,6 +20,7 @@ import {
   buildPageMetadata,
 } from '@fxa/payments/ui/server';
 import { config } from 'apps/payments/next/config';
+import { redirect } from 'next/navigation';
 
 export const dynamic = 'force-dynamic';
 
@@ -67,6 +68,25 @@ export default async function CheckoutSuccess({
     cartDataPromise,
     sessionPromise,
   ]);
+
+  if (!session?.user?.id || cart.uid !== session.user.id) {
+    const redirectSearchParams: Record<string, string | string[]> =
+      searchParams || {};
+    delete redirectSearchParams.cartId;
+    delete redirectSearchParams.cartVersion;
+    const redirectTo = buildRedirectUrl(
+      params.offeringId,
+      params.interval,
+      'new',
+      'checkout',
+      {
+        baseUrl: config.paymentsNextHostedUrl,
+        locale,
+        searchParams: redirectSearchParams,
+      }
+    );
+    redirect(redirectTo);
+  }
 
   const { successActionButtonUrl, successActionButtonLabel } =
     cms.commonContent.localizations.at(0) || cms.commonContent;


### PR DESCRIPTION
Because:

* Users can currently view carts associated with another account's uid when provided with the URL

This commit:

* Adds in a frontend intercept that redirects the user to the start of the checkout process if the request cart's UID does not match the signed in user's UID

Closes #PAY-3155

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other Information
The front end still receives the cart data that isn't associated with the current user. This PR only aims to address accidental cart views, and isn't a true security measure.
