### PR TITLE
feat(payments): Update Cancel and Stay subscribed pages

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.tsx
@@ -40,6 +40,16 @@ export default async function CancelSubscriptionPage({
     notFound();
   }
 
+  if (pageContent.isEligibleForChurnCancel === true) {
+    redirect(
+      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/cancel`
+    );
+  }
+
+  if (pageContent.isEligibleForCancelInterstitialOffer === true) {
+    redirect(`/${locale}/subscriptions/${subscriptionId}/offer`);
+  }
+
   return (
     <CancelSubscription
       userId={uid}

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.tsx
@@ -41,6 +41,12 @@ export default async function StaySubscribedPage({
     notFound();
   }
 
+  if (pageContent.isEligibleforChurnStaySubscribed === true) {
+    redirect(
+      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/stay-subscribed`
+    );
+  }
+
   return (
     <StaySubscribed
       userId={uid}

--- a/libs/payments/ui/src/lib/actions/determineCancellationIntervention.ts
+++ b/libs/payments/ui/src/lib/actions/determineCancellationIntervention.ts
@@ -5,23 +5,16 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
-import { SubplatInterval } from '@fxa/payments/customer';
 
 export const determineCancellationInterventionAction = async (args: {
   uid: string;
   subscriptionId: string;
-  offeringApiIdentifier: string;
-  currentInterval: SubplatInterval;
-  upgradeInterval: SubplatInterval;
   acceptLanguage?: string | null;
   selectedLanguage?: string;
 }) => {
   return await getApp().getActionsService().determineCancellationIntervention({
     uid: args.uid,
     subscriptionId: args.subscriptionId,
-    offeringApiIdentifier: args.offeringApiIdentifier,
-    currentInterval: args.currentInterval,
-    upgradeInterval: args.upgradeInterval,
     acceptLanguage: args.acceptLanguage,
     selectedLanguage: args.selectedLanguage,
   });

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -318,9 +318,6 @@ export class NextJSActionsService {
   async determineCancellationIntervention(args: {
     uid: string;
     subscriptionId: string;
-    offeringApiIdentifier: string;
-    currentInterval: SubplatInterval;
-    upgradeInterval: SubplatInterval;
     acceptLanguage?: string | null;
     selectedLanguage?: string;
   }) {
@@ -328,9 +325,6 @@ export class NextJSActionsService {
       {
         uid: args.uid,
         subscriptionId: args.subscriptionId,
-        offeringApiIdentifier: args.offeringApiIdentifier,
-        currentInterval: args.currentInterval,
-        upgradeInterval: args.upgradeInterval,
         acceptLanguage: args.acceptLanguage,
         selectedLanguage: args.selectedLanguage,
       }
@@ -677,7 +671,25 @@ export class NextJSActionsService {
         args.selectedLanguage
       );
 
-    return result;
+    const churnCancelEligibility =
+      await this.churnInterventionService.determineCancellationIntervention({
+        uid: args.uid,
+        subscriptionId: args.subscriptionId,
+        acceptLanguage: args.acceptLanguage,
+        selectedLanguage: args.selectedLanguage,
+      });
+
+    return {
+      ...result,
+      isEligibleForChurnCancel:
+        churnCancelEligibility.reason === 'eligible' &&
+        churnCancelEligibility.cancelChurnInterventionType ===
+          'cancel_churn_intervention',
+      isEligibleForCancelInterstitialOffer:
+        churnCancelEligibility.reason === 'eligible' &&
+        churnCancelEligibility.cancelChurnInterventionType ===
+          'cancel_interstitial_offer',
+    };
   }
 
   @SanitizeExceptions()
@@ -701,7 +713,19 @@ export class NextJSActionsService {
         args.selectedLanguage
       );
 
-    return result;
+    const churnStaySubscribedEligibility =
+      await this.churnInterventionService.determineStaySubscribedEligibility(
+        args.uid,
+        args.subscriptionId,
+        args.acceptLanguage,
+        args.selectedLanguage
+      );
+
+    return {
+      ...result,
+      isEligibleforChurnStaySubscribed:
+        churnStaySubscribedEligibility.isEligible,
+    };
   }
 
   @SanitizeExceptions()


### PR DESCRIPTION
## This pull request

- Updates Cancel and Stay subscribed pages to check if customer is eligible for existing churn coupon, if so, navigate to respective pages.

## Issue that this pull request solves

Closes: PAY-3455

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
