### PR TITLE
feat(signin): Allow cached signin when keys optional

### DIFF
--- a/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/VerifiedSessionGuard/index.test.tsx
@@ -64,7 +64,19 @@ it('renders the guard when unverified', async () => {
     async () =>
       await renderWithRouter(
         <AppContext.Provider
-          value={mockAppContext({ account, session: mockSession(false) })}
+          value={mockAppContext({
+            account,
+            session: mockSession(false),
+            authClient: {
+              sessionStatus: () => {
+                return {
+                  details: {
+                    sessionVerified: false,
+                  },
+                };
+              },
+            } as unknown as AuthClient,
+          })}
         >
           <VerifiedSessionGuard {...{ onDismiss, onError }}>
             <div>Content</div>

--- a/packages/fxa-settings/src/models/mocks.tsx
+++ b/packages/fxa-settings/src/models/mocks.tsx
@@ -204,7 +204,6 @@ export function mockAppContext(context?: AppContextValue) {
     {
       account: MOCK_ACCOUNT,
       session: mockSession(),
-      authClient: mockAuthClient(),
       config: getDefault(),
       sensitiveDataClient: mockSensitiveDataClient(),
       uniqueUserId: '4a9512ac-3110-43df-aa8a-958A3d210b9c3',

--- a/packages/fxa-settings/src/pages/Signin/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.stories.tsx
@@ -139,6 +139,24 @@ export const SignInRelayWithPasswordlessSupport = storyWithProps({
   supportsKeysOptionalLogin: true,
 });
 
+export const CachedSignInAiWindowWithPasswordlessSupport = storyWithProps({
+  sessionToken: MOCK_SESSION_TOKEN,
+  integration: createMockSigninOAuthNativeIntegration({
+    service: OAuthNativeServices.AiWindow,
+    isSync: false,
+  }),
+  supportsKeysOptionalLogin: true,
+});
+
+export const CachedSignInRelayWithPasswordlessSupport = storyWithProps({
+  sessionToken: MOCK_SESSION_TOKEN,
+  integration: createMockSigninOAuthNativeIntegration({
+    service: OAuthNativeServices.Relay,
+    isSync: false,
+  }),
+  supportsKeysOptionalLogin: true,
+});
+
 export const SignInAiWindowWithPasswordlessSupport = storyWithProps({
   integration: createMockSigninOAuthNativeIntegration({
     service: OAuthNativeServices.AiWindow,

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -1031,6 +1031,81 @@ describe('Signin component', () => {
       passwordInputNotRendered();
     });
 
+    it('shows cached signin for service=relay when supportsKeysOptionalLogin is true', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Relay,
+        isSync: false,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        supportsKeysOptionalLogin: true,
+      });
+
+      passwordInputNotRendered();
+      expect(GleanMetrics.cachedLogin.view).toHaveBeenCalledWith({
+        event: { thirdPartyLinks: true },
+      });
+    });
+
+    it('shows cached signin for service=aiwindow when supportsKeysOptionalLogin is true', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.AiWindow,
+        isSync: false,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        supportsKeysOptionalLogin: true,
+      });
+
+      passwordInputNotRendered();
+      expect(GleanMetrics.cachedLogin.view).toHaveBeenCalledWith({
+        event: { thirdPartyLinks: true },
+      });
+    });
+
+    it('requires password for service=relay when supportsKeysOptionalLogin is false', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Relay,
+        isSync: false,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        supportsKeysOptionalLogin: false,
+      });
+
+      passwordInputRendered();
+      expect(GleanMetrics.login.view).toHaveBeenCalledWith({
+        event: { thirdPartyLinks: false },
+      });
+    });
+
+    it('sends webchannel message if cached signin for service=relay when supportsKeysOptionalLogin is true', async () => {
+      const fxaLoginSpy = jest.spyOn(firefox, 'fxaLogin');
+
+      const integration = createMockSigninOAuthNativeIntegration({
+        service: OAuthNativeServices.Relay,
+        isSync: false,
+      });
+      render({
+        integration,
+        sessionToken: MOCK_SESSION_TOKEN,
+        supportsKeysOptionalLogin: true,
+      });
+      await submit();
+      await waitFor(() => {
+        expect(fxaLoginSpy).toHaveBeenCalledWith({
+          email: MOCK_EMAIL,
+          sessionToken: MOCK_SESSION_TOKEN,
+          uid: MOCK_UID,
+          verified: true,
+          services: { relay: {} },
+        });
+      });
+    });
+
     it('emits an event on forgot password link click', async () => {
       renderWithLocalizationProvider(
         <Subject sessionToken={MOCK_SESSION_TOKEN} />


### PR DESCRIPTION
## Because

- we want cached signin for smart window/relay

## This pull request

- enables cached signin when keys optional

## Issue that this pull request solves

Closes: FXA-12800

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
