### PR TITLE
fix(payments-next): Fix update button for Link as saved method

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
@@ -41,7 +41,7 @@ export default async function StripePaymentManagementPage({
       throw error;
     }
   }
-  const { clientSecret, defaultPaymentMethodId, currency } =
+  const { clientSecret, defaultPaymentMethod, currency } =
     stripeClientSession;
 
   return (
@@ -58,7 +58,7 @@ export default async function StripePaymentManagementPage({
       >
         <PaymentMethodManagement
           uid={session?.user?.id}
-          defaultPaymentMethodId={defaultPaymentMethodId}
+          defaultPaymentMethod={defaultPaymentMethod}
           sessionEmail={session?.user?.email ?? undefined}
         />
       </StripeManagementWrapper>

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -1002,7 +1002,10 @@ describe('SubscriptionManagementService', () => {
       expect(result).toEqual({
         clientSecret: mockCustomerSession.client_secret,
         customer: mockCustomer.id,
-        defaultPaymentMethodId: mockPaymentMethod.id,
+        defaultPaymentMethod: {
+          id: mockPaymentMethod.id,
+          type: mockPaymentMethod.type,
+        },
         currency: mockCustomer.currency,
       });
     });
@@ -1072,7 +1075,10 @@ describe('SubscriptionManagementService', () => {
       expect(result).toEqual({
         clientSecret: mockCustomerSession.client_secret,
         customer: mockCustomer.id,
-        defaultPaymentMethodId: mockPaymentMethod.id,
+        defaultPaymentMethod: {
+          id: mockPaymentMethod.id,
+          type: mockPaymentMethod.type,
+        },
         currency: mockCurrency,
       });
     });
@@ -1132,7 +1138,10 @@ describe('SubscriptionManagementService', () => {
       expect(result).toEqual({
         clientSecret: mockCustomerSession.client_secret,
         customer: mockCustomer.id,
-        defaultPaymentMethodId: mockPaymentMethod.id,
+        defaultPaymentMethod: {
+          id: mockPaymentMethod.id,
+          type: mockPaymentMethod.type,
+        },
         currency: mockCurrency,
       });
     });

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -805,8 +805,15 @@ export class SubscriptionManagementService {
     return {
       clientSecret: customerSession.client_secret,
       customer: customerSession.customer,
-      defaultPaymentMethodId: defaultPaymentMethod?.id,
       currency,
+      ...(defaultPaymentMethod
+        ? {
+            defaultPaymentMethod: {
+              type: defaultPaymentMethod?.type,
+              id: defaultPaymentMethod?.id,
+            },
+          }
+        : {}),
     };
   }
 

--- a/libs/payments/ui/src/lib/nestapp/validators/GetStripePaymentManagementDetailsResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetStripePaymentManagementDetailsResult.ts
@@ -2,7 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
+
+export class PaymentMethodDetails {
+  @IsString()
+  id!: string;
+
+  @IsString()
+  @IsOptional()
+  type?: string;
+}
 
 export class GetStripePaymentManagementDetailsResult {
   @IsString()
@@ -11,9 +21,10 @@ export class GetStripePaymentManagementDetailsResult {
   @IsString()
   customer!: string;
 
-  @IsString()
+  @ValidateNested({ each: true })
+  @Type(() => PaymentMethodDetails)
   @IsOptional()
-  defaultPaymentMethodId?: string;
+  defaultPaymentMethod?: PaymentMethodDetails;
 
   @IsString()
   currency!: string;


### PR DESCRIPTION
Because:

* When the user had Link as their saved payment method, the Manage Payment Methods page would show the option to update/save their payment method even when no changes had been made

This commit:

* Fixes the check to require a payment method ID. This results in the Payment Element correctly showing the "Set as default" button when a change is made, and not showing the button when no change is made.

Closes #PAY-3422

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

The PaymentMethod element no longer shows the button to set as default when Link is the default
<img width="1008" height="623" alt="Screenshot 2026-01-06 at 6 20 23 PM" src="https://github.com/user-attachments/assets/86a75432-2996-4420-8e42-eeb15bc93b55" />

Changing the payment method, and then changing back to Link still shows the button
<img width="1111" height="771" alt="Screenshot 2026-01-06 at 6 23 37 PM" src="https://github.com/user-attachments/assets/2402a429-86d0-4d58-a518-a7d8d73be81d" />



## Other information (Optional)

Any other information that is important to this pull request.
