### PR TITLE
fix(emails): Add more email logging

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -567,14 +567,32 @@ module.exports = function (log, config, bounces, statsd) {
     await new Promise((resolve, reject) => {
       this.mailer.sendMail(emailConfig, (err, status) => {
         if (err) {
-          log.error('mailer.send.error', {
+          const errorLogDetails = {
             err: err.message,
             code: err.code,
             errno: err.errno,
             message: status && status.message,
             to: emailConfig && emailConfig.to,
             template,
-          });
+          };
+
+          if (emailConfig && emailConfig.cc) {
+            errorLogDetails.cc = emailConfig.cc;
+          }
+          if (err.response) {
+            errorLogDetails.smtpResponse = err.response;
+          }
+          if (err.responseCode) {
+            errorLogDetails.smtpResponseCode = err.responseCode;
+          }
+          if (err.rejected && err.rejected.length) {
+            errorLogDetails.rejectedRecipients = err.rejected;
+          }
+          if (err.accepted && err.accepted.length) {
+            errorLogDetails.acceptedRecipients = err.accepted;
+          }
+
+          log.error('mailer.send.error', errorLogDetails);
 
           return reject(err);
         }


### PR DESCRIPTION
## Because

- Email sending failures with "501 Invalid RCPT TO address provided" errors don't include which recipient addresses are being rejected
- Debugging SMTP errors requires more context about rejected vs accepted recipients
- CC recipients aren't logged in error cases, making it harder to identify problematic addresses

## This pull request

- Adds SMTP response code and message to error logs in `EmailSender` and auth-server mailer
- Logs rejected and accepted recipient addresses when email sending fails
- Includes CC recipients in error log details
- Adds test coverage for SMTP error logging with recipient details
- Enhances retry attempt logs with SMTP response information

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12710

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information