### PR TITLE
fix(auth-server): Add email claims to ID Token for compatibility

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -249,6 +249,17 @@ async function generateIdToken(grant, accessToken) {
     claims.auth_time = Math.floor(grant.authAt / 1000);
   }
 
+  if (
+    grant.email &&
+    grant.scope &&
+    (grant.scope.contains('email') ||
+      grant.scope.contains('profile') ||
+      grant.scope.contains('profile:email'))
+  ) {
+    claims.email = grant.email;
+    claims.email_verified = true;
+  }
+
   return jwt.sign(claims);
 }
 

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -415,4 +415,24 @@ describe('generateTokens', () => {
       Math.floor(requestedGrant.authAt / 1000)
     );
   });
+
+  it('should include email and email_verified in ID token claims when requested by scope', async () => {
+    requestedGrant.scope = ScopeSet.fromArray(['openid', 'email']);
+    requestedGrant.email = 'test@example.com';
+    const result = await generateTokens(requestedGrant);
+    assert.ok(result.id_token);
+    const jwt = decodeJWT(result.id_token);
+    assert.strictEqual(jwt.claims.email, 'test@example.com');
+    assert.strictEqual(jwt.claims.email_verified, true);
+  });
+
+  it('should NOT include email and email_verified in ID token claims when NOT requested by scope', async () => {
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
+    requestedGrant.email = 'test@example.com';
+    const result = await generateTokens(requestedGrant);
+    assert.ok(result.id_token);
+    const jwt = decodeJWT(result.id_token);
+    assert.isUndefined(jwt.claims.email);
+    assert.isUndefined(jwt.claims.email_verified);
+  });
 });


### PR DESCRIPTION
Mozilla Connect requires `email` and `email_verified` claims in the ID Token to authenticate (it throws a 401 otherwise).

I updated `grant.js` to explicitly include these claims in the `id_token` payload when the `email` or `profile` scope is requested.

Fixes https://github.com/mozilla/fxa/issues/18854

## Because

Khoros (Mozilla Connect) expects these claims to verify identity. Without them, login fails.

## This pull request

- Updates `generateIdToken` in `packages/fxa-auth-server/lib/oauth/grant.js` to include `email` and `email_verified` in the token if we have the right scopes.
- Adds unit tests to `packages/fxa-auth-server/test/oauth/grant.js` to verify the claims are added correctly and restricted to the proper scopes.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
