### PR TITLE
chore(scripts): Add list of services at end of pm2 start so can quickly launch

### DIFF
--- a/_scripts/pm2-all.sh
+++ b/_scripts/pm2-all.sh
@@ -47,6 +47,14 @@ fi
 end=`date +%s`
 runtime=$((end-start))
 
-echo -e "\n###########################################################\n"
-echo "# Stack Started Successfully ! ${runtime}s"
-echo -e "\n###########################################################\n"
+echo -e "\n###########################################################"
+echo -e "#  ✅ Stack Started Successfully in ${runtime}s"
+echo -e "###########################################################"
+echo -e ""
+echo -e "  📍 Services:"
+echo -e "     Content Server       http://localhost:3030"
+echo -e "     Admin Panel          http://localhost:8091"
+echo -e "     123done (RP)         http://localhost:8080"
+echo -e ""
+echo -e "  💡 Run 'yarn ports' to see all service ports"
+echo -e "###########################################################\n"


### PR DESCRIPTION
I was just annoyed that I had to open browser and type in urls. This just prints service urls at end of stack startup.

<img width="449" height="174" alt="Screenshot 2026-01-13 at 10 55 39 AM" src="https://github.com/user-attachments/assets/57efb4b4-362a-49cd-a3ae-ed966746b0bb" />
