### PR TITLE
fix(email-renderer): Remove default acceptLanguage from email-renderer

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/email-renderer.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-renderer.ts
@@ -84,7 +84,7 @@ export class EmailRenderer extends Localizer {
       includes,
     } = templateContext;
     const { l10n, selectedLocale } = await super.setupDomLocalizer(
-      acceptLanguage || 'en-US'
+      acceptLanguage || ''
     );
 
     const context = {

--- a/libs/accounts/email-renderer/src/templates/index.ts
+++ b/libs/accounts/email-renderer/src/templates/index.ts
@@ -48,7 +48,6 @@ export * as fraudulentAccountDeletion from './fraudulentAccountDeletion';
 export * as inactiveAccountFirstWarning from './inactiveAccountFirstWarning';
 export * as inactiveAccountSecondWarning from './inactiveAccountSecondWarning';
 export * as inactiveAccountFinalWarning from './inactiveAccountFinalWarning';
-export * as subscriptionAccountFinishSetup from './subscriptionAccountFinishSetup';
 export * as subscriptionAccountReminderFirst from './subscriptionAccountReminderFirst';
 export * as subscriptionAccountReminderSecond from './subscriptionAccountReminderSecond';
 export * as subscriptionReactivation from './subscriptionReactivation';

--- a/packages/fxa-auth-server/scripts/install-ejs.sh
+++ b/packages/fxa-auth-server/scripts/install-ejs.sh
@@ -6,7 +6,9 @@
 # the package used by the browser.
 
 # Get current version
-ejs_version=$(npm info ejs version)
+# ejs_version=$(npm info ejs version)
+# Temoporary fix for now... Latest version doesn't have minified file
+ejs_version=3.1.10
 
 # Ensure vendor dir
 [ ! -d "./vendor" ] && mkdir vendor


### PR DESCRIPTION
Because:
 - Using the wrong default causes the snapshots to not find l10n ftls

This Commit:
 - Reverts the default value to use proper, internal default
 - Adds a temporary fix for an issue with ejs
 - Removes an unused import in email-renderer

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
