### PR TITLE
fix(settings): Don't show recoverky key promo if no password set

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.test.tsx
@@ -18,6 +18,7 @@ import { mockWebIntegration } from '../../../pages/Signin/SigninRecoveryCode/moc
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import { Constants } from '../../../lib/constants';
 import {
+  accountAlmostEligibleForRecoveryKeyButHasNoPassword,
   accountEligibleForRecoveryKey,
   accountEligibleForRecoveryPhoneAndKey,
   accountEligibleForRecoveryPhoneOnly,
@@ -262,6 +263,23 @@ describe('PageSettings', () => {
         expect(
           screen.getByTestId('submit_create_recovery_key')
         ).toBeInTheDocument()
+      );
+    });
+
+    it('does not show key banner for passwordless accounts', async () => {
+      renderWithRouter(
+        <AppContext.Provider
+          value={mockAppContext({
+            account: accountAlmostEligibleForRecoveryKeyButHasNoPassword,
+          })}
+        >
+          <PageSettings integration={mockWebIntegration} />
+        </AppContext.Provider>
+      );
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId('submit_create_recovery_key')
+        ).not.toBeInTheDocument()
       );
     });
 

--- a/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/index.tsx
@@ -166,6 +166,7 @@ export const PageSettings = ({
     (!eligibleForRecoveryPhonePromo || dismissedRecoveryPhonePromo) &&
     !dismissedRecoveryKeyPromo &&
     estimatedSyncDeviceCount > 0 &&
+    account.hasPassword &&
     !recoveryKey.exists;
 
   // Scroll to effect

--- a/packages/fxa-settings/src/components/Settings/PageSettings/mocks.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSettings/mocks.tsx
@@ -34,6 +34,17 @@ export const accountEligibleForRecoveryKey = {
   totp: { exists: false, verified: false },
   attachedClients: MOCK_SERVICES,
   linkedAccounts: MOCK_LINKED_ACCOUNTS,
+  hasPassword: true,
+} as unknown as Account;
+
+export const accountAlmostEligibleForRecoveryKeyButHasNoPassword = {
+  ...MOCK_ACCOUNT,
+  displayName: null,
+  recoveryKey: { exists: false, estimatedSyncDeviceCount: 2 },
+  totp: { exists: false, verified: false },
+  attachedClients: MOCK_SERVICES,
+  linkedAccounts: MOCK_LINKED_ACCOUNTS,
+  hasPassword: false,
 } as unknown as Account;
 
 export const completelyFilledOutAccount = {


### PR DESCRIPTION
## Because

* Recovery key can't be created without a password

## This pull request

* Adds a hasPassword check

## Issue that this pull request solves

Closes: FXA-12789

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
