### PR TITLE
chore(fxa): Adjust rate limit rules for stage

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -33,7 +33,10 @@ getCredentialsStatus                  : ip                : 100         : 15 min
 # Password Reset Email Send Limits
 # Controls the number of emails that can be sent
 #
-passwordForgotSendOtp                 : ip_email          : 5           : 10 minutes      : 15 minutes  : block
+passwordForgotSendOtp                 : email             : 2           : 15 minutes      : 15 minutes  : block
+passwordForgotSendOtp                 : email             : 5           : 24 hours        : 12 hours    : block
+passwordForgotSendOtp                 : ip                : 50          : 24 hours        : 12 hours    : block
+passwordForgotSendOtp                 : ip                : 20          : 15 minutes      : 30 minutes  : block
 passwordForgotSendOtp                 : ip                : 100         : 24 hours        : 15 minutes  : ban
 
 #


### PR DESCRIPTION
Because:
* We want to bring some prod values over to stage

This commit:
* Adjusts the default rate limiting for passwordForgotSendOtp

