### PR TITLE
feat(auth-server): Add new attached_oauth_clients endpoint

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1844,6 +1844,14 @@ export default class AuthClient {
     return this.sessionGet('/account/attached_clients', sessionToken, headers);
   }
 
+  async attachedOauthClients(sessionToken: hexstring, headers?: Headers) {
+    return this.sessionGet(
+      '/account/attached_oauth_clients',
+      sessionToken,
+      headers
+    );
+  }
+
   async attachedClientDestroy(
     sessionToken: hexstring,
     clientInfo: any,

--- a/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/devices-and-sessions-api.ts
@@ -36,6 +36,22 @@ const ACCOUNT_ATTACHED_CLIENTS_GET = {
   ],
 };
 
+const ACCOUNT_ATTACHED_OAUTH_CLIENTS_GET = {
+  ...TAGS_DEVICES_AND_SESSIONS,
+  description: '/account/attached_oauth_clients',
+  notes: [
+    dedent`
+      🔒 Authenticated with session token
+
+      Returns an array listing all the OAuth Clients that the authenticated user has connected to their account.
+
+      This will only return active sessions. For example, if a user has signed into a service and then later disconnects from that service via account settings connected devices, they would not appear on this list.
+
+      Each OAuth Client will have exactly one record, and include the 'lastAccessTime' property.
+    `,
+  ],
+};
+
 const ACCOUNT_ATTACHED_CLIENT_DESTROY_POST = {
   ...TAGS_DEVICES_AND_SESSIONS,
   description: '/account/attached_client/destroy',
@@ -71,13 +87,13 @@ const ACCOUNT_DEVICE_POST = {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
             - \`errno: 107\` - Invalid parameter in request body
-          `
+          `,
         },
         503: {
           description: dedent`
             Failing requests may be caused by the following errors (this is not an exhaustive list):
             - \`errno: 202\` - Feature not enabled
-          `
+          `,
         },
       },
     },
@@ -200,6 +216,7 @@ const ACCOUNT_DEVICE_DESTROY_POST = {
 const API_DOCS = {
   ACCOUNT_ATTACHED_CLIENT_DESTROY_POST,
   ACCOUNT_ATTACHED_CLIENTS_GET,
+  ACCOUNT_ATTACHED_OAUTH_CLIENTS_GET,
   ACCOUNT_DEVICE_COMMANDS_GET,
   ACCOUNT_DEVICE_DESTROY_POST,
   ACCOUNT_DEVICE_POST,

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -655,8 +655,13 @@ module.exports = (config) => {
   };
 
   ClientApi.prototype.changePasswordJWT = function (jwt, options = {}) {
-    return this.doRequestWithBearerToken('POST', `${this.baseURL}/mfa/password/change`, jwt, options);
-  }
+    return this.doRequestWithBearerToken(
+      'POST',
+      `${this.baseURL}/mfa/password/change`,
+      jwt,
+      options
+    );
+  };
 
   ClientApi.prototype.passwordChangeStart = async function (
     email,
@@ -887,11 +892,16 @@ module.exports = (config) => {
     code,
     options = {}
   ) {
-    return this.doRequest('POST', `${this.baseURL}/password/forgot/verify_otp`, null, {
-      email: email,
-      code: code,
-      metricsContext: options.metricsContext || undefined,
-    });
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/password/forgot/verify_otp`,
+      null,
+      {
+        email: email,
+        code: code,
+        metricsContext: options.metricsContext || undefined,
+      }
+    );
   };
 
   ClientApi.prototype.passwordForgotStatus = function (passwordForgotTokenHex) {
@@ -1124,6 +1134,16 @@ module.exports = (config) => {
     });
   };
 
