### PR TITLE
task(auth): Configure email renderer to use auth.ftl for now

### DIFF
--- a/libs/accounts/email-renderer/src/l10n.ts
+++ b/libs/accounts/email-renderer/src/l10n.ts
@@ -9,6 +9,7 @@ import { determineLocale, parseAcceptLanguage } from '@fxa/shared/l10n';
 export type LocalizerOpts = {
   translations: {
     basePath: string;
+    ftlFileName: string;
   };
   templates: {
     cssPath: string;
@@ -135,17 +136,14 @@ class Localizer {
    */
   protected async fetchTranslatedMessages(locale?: string) {
     const results: string[] = [];
+    const basePath = this.bindings.opts.translations.basePath;
+    const ftlFileName = this.bindings.opts.translations.ftlFileName;
 
     // Note: 'en' auth.ftl only exists for browser bindings / Storybook. The fallback
     // English strings within the templates are tested and are shown in other envs
-    const authPath = `${this.bindings.opts.translations.basePath}/${
-      locale || 'en'
-    }/emails.ftl`;
-    results.push(await this.bindings.fetchResource(authPath));
-
-    const brandingPath = `${this.bindings.opts.translations.basePath}/${
-      locale || 'en'
-    }/branding.ftl`;
+    const mainFtlPath = `${basePath}/${locale || 'en'}/${ftlFileName}`;
+    const brandingPath = `${basePath}/${locale || 'en'}/branding.ftl`;
+    results.push(await this.bindings.fetchResource(mainFtlPath));
     results.push(await this.bindings.fetchResource(brandingPath));
 
     return results.join('\n\n\n');

--- a/libs/accounts/email-renderer/src/renderer/bindings-browser.ts
+++ b/libs/accounts/email-renderer/src/renderer/bindings-browser.ts
@@ -58,6 +58,7 @@ export class BrowserRendererBindings extends RendererBindings {
         },
         translations: {
           basePath: './public/locales',
+          ftlFileName: 'emails.ftl',
         },
       },
       opts

--- a/libs/accounts/email-renderer/src/renderer/bindings-node.ts
+++ b/libs/accounts/email-renderer/src/renderer/bindings-node.ts
@@ -45,6 +45,7 @@ export class NodeRendererBindings extends RendererBindings {
         },
         translations: {
           basePath: join(__dirname, '../../public/locales'),
+          ftlFileName: 'emails.ftl',
         },
       },
       opts

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -10,7 +10,7 @@ require('../lib/monitoring');
 const { config } = require('../config');
 
 const Redis = require('ioredis');
-
+const { join } = require('node:path');
 const { CapabilityManager } = require('@fxa/payments/capability');
 const { EligibilityManager } = require('@fxa/payments/eligibility');
 const {
@@ -377,7 +377,15 @@ async function run(config) {
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings()
+    new NodeRendererBindings({
+      translations: {
+        // TODO: Once this PR, https://github.com/mozilla/fxa-content-server-l10n/pull/989, is finalized we can:
+        //  - switch this to point libs/accounts/public/locales or ../public/locales (either is probably fine...)
+        //  - switch to using emails.ftl, since all email specific strings will have been migrated over
+        basePath: join(__dirname, '../public/locales'),
+        ftlFileName: 'auth.ftl',
+      },
+    })
   );
   Container.set(FxaMailer, fxaMailer);
 


### PR DESCRIPTION
## Because

- We are still working with the l10n team to get emails translations squared away.
- We can't finalize this process until we fully stop using the email templates in auth server

## This pull request

- Tells the email render in auth-server to look for translations in auth server's auth.ftl file.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1329" height="345" alt="image" src="https://github.com/user-attachments/assets/46bb7070-25d6-4701-b19a-b0f04a66267f" />

## Other information (Optional)

Any other information that is important to this pull request.
