### PR TITLE
fix(settings): Keep loading indicator consistent for 3rd party signin

### DIFF
--- a/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/ThirdPartyAuthCallback/index.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { hardNavigate } from 'fxa-react/lib/utils';
 import { RouteComponentProps, useLocation } from '@reach/router';
-import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { AppLayout } from '../../../components/AppLayout';
 import {
   useAccount,
   useAuthClient,
@@ -258,7 +258,7 @@ const ThirdPartyAuthCallback = ({
     }
   }, [integration, navigateNext]);
 
-  return <LoadingSpinner fullScreen />;
+  return <AppLayout cmsInfo={integration.getCmsInfo()} loading />;
 };
 
 export default ThirdPartyAuthCallback;


### PR DESCRIPTION
## Because

- the third party auth callback page flashes between fullscreen and in-card loading spinner

## This pull request

- make it consistently use in-card loading spinner

## Issue that this pull request solves

Closes: FXA-12852

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