+  ClientApi.prototype.attachedOAuthClients = function (sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex).then((token) => {
+      return this.doRequest(
+        'GET',
+        `${this.baseURL}/account/attached_oauth_clients`,
+        token
+      );
+    });
+  };
+
   ClientApi.prototype.sessionStatus = function (sessionTokenHex) {
     return tokens.SessionToken.fromHex(sessionTokenHex).then((token) => {
       return this.doRequest('GET', `${this.baseURL}/session/status`, token);
@@ -1166,10 +1186,15 @@ module.exports = (config) => {
   };
 
   ClientApi.prototype.createEmail = function (jwt, email, options = {}) {
-    return this.doRequestWithBearerToken('POST', `${this.baseURL}/mfa/recovery_email`, jwt, {
-      email: email,
-      verificationMethod: options.verificationMethod,
-    });
+    return this.doRequestWithBearerToken(
+      'POST',
+      `${this.baseURL}/mfa/recovery_email`,
+      jwt,
+      {
+        email: email,
+        verificationMethod: options.verificationMethod,
+      }
+    );
   };
 
   ClientApi.prototype.deleteEmail = function (jwt, email) {
@@ -1258,7 +1283,12 @@ module.exports = (config) => {
   };
 
   ClientApi.prototype.deleteTotpToken = function (jwt) {
-    return this.doRequestWithBearerToken('POST', `${this.baseURL}/mfa/totp/destroy`, jwt, {});
+    return this.doRequestWithBearerToken(
+      'POST',
+      `${this.baseURL}/mfa/totp/destroy`,
+      jwt,
+      {}
+    );
   };
 
   ClientApi.prototype.checkTotpTokenExists = function (sessionTokenHex) {

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -530,11 +530,18 @@ module.exports = (config) => {
     );
   };
 
-  Client.prototype.verifySecondaryEmailWithCode = async function (jwt, code, email) {
+  Client.prototype.verifySecondaryEmailWithCode = async function (
+    jwt,
+    code,
+    email
+  ) {
     return this.api.recoveryEmailSecondaryVerifyCode(jwt, code, email);
   };
 
-  Client.prototype.resendVerifySecondaryEmailWithCode = async function (jwt, email) {
+  Client.prototype.resendVerifySecondaryEmailWithCode = async function (
+    jwt,
+    email
+  ) {
     return this.api.recoveryEmailSecondaryResendCode(jwt, email);
   };
 
@@ -554,7 +561,7 @@ module.exports = (config) => {
 
   Client.prototype.changePasswordJWT = function (jwt, options = {}) {
     return this.api.changePasswordJWT(jwt, options);
-  }
+  };
 
   Client.prototype.changePassword = function (
     newPassword,
@@ -676,6 +683,13 @@ module.exports = (config) => {
     const o = this.sessionToken ? Promise.resolve(null) : this.login();
     return o.then(() => {
       return this.api.attachedClients(this.sessionToken);
+    });
+  };
+
+  Client.prototype.attachedOAuthClients = function () {
+    const o = this.sessionToken ? Promise.resolve(null) : this.login();
+    return o.then(() => {
+      return this.api.attachedOAuthClients(this.sessionToken);
     });
   };
 


### PR DESCRIPTION
Because:
 - Some partners that use the existing attached_clients enpoint don't need as much data as it currently provides
 - And the existing endpoint can be slow depending on other data being fetched

This Commit:
 - Adds a new attached_oauth_clients endpoint
 - Adds support for a new query to handle the unique clientId constraint at the db level
 - Adds tests

Closes: FXA-12616

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This adds a new endpoint at `account/attached_oauth_clients`. No parameters are needed since we use the uid off of the sessiontoken.

It will return a unique list of authorized oauth clients, or empty if there are none. If there are multiple refreshTokens for the same clientId, then we prioritize the most recent `lastUsedAt`. Responses are simple and look like this:
```jsonc
[ 
  { 
    clientId: "3c49430b43dfba77", 
    lastAccessTime: 1769311751000 
  }, 
  { /** more unique clients...*/ }
]

// or, for no authorized clients
[]
```
