### PR TITLE
bug(auth): Fixing missing email templates for production build

### DIFF
--- a/libs/accounts/email-renderer/project.json
+++ b/libs/accounts/email-renderer/project.json
@@ -26,7 +26,11 @@
         "outputPath": "dist/libs/accounts/email-renderer",
         "main": "libs/accounts/email-renderer/src/index.ts",
         "tsConfig": "libs/accounts/email-renderer/tsconfig.lib.json",
-        "assets": ["libs/accounts/email-renderer/*.md"],
+        "assets": [
+          "libs/accounts/email-renderer/*.md",
+          "libs/accounts/email-renderer/src/**/*.txt",
+          "libs/accounts/email-renderer/src/**/*.mjml"
+        ],
         "format": ["cjs"],
         "generatePackageJson": true
       }

--- a/libs/accounts/email-renderer/src/renderer/bindings-node.ts
+++ b/libs/accounts/email-renderer/src/renderer/bindings-node.ts
@@ -64,10 +64,12 @@ export class NodeRendererBindings extends RendererBindings {
   }
 
   async fetchResource(path: string): Promise<string> {
+    if (!existsSync(path)) {
+      throw new Error('Resource file does not exist: ' + path);
+    }
     const raw = readFileSync(path, {
       encoding: 'utf8',
     });
-
     return raw;
   }
 

--- a/packages/fxa-auth-server/scripts/copy-assets.sh
+++ b/packages/fxa-auth-server/scripts/copy-assets.sh
@@ -8,3 +8,18 @@ xargs -L1 bash -c 'mkdir -p dist/packages/fxa-auth-server/$0'
 find config lib scripts bin public -type f | \
 grep --invert -E "\.js$|\.ts$|\.sh" | \
 xargs -L1 bash -c 'cp $0 dist/packages/fxa-auth-server/$0'
+
+# Copy email templates into dist...
+# Note that if we ran off the dist folder in the monorepo root we would not have this problem.
+cd ../..
+
+# First create all the directories
+find dist/libs/accounts/email-renderer -type d | \
+xargs -L1 bash -c 'mkdir -p packages/fxa-auth-server/$0'
+
+# Then copy the template files
+find dist/libs/accounts/email-renderer -type f | \
+grep -E "\.mjml$|\.txt$" | \
+xargs -L1 bash -c 'cp $0 packages/fxa-auth-server/$0'
+
+cd packages/fxa-auth-server


### PR DESCRIPTION
## Because

- Email sent using the new email library were failing.

## This pull request

- Resolves an issue where the templates assets (.mjml & .txt) files were getting copied into the `dist` folder.
- Provides a more developer friendly error message if the asset cannot be loaded.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before:
<img width="525" height="430" alt="image" src="https://github.com/user-attachments/assets/c818d988-44e4-4568-bcf8-445fb9abc717" />

After:
<img width="523" height="627" alt="image" src="https://github.com/user-attachments/assets/54dc8368-afca-41ca-8107-e4bc31c70dba" />


## Other information (Optional)

I feel like there should be a better way to do this, but... this will do for now. As mentioned in the code comment, the `fxa/dist/lib/accounts/email-render/*` is correct and has the extra assets. It'd be nice if all our builds were housed in the `fxa/dist` folder (ie mono repo root), butt that's too big of a change for a patch.
