### PR TITLE
polish(accounts-email): A little polishing before building

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/email-link-builder.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-link-builder.spec.ts
@@ -10,6 +10,7 @@ describe('EmailLinkBuilder', () => {
     initiatePasswordResetUrl: 'http://localhost:3030/reset_password',
     privacyUrl: 'http://localhost:3030/privacy',
     supportUrl: 'http://localhost:3030/support',
+    accountSettingsUrl: 'http://localhost:3030/settings',
   };
 
   let linkBuilder: EmailLinkBuilder;
@@ -18,108 +19,11 @@ describe('EmailLinkBuilder', () => {
     linkBuilder = new EmailLinkBuilder(mockConfig);
   });
 
-  describe('urls getter', () => {
-    it('should return configured URLs', () => {
-      const urls = linkBuilder.urls;
-
-      expect(urls.initiatePasswordReset).toBe(
-        'http://localhost:3030/reset_password'
-      );
-      expect(urls.privacy).toBe('http://localhost:3030/privacy');
-      expect(urls.support).toBe('http://localhost:3030/support');
-    });
-  });
-
-  describe('getCampaign', () => {
-    it('should return campaign with prefix for valid template', () => {
-      const templateName = 'recovery';
-
-      const campaign = linkBuilder.getCampaign(templateName);
-
-      expect(campaign).toBe('fx-forgot-password');
-    });
-
-    it('should return empty string for unknown template', () => {
-      const templateName = 'unknownTemplate';
-
-      const campaign = linkBuilder.getCampaign(templateName);
-
-      expect(campaign).toBe('');
-    });
-  });
-
-  describe('getContent', () => {
-    it('should return content for valid template', () => {
-      const templateName = 'recovery';
-
-      const content = linkBuilder.getContent(templateName);
-
-      expect(content).toBe('reset-password');
-    });
-
-    it('should return empty string for unknown template', () => {
-      const templateName = 'unknownTemplate';
-
-      const content = linkBuilder.getContent(templateName);
-
-      expect(content).toBe('');
-    });
-  });
-
-  describe('addUTMParams', () => {
-    it('should add UTM parameters when metrics enabled', () => {
-      const link = new URL('http://localhost:3030/some-page');
-      const templateName = 'recovery';
-
-      linkBuilder.addUTMParams(link, templateName);
-
-      expect(link.searchParams.get('utm_medium')).toBe('email');
-      expect(link.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
-      expect(link.searchParams.get('utm_content')).toBe('fx-reset-password');
-    });
-
-    it('should use custom content when provided', () => {
-      const link = new URL('http://localhost:3030/some-page');
-      const templateName = 'recovery';
-      const customContent = 'custom-content';
-
-      linkBuilder.addUTMParams(link, templateName, customContent);
-
-      expect(link.searchParams.get('utm_content')).toBe('fx-custom-content');
-    });
-
-    it('should not add UTM parameters when metrics disabled', () => {
-      const disabledLinkBuilder = new EmailLinkBuilder({
-        ...mockConfig,
-        metricsEnabled: false,
-      });
-      const link = new URL('http://localhost:3030/some-page');
-      const templateName = 'recovery';
-
-      disabledLinkBuilder.addUTMParams(link, templateName);
-
-      expect(link.searchParams.get('utm_medium')).toBeNull();
-      expect(link.searchParams.get('utm_campaign')).toBeNull();
-      expect(link.searchParams.get('utm_content')).toBeNull();
-    });
-
-    it('should not override existing utm_campaign', () => {
-      const link = new URL(
-        'http://localhost:3030/some-page?utm_campaign=existing'
-      );
-      const templateName = 'recovery';
-
-      linkBuilder.addUTMParams(link, templateName);
-
-      expect(link.searchParams.get('utm_campaign')).toBe('existing');
-    });
-  });
-
   describe('buildCommonLinks', () => {
     it('should build privacy and support links with UTM params', () => {
       const templateName = 'recovery';
 
-      const links = linkBuilder.buildCommonLinks(templateName);
+      const links = linkBuilder.buildCommonLinks(templateName, true);
 
       expect(links.privacyUrl).toContain('http://localhost:3030/privacy');
       expect(links.privacyUrl).toContain('utm_medium=email');
@@ -135,40 +39,52 @@ describe('EmailLinkBuilder', () => {
 
   describe('buildLinkWithQueryParamsAndUTM', () => {
     it('should add query params and UTM params to link', () => {
-      const link = new URL('http://localhost:3030/some-page');
-      const templateName = 'recovery';
-      const queryParams = {
-        uid: '12345',
-        token: 'abc123',
-        email: 'test@example.com',
-      };
-
-      linkBuilder.buildLinkWithQueryParamsAndUTM(
-        link,
-        templateName,
-        queryParams
+      const link = linkBuilder.buildLinkWithQueryParamsAndUTM(
+        'http://localhost:3030/some-page',
+        'recovery',
+        {
+          uid: '12345',
+          token: 'abc123',
+          email: 'test@example.com',
+        },
+        true
       );
 
-      expect(link.searchParams.get('uid')).toBe('12345');
-      expect(link.searchParams.get('token')).toBe('abc123');
-      expect(link.searchParams.get('email')).toBe('test@example.com');
-      expect(link.searchParams.get('utm_medium')).toBe('email');
-      expect(link.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
+      const url = new URL(link);
+      expect(url.searchParams.get('uid')).toBe('12345');
+      expect(url.searchParams.get('token')).toBe('abc123');
+      expect(url.searchParams.get('email')).toBe('test@example.com');
+      expect(url.searchParams.get('utm_medium')).toBe('email');
+      expect(url.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
     });
 
     it('should handle empty query params', () => {
-      const link = new URL('http://localhost:3030/some-page');
       const templateName = 'recovery';
       const queryParams = {};
 
-      linkBuilder.buildLinkWithQueryParamsAndUTM(
-        link,
+      const link = linkBuilder.buildLinkWithQueryParamsAndUTM(
+        'http://localhost:3030/some-page',
         templateName,
-        queryParams
+        queryParams,
+        true
       );
 
-      expect(link.searchParams.get('utm_medium')).toBe('email');
-      expect(link.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
+      const url = new URL(link);
+      expect(url.searchParams.get('utm_medium')).toBe('email');
+      expect(url.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
+    });
+
+    it('should respect metricsEnabled flag', () => {
+      const link = linkBuilder.buildLinkWithQueryParamsAndUTM(
+        'http://localhost:3030/some-page',
+        'recovery',
+        {},
+        false
+      );
+
+      const url = new URL(link);
+      expect(url.searchParams.get('utm_medium')).toBeNull();
+      expect(url.searchParams.get('utm_campaign')).toBeNull();
     });
   });
 
@@ -179,7 +95,11 @@ describe('EmailLinkBuilder', () => {
         email: 'test@example.com',
       };
 
-      const link = linkBuilder.buildPasswordChangeRequiredLink(opts);
+      const link = linkBuilder.buildPasswordChangeRequiredLink(
+        opts.url,
+        opts.email,
+        true
+      );
 
       expect(link).toContain('http://localhost:3030/reset_password');
       expect(link).toContain('email=test%40example.com');

--- a/libs/accounts/email-sender/src/email-sender.ts
+++ b/libs/accounts/email-sender/src/email-sender.ts
@@ -104,6 +104,24 @@ type SmtpTransportOptions = nodemailer.TransportOptions & {
   };
 };
 
+export type EmailHeaderContext = {
+  language: string;
+  serverName: string;
+  cmsRpClientId?: string;
+  deviceId?: string;
+  entrypoint?: string;
+  flowBeginTime?: number;
+  flowId?: string;
+  service?: string;
+  uid?: string;
+};
+
+export type EmailTemplateInfo = {
+  name: string;
+  version: number;
+  metricsName?: string;
+};
+
 /**
  * Sends an email to end end user.
  */
@@ -157,23 +175,9 @@ export class EmailSender {
     headers,
     template,
   }: {
-    context: {
-      language: string;
-      serverName: string;
-      cmsRpClientId?: string;
-      deviceId?: string;
-      entrypoint?: string;
-      flowBeginTime?: number;
-      flowId?: string;
-      service?: string;
-      uid?: string;
-    };
+    context: EmailHeaderContext;
     headers: Record<string, string>;
-    template: {
-      name: string;
-      version: number;
-      metricsName?: string;
-    };
+    template: EmailTemplateInfo;
   }) {
     const optionalHeader = (key: string, value?: string | number) => {
       if (value) {

--- a/packages/fxa-admin-server/src/backend/email.service.ts
+++ b/packages/fxa-admin-server/src/backend/email.service.ts
@@ -72,10 +72,11 @@ export class EmailService {
     const linksConfig = this.linksConfig;
 
     // Render the email
-    const link = this.linkBuilder.buildPasswordChangeRequiredLink({
-      url: linksConfig.initiatePasswordResetUrl,
-      email: account.primaryEmail?.email || account.email,
-    });
+    const link = this.linkBuilder.buildPasswordChangeRequiredLink(
+      linksConfig.initiatePasswordResetUrl,
+      account.primaryEmail?.email || account.email,
+      account.metricsOptOutAt === null
+    );
 
     const emailContent = await this.renderer.renderPasswordChangeRequired({
       link,

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -728,6 +728,12 @@ const conf = convict({
       env: 'ACCOUNT_RESET_URL',
       default: 'http://localhost:3030/reset_password',
     },
+    accountSettingsUrl: {
+      doc: 'URL for account settings',
+      format: String,
+      env: 'ACCOUNT_SETTINGS_URL',
+      default: 'http://localhost:3030/settings',
+    },
   },
   smtp: {
     api: {
@@ -926,12 +932,7 @@ const conf = convict({
     ignoreTemplates: {
       doc: 'Always ignore bounces from these email templates',
       format: Array,
-      default: [
-        'verifyLoginCode',
-        'verifyLogin',
-        'recovery',
-        'unblockCode',
-      ],
+      default: ['verifyLoginCode', 'verifyLogin', 'recovery', 'unblockCode'],
       env: 'BOUNCES_IGNORE_TEMPLATES',
     },
   },

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -1049,7 +1049,9 @@ module.exports = function (
             geoData.timeZone
           );
         await fxaMailer.sendPasswordForgotOtpEmail({
+          metricsEnabled: account.metricsEnabled,
           code,
+          uid: account.uid,
           to,
           cc,
           deviceId,


### PR DESCRIPTION
## Because
- We to polish a few things before landing more code in fxa-mailer.


## This pull request

- Pass in metrics enabled
- Handle undefined params in `buildLInkWithQueryParam`
- Small polish on compound types in fxa-mailer
- Normalize on strings as format for links, not url objects
- Better encapsulation for link builder.


## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is pre-work for the using email lib in fxa-auth-server ticket.