### PR TITLE
task(): remove 3rd-party auth deeplink functionality

### DIFF
--- a/packages/fxa-settings/src/components/ThirdPartyAuth/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/__snapshots__/index.test.tsx.snap
@@ -4,8 +4,8 @@ exports[`ThirdPartyAuthComponent buttons match snapshot: apple 1`] = `
 <button
   aria-label="Continue with Apple"
   class="w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
-          bg-black border-transparent
-          "
+        bg-black border-transparent
+        "
   type="submit"
 >
   <svg
@@ -20,8 +20,8 @@ exports[`ThirdPartyAuthComponent buttons match snapshot: google 1`] = `
 <button
   aria-label="Continue with Google"
   class="w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
-          bg-[#F9F4F4] border-[#747775] border-[1px]
-          "
+        bg-[#F9F4F4] border-[#747775] border-[1px]
+        "
   type="submit"
 >
   <svg

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -143,36 +143,6 @@ describe('ThirdPartyAuthComponent', () => {
     expect(onContinueWithApple).not.toHaveBeenCalled();
   });
 
-  it('should deeplink directly to google auth, if deeplink=`googleLogin`', async () => {
-    renderWith({
-      enabled: true,
-      showSeparator: false,
-      deeplink: 'googleLogin',
-      view: 'index',
-    });
-
-    expect(
-      (await screen.findByTestId('google-signin-form-state')).getAttribute(
-        'value'
-      )
-    ).not.toEqual('');
-  });
-
-  it('should deeplink directly to apple auth, if deeplink=`appleLogin`', async () => {
-    renderWith({
-      enabled: true,
-      showSeparator: false,
-      deeplink: 'appleLogin',
-      view: 'index',
-    });
-
-    expect(
-      (await screen.findByTestId('apple-signin-form-state')).getAttribute(
-        'value'
-      )
-    ).not.toEqual('');
-  });
-
   it('hides separator', async () => {
     renderWith({
       enabled: true,

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.tsx
@@ -20,7 +20,6 @@ export type ThirdPartyAuthProps = {
   onContinueWithApple?: FormEventHandler<HTMLFormElement>;
   showSeparator?: boolean;
   viewName?: string;
-  deeplink?: string;
   flowQueryParams?: QueryParams;
   separatorType?: 'or' | 'signInWith';
 };
@@ -35,7 +34,6 @@ const ThirdPartyAuth = ({
   onContinueWithApple,
   showSeparator = true,
   viewName = 'unknown',
-  deeplink,
   flowQueryParams,
   separatorType = 'or',
 }: ThirdPartyAuthProps) => {
@@ -91,7 +89,6 @@ const ThirdPartyAuth = ({
                   <GoogleLogo className="w-full h-auto" />
                 </>
               ),
-              deeplink,
             }}
           />
           <ThirdPartySignInForm
@@ -111,7 +108,6 @@ const ThirdPartyAuth = ({
                   <AppleLogo className="w-full h-auto" />
                 </>
               ),
-              deeplink,
             }}
           />
         </div>
@@ -139,7 +135,6 @@ const ThirdPartySignInForm = ({
   buttonText,
   onSubmit,
   viewName,
-  deeplink,
   flowQueryParams,
 }: {
   party: 'google' | 'apple';
@@ -155,14 +150,12 @@ const ThirdPartySignInForm = ({
   buttonText: ReactElement;
   onSubmit?: FormEventHandler<HTMLFormElement>;
   viewName?: string;
-  deeplink?: string;
   flowQueryParams?: QueryParams;
 }) => {
   const { logViewEventOnce } = useMetrics();
   const { l10n } = useLocalization();
   const stateRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
-  const isDeeplinking = deeplink !== undefined;
 
   const getLoginAriaLabel = () => {
     const labels = {
@@ -201,12 +194,6 @@ const ThirdPartySignInForm = ({
       case 'apple-signup':
         GleanMetrics.thirdPartyAuth.startAppleAuthFromReg();
         break;
-      case 'google-deeplink':
-        GleanMetrics.thirdPartyAuth.googleDeeplink();
-        break;
-      case 'apple-deeplink':
-        GleanMetrics.thirdPartyAuth.appleDeeplink();
-        break;
     }
 
     // wait for all the Glean events to be sent before the page unloads
@@ -220,19 +207,6 @@ const ThirdPartySignInForm = ({
   if (onSubmit === undefined) {
     onSubmit = () => true;
   }
-
-  useEffect(() => {
-    if (deeplink && formRef.current) {
-      // Only deeplink if this is the correct button
-      if (
-        (deeplink === 'googleLogin' && party === 'google') ||
-        (deeplink === 'appleLogin' && party === 'apple')
-      ) {
-        onClick();
-        formRef.current.submit();
-      }
-    }
-  }, [deeplink, onClick, party]);
 
   return (
     <form
@@ -258,22 +232,20 @@ const ThirdPartySignInForm = ({
         <input type="hidden" name="response_mode" value={responseMode} />
       )}
 
-      {!isDeeplinking ? (
-        <button
-          type="submit"
-          className={`w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
-          ${
-            party === 'google'
-              ? 'bg-[#F9F4F4] border-[#747775] border-[1px]'
-              : 'bg-black border-transparent'
-          }
-          `}
-          onClick={onClick}
-          aria-label={getLoginAriaLabel()}
-        >
-          {buttonText}
-        </button>
-      ) : null}
+      <button
+        type="submit"
+        className={`w-[60px] h-[60px] p-4 flex items-center justify-center rounded-full border focus-visible-default outline-offset-2
+        ${
+          party === 'google'
+            ? 'bg-[#F9F4F4] border-[#747775] border-[1px]'
+            : 'bg-black border-transparent'
+        }
+        `}
+        onClick={onClick}
+        aria-label={getLoginAriaLabel()}
+      >
+        {buttonText}
+      </button>
     </form>
   );
 };
@@ -302,7 +274,6 @@ function getState(flowQueryParams: QueryParams | undefined) {
 
   // Remove unwanted keys
   const filteredParams = deleteParams(new URLSearchParams(combinedParams), [
-    'deeplink',
     'email',
     'emailStatusChecked',
     'forceExperiment',

--- a/packages/fxa-settings/src/lib/glean/index.ts
+++ b/packages/fxa-settings/src/lib/glean/index.ts
@@ -427,12 +427,6 @@ const recordEventMetric = (
     case 'third_party_auth_apple_login_start':
       thirdPartyAuth.appleLoginStart.record();
       break;
-    case 'third_party_auth_apple_deeplink':
-      thirdPartyAuth.appleDeeplink.record();
-      break;
-    case 'third_party_auth_google_deeplink':
-      thirdPartyAuth.googleDeeplink.record();
-      break;
     case 'cad_firefox_notnow_submit':
       cadFirefox.notnowSubmit.record();
       break;

--- a/packages/fxa-settings/src/models/pages/index/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/index/query-params.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsEmail, IsIn, IsOptional, Validate } from 'class-validator';
+import { IsEmail, IsOptional, Validate } from 'class-validator';
 import {
   bind,
   KeyTransforms,
@@ -20,9 +20,4 @@ export class IndexQueryParams extends ModelDataProvider {
   @Validate(IsEmailOrEmpty, {})
   @bind(KeyTransforms.snakeCase)
   loginHint: string | undefined;
-
-  @IsOptional()
-  @IsIn(['googleLogin', 'appleLogin'])
-  @bind()
-  deeplink: string | undefined;
 }

--- a/packages/fxa-settings/src/models/pages/signin/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signin/query-params.ts
@@ -11,7 +11,6 @@ import {
   MaxLength,
   Matches,
   Validate,
-  IsIn,
 } from 'class-validator';
 import {
   bind,
@@ -51,9 +50,4 @@ export class SigninQueryParams extends ModelDataProvider {
   @Validate(IsFxaRedirectToUrl, {})
   @bind(T.snakeCase)
   redirectTo: string | undefined = undefined;
-
-  @IsOptional()
-  @IsIn(['googleLogin', 'appleLogin'])
-  @bind(T.snakeCase)
-  deeplink!: string;
 }

--- a/packages/fxa-settings/src/models/pages/signup/query-params.ts
+++ b/packages/fxa-settings/src/models/pages/signup/query-params.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsBoolean, IsEmail, IsIn, IsOptional } from 'class-validator';
-import { bind, KeyTransforms as T, ModelDataProvider } from '../../../lib/model-data';
+import { IsBoolean, IsEmail, IsOptional } from 'class-validator';
+import { bind, ModelDataProvider } from '../../../lib/model-data';
 
 export class SignupQueryParams extends ModelDataProvider {
   // 'email' will be optional once the index page is converted to React
@@ -20,9 +20,4 @@ export class SignupQueryParams extends ModelDataProvider {
   @IsBoolean()
   @bind()
   emailStatusChecked: boolean = false;
-
-  @IsOptional()
-  @IsIn(['googleLogin', 'appleLogin'])
-  @bind(T.snakeCase)
-  deeplink!: string;
 }

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -315,7 +315,6 @@ const IndexContainer = ({
   }, [ftlMsgResolver, deleteAccountSuccess]);
 
   const initialPrefill = prefillEmail || suggestedEmail;
-  const deeplink = queryParamModel.deeplink;
   const isMobile = isMobileDevice();
 
   const cmsInfo = integration.getCmsInfo();
@@ -339,7 +338,6 @@ const IndexContainer = ({
         errorBannerMessage,
         successBannerMessage,
         tooltipErrorMessage,
-        deeplink,
         flowQueryParams,
         isMobile,
         useFxAStatusResult,

--- a/packages/fxa-settings/src/pages/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.test.tsx
@@ -5,14 +5,9 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import {
-  createMockIndexOAuthIntegration,
-  createMockIndexOAuthNativeIntegration,
-  Subject,
-} from './mocks';
+import { createMockIndexOAuthNativeIntegration, Subject } from './mocks';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { MozServices } from '../../lib/types';
-import { MONITOR_CLIENTIDS } from '../../models/integrations/client-matching';
 import GleanMetrics from '../../lib/glean';
 import { MOCK_CMS_INFO } from '../mocks';
 
@@ -217,29 +212,6 @@ describe('Index page', () => {
     expect(
       screen.queryByAltText(MOCK_CMS_INFO.EmailFirstPage.logoAltText)
     ).not.toBeInTheDocument();
-  });
-
-  // This is wrapped so that the HTMLFormElement.submit can be mocked
-  // without affecting other tests.
-  describe('deep linking', () => {
-    beforeEach(() => {
-      HTMLFormElement.prototype.submit = jest.fn();
-    });
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-    it('does not render when deeplinking third party auth', () => {
-      renderWithLocalizationProvider(
-        <Subject
-          integration={createMockIndexOAuthIntegration({
-            clientId: MONITOR_CLIENTIDS[0],
-          })}
-          deeplink="appleLogin"
-        />
-      );
-
-      thirdPartyAuthNotRendered();
-    });
   });
 
   describe('glean metrics', () => {

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -28,7 +28,6 @@ export const Index = ({
   setErrorBannerMessage,
   setSuccessBannerMessage,
   setTooltipErrorMessage,
-  deeplink,
   flowQueryParams,
   isMobile,
   useFxAStatusResult,
@@ -42,8 +41,6 @@ export const Index = ({
   const legalTerms = integration.getLegalTerms();
 
   const emailEngageEventEmitted = useRef(false);
-
-  const isDeeplinking = !!deeplink;
 
   useEffect(() => {
     GleanMetrics.emailFirst.view();
@@ -81,18 +78,6 @@ export const Index = ({
       email: prefillEmail,
     },
   });
-
-  if (isDeeplinking) {
-    // To avoid flickering, we just render third party auth when deeplinking
-    return (
-      <ThirdPartyAuth
-        showSeparator={false}
-        viewName="deeplink"
-        deeplink={deeplink}
-        flowQueryParams={flowQueryParams}
-      />
-    );
-  }
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.EmailFirstPage?.pageTitle;

--- a/packages/fxa-settings/src/pages/Index/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Index/interfaces.ts
@@ -45,7 +45,6 @@ export interface IndexProps extends LocationState {
   errorBannerMessage?: string;
   successBannerMessage?: string;
   tooltipErrorMessage?: string;
-  deeplink?: string;
   flowQueryParams?: QueryParams;
   isMobile: boolean;
   useFxAStatusResult: UseFxAStatusResult;

--- a/packages/fxa-settings/src/pages/Index/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Index/mocks.tsx
@@ -104,7 +104,6 @@ export const Subject = ({
   initialErrorBanner = '',
   initialSuccessBanner = '',
   initialTooltipMessage = '',
-  deeplink,
   isMobile = false,
   supportsKeysOptionalLogin = false,
 }: {
@@ -114,7 +113,6 @@ export const Subject = ({
   initialErrorBanner?: string;
   initialSuccessBanner?: string;
   initialTooltipMessage?: string;
-  deeplink?: string;
   isMobile?: boolean;
   supportsKeysOptionalLogin?: boolean;
 }) => {
@@ -142,7 +140,6 @@ export const Subject = ({
           setErrorBannerMessage,
           setSuccessBannerMessage,
           setTooltipErrorMessage,
-          deeplink,
           isMobile,
           useFxAStatusResult: mockUseFxAStatusResult,
         }}

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -566,8 +566,6 @@ const SigninContainer = ({
     );
   }
 
-  const deeplink = queryParamModel.deeplink;
-
   return (
     <Signin
       {...{
@@ -586,7 +584,6 @@ const SigninContainer = ({
         finishOAuthFlowHandler,
         localizedSuccessBannerHeading,
         localizedSuccessBannerDescription,
-        deeplink,
         flowQueryParams,
         useFxAStatusResult,
         setCurrentSplitLayout,

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -1031,29 +1031,6 @@ describe('Signin component', () => {
       passwordInputNotRendered();
     });
 
-    // This is wrapped so that the HTMLFormElement.submit can be mocked
-    // without affecting other tests.
-    describe('deeplinking', () => {
-      beforeEach(() => {
-        HTMLFormElement.prototype.submit = jest.fn();
-      });
-      afterEach(() => {
-        jest.resetAllMocks();
-      });
-      it('does not render when deeplinking third party auth', () => {
-        renderWithLocalizationProvider(
-          <Subject sessionToken={MOCK_SESSION_TOKEN} deeplink="appleLogin" />
-        );
-
-        expect(
-          screen.queryByRole('button', { name: /Continue with Google/ })
-        ).not.toBeInTheDocument();
-        expect(
-          screen.queryByRole('button', { name: /Continue with Apple/ })
-        ).not.toBeInTheDocument();
-      });
-    });
-
     it('emits an event on forgot password link click', async () => {
       renderWithLocalizationProvider(
         <Subject sessionToken={MOCK_SESSION_TOKEN} />

--- a/packages/fxa-settings/src/pages/Signin/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.tsx
@@ -56,7 +56,6 @@ const Signin = ({
   finishOAuthFlowHandler,
   localizedSuccessBannerHeading,
   localizedSuccessBannerDescription,
-  deeplink,
   flowQueryParams,
   useFxAStatusResult: { supportsKeysOptionalLogin },
   setCurrentSplitLayout,
@@ -90,7 +89,6 @@ const Signin = ({
 
   const legalTerms = integration.getLegalTerms();
 
-  const isDeeplinking = !!deeplink;
   const isServiceWithEmailVerification =
     !!clientId && config.servicesWithEmailVerification.includes(clientId);
 
@@ -358,18 +356,6 @@ const Signin = ({
       sessionToken,
     ]
   );
-
-  if (isDeeplinking) {
-    // To avoid flickering, we only render third party auth and navigate
-    return (
-      <ThirdPartyAuth
-        showSeparator={false}
-        viewName="deeplink"
-        deeplink={deeplink}
-        flowQueryParams={flowQueryParams}
-      />
-    );
-  }
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.SigninPage.pageTitle;

--- a/packages/fxa-settings/src/pages/Signin/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/interfaces.ts
@@ -108,7 +108,6 @@ export interface SigninProps {
   finishOAuthFlowHandler: FinishOAuthFlowHandler;
   localizedSuccessBannerHeading?: string;
   localizedSuccessBannerDescription?: string;
-  deeplink?: string;
   flowQueryParams?: QueryParams;
   useFxAStatusResult: UseFxAStatusResult;
   setCurrentSplitLayout?: (value: boolean) => void;

--- a/packages/fxa-settings/src/pages/Signup/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/container.tsx
@@ -132,12 +132,14 @@ const SignupContainer = ({
         const credentialsV1 = await getCredentials(email, password);
 
         let credentialsV2 = undefined;
-        let v2Payload: {
-          wrapKb: string;
-          authPWVersion2: string;
-          wrapKbVersion2: string;
-          clientSalt: string;
-        } | {} = {};
+        let v2Payload:
+          | {
+              wrapKb: string;
+              authPWVersion2: string;
+              wrapKbVersion2: string;
+              clientSalt: string;
+            }
+          | {} = {};
 
         if (keyStretchExp.queryParamModel.isV2(config)) {
           credentialsV2 = await getCredentialsV2({
@@ -183,7 +185,14 @@ const SignupContainer = ({
         return handleAuthClientError(error);
       }
     },
-    [authClient, integration, wantsKeys, flowQueryParams, keyStretchExp.queryParamModel, config]
+    [
+      authClient,
+      integration,
+      wantsKeys,
+      flowQueryParams,
+      keyStretchExp.queryParamModel,
+      config,
+    ]
   );
 
   const cmsInfo = integration.getCmsInfo();
@@ -198,7 +207,6 @@ const SignupContainer = ({
     );
   }
 
-  const deeplink = queryParamModel.deeplink;
   const isMobile = isMobileDevice();
 
   return (
@@ -208,7 +216,6 @@ const SignupContainer = ({
         email,
         beginSignupHandler,
         useFxAStatusResult,
-        deeplink,
         flowQueryParams,
         isMobile,
         setCurrentSplitLayout,

--- a/packages/fxa-settings/src/pages/Signup/index.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.tsx
@@ -50,7 +50,6 @@ export const Signup = ({
     selectedEnginesForGlean,
     supportsKeysOptionalLogin,
   },
-  deeplink,
   flowQueryParams,
   isMobile,
   setCurrentSplitLayout,
@@ -226,19 +225,6 @@ export const Signup = ({
       sensitiveDataClient,
     ]
   );
-
-  const isDeeplinking = !!deeplink;
-  if (isDeeplinking) {
-    // To avoid flickering, we only render third party auth and navigate
-    return (
-      <ThirdPartyAuth
-        showSeparator={false}
-        viewName="deeplink"
-        deeplink={deeplink}
-        flowQueryParams={flowQueryParams}
-      />
-    );
-  }
 
   const cmsInfo = integration.getCmsInfo();
   const title = cmsInfo?.SignupSetPasswordPage?.pageTitle;

--- a/packages/fxa-settings/src/pages/Signup/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signup/interfaces.ts
@@ -33,7 +33,6 @@ export interface SignupProps {
   email: string;
   beginSignupHandler: BeginSignupHandler;
   useFxAStatusResult: UseFxAStatusResult;
-  deeplink?: string;
   flowQueryParams?: QueryParams;
   isMobile: boolean;
   setCurrentSplitLayout?: (value: boolean) => void;

--- a/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
+++ b/packages/fxa-shared/metrics/glean/fxa-ui-metrics.yaml
@@ -1947,44 +1947,6 @@ cad:
     data_sensitivity:
       - interaction
 third_party_auth:
-  apple_deeplink:
-    type: event
-    description: |
-      User clicked Apple Signin link from an RP hosted site and is taken
-      directly to Apple authentication flow, bypassing Mozilla Accounts email
-      first page.
-    send_in_pings:
-      - events
-    notification_emails:
-      - vzare@mozilla.com
-      - fxa-staff@mozilla.com
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXA-9116
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
-    expires: never
-    data_sensitivity:
-      - interaction
-  google_deeplink:
-    type: event
-    description: |
-      User clicked Google Signin link from an RP hosted site and is taken
-      directly to Google authentication flow, bypassing Mozilla Accounts email
-      first page.
-    send_in_pings:
-      - events
-    notification_emails:
-      - vzare@mozilla.com
-      - fxa-staff@mozilla.com
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/FXA-9116
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1830504
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1844121
-    expires: never
-    data_sensitivity:
-      - interaction
   login_no_pw_view:
     type: event
     description: |

--- a/packages/fxa-shared/metrics/glean/web/index.ts
+++ b/packages/fxa-shared/metrics/glean/web/index.ts
@@ -148,8 +148,6 @@ export const eventsMap = {
     startGoogleAuthFromLogin: 'third_party_auth_google_login_start',
     startAppleAuthFromLogin: 'third_party_auth_apple_login_start',
     loginNoPwView: 'third_party_auth_login_no_pw_view',
-    googleDeeplink: 'third_party_auth_google_deeplink',
-    appleDeeplink: 'third_party_auth_apple_deeplink',
   },
 
   thirdPartyAuthSetPassword: {

--- a/packages/fxa-shared/metrics/glean/web/thirdPartyAuth.ts
+++ b/packages/fxa-shared/metrics/glean/web/thirdPartyAuth.ts
@@ -7,24 +7,6 @@
 import EventMetricType from '@mozilla/glean/private/metrics/event';
 
 /**
- * User clicked Apple Signin link from an RP hosted site and is taken
- * directly to Apple authentication flow, bypassing Mozilla Accounts email
- * first page.
- *
- * Generated from `third_party_auth.apple_deeplink`.
- */
-export const appleDeeplink = new EventMetricType(
-  {
-    category: 'third_party_auth',
-    name: 'apple_deeplink',
-    sendInPings: ['events'],
-    lifetime: 'ping',
-    disabled: false,
-  },
-  []
-);
-
-/**
  * User click "Continue with Apple" from the login page
  *
  * Generated from `third_party_auth.apple_login_start`.
@@ -49,24 +31,6 @@ export const appleRegStart = new EventMetricType(
   {
     category: 'third_party_auth',
     name: 'apple_reg_start',
-    sendInPings: ['events'],
-    lifetime: 'ping',
-    disabled: false,
-  },
-  []
-);
-
-/**
- * User clicked Google Signin link from an RP hosted site and is taken
- * directly to Google authentication flow, bypassing Mozilla Accounts email
- * first page.
- *
- * Generated from `third_party_auth.google_deeplink`.
- */
-export const googleDeeplink = new EventMetricType(
-  {
-    category: 'third_party_auth',
-    name: 'google_deeplink',
     sendInPings: ['events'],
     lifetime: 'ping',
     disabled: false,


### PR DESCRIPTION
## Because

- Adding the 3rd-party auth deeplink query param was only introduced for the Pocket user migration

## This pull request

- removes that functionality

## Issue that this pull request solves

Closes: FXA-8873