### PR TITLE
chore(docker): Disable GH Action caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -126,5 +126,3 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max


### PR DESCRIPTION
Because:
* We keep hitting a disk space error and want to temporarily disable this to unblock pushing

This commit:
* Removes cache-from/cache-to