### PR TITLE
fix(next): show relevant stripe error msg

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
@@ -17,10 +17,8 @@ import { getStripeClientSession } from '@fxa/payments/ui/actions';
 
 export default async function StripePaymentManagementPage({
   params,
-  searchParams,
 }: {
   params: ManageParams;
-  searchParams: Record<string, string | string[]> | undefined;
 }) {
   const session = await auth();
   const { locale } = params;
@@ -44,6 +42,9 @@ export default async function StripePaymentManagementPage({
   const { clientSecret, defaultPaymentMethod, currency } =
     stripeClientSession;
 
+  // Only change the instanceKey, thereby remounting the StripeManagementWrapper, when the defaultPaymentMethod changes.
+  const instanceKey = defaultPaymentMethod ? `${defaultPaymentMethod.type}-${defaultPaymentMethod.id}` : uuidv4();
+
   return (
     <section
       className="w-full tablet:px-8 desktop:max-w-[1024px]"
@@ -54,7 +55,7 @@ export default async function StripePaymentManagementPage({
         locale={locale}
         currency={currency}
         sessionSecret={clientSecret}
-        instanceKey={uuidv4()}
+        instanceKey={instanceKey}
       >
         <PaymentMethodManagement
           uid={session?.user?.id}

--- a/libs/payments/customer/src/lib/setupIntent.manager.spec.ts
+++ b/libs/payments/customer/src/lib/setupIntent.manager.spec.ts
@@ -55,6 +55,7 @@ describe('SetupIntentManager', () => {
           enabled: true,
           allow_redirects: 'never',
         },
+        use_stripe_sdk: true,
       });
       expect(result).toEqual(mockResponse);
     });

--- a/libs/payments/customer/src/lib/setupIntent.manager.ts
+++ b/libs/payments/customer/src/lib/setupIntent.manager.ts
@@ -19,6 +19,7 @@ export class SetupIntentManager {
         enabled: true,
         allow_redirects: 'never',
       },
+      use_stripe_sdk: true,
     });
   }
 

--- a/libs/payments/ui/src/lib/actions/updateStripePaymentDetails.ts
+++ b/libs/payments/ui/src/lib/actions/updateStripePaymentDetails.ts
@@ -12,7 +12,7 @@ export const updateStripePaymentDetails = async (
 ) => {
   const actionsService = getApp().getActionsService();
 
-  return await actionsService.updateStripePaymentDetails({
+  return actionsService.updateStripePaymentDetails({
     uid,
     confirmationTokenId,
   });

--- a/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
+++ b/libs/payments/ui/src/lib/client/components/StripeWrapper.tsx
@@ -108,10 +108,10 @@ interface StripeWrapperProps {
   cart: {
     paymentInfo?: {
       type:
-        | Stripe.PaymentMethod.Type
-        | 'google_iap'
-        | 'apple_iap'
-        | 'external_paypal';
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -915,10 +915,24 @@ export class NextJSActionsService {
     uid: string;
     confirmationTokenId: string;
   }) {
-    return await this.subscriptionManagementService.updateStripePaymentDetails(
-      args.uid,
-      args.confirmationTokenId
-    );
+    try {
+      const result =
+        await this.subscriptionManagementService.updateStripePaymentDetails(
+          args.uid,
+          args.confirmationTokenId
+        );
+      return {
+        ok: true,
+        result,
+        errorMessage: null,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        result: null,
+        errorMessage: error.message,
+      };
+    }
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/TemplateResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/TemplateResult.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Validate,
+  ValidateNested,
+  ValidatorConstraint,
+  type ValidationArguments,
+  type ValidatorConstraintInterface,
+} from 'class-validator';
+
+@ValidatorConstraint({ name: 'ResultErrorConsistency', async: false })
+class ResultErrorConsistency implements ValidatorConstraintInterface {
+  validate(_: any, args: ValidationArguments) {
+    const obj = args.object as TemplateResult;
+
+    if (obj.ok) {
+      return obj.result != null && obj.errorMessage == null;
+    }
+
+    return obj.result == null && typeof obj.errorMessage === 'string';
+  }
+
+  defaultMessage() {
+    return 'Invalid combination of ok, result, and errorMessage';
+  }
+}
+
+class TemplateSuccessResponse {
+  @IsString()
+  id!: string;
+}
+
+export class TemplateResult {
+  @IsBoolean()
+  ok!: boolean;
+
+  @ValidateNested()
+  @Type(() => TemplateSuccessResponse)
+  @IsOptional()
+  result!: TemplateSuccessResponse | null;
+
+  @IsString()
+  @IsOptional()
+  errorMessage!: string | null;
+
+  @Validate(ResultErrorConsistency)
+  _consistencyCheck!: boolean;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/UpdateStripePaymentDetailsActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/UpdateStripePaymentDetailsActionResult.ts
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsOptional, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { TemplateResult } from './TemplateResult';
 
-export class UpdateStripePaymentDetailsResult {
+class UpdateStripePaymentDetailsSuccessResponse {
   @IsString()
   id!: string;
 
@@ -14,4 +16,11 @@ export class UpdateStripePaymentDetailsResult {
   @IsString()
   @IsOptional()
   clientSecret?: string;
+}
+
+export class UpdateStripePaymentDetailsResult extends TemplateResult {
+  @ValidateNested()
+  @Type(() => UpdateStripePaymentDetailsSuccessResponse)
+  @IsOptional()
+  result!: UpdateStripePaymentDetailsSuccessResponse | null;
 }

--- a/libs/payments/ui/src/lib/utils/getManagePaymentMethodErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getManagePaymentMethodErrorFtlInfo.ts
@@ -2,9 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export function getManagePaymentMethodErrorFtlInfo(
-  errorCode: string,
-) {
+export function getManagePaymentMethodErrorFtlInfo(errorCode?: string) {
   switch (errorCode) {
     case 'intent_failed_card_declined':
       return {


### PR DESCRIPTION
## Because

- Although a specific error message is thrown from the backend, the SubManage stripe payment method page still shows the generic error message.

## This pull request

- Updates the nextjs action service to return the error message instead of the entire Error object. In a production environment, the entire error object could not be passed to the frontend, resulting in the generic error message being shown.
- Only change the StripeManagementWrapper instanceKey when the default payment method has changed and the component needs to be refreshed.

## Issue that this pull request solves

Closes: PAY-3460

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
