### PR TITLE
fix(auth): use strapi links for non-webhook emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2782,7 +2782,7 @@ module.exports = function (log, config, bounces, statsd) {
   };
 
   Mailer.prototype.subscriptionPaymentExpiredEmail = async function (message) {
-    const { email, uid, planId, acceptLanguage, subscriptions } = message;
+    const { email, uid, acceptLanguage, subscriptions } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
     log.trace('mailer.subscriptionPaymentExpired', {
@@ -2817,7 +2817,7 @@ module.exports = function (log, config, bounces, statsd) {
     }
 
     const cmsLinks = await this._generateCmsLinks(
-      planId,
+      subscriptions[0]?.planId,
       acceptLanguage,
       template
     );
@@ -2841,7 +2841,7 @@ module.exports = function (log, config, bounces, statsd) {
   Mailer.prototype.subscriptionPaymentProviderCancelledEmail = async function (
     message
   ) {
-    const { email, uid, planId, acceptLanguage, subscriptions } = message;
+    const { email, uid, acceptLanguage, subscriptions } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
     log.trace('mailer.subscriptionPaymentProviderCancelled', {
@@ -2876,7 +2876,7 @@ module.exports = function (log, config, bounces, statsd) {
     }
 
     const cmsLinks = await this._generateCmsLinks(
-      planId,
+      subscriptions[0]?.planId,
       acceptLanguage,
       template
     );
@@ -3201,7 +3201,7 @@ module.exports = function (log, config, bounces, statsd) {
   };
 
   Mailer.prototype.subscriptionEndingReminderEmail = async function (message) {
-    const { email, uid, planId, acceptLanguage, subscription } = message;
+    const { email, uid, acceptLanguage, subscription } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
     log.trace('mailer.subscriptionEndingReminderEmail', {
@@ -3227,7 +3227,7 @@ module.exports = function (log, config, bounces, statsd) {
       template
     );
     const cmsLinks = await this._generateCmsLinks(
-      planId,
+      subscription.planId,
       acceptLanguage,
       template
     );
@@ -3280,7 +3280,7 @@ module.exports = function (log, config, bounces, statsd) {
   };
 
   Mailer.prototype.subscriptionRenewalReminderEmail = async function (message) {
-    const { email, uid, planId, acceptLanguage, subscription } = message;
+    const { email, uid, acceptLanguage, subscription } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
     log.trace('mailer.subscriptionRenewalReminderEmail', {
@@ -3306,7 +3306,7 @@ module.exports = function (log, config, bounces, statsd) {
       template
     );
     const cmsLinks = await this._generateCmsLinks(
-      planId,
+      subscription.planId,
       acceptLanguage,
       template
     );

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -140,8 +140,8 @@ const MESSAGE = {
     productId: 'wibble',
   },
   subscriptions: [
-    { productName: 'Firefox Fortress' },
-    { productName: 'Cooking with Foxkeh' },
+    { planId: 'plan-example', productName: 'Firefox Fortress' },
+    { planId: 'other-plan', productName: 'Cooking with Foxkeh' },
   ],
   showPaymentMethod: true,
   discountType: 'forever',


### PR DESCRIPTION
## Because

- Some emails that are not triggered by stripe webhooks do not include privacy and terms of service links from the CMS.

## This pull request

- Ensure that planId is populated when generating the CMS links.

## Issue that this pull request solves

Closes: PAY-3431

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
