### PR TITLE
Support new Firefox webchannel message to resume login

### DIFF
--- a/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.test.tsx
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useOAuthFlowRecovery } from '.';
+import firefox from '../../channels/firefox';
+import * as ReactUtils from 'fxa-react/lib/utils';
+import {
+  IntegrationType,
+  isProbablyFirefox,
+  isOAuthNativeIntegration,
+} from '../../../models';
+
+jest.mock('../../channels/firefox', () => ({
+  __esModule: true,
+  default: {
+    fxaOAuthFlowBegin: jest.fn(),
+  },
+}));
+
+jest.mock('../../../models', () => {
+  const actual = jest.requireActual('../../../models');
+  return {
+    ...actual,
+    isProbablyFirefox: jest.fn(() => true),
+    isOAuthNativeIntegration: jest.fn(() => true),
+  };
+});
+
+const mockIntegration = (isOAuthNative: boolean = true) => {
+  (isOAuthNativeIntegration as unknown as jest.Mock).mockReturnValue(
+    isOAuthNative
+  );
+  return {
+    type: IntegrationType.OAuthNative,
+    getPermissions: jest
+      .fn()
+      .mockReturnValue(['profile', 'https://identity.mozilla.com/apps/oldsync']),
+  };
+};
+
+describe('useOAuthFlowRecovery', () => {
+  let hardNavigateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isProbablyFirefox as unknown as jest.Mock).mockReturnValue(true);
+    (isOAuthNativeIntegration as unknown as jest.Mock).mockReturnValue(true);
+    hardNavigateSpy = jest
+      .spyOn(ReactUtils, 'hardNavigate')
+      .mockImplementation(() => {});
+
+    Object.defineProperty(window, 'location', {
+      value: { search: '?flowId=abc123&utm_source=firefox' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    hardNavigateSpy.mockRestore();
+  });
+
+  it('skips recovery for non-OAuth Native integrations', async () => {
+    const integration = mockIntegration(false);
+    const { result } = renderHook(() =>
+      useOAuthFlowRecovery(integration as any)
+    );
+
+    let response: any;
+    await act(async () => {
+      response = await result.current.attemptOAuthFlowRecovery();
+    });
+
+    expect(response.success).toBe(false);
+    expect(firefox.fxaOAuthFlowBegin).not.toHaveBeenCalled();
+  });
+
+  it('skips recovery for non-Firefox browsers', async () => {
+    (isProbablyFirefox as unknown as jest.Mock).mockReturnValue(false);
+    const integration = mockIntegration();
+    const { result } = renderHook(() =>
+      useOAuthFlowRecovery(integration as any)
+    );
+
+    let response: any;
+    await act(async () => {
+      response = await result.current.attemptOAuthFlowRecovery();
+    });
+
+    expect(response.success).toBe(false);
+    expect(firefox.fxaOAuthFlowBegin).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /signin with fresh OAuth params on success', async () => {
+    (firefox.fxaOAuthFlowBegin as jest.Mock).mockResolvedValue({
+      client_id: 'new-client-id',
+      state: 'new-state',
+      scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      access_type: 'offline',
+      action: 'signin',
+      code_challenge: 'pkce-challenge',
+      code_challenge_method: 'S256',
+    });
+
+    const integration = mockIntegration();
+    const { result } = renderHook(() =>
+      useOAuthFlowRecovery(integration as any)
+    );
+
+    let response: any;
+    await act(async () => {
+      response = await result.current.attemptOAuthFlowRecovery();
+    });
+
+    expect(response.success).toBe(true);
+    const url = hardNavigateSpy.mock.calls[0][0];
+    expect(url).toContain('/signin?');
+    expect(url).toContain('client_id=new-client-id');
+    expect(url).toContain('state=new-state');
+    expect(url).toContain('context=oauth_webchannel_v1');
+    expect(url).toContain('flowId=abc123'); // preserved
+    expect(url).toContain('utm_source=firefox'); // preserved
+  });
+
+  it('sets recoveryFailed when fxaOAuthFlowBegin returns null', async () => {
+    (firefox.fxaOAuthFlowBegin as jest.Mock).mockResolvedValue(null);
+
+    const integration = mockIntegration();
+    const { result } = renderHook(() =>
+      useOAuthFlowRecovery(integration as any)
+    );
+
+    expect(result.current.recoveryFailed).toBe(false);
+
+    await act(async () => {
+      await result.current.attemptOAuthFlowRecovery();
+    });
+
+    expect(result.current.recoveryFailed).toBe(true);
+    expect(hardNavigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('sets recoveryFailed when fxaOAuthFlowBegin throws', async () => {
+    (firefox.fxaOAuthFlowBegin as jest.Mock).mockRejectedValue(
+      new Error('WebChannel error')
+    );
+
+    const integration = mockIntegration();
+    const { result } = renderHook(() =>
+      useOAuthFlowRecovery(integration as any)
+    );
+
+    let response: any;
+    await act(async () => {
+      response = await result.current.attemptOAuthFlowRecovery();
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toBeDefined();
+    expect(result.current.recoveryFailed).toBe(true);
+  });
+
+  it('uses fallback scopes when getPermissions throws', async () => {
+    (firefox.fxaOAuthFlowBegin as jest.Mock).mockResolvedValue(null);
+
+    const integration = {
+      type: IntegrationType.OAuthNative,
+      getPermissions: jest.fn().mockImplementation(() => {
+        throw new Error('No permissions');
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useOAuthFlowRecovery(integration as any)
+    );
+
+    await act(async () => {
+      await result.current.attemptOAuthFlowRecovery();
+    });
+
+    expect(firefox.fxaOAuthFlowBegin).toHaveBeenCalledWith([
+      'profile',
+      'https://identity.mozilla.com/apps/oldsync',
+    ]);
+  });
+});

--- a/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.tsx
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useState } from 'react';
+import {
+  Integration,
+  isOAuthNativeIntegration,
+  isProbablyFirefox,
+} from '../../../models';
+import firefox from '../../channels/firefox';
+import { hardNavigate } from 'fxa-react/lib/utils';
+
+export type OAuthFlowRecoveryResult = {
+  isRecovering: boolean;
+  recoveryFailed: boolean;
+  attemptOAuthFlowRecovery: () => Promise<{ success: boolean; error?: Error }>;
+};
+
+/**
+ * Recovers from broken OAuth Native flows after page refresh or browser crash.
+ * Uses Firefox webchannel to get fresh OAuth params and redirects to /signin.
+ */
+export function useOAuthFlowRecovery(
+  integration: Integration
+): OAuthFlowRecoveryResult {
+  const [isRecovering, setIsRecovering] = useState(false);
+  const [recoveryFailed, setRecoveryFailed] = useState(false);
+
+  const attemptOAuthFlowRecovery = useCallback(async () => {
+    // Only attempt recovery for OAuth Native integrations (Firefox/Sync)
+    if (!isOAuthNativeIntegration(integration) || !isProbablyFirefox()) {
+      return { success: false };
+    }
+
+    setIsRecovering(true);
+    setRecoveryFailed(false);
+
+    try {
+      // Get scopes from integration or use default Sync scopes
+      let scopes: string[];
+      try {
+        scopes = integration.getPermissions();
+      } catch (e) {
+        scopes = ['profile', 'https://identity.mozilla.com/apps/oldsync'];
+      }
+
+      // Start a new OAuth flow in Firefox to get fresh params
+      const params = await firefox.fxaOAuthFlowBegin(scopes);
+      if (!params) {
+        setRecoveryFailed(true);
+        return { success: false };
+      }
+
+      // Build redirect URL preserving existing flow/utm params
+      const currentParams = new URLSearchParams(window.location.search);
+      currentParams.set('client_id', params.client_id);
+      currentParams.set('state', params.state);
+      currentParams.set('scope', params.scope);
+      currentParams.set('access_type', params.access_type || 'offline');
+      currentParams.set('context', 'oauth_webchannel_v1');
+
+      if (params.action) {
+        currentParams.set('action', params.action);
+      }
+      if (params.code_challenge) {
+        currentParams.set('code_challenge', params.code_challenge);
+      }
+      if (params.code_challenge_method) {
+        currentParams.set('code_challenge_method', params.code_challenge_method);
+      }
+
+      // Redirect to /signin - user will re-enter password
+      hardNavigate(`/signin?${currentParams.toString()}`);
+
+      return { success: true };
+    } catch (error) {
+      console.error('[useOAuthFlowRecovery] Error during recovery:', error);
+      setRecoveryFailed(true);
+      return { success: false, error: error as Error };
+    } finally {
+      setIsRecovering(false);
+    }
+  }, [integration]);
+
+  return {
+    isRecovering,
+    recoveryFailed,
+    attemptOAuthFlowRecovery,
+  };
+}
+
+export default useOAuthFlowRecovery;

--- a/packages/fxa-settings/src/pages/Signin/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/en.ftl
@@ -19,6 +19,9 @@ signin-desktop-relay = { -brand-firefox } will try sending you back to use an em
 
 signin-code-expired-error = Code expired. Please sign in again.
 
+# Error message displayed when OAuth native flow recovery fails
+signin-recovery-error = Something went wrong. Please sign in again.
+
 signin-account-locked-banner-heading = Reset your password
 signin-account-locked-banner-description = We locked your account to keep it safe from suspicious activity.
 # This link points to https://accounts.firefox.com/reset_password


### PR DESCRIPTION
## Because

  - Users refreshing the confirmation code page during Firefox Sync OAuth flow saw "Bad Request" error
  - In-memory OAuth keys (`keyFetchToken`, `unwrapBKey`) are lost on page refresh with no recovery path

  ## This pull request

  - Adds [`useOAuthFlowRecovery`](https://github.com/mozilla/fxa/blob/fxa-12118/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.tsx) hook to recover from interrupted OAuth Native flows via Firefox webchannel
  - Adds `fxaOAuthFlowBegin` and `fxaOAuthFlowIsActive` commands to [`firefox.ts`](https://github.com/mozilla/fxa/blob/fxa-12118/packages/fxa-settings/src/lib/channels/firefox.ts)
  - Updates [`SigninTokenCode`](https://github.com/mozilla/fxa/blob/fxa-12118/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx) and [`ConfirmSignupCode`](https://github.com/mozilla/fxa/blob/fxa-12118/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx) to attempt recovery when state is missing
  - Redirects to `/signin` with fresh OAuth params on successful recovery

  ## Issue

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-12118

  ## Checklist

  - [x] My commit is GPG signed
  - [x] Tests pass locally (if applicable)
  - [ ] Documentation updated (if applicable)
  - [ ] RTL rendering verified (if UI changed)

  ## Other Information

  **How to test:**
  1. Open Firefox → Settings → Sync → Sign in
  2. Enter credentials, reach confirmation code page
  3. Refresh the page (F5)
  4. Should redirect to `/signin` instead of "Bad Request" error

  **Note:** Requires Firefox with `fxaccounts:oauth_flow_begin` webchannel support

YOu can download it here: https://drive.google.com/file/d/1oKZHHJXqJ5C0LniU-iJwxnLoCQE1FvWt/view?usp=drive_link