### PR TITLE
fix(session): Update GQL session.isValid to not check that the session is also verified

### DIFF
--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -9,11 +9,11 @@ import { MozLoggerService } from '@fxa/shared/mozlog';
 import { AuthClientService } from '../backend/auth-client.service';
 import { SessionResolver } from './session.resolver';
 
-import { validateSessionToken } from '../auth/session-token.strategy';
+import { sessionTokenExists } from '../auth/session-token.strategy';
 
 jest.mock('../auth/session-token.strategy', () => ({
   ...jest.requireActual('../auth/session-token.strategy'),
-  validateSessionToken: jest.fn(),
+  sessionTokenExists: jest.fn(),
 }));
 
 describe('SessionResolver', () => {
@@ -53,7 +53,7 @@ describe('SessionResolver', () => {
     resolver = module.get<SessionResolver>(SessionResolver);
   });
   afterEach(() => {
-    (validateSessionToken as jest.Mock).mockRestore();
+    (sessionTokenExists as jest.Mock).mockRestore();
   });
 
   it('should be defined', () => {
@@ -81,16 +81,16 @@ describe('SessionResolver', () => {
 
   it('validates a session token', async () => {
     const result = await resolver.isValidToken('aaaa');
-    expect(validateSessionToken as jest.Mock).toBeCalledWith('aaaa');
+    expect(sessionTokenExists as jest.Mock).toBeCalledWith('aaaa');
     expect(result).toEqual(true);
   });
 
   it('invalidates a session token', async () => {
-    (validateSessionToken as jest.Mock).mockImplementation(() => {
+    (sessionTokenExists as jest.Mock).mockImplementation(() => {
       throw new Error('Invalid token');
     });
     const result = await resolver.isValidToken('aaaa');
-    expect(validateSessionToken as jest.Mock).toBeCalledWith('aaaa');
+    expect(sessionTokenExists as jest.Mock).toBeCalledWith('aaaa');
     expect(result).toEqual(false);
   });
 

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -27,7 +27,7 @@ import { SessionVerifyCodeInput } from './dto/input/session-verify-code';
 import { ConsumeRecoveryCodePayload } from './dto/payload/consume-recovery-code';
 import { ConsumeRecoveryCodeInput } from './dto/input/consume-recovery-code';
 import { UnverifiedSessionGuard } from '../auth/unverified-session-guard';
-import { validateSessionToken } from '../auth/session-token.strategy';
+import { sessionTokenExists } from '../auth/session-token.strategy';
 
 @Resolver((of: any) => SessionType)
 export class SessionResolver {
@@ -66,7 +66,7 @@ export class SessionResolver {
     @Args('sessionToken', { nullable: false }) sessionToken: string
   ) {
     try {
-      await validateSessionToken(sessionToken);
+      await sessionTokenExists(sessionToken);
       return true;
     } catch (err) {
       return false;


### PR DESCRIPTION
Because:
* We create a new session token on password entry, and when the user is signed into the browser without a password but not into Sync, signing into Sync will create a new session token that we do not want overwritten by the requestSignedInUser request

This commit:
* Tweaks the session.isValidToken call to only check for the session token's existence and not if it's fully verified as well


fixes FXA-12821