### PR TITLE
fix(css): Adjust split layout content width

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -187,8 +187,8 @@ export const AppLayout = ({
               }
             />
             <div className="mobileLandscape:items-center tablet:flex-1 tablet:bg-white tablet:ml-auto flex flex-col flex-1">
-              <main className="py-8 px-6 tablet:px-10 mobileLandscape:py-9 flex justify-center items-center flex-1">
-                <section className="max-w-120">
+              <main className="flex justify-center items-center flex-1">
+                <section className="max-w-120 desktop:w-120 px-8 py-8">
                   {loading ? (
                     <LoadingSpinner className="h-full flex items-center" />
                   ) : (


### PR DESCRIPTION
Because:
* Not having an explicit width on the split layout content is causing content sizing variations depending on how long the headline is

This commit:
* Adds an explicit width at desktop and above and moves padding/margin inward to better match the existing .card component

fixes FXA-12794

---

The first point of the issue was already addressed in another ticket.

For the second point, the split layout content appears to shift in width from email-first to signin. This happens because the email-first headline is much longer than the signin page headline, so the button and entire content grows. This fix still allows tablet content to shink in size which keeps the split layout 50/50 but keeps the width consistent at desktop and above, and also uses the same inner padding as `.card` so the content widths match.