### PR TITLE
polish(auth): Only fail hard on email send for emails with codes

### DIFF
--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -156,7 +156,7 @@ export class FxaMailer extends FxaEmailRenderer {
       ...opts,
       ...links,
     });
-    return this.sendEmail(opts, headers, rendered);
+    return this.sendEmail(opts, headers, rendered, true);
   }
 
   /**
@@ -189,7 +189,7 @@ export class FxaMailer extends FxaEmailRenderer {
       ...opts,
       ...links,
     });
-    return this.sendEmail(opts, headers, rendered);
+    return this.sendEmail(opts, headers, rendered, true);
   }
 
   async sendPostVerifySecondaryEmail(
@@ -1030,7 +1030,7 @@ export class FxaMailer extends FxaEmailRenderer {
       ...opts,
       ...links,
     });
-    return this.sendEmail(opts, headers, rendered);
+    return this.sendEmail(opts, headers, rendered, true);
   }
 
   async sendVerifyShortCodeEmail(
@@ -1067,7 +1067,7 @@ export class FxaMailer extends FxaEmailRenderer {
       ...opts,
       ...links,
     });
-    return this.sendEmail(opts, headers, rendered);
+    return this.sendEmail(opts, headers, rendered, true);
   }
 
   async sendVerifyEmail(
@@ -1686,19 +1686,23 @@ export class FxaMailer extends FxaEmailRenderer {
   private async sendEmail(
     opts: { to: string; cc?: string[]; cmsRpFromName?: string },
     headers: Record<string, string>,
-    rendered: RenderedTemplate
+    rendered: RenderedTemplate,
+    throwErrorOnSendFailure = true
   ) {
     const { cmsRpFromName, to, cc } = opts;
     const from = cmsRpFromName
       ? `${cmsRpFromName} <${this.mailerConfig.sender}>`
       : this.mailerConfig.sender;
 
-    return this.emailSender.send({
-      to,
-      cc,
-      from,
-      headers,
-      ...rendered,
-    });
+    return this.emailSender.send(
+      {
+        to,
+        cc,
+        from,
+        headers,
+        ...rendered,
+      },
+      throwErrorOnSendFailure
+    );
   }
 }


### PR DESCRIPTION
## Because

- We might not want to error out if an email fails to send
- Some emails are critical, others aren't

## This pull request

- Adds option to suppress an exception on email send
- Updates `auth-server` to suppress errors for not critical emails

## Issue that this pull request solves

Closes: FXA-13030

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
