### PR TITLE
feat(auth): Use libs email in auth server

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/email-helpers.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-helpers.ts
@@ -45,7 +45,8 @@ export const splitEmails = (
  */
 export const constructLocalTimeAndDateStrings = (
   timeZone?: string,
-  acceptLanguage?: string
+  acceptLanguage?: string,
+  date?: Date | number
 ): {
   acceptLanguage: string;
   date: string;
@@ -57,18 +58,18 @@ export const constructLocalTimeAndDateStrings = (
   const locale = determineLocale(acceptLanguage) || DEFAULT_LOCALE;
   moment.locale(locale);
 
-  let timeMoment = moment();
+  let timeMoment = moment(date ? date : undefined);
   if (timeZone) {
     timeMoment = timeMoment.tz(timeZone);
   }
 
-  const time = timeMoment.format('LTS (z)');
-  const date = timeMoment.format('dddd, ll');
+  const formattedTime = timeMoment.format('LTS (z)');
+  const formattedDate = timeMoment.format('dddd, ll');
 
   return {
     acceptLanguage: locale,
-    date,
-    time,
+    date: formattedDate,
+    time: formattedTime,
     timeZone: timeZone || DEFAULT_TIMEZONE,
   };
 };

--- a/libs/accounts/email-renderer/src/renderer/email-link-builder.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-link-builder.spec.ts
@@ -34,6 +34,8 @@ describe('EmailLinkBuilder', () => {
       'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
     firefoxDesktopUrl:
       'https://firefox.com?utm_content=registration-confirmation&utm_medium=email&utm_source=fxa',
+    unsubscribeUrl:
+      'https://privacyportal.onetrust.com/webform/1350748f-7139-405c-8188-22740b3b5587/4ba08202-2ede-4934-a89e-f0b0870f95f0',
   };
 
   let linkBuilder: EmailLinkBuilder;
@@ -319,6 +321,13 @@ describe('EmailLinkBuilder', () => {
       const attrs = linkBuilder.buildCadLink('postVerify', false);
       expect(attrs).toEqual('http://localhost:30303/connect_another_device');
     });
+
+    it('can build one click link', () => {
+      const attrs = linkBuilder.buildCadLink('postVerify', true, true);
+      expect(attrs).toEqual(
+        'http://localhost:30303/connect_another_device?utm_medium=email&utm_campaign=fx-account-verified&utm_content=fx-account-verified-one-click&one_click=true'
+      );
+    });
   });
 
   describe('buildVerifyLoginLink', () => {
@@ -384,6 +393,51 @@ describe('EmailLinkBuilder', () => {
       const link = linkBuilder.buildDesktopLink();
 
       expect(link).toEqual(mockConfig.firefoxDesktopUrl);
+    });
+  });
+
+  describe('buildVerifyEmailLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildVerifyEmailLink('verifyEmail', true, {
+        code: 'abcd',
+        uid: '123',
+        redirectTo: 'http://mozilla.org',
+        reminder: 'first',
+        resume: 'xyz',
+        service: 'sync',
+      });
+      expect(link).toEqual(
+        'http://test.localhost:30303/verify_email?utm_medium=email&utm_campaign=fx-welcome&utm_content=fx-welcome&code=abcd&uid=123&redirectTo=http%3A%2F%2Fmozilla.org&reminder=first&resume=xyz&service=sync'
+      );
+    });
+    it(' can build without utm', () => {
+      const link = linkBuilder.buildVerifyEmailLink('verifyEmail', false, {
+        code: 'abcd',
+        uid: '123',
+      });
+      expect(link).toEqual(
+        'http://test.localhost:30303/verify_email?code=abcd&uid=123'
+      );
+    });
+  });
+  describe('buildReportSigninLink', () => {
+    it('can build', () => {
+      const link = linkBuilder.buildReportSignInLink('verifyEmail', true, {
+        uid: '123',
+        unblockCode: 'abcd',
+      });
+      expect(link).toEqual(
+        'http://localhost:30303/report_signin?utm_medium=email&utm_campaign=fx-welcome&utm_content=fx-report&uid=123&unblockCode=abcd'
+      );
+    });
+    it('can build without utm', () => {
+      const link = linkBuilder.buildReportSignInLink('verifyEmail', false, {
+        uid: '123',
+        unblockCode: 'abcd',
+      });
+      expect(link).toEqual(
+        'http://localhost:30303/report_signin?uid=123&unblockCode=abcd'
+      );
     });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -458,18 +458,29 @@ module.exports = function (
           } = request.app.ua;
 
           try {
-            await mailer.sendPasswordChangedEmail(emails, account, {
-              acceptLanguage: request.app.acceptLanguage,
-              ip,
-              location: geoData.location,
-              timeZone: geoData.timeZone,
-              uaBrowser,
-              uaBrowserVersion,
-              uaOS,
-              uaOSVersion,
-              uaDeviceType,
-              uid: passwordChangeToken.uid,
-            });
+            if (fxaMailer.canSend('passwordChanged')) {
+              await fxaMailer.sendPasswordChangedEmail({
+                ...FxaMailerFormat.account(account),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.sync(false),
+              });
+            } else {
+              await mailer.sendPasswordChangedEmail(emails, account, {
+                acceptLanguage: request.app.acceptLanguage,
+                ip,
+                location: geoData.location,
+                timeZone: geoData.timeZone,
+                uaBrowser,
+                uaBrowserVersion,
+                uaOS,
+                uaOSVersion,
+                uaDeviceType,
+                uid: passwordChangeToken.uid,
+              });
+            }
           } catch (error) {
             // If we couldn't email them, no big deal. Log
             // and pretend everything worked.
@@ -846,18 +857,29 @@ module.exports = function (
           } = request.app.ua;
 
           try {
-            await mailer.sendPasswordChangedEmail(emails, account, {
-              acceptLanguage: request.app.acceptLanguage,
-              ip,
-              location: geoData.location,
-              timeZone: geoData.timeZone,
-              uaBrowser,
-              uaBrowserVersion,
-              uaOS,
-              uaOSVersion,
-              uaDeviceType,
-              uid: uid,
-            });
+            if (fxaMailer.canSend('passwordChanged')) {
+              await fxaMailer.sendPasswordChangedEmail({
+                ...FxaMailerFormat.account(account),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.sync(false),
+              });
+            } else {
+              await mailer.sendPasswordChangedEmail(emails, account, {
+                acceptLanguage: request.app.acceptLanguage,
+                ip,
+                location: geoData.location,
+                timeZone: geoData.timeZone,
+                uaBrowser,
+                uaBrowserVersion,
+                uaOS,
+                uaOSVersion,
+                uaDeviceType,
+                uid: uid,
+              });
+            }
           } catch (error) {
             // If we couldn't email them, no big deal. Log
             // and pretend everything worked.
@@ -1216,12 +1238,13 @@ module.exports = function (
           });
         }
 
-        const [, emails] = await Promise.all([
+        const [, emails, account] = await Promise.all([
           request.propagateMetricsContext(
             passwordForgotToken,
             accountResetToken
           ),
           db.accountEmails(passwordForgotToken.uid),
+          db.account(passwordForgotToken.uid),
         ]);
 
         const {
@@ -1257,11 +1280,22 @@ module.exports = function (
               emailOptions
             );
           } else {
-            await mailer.sendPasswordResetEmail(
-              emails,
-              passwordForgotToken,
-              emailOptions
-            );
+            if (fxaMailer.canSend('passwordReset')) {
+              await fxaMailer.sendPasswordResetEmail({
+                ...FxaMailerFormat.account(account),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.sync(false),
+              });
+            } else {
+              await mailer.sendPasswordResetEmail(
+                emails,
+                passwordForgotToken,
+                emailOptions
+              );
+            }
           }
         }
 

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-format.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-format.ts
@@ -28,7 +28,7 @@ export const FxaMailerFormat = {
     uid: string;
     email: string;
     emails?: Array<{ isPrimary: boolean; isVerified: boolean; email: string }>;
-    metricsOptOutAt: number | undefined | null;
+    metricsOptOutAt?: number | null;
   }) {
     return {
       to:
@@ -48,12 +48,24 @@ export const FxaMailerFormat = {
       device: formatUserAgentInfo(request.app.ua),
     };
   },
-  localTime(request: {
-    app: { geo: { timeZone: string }; acceptLanguage: string };
-  }) {
+  /**
+   * Formats local time and date strings based on request info.
+   *
+   * Optional date parameter can be used to specify a date other than current date.
+   * @param request
+   * @param date
+   * @returns
+   */
+  localTime(
+    request: {
+      app: { geo: { timeZone: string }; acceptLanguage: string };
+    },
+    date?: Date | number
+  ) {
     return constructLocalTimeAndDateStrings(
       request.app.geo.timeZone,
-      request.app.acceptLanguage
+      request.app.acceptLanguage,
+      date
     );
   },
   location(request: {

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
@@ -396,3 +396,150 @@ async function __sendPostVerifyEmail() {
     onDesktopOrTabletDevice: true,
   });
 }
+
+async function __sendVerifyEmail() {
+  await fxaMailer.sendVerifyEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.sync(service),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    code: 'todo',
+    resume: 'todo',
+  });
+}
+
+async function __sendVerifyLoginEmail() {
+  await fxaMailer.sendVerifyLoginEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    code: '123456',
+    clientName: 'Firefox',
+    redirectTo: 'https://example.com',
+    resume: 'resumeToken',
+  });
+}
+
+async function __sendUnblockCodeEmail() {
+  await fxaMailer.sendUnblockCodeEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    unblockCode: 'ABCD1234',
+  });
+}
+
+async function __sendPasswordChangedEmail() {
+  await fxaMailer.sendPasswordChangedEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPasswordChangeRequiredEmail() {
+  await fxaMailer.sendPasswordChangeRequiredEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendPasswordResetEmail() {
+  await fxaMailer.sendPasswordResetEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+  });
+}
+
+async function __sendVerifyPrimaryEmail() {
+  await fxaMailer.sendVerifyPrimaryEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    code: 'VERIFY123',
+  });
+}
+
+async function __sendVerifySecondaryCodeEmail() {
+  await fxaMailer.sendVerifySecondaryCodeEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    code: 'SEC456',
+    email: FxaMailerFormat.account(account).to,
+  });
+}
+
+async function __sendVerifyAccountChangeEmail() {
+  await fxaMailer.sendVerifyAccountChangeEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    code: 'CHANGE789',
+    expirationTime: 5,
+  });
+}
+
+async function __sendInactiveAccountFirstWarningEmail() {
+  await fxaMailer.sendInactiveAccountFirstWarningEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    deletionDate: '',
+  });
+}
+async function __sendVerificationReminderFirstEmail() {
+  await fxaMailer.sendVerificationReminderFirstEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    email: '',
+    code: '',
+  });
+}
+
+async function __sendCadReminderFirstEmail() {
+  await fxaMailer.sendCadReminderFirstEmail({
+    ...FxaMailerFormat.account(account),
+    ...(await FxaMailerFormat.metricsContext(request)),
+    ...FxaMailerFormat.localTime(request),
+    ...FxaMailerFormat.location(request),
+    ...FxaMailerFormat.device(request),
+    ...FxaMailerFormat.sync(service),
+    productName: 'Firefox',
+  });
+}

