### PR TITLE
feat(auth): update subscription reminders script for cron

### DIFF
--- a/packages/fxa-auth-server/lib/payments/initSubplat.ts
+++ b/packages/fxa-auth-server/lib/payments/initSubplat.ts
@@ -216,6 +216,7 @@ export async function initSubplat({
     paypalCustomerManager,
     logger
   );
+
   /**
    * Add initialized instances to Container
    */

--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -34,6 +34,7 @@ const planIntervalsToDuration = {
 interface EndingRemindersOptions {
   enabled: boolean;
   paymentsNextUrl: string;
+  dailyReminderDays?: number;
   monthlyReminderDays: number;
   yearlyReminderDays: number;
 }
@@ -45,6 +46,7 @@ export class SubscriptionReminders {
   private planDuration: Duration;
   private reminderDuration: Duration;
   private endingReminderEnabled: boolean;
+  private dailyEndingReminderDuration: Duration | undefined;
   private monthlyEndingReminderDuration: Duration;
   private yearlyEndingReminderDuration: Duration;
   private paymentsNextUrl: string;
@@ -74,6 +76,11 @@ export class SubscriptionReminders {
     this.planDuration = Duration.fromObject({ days: planLength });
     this.reminderDuration = Duration.fromObject({ days: reminderLength });
     this.endingReminderEnabled = endingReminderOptions.enabled;
+    if (endingReminderOptions.dailyReminderDays) {
+      this.dailyEndingReminderDuration = Duration.fromObject({
+        days: endingReminderOptions.dailyReminderDays,
+      });
+    }
     this.monthlyEndingReminderDuration = Duration.fromObject({
       days: endingReminderOptions.monthlyReminderDays,
     });
@@ -414,6 +421,13 @@ export class SubscriptionReminders {
 
     // 4
     if (this.endingReminderEnabled) {
+      // Daily
+      if (this.dailyEndingReminderDuration) {
+        await this.sendEndingReminders(
+          this.dailyEndingReminderDuration,
+          SubplatInterval.Daily
+        );
+      }
       // Monthly
       await this.sendEndingReminders(
         this.monthlyEndingReminderDuration,

--- a/packages/fxa-auth-server/scripts/subscription-reminders.ts
+++ b/packages/fxa-auth-server/scripts/subscription-reminders.ts
@@ -20,6 +20,7 @@ import { parseBooleanArg } from './lib/args';
 
 const DEFAULT_PLAN_LENGTH = 180;
 const DEFAULT_REMINDER_LENGTH = 14;
+const DEFAULT_ENDING_REMINDER_DAILY_LENGTH = 0;
 const DEFAULT_ENDING_REMINDER_MONTHLY_LENGTH = 7;
 const DEFAULT_ENDING_REMINDER_YEARLY_LENGTH = 14;
 
@@ -28,6 +29,7 @@ Sentry.init({});
 async function init() {
   program
     .version(pckg.version)
+    .allowUnknownOption(true)
     .option(
       '-p, --plan-length [days]',
       'Plan length in days beyond which a reminder email before the next recurring charge should be sent. Defaults to 180.',
@@ -42,6 +44,11 @@ async function init() {
       '-e, --enableEndingReminders [boolean]',
       'Enable the sending of subscription ending reminder emails. Defaults to false.',
       false
+    )
+    .option(
+      '-d, --ending-reminder-daily-length [days]',
+      'Reminder length in days before the daily subscription ending date to send the reminder email. Defaults to 0.',
+      DEFAULT_ENDING_REMINDER_DAILY_LENGTH.toString()
     )
     .option(
       '-m, --ending-reminder-monthly-length [days]',
@@ -78,6 +85,7 @@ async function init() {
     {
       enabled: parseBooleanArg(program.enableEndingReminders),
       paymentsNextUrl: config.smtp.subscriptionSettingsUrl,
+      dailyReminderDays: parseInt(program.endingReminderDailyLength),
       monthlyReminderDays: parseInt(program.endingReminderMonthlyLength),
       yearlyReminderDays: parseInt(program.endingReminderYearlyLength),
     },

--- a/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
+++ b/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
@@ -60,6 +60,7 @@ describe('SubscriptionReminders', () => {
   let mockConfig;
   let realDateNow;
 
+  const mockDailyReminderDuration = undefined;
   const mockMonthlyReminderDuration = 7;
   const mockYearlyReminderDuration = 14;
 
@@ -97,6 +98,7 @@ describe('SubscriptionReminders', () => {
       {
         enabled: false,
         paymentsNextUrl: 'http://localhost:3035',
+        dailyReminderDays: mockDailyReminderDuration,
         monthlyReminderDays: mockMonthlyReminderDuration,
         yearlyReminderDays: mockYearlyReminderDuration,
       },
@@ -716,6 +718,32 @@ describe('SubscriptionReminders', () => {
       reminder.endingReminderEnabled = true;
       await reminder.sendReminders();
 
+      sinon.assert.calledWith(
+        reminder.sendEndingReminders,
+        Duration.fromObject({ days: mockMonthlyReminderDuration }),
+        'monthly'
+      );
+      sinon.assert.calledWith(
+        reminder.sendEndingReminders,
+        Duration.fromObject({ days: mockYearlyReminderDuration }),
+        'yearly'
+      );
+    });
+
+    it('calls sendEndingReminders for daily if dailyEndingReminderDuration is provided', async () => {
+      const mockDailyReminderDays = 3;
+      reminder.sendEndingReminders = sandbox.fake.resolves({});
+      reminder.endingReminderEnabled = true;
+      reminder.dailyEndingReminderDuration = Duration.fromObject({
+        days: mockDailyReminderDays,
+      });
+      await reminder.sendReminders();
+
+      sinon.assert.calledWith(
+        reminder.sendEndingReminders,
+        Duration.fromObject({ days: mockDailyReminderDays }),
+        'daily'
+      );
       sinon.assert.calledWith(
         reminder.sendEndingReminders,
         Duration.fromObject({ days: mockMonthlyReminderDuration }),


### PR DESCRIPTION
## Because

- The subscription reminders script needs to support daily subscription prices.

## This pull request

- Optionally adds support for daily subscription prices, so that it can be toggled on and off where required.
- Updates script to allow unsupported params. This was done to allow updates to the CRON jobs with new parameters, before those parameters have shipped.

## Issue that this pull request solves

Closes: PAY-2294

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
