### PR TITLE
fix(auth): Update keys check params in 2fa flow, block render on password status on SetPassword

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.tsx
@@ -8,7 +8,7 @@ import { currentAccount } from '../../../lib/cache';
 import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import { Integration, useAuthClient } from '../../../models';
 import { cache } from '../../../lib/cache';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CreatePasswordHandler } from './interfaces';
 import { HandledError } from '../../../lib/error-utils';
 import {
@@ -51,6 +51,13 @@ const SetPasswordContainer = ({
     flowQueryParams as unknown as Record<string, string>
   );
 
+  const [passwordStatus, setPasswordStatus] = useState<{
+    isLoading: boolean;
+    hasPassword: boolean;
+  }>({
+    isLoading: true,
+    hasPassword: false,
+  });
   const didRunPasswordStatusCheckRef = useRef(false);
   useEffect(() => {
     if (didRunPasswordStatusCheckRef.current) return;
@@ -62,21 +69,27 @@ const SetPasswordContainer = ({
             undefined,
             sessionToken
           );
-          if (status.hasPassword) {
-            // User already has a password, redirect to signin.
-            // This can happen when a user signs into the browser with third party
-            // oauth and they try to use Sync or Send Tab later, but keys are missing.
-            // Firefox will send users to this page to set a password and receive keys.
-            navigateWithQuery('/signin', { replace: true });
-          }
+          setPasswordStatus({
+            isLoading: false,
+            hasPassword: !!status.hasPassword,
+          });
         } catch (error) {
           // TODO? Might need to retry.
           // Request to create a PW won't go through if they already have one.
+          setPasswordStatus({
+            isLoading: false,
+            hasPassword: false,
+          });
         }
+      } else {
+        setPasswordStatus({
+          isLoading: false,
+          hasPassword: false,
+        });
       }
     };
     checkPasswordStatus();
-  }, [authClient, sessionToken, navigateWithQuery]);
+  }, [authClient, sessionToken]);
 
   const { finishOAuthFlowHandler, oAuthDataError } = useFinishOAuthFlowHandler(
     authClient,
@@ -185,6 +198,22 @@ const SetPasswordContainer = ({
   if (oAuthDataError) {
     return <OAuthDataError error={oAuthDataError} />;
   }
+
+  // Don't render SetPassword until this check is finished, otherwise
+  // some users might see a flash of that page before redirecting.
+  if (passwordStatus.isLoading) {
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+  }
+
+  // User already has a password, redirect to signin.
+  // This can happen when a user signs into the browser with third party
+  // oauth and they try to use Sync or Send Tab later, but keys are missing.
+  // Firefox will send users to this page to set a password and receive keys.
+  if (passwordStatus.hasPassword) {
+    navigateWithQuery('/signin', { replace: true });
+    return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
+  }
+
   // Curry already checked values
   const createPasswordHandler = createPassword(uid, email, sessionToken);
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryCode/container.tsx
@@ -57,7 +57,8 @@ export const SigninRecoveryCodeContainer = ({
   const { oAuthKeysCheckError } = useOAuthKeysCheck(
     integration,
     keyFetchToken,
-    unwrapBKey
+    unwrapBKey,
+    signinState?.isSignInWithThirdPartyAuth
   );
 
   const [consumeRecoveryCode] = useMutation<ConsumeRecoveryCodeResponse>(


### PR DESCRIPTION
Because:
* Signing into the third party auth browser flow with 2FA and a recovery code results in an error
* Users with a password already set see a flash of the SetPassword page before redirect to /signin

This commit:
* Passes the signin state into the recovery code page keys check so it skips for third party auth
* Blocks the render for SetPassword on password check, so users with a password get redirected before seeing the page render

fixes FXA-12809
fixes FXA-12811

---

For 12809 follow the STR in the ticket (this is the same fix as #19830). For 12811:

1. Create an account with a password
2. Launch Nightly, e.g. `FIREFOX_BIN=/Applications/Firefox\ Nightly.app/Contents/MacOS/firefox yarn firefox`
3. Open the Sync menu
4. Keep the query params but change the URL to `/post_verify/third_party_auth/set_password`
5. There should be no flash of the "set password" page before redirect. Even without this patch, locally this is super fast and easy to miss, so I verified by sticking a console log in the SetPassword component to show it's never rendered