### PR TITLE
task(auth): Use new email library for sending emails in auth-server

### DIFF
--- a/libs/accounts/email-renderer/src/partials/appBadges/index.ts
+++ b/libs/accounts/email-renderer/src/partials/appBadges/index.ts
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export type TemplateData = {
-  cssPath: string;
-  productName: string;
-  hideDeviceLink: boolean;
-  onDesktopOrTabletDevice: boolean;
+  cssPath?: string; // Not passed as template data?
+  productName: string; // Not passed as template data?
+  hideDeviceLink?: boolean; // Not passed as template data?
+  onDesktopOrTabletDevice?: boolean; // Not passed as template data?
   iosUrl?: string;
   androidUrl?: string;
   desktopLink?: string;

--- a/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
+++ b/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
@@ -7623,6 +7623,846 @@ For more information, please visit <a class="link-blue" href="http://localhost:3
   </body></html>"
 `;
 
+exports[`FxA Email Renderer should render renderPostAddTwoStepAuthentication with a recovery codes messaging: matches full email snapshot 1`] = `
+"<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
+    <title>Two-step authentication is on</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+  </head>
+  <body style="word-spacing:normal;">
+    
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your account is protected</div>
+  
+    
+      <div style="" lang="und" dir="auto">
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="body-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="body" style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="mozilla-logo" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:120px;" data-l10n-id="fxa-header-mozilla-logo"><img alt="Mozilla logo" src="https://cdn.accounts.firefox.com/product-icons/mozilla-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="120" height="auto" data-l10n-name="mozilla-logo"></td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-header" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-title-2">You turned on two-step authentication</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-code-required-v4">Security codes from your authenticator app are now required every time you sign in.</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-recovery-method-codes">You also added backup authentication codes as your recovery method.</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" href="http://localhost:3030/mock-support-link">
+        <span data-l10n-id="postAddTwoStepAuthentication-how-protects-link">How this protects your account</span>
+      </a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-grey" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="device-all" data-l10n-args="{&quot;uaBrowser&quot;:&quot;Firefox&quot;,&quot;uaOS&quot;:&quot;Windows&quot;,&quot;uaOSVersion&quot;:&quot;100&quot;}">Firefox on Windows 100</span>
+      
+    
+  
+
+        <br>
+      
+      
+        
+
+
+  
+    
+      <span data-l10n-id="location-all" data-l10n-args="{&quot;city&quot;:&quot;San Francisco&quot;,&quot;stateCode&quot;:&quot;CA&quot;,&quot;country&quot;:&quot;US&quot;}">San Francisco, CA, US (estimated)</span>
+    
+  
+
+        <br>
+      
+      
+        Jan 1, 2024
+        <br>
+      
+      
+        12:00 PM
+        <br></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="primary-button" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#414141" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#414141;" valign="middle">
+              <a href="http://localhost:3030/mock-link" style="display:inline-block;background:#414141;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
+                <span data-l10n-id="postAddTwoStepAuthentication-action">Manage account</span>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer-automatedEmail" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="automated-email-change-2">If you didn’t take this action, <a class="link-blue" href="http://localhost:3030/mock-password-change-link" data-l10n-name="passwordChangeLink">change your password</a> right away.</span>
+      <span data-l10n-id="automated-email-support">For more info, visit <a class="link-blue" href="http://localhost:3030/support" data-l10n-name="supportLink">Mozilla Support</a>.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="http://localhost:3030/privacy">Mozilla Accounts Privacy Notice</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-terms-url" href="https://www.mozilla.org/about/legal/terms/services/">Mozilla Accounts Terms of Service</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  
+
+  </body></html>"
+`;
+
+exports[`FxA Email Renderer should render renderPostAddTwoStepAuthentication with a recovery phone messaging: matches full email snapshot 1`] = `
+"<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
+    <title>Two-step authentication is on</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+  </head>
+  <body style="word-spacing:normal;">
+    
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Your account is protected</div>
+  
+    
+      <div style="" lang="und" dir="auto">
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="body-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="body" style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="mozilla-logo" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:120px;" data-l10n-id="fxa-header-mozilla-logo"><img alt="Mozilla logo" src="https://cdn.accounts.firefox.com/product-icons/mozilla-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="120" height="auto" data-l10n-name="mozilla-logo"></td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-header" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-title-2">You turned on two-step authentication</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-code-required-v4">Security codes from your authenticator app are now required every time you sign in.</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span dir="ltr" data-l10n-id="postAddTwoStepAuthentication-recovery-method-phone" data-l10n-args="{&quot;maskedPhoneNumber&quot;:&quot;*******123&quot;}">You also added *******123 as your recovery phone number.</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" href="http://localhost:3030/mock-support-link">
+        <span data-l10n-id="postAddTwoStepAuthentication-how-protects-link">How this protects your account</span>
+      </a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-grey" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="device-all" data-l10n-args="{&quot;uaBrowser&quot;:&quot;Firefox&quot;,&quot;uaOS&quot;:&quot;Windows&quot;,&quot;uaOSVersion&quot;:&quot;100&quot;}">Firefox on Windows 100</span>
+      
+    
+  
+
+        <br>
+      
+      
+        
+
+
+  
+    
+      <span data-l10n-id="location-all" data-l10n-args="{&quot;city&quot;:&quot;San Francisco&quot;,&quot;stateCode&quot;:&quot;CA&quot;,&quot;country&quot;:&quot;US&quot;}">San Francisco, CA, US (estimated)</span>
+    
+  
+
+        <br>
+      
+      
+        Jan 1, 2024
+        <br>
+      
+      
+        12:00 PM
+        <br></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="primary-button" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
+        <tbody>
+          <tr>
+            <td align="center" bgcolor="#414141" role="presentation" style="border:none;border-radius:3px;cursor:auto;mso-padding-alt:10px 25px;background:#414141;" valign="middle">
+              <a href="http://localhost:3030/mock-link" style="display:inline-block;background:#414141;color:#ffffff;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:3px;" target="_blank">
+                <span data-l10n-id="postAddTwoStepAuthentication-action">Manage account</span>
+              </a>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer-automatedEmail" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="automated-email-change-2">If you didn’t take this action, <a class="link-blue" href="http://localhost:3030/mock-password-change-link" data-l10n-name="passwordChangeLink">change your password</a> right away.</span>
+      <span data-l10n-id="automated-email-support">For more info, visit <a class="link-blue" href="http://localhost:3030/support" data-l10n-name="supportLink">Mozilla Support</a>.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="http://localhost:3030/privacy">Mozilla Accounts Privacy Notice</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-terms-url" href="https://www.mozilla.org/about/legal/terms/services/">Mozilla Accounts Terms of Service</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  
+
+  </body></html>"
+`;
+
 exports[`FxA Email Renderer should render renderPostAddTwoStepAuthentication: matches full email snapshot 1`] = `
 "<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
     <title>Two-step authentication is on</title>

--- a/libs/accounts/email-renderer/src/renderer/email-link-builder.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-link-builder.spec.ts
@@ -11,6 +11,29 @@ describe('EmailLinkBuilder', () => {
     privacyUrl: 'http://localhost:3030/privacy',
     supportUrl: 'http://localhost:3030/support',
     accountSettingsUrl: 'http://localhost:3030/settings',
+    passwordResetUrl: 'http://localhost:3030/reset_password_xxx',
+    verificationUrl: 'http://localhost:3030/verify_email',
+    verifyLoginUrl: 'http://localhost:3030/complete_signin',
+    prependVerificationSubdomain: {
+      enabled: true,
+      subdomain: 'test',
+    },
+
+    baseUri: 'http://localhost:30303',
+    androidUrl:
+      'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=android&creative=button&utm_source=email',
+    iosUrl:
+      'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=ios&creative=button&fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8&utm_source=email',
+    mozillaSupportUrl: 'https://support.mozilla.org',
+    twoFactorSupportUrl:
+      'https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0',
+    subscriptionSupportUrl: 'https://support.mozilla.org/products',
+    subscriptionTermsUrl:
+      'https://www.mozilla.org/about/legal/terms/subscription-services',
+    defaultSurveyUrl:
+      'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+    firefoxDesktopUrl:
+      'https://firefox.com?utm_content=registration-confirmation&utm_medium=email&utm_source=fxa',
   };
 
   let linkBuilder: EmailLinkBuilder;
@@ -19,92 +42,348 @@ describe('EmailLinkBuilder', () => {
     linkBuilder = new EmailLinkBuilder(mockConfig);
   });
 
-  describe('buildCommonLinks', () => {
-    it('should build privacy and support links with UTM params', () => {
-      const templateName = 'recovery';
-
-      const links = linkBuilder.buildCommonLinks(templateName, true);
-
-      expect(links.privacyUrl).toContain('http://localhost:3030/privacy');
-      expect(links.privacyUrl).toContain('utm_medium=email');
-      expect(links.privacyUrl).toContain('utm_campaign=fx-forgot-password');
-      expect(links.privacyUrl).toContain('utm_content=fx-privacy');
-
-      expect(links.supportUrl).toContain('http://localhost:3030/support');
-      expect(links.supportUrl).toContain('utm_medium=email');
-      expect(links.supportUrl).toContain('utm_campaign=fx-forgot-password');
-      expect(links.supportUrl).toContain('utm_content=fx-support');
-    });
-  });
-
-  describe('buildLinkWithQueryParamsAndUTM', () => {
-    it('should add query params and UTM params to link', () => {
-      const link = linkBuilder.buildLinkWithQueryParamsAndUTM(
-        'http://localhost:3030/some-page',
-        'recovery',
-        {
-          uid: '12345',
-          token: 'abc123',
-          email: 'test@example.com',
-        },
-        true
-      );
-
-      const url = new URL(link);
-      expect(url.searchParams.get('uid')).toBe('12345');
-      expect(url.searchParams.get('token')).toBe('abc123');
-      expect(url.searchParams.get('email')).toBe('test@example.com');
-      expect(url.searchParams.get('utm_medium')).toBe('email');
-      expect(url.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
-    });
-
-    it('should handle empty query params', () => {
-      const templateName = 'recovery';
-      const queryParams = {};
-
-      const link = linkBuilder.buildLinkWithQueryParamsAndUTM(
-        'http://localhost:3030/some-page',
-        templateName,
-        queryParams,
-        true
-      );
-
-      const url = new URL(link);
-      expect(url.searchParams.get('utm_medium')).toBe('email');
-      expect(url.searchParams.get('utm_campaign')).toBe('fx-forgot-password');
-    });
-
-    it('should respect metricsEnabled flag', () => {
-      const link = linkBuilder.buildLinkWithQueryParamsAndUTM(
-        'http://localhost:3030/some-page',
-        'recovery',
-        {},
-        false
-      );
-
-      const url = new URL(link);
-      expect(url.searchParams.get('utm_medium')).toBeNull();
-      expect(url.searchParams.get('utm_campaign')).toBeNull();
-    });
-  });
-
   describe('buildPasswordChangeRequiredLink', () => {
     it('should build password change required link with params', () => {
-      const opts = {
-        url: 'http://localhost:3030/reset_password',
-        email: 'test@example.com',
-      };
-
       const link = linkBuilder.buildPasswordChangeRequiredLink(
-        opts.url,
-        opts.email,
-        true
+        'passwordChangeRequired',
+        true,
+        { email: 'foo@mozilla.com' }
       );
 
-      expect(link).toContain('http://localhost:3030/reset_password');
-      expect(link).toContain('email=test%40example.com');
+      // There will be no utm_campaign because, passwordChangeRequired has no campaign mapping.
+      expect(link).toEqual(
+        'http://localhost:30303/settings/change_password?utm_medium=email&utm_content=fx-change-password&email=foo%40mozilla.com'
+      );
+    });
+
+    it('should build password change required link without utml params', () => {
+      const link = linkBuilder.buildPasswordChangeRequiredLink(
+        'passwordChangeRequired',
+        false,
+        { email: 'foo@mozilla.com' }
+      );
+
+      // There will be no utm_campaign because, passwordChangeRequired has no campaign mapping.
+      expect(link).toEqual(
+        'http://localhost:30303/settings/change_password?email=foo%40mozilla.com'
+      );
+    });
+  });
+
+  describe('buildPasswordChangeLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildPasswordChangeLink('recovery', true, {
+        email: 'foo@mozilla.com',
+      });
+      expect(link).toEqual(
+        'http://localhost:30303/settings/change_password?utm_medium=email&utm_campaign=fx-forgot-password&utm_content=fx-change-password&email=foo%40mozilla.com'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildPasswordChangeLink('recovery', false, {
+        email: 'foo@mozilla.com',
+      });
+      expect(link).toEqual(
+        'http://localhost:30303/settings/change_password?email=foo%40mozilla.com'
+      );
+    });
+  });
+
+  describe('buildRevokeAccountRecoveryLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildRevokeAccountRecoveryLink('recovery', true);
+      expect(link).toEqual(
+        'http://localhost:30303/settings?utm_medium=email&utm_campaign=fx-forgot-password&utm_content=fx-report#recovery-key'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildRevokeAccountRecoveryLink(
+        'recovery',
+        false
+      );
+      expect(link).toEqual('http://localhost:30303/settings#recovery-key');
+    });
+  });
+
+  describe('buildLowRecoveryCodesLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildLowRecoveryCodesLink(
+        'lowRecoveryCodes',
+        true,
+        {
+          email: 'foo@mozilla.com',
+          uid: '123',
+        }
+      );
+      expect(link).toEqual(
+        'http://localhost:30303/settings/two_step_authentication/replace_codes?utm_medium=email&utm_campaign=fx-low-recovery-codes&utm_content=fx-low-recovery-codes&low_recovery_codes=true&email=foo%40mozilla.com&uid=123'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildLowRecoveryCodesLink(
+        'lowRecoveryCodes',
+        false,
+        {
+          email: 'foo@mozilla.com',
+          uid: '123',
+        }
+      );
+      expect(link).toEqual(
+        'http://localhost:30303/settings/two_step_authentication/replace_codes?low_recovery_codes=true&email=foo%40mozilla.com&uid=123'
+      );
+    });
+  });
+  describe('buildPostNewRecoveryCodesLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildPostNewRecoveryCodesLink(
+        'postNewRecoveryCodes',
+        true,
+        {
+          email: 'foo@mozilla.com',
+          uid: '123',
+        }
+      );
+      expect(link).toEqual(
+        'http://localhost:30303/settings?utm_medium=email&utm_campaign=fx-account-replace-recovery-codes&utm_content=fx-account-replace-recovery-codes&email=foo%40mozilla.com&uid=123'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildPostNewRecoveryCodesLink(
+        'postNewRecoveryCodes',
+        false,
+        {
+          email: 'foo@mozilla.com',
+          uid: '123',
+        }
+      );
+      expect(link).toEqual(
+        'http://localhost:30303/settings?email=foo%40mozilla.com&uid=123'
+      );
+    });
+  });
+  describe('buildTwoFactorSettignsLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildTwoFactorSettignsLink(
+        'postConsumeRecoveryCode',
+        true,
+        {
+          email: 'foo@mozilla.com',
+        }
+      );
+      expect(link).toEqual(
+        'http://localhost:30303/settings?utm_medium=email&utm_campaign=fx-account-consume-recovery-code&utm_content=fx-manage-two-factor&email=foo%40mozilla.com#two-step-authentication'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildTwoFactorSettignsLink(
+        'postConsumeRecoveryCode',
+        false,
+        {
+          email: 'foo@mozilla.com',
+        }
+      );
+      expect(link).toEqual(
+        'http://localhost:30303/settings?email=foo%40mozilla.com#two-step-authentication'
+      );
+    });
+  });
+  describe('buildTwoFactorSupportLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildTwoFactorSupportLink();
+      expect(link).toEqual(mockConfig.twoFactorSupportUrl);
+    });
+  });
+  describe('buildAndroidLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildAndroidLink();
+      expect(link).toEqual(mockConfig.androidUrl);
+    });
+  });
+  describe('buildIosLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildIosLink();
+      expect(link).toEqual(mockConfig.iosUrl);
+    });
+  });
+
+  describe('buildTermsOfServiceDownloadLink', () => {
+    it('can build link', () => {
+      const link = linkBuilder.buildTermsOfServiceDownloadLink(
+        'downloadSubscription',
+        true
+      );
+      expect(link).toEqual(
+        `${mockConfig.subscriptionTermsUrl}?utm_medium=email&utm_content=fx-subscription-terms`
+      );
+    });
+    it('can build link without utm', () => {
+      const link = linkBuilder.buildTermsOfServiceDownloadLink(
+        'downloadSubscription',
+        false
+      );
+      expect(link).toEqual(`${mockConfig.subscriptionTermsUrl}`);
+    });
+  });
+
+  describe('buildPrivacyLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildPrivacyLink('recovery', true);
+      expect(link).toEqual(
+        'http://localhost:3030/privacy?utm_medium=email&utm_campaign=fx-forgot-password&utm_content=fx-privacy'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildPrivacyLink('recovery', false);
+      expect(link).toEqual('http://localhost:3030/privacy');
+    });
+  });
+
+  describe('buildSupportLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildSupportLink('recovery', true);
+      expect(link).toContain('http://localhost:3030/support');
       expect(link).toContain('utm_medium=email');
-      expect(link).toContain('utm_campaign=fx-password-reset-required');
+      expect(link).toContain('utm_campaign=fx-forgot-password');
+      expect(link).toContain('utm_content=fx-support');
+    });
+  });
+
+  describe('buildRecoveryLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildRecoveryLink('recovery', true, {
+        code: '1234',
+        email: 'foo@mozilla.com',
+        emailToHashWith: 'foo@mozilla.com',
+        redirectTo: 'https://mozilla.org',
+        resume: '111',
+        service: 'sync',
+        token: '222',
+        uid: '123',
+      });
+
+      expect(link).toEqual(
+        'http://localhost:30303/complete_reset_password?utm_medium=email&utm_campaign=fx-forgot-password&utm_content=fx-reset-password&code=1234&email=foo%40mozilla.com&emailToHashWith=foo%40mozilla.com&redirectTo=https%3A%2F%2Fmozilla.org&resume=111&service=sync&token=222&uid=123'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildRecoveryLink('recovery', false, {
+        code: '1234',
+        email: 'foo@mozilla.com',
+        emailToHashWith: 'foo@mozilla.com',
+        redirectTo: 'https://mozilla.org',
+        resume: '111',
+        service: 'sync',
+        token: '222',
+        uid: '123',
+      });
+
+      expect(link).toEqual(
+        'http://localhost:30303/complete_reset_password?code=1234&email=foo%40mozilla.com&emailToHashWith=foo%40mozilla.com&redirectTo=https%3A%2F%2Fmozilla.org&resume=111&service=sync&token=222&uid=123'
+      );
+    });
+  });
+
+  describe('buildMozillaSupportUrl', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildMozillaSupportUrl();
+
+      expect(link).toEqual(mockConfig.mozillaSupportUrl);
+    });
+  });
+
+  describe('buildLinkAttributes', () => {
+    it('can build', () => {
+      const attrs = linkBuilder.buildLinkAttributes('http://mozilla.org');
+      expect(attrs).toEqual(
+        `href="http://mozilla.org" style="color: #0a84ff; text-decoration: none; font-family: sans-serif;"`
+      );
+    });
+  });
+
+  describe('buildCadLink', () => {
+    it('can build', () => {
+      const attrs = linkBuilder.buildCadLink('postVerify', true);
+      expect(attrs).toEqual(
+        'http://localhost:30303/connect_another_device?utm_medium=email&utm_campaign=fx-account-verified&utm_content=fx-account-verified'
+      );
+    });
+
+    it('can build without utm', () => {
+      const attrs = linkBuilder.buildCadLink('postVerify', false);
+      expect(attrs).toEqual('http://localhost:30303/connect_another_device');
+    });
+  });
+
+  describe('buildVerifyLoginLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildVerifyLoginLink('verifyLoginCode', true, {
+        code: '1234',
+        uid: '123',
+        service: 'sync',
+        redirectTo: 'http://mozilla.org',
+        resume: '1111',
+      });
+      expect(link).toEqual(
+        'http://test.localhost:30303/complete_signin?utm_medium=email&utm_campaign=fx-new-device-signin&utm_content=fx-new-device-signin&code=1234&uid=123&service=sync&redirectTo=http%3A%2F%2Fmozilla.org&resume=1111'
+      );
+    });
+
+    it('can build without utm', () => {
+      const link = linkBuilder.buildVerifyLoginLink('verifyLoginCode', false, {
+        code: '1234',
+        uid: '123',
+        service: 'sync',
+        redirectTo: 'http://mozilla.org',
+        resume: '1111',
+      });
+      expect(link).toEqual(
+        'http://test.localhost:30303/complete_signin?code=1234&uid=123&service=sync&redirectTo=http%3A%2F%2Fmozilla.org&resume=1111'
+      );
+    });
+  });
+
+  describe('buildVerifyShortCodeLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildVerifyShortCodeLink(
+        'verifyShortCode',
+        true,
+        {
+          email: 'foo@mozilla.com',
+          uid: '123',
+        }
+      );
+
+      expect(link).toEqual(
+        'http://test.localhost:30303/verify_email?utm_medium=email&utm_campaign=fx-welcome&utm_content=fx-welcome&email=foo%40mozilla.com&uid=123'
+      );
+    });
+    it('can build without utm', () => {
+      const link = linkBuilder.buildVerifyShortCodeLink(
+        'verifyShortCode',
+        false,
+        {
+          email: 'foo@mozilla.com',
+          uid: '123',
+        }
+      );
+      expect(link).toEqual(
+        'http://test.localhost:30303/verify_email?email=foo%40mozilla.com&uid=123'
+      );
+    });
+  });
+
+  describe('buildDesktopLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildDesktopLink();
+
+      expect(link).toEqual(mockConfig.firefoxDesktopUrl);
     });
   });
 });

