### PR TITLE
fix(l10n): use localized string for secondary email none status

### DIFF
--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -191,6 +191,11 @@ export const UnitRowSecondaryEmail = () => {
         header={l10n.getString('se-heading', null, 'Secondary email')}
         headerId="secondary-email"
         prefixDataTestId="secondary-email"
+        defaultHeaderValueText={l10n.getString(
+          'se-secondary-email-none',
+          null,
+          'None'
+        )}
         route={`${SETTINGS_PATH}/emails`}
         ctaOnClickAction={() => GleanMetrics.accountPref.secondaryEmailSubmit()}
         {...{


### PR DESCRIPTION
Currently, when no secondary email is set, the status displays a hardcoded 'None' instead of using the localized 'se-secondary-email-none' string. This restores the intended behavior and fixes a minor l10n regression.

Closes #18685