### PR TITLE
fix(payments): replace assertion errors

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -375,6 +375,97 @@ export class CartIntentNotFoundError extends CartError {
   }
 }
 
+export class GetCartMissingTaxAddressError extends CartError {
+  constructor(cartId: string) {
+    super('Cart must have a tax address', { cartId });
+    this.name = 'GetCartMissingTaxAddressError';
+  }
+}
+
+export class GetCartFailureFromPriceMissingError extends CartError {
+  constructor(cartId: string) {
+    super('fromPrice not present for upgrade cart', { cartId });
+    this.name = 'GetCartFailureFromPriceMissingError';
+  }
+}
+
+export class GetCartFromPriceMissingError extends CartError {
+  constructor(cartId: string) {
+    super('fromPrice not present for upgrade cart', { cartId });
+    this.name = 'GetCartFromPriceMissingError';
+  }
+}
+
+export class GetCartCustomerMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Customer is required for upgrade', { cartId });
+    this.name = 'GetCartCustomerMissingError';
+  }
+}
+
+export class GetCartSubscriptionMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Subscription required', { cartId });
+    this.name = 'GetCartSubscriptionMissingError';
+  }
+}
+
+export class GetCartLatestInvoicePreviewMissingError extends CartError {
+  constructor(cartId: string) {
+    super('latestInvoicePreview not present for success cart', { cartId });
+    this.name = 'GetCartLatestInvoicePreviewMissingError';
+  }
+}
+
+export class GetCartPaymentInfoMissingError extends CartError {
+  constructor(cartId: string) {
+    super('PaymentInfo not present for success cart', { cartId });
+    this.name = 'GetCartPaymentInfoMissingError';
+  }
+}
+
+export class GetCartIntervalMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Interval not found but is required', { cartId });
+    this.name = 'GetCartIntervalMissingError';
+  }
+}
+
+export class GetCartUnitAmountForCurrencyMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Unit amount for currency is required', { cartId });
+    this.name = 'GetCartUnitAmountForCurrencyMissingError';
+  }
+}
+
+export class GetCartPriceForCurrencyRecurringMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Price for currency recurring is required', { cartId });
+    this.name = 'GetCartPriceForCurrencyRecurringMissingError';
+  }
+}
+
+export class SubmitNeedsInputCustomerIdMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Cart must have a stripeCustomerId', { cartId });
+    this.name = 'SubmitNeedsInputCustomerIdMissingError';
+  }
+}
+
+export class SubmitNeedsInputSubscriptionIdMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Cart must have a stripeSubscriptionId', { cartId });
+    this.name = 'SubmitNeedsInputSubscriptionIdMissingError';
+  }
+}
+
+export class SubmitNeedsInputUidMissingError extends CartError {
+  constructor(cartId: string) {
+    super('Cart must have a uid', { cartId });
+    this.name = 'SubmitNeedsInputUidMissingError';
+  }
+}
+
 export class CartSubscriptionNotFoundError extends CartError {
   constructor(message: string, cartId: string, subscriptionId?: string) {
     super(message, {

--- a/libs/payments/cart/src/lib/checkout.error.ts
+++ b/libs/payments/cart/src/lib/checkout.error.ts
@@ -71,6 +71,16 @@ export class UpgradeForSubscriptionNotFoundError extends CheckoutError {
   }
 }
 
+export class UpgradeSubscriptionNullCurrencyError extends CheckoutError {
+  constructor(cartId: string, priceId: string) {
+    super('Currency should not be null', {
+      cartId,
+      priceId,
+    });
+    this.name = 'UpgradeSubscriptionNullCurrencyError';
+  }
+}
+
 export class LatestInvoiceNotFoundOnSubscriptionError extends CheckoutError {
   constructor(cartId: string, subscriptionId: string) {
     super('latest_invoice could not be found on subscription', {
@@ -91,6 +101,36 @@ export class PaymentMethodUpdateFailedError extends CheckoutError {
   }
 }
 
+export class PayWithStripeLatestInvoiceNotFoundOnSubscriptionError extends CheckoutError {
+  constructor(cartId: string, subscriptionId: string) {
+    super('latest_invoice does not exist on subscription', {
+      cartId,
+      subscriptionId,
+    });
+    this.name = 'PayWithStripeLatestInvoiceNotFoundOnSubscriptionError';
+  }
+}
+
+export class PayWithStripeNullCurrencyError extends CheckoutError {
+  constructor(cartId: string, priceId: string) {
+    super('Currency should not be null', {
+      cartId,
+      priceId,
+    });
+    this.name = 'PayWithStripeNullCurrencyError';
+  }
+}
+
+export class PayWithPaypalNullCurrencyError extends CheckoutError {
+  constructor(cartId: string, priceId: string) {
+    super('Currency should not be null', {
+      cartId,
+      priceId,
+    });
+    this.name = 'PayWithPaypalNullCurrencyError';
+  }
+}
+
 export class DetermineCheckoutAmountCustomerRequiredError extends CheckoutError {
   constructor(priceId: string, currency: string, taxAddress: TaxAddress) {
     super('Customer is required for upgrade', {
@@ -108,7 +148,7 @@ export class DetermineCheckoutAmountSubscriptionRequiredError extends CheckoutEr
       customerId,
       fromPriceId,
     });
-    this.name = 'DetermineCheckoutAmountCustomerRequiredError';
+    this.name = 'DetermineCheckoutAmountSubscriptionRequiredError';
   }
 }
 
@@ -205,14 +245,11 @@ export class IntentInsufficientFundsError extends IntentFailedHandledError {
     paymentIntentId: string,
     intentType: 'SetupIntent' | 'PaymentIntent'
   ) {
-    super(
-      'Intent payment method card has insufficient funds',
-      {
-        cartId,
-        paymentIntentId,
-        intentType,
-      }
-    );
+    super('Intent payment method card has insufficient funds', {
+      cartId,
+      paymentIntentId,
+      intentType,
+    });
     this.name = 'IntentInsufficientFundsError';
   }
 }

--- a/libs/payments/customer/src/lib/customer.manager.ts
+++ b/libs/payments/customer/src/lib/customer.manager.ts
@@ -11,7 +11,11 @@ import {
   MOZILLA_TAX_ID,
 } from '@fxa/payments/stripe';
 import { CustomerDeletedError } from './customer.error';
-import { TaxAddress, STRIPE_CUSTOMER_METADATA, type StripeCustomerMetadataInput } from './types';
+import {
+  TaxAddress,
+  STRIPE_CUSTOMER_METADATA,
+  type StripeCustomerMetadataInput,
+} from './types';
 import { isCustomerTaxEligible } from './util/isCustomerTaxEligible';
 
 @Injectable()
@@ -33,8 +37,8 @@ export class CustomerManager {
   async update(
     customerId: string,
     params: Omit<Stripe.CustomerUpdateParams, 'metadata'> & {
-      metadata?: StripeCustomerMetadataInput,
-    },
+      metadata?: StripeCustomerMetadataInput;
+    }
   ) {
     return this.stripeClient.customersUpdate(customerId, params);
   }
@@ -42,11 +46,7 @@ export class CustomerManager {
   /**
    * Create a customer
    */
-  async create(args: {
-    uid: string;
-    email: string;
-    taxAddress?: TaxAddress;
-  }) {
+  async create(args: { uid: string; email: string; taxAddress?: TaxAddress }) {
     const { uid, email, taxAddress } = args;
 
     const shipping = taxAddress


### PR DESCRIPTION
## Because

- Ensure that assertion errors throw a unique error providing additional information related to the error.

## This pull request

- Where necessary update assertion errors to throw a unique error.
- Add tests for all assertion errors.

## Issue that this pull request solves

Closes: PAY-3392

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
