### PR TITLE
bug(shared): Make sure ip is sanitized before writing to db

### DIFF
--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -142,7 +142,7 @@ export class SecurityEvent extends BaseAuthModel {
         EVENT_NAMES[name],
         ipAddrHmac,
         Date.now(),
-        ipAddr,
+        sanitizeIp(ipAddr),
         additionalInfo ? JSON.stringify(additionalInfo) : null
       );
     } catch (e) {


### PR DESCRIPTION
## Because

- Account reset was failing in admin panel
- This in turn resulted in a DB error on insert
- The hunch is we are getting an set of IPs separated by commas. 

## This pull request

- Sanitizes the IP before recording it in security events.

## Issue that this pull request solves

Closes: FXA-12978

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
