### PR TITLE
fix(auth): Fix Terms URL for Stay subscribed email

### DIFF
--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -240,7 +240,7 @@ export class SubscriptionReminders {
             purchase.purchaseDetails.localizations.at(0)?.webIcon ||
             purchase.purchaseDetails.webIcon,
           churnTermsUrl: new URL(
-            `${this.paymentsNextUrl}/${offeringId}/${priceSubplatInterval}/stay-subscribed/loyalty-discount/terms`
+            `${this.paymentsNextUrl}/${offeringId}/${priceSubplatInterval}/stay_subscribed/loyalty-discount/terms`
           ).toString(),
           ctaButtonLabel: cmsChurnInterventionEntry?.ctaMessage,
           ctaButtonUrl: new URL(


### PR DESCRIPTION
## Because

- Sentry event - handleException: An instance of GetCMSChurnInterventionActionArgs has failed the validation: - property churnType has failed the following constraints: isIn (https://mozilla.sentry.io/issues/7090829184/?environment=stage&project=4505948913139712&query=is%3Aunresolved&referrer=issue-stream)
  - Valid churnType options are ‘cancel’ and ‘stay_subscribed’, but the URL has ‘stay-subscribed’ as the churn type

## This pull request

- Fix URL

## Issue that this pull request solves

Closes: PAY-3491

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.