--- a/libs/accounts/email-renderer/src/renderer/email-link-builder.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-link-builder.ts
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import parser from 'accept-language-parser';
 
 const UTM_PREFIX = 'fx-';
 
@@ -80,10 +81,45 @@ const TEMPLATE_NAME_TO_CONTENT_MAP: Record<string, string> = {
 
 export interface EmailLinkBuilderConfig {
   metricsEnabled: boolean;
-  initiatePasswordResetUrl: string;
-  privacyUrl: string;
+  prependVerificationSubdomain: {
+    enabled: boolean;
+    subdomain: string;
+  };
+
+  /** Url for the front end. e.g. https://accounts.firefox.com */
+  baseUri: string;
+
+  defaultSurveyUrl: string;
+  subscriptionTermsUrl: string;
+  androidUrl: string;
+  iosUrl: string;
   supportUrl: string;
+  subscriptionSupportUrl: string;
+  privacyUrl: string;
+  twoFactorSupportUrl: string;
+  mozillaSupportUrl: string;
+  firefoxDesktopUrl: string;
 }
+
+export type RecoveryLinkQueryParams =
+  | {
+      uid: string;
+      token: string;
+      code: string;
+      email: string;
+      resume: string;
+      emailToHashWith: string;
+    }
+  | {
+      uid: string;
+      token: string;
+      code: string;
+      email: string;
+      resume: string;
+      emailToHashWith: string;
+      service: string;
+      redirectTo: string;
+    };
 
 export class EmailLinkBuilder {
   constructor(private readonly config: EmailLinkBuilderConfig) {}
@@ -92,12 +128,15 @@ export class EmailLinkBuilder {
    * Common base URLs used in emails. Most often paired with UTM parameters
    * to attach tracking info.
    */
-  private get urls() {
+  public get urls() {
     return {
-      initiatePasswordReset: this.config.initiatePasswordResetUrl,
       privacy: this.config.privacyUrl,
       support: this.config.supportUrl,
     };
+  }
+
+  private get baseUri() {
+    return this.config.baseUri;
   }
 
   /**
@@ -108,7 +147,7 @@ export class EmailLinkBuilder {
    * @param content - Optional content override (defaults to template's content map value)
    */
   private addUTMParams(
-    link: URL,
+    url: URL,
     templateName: string,
     metricsEnabled: boolean,
     content?: string
@@ -119,36 +158,171 @@ export class EmailLinkBuilder {
       return;
     }
 
-    link.searchParams.set('utm_medium', 'email');
+    const hash = url.hash;
+
+    url.searchParams.set('utm_medium', 'email');
 
     const campaign = this.getCampaign(templateName);
-    if (campaign && !link.searchParams.has('utm_campaign')) {
-      link.searchParams.set('utm_campaign', campaign);
+    if (campaign && !url.searchParams.has('utm_campaign')) {
+      url.searchParams.set('utm_campaign', campaign);
     }
 
     const contentValue = content || this.getContent(templateName);
     if (contentValue) {
-      link.searchParams.set('utm_content', UTM_PREFIX + contentValue);
+      url.searchParams.set('utm_content', UTM_PREFIX + contentValue);
+    }
+
+    url.hash = hash; // restore hash!
+  }
+
+  private addQueryParams(url: URL, query: Record<string, string>) {
+    const hash = url.hash;
+    Object.entries(query).forEach(([k, v]) => {
+      if (v) {
+        url.searchParams.set(k, v);
+      }
+    });
+
+    if (hash) {
+      url.hash = hash;
     }
   }
 
-  /**
-   * Build common links with UTM parameters (privacy, support)
-   * @param templateName
-   * @param metricsEnabled - Inidicates if metrics/tracking is enabled for the user
-   * @returns Object containing privacyUrl and supportUrl as strings
-   */
-  buildCommonLinks(templateName: string, metricsEnabled: boolean) {
-    const privacyUrl = new URL(this.urls.privacy);
-    const supportUrl = new URL(this.urls.support);
+  buildPasswordChangeLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      email: string;
+    }
+  ): string {
+    const url = new URL(`${this.baseUri}/settings/change_password`);
+    this.addUTMParams(url, templateName, metricsEnabled, 'change-password');
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
 
+  buildRevokeAccountRecoveryLink(
+    templateName: string,
+    metricsEnabled: boolean
+  ): string {
+    const url = new URL(`${this.baseUri}/settings#recovery-key`);
+    this.addUTMParams(url, templateName, metricsEnabled, 'report');
+    return url.toString();
+  }
+
+  buildLowRecoveryCodesLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      email: string;
+      uid: string;
+    }
+  ): string {
+    const url = new URL(
+      `${this.baseUri}/settings/two_step_authentication/replace_codes`
+    );
+    this.addUTMParams(url, templateName, metricsEnabled);
+    this.addQueryParams(url, {
+      low_recovery_codes: 'true',
+      ...query,
+    });
+
+    return url.toString();
+  }
+
+  buildPostNewRecoveryCodesLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      email: string;
+      uid: string;
+    }
+  ): string {
+    const url = new URL(`${this.baseUri}/settings`);
+    this.addUTMParams(url, templateName, metricsEnabled);
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  buildTwoFactorSettignsLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      email: string;
+    }
+  ): string {
+    const url = new URL(`${this.baseUri}/settings#two-step-authentication`);
+    this.addUTMParams(url, templateName, metricsEnabled, 'manage-two-factor');
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  buildTwoFactorSupportLink(): string {
+    return this.config.twoFactorSupportUrl;
+  }
+
+  buildAndroidLink(): string {
+    return this.config.androidUrl;
+  }
+
+  buildIosLink(): string {
+    return this.config.iosUrl;
+  }
+
+  buildTermsOfServiceDownloadLink(
+    templateName: string,
+    metricsEnabled: boolean
+  ) {
+    const url = new URL(this.config.subscriptionTermsUrl);
+    this.addUTMParams(url, templateName, metricsEnabled, 'subscription-terms');
+    return url.toString();
+  }
+
+  buildPrivacyLink(templateName: string, metricsEnabled: boolean) {
+    const privacyUrl = new URL(this.config.privacyUrl);
     this.addUTMParams(privacyUrl, templateName, metricsEnabled, 'privacy');
-    this.addUTMParams(supportUrl, templateName, metricsEnabled, 'support');
+    return privacyUrl.toString();
+  }
 
-    return {
-      privacyUrl: privacyUrl.toString(),
-      supportUrl: supportUrl.toString(),
-    };
+  buildSupportLink(templateName: string, metricsEnabled: boolean) {
+    const supportUrl = new URL(this.config.supportUrl);
+    this.addUTMParams(supportUrl, templateName, metricsEnabled, 'support');
+    return supportUrl.toString();
+  }
+
+  buildRecoveryLink(
+    templateName: 'recovery',
+    metricsEnabled: boolean,
+    query: RecoveryLinkQueryParams
+  ): string {
+    const url = new URL(`${this.baseUri}/complete_reset_password`);
+    this.addUTMParams(url, templateName, metricsEnabled);
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  buildMozillaSupportUrl() {
+    return this.config.mozillaSupportUrl;
+  }
+
+  buildAccountSettingsLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: { email?: string; uid?: string }
+  ) {
+    const url = new URL(`${this.baseUri}/settings`);
+    this.addUTMParams(url, templateName, metricsEnabled);
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  /**
+   * Creates HTML link attributes to be written into document
+   * @param link The href link value
+   * @returns A set of attributes that can be placed in an <a>
+   */
+  buildLinkAttributes(link: string) {
+    return `href="${link}" style="color: #0a84ff; text-decoration: none; font-family: sans-serif;"`;
   }
 
   /**
@@ -168,64 +342,138 @@ export class EmailLinkBuilder {
   }
 
   /**
-   * Adds query parameters to the provided link; includes UTM parameters if metrics are enabled.
-   * @param link - Base link string
-   * @param templateName - Email template name (used to lookup campaign)
-   * @param opts - Key/value pairs to add as query parameters
-   * @param metricsEnabled - Inidicates if metrics/tracking is enabled for the user
-   * @returns Link string with query parameters and UTM parameters (if enabled)
-   */
-  buildLinkWithQueryParamsAndUTM(
-    link: string,
-    templateName: string,
-    opts: Record<string, string | undefined>,
-    metricsEnabled: boolean
-  ): string {
-    const url = new URL(link);
-
-    for (const [key, value] of Object.entries(opts)) {
-      if (value !== undefined) {
-        url.searchParams.set(key, value);
-      }
-    }
-    this.addUTMParams(url, templateName, metricsEnabled);
-    return url.toString();
-  }
-
-  /**
    * Builds a password change required link with email and UTM parameters.
    * @param opts
    * @returns Link to for changing user's password
    */
   buildPasswordChangeRequiredLink(
-    url: string,
-    email: string,
-    metricsEnabled: boolean
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      email: string;
+    }
   ): string {
-    const link = new URL(url);
-    this.addUTMParams(link, 'passwordResetRequired', metricsEnabled);
-    link.searchParams.set('email', email);
-    return link.toString();
+    const url = new URL(`${this.baseUri}/settings/change_password`);
+    this.addUTMParams(url, templateName, metricsEnabled, 'change-password');
+    this.addQueryParams(url, query);
+    return url.toString();
   }
 
-  buildInitiatePasswordResetLink(
-    opts: {
-      uid: string;
-      token: string;
-      code: string;
+  /**
+   * Builds a password reset link
+   * @param email Users email
+   * @param metricsEnabled If user has metrics enabled
+   * @returns A link to initiate a password reset
+   */
+  buildResetLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
       email: string;
+    }
+  ): string {
+    const url = new URL(`${this.baseUri}/reset_password`);
+    this.addUTMParams(url, templateName, metricsEnabled, 'reset-password');
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  buildCadLink(templateName: string, metricsEnabled: boolean) {
+    const url = new URL(`${this.baseUri}/connect_another_device`);
+    this.addUTMParams(url, templateName, metricsEnabled);
+    return url.toString();
+  }
+
+  buildVerifyLoginLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      code: string;
+      uid: string;
       service?: string;
       redirectTo?: string;
       resume?: string;
-      emailToHashWith?: string;
-    },
-    metricsEnabled: boolean
-  ): string {
-    return this.buildLinkWithQueryParamsAndUTM(
-      this.urls.initiatePasswordReset,
-      'recovery',
-      opts,
-      metricsEnabled
-    );
+    }
+  ) {
+    const url = new URL(`${this.baseUri}/complete_signin`);
+    if (this.config.prependVerificationSubdomain.enabled) {
+      url.host = `${this.config.prependVerificationSubdomain.subdomain}.${url.host}`;
+    }
+    this.addUTMParams(url, templateName, metricsEnabled);
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  buildVerifyShortCodeLink(
+    templateName: string,
+    metricsEnabled: boolean,
+    query: {
+      email?: string;
+      uid?: string;
+    }
+  ) {
+    const url = new URL(`${this.baseUri}/verify_email`);
+    if (this.config.prependVerificationSubdomain.enabled) {
+      url.host = `${this.config.prependVerificationSubdomain.subdomain}.${url.host}`;
+    }
+    this.addUTMParams(url, templateName, metricsEnabled);
+    this.addQueryParams(url, query);
+    return url.toString();
+  }
+
+  buildDesktopLink() {
+    return this.config.firefoxDesktopUrl;
   }
 }
