### PR TITLE
chore: mark accepted ADRs as accepted

### DIFF
--- a/docs/adr/0045-testing-updates-and-recommendations.md
+++ b/docs/adr/0045-testing-updates-and-recommendations.md
@@ -1,6 +1,6 @@
 # Improving Testing Standards and Experience in the Monorepo
 
-- Status: Proposed
+- Status: accepted
 - Deciders: Wil Clouser, Dan Schomburg, Valerie Pomerleau, Barry Chen, Amri Toufali, Vijay Budhram
 
 ## Context and Problem Statement

--- a/docs/adr/0046-monorepo-split.md
+++ b/docs/adr/0046-monorepo-split.md
@@ -1,6 +1,6 @@
 # Keep SubPlat in the Nx monorepo with targeted improvements
 
-* **Status:** proposed
+* **Status:** accepted
 * **Deciders:** Julian Poyourow, Reino Muhl, Vijay Budhram
 * **Date:** 2025-08-18
 


### PR DESCRIPTION
## Because

- These ADRs have already undergone review and have been accepted in their current form. This updates their status to reflect that.

## This pull request

- Updates ADR statuses.