### PR TITLE
task(auth-bounce-handler): Add fallback for unknown bounce types

### DIFF
--- a/packages/fxa-shared/db/models/auth/email-bounce.ts
+++ b/packages/fxa-shared/db/models/auth/email-bounce.ts
@@ -62,10 +62,10 @@ export class EmailBounce extends BaseAuthModel {
     try {
       await EmailBounce.callProcedure(
         Proc.CreateEmailBounce,
-        email,
-        templateName,
-        BOUNCE_TYPES[bounceType],
-        BOUNCE_SUB_TYPES[bounceSubType],
+        email || '',
+        templateName || 'unknown',
+        BOUNCE_TYPES[bounceType] || BOUNCE_TYPES['__fxa__unmapped'],
+        BOUNCE_SUB_TYPES[bounceSubType] || BOUNCE_TYPES['__fxa__unmapped'],
         Date.now(),
         (diagnosticCode ?? '').substring(0, 255)
       );


### PR DESCRIPTION
## Because
- We have examples where messages did not contain a bounce type.
- This is still a valid bounce
- We shouldn't allow invalid calls to the sproc

## This pull request
- Falls back to _fxa_unmapped in this scenaro.

## Issue that this pull request solves

Closes: FXA-12808

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
