### PR TITLE
fix(email-renderer): Remove subscriptionAccountFinishSetup from index

### DIFF
--- a/libs/accounts/email-renderer/src/templates/index.ts
+++ b/libs/accounts/email-renderer/src/templates/index.ts
@@ -48,7 +48,6 @@ export * as fraudulentAccountDeletion from './fraudulentAccountDeletion';
 export * as inactiveAccountFirstWarning from './inactiveAccountFirstWarning';
 export * as inactiveAccountSecondWarning from './inactiveAccountSecondWarning';
 export * as inactiveAccountFinalWarning from './inactiveAccountFinalWarning';
-export * as subscriptionAccountFinishSetup from './subscriptionAccountFinishSetup';
 export * as subscriptionAccountReminderFirst from './subscriptionAccountReminderFirst';
 export * as subscriptionAccountReminderSecond from './subscriptionAccountReminderSecond';
 export * as subscriptionReactivation from './subscriptionReactivation';


### PR DESCRIPTION
## This pull request

- Removed subscriptionAccountFinishSetup from index as it no longer exists

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.