### PR TITLE
chore(auth): Add oauth-client-info to Container

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -381,6 +381,13 @@ async function run(config) {
   );
   Container.set(FxaMailer, fxaMailer);
 
+  const oauthClientInfo = require('../lib/senders/oauth_client_info');
+  const { OAuthClientInfoServiceName } = oauthClientInfo;
+  Container.set({
+    id: OAuthClientInfoServiceName,
+    factory: () => oauthClientInfo(log, database),
+  });
+
   const routes = require('../lib/routes')(
     log,
     serverPublicKeys,

--- a/packages/fxa-auth-server/lib/senders/oauth_client_info.js
+++ b/packages/fxa-auth-server/lib/senders/oauth_client_info.js
@@ -81,3 +81,5 @@ module.exports = (log, config) => {
     __clientCache: clientCache,
   };
 };
+
+export const OAuthClientInfoServiceName = 'OAuthClientInfo';


### PR DESCRIPTION
Because:
 - The fxa-mailer removes calls to oauth-client-info service

This Commit:
 - Adds the OAuthClientInfo to the di container for handerls to access

Closes:

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
