### PR TITLE
fxa(email): Add email normalization check to email libs

### DIFF
--- a/libs/accounts/email-sender/src/email-normalization.spec.ts
+++ b/libs/accounts/email-sender/src/email-normalization.spec.ts
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { EmailNormalization } from './email-normalization';
+
+describe('EmailNormalization', () => {
+  it('trims and lowercases the email before processing', () => {
+    const emailNormalization = new EmailNormalization(JSON.stringify([]));
+
+    const result = emailNormalization.normalizeEmailAliases(
+      '  Foo.Bar@Example.COM  '
+    );
+
+    expect(result).toBe('foo.bar@example.com');
+  });
+
+  it('throws on bad json', () => {
+    expect(() => new EmailNormalization('{')).toThrow(
+      'emailTransforms must be JSON formatted string'
+    );
+  });
+
+  it('throws on invalid email: missing @', () => {
+    const emailNormalization = new EmailNormalization(JSON.stringify([]));
+
+    expect(() =>
+      emailNormalization.normalizeEmailAliases('not-an-email')
+    ).toThrow('Invalid Email!');
+  });
+
+  it('throws on invalid email: too many @', () => {
+    const emailNormalization = new EmailNormalization(JSON.stringify([]));
+
+    expect(() => emailNormalization.normalizeEmailAliases('a@b@c')).toThrow(
+      'Invalid Email!'
+    );
+  });
+
+  it('applies transforms only for matching domain', () => {
+    const transforms = JSON.stringify([
+      { domain: 'example.com', regex: '\\.', replace: '' },
+      { domain: 'other.com', regex: 'foo', replace: 'bar' },
+    ]);
+    const emailNormalization = new EmailNormalization(transforms);
+
+    const result1 = emailNormalization.normalizeEmailAliases(
+      'Foo.Bar@Example.com'
+    );
+    const result2 = emailNormalization.normalizeEmailAliases(
+      'foo.bar@allowed.com'
+    );
+
+    expect(result1).toBe('foobar@example.com');
+    expect(result2).toBe('foo.bar@allowed.com');
+  });
+
+  it('applies multiple transforms for the same domain in order', () => {
+    const transforms = JSON.stringify([
+      { domain: 'example.com', regex: '\\.', replace: '' }, // foo.bar -> foobar
+      { domain: 'example.com', regex: '^foo', replace: 'baz' }, // foobar -> bazbar
+    ]);
+    const emailNormalization = new EmailNormalization(transforms);
+
+    const result = emailNormalization.normalizeEmailAliases(
+      'Foo.Bar@Example.com'
+    );
+
+    expect(result).toBe('bazbar@example.com');
+  });
+
+  it('returns the normalized local-part plus the (lowercased) domain', () => {
+    const transforms = JSON.stringify([
+      { domain: 'example.com', regex: '\\+.*', replace: '' },
+    ]);
+    const emailNormalization = new EmailNormalization(transforms);
+
+    const result = emailNormalization.normalizeEmailAliases(
+      'User+tag@Example.com'
+    );
+
+    expect(result).toBe('user@example.com');
+  });
+
+  it('does nothing if there are no matching transforms', () => {
+    const transforms = JSON.stringify([
+      { domain: 'other.com', regex: '\\.', replace: '' },
+    ]);
+    const emailNormalization = new EmailNormalization(transforms);
+
+    const result = emailNormalization.normalizeEmailAliases(
+      'Foo.Bar@example.com'
+    );
+
+    expect(result).toBe('foo.bar@example.com');
+  });
+});