+
+// PORTED FROM fxa-shared/subscriptions/configuration/utils.ts
+const DEFAULT_LOCALE = 'en';
+export const localizedPlanConfig = (
+  planConfig: Readonly<{
+    uiContent: Record<string, any>;
+    urls: Record<string, string>;
+    support: Record<string, string>;
+    locales?: {
+      [key: string]: {
+        uiContent?: Record<string, any>;
+        urls?: Record<string, string>;
+        support?: Record<string, string>;
+      };
+    };
+  }>,
+  userLocales: string[]
+) => {
+  const planConfigLocales = Object.keys(planConfig.locales || {});
+  const defaults = {
+    uiContent: planConfig.uiContent,
+    urls: planConfig.urls,
+    support: planConfig.support,
+  };
+
+  if (!planConfigLocales.length || !userLocales.length) {
+    return defaults;
+  }
+
+  if (!planConfigLocales.includes(DEFAULT_LOCALE)) {
+    planConfigLocales.push(DEFAULT_LOCALE);
+  }
+
+  const pickedLang = parser.pick(planConfigLocales, userLocales.join(','));
+
+  if (
+    pickedLang &&
+    pickedLang !== DEFAULT_LOCALE &&
+    planConfig.locales &&
+    planConfig.locales[pickedLang]
+  ) {
+    const localizedConfigs = planConfig.locales[pickedLang];
+
+    return {
+      uiContent: { ...defaults.uiContent, ...localizedConfigs.uiContent },
+      urls: { ...defaults.urls, ...localizedConfigs.urls },
+      support: { ...defaults.support, ...localizedConfigs.support },
+    };
+  }
+
+  return defaults;
+};

--- a/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
@@ -252,7 +252,6 @@ describe('FxA Email Renderer', () => {
       link: mockLink,
       time: '12:00 PM',
       passwordChangeLink: mockLinkPasswordChange,
-      productName: 'Sync',
       ...defaultLayoutTemplateValues,
     });
     expect(email).toBeDefined();
