### PR TITLE
polish(auth): Add allow list for new fxa mailer sending

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -597,12 +597,7 @@ const convictConf = convict({
       ignoreTemplates: {
         doc: 'Always ignore bounces from these email templates',
         format: Array,
-        default: [
-          'verifyLoginCode',
-          'verifyLogin',
-          'recovery',
-          'unblockCode',
-        ],
+        default: ['verifyLoginCode', 'verifyLogin', 'recovery', 'unblockCode'],
         env: 'BOUNCES_IGNORE_TEMPLATES',
       },
       deleteAccount: {
@@ -681,6 +676,12 @@ const convictConf = convict({
       format: Boolean,
       default: true,
       env: 'SMTP_METRICS_ENABLED',
+    },
+    fxaMailerDisableSend: {
+      doc: 'Array of templates that should not be supported by fxa mailer. Used to fallback to previous email sending if in a pinch.',
+      format: Array,
+      default: [''],
+      env: 'SMTP_FXA_MAILER_DISABLE_SEND',
     },
   },
   maxEventLoopDelay: {

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -53,6 +53,19 @@ export class FxaMailer extends FxaEmailRenderer {
     super(bindings);
   }
 
+  /**
+   * Feature flag esque method that signals if the template is supported by the new mailer. Used to easily
+   * fall back to old email code if necessary.
+   * @param templateName The name of the template to check on.
+   * @returns True if the email can be sent, and false if the template is included in the SMTP_FXA_MAILER_DISABLE_SEND list.
+   */
+  canSend(templateName: string) {
+    if (this.mailerConfig.fxaMailerDisableSend.includes(templateName)) {
+      return false;
+    }
+    return true;
+  }
+
   async sendRecoveryEmail(
     opts: EmailSenderOpts &
       OmitCommonLinks<TemplateData> &


### PR DESCRIPTION
## Because

- We want to feature flag the send operations with the new fxa-mailer

## This pull request

- Adds a `canSend` method on FxaMailer
- Adds a new config setting to disable certain email templates from being sent by FxaMailer.

## Issue that this pull request solves

Closes: FXA-12934

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