--- a/libs/accounts/email-sender/src/email-normalization.ts
+++ b/libs/accounts/email-sender/src/email-normalization.ts
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/node';
+
+/**
+ * Config shape for transforms
+ */
+export type EmailAliasConfig = {
+  domain: string;
+  regex: string;
+  replace: string;
+};
+
+/**
+ * Handles normalization of email addresses
+ */
+export class EmailNormalization {
+  private readonly emailTransforms: Array<EmailAliasConfig>;
+
+  constructor(emailTransforms: string) {
+    try {
+      const obj = JSON.parse(emailTransforms || '[]');
+      // Parse regexes
+      this.emailTransforms = obj.map((x: any) => ({
+        ...x,
+        regex: new RegExp(x.regex),
+      }));
+    } catch (err) {
+      Sentry.captureException(err);
+      throw new Error('emailTransforms must be JSON formatted string');
+    }
+  }
+
+  /**
+   * Normalizes email aliases by applying configured regex replacements.
+   * Optionally, a replacement string can be overridden.
+   * @param email The email address to normalize.
+   * @param replaceOverride Optional string to replace matched aliases.
+   * @returns The normalized email address.
+   */
+  normalizeEmailAliases(email: string, replaceOverride?: string): string {
+    email = email?.trim()?.toLocaleLowerCase() || '';
+    const parts = email.split('@');
+    if (parts?.length !== 2) {
+      // Should not happen! If it does, a handler is missing a check.
+      // See our joi validator on email for reference.
+      throw new Error('Invalid Email!');
+    }
+
+    // Apply transforms
+    const domain = parts[1];
+    email = parts[0];
+    this.emailTransforms
+      .filter((x) => x.domain === domain)
+      .forEach((x) => {
+        email = email.replace(x.regex, replaceOverride || x.replace);
+      });
+
+    return `${email}@${domain}`;
+  }
+}


### PR DESCRIPTION
  ## Because                                                                                                                                                                                                                  
                                                                                                                                                                                                                              
  - The auth-server already checks bounces against email aliases (e.g., `test+123@gmail.com` → `test@gmail.com`), but the shared email-sender library in `libs/accounts/email-sender/` does not                               
                                                                                                                                                                                                                              
  ## This pull request                                                                                                                                                                                                        
                                                                                                                                                                                                                              
  - Adds [`checkBouncesWithAliases`](https://github.com/mozilla/fxa/blob/fxa-12829/libs/accounts/email-sender/src/bounces.ts) method that queries both the normalized root email and a wildcard alias pattern in parallel     
  - Updates [`BouncesConfig`](https://github.com/mozilla/fxa/blob/fxa-12829/libs/accounts/email-sender/src/bounces.ts) with `aliasCheckEnabled` and `emailAliasNormalization` config fields                                   
  - Adds optional `email` field to `Bounce` type for deduplication of merged results                                                                                                                                          
  - Reuses existing [`EmailNormalization`](https://github.com/mozilla/fxa/blob/fxa-12829/packages/fxa-shared/email/email-normalization.ts) class from `fxa-shared`                                                                                                                                                                                    
                                                                                                                                                                                                                              
  ## Issue                                                                                                                                                                                                                    
                                                                                                                                                                                                                              
  Closes: https://mozilla-hub.atlassian.net/browse/FXA-12829                                                                                                                                                                  
                                                                                                                                                                                                                              
  ## Checklist                                                                                                                                                                                                                
                                                                                                                                                                                                                              
  - [x] My commit is GPG signed                                                                                                                                                                                               
  - [x] Tests pass locally (if applicable)                                                                                                                                                                                    
  - [ ] Documentation updated (if applicable)                                                                                                                                                                                 
  - [ ] RTL rendering verified (if UI changed)                                                                                                                                                                                
                                                                                                                                                                                                                              
  ## Other Information                                                                                                                                                                                                        
                                                                                                                                                                                                                              
  - Feature is **off by default** (`aliasCheckEnabled: false`). No behavior change unless explicitly enabled.                                                                                                                 
  - The underlying DB stored procedure (`fetchEmailBounces_4`) already uses `LIKE`, so wildcard queries (`test+%@domain.com`) work without DB changes.                                                                        
  - Ports the same logic from `packages/fxa-auth-server/lib/bounces.js` to the shared lib. 