@@ -315,6 +314,40 @@ describe('FxA Email Renderer', () => {
       twoFactorSupportLink: mockLinkSupport,
       passwordChangeLink: mockLinkPasswordChange,
       ...defaultLayoutTemplateValues,
+      recoveryMethod: '', // Won't render phone or recovery codes section.
+    });
+    expect(email).toBeDefined();
+    expect(email.html).toMatchSnapshot('matches full email snapshot');
+  });
+
+  it('should render renderPostAddTwoStepAuthentication with a recovery phone messaging', async () => {
+    const email = await renderer.renderPostAddTwoStepAuthentication({
+      date: 'Jan 1, 2024',
+      device: mockDevice,
+      location: mockLocation,
+      link: mockLink,
+      time: '12:00 PM',
+      twoFactorSupportLink: mockLinkSupport,
+      passwordChangeLink: mockLinkPasswordChange,
+      ...defaultLayoutTemplateValues,
+      recoveryMethod: 'phone',
+      maskedPhoneNumber: '*******123',
+    });
+    expect(email).toBeDefined();
+    expect(email.html).toMatchSnapshot('matches full email snapshot');
+  });
+
+  it('should render renderPostAddTwoStepAuthentication with a recovery codes messaging', async () => {
+    const email = await renderer.renderPostAddTwoStepAuthentication({
+      date: 'Jan 1, 2024',
+      device: mockDevice,
+      location: mockLocation,
+      link: mockLink,
+      time: '12:00 PM',
+      twoFactorSupportLink: mockLinkSupport,
+      passwordChangeLink: mockLinkPasswordChange,
+      ...defaultLayoutTemplateValues,
+      recoveryMethod: 'codes',
     });
     expect(email).toBeDefined();
     expect(email.html).toMatchSnapshot('matches full email snapshot');

--- a/libs/accounts/email-renderer/src/templates/passwordResetAccountRecovery/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetAccountRecovery/index.ts
@@ -11,7 +11,6 @@ export type TemplateData = AppBadgesTemplateData &
   UserInfoTemplateData & {
     link: string;
     passwordChangeLink: string;
-    productName: string;
   };
 
 export const template = 'passwordResetAccountRecovery';

--- a/libs/accounts/email-renderer/src/templates/passwordResetWithRecoveryKeyPrompt/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordResetWithRecoveryKeyPrompt/index.ts
@@ -9,7 +9,6 @@ export type TemplateData = AutomatedEmailChangePasswordTemplateData &
   UserInfoTemplateData & {
     link: string;
     passwordChangeLink: string;
-    productName: string;
     time: string;
     device: {
       uaBrowser: string;

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.stories.ts
@@ -18,6 +18,8 @@ const data = {
   twoFactorSupportLink:
     'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
   supportUrl: 'https://support.mozilla.org',
+  recoveryMethod: 'phone',
+  maskedPhoneNumber: '1234',
 };
 
 const createStory = storyWithProps<TemplateData>(

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.ts
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.ts
@@ -22,6 +22,8 @@ export type TemplateData = AutomatedEmailChangePasswordTemplateData &
       city: string;
     };
     date: string;
+    recoveryMethod: string;
+    maskedPhoneNumber?: string;
   };
 
 export const template = 'postAddTwoStepAuthentication';

--- a/packages/fxa-admin-server/src/backend/email.service.ts
+++ b/packages/fxa-admin-server/src/backend/email.service.ts
@@ -69,13 +69,14 @@ export class EmailService {
 
   public async sendPasswordChangeRequired(account: Account) {
     const smtpConfig = this.smtpConfig;
-    const linksConfig = this.linksConfig;
 
     // Render the email
     const link = this.linkBuilder.buildPasswordChangeRequiredLink(
-      linksConfig.initiatePasswordResetUrl,
-      account.primaryEmail?.email || account.email,
-      account.metricsOptOutAt === null
+      'passwordChangeRequired',
+      !account.metricsOptOutAt,
+      {
+        email: account.primaryEmail?.email || account.email,
+      }
     );
 
     const emailContent = await this.renderer.renderPasswordChangeRequired({
@@ -135,9 +136,13 @@ export class EmailService {
 export const EmailLinkBuilderFactory: Provider = {
   provide: EmailLinkBuilder,
   useFactory: async (config: ConfigService<AppConfig>) => {
+    const contentServerConfig = config.get(
+      'contentServer'
+    ) as AppConfig['contentServer'];
     const smtpConfig = config.get('smtp') as AppConfig['smtp'];
     const linksConfig = config.get('links') as AppConfig['links'];
     return new EmailLinkBuilder({
+      baseUri: contentServerConfig.url,
       ...smtpConfig,
       ...linksConfig,
     });

--- a/packages/fxa-admin-server/src/config/index.ts
+++ b/packages/fxa-admin-server/src/config/index.ts
@@ -662,6 +662,12 @@ const conf = convict({
       default:
         'https://firefox.com?utm_content=registration-confirmation&utm_medium=email&utm_source=fxa',
     },
+    firefoxDesktopUrl: {
+      doc: 'url to download Firefox page',
+      format: String,
+      default:
+        'https://firefox.com?utm_content=registration-confirmation&utm_medium=email&utm_source=fxa',
+    },
     androidUrl: {
       doc: 'url to Android product page',
       format: String,
@@ -722,17 +728,32 @@ const conf = convict({
       default:
         'https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0',
     },
-    initiatePasswordResetUrl: {
-      doc: 'URL that allows a user to reset their account.',
+    twoFactorSupportUrl: {
+      doc: 'URL to unsubscribe from MoCo and MoFo emails',
       format: String,
-      env: 'ACCOUNT_RESET_URL',
-      default: 'http://localhost:3030/reset_password',
+      env: 'TWO_FACTOR_SUPPORT_URL',
+      default:
+        'https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0',
     },
-    accountSettingsUrl: {
-      doc: 'URL for account settings',
+    mozillaSupportUrl: {
+      doc: 'URL to unsubscribe from MoCo and MoFo emails',
       format: String,
-      env: 'ACCOUNT_SETTINGS_URL',
-      default: 'http://localhost:3030/settings',
+      env: 'MOZILLA_SUPPORT_URL',
+      default: 'https://support.mozilla.org',
+    },
+    defaultSurveyUrl: {
+      doc: 'The default survey link',
+      format: String,
+      env: 'DEFAULT_SURVEY_URL',
+      default:
+        'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+    },
+  },
+  contentServer: {
+    url: {
+      doc: 'The url of the corresponding fxa-content-server instance',
+      default: 'http://localhost:3030',
+      env: 'CONTENT_SERVER_URL',
     },
   },
   smtp: {
@@ -891,6 +912,18 @@ const conf = convict({
       format: Boolean,
       default: true,
       env: 'SMTP_METRICS_ENABLED',
+    },
+    verificationUrl: {
+      doc: 'Link for verification URLs in emails',
+      format: String,
+      default: 'http://localhost:3030/verify_email',
+      env: 'SMTP_VERIFICATION_URL',
+    },
+    verifyLoginUrl: {
+      doc: 'Link for verifying logins used in emails',
+      format: String,
+      default: 'http://locahost:3030/complete_signin',
+      env: 'SMTP_VERIFY_LOGIN_URL',
     },
   },
   bounces: {

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -369,8 +369,8 @@ async function run(config) {
   // mailer lib setup
   const emailSender = new EmailSender(config.smtp, bounces, statsd, log);
   const linkBuilderConfig = {
+    baseUri: config.contentServer.url,
     ...config.smtp,
-    ...config.links,
   };
   const linkBuilder = new EmailLinkBuilder(linkBuilderConfig);
   const fxaMailer = new FxaMailer(
@@ -385,7 +385,7 @@ async function run(config) {
   const { OAuthClientInfoServiceName } = oauthClientInfo;
   Container.set({
     id: OAuthClientInfoServiceName,
-    factory: () => oauthClientInfo(log, database),
+    factory: () => oauthClientInfo(log, config),
   });
 
   const routes = require('../lib/routes')(

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -470,6 +470,12 @@ const convictConf = convict({
       env: 'SMTP_MAX_CONNECTIONS',
       format: Number,
     },
+    sendingRate: {
+      default: 1000,
+      doc: 'Maximum number of ses messages to send per second.',
+      env: 'SMTP_MAX_SENDING_RATE',
+      format: Number,
+    },
     prependVerificationSubdomain: {
       enabled: {
         doc: 'Flag to prepend a verification subdomain to verification emails',
@@ -501,6 +507,11 @@ const convictConf = convict({
       default:
         'https://app.adjust.com/2uo1qc?campaign=fxa-conf-email&adgroup=ios&creative=button&fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8&utm_source=email',
     },
+    mozillaSupportUrl: {
+      doc: 'url to general Mozilla support page',
+      format: String,
+      default: 'https://support.mozilla.org',
+    },
     supportUrl: {
       doc: 'url to Mozilla account support page',
       format: String,
@@ -522,6 +533,12 @@ const convictConf = convict({
       doc: 'url to Mozilla Accounts privacy page',
       format: String,
       default: 'https://www.mozilla.org/privacy/mozilla-accounts/',
+    },
+    twoFactorSupportUrl: {
+      doc: 'url to support page about two factor auth',
+      format: String,
+      default:
+        'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication',
     },
     passwordManagerInfoUrl: {
       doc: 'url to Firefox password manager information',
@@ -548,6 +565,12 @@ const convictConf = convict({
       env: 'UNSUBSCRIBE_EMAIL_LISTS_URL',
       default:
         'https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0',
+    },
+    defaultSurveyUrl: {
+      doc: 'The default survey link',
+      format: String,
+      default:
+        'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
     },
     sesConfigurationSet: {
       doc:
@@ -2718,6 +2741,10 @@ convictConf.set('smtp.accountSettingsUrl', `${baseUri}/settings`);
 convictConf.set(
   'smtp.accountRecoveryCodesUrl',
   `${baseUri}/settings/two_step_authentication/replace_codes`
+);
+convictConf.set(
+  'smpt.twoFactorSupportUrl',
+  'https://support.mozilla.org/kb/secure-mozilla-account-two-step-authentication'
 );
 convictConf.set('smtp.verificationUrl', `${baseUri}/verify_email`);
 convictConf.set('smtp.pushVerificationUrl', `${baseUri}/push/confirm_login`);

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-format.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-format.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { formatUserAgentInfo } from 'fxa-shared/lib/user-agent';
+import { constructLocalTimeAndDateStrings } from '@fxa/accounts/email-renderer';
+
+export const FxaMailerFormat = {
+  async metricsContext(request: {
+    app: {
+      metricsContext: Promise<{
+        deviceId?: string;
+        entrypoint?: string;
+        flowId: string;
+        flowBeginTime: number;
+      }>;
+    };
+  }) {
+    let metricsContext = await request.app.metricsContext;
+
+    return {
+      deviceId: metricsContext.deviceId,
+      flowId: metricsContext.flowId,
+      flowBeginTime: metricsContext.flowBeginTime,
+      entrypoint: metricsContext.entrypoint,
+    };
+  },
+  account(account: {
+    uid: string;
+    email: string;
+    emails?: Array<{ isPrimary: boolean; isVerified: boolean; email: string }>;
+    metricsOptOutAt: number | undefined | null;
+  }) {
+    return {
+      to:
+        account.emails?.find((e) => e.isPrimary && e.isVerified)?.email ||
+        account.email,
+      cc: account.emails
+        ?.filter((e) => !e.isPrimary && e.isVerified)
+        .map((e) => e.email),
+      metricsEnabled: !account.metricsOptOutAt,
+      uid: account.uid,
+    };
+  },
+  device(request: {
+    app: { ua: { browser?: string; os?: string; osVersion?: string } };
+  }) {
+    return {
+      device: formatUserAgentInfo(request.app.ua),
+    };
+  },
+  localTime(request: {
+    app: { geo: { timeZone: string }; acceptLanguage: string };
+  }) {
+    return constructLocalTimeAndDateStrings(
+      request.app.geo.timeZone,
+      request.app.acceptLanguage
+    );
+  },
+  location(request: {
+    app: {
+      geo: {
+        location?: {
+          city: string;
+          state: string;
+          stateCode: string;
+          country: string;
+          countryCode: string;
+          postalCode?: string;
+        };
+      };
+    };
+  }): {
+    location: {
+      stateCode: string;
+      country: string;
+      city: string;
+    };
+  } {
+    return {
+      location: {
+        stateCode: request.app.geo.location?.stateCode || '',
+        country: request.app.geo.location?.country || '',
+        city: request.app.geo.location?.city || '',
+      },
+    };
+  },
+  sync(service: string | false) {
+    return {
+      sync: service === 'sync',
+    };
+  },
+  cmsLogo(opts?: {
+    emailLogoAltText: string | null;
+    emailLogoUrl: string | null;
+    emailLogoWidth: string | null;
+  }) {
+    return {
+      logoAltText: opts?.emailLogoAltText || undefined,
+      logoUrl: opts?.emailLogoUrl || undefined,
+      logoWidth: opts?.emailLogoWidth || undefined,
+    };
+  },
+  cmsRpInfo(opts?: {
+    clientId: string | null;
+    shared?: { emailFromName: string | null };
+  }) {
+    return {
+      cmsRpClientId: opts?.clientId || undefined,
+      cmsRpFromName: opts?.shared?.emailFromName || undefined,
+    };
+  },
+  cmsEmailSubject(opts?: {
+    description: string | null;
+    headline: string | null;
+    subject: string | null;
+  }) {
+    return {
+      description: opts?.description || undefined,
+      headline: opts?.headline || undefined,
+      subject: opts?.subject || undefined,
+    };
+  },
+};

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
@@ -1,0 +1,398 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { EmailSender } from '../../../../libs/accounts/email-sender/src';
+import { FxaMailer } from './fxa-mailer';
+import { FxaMailerFormat } from './fxa-mailer-format';
+import {
+  EmailLinkBuilder,
+  NodeRendererBindings,
+} from '@fxa/accounts/email-renderer';
+import { ConfigType } from '../../config';
+
+/**
+ * This is jsut a strong typed driver that allows us to validate the params we pass into FxaMailer
+ * functions are type safe. Since there's still a lot of code in auth-server that isn't type safe
+ * this gives us some level of sanity that we are invoking the mailer methods correctly.
+ */
+
+// Create dummy mailer
+const fxaMailer = new FxaMailer(
+  {} as unknown as EmailSender,
+  {} as unknown as EmailLinkBuilder,
+  {} as unknown as ConfigType['smtp'],
+  {} as unknown as NodeRendererBindings
+);
+
+// Setup fake / mocked objects
+const account = {
+  uid: '',
+  metricsOptOutAt: null,
+  email: 'foo',
+  primaryEmail: { email: 'foo', isPrimary: true, isVerified: true },
+  emails: [
+    { email: 'foo', isPrimary: true, isVerified: true },
+    { email: 'bar', isPrimary: false, isVerified: true },
+  ],
+};
+
+const request = {
+  payload: {
+    metricsContext: {
+      flowId: '',
+      flowBeginTime: 0,
+      deviceId: '',
+    },
+  },
+  app: {
+    acceptLanguage: 'en',
+    geo: {
+      timeZone: '',
+      location: {
+        city: '',
+        state: '',
+        stateCode: '',
+        country: '',
+        countryCode: '',
+      },
+    },
+    clientAddress: '',
+    metricsContext: Promise.resolve({
+      flowId: '',
+      flowBeginTime: 0,
+      deviceId: '',
+    }),
+    ua: {
+      browser: '',
+      os: '',
+      osVersion: '',
+    },
+  },
+  auth: {
+    credentials: {
+      uaBrowser: '',
+      uaBrowserVersion: '',
+      uaOS: '',
+      uaOSVersion: '',
+      uaDeviceType: '',
+    },
+  },
+};
+
+const rpCmsConfig = {
+  shared: {
+    emailLogoUrl: '',
+    emailLogoAltText: '',
+    emailLogoWidth: '',
+  },
+};
+
+const service = 'sync';
+
+async function __sendRecoveryEmail() {
+  await fxaMailer.sendRecoveryEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.sync(service),
+    token: 'todo',
+    code: 'todo',
+    email: FxaMailerFormat.account(account).to,
+    resume: 'todo',
+    emailToHashWith: account.email,
+  });
+}
+
+async function __sendPasswordForgotOtpEmail() {
+  await fxaMailer.sendPasswordForgotOtpEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.sync(service),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.localTime(request),
+    code: 'todo',
+  });
+}
+
+async function _sendPostVerifySecondaryEmail() {
+  await fxaMailer.sendPostVerifySecondaryEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.sync(service),
+    secondaryEmail: 'foo@mozilla.com',
+  });
+}
+
+async function _sendPostChangePrimaryEmail() {
+  await fxaMailer.sendPostChangePrimaryEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.sync(false),
+    ...FxaMailerFormat.localTime(request),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.cmsLogo(rpCmsConfig.shared),
+    email: FxaMailerFormat.account(account).to,
+  });
+}
+
+async function _sendPostRemoveSecondaryEmail() {
+  await fxaMailer.sendPostRemoveSecondaryEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.localTime(request),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.sync(false),
+    secondaryEmail: 'foo@mozilla.com',
+  });
+}
+
+async function _sendPostAddLinkedAccountEmail() {
+  await fxaMailer.sendPostAddLinkedAccountEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    providerName: 'todo',
+  });
+}
+
+async function _sendNewDeviceLoginEmail() {
+  await fxaMailer.sendNewDeviceLoginEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.sync(service),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    clientName: 'sync',
+    showBannerWarning: false,
+  });
+}
+
+async function _sendPostAddTwoStepAuthenticationEmail() {
+  await fxaMailer.sendPostAddTwoStepAuthenticationEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.device(request),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.sync(service),
+    ...FxaMailerFormat.location(request),
+    recoveryMethod: 'phone',
+    maskedPhoneNumber: '3242',
+  });
+}
+
+async function _sendPostChangeTwoStepAuthenticationEmail() {
+  await fxaMailer.sendPostChangeTwoStepAuthenticationEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.localTime(request),
+  });
+}
+
+async function __sendPostRemoveTwoStepAuthenticationEmail() {
+  await fxaMailer.sendPostRemoveTwoStepAuthenticationEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.device(request),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function _sendPostNewRecoveryCodesEmail() {
+  await fxaMailer.sendPostNewRecoveryCodesEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.sync(service),
+    ...FxaMailerFormat.localTime(request),
+  });
+}
+
+async function __sendPostConsumeRecoveryCodeEmail() {
+  await fxaMailer.sendPostConsumeRecoveryCodeEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.device(request),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendLowRecoveryCodesEmail() {
+  await fxaMailer.sendLowRecoveryCodesEmail({
+    ...FxaMailerFormat.account(account),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.device(request),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.sync(service),
+    numberRemaining: 1,
+  });
+}
+
+async function __sendPostSigninRecoveryCodeEmail() {
+  await fxaMailer.sendPostSigninRecoveryCodeEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPostAddRecoveryPhoneEmail() {
+  await fxaMailer.sendPostAddRecoveryPhoneEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    maskedLastFourPhoneNumber: '4444',
+  });
+}
+
+async function __sendPostChangeRecoveryPhoneEmail() {
+  await fxaMailer.sendPostChangeRecoveryPhoneEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPostRemoveRecoveryPhoneEmail() {
+  await fxaMailer.sendPostRemoveRecoveryPhoneEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPasswordResetRecoveryPhoneEmail() {
+  await fxaMailer.sendPasswordResetRecoveryPhoneEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPostSigninRecoveryPhoneEmail() {
+  await fxaMailer.sendPostSigninRecoveryPhoneEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPostAddAccountRecoveryEmail() {
+  await fxaMailer.sendPostAddAccountRecoveryEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPostChangeAccountRecoveryEmail() {
+  await fxaMailer.sendPostChangeAccountRecoveryEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPostRemoveAccountRecoveryEmail() {
+  await fxaMailer.sendPostRemoveAccountRecoveryEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPasswordResetAccountRecoveryEmail() {
+  await fxaMailer.sendPasswordResetAccountRecoveryEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    productName: 'Firefox',
+  });
+}
+
+async function __sendPasswordResetWithRecoveryKeyPromptEmail() {
+  await fxaMailer.sendPasswordResetWithRecoveryKeyPromptEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendVerifyLoginCodeEmail() {
+  await fxaMailer.sendVerifyLoginCodeEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    code: '1234',
+    serviceName: 'foo',
+  });
+}
+
+async function __sendVerifyShortCodeEmail() {
+  await fxaMailer.sendVerifyShortCodeEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    code: '1234',
+  });
+}
+
+async function __sendPostVerifyEmail() {
+  await fxaMailer.sendPostVerifyEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.sync(service),
+    productName: 'Firefox',
+    onDesktopOrTabletDevice: true,
+  });
+}

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -9,11 +9,43 @@ import {
   WithFxaLayouts,
   recovery,
   passwordForgotOtp,
+  postVerifySecondary,
+  postChangePrimary,
+  postAddLinkedAccount,
+  newDeviceLogin,
+  postAddTwoStepAuthentication,
+  postChangeTwoStepAuthentication,
+  postRemoveTwoStepAuthentication,
+  postNewRecoveryCodes,
+  postConsumeRecoveryCode,
+  lowRecoveryCodes,
+  postSigninRecoveryCode,
+  postAddRecoveryPhone,
+  postChangeRecoveryPhone,
+  postRemoveRecoveryPhone,
+  passwordResetRecoveryPhone,
+  postSigninRecoveryPhone,
+  postAddAccountRecovery,
+  postChangeAccountRecovery,
+  postRemoveAccountRecovery,
+  passwordResetAccountRecovery,
+  passwordResetWithRecoveryKeyPrompt,
+  postRemoveSecondary,
+  RenderedTemplate,
+  RecoveryLinkQueryParams,
+  postVerify,
+  verifyLoginCode,
+  verifyShortCode,
 } from '@fxa/accounts/email-renderer';
 
 import { EmailSender } from '@fxa/accounts/email-sender';
 import { FxaEmailRenderer } from '@fxa/accounts/email-renderer';
 import { ConfigType } from '../../config';
+import moment from 'moment-timezone';
+import { metrics } from '@opentelemetry/api';
+import { TemplateInstance } from 'twilio/lib/rest/verify/v2/template';
+import { r } from '@faker-js/faker/dist/airline-BUL6NtOJ';
+import otp from '../routes/utils/otp';
 
 const SERVER = 'fxa-auth-server';
 
@@ -32,6 +64,7 @@ type EmailFlowParams = {
 
 type EmailSenderOpts = AccountOpts &
   EmailFlowParams & {
+    cmsRpFromName?: string;
     to: string;
     cc?: string[];
   };
@@ -40,8 +73,23 @@ type EmailSenderOpts = AccountOpts &
  * Some links are required on the underlying types, but shouldn't be
  * the responsibility of the caller to provide. Use this to wrap templateValues
  * and layoutTemplateValues types to omit those fields.
+ *
+ * Additional properties can be omitted by specifying them as the second generic parameter K.
  */
-type OmitCommonLinks<T> = Omit<T, 'supportUrl' | 'privacyUrl' | 'link'>;
+type OmitCommonLinks<T, K extends keyof T = never> = Omit<
+  T,
+  | 'supportUrl'
+  | 'privacyUrl'
+  | 'link'
+  | 'passwordChangeLink'
+  | 'revokeAccountRecoveryLink'
+  | 'mozillaSupportUrl'
+  | 'twoFactorSupportLink'
+  | 'twoFactorSettingsLink'
+  | 'resetLink'
+  | 'desktopLink'
+  | K
+>;
 
 export class FxaMailer extends FxaEmailRenderer {
   constructor(
@@ -69,64 +117,31 @@ export class FxaMailer extends FxaEmailRenderer {
   async sendRecoveryEmail(
     opts: EmailSenderOpts &
       OmitCommonLinks<TemplateData> &
-      OmitCommonLinks<recovery.TemplateData> & {
-        token: string;
-        code: string;
-        emailToHashWith?: string;
-        service?: string;
-        redirectTo?: string;
-        resume?: string;
-      } & OmitCommonLinks<WithFxaLayouts<recovery.TemplateData>>
+      OmitCommonLinks<recovery.TemplateData> &
+      OmitCommonLinks<WithFxaLayouts<recovery.TemplateData>> &
+      RecoveryLinkQueryParams
   ) {
-    const { template: name, version } = recovery;
+    const { template, version } = recovery;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      link: this.linkBuilder.buildRecoveryLink(template, metricsEnabled, opts),
+    };
 
-    // Build links for template
-    const initiatePasswordResetLink =
-      this.linkBuilder.buildInitiatePasswordResetLink(
-        {
-          uid: opts.uid,
-          token: opts.token,
-          code: opts.code,
-          email: opts.to,
-          service: opts.service,
-          redirectTo: opts.redirectTo,
-          resume: opts.resume,
-          emailToHashWith: opts.emailToHashWith,
-        },
-        opts.metricsEnabled
-      );
-    const { supportUrl, privacyUrl } = this.linkBuilder.buildCommonLinks(
-      name,
-      opts.metricsEnabled
-    );
-
-    const rendered = await this.renderRecovery({
-      ...opts,
-      link: initiatePasswordResetLink,
-      supportUrl,
-      privacyUrl,
-    });
-
-    const headers = this.emailSender.buildHeaders({
-      context: { ...opts, serverName: SERVER, language: opts.acceptLanguage },
-      headers: {
-        'X-Link': initiatePasswordResetLink,
+    const headers = this.buildHeaders(
+      { template, version },
+      {
+        'X-Link': links.link,
         'X-Recovery-Code': opts.code,
       },
-      template: {
-        name,
-        version,
-      },
+      opts
+    );
+    const rendered = await this.renderRecovery({
+      ...opts,
+      ...links,
     });
-
-    // Send email
-    return this.emailSender.send({
-      to: opts.to,
-      cc: opts.cc,
-      from: this.mailerConfig.sender,
-      headers,
-      ...rendered,
-    });
+    return this.sendEmail(opts, headers, rendered);
   }
 
   /**
@@ -139,34 +154,942 @@ export class FxaMailer extends FxaEmailRenderer {
       EmailFlowParams &
       OmitCommonLinks<WithFxaLayouts<passwordForgotOtp.TemplateData>>
   ) {
-    const { template: name, version } = passwordForgotOtp;
-
-    const { privacyUrl, supportUrl } = this.linkBuilder.buildCommonLinks(
-      name,
-      opts.metricsEnabled
+    const { template, version } = passwordForgotOtp;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'x-password-forgot-otp': opts.code },
+      opts
     );
-
     const rendered = await this.renderPasswordForgotOtp({
       ...opts,
-      supportUrl,
-      privacyUrl,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostVerifySecondaryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postVerifySecondary.TemplateData>
+  ) {
+    const { template, version } = postVerifySecondary;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        {
+          email: opts.to,
+          uid: opts.uid,
+        }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostVerifySecondary({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostChangePrimaryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postChangePrimary.TemplateData>
+  ) {
+    const { template, version } = postChangePrimary;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostChangePrimary({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostRemoveSecondaryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postRemoveSecondary.TemplateData>
+  ) {
+    const { template, version } = postRemoveSecondary;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostRemoveSecondary({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostAddLinkedAccountEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postAddLinkedAccount.TemplateData>
+  ) {
+    const { template, version } = postAddLinkedAccount;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      {
+        'X-Link': links.passwordChangeLink,
+        'X-Linked-Account-Provider-Id': opts.providerName,
+      },
+      opts
+    );
+    const rendered = await this.renderPostAddLinkedAccount({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendNewDeviceLoginEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<newDeviceLogin.TemplateData>
+  ) {
+    const { template, version } = newDeviceLogin;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      mozillaSupportUrl: this.linkBuilder.buildMozillaSupportUrl(),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.passwordChangeLink },
+      opts
+    );
+    const rendered = await this.renderNewDeviceLogin({
+      ...opts,
+      ...links,
     });
 
-    const headers = this.emailSender.buildHeaders({
-      context: { ...opts, serverName: SERVER, language: opts.acceptLanguage },
-      headers: {
-        'x-password-forgot-otp': opts.code,
-      },
-      template: {
-        name,
-        version,
-      },
-    });
+    return this.sendEmail(opts, headers, rendered);
+  }
 
+  async sendPostAddTwoStepAuthenticationEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postAddTwoStepAuthentication.TemplateData>
+  ) {
+    const { template, version } = postAddTwoStepAuthentication;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      twoFactorSupportLink: this.linkBuilder.buildTwoFactorSupportLink(),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostAddTwoStepAuthentication({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostChangeTwoStepAuthenticationEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postChangeTwoStepAuthentication.TemplateData>
+  ) {
+    const { template, version } = postChangeTwoStepAuthentication;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      twoFactorSupportLink: this.linkBuilder.buildTwoFactorSupportLink(),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostChangeTwoStepAuthentication({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostRemoveTwoStepAuthenticationEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postRemoveTwoStepAuthentication.TemplateData>
+  ) {
+    const { template, version } = postRemoveTwoStepAuthentication;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostRemoveTwoStepAuthentication({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostNewRecoveryCodesEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postNewRecoveryCodes.TemplateData>
+  ) {
+    const { template, version } = postNewRecoveryCodes;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildPostNewRecoveryCodesLink(
+        template,
+        metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostNewRecoveryCodes({
+      ...opts,
+      ...links,
+    });
     return this.emailSender.send({
       to: opts.to,
       cc: opts.cc,
       from: this.mailerConfig.sender,
+      headers,
+      ...rendered,
+    });
+  }
+
+  async sendPostConsumeRecoveryCodeEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postConsumeRecoveryCode.TemplateData>
+  ) {
+    const { template, version } = postConsumeRecoveryCode;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      twoFactorSettingsLink: this.linkBuilder.buildTwoFactorSettignsLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostConsumeRecoveryCode({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendLowRecoveryCodesEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<lowRecoveryCodes.TemplateData>
+  ) {
+    const { template, version } = lowRecoveryCodes;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      link: this.linkBuilder.buildLowRecoveryCodesLink(
+        template,
+        metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderLowRecoveryCodes({
+      ...opts,
+      ...links,
+    });
+    return this.emailSender.send({
+      to: opts.to,
+      cc: opts.cc,
+      from: this.mailerConfig.sender,
+      headers,
+      ...rendered,
+    });
+  }
+
+  async sendPostSigninRecoveryCodeEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postSigninRecoveryCode.TemplateData>
+  ) {
+    const { template, version } = postSigninRecoveryCode;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostSigninRecoveryCode({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostAddRecoveryPhoneEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postAddRecoveryPhone.TemplateData>
+  ) {
+    const { template, version } = postAddRecoveryPhone;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      twoFactorSupportLink: this.linkBuilder.buildTwoFactorSupportLink(),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostAddRecoveryPhone({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostChangeRecoveryPhoneEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postChangeRecoveryPhone.TemplateData>
+  ) {
+    const { template, version } = postChangeRecoveryPhone;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.resetLink },
+      opts
+    );
+    const rendered = await this.renderPostChangeRecoveryPhone({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostRemoveRecoveryPhoneEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postRemoveRecoveryPhone.TemplateData>
+  ) {
+    const { template, version } = postRemoveRecoveryPhone;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostRemoveRecoveryPhone({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPasswordResetRecoveryPhoneEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<passwordResetRecoveryPhone.TemplateData>
+  ) {
+    const { template, version } = passwordResetRecoveryPhone;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+      twoFactorSettingsLink: this.linkBuilder.buildTwoFactorSettignsLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPasswordResetRecoveryPhone({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostSigninRecoveryPhoneEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postSigninRecoveryPhone.TemplateData>
+  ) {
+    const { template, version } = postSigninRecoveryPhone;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      resetLink: this.linkBuilder.buildResetLink(template, metricsEnabled, {
+        email: opts.to,
+      }),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostSigninRecoveryPhone({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostAddAccountRecoveryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postAddAccountRecovery.TemplateData>
+  ) {
+    const { template, version } = postAddAccountRecovery;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      revokeAccountRecoveryLink:
+        this.linkBuilder.buildRevokeAccountRecoveryLink(
+          template,
+          metricsEnabled
+        ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        {
+          email: opts.to,
+          uid: opts.uid,
+        }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostAddAccountRecovery({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostChangeAccountRecoveryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postChangeAccountRecovery.TemplateData>
+  ) {
+    const { template, version } = postChangeAccountRecovery;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      revokeAccountRecoveryLink:
+        this.linkBuilder.buildRevokeAccountRecoveryLink(
+          template,
+          metricsEnabled
+        ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostChangeAccountRecovery({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostRemoveAccountRecoveryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postRemoveAccountRecovery.TemplateData>
+  ) {
+    const { template, version } = postRemoveAccountRecovery;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      revokeAccountRecoveryLink:
+        this.linkBuilder.buildRevokeAccountRecoveryLink(
+          template,
+          metricsEnabled
+        ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostRemoveAccountRecovery({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPasswordResetAccountRecoveryEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<passwordResetAccountRecovery.TemplateData>
+  ) {
+    const { template, version } = passwordResetAccountRecovery;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeRequiredLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPasswordResetAccountRecovery({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPasswordResetWithRecoveryKeyPromptEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<passwordResetWithRecoveryKeyPrompt.TemplateData>
+  ) {
+    const { template, version } = passwordResetWithRecoveryKeyPrompt;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeRequiredLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildAccountSettingsLink(
+        template,
+        opts.metricsEnabled,
+        { email: opts.to, uid: opts.uid }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPasswordResetWithRecoveryKeyPrompt({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendPostVerifyEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<postVerify.TemplateData>
+  ) {
+    const { template, version } = postVerify;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeRequiredLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      desktopLink: this.linkBuilder.buildDesktopLink(),
+      link: this.linkBuilder.buildCadLink(template, opts.metricsEnabled),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Link': links.link },
+      opts
+    );
+    const rendered = await this.renderPostVerify({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendVerifyLoginCodeEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<verifyLoginCode.TemplateData> & {
+        redirectTo?: string;
+        resume?: string;
+      }
+  ) {
+    const { template, version } = verifyLoginCode;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeRequiredLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildVerifyLoginLink(template, metricsEnabled, {
+        code: opts.code,
+        uid: opts.uid,
+        service: opts.serviceName,
+        redirectTo: opts.redirectTo,
+        resume: opts.resume,
+      }),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Signin-Verify-Code': opts.code },
+      opts
+    );
+    const rendered = await this.renderVerifyLoginCode({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  async sendVerifyShortCodeEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<TemplateData> &
+      OmitCommonLinks<verifyShortCode.TemplateData>
+  ) {
+    const { template, version } = verifyShortCode;
+    const { metricsEnabled } = opts;
+    const links = {
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeRequiredLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+      link: this.linkBuilder.buildVerifyShortCodeLink(
+        template,
+        metricsEnabled,
+        {
+          uid: opts.uid,
+          email: opts.to,
+        }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'X-Verify-Short-Code': opts.code },
+      opts
+    );
+    const rendered = await this.renderVerifyShortCode({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered);
+  }
+
+  private buildHeaders(
+    template: { template: string; version: number },
+    headers: Record<string, string>,
+    opts: { acceptLanguage: string }
+  ) {
+    return this.emailSender.buildHeaders({
+      context: {
+        ...opts,
+        serverName: SERVER,
+        language: opts.acceptLanguage,
+      },
+      headers,
+      template: {
+        name: template.template,
+        version: template.version,
+      },
+    });
+  }
+
+  private async sendEmail(
+    opts: { to: string; cc?: string[]; cmsRpFromName?: string },
+    headers: Record<string, string>,
+    rendered: RenderedTemplate
+  ) {
+    const { cmsRpFromName, to, cc } = opts;
+    const from = cmsRpFromName
+      ? `${cmsRpFromName} <${this.mailerConfig.sender}>`
+      : this.mailerConfig.sender;
+
+    return this.emailSender.send({
+      to,
+      cc,
+      from,
       headers,
       ...rendered,
     });

--- a/packages/fxa-auth-server/lib/senders/oauth_client_info.js
+++ b/packages/fxa-auth-server/lib/senders/oauth_client_info.js
@@ -82,4 +82,4 @@ module.exports = (log, config) => {
   };
 };
 
-export const OAuthClientInfoServiceName = 'OAuthClientInfo';
+module.exports.OAuthClientInfoServiceName = 'OAuthClientInfo';

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -37,6 +37,7 @@ export interface AuthApp extends RequestApplicationState {
     location?: {
       city: string;
       state: string;
+      stateCode: string;
       country: string;
       countryCode: string;
       postalCode?: string;
@@ -113,6 +114,12 @@ export interface AuthLogger extends Logger {
     request: AuthRequest,
     data: Record<string, any>
   ): Promise<void>;
+}
+
+export interface AuthClientInfoService {
+  fetch(service: string): Promise<{
+    name: string;
+  }>;
 }
 
 // Container token types

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -97,10 +97,12 @@ function runTest(route, request, assertions) {
 }
 
 describe('IP Profiling', function () {
-  let route, accountRoutes, mockDB, mockMailer, mockRequest;
+  let route, accountRoutes, mockDB, mockMailer, mockFxaMailer, mockRequest;
   this.timeout(30000);
 
   beforeEach(() => {
+    mockFxaMailer = mocks.mockFxaMailer();
+    mocks.mockOAuthClientInfo();
     mockDB = mocks.mockDB({
       email: TEST_EMAIL,
       emailVerified: true,
@@ -152,7 +154,7 @@ describe('IP Profiling', function () {
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 0);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 0);
       assert.equal(response.sessionVerified, false, 'session not verified');
     });
   });
@@ -174,7 +176,7 @@ describe('IP Profiling', function () {
         0,
         'mailer.sendVerifyLoginEmail was not called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 1);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 1);
       assert.equal(response.sessionVerified, true, 'session verified');
     });
   });
@@ -196,7 +198,7 @@ describe('IP Profiling', function () {
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 0);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 0);
       assert.equal(response.sessionVerified, false, 'session verified');
     });
   });
@@ -232,7 +234,7 @@ describe('IP Profiling', function () {
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 0);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 0);
       assert.equal(response.sessionVerified, false, 'session verified');
       return runTest(route, mockRequest);
     }).then((response) => {
@@ -241,7 +243,7 @@ describe('IP Profiling', function () {
         2,
         'mailer.sendVerifyLoginEmail was called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 0);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 0);
       assert.equal(response.sessionVerified, false, 'session verified');
     });
   });
@@ -256,7 +258,7 @@ describe('IP Profiling', function () {
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 0);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 0);
       assert.equal(response.sessionVerified, false, 'session verified');
       return runTest(route, mockRequest);
     }).then((response) => {
@@ -265,7 +267,7 @@ describe('IP Profiling', function () {
         2,
         'mailer.sendVerifyLoginEmail was called'
       );
-      assert.equal(mockMailer.sendNewDeviceLoginEmail.callCount, 0);
+      assert.equal(mockFxaMailer.sendNewDeviceLoginEmail.callCount, 0);
       assert.equal(response.sessionVerified, false, 'session verified');
     });
   });

--- a/packages/fxa-auth-server/test/local/routes/linked-accounts.js
+++ b/packages/fxa-auth-server/test/local/routes/linked-accounts.js
@@ -45,7 +45,14 @@ function runTest(route, request, assertions) {
 
 describe('/linked_account', function () {
   this.timeout(5000);
-  let mockLog, mockDB, mockMailer, mockRequest, route, axiosMock, statsd;
+  let mockLog,
+    mockDB,
+    mockMailer,
+    mockFxaMailer,
+    mockRequest,
+    route,
+    axiosMock,
+    statsd;
 
   const UID = 'fxauid';
 
@@ -66,6 +73,8 @@ describe('/linked_account', function () {
           googleAuthConfig: { clientId: 'OooOoo' },
         };
         mockMailer = mocks.mockMailer();
+        mockFxaMailer = mocks.mockFxaMailer();
+        mocks.mockOAuthClientInfo();
         mockRequest = mocks.mockRequest({
           log: mockLog,
           payload: {
@@ -229,7 +238,7 @@ describe('/linked_account', function () {
             GOOGLE_PROVIDER
           )
         );
-        assert.equal(mockMailer.sendPostAddLinkedAccountEmail.callCount, 1);
+        assert.equal(mockFxaMailer.sendPostAddLinkedAccountEmail.callCount, 1);
         assert.isTrue(mockDB.createSessionToken.calledOnce);
         assert.equal(result.uid, UID);
         assert.ok(result.sessionToken);
@@ -461,7 +470,7 @@ describe('/linked_account', function () {
             APPLE_PROVIDER
           )
         );
-        assert.equal(mockMailer.sendPostAddLinkedAccountEmail.callCount, 1);
+        assert.equal(mockFxaMailer.sendPostAddLinkedAccountEmail.callCount, 1);
         assert.isTrue(mockDB.createSessionToken.calledOnce);
         assert.equal(result.uid, UID);
         assert.ok(result.sessionToken);

--- a/packages/fxa-auth-server/test/local/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-codes.js
@@ -13,7 +13,16 @@ const { Container } = require('typedi');
 const { BackupCodeManager } = require('@fxa/accounts/two-factor');
 const { AccountEventsManager } = require('../../../lib/account-events');
 
-let log, db, customs, routes, route, request, requestOptions, mailer, glean;
+let log,
+  db,
+  customs,
+  routes,
+  route,
+  request,
+  requestOptions,
+  mailer,
+  fxaMailer,
+  glean;
 const TEST_EMAIL = 'test@email.com';
 const UID = 'uid';
 let sandbox;
@@ -53,6 +62,7 @@ describe('backup authentication codes', () => {
     log = mocks.mockLog();
     customs = mocks.mockCustoms();
     mailer = mocks.mockMailer();
+    fxaMailer = mocks.mockFxaMailer();
     db = mocks.mockDB({
       uid: UID,
       email: TEST_EMAIL,
@@ -193,10 +203,10 @@ describe('backup authentication codes', () => {
         return Promise.resolve({ remaining: 1 });
       });
       await runTest('/session/verify/recoveryCode', requestOptions);
-      assert.equal(mailer.sendLowRecoveryCodesEmail.callCount, 1);
-      const args = mailer.sendLowRecoveryCodesEmail.args[0];
-      assert.lengthOf(args, 3);
-      assert.equal(args[2].numberRemaining, 1);
+      assert.equal(fxaMailer.sendLowRecoveryCodesEmail.callCount, 1);
+      const args = fxaMailer.sendLowRecoveryCodesEmail.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0].numberRemaining, 1);
 
       assert.calledOnceWithExactly(
         mockAccountEventsManager.recordSecurityEvent,

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -13,7 +13,16 @@ const { AppError: errors } = require('@fxa/accounts/errors');
 const proxyquire = require('proxyquire');
 const { OAUTH_SCOPE_OLD_SYNC } = require('fxa-shared/oauth/constants');
 
-let log, db, customs, mailer, glean, routes, route, request, response;
+let log,
+  db,
+  customs,
+  mailer,
+  fxaMailer,
+  glean,
+  routes,
+  route,
+  request,
+  response;
 const email = 'test@email.com';
 const recoveryKeyId = '000000';
 const recoveryData = '11111111111';
@@ -25,6 +34,7 @@ let mockAccountEventsManager;
 describe('POST /recoveryKey', () => {
   beforeEach(() => {
     mockAccountEventsManager = mocks.mockAccountEventsManager();
+    fxaMailer = mocks.mockFxaMailer();
   });
 
   afterEach(() => {
@@ -118,10 +128,10 @@ describe('POST /recoveryKey', () => {
     });
 
     it('called mailer.sendPostAddAccountRecoveryEmail correctly', () => {
-      assert.equal(mailer.sendPostAddAccountRecoveryEmail.callCount, 1);
-      const args = mailer.sendPostAddAccountRecoveryEmail.args[0];
-      assert.equal(args.length, 3);
-      assert.equal(args[0][0].email, email);
+      assert.equal(fxaMailer.sendPostAddAccountRecoveryEmail.callCount, 1);
+      const args = fxaMailer.sendPostAddAccountRecoveryEmail.args[0];
+      assert.equal(args.length, 1);
+      assert.equal(args[0].to, email);
     });
   });
 
@@ -140,7 +150,13 @@ describe('POST /recoveryKey', () => {
         },
       };
       response = await setup(
-        { db: { recoveryData, email } },
+        {
+          db: {
+            recoveryData,
+            email,
+            uid,
+          },
+        },
         {},
         '/recoveryKey',
         requestOptions
@@ -229,10 +245,10 @@ describe('POST /recoveryKey', () => {
     });
 
     it('called mailer.sendPostChangeAccountRecoveryEmail correctly', () => {
-      assert.equal(mailer.sendPostChangeAccountRecoveryEmail.callCount, 1);
-      const args = mailer.sendPostChangeAccountRecoveryEmail.args[0];
-      assert.equal(args.length, 3);
-      assert.equal(args[0][0].email, email);
+      assert.equal(fxaMailer.sendPostChangeAccountRecoveryEmail.callCount, 1);
+      const args = fxaMailer.sendPostChangeAccountRecoveryEmail.args[0];
+      assert.equal(args.length, 1);
+      assert.equal(args[0].to, email);
     });
   });
 
@@ -301,8 +317,8 @@ describe('POST /recoveryKey', () => {
       assert.equal(request.emitMetricsEvent.callCount, 0);
     });
 
-    it('did not call mailer.sendPostAddAccountRecoveryEmail', () => {
-      assert.equal(mailer.sendPostAddAccountRecoveryEmail.callCount, 0);
+    it('did not call fxaMailer.sendPostAddAccountRecoveryEmail', () => {
+      assert.equal(fxaMailer.sendPostAddAccountRecoveryEmail.callCount, 0);
     });
   });
 
@@ -398,10 +414,10 @@ describe('POST /recoveryKey', () => {
     });
 
     it('called mailer.sendPostAddAccountRecoveryEmail correctly', () => {
-      assert.equal(mailer.sendPostAddAccountRecoveryEmail.callCount, 1);
-      const args = mailer.sendPostAddAccountRecoveryEmail.args[0];
-      assert.equal(args.length, 3);
-      assert.equal(args[0][0].email, email);
+      assert.equal(fxaMailer.sendPostAddAccountRecoveryEmail.callCount, 1);
+      const args = fxaMailer.sendPostAddAccountRecoveryEmail.args[0];
+      assert.equal(args.length, 1);
+      assert.equal(args[0].to, email);
     });
 
     it('records security event', () => {
@@ -637,6 +653,7 @@ describe('POST /recoveryKey/exists', () => {
 describe('DELETE /recoveryKey', () => {
   beforeEach(() => {
     mockAccountEventsManager = mocks.mockAccountEventsManager();
+    fxaMailer = mocks.mockFxaMailer();
   });
 
   afterEach(() => {
@@ -678,10 +695,10 @@ describe('DELETE /recoveryKey', () => {
     });
 
     it('called mailer.sendPostRemoveAccountRecoveryEmail correctly', () => {
-      assert.equal(mailer.sendPostRemoveAccountRecoveryEmail.callCount, 1);
-      const args = mailer.sendPostRemoveAccountRecoveryEmail.args[0];
-      assert.equal(args.length, 3);
-      assert.equal(args[0][0].email, email);
+      assert.equal(fxaMailer.sendPostRemoveAccountRecoveryEmail.callCount, 1);
+      const args = fxaMailer.sendPostRemoveAccountRecoveryEmail.args[0];
+      assert.equal(args.length, 1);
+      assert.equal(args[0].to, email);
     });
 
     it('recorded security event', () => {

--- a/packages/fxa-auth-server/test/local/routes/recovery-phone.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-phone.js
@@ -34,6 +34,8 @@ describe('/recovery_phone', () => {
   const mockDb = mocks.mockDB({ uid: uid, email: email });
   const mockLog = mocks.mockLog();
   let mockMailer;
+  let mockFxaMailer;
+
   const mockCustoms = {
     check: sandbox.fake(),
     checkAuthenticated: sandbox.fake(),
@@ -93,6 +95,7 @@ describe('/recovery_phone', () => {
     Container.set(AccountManager, mockAccountManager);
     Container.set(AccountEventsManager, mockAccountEventsManager);
     mockMailer = mocks.mockMailer();
+    mockFxaMailer = mocks.mockFxaMailer();
     // Ensure RecoveryPhoneHandler resolves OtpUtils with our mocked db/statsd
     otpUtils = new OtpUtils(mockDb, mockStatsd);
     Container.set(OtpUtils, otpUtils);
@@ -529,7 +532,7 @@ describe('/recovery_phone', () => {
         code
       );
       assert.equal(mockGlean.twoStepAuthPhoneCode.complete.callCount, 1);
-      assert.calledOnce(mockMailer.sendPostAddRecoveryPhoneEmail);
+      assert.calledOnce(mockFxaMailer.sendPostAddRecoveryPhoneEmail);
       assert.calledOnceWithExactly(
         mockAccountEventsManager.recordSecurityEvent,
         mockDb,
@@ -590,6 +593,7 @@ describe('/recovery_phone', () => {
       );
       assert.equal(mockGlean.twoStepAuthPhoneCode.complete.callCount, 1);
       assert.notCalled(mockMailer.sendPostAddRecoveryPhoneEmail);
+      assert.notCalled(mockFxaMailer.sendPostAddRecoveryPhoneEmail);
     });
 
     it('indicates a failure confirming code', async () => {
@@ -607,7 +611,7 @@ describe('/recovery_phone', () => {
 
       await assert.isRejected(promise, 'Invalid or expired confirmation code');
       assert.equal(mockGlean.twoStepAuthPhoneCode.complete.callCount, 0);
-      assert.notCalled(mockMailer.sendPostAddRecoveryPhoneEmail);
+      assert.notCalled(mockFxaMailer.sendPostAddRecoveryPhoneEmail);
     });
 
     it('indicates an issue with the backend service', async () => {
@@ -627,7 +631,7 @@ describe('/recovery_phone', () => {
       await assert.isRejected(promise, 'System unavailable, try again soon');
 
       assert.equal(mockGlean.twoStepAuthPhoneCode.complete.callCount, 0);
-      assert.notCalled(mockMailer.sendPostAddRecoveryPhoneEmail);
+      assert.notCalled(mockFxaMailer.sendPostAddRecoveryPhoneEmail);
     });
   });
 
@@ -655,7 +659,7 @@ describe('/recovery_phone', () => {
       );
       assert.equal(mockAccountManager.verifySession.callCount, 1);
       assert.equal(mockGlean.login.recoveryPhoneSuccess.callCount, 1);
-      assert.calledOnce(mockMailer.sendPostSigninRecoveryPhoneEmail);
+      assert.calledOnce(mockFxaMailer.sendPostSigninRecoveryPhoneEmail);
       assert.calledOnceWithExactly(
         mockAccountEventsManager.recordSecurityEvent,
         mockDb,
@@ -778,7 +782,7 @@ describe('/recovery_phone', () => {
         mockStatsd.increment,
         'account.resetPassword.recoveryPhone.success'
       );
-      assert.calledOnce(mockMailer.sendPasswordResetRecoveryPhoneEmail);
+      assert.calledOnce(mockFxaMailer.sendPasswordResetRecoveryPhoneEmail);
     });
 
     it('fails confirms a code during signin', async () => {
@@ -835,7 +839,7 @@ describe('/recovery_phone', () => {
         uid
       );
       assert.equal(mockGlean.twoStepAuthPhoneRemove.success.callCount, 1);
-      assert.calledOnce(mockMailer.sendPostRemoveRecoveryPhoneEmail);
+      assert.calledOnce(mockFxaMailer.sendPostRemoveRecoveryPhoneEmail);
       assert.calledOnceWithExactly(
         mockAccountEventsManager.recordSecurityEvent,
         mockDb,
@@ -874,7 +878,7 @@ describe('/recovery_phone', () => {
 
       await assert.isRejected(promise, 'System unavailable, try again soon');
       assert.equal(mockGlean.twoStepAuthPhoneRemove.success.callCount, 0);
-      assert.notCalled(mockMailer.sendPostRemoveRecoveryPhoneEmail);
+      assert.notCalled(mockFxaMailer.sendPostRemoveRecoveryPhoneEmail);
     });
 
     it('handles uid without registered phone number', async () => {

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -24,6 +24,7 @@ let log,
   request,
   requestOptions,
   mailer,
+  fxaMailer,
   profile,
   accountEventsManager,
   authServerCacheRedis;
@@ -63,6 +64,9 @@ describe('totp', () => {
     accountEventsManager = {
       recordSecurityEvent: sinon.fake.resolves({}),
     };
+
+    mocks.mockOAuthClientInfo();
+    fxaMailer = mocks.mockFxaMailer();
 
     Container.set(RecoveryPhoneService, mockRecoveryPhoneService);
     Container.set(BackupCodeManager, mockBackupCodeManager);
@@ -189,8 +193,11 @@ describe('totp', () => {
         });
 
         // correct emails sent
-        assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
-        assert.equal(mailer.sendPostAddTwoStepAuthenticationEmail.callCount, 0);
+        assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 1);
+        assert.equal(
+          fxaMailer.sendPostAddTwoStepAuthenticationEmail.callCount,
+          0
+        );
 
         assert.calledOnceWithExactly(
           accountEventsManager.recordSecurityEvent,
@@ -272,8 +279,11 @@ describe('totp', () => {
         });
 
         // correct emails sent
-        assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
-        assert.equal(mailer.sendPostAddTwoStepAuthenticationEmail.callCount, 0);
+        assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 1);
+        assert.equal(
+          fxaMailer.sendPostAddTwoStepAuthenticationEmail.callCount,
+          0
+        );
       });
     });
 
@@ -313,8 +323,11 @@ describe('totp', () => {
         );
 
         // correct emails sent
-        assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
-        assert.equal(mailer.sendPostAddTwoStepAuthenticationEmail.callCount, 0);
+        assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 0);
+        assert.equal(
+          fxaMailer.sendPostAddTwoStepAuthenticationEmail.callCount,
+          0
+        );
 
         assert.calledOnceWithExactly(
           accountEventsManager.recordSecurityEvent,
@@ -446,7 +459,7 @@ describe('totp', () => {
       assert.calledOnce(profile.deleteCache);
       assert.calledOnce(log.notifyAttachedServices);
       assert.calledOnce(glean.twoFactorAuth.codeComplete);
-      assert.calledOnce(mailer.sendPostAddTwoStepAuthenticationEmail);
+      assert.calledOnce(fxaMailer.sendPostAddTwoStepAuthenticationEmail);
     });
 
     it('should fail for a missing secret', async () => {
@@ -558,8 +571,8 @@ describe('totp', () => {
 
       assert.calledOnce(glean.resetPassword.twoFactorRecoveryCodeSuccess);
 
-      assert.calledOnce(mailer.sendPostConsumeRecoveryCodeEmail);
-      assert.notCalled(mailer.sendLowRecoveryCodesEmail);
+      assert.calledOnce(fxaMailer.sendPostConsumeRecoveryCodeEmail);
+      assert.notCalled(fxaMailer.sendLowRecoveryCodesEmail);
 
       assert.equal(response.remaining, 2);
       assert.calledOnceWithExactly(db.consumeRecoveryCode, 'uid', '1234567890');
@@ -603,7 +616,7 @@ describe('totp', () => {
         requestOptions
       );
 
-      assert.calledOnce(mailer.sendLowRecoveryCodesEmail);
+      assert.calledOnce(fxaMailer.sendLowRecoveryCodesEmail);
       assert.equal(response.remaining, 1);
       assert.calledOnceWithExactly(db.consumeRecoveryCode, 'uid', '1234567890');
     });

--- a/packages/fxa-auth-server/test/local/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/oauth.js
@@ -28,6 +28,7 @@ const MOCK_DEVICE_ID = 'a72ed885e66cb9c96a12fde247112daa';
 describe('newTokenNotification', () => {
   let db;
   let mailer;
+  let fxaMailer;
   let devices;
   let request;
   let credentials;
@@ -52,6 +53,8 @@ describe('newTokenNotification', () => {
       uid: MOCK_UID,
     });
     mailer = mocks.mockMailer();
+    fxaMailer = mocks.mockFxaMailer();
+    mocks.mockOAuthClientInfo();
     devices = mocks.mockDevices();
     credentials = {
       uid: MOCK_UID,
@@ -67,7 +70,7 @@ describe('newTokenNotification', () => {
   it('creates a device and sends an email with credentials uid', async () => {
     await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
 
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
+    assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 1);
     assert.equal(devices.upsert.callCount, 1, 'created a device');
     const args = devices.upsert.args[0];
     assert.equal(
@@ -85,7 +88,7 @@ describe('newTokenNotification', () => {
     });
     await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
 
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
+    assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 0);
     assert.equal(devices.upsert.callCount, 1, 'created a device');
   });
 
@@ -94,7 +97,7 @@ describe('newTokenNotification', () => {
     request = mocks.mockRequest({ credentials });
     await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
 
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
+    assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 1);
     assert.equal(devices.upsert.callCount, 1, 'created a device');
   });
 
@@ -102,7 +105,7 @@ describe('newTokenNotification', () => {
     grant.scope = 'profile';
     await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
 
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
+    assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 0);
     assert.equal(devices.upsert.callCount, 0);
   });
 
@@ -113,7 +116,7 @@ describe('newTokenNotification', () => {
     request = mocks.mockRequest({ credentials });
     await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
 
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
+    assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 1);
     assert.equal(devices.upsert.callCount, 1);
     const args = devices.upsert.args[0];
     assert.equal(args[1].refreshTokenId, MOCK_REFRESH_TOKEN_ID_2);
@@ -128,7 +131,7 @@ describe('newTokenNotification', () => {
     request = mocks.mockRequest({ credentials });
     await oauthUtils.newTokenNotification(db, mailer, devices, request, grant);
 
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
+    assert.equal(fxaMailer.sendNewDeviceLoginEmail.callCount, 0);
     assert.equal(devices.upsert.callCount, 1);
     const args = devices.upsert.args[0];
     assert.equal(args[1].refreshTokenId, MOCK_REFRESH_TOKEN_ID_2);

--- a/packages/fxa-auth-server/test/local/routes/utils/signup.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signup.js
@@ -12,7 +12,15 @@ const { gleanMetrics } = require('../../../../lib/metrics/glean');
 const TEST_EMAIL = 'test@email.com';
 const TEST_UID = '123123';
 
-let db, log, mailer, push, request, verificationReminders, utils, account;
+let db,
+  log,
+  mailer,
+  fxaMailer,
+  push,
+  request,
+  verificationReminders,
+  utils,
+  account;
 
 const gleanConfig = {
   enabled: false,
@@ -25,6 +33,7 @@ const glean = gleanMetrics({ gleanMetrics: gleanConfig });
 async function setup(options) {
   const log = options.log || mocks.mockLog();
   const db = options.db || mocks.mockDB();
+  fxaMailer = mocks.mockFxaMailer();
   const mailer = options.mailer || {};
   const verificationReminders =
     options.verificationReminders || mocks.mockVerificationReminders();
@@ -132,12 +141,12 @@ describe('verifyAccount', () => {
     });
 
     it('should send post account verification email', () => {
-      assert.calledOnce(mailer.sendPostVerifyEmail);
+      assert.calledOnce(fxaMailer.sendPostVerifyEmail);
       assert.equal(
-        mailer.sendPostVerifyEmail.args[0][2].service,
-        options.service
+        fxaMailer.sendPostVerifyEmail.args[0][0].sync,
+        options.service === 'sync'
       );
-      assert.equal(mailer.sendPostVerifyEmail.args[0][2].uid, TEST_UID);
+      assert.equal(fxaMailer.sendPostVerifyEmail.args[0][0].uid, TEST_UID);
     });
   });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -23,6 +23,9 @@ const { ProductConfigurationManager } = require('@fxa/shared/cms');
 const { FxaMailer } = require('../lib/senders/fxa-mailer');
 
 const proxyquire = require('proxyquire');
+const {
+  OAuthClientInfoServiceName,
+} = require('../lib/senders/oauth_client_info');
 const amplitudeModule = proxyquire('../lib/metrics/amplitude', {
   'fxa-shared/db/models/auth': {
     Account: {
@@ -357,6 +360,7 @@ module.exports = {
   mockPriceManager,
   mockProductConfigurationManager,
   mockFxaMailer,
+  mockOAuthClientInfo,
 };
 
 function mockCustoms(errors) {
@@ -1154,11 +1158,47 @@ function mockProductConfigurationManager() {
 function mockFxaMailer(overrides) {
   const mockFxaMailer = {
     // add new email methods here!
-    canSend: sinon.stub().resolves(false),
+    canSend: sinon.stub().resolves(true),
     sendRecoveryEmail: sinon.stub().resolves(),
     sendPasswordForgotOtpEmail: sinon.stub().resolves(),
+    sendPostVerifySecondaryEmail: sinon.stub().resolves(),
+    sendPostChangePrimaryEmail: sinon.stub().resolves(),
+    sendPostRemoveSecondaryEmail: sinon.stub().resolves(),
+    sendPostAddLinkedAccountEmail: sinon.stub().resolves(),
+    sendNewDeviceLoginEmail: sinon.stub().resolves(),
+    sendPostAddTwoStepAuthenticationEmail: sinon.stub().resolves(),
+    sendPostChangeTwoStepAuthenticationEmail: sinon.stub().resolves(),
+    sendPostNewRecoveryCodesEmail: sinon.stub().resolves(),
+    sendPostConsumeRecoveryCodeEmail: sinon.stub().resolves(),
+    sendLowRecoveryCodesEmail: sinon.stub().resolves(),
+    sendPostSigninRecoveryCodeEmail: sinon.stub().resolves(),
+    sendPostAddRecoveryPhoneEmail: sinon.stub().resolves(),
+    sendPostChangeRecoveryPhoneEmail: sinon.stub().resolves(),
+    sendPostRemoveRecoveryPhoneEmail: sinon.stub().resolves(),
+    sendPasswordResetRecoveryPhoneEmail: sinon.stub().resolves(),
+    sendPostSigninRecoveryPhoneEmail: sinon.stub().resolves(),
+    sendPostAddAccountRecoveryEmail: sinon.stub().resolves(),
+    sendPostChangeAccountRecoveryEmail: sinon.stub().resolves(),
+    sendPostRemoveAccountRecoveryEmail: sinon.stub().resolves(),
+    sendPasswordResetAccountRecoveryEmail: sinon.stub().resolves(),
+    sendPasswordResetWithRecoveryKeyPromptEmail: sinon.stub().resolves(),
+    sendPostVerifyEmail: sinon.stub().resolves(),
+    sendVerifyLoginCodeEmail: sinon.stub().resolves(),
+    sendVerifyShortCodeEmail: sinon.stub().resolves(),
+    sendVerifySecondaryCodeEmail: sinon.stub().resolves(),
+    sendVerifyLoginEmail: sinon.stub().resolves(),
+    sendVerifyEmail: sinon.stub().resolves(),
     ...overrides,
   };
   Container.set(FxaMailer, mockFxaMailer);
   return mockFxaMailer;
+}
+
+function mockOAuthClientInfo(overrides) {
+  const mock = {
+    fetch: sinon.stub().resolves('sync'),
+    ...overrides,
+  };
+  Container.set(OAuthClientInfoServiceName, mock);
+  return mock;
 }

--- a/packages/fxa-auth-server/test/oauth/routes/token.js
+++ b/packages/fxa-auth-server/test/oauth/routes/token.js
@@ -5,9 +5,11 @@
 const { assert } = require('chai');
 const buf = (v) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
 const hex = (v) => (Buffer.isBuffer(v) ? v.toString('hex') : v);
-const path = require('path');
-const proxyquire = require('proxyquire');
 const sinon = require('sinon');
+const path = require('path');
+const { Container } = require('typedi');
+
+const proxyquire = require('proxyquire');
 
 const UID = 'eaf0';
 const CLIENT_SECRET =
@@ -102,8 +104,17 @@ function joiNotAllowed(err, param) {
   assert.equal(err.details[0].message, `"${param}" is not allowed`);
 }
 
+before(() => {
+  Container.set('OAuthClientInfo', {
+    async fetch() {
+      return 'sync';
+    },
+  });
+});
+
 describe('/token POST', function () {
   const route = tokenRoutes[0];
+
   describe('input validation', () => {
     // route validation function
     function v(req, ctx, cb) {

--- a/packages/fxa-auth-server/test/scripts/delete-account.js
+++ b/packages/fxa-auth-server/test/scripts/delete-account.js
@@ -25,9 +25,9 @@ const execOptions = {
 };
 
 describe('#integration - scripts/delete-account:', function () {
-  it('does not fail', function () {
-    this.timeout(15000);
-    return execAsync(
+  it('does not fail', async function () {
+    this.timeout(30000);
+    await execAsync(
       'node -r esbuild-register scripts/delete-account',
       execOptions
     );

--- a/packages/fxa-shared/lib/user-agent.ts
+++ b/packages/fxa-shared/lib/user-agent.ts
@@ -38,6 +38,7 @@ export type UAScalarProperties = {
 
 // @ts-ignore
 import * as ua from 'node-uap';
+import { Account } from '../db/models';
 
 // We know this won't match "Symbian^3", "UI/WKWebView" or "Mail.ru" but
 // it's simpler and safer to limit to alphanumerics, underscore and space.
@@ -225,23 +226,29 @@ function marshallDeviceType(formFactor: string) {
  * @param uaOS - OS name from user agent
  * @param uaOSVersion - OS version from user agent
  */
-export const formatUserAgentInfo = (
-  uaBrowser?: string,
-  uaOS?: string,
-  uaOSVersion?: string
-):
-  | {
-      uaBrowser: string;
-      uaOS: string;
-      uaOSVersion: string;
-    }
-  | undefined => {
-  const safeBrowser = safeReturnName(uaBrowser || '');
-  const safeOS = safeReturnName(uaOS || '');
-  const safeOSVersion = safeReturnVersion(uaOSVersion || '');
+export const formatUserAgentInfo = ({
+  browser,
+  os,
+  osVersion,
+}: {
+  browser?: string;
+  os?: string;
+  osVersion?: string;
+}): {
+  uaBrowser: string;
+  uaOS: string;
+  uaOSVersion: string;
+} => {
+  const safeBrowser = safeReturnName(browser || '');
+  const safeOS = safeReturnName(os || '');
+  const safeOSVersion = safeReturnVersion(osVersion || '');
 
   return !safeBrowser && !safeOS
-    ? undefined
+    ? {
+        uaBrowser: '',
+        uaOS: '',
+        uaOSVersion: '',
+      }
     : {
         uaBrowser: safeBrowser || '',
         uaOS: safeOS || '',


### PR DESCRIPTION
## Because

- We want to start using the new email library to send out emails.

## This pull request

- Switches about half the calls in `auth-server` over to using the new `fxa-mailer`.

## Issue that this pull request solves

Closes: FXA-12884

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