--- a/packages/fxa-auth-server/scripts/delete-account.ts
+++ b/packages/fxa-auth-server/scripts/delete-account.ts
@@ -20,6 +20,7 @@
 import { StatsD } from 'hot-shots';
 import readline from 'readline';
 import { Container } from 'typedi';
+import { join } from 'path';
 
 import { PayPalClient } from '@fxa/payments/paypal';
 
@@ -161,7 +162,12 @@ DB.connect(config).then(async (db: any) => {
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings()
+    new NodeRendererBindings({
+      translations: {
+        basePath: join(__dirname, '../public/locales'),
+        ftlFileName: 'auth.ftl',
+      },
+    })
   );
   Container.set(FxaMailer, fxaMailer);
 

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -150,7 +150,7 @@ describe('IP Profiling', function () {
 
     return runTest(route, mockRequest, (response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
@@ -172,7 +172,7 @@ describe('IP Profiling', function () {
 
     return runTest(route, mockRequest, (response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         0,
         'mailer.sendVerifyLoginEmail was not called'
       );
@@ -194,7 +194,7 @@ describe('IP Profiling', function () {
 
     return runTest(route, mockRequest, (response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
@@ -230,7 +230,7 @@ describe('IP Profiling', function () {
 
     return runTest(route, mockRequest, (response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
@@ -239,7 +239,7 @@ describe('IP Profiling', function () {
       return runTest(route, mockRequest);
     }).then((response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         2,
         'mailer.sendVerifyLoginEmail was called'
       );
@@ -254,7 +254,7 @@ describe('IP Profiling', function () {
 
     return runTest(route, mockRequest, (response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         1,
         'mailer.sendVerifyLoginEmail was called'
       );
@@ -263,7 +263,7 @@ describe('IP Profiling', function () {
       return runTest(route, mockRequest);
     }).then((response) => {
       assert.equal(
-        mockMailer.sendVerifyLoginEmail.callCount,
+        mockFxaMailer.sendVerifyLoginEmail.callCount,
         2,
         'mailer.sendVerifyLoginEmail was called'
       );

--- a/packages/fxa-auth-server/test/local/routes/mfa.js
+++ b/packages/fxa-auth-server/test/local/routes/mfa.js
@@ -96,6 +96,7 @@ describe('mfa', () => {
     log = mocks.mockLog();
     customs = mocks.mockCustoms();
     mailer = mocks.mockMailer();
+    const fxaMailer = mocks.mockFxaMailer();
     statsd = mocks.mockStatsd();
     db = mocks.mockDB({
       uid: UID,
@@ -121,6 +122,11 @@ describe('mfa', () => {
     code = '';
     mailer.sendVerifyAccountChangeEmail = sandbox.spy(
       (_emails, _account, data) => {
+        code = data.code;
+      }
+    );
+    fxaMailer.sendVerifyAccountChangeEmail = sandbox.spy(
+      (data) => {
         code = data.code;
       }
     );

--- a/packages/fxa-auth-server/test/local/routes/unblock-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/unblock-codes.js
@@ -49,6 +49,7 @@ describe('/account/login/send_unblock_code', () => {
     },
   });
   const mockMailer = mocks.mockMailer();
+  const mockFxaMailer = mocks.mockFxaMailer();
   const mockDb = mocks.mockDB({
     uid: uid,
     email: email,
@@ -67,7 +68,7 @@ describe('/account/login/send_unblock_code', () => {
   afterEach(() => {
     mockDb.accountRecord.resetHistory();
     mockDb.createUnblockCode.resetHistory();
-    mockMailer.sendUnblockCodeEmail.resetHistory();
+    mockFxaMailer.sendUnblockCodeEmail.resetHistory();
   });
 
   it('signin unblock enabled', () => {
@@ -91,9 +92,9 @@ describe('/account/login/send_unblock_code', () => {
       assert.equal(dbArgs.length, 1);
       assert.equal(dbArgs[0], uid);
 
-      assert.equal(mockMailer.sendUnblockCodeEmail.callCount, 1);
-      const args = mockMailer.sendUnblockCodeEmail.args[0];
-      assert.equal(args.length, 3);
+      assert.equal(mockFxaMailer.sendUnblockCodeEmail.callCount, 1);
+      const args = mockFxaMailer.sendUnblockCodeEmail.args[0];
+      assert.equal(args.length, 1);
 
       assert.equal(
         mockLog.flowEvent.callCount,
@@ -127,7 +128,7 @@ describe('/account/login/send_unblock_code', () => {
         1,
         'db.createUnblockCode called'
       );
-      assert.equal(mockMailer.sendUnblockCodeEmail.callCount, 1);
+      assert.equal(mockFxaMailer.sendUnblockCodeEmail.callCount, 1);
     });
   });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -413,9 +413,10 @@ function mockDB(data, errors) {
             isPrimary: true,
           },
         ],
-        uid: data.uid,
+        uid: uid || data.uid, // Prefer the uid parameter, fall back to data.uid
         verifierSetAt: data.verifierSetAt ?? Date.now(),
         wrapWrapKb: data.wrapWrapKb,
+        metricsOptOutAt: data.metricsOptOutAt || null,
       });
     }),
     accountEmails: sinon.spy((uid) => {
@@ -1160,7 +1161,7 @@ function mockProductConfigurationManager() {
 function mockFxaMailer(overrides) {
   const mockFxaMailer = {
     // add new email methods here!
-    canSend: sinon.stub().resolves(true),
+    canSend: sinon.stub().returns(true),
     sendRecoveryEmail: sinon.stub().resolves(),
     sendPasswordForgotOtpEmail: sinon.stub().resolves(),
     sendPostVerifySecondaryEmail: sinon.stub().resolves(),
@@ -1190,6 +1191,18 @@ function mockFxaMailer(overrides) {
     sendVerifySecondaryCodeEmail: sinon.stub().resolves(),
     sendVerifyLoginEmail: sinon.stub().resolves(),
     sendVerifyEmail: sinon.stub().resolves(),
+    sendVerifyAccountChangeEmail: sinon.stub().resolves(),
+    sendUnblockCodeEmail: sinon.stub().resolves(),
+    sendPasswordResetEmail: sinon.stub().resolves(),
+    sendPasswordChangedEmail: sinon.stub().resolves(),
+    sendInactiveAccountFirstWarningEmail: sinon.stub().resolves(),
+    sendInactiveAccountSecondWarningEmail: sinon.stub().resolves(),
+    sendInactiveAccountFinalWarningEmail: sinon.stub().resolves(),
+    sendVerificationReminderFirstEmail: sinon.stub().resolves(),
+    sendVerificationReminderSecondEmail: sinon.stub().resolves(),
+    sendVerificationReminderFinalEmail: sinon.stub().resolves(),
+    sendCadReminderFirstEmail: sinon.stub().resolves(),
+    sendCadReminderSecondEmail: sinon.stub().resolves(),
     ...overrides,
   };
   Container.set(FxaMailer, mockFxaMailer);

--- a/packages/fxa-auth-server/test/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
+++ b/packages/fxa-auth-server/test/scripts/delete-inactive-accounts/enqueue-inactive-account-deletions.ts
@@ -60,23 +60,27 @@ describe('enqueue inactive account deletions script', () => {
     }
   });
 
-  it('requires an BQ dataset id', async () => {
-    try {
-      await exec(command.join(' '), execOptions);
-      assert.fail('Expected script to fail without a BQ dataset id');
-    } catch (err) {
-      assert.equal(err.code, 1);
-      assert.include(err.stderr, 'BigQuery dataset ID is required.');
-    }
+  it(
+    'requires an BQ dataset id',
+    async () => {
+      try {
+        await exec(command.join(' '), execOptions);
+        assert.fail('Expected script to fail without a BQ dataset id');
+      } catch (err) {
+        assert.equal(err.code, 1);
+        assert.include(err.stderr, 'BigQuery dataset ID is required.');
+      }
 
-    try {
-      const cmd = [...command, '--bq-dataset fxa-dev.inactives-testo'];
-      await exec(cmd.join(' '), execOptions);
-      assert.ok('Script executed without error');
-    } catch (err) {
-      assert.fail(`Script failed with error: ${err}`);
-    }
-  });
+      try {
+        const cmd = [...command, '--bq-dataset fxa-dev.inactives-testo'];
+        await exec(cmd.join(' '), execOptions);
+        assert.ok('Script executed without error');
+      } catch (err) {
+        assert.fail(`Script failed with error: ${err}`);
+      }
+    },
+    30 * 1000 // increase timeout since exec can be slow, band-aid fix for now
+  );
 
   it('requires the end date to be the same or later than the start date', async () => {
     try {


### PR DESCRIPTION
Because:
 - We've moved email sending and rendering out of auth-server

This Commit:
 - Updates several emails to send using the new fxa-mailer, renderer and sender

Closes: FXA-12883

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
