### PR TITLE
chore(auth-server): Add shared fxaMailer mock

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -17,27 +17,8 @@ const log = require('../../../lib/log');
 const random = require('../../../lib/crypto/random');
 const glean = mocks.mockGlean();
 const Container = require('typedi').Container;
-const { FxaMailer } = require('../../../lib/senders/fxa-mailer');
 
 const TEST_EMAIL = 'foo@gmail.com';
-
-function setupFxaMailerMock() {
-  const mockFxaMailer = {
-    sendRecoveryEmail: sinon.stub().resolves(),
-    sendPasswordForgotOtpEmail: sinon.stub().resolves(),
-    splitEmails: sinon.stub().returns({ to: TEST_EMAIL, cc: [] }),
-    helpers: {
-      constructLocalTimeString: sinon.stub().returns({
-        timeNow: '12:00:00 PM (UTC)',
-        dateNow: 'Monday, Jan 1, 2024',
-      }),
-    },
-  };
-
-  Container.set(FxaMailer, mockFxaMailer);
-
-  return mockFxaMailer;
-}
 
 function makeRoutes(options = {}) {
   const config = options.config || {
@@ -92,7 +73,7 @@ describe('/password', () => {
     // mailer mock must be done before route creation/require
     // otherwise it won't pickup the mock we define because
     // of module caching
-    mockFxaMailer = setupFxaMailerMock();
+    mockFxaMailer = mocks.mockFxaMailer();
     mockAccountEventsManager = mocks.mockAccountEventsManager();
     glean.resetPassword.emailSent.reset();
   });


### PR DESCRIPTION
Because:
 - We have a lot of tests that will need a new mockFxaMailer
   implementation

This Commit:
 - Adds a shared mockFxaMailer setup function with ability to override
   properties for testing.

Closes: FXA-12933
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
