### PR TITLE
fix cms smoke tests

### DIFF
--- a/packages/functional-tests/tests/cms/cms-2fa.spec.ts
+++ b/packages/functional-tests/tests/cms/cms-2fa.spec.ts
@@ -56,7 +56,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(button).toHaveCSS('--cta-bg', buttonColor);
       await expect(button).toHaveCSS('--cta-border', buttonColor);
       await expect(button).toHaveCSS('--cta-active', buttonColor);
-      await expect(button).toHaveCSS('--cta-disabled', `${buttonColor}60`);
+      await expect(button).toHaveCSS('--cta-disabled', buttonColor);
     }
 
     test.beforeAll(async ({ target }) => {

--- a/packages/functional-tests/tests/cms/cms.spec.ts
+++ b/packages/functional-tests/tests/cms/cms.spec.ts
@@ -55,7 +55,7 @@ test.describe('severity-1 #smoke', () => {
       await expect(button).toHaveCSS('--cta-bg', buttonColor);
       await expect(button).toHaveCSS('--cta-border', buttonColor);
       await expect(button).toHaveCSS('--cta-active', buttonColor);
-      await expect(button).toHaveCSS('--cta-disabled', `${buttonColor}60`);
+      await expect(button).toHaveCSS('--cta-disabled', buttonColor);
     }
 
     test.beforeAll(async ({ target }) => {
@@ -160,11 +160,16 @@ test.describe('severity-1 #smoke', () => {
           buttonColor: '#4845D2',
           buttonText: 'Continue',
         });
-        await signin.passwordTextbox.fill(credentials.password);
         submitButton = page.getByRole('button', {
           name: 'Continue',
           exact: true,
         });
+        // expect button to be disabled until password fields are filled
+        await expect(submitButton).toBeDisabled();
+        await expect(submitButton).toHaveCSS('opacity', '0.5');
+        await signin.passwordTextbox.fill(credentials.password);
+        await expect(submitButton).toBeEnabled();
+        await expect(submitButton).toHaveCSS('opacity', '1');
         await submitButton.click();
 
         await assertCmsCustomization(page, {


### PR DESCRIPTION
## Because

- cms smoke tests were failing on disable button styling
- Disabled styling now controlled with opacity (works for both solid colors and gradients

## This pull request

- Update tests, add a check for disabled/enabled state + opacity change

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
