### PR TITLE
fix(auth): new device email not sent after verify success

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -1584,6 +1584,7 @@ describe('/session/verify_code', () => {
     assert.equal(args[0], 'account.confirmed');
     assert.equal(args[1].uid, signupCodeAccount.uid);
     sinon.assert.calledOnce(gleanMock.login.verifyCodeConfirmed);
+    assert.calledOnce(mailer.sendNewDeviceLoginEmail);
   });
 
   it('should fail for invalid code', async () => {


### PR DESCRIPTION
## Because

- the "new device" email is not sent after successful email confirmation

## This pull request

- adds the functionality

## Issue that this pull request solves

Closes: FXA-12802

## Other information (Optional)

See [the original comment](https://github.com/mozilla/fxa/pull/19810#pullrequestreview-3589026738) from @vpomerleau, who discovered the issue.  From that comment, steps to repro:

1. Set env vars:
    SERVICES_WITH_EMAIL_VERIFICATION=dcdb5ae7add825d2
    SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS=false
2. Create a new account
3. Open new profile with the dev launcher (yarn firefox)
4. Go to 123Done (localhost:8080)
5. Sign in with email
6. Enter password

