### PR TITLE
chore(fxa-settings): Adjust loading modal window size.  Fix FXA-12851

### DIFF
--- a/packages/fxa-settings/src/components/CardLoadingSpinner/index.tsx
+++ b/packages/fxa-settings/src/components/CardLoadingSpinner/index.tsx
@@ -22,7 +22,7 @@ export const CardLoadingSpinner = ({
   return (
     <div
       className={classNames(
-        'card flex items-center justify-center min-h-48 mobileLandscape:min-h-64',
+        'card flex items-center justify-center h-full mobileLandscape:h-48',
         className
       )}
     >


### PR DESCRIPTION
## Because

- The default window size is too small and is jarring when it loads content

## This pull request

- sets a minimum default size

## Issue that this pull request solves

Closes: FXA-12851
