### PR TITLE
fix(auth): Skip newTokenNotification for token-exchange grant type

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -788,7 +788,9 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
           grant.session_token = newSessionToken.data;
         }
 
-        if (grant.refresh_token) {
+        // Token exchange is swapping tokens for an already-authenticated user,
+        // so we skip the new token notification.
+        if (grant.refresh_token && req.payload.grant_type !== GRANT_TOKEN_EXCHANGE) {
           // if a refresh token has
           // been provisioned as part of the flow
           // then we want to send some notifications to the user


### PR DESCRIPTION
Because:
* This function errors out because it looks for client_id in the request. We could pull the client_id from subject_token to use here, however, we don't want users to be notified about the token exchange since it occurs silently and should not be counted as a new login from the user's perspective

This commit:
* Skips newTokenNotification when the requested grant type results in a refresh token, and is for token-exchange grant type

fixes FXA-12963