### PR TITLE
chore(auth-server): minor code cleanup and fixes

### DIFF
--- a/packages/fxa-auth-server/lib/db.ts
+++ b/packages/fxa-auth-server/lib/db.ts
@@ -83,6 +83,11 @@ export const createDB = (
   const { enabled: TOKEN_PRUNING_ENABLED, maxAge: TOKEN_PRUNING_MAX_AGE } =
     config.tokenPruning;
 
+  // Configure the shared model's expiry from the server's config
+  if (MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE) {
+    RawSessionToken.sessionExpiryMs = MAX_AGE_SESSION_TOKEN_WITHOUT_DEVICE;
+  }
+
   class DB {
     redis: any;
     knex: Knex | null;

--- a/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
@@ -3292,7 +3292,7 @@ describe('#integration - /v1', function () {
         expect(clients2[0].client_id).toBe(client2Id.toString('hex'));
       });
 
-      it('should seperately list different refresh tokens from the same client', async () => {
+      it('should separately list different refresh tokens from the same client', async () => {
         await makeAccessToken(client1, user1, ['profile']);
         await makeAccessToken(client1, user1, ['other', 'scope']);
         await makeRefreshToken(client2, user1, ['profile']);

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -11,12 +11,14 @@ import {
 } from '../../transformers';
 import { convertError, notFound } from '../../mysql';
 
-//TODO FIXME unhardcode the 28 day expiry
 function notExpired(token: SessionToken) {
-  return !!(token.deviceId || token.createdAt > Date.now() - 2419200000);
+  return !!(
+    token.deviceId ||
+    token.createdAt > Date.now() - SessionToken.sessionExpiryMs
+  );
 }
 
-const VERIFICATION_METHOD = {
+export const VERIFICATION_METHOD = {
   email: 0,
   'email-2fa': 1,
   'totp-2fa': 2,
@@ -55,6 +57,7 @@ export function verificationMethodToString(
 export class SessionToken extends BaseToken {
   public static tableName = 'sessionTokens';
   public static idColumn = 'tokenId';
+  public static sessionExpiryMs = 2419200000; // 28 days
 
   protected $uuidFields = [
     'tokenId',

--- a/packages/fxa-shared/test/db/models/auth/session-token.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/session-token.spec.ts
@@ -1,0 +1,121 @@
+import 'mocha';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { SessionToken } from '../../../../db/models/auth';
+import { uuidTransformer } from '../../../../db/transformers';
+import crypto from 'crypto';
+
+const toRandomBuff = (size) =>
+  uuidTransformer.to(crypto.randomBytes(size).toString('hex'));
+
+describe('SessionToken Unit Tests', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('filters out expired tokens (older than 28 days by default)', async () => {
+    const now = Date.now();
+    // 28 days in milliseconds is 2419200000
+    const validTime = now - 2419200000 + 10000; // 10 seconds remaining
+    const expiredTime = now - 2419200000 - 10000; // 10 seconds overdue
+
+    const uidBuff = toRandomBuff(16);
+
+    const validRow = {
+      tokenId: toRandomBuff(16),
+      tokenData: toRandomBuff(16),
+      uid: uidBuff,
+      createdAt: validTime,
+      lastAccessTime: validTime,
+      authAt: 1,
+      verificationMethod: 0,
+      verifiedAt: 0,
+      mustVerify: 0,
+      deviceId: null, // explicit null for no device
+      emailVerified: 1,
+      email: 'test@test.com',
+      emailCode: 'code',
+      deviceCallbackIsExpired: 0,
+    };
+
+    const expiredRow = {
+      ...validRow,
+      tokenId: toRandomBuff(16),
+      createdAt: expiredTime,
+    };
+
+    sandbox.stub(SessionToken, 'callProcedure').resolves({
+      rows: [validRow, expiredRow],
+    });
+
+    const tokens = await SessionToken.findByUid(
+      '0123456789abcdef0123456789abcdef'
+    );
+
+    assert.equal(
+      tokens.length,
+      1,
+      'Should return exactly 1 token (the valid one)'
+    );
+    assert.equal(tokens[0].createdAt, validTime);
+  });
+
+  it('respects configured expiry', async () => {
+    const originalExpiry = SessionToken.sessionExpiryMs;
+    try {
+      // Set expiry to 1 hour
+      SessionToken.sessionExpiryMs = 60 * 60 * 1000; // 1 hour
+      const now = Date.now();
+      const validTime = now - 30 * 60 * 1000; // 30 mins old (valid)
+      const expiredTime = now - 90 * 60 * 1000; // 90 mins old (expired)
+
+      const uidBuff = toRandomBuff(16);
+
+      const validRow = {
+        tokenId: toRandomBuff(16),
+        tokenData: toRandomBuff(16),
+        uid: uidBuff,
+        createdAt: validTime,
+        lastAccessTime: validTime,
+        authAt: 1,
+        verificationMethod: 0,
+        verifiedAt: 0,
+        mustVerify: 0,
+        deviceId: null,
+        emailVerified: 1,
+        email: 'test@test.com',
+        emailCode: 'code',
+        deviceCallbackIsExpired: 0,
+      };
+
+      const expiredRow = {
+        ...validRow,
+        tokenId: toRandomBuff(16),
+        createdAt: expiredTime,
+      };
+
+      sandbox.stub(SessionToken, 'callProcedure').resolves({
+        rows: [validRow, expiredRow],
+      });
+
+      const tokens = await SessionToken.findByUid(
+        '0123456789abcdef0123456789abcdef'
+      );
+
+      assert.equal(
+          tokens.length,
+          1,
+          'Should return exactly 1 token (the valid one)'
+      );
+      assert.equal(tokens[0].createdAt, validTime);
+    } finally {
+      SessionToken.sessionExpiryMs = originalExpiry;
+    }
+  });
+});


### PR DESCRIPTION
This PR introduces a few targeted cleanups and improvements to the fxa-auth-server package:

- **Fix Typo**: Corrected 'seperately' to 'separately' in the OAuth API test suite.
- **Unhardcode Session Token Expiry**: Updated the `SessionToken` model to pull its expiry from the `auth-server` configuration instead of using a hardcoded static value.
- **Added Regression Tests**: Included unit tests for the session token expiry filtering logic to ensure correctness.

These changes address the maintainer's feedback regarding targeted PRs and unhardcoding configuration values, while maintaining existing functionality.