### PR TITLE
fix(auth): Pass signinState to recovery code page from phone code page

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.test.tsx
@@ -171,6 +171,7 @@ describe('SigninRecoveryPhoneContainer', () => {
         integration: expect.any(Object),
         numBackupCodes: undefined,
         sendError: undefined,
+        signinState: mockSigninLocationState,
       });
     });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/container.tsx
@@ -199,6 +199,7 @@ const SigninRecoveryPhoneContainer = ({
         sendError,
         numBackupCodes,
         integration,
+        signinState,
       }}
     />
   );

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.test.tsx
@@ -9,6 +9,7 @@ import { userEvent } from '@testing-library/user-event';
 import SigninRecoveryPhone from './index';
 import { AuthUiErrors } from '../../../lib/auth-errors/auth-errors';
 import { HandledError } from '../../../lib/error-utils';
+import { mockSigninLocationState } from '../mocks';
 
 describe('SigninRecoveryPhone', () => {
   const mockVerifyCode = jest.fn(() => Promise.resolve());
@@ -25,6 +26,7 @@ describe('SigninRecoveryPhone', () => {
     verifyCode: mockVerifyCode,
     resendCode: mockResendCode,
     numBackupCodes: 4,
+    signinState: mockSigninLocationState,
   };
 
   const propsWithError = {
@@ -32,6 +34,7 @@ describe('SigninRecoveryPhone', () => {
     verifyCode: mockVerifyCodeError,
     resendCode: mockResendCodeError,
     numBackupCodes: 4,
+    signinState: mockSigninLocationState,
   };
 
   const propsWithErrorNoBackupCodes = {
@@ -39,6 +42,7 @@ describe('SigninRecoveryPhone', () => {
     verifyCode: mockVerifyCodeError,
     resendCode: mockResendCodeError,
     numBackupCodes: 0,
+    signinState: mockSigninLocationState,
   };
 
   beforeEach(() => {

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/index.tsx
@@ -59,6 +59,7 @@ const SigninRecoveryPhone = ({
   sendError,
   numBackupCodes,
   integration,
+  signinState,
 }: SigninRecoveryPhoneProps & RouteComponentProps) => {
   const [errorMessage, setErrorMessage] = useState('');
   const [errorDescription, setErrorDescription] = useState('');
@@ -133,6 +134,7 @@ const SigninRecoveryPhone = ({
               'Use backup authentication codes instead?'
             ),
             gleanId: 'login_backup_phone_error_use_backup_code_link',
+            locationState: { signinState, lastFourPhoneDigits },
           });
         }
         return;
@@ -191,6 +193,7 @@ const SigninRecoveryPhone = ({
               path: errorLink.path,
               localizedText: errorLink.localizedText,
               gleanId: errorLink.gleanId,
+              locationState: errorLink.locationState,
             } as BannerLinkProps,
           })}
         />

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/interfaces.ts
@@ -25,4 +25,5 @@ export type SigninRecoveryPhoneProps = {
   integration?: SigninIntegration;
   sendError?: AuthUiError;
   numBackupCodes?: number;
+  signinState: SigninLocationState | null;
 };

--- a/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninRecoveryPhone/mocks.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { LocationProvider } from '@reach/router';
 import SigninRecoveryPhone from '.';
 import { SigninRecoveryPhoneProps } from './interfaces';
+import { mockSigninLocationState } from '../mocks';
 
 const mockVerifyCodeSuccess = (code: string) => Promise.resolve();
 const mockResendCodeSuccess = () => Promise.resolve();
@@ -16,6 +17,7 @@ export const Subject = ({
   integration,
   sendError,
   numBackupCodes = 4,
+  signinState = mockSigninLocationState,
 }: Partial<SigninRecoveryPhoneProps>) => {
   const lastFourPhoneDigits = '1234';
 
@@ -29,6 +31,7 @@ export const Subject = ({
           numBackupCodes,
           integration,
           sendError,
+          signinState,
         }}
       />
     </LocationProvider>


### PR DESCRIPTION
Because:
* Signing in with third party auth errors out in this state, because the 'isThirdPartyAuthSignin' location state piece is undefined

This commit:
* Passes the location state to the recovery code page via the rendered link when a user enters the wrong recovery code phone

fixes FXA-12825

