### PR TITLE
chore(fxa-auth): Make validation for account create email more strict

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -179,7 +179,8 @@ module.exports.accessToken = isA
 //
 // https://github.com/mozilla/fxa-email-service/blob/6fc6c31043598b246102cd1fdd27fc325f4514fb/src/validate/mod.rs#L28-L30
 
-const EMAIL_USER = /^[A-Z0-9.!#$%&'*+\/=?^_`{|}~-]{1,64}$/i;
+const EMAIL_USER =
+  /^(?!\-)(?!\+)(?!\.)(?!.*\.\.)[A-Z0-9.!#$%&'*+\/=?^_`{|}~-]{1,64}$/i;
 const EMAIL_DOMAIN =
   /^[A-Z0-9](?:[A-Z0-9-]{0,253}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,253}[A-Z0-9])?)+$/i;
 

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -18,8 +18,9 @@ describe('lib/routes/validators:', () => {
     assert.strictEqual(validators.isValidEmailAddress('foo@example.com'), true);
     assert.strictEqual(validators.isValidEmailAddress('FOO@example.com'), true);
     assert.strictEqual(validators.isValidEmailAddress('42@example.com'), true);
+    // special characters are not allowed at the start of the email.
     assert.strictEqual(
-      validators.isValidEmailAddress('.+#$!%&|*/+-=?^_{}~`@example.com'),
+      validators.isValidEmailAddress('a.+#$!%&|*/+-=?^_{}~`@example.com'),
       true
     );
     assert.strictEqual(validators.isValidEmailAddress('Δ٢@example.com'), true);
@@ -145,6 +146,35 @@ describe('lib/routes/validators:', () => {
       validators.isValidEmailAddress(
         `${new Array(65).fill('a').join('')}@example.com`
       ),
+      false
+    );
+  });
+
+  it('isValidEmailAddress returns false if the user part starts with a special character', () => {
+    // no dots
+    assert.strictEqual(
+      validators.isValidEmailAddress('.foo@example.com'),
+      false
+    );
+    // no pluses
+    assert.strictEqual(
+      validators.isValidEmailAddress('+foo@example.com'),
+      false
+    );
+    // no dashes
+    assert.strictEqual(
+      validators.isValidEmailAddress('-foo@example.com'),
+      false
+    );
+  });
+
+  it('isValidEmailAddress returns false if the user part contains consecutive periods', () => {
+    assert.strictEqual(
+      validators.isValidEmailAddress('foo..bar@example.com'),
+      false
+    );
+    assert.strictEqual(
+      validators.isValidEmailAddress('foo..@example.com'),
       false
     );
   });


### PR DESCRIPTION
Because:
 - We are allowing emails with leading special characters

This commit:
 - Restricts the email validation helper to dissallow leading special characters and repeat special characters

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
