### PR TITLE
chore(ci): Stop building docker images on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ commands:
         type: string
       grep_invert:
         type: string
-        default: ""
+        default: ''
       fail_fast:
         type: boolean
         default: true
@@ -818,7 +818,7 @@ jobs:
           project: << parameters.project >>
       - run-playwright-tests:
           project: << parameters.project >>
-          grep_invert: "#phone"
+          grep_invert: '#phone'
           fail_fast: << parameters.fail_fast >>
       - store-artifacts
       - upload_to_gcs:
@@ -861,7 +861,7 @@ jobs:
           project: local
       - run-playwright-tests:
           project: local
-          grep_invert: "#phone"
+          grep_invert: '#phone'
           fail_fast: << parameters.fail_fast >>
       - store-artifacts
       - upload_to_gcs:
@@ -1231,15 +1231,6 @@ workflows:
       - playwright-functional-tests:
           name: Functional Tests - Playwright
           workflow: test_and_deploy_tag
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
-          requires:
-            - Build
-      - create-fxa-image:
-          name: Create FxA Image
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Because

- We build and push images with gh actions
- Building takes a long time

## This pull request

- Removes the process that build images when we test and deploy.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
