### PR TITLE
fix(settings): support Multi-Account Containers in WebChannel status requests

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -89,9 +89,7 @@ const ResetPasswordConfirmedContainer = lazy(
 );
 const ResetPasswordWithRecoveryKeyVerifiedContainer = lazy(
   () =>
-    import(
-      '../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/container'
-    )
+    import('../../pages/ResetPassword/ResetPasswordWithRecoveryKeyVerified/container')
 );
 const CompleteSigninContainer = lazy(
   () => import('../../pages/Signin/CompleteSignin/container')
@@ -228,7 +226,8 @@ export const App = ({
           integration.data.context || '',
           // TODO with React pairing flow, update this if pairing flow
           false,
-          integration.data.service || ''
+          integration.data.service || '',
+          integration.data.userContextId
         );
       }
 

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -63,6 +63,7 @@ type FxAStatusRequest = {
   service: string; // ex. 'sync'
   isPairing: boolean;
   context: string; // ex. 'fx_desktop_v3'
+  userContextId?: string;
 };
 
 export type FxAStatusResponse = {
@@ -382,7 +383,8 @@ export class Firefox extends EventTarget {
   async requestSignedInUser(
     context: string,
     isPairing: boolean,
-    service: string
+    service: string,
+    userContextId?: string
   ): Promise<undefined | SignedInUser> {
     let timeoutId: number;
     return Promise.race<undefined | SignedInUser>([
@@ -406,6 +408,7 @@ export class Firefox extends EventTarget {
             context,
             isPairing,
             service,
+            userContextId,
           });
         });
       }),

--- a/packages/fxa-settings/src/models/integrations/data/data.ts
+++ b/packages/fxa-settings/src/models/integrations/data/data.ts
@@ -22,7 +22,11 @@ import {
   KeyTransforms as T,
   ModelDataProvider,
 } from '../../../lib/model-data';
-import { IsEmailOrEmpty, IsFxaRedirectToUrl, IsFxaRedirectUri } from '../../../lib/validation';
+import {
+  IsEmailOrEmpty,
+  IsFxaRedirectToUrl,
+  IsFxaRedirectUri,
+} from '../../../lib/validation';
 
 /**
  * Base integration class. Fields in this class represents data commonly accessed across many pages and is useful for various flows.
@@ -115,6 +119,11 @@ export class IntegrationData extends ModelDataProvider {
   @IsString()
   @bind(T.snakeCase)
   flowBeginTime: string | undefined;
+
+  @IsOptional()
+  @IsString()
+  @bind(T.snakeCase)
+  userContextId: string | undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes #18781. This PR ensures that 'fxa-settings' correctly passes the 'userContextId' (if available from integration data) when requesting the signed-in user status from the browser via WebChannel. This is necessary to support Firefox Multi-Account Containers, ensuring that the correct container-specific session status is returned instead of defaulting to the main profile or an incorrect container context. This prevents the issue where signing into Container sync causes the account to appear unverified in Settings.