### PR TITLE
chore(storybook): stop deploying storybooks to GCP

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ parameters:
   enable_deploy_ci_images:
     type: boolean
     default: true
-  enable_deploy_story_book:
-    type: boolean
-    default: true
   enable_test_and_deploy_tag:
     type: boolean
     default: true
@@ -868,21 +865,6 @@ jobs:
           workflow: << parameters.workflow >>
           test_suite: e2e
 
-  build-and-deploy-storybooks:
-    executor: default-executor
-    resource_class: xlarge
-    steps:
-      - git-checkout
-      - restore-workspace
-      - run:
-          name: Build Storybooks
-          command: |
-            npx nx run-many -t build-storybook
-      - run:
-          name: Publish Storybooks
-          command: |
-            STORYBOOKS_PACKAGES_ROOT="." STORYBOOKS_PACKAGES_DEPTH=4 STORYBOOKS_USE_YARN_WORKSPACES=false STORYBOOKS_SKIP_BUILD=true LOG_LEVEL=TRACE npx github:mozilla-fxa/storybook-gcp-publisher
-
   update-yarn-cache:
     executor: default-executor
     resource_class: medium+
@@ -994,10 +976,6 @@ workflows:
           workflow: test_pull_request
           requires:
             - Build (PR)
-      - build-and-deploy-storybooks:
-          name: Deploy Storybooks (PR)
-          requires:
-            - Build (PR)
       - on-complete:
           name: Tests Complete (PR)
           stage: Tests
@@ -1012,7 +990,6 @@ workflows:
             - Integration Test - Servers - Auth V2 (PR)
             - Integration Test - Libraries (PR)
             - Firefox Functional Tests - Playwright (PR)
-            - Deploy Storybooks (PR)
 
   # Triggered remotely. See .circleci/README.md
   production_smoke_tests:
@@ -1089,24 +1066,6 @@ workflows:
             tags:
               ignore: /.*/
           force-deploy: << pipeline.parameters.force-deploy-fxa-ci-images >>
-
-  deploy_story_book:
-    # This workflow is triggered after a PR lands on main. It requires approval.
-    # The same operation will eventually run nightly.
-    when: << pipeline.parameters.enable_deploy_story_book >>
-    jobs:
-      - request-build-and-deploy-storybooks:
-          name: Request Deploy Storybooks
-          type: approval
-          filters:
-            branches:
-              only: main
-            tags:
-              ignore: /.*/
-      - build-and-deploy-storybooks:
-          name: Deploy Storybooks
-          requires:
-            - Request Deploy Storybooks
 
   test_and_deploy_tag:
     # This workflow is used for building docker containers that are then deployed to
@@ -1347,10 +1306,6 @@ workflows:
             - Integration Test - Servers - Auth V2 (nightly)
             - Integration Test - Libraries (nightly)
             - Firefox Functional Tests - Playwright (nightly)
-      - build-and-deploy-storybooks:
-          name: Deploy Storybooks (nightly)
-          requires:
-            - Tests Complete (nightly)
       - create-fxa-image:
           name: Create FxA Image (nightly)
           requires:


### PR DESCRIPTION
## Because

- we already have github pages

## This pull request

- removes building and deploying storybooks from circleCI config

## Issue that this pull request solves

Closes: FXA-12812

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
