### PR TITLE
fix(gql): fix typo 'recieved' to 'received' in metrics opt state error

### DIFF
--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -436,7 +436,9 @@ describe('#integration - AccountResolver', () => {
 
     describe('deleteSecondaryEmail', () => {
       it('succeeds', async () => {
-        authClient.recoveryEmailDestroyWithJwt = jest.fn().mockResolvedValue(true);
+        authClient.recoveryEmailDestroyWithJwt = jest
+          .fn()
+          .mockResolvedValue(true);
         const result = await resolver.deleteSecondaryEmail(headers, {
           jwt: 'jwtToken',
           clientMutationId: 'testid',
@@ -576,7 +578,7 @@ describe('#integration - AccountResolver', () => {
             state: 'In' as 'in',
           })
         ).rejects.toThrow(
-          'Invalid metrics opt state! State must be in or out, but recieved In.'
+          'Invalid metrics opt state! State must be in or out, but received In.'
         );
       });
     });

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -374,7 +374,11 @@ export class AccountResolver {
     @GqlXHeaders() headers: Headers,
     @Args('input', { type: () => EmailInput }) input: EmailInput
   ): Promise<BasicPayload> {
-    await this.authAPI.recoveryEmailDestroyWithJwt(input.jwt, input.email, headers);
+    await this.authAPI.recoveryEmailDestroyWithJwt(
+      input.jwt,
+      input.email,
+      headers
+    );
     return { clientMutationId: input.clientMutationId };
   }
 
@@ -456,7 +460,7 @@ export class AccountResolver {
 
     if (!['in', 'out'].includes(input.state)) {
       throw new Error(
-        `Invalid metrics opt state! State must be in or out, but recieved ${input.state}.`
+        `Invalid metrics opt state! State must be in or out, but received ${input.state}.`
       );
     }
 


### PR DESCRIPTION
Small fix for a typo in the error message for invalid metrics opt state. Fixed in both the resolver and its corresponding test suite.