### PR TITLE
fix(emails): Don't send password reset emails to unverified accounts

### DIFF
--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -1010,6 +1010,10 @@ module.exports = function (
           throw error.unknownAccount();
         }
 
+        if (!account.emailVerified) {
+          throw error.unknownAccount();
+        }
+
         let flowCompleteSignal;
         if (requestHelper.wantsKeys(request)) {
           flowCompleteSignal = 'account.signed';


### PR DESCRIPTION
## Because

- We don't want to send these emails because they have not verified their account

## This pull request

- Don't send the emails

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12826

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
