### PR TITLE
chore(event-broker): Stop including clientId in statsd

### DIFF
--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -359,11 +359,19 @@ describe('QueueworkerService', () => {
       webHookService.hasWebhookRegistered = jest.fn().mockReturnValue(false);
       const msg = updateStubMessage(baseDeleteMessage);
       await (service as any).handleMessage(msg);
-      expect(logger.debug).toBeCalledTimes(3);
+      expect(logger.debug).toHaveBeenCalledTimes(3);
+
       expect(logger.debug.mock.calls[1][0]).toBe('noWebhookRegistered');
-      expect(metrics.increment).toBeCalledWith('message.webhookNotFound', {
-        clientId: baseLoginMessage.clientId,
+      expect(logger.debug.mock.calls[1][1]).toEqual({
+        clientId: '444c5d137fc34d82ae65441d7f26a504',
+        eventType: 'delete',
       });
+      expect(metrics.increment).toHaveBeenCalledWith(
+        'message.webhookNotFound',
+        {
+          eventType: 'delete',
+        }
+      );
     });
   });
 });

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -134,11 +134,17 @@ export class QueueworkerService
    * Publish a message to the pubsub topic for the client.
    */
   private async publishMessage(clientId: string, json: any) {
+    const eventType = json.event ?? 'unknown';
     // Ensure clientId is normalized
     clientId = clientId.toLowerCase();
     if (!this.clientWebhooks.hasWebhookRegistered(clientId)) {
-      this.log.debug('noWebhookRegistered', { clientId });
-      this.metrics.increment('message.webhookNotFound', { clientId });
+      this.log.debug('noWebhookRegistered', {
+        clientId,
+        eventType,
+      });
+      this.metrics.increment('message.webhookNotFound', {
+        eventType,
+      });
       return;
     }
     const topicName = this.topicPrefix + clientId;


### PR DESCRIPTION
Because:
 - Statsd metrics are grouped by name and label
 - and each unique name/label group costs money

This Commit:
 - Stops including the clientId in the webhookNotFound message for message publishing

Closes: FXA-12846

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
