### PR TITLE
fix(auth): Update ctaButtonUrl for subscriptionEndingReminder email

### DIFF
--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -243,7 +243,9 @@ export class SubscriptionReminders {
             `${this.paymentsNextUrl}/${offeringId}/${priceSubplatInterval}/stay-subscribed/loyalty-discount/terms`
           ).toString(),
           ctaButtonLabel: cmsChurnInterventionEntry?.ctaMessage,
-          ctaButtonUrl: cmsChurnInterventionEntry?.productPageUrl,
+          ctaButtonUrl: new URL(
+            `${this.paymentsNextUrl}/subscriptions/${subscription.id}/loyalty-discount/stay-subscribed`
+          ).toString(),
           showChurn: isEligible,
         }
       );


### PR DESCRIPTION
## This pull request

- Fixes ctaButtonUrl

## Issue that this pull request solves

Closes: PAY-3478

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.