### PR TITLE
fix(payments): Update buttons to navigate to appropriate pages

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.tsx
@@ -40,16 +40,6 @@ export default async function CancelSubscriptionPage({
     notFound();
   }
 
-  if (pageContent.isEligibleForChurnCancel === true) {
-    redirect(
-      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/cancel`
-    );
-  }
-
-  if (pageContent.isEligibleForCancelInterstitialOffer === true) {
-    redirect(`/${locale}/subscriptions/${subscriptionId}/offer`);
-  }
-
   return (
     <CancelSubscription
       userId={uid}

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.tsx
@@ -41,12 +41,6 @@ export default async function StaySubscribedPage({
     notFound();
   }
 
-  if (pageContent.isEligibleforChurnStaySubscribed === true) {
-    redirect(
-      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/stay-subscribed`
-    );
-  }
-
   return (
     <StaySubscribed
       userId={uid}

--- a/libs/payments/management/src/lib/factories/subscriptionContent.factory.ts
+++ b/libs/payments/management/src/lib/factories/subscriptionContent.factory.ts
@@ -89,7 +89,9 @@ export const SubscriptionContentFactory = (
   nextInvoiceDate: faker.date.future().getDate(),
   nextInvoiceTax: faker.number.int({ min: 1, max: 1000 }),
   nextInvoiceTotal: faker.number.int({ min: 1, max: 1000 }),
+  isEligibleForChurnCancel: faker.datatype.boolean(),
   isEligibleForChurnStaySubscribed: faker.datatype.boolean(),
+  isEligibleForOffer: faker.datatype.boolean(),
   churnStaySubscribedCtaMessage: faker.string.sample(),
   ...override,
 });

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -481,6 +481,14 @@ export class SubscriptionManagementService {
         selectedLanguage
       );
 
+    const cancelIntervention =
+      await this.churnInterventionService.determineCancellationIntervention({
+        uid,
+        subscriptionId: subscription.id,
+        acceptLanguage,
+        selectedLanguage,
+      });
+
     return {
       id: subscription.id,
       productName,
@@ -511,7 +519,15 @@ export class SubscriptionManagementService {
       nextPromotionName,
       promotionName,
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
+      isEligibleForChurnCancel:
+        cancelIntervention.reason === 'eligible' &&
+        cancelIntervention.cancelChurnInterventionType ===
+          'cancel_churn_intervention',
       isEligibleForChurnStaySubscribed: staySubscribedResult.isEligible,
+      isEligibleForOffer:
+        cancelIntervention.reason === 'eligible' &&
+        cancelIntervention.cancelChurnInterventionType ===
+          'cancel_interstitial_offer',
       churnStaySubscribedCtaMessage:
         staySubscribedResult.cmsChurnInterventionEntry?.ctaMessage,
     };

--- a/libs/payments/management/src/lib/types.ts
+++ b/libs/payments/management/src/lib/types.ts
@@ -93,6 +93,8 @@ export interface SubscriptionContent {
   promotionName?: string | null;
   isEligibleForChurnStaySubscribed: boolean;
   churnStaySubscribedCtaMessage?: string | null;
+  isEligibleForChurnCancel: boolean;
+  isEligibleForOffer: boolean;
 }
 
 export enum ChurnErrorReason {

--- a/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SubscriptionContent/index.tsx
@@ -37,7 +37,9 @@ interface Subscription {
   nextInvoiceTotal?: number;
   nextPromotionName?: string | null;
   promotionName?: string | null;
+  isEligibleForChurnCancel: boolean;
   isEligibleForChurnStaySubscribed: boolean;
+  isEligibleForOffer: boolean;
   churnStaySubscribedCtaMessage?: string | null;
 }
 
@@ -58,6 +60,9 @@ export const SubscriptionContent = ({
     currentInvoiceTotal,
     currentInvoiceUrl,
     currentPeriodEnd,
+    isEligibleForChurnCancel,
+    isEligibleForChurnStaySubscribed,
+    isEligibleForOffer,
     nextInvoiceTax,
     nextInvoiceTotal,
     nextPromotionName,
@@ -250,9 +255,7 @@ export const SubscriptionContent = ({
             </div>
 
             <div>
-              <p>
-                {subscription.churnStaySubscribedCtaMessage}
-              </p>
+              <p>{subscription.churnStaySubscribedCtaMessage}</p>
               <LinkExternal
                 href={`/${locale}/${subscription.offeringApiIdentifier}/${subscription.interval}/stay_subscribed/loyalty-discount/terms`}
                 className="w-fit text-sm text-blue-500 underline hover:text-blue-600"
@@ -262,7 +265,7 @@ export const SubscriptionContent = ({
                   'View coupon terms and restrictions'
                 )}
               >
-                <Localized id='subscription-content-link-churn-intervention-terms-apply'>
+                <Localized id="subscription-content-link-churn-intervention-terms-apply">
                   <span>Terms apply</span>
                 </Localized>
               </LinkExternal>
@@ -272,7 +275,11 @@ export const SubscriptionContent = ({
         <div className="ms-auto w-full tablet:w-auto">
           {canResubscribe ? (
             <Link
-              href={`/${locale}/subscriptions/${subscription.id}/stay-subscribed`}
+              href={
+                isEligibleForChurnStaySubscribed
+                  ? `/${locale}/subscriptions/${subscription.id}/loyalty-discount/stay-subscribed`
+                  : `/${locale}/subscriptions/${subscription.id}/stay-subscribed`
+              }
               className="border box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-blue-500 hover:bg-blue-700 text-white w-full tablet:w-auto"
               aria-label={`Stay subscribed to ${productName}`}
             >
@@ -285,7 +292,13 @@ export const SubscriptionContent = ({
             </Link>
           ) : (
             <Link
-              href={`/${locale}/subscriptions/${subscription.id}/cancel`}
+              href={
+                isEligibleForChurnCancel
+                  ? `/${locale}/subscriptions/${subscription.id}/loyalty-discount/cancel`
+                  : isEligibleForOffer
+                    ? `/${locale}/subscriptions/${subscription.id}/offer`
+                    : `/${locale}/subscriptions/${subscription.id}/cancel`
+              }
               className="border border-grey-200 box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-grey-10 hover:bg-grey-50 w-full tablet:w-auto"
               aria-label={`Cancel your subscription to ${productName}`}
             >

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -663,33 +663,12 @@ export class NextJSActionsService {
     acceptLanguage?: string | null;
     selectedLanguage?: string;
   }) {
-    const result =
-      await this.subscriptionManagementService.getCancelFlowContent(
-        args.uid,
-        args.subscriptionId,
-        args.acceptLanguage || undefined,
-        args.selectedLanguage
-      );
-
-    const churnCancelEligibility =
-      await this.churnInterventionService.determineCancellationIntervention({
-        uid: args.uid,
-        subscriptionId: args.subscriptionId,
-        acceptLanguage: args.acceptLanguage,
-        selectedLanguage: args.selectedLanguage,
-      });
-
-    return {
-      ...result,
-      isEligibleForChurnCancel:
-        churnCancelEligibility.reason === 'eligible' &&
-        churnCancelEligibility.cancelChurnInterventionType ===
-          'cancel_churn_intervention',
-      isEligibleForCancelInterstitialOffer:
-        churnCancelEligibility.reason === 'eligible' &&
-        churnCancelEligibility.cancelChurnInterventionType ===
-          'cancel_interstitial_offer',
-    };
+    return await this.subscriptionManagementService.getCancelFlowContent(
+      args.uid,
+      args.subscriptionId,
+      args.acceptLanguage || undefined,
+      args.selectedLanguage
+    );
   }
 
   @SanitizeExceptions()
@@ -705,27 +684,12 @@ export class NextJSActionsService {
     acceptLanguage?: string | null;
     selectedLanguage?: string;
   }) {
-    const result =
-      await this.subscriptionManagementService.getStaySubscribedFlowContent(
-        args.uid,
-        args.subscriptionId,
-        args.acceptLanguage || undefined,
-        args.selectedLanguage
-      );
-
-    const churnStaySubscribedEligibility =
-      await this.churnInterventionService.determineStaySubscribedEligibility(
-        args.uid,
-        args.subscriptionId,
-        args.acceptLanguage,
-        args.selectedLanguage
-      );
-
-    return {
-      ...result,
-      isEligibleforChurnStaySubscribed:
-        churnStaySubscribedEligibility.isEligible,
-    };
+    return this.subscriptionManagementService.getStaySubscribedFlowContent(
+      args.uid,
+      args.subscriptionId,
+      args.acceptLanguage || undefined,
+      args.selectedLanguage
+    );
   }
 
   @SanitizeExceptions()

--- a/libs/shared/cms/src/lib/queries/cancel-interstitial-offer/util.ts
+++ b/libs/shared/cms/src/lib/queries/cancel-interstitial-offer/util.ts
@@ -10,19 +10,18 @@ import * as Sentry from '@sentry/node';
 
 export class CancelInterstitialOfferUtil {
   constructor(private rawResult: CancelInterstitialOfferResult) {}
-  getTransformedResult(): CancelInterstitialOfferTransformed {
-    if (this.rawResult.cancelInterstitialOffers.length !== 1) {
+  getTransformedResult(): CancelInterstitialOfferTransformed | undefined {
+    const offers = this.rawResult?.cancelInterstitialOffers ?? [];
+
+    if (offers.length !== 1) {
       Sentry.captureMessage(
         'Unexpected number of cancel interstitial offers found for api identifier, intervals, and locale',
-        {
-          extra: {
-            cancelInterstitialOffersCount:
-              this.rawResult.cancelInterstitialOffers.length,
-          },
-        }
+        { extra: { cancelInterstitialOffersCount: offers.length } }
       );
     }
-    const cancelInterstitialOffer = this.rawResult.cancelInterstitialOffers[0];
+
+    const cancelInterstitialOffer = offers.at(0);
+    if (!cancelInterstitialOffer) return undefined;
 
     return {
       ...cancelInterstitialOffer,
@@ -39,24 +38,17 @@ export class CancelInterstitialOfferUtil {
         cancelInterstitialOffer.localizations.at(0)?.modalMessage ??
           cancelInterstitialOffer.modalMessage
       ),
-      productPageUrl:
-        cancelInterstitialOffer.localizations.at(0)?.productPageUrl ??
-        cancelInterstitialOffer.productPageUrl,
+      productPageUrl: cancelInterstitialOffer.productPageUrl,
       upgradeButtonLabel:
         cancelInterstitialOffer.localizations.at(0)?.upgradeButtonLabel ??
         cancelInterstitialOffer.upgradeButtonLabel,
-      upgradeButtonUrl:
-        cancelInterstitialOffer.localizations.at(0)?.upgradeButtonUrl ??
-        cancelInterstitialOffer.upgradeButtonUrl,
+      upgradeButtonUrl: cancelInterstitialOffer.upgradeButtonUrl,
       offering: {
         ...cancelInterstitialOffer.offering,
         defaultPurchase: {
           purchaseDetails: {
             ...cancelInterstitialOffer.offering.defaultPurchase.purchaseDetails,
             webIcon:
-              cancelInterstitialOffer.offering.defaultPurchase.purchaseDetails.localizations.at(
-                0
-              )?.webIcon ??
               cancelInterstitialOffer.offering.defaultPurchase.purchaseDetails
                 .webIcon,
           },


### PR DESCRIPTION
## This pull request

Navigate to appropriate pages from the Subscription Management page, per subscription:
- Stay subscribed flow
  - If the customer is eligible for the churn coupon, the “Stay subscribed” button will navigate to /[locale]/subscriptions/[subscription_id]/loyalty-discount/stay-subscribed
  - If no churn coupon is available, the “Stay subscribed” button will navigate to /[locale]/subscriptions/[subscription_id]/stay-subscribed 

- Cancel subscription flow
  - If customer is eligible for churn coupon, the “Cancel subscription” will navigate to /[locale/subscriptions/[subscription_id]/loyalty-discount/cancel
  - If no churn coupon is available, but there is a cancel interstitial offer, the “Cancel subscription” button will navigate to /[locale]/subscriptions/[subscription_id]/offer 
  - If no churn coupon or cancel interstitial offer is available, the “Cancel subscription” button will navigate to /[locale]/subscriptions/[subscription_id]/cancel

## Issue that this pull request solves

Closes: PAY-3455

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.