### PR TITLE
feat(passkeys): configure passkey feature flags

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2493,6 +2493,14 @@ const convictConf = convict({
       },
     },
   },
+  passkeys: {
+    enabled: {
+      default: false,
+      doc: 'Enable passkeys authentication feature',
+      env: 'PASSKEYS__ENABLED',
+      format: Boolean,
+    },
+  },
   twilio: {
     credentialMode: {
       default: '',

--- a/packages/fxa-auth-server/lib/passkey-utils.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ConfigType } from '../config';
+import { AppError } from '@fxa/accounts/errors';
+
+/**
+ * Checks if the passkey feature is enabled in the configuration
+ * @param config - The application configuration object
+ * @returns true if the passkey feature is enabled
+ * @throws AppError.featureNotEnabled if the feature is disabled
+ */
+export function isPasskeyFeatureEnabled(config: ConfigType): boolean {
+  if (!config.passkeys.enabled) {
+    throw AppError.featureNotEnabled();
+  }
+  return true;
+}

--- a/packages/fxa-auth-server/test/local/passkey-utils.js
+++ b/packages/fxa-auth-server/test/local/passkey-utils.js
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const { isPasskeyFeatureEnabled } = require('../../lib/passkey-utils');
+const { AppError } = require('@fxa/accounts/errors');
+
+describe('passkey-utils', () => {
+  describe('isPasskeyFeatureEnabled', () => {
+    it('should return true when passkeys are enabled', () => {
+      const config = {
+        passkeys: {
+          enabled: true,
+        },
+      };
+
+      const result = isPasskeyFeatureEnabled(config);
+      assert.equal(result, true, 'should return true when enabled');
+    });
+
+    it('should throw featureNotEnabled error when passkeys are disabled', () => {
+      const config = {
+        passkeys: {
+          enabled: false,
+        },
+      };
+
+      try {
+        isPasskeyFeatureEnabled(config);
+        assert.fail('should have thrown an error');
+      } catch (error) {
+        assert.equal(
+          error.errno,
+          AppError.featureNotEnabled().errno,
+          'should throw featureNotEnabled error'
+        );
+        assert.equal(
+          error.message,
+          'Feature not enabled',
+          'should have correct error message'
+        );
+      }
+    });
+
+    it('should throw featureNotEnabled error when config.passkeys.enabled is undefined', () => {
+      const config = {
+        passkeys: {},
+      };
+
+      try {
+        isPasskeyFeatureEnabled(config);
+        assert.fail('should have thrown an error');
+      } catch (error) {
+        assert.equal(
+          error.errno,
+          AppError.featureNotEnabled().errno,
+          'should throw featureNotEnabled error'
+        );
+      }
+    });
+  });
+});

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -121,6 +121,7 @@ const settingsConfig = {
     paymentsNextSubscriptionManagement: config.get(
       'featureFlags.paymentsNextSubscriptionManagement'
     ),
+    passkeysEnabled: config.get('featureFlags.passkeysEnabled'),
   },
   nimbus: {
     enabled: config.get('nimbus.enabled'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -247,6 +247,12 @@ const conf = (module.exports = convict({
       format: Boolean,
       env: 'FEATURE_FLAGS_PAYMENTS_NEXT_SUBSCRIPTION_MANAGEMENT',
     },
+    passkeysEnabled: {
+      default: false,
+      doc: 'Enables passkeys authentication',
+      format: Boolean,
+      env: 'FEATURE_FLAGS_PASSKEYS_ENABLED',
+    },
   },
   cms: {
     enabled: {

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -55,6 +55,9 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_SHOW_LOCALE_TOGGLE = config.get(
     'featureFlags.showLocaleToggle'
   );
+  const FEATURE_FLAGS_PASSKEYS_ENABLED = config.get(
+    'featureFlags.passkeysEnabled'
+  );
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
   const GLEAN_UPLOAD_ENABLED = config.get('glean.uploadEnabled');
@@ -121,6 +124,7 @@ function getIndexRouteDefinition(config) {
       recoveryCodeSetupOnSyncSignIn:
         FEATURE_FLAGS_RECOVERY_CODE_SETUP_ON_SYNC_SIGN_IN,
       showLocaleToggle: FEATURE_FLAGS_SHOW_LOCALE_TOGGLE,
+      passkeysEnabled: FEATURE_FLAGS_PASSKEYS_ENABLED,
     },
     cms: {
       enabled: CMS_ENABLED,

--- a/packages/fxa-settings/src/lib/config.test.ts
+++ b/packages/fxa-settings/src/lib/config.test.ts
@@ -158,3 +158,62 @@ describe('reset', () => {
     expect(config.version).toBeUndefined();
   });
 });
+
+describe('featureFlags', () => {
+  it('can parse passkeysEnabled feature flag', () => {
+    const data = {
+      featureFlags: {
+        passkeysEnabled: true,
+      },
+    };
+
+    readConfigMeta(() => {
+      return {
+        getAttribute() {
+          return encodeURIComponent(JSON.stringify(data));
+        },
+      };
+    });
+
+    expect(config.featureFlags).toBeDefined();
+    expect(config.featureFlags?.passkeysEnabled).toBe(true);
+  });
+
+  it('handles passkeysEnabled as false', () => {
+    const data = {
+      featureFlags: {
+        passkeysEnabled: false,
+      },
+    };
+
+    readConfigMeta(() => {
+      return {
+        getAttribute() {
+          return encodeURIComponent(JSON.stringify(data));
+        },
+      };
+    });
+
+    expect(config.featureFlags).toBeDefined();
+    expect(config.featureFlags?.passkeysEnabled).toBe(false);
+  });
+
+  it('handles undefined passkeysEnabled flag', () => {
+    const data = {
+      featureFlags: {
+        keyStretchV2: true,
+      },
+    };
+
+    readConfigMeta(() => {
+      return {
+        getAttribute() {
+          return encodeURIComponent(JSON.stringify(data));
+        },
+      };
+    });
+
+    expect(config.featureFlags).toBeDefined();
+    expect(config.featureFlags?.passkeysEnabled).toBeUndefined();
+  });
+});

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -101,6 +101,7 @@ export interface Config {
     recoveryCodeSetupOnSyncSignIn?: boolean;
     showLocaleToggle?: boolean;
     paymentsNextSubscriptionManagement?: boolean;
+    passkeysEnabled?: boolean;
   };
   nimbus: {
     enabled: boolean;


### PR DESCRIPTION
## Because

- we want a feature flag for passkeys

## This pull request

- Adds passkeys.enabled config to fxa-auth-server (default: false, env: PASSKEYS__ENABLED)
- Creates isPasskeyFeatureEnabled() utility for route-level feature gating
- Adds passkeysEnabled flag to content-server and fxa-settings configs
- Adds unit tests for backend utility and frontend config parsing

## Issue that this pull request solves

Closes: FXA-12903
