### PR TITLE
feat(ci): add header to identify CI on stage

### DIFF
--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -10,6 +10,16 @@ import { TargetNames } from './lib/targets';
 import { getFirefoxUserPrefs } from './lib/targets/firefoxUserPrefs';
 
 const CI = !!process.env.CI;
+const CI_WAF_TOKEN = process.env.CI_WAF_TOKEN;
+
+/**
+ * Returns a header used for WAF bypass on stage domain.
+ * Production ignores this header.
+ * Requires CI_WAF_TOKEN to be set in CircleCI.
+ */
+function getCIHeader(): Record<string, string> {
+  return CI && CI_WAF_TOKEN ? { 'fxa-ci': CI_WAF_TOKEN } : {};
+}
 
 // If using the CircleCI parallelism feature, assure that the JUNIT XML report
 // has a unique name
@@ -64,6 +74,7 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
 
   use: {
     viewport: { width: 1280, height: 720 },
+    extraHTTPHeaders: getCIHeader(),
   },
   projects: [
     ...TargetNames.map(


### PR DESCRIPTION
## Because

- we want to allow tests to bypass WAF rate-limits on stage.

## This pull request

- adds a CI header identifier

## Issue that this pull request solves

Closes: FXA-13006
https://mozilla-hub.atlassian.net/browse/FXA-13006