### PR TITLE
fix(payments-next): Unexpected number of cancel interstitial offers found for api identifier, intervals, and locale

### DIFF
--- a/libs/shared/cms/src/lib/queries/cancel-interstitial-offer/util.ts
+++ b/libs/shared/cms/src/lib/queries/cancel-interstitial-offer/util.ts
@@ -13,7 +13,7 @@ export class CancelInterstitialOfferUtil {
   getTransformedResult(): CancelInterstitialOfferTransformed | undefined {
     const offers = this.rawResult?.cancelInterstitialOffers ?? [];
 
-    if (offers.length !== 1) {
+    if (offers.length > 1) {
       Sentry.captureMessage(
         'Unexpected number of cancel interstitial offers found for api identifier, intervals, and locale',
         { extra: { cancelInterstitialOffersCount: offers.length } }


### PR DESCRIPTION
## Because

- 0 and 1 are expected, more than 1 isnt. Right now, Sentry reports an issue when offers.length is not 1.

## This pull request

- Changes if (offers.length !== 1) { to if (offers.length > 1

Closes: PAY-3470

## Issue that this pull request solves

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
