### PR TITLE
feat(next): add script for local prod start

### DIFF
--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -33,6 +33,10 @@
       },
       "dependsOn": ["glean-lint"]
     },
+    "start-prod-local": {
+      "command": "npm start --prefix apps/payments/next -- -p 3035",
+      "dependsOn": ["build", "delete"]
+    },
     "start": {
       "command": "pm2 start apps/payments/next/pm2.config.js && yarn check:url localhost:3035/__heartbeat__",
       "dependsOn": ["l10n-bundle", "glean-generate"]


### PR DESCRIPTION
## Because

- Easily start payments-next in a prod like fashion locally.

## This pull request

- Add a script to payments-next to start the application in a similar fashion to how it would be run in a deployed environment.

## Issue that this pull request solves

Closes: PAY-3489

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
