### PR TITLE
PART 1: feat(auth): Add backend APIs needed to move off GraphQL

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1176,12 +1176,37 @@ export default class AuthClient {
     );
   }
 
+  async emailBounceStatus(
+    email: string,
+    headers?: Headers
+  ): Promise<{ hasHardBounce: boolean }> {
+    return this.request(
+      'POST',
+      '/account/email_bounce_status',
+      { email },
+      headers
+    );
+  }
+
   async accountProfile(sessionToken: hexstring, headers?: Headers) {
     return this.sessionGet('/account/profile', sessionToken, headers);
   }
 
   async account(sessionToken: hexstring, headers?: Headers) {
     return this.sessionGet('/account', sessionToken, headers);
+  }
+
+  async metricsOpt(
+    sessionToken: hexstring,
+    state: 'in' | 'out',
+    headers?: Headers
+  ): Promise<{}> {
+    return this.sessionPost(
+      '/account/metrics_opt',
+      sessionToken,
+      { state },
+      headers
+    );
   }
 
   async sessionDestroy(

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -23,7 +23,11 @@
     "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/subscription-services",
     "subscriptionSettingsUrl": "http://localhost:3035/",
     "user": "local",
-    "password": "local"
+    "password": "local",
+    "bounces": {
+      "enabled": true,
+      "aliasCheckEnabled": true
+    }
   },
   "snsTopicArn": "arn:aws:sns:us-east-1:100010001000:fxa-account-change-dev",
   "snsTopicEndpoint": "http://localhost:4100/",

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -26,6 +26,7 @@ loadAccountFailed                     : ip                : 50          : 24 hou
 #
 accountCreate                         : ip                : 100         : 24 hours        : 24 hours    : block
 accountStatusCheck                    : ip                : 100         : 15 minute       : 15 minute   : block
+emailBounceStatusCheck                : ip                : 100         : 15 minute       : 15 minute   : block
 recoveryKeyExists                     : ip                : 100         : 15 minute       : 15 minute   : block
 getCredentialsStatus                  : ip                : 100         : 15 minute       : 15 minute   : block
 

--- a/packages/fxa-auth-server/docs/swagger/account-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/account-api.ts
@@ -109,6 +109,14 @@ const ACCOUNT_STATUS_POST = {
   ],
 };
 
+const ACCOUNT_EMAIL_BOUNCE_STATUS_POST = {
+  ...TAGS_ACCOUNT,
+  description: '/account/email_bounce_status',
+  notes: [
+    'Checks if there are any hard (permanent) email bounces recorded for the provided email address. Used during signup confirmation to detect if verification emails are bouncing.',
+  ],
+};
+
 const ACCOUNT_PROFILE_GET = {
   ...TAGS_ACCOUNT,
   description: '/account/profile',
@@ -310,12 +318,24 @@ const ACCOUNT_STUB_POST = {
   description: '/account/stub',
 };
 
+const ACCOUNT_METRICS_OPT_POST = {
+  ...TAGS_ACCOUNT,
+  description: '/account/metrics_opt',
+  notes: [
+    dedent`
+      Set the metrics opt-in or opt-out state for the account. Notifies relying parties of the profile data change.
+    `,
+  ],
+};
+
 const API_DOCS = {
   ACCOUNT_CREATE_POST,
   ACCOUNT_DESTROY_POST,
+  ACCOUNT_EMAIL_BOUNCE_STATUS_POST,
   ACCOUNT_FINISH_SETUP_POST,
   ACCOUNT_KEYS_GET,
   ACCOUNT_LOGIN_POST,
+  ACCOUNT_METRICS_OPT_POST,
   ACCOUNT_PROFILE_GET,
   ACCOUNT_RESET_POST,
   ACCOUNT_CREDENTIALS_STATUS,

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -10,6 +10,8 @@ import { WrappedErrorCodes } from 'fxa-shared/email/emailValidatorErrors';
 import TopEmailDomains from 'fxa-shared/email/topEmailDomains';
 import { tryResolveIpv4, tryResolveMx } from 'fxa-shared/email/validateEmail';
 import ScopeSet from 'fxa-shared/oauth/scopes';
+import { OAUTH_SCOPE_OLD_SYNC } from 'fxa-shared/oauth/constants';
+import { list as listAuthorizedClients } from '../oauth/authorized_clients';
 import { WebSubscription } from 'fxa-shared/subscriptions/types';
 import isA from 'joi';
 import Stripe from 'stripe';
@@ -44,6 +46,7 @@ import { gleanMetrics } from '../metrics/glean';
 import { AccountDeleteManager } from '../account-delete';
 import { uuidTransformer } from 'fxa-shared/db/transformers';
 import { normalizeEmail } from 'fxa-shared/email/helpers';
+import { EmailNormalization } from 'fxa-shared/email/email-normalization';
 import { DeleteAccountTasks, ReasonForDeletion } from '@fxa/shared/cloud-tasks';
 import { ProfileClient } from '@fxa/profile/client';
 import { DB } from '../db';
@@ -59,6 +62,9 @@ import { Redis } from 'ioredis';
 import { FxaMailer } from '../senders/fxa-mailer';
 import { FxaMailerFormat } from '../senders/fxa-mailer-format';
 import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
+import { BackupCodeManager } from '@fxa/accounts/two-factor';
+import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
+import { BOUNCE_TYPE_HARD } from '@fxa/accounts/email-sender';
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -1630,6 +1636,65 @@ export class AccountHandler {
     }
   }
 
+  async emailBounceStatus(request: AuthRequest) {
+    const { email } = request.payload as { email: string };
+
+    await this.customs.check(request, email, 'emailBounceStatusCheck');
+
+    try {
+      const bouncesConfig = this.config.smtp?.bounces || {};
+      const aliasCheckEnabled = !!bouncesConfig.aliasCheckEnabled;
+
+      let bounces: Array<{ bounceType: number }>;
+
+      if (aliasCheckEnabled) {
+        // Check bounces with email alias normalization
+        // Given an email alias like test+123@domain.com:
+        // We look for bounces to the 'root' email -> `test@domain.com`
+        // And look for bounces to the alias with a wildcard -> `test+%@domain.com`
+        const emailNormalization = new EmailNormalization(
+          bouncesConfig.emailAliasNormalization
+        );
+        const normalizedEmail = emailNormalization.normalizeEmailAliases(
+          email,
+          ''
+        );
+        const wildcardEmail = emailNormalization.normalizeEmailAliases(
+          email,
+          '+%'
+        );
+
+        const [normalizedBounces, wildcardBounces] = await Promise.all([
+          this.db.emailBounces(normalizedEmail),
+          this.db.emailBounces(wildcardEmail),
+        ]);
+
+        // Combine and dedupe bounces by email and createdAt
+        const seen = new Set<string>();
+        bounces = [...normalizedBounces, ...wildcardBounces].filter(
+          (bounce: any) => {
+            const key = `${bounce.email}:${bounce.createdAt}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          }
+        );
+      } else {
+        bounces = await this.db.emailBounces(email);
+      }
+
+      const hasHardBounce = bounces.some(
+        (bounce: { bounceType: number }) =>
+          bounce.bounceType === BOUNCE_TYPE_HARD
+      );
+      return { hasHardBounce };
+    } catch (err) {
+      this.log.error('emailBounceStatus.error', { err });
+      // Return false on error to not block user flow
+      return { hasHardBounce: false };
+    }
+  }
+
   async profile(request: AuthRequest) {
     const auth = request.auth;
     let uid, scope;
@@ -2217,11 +2282,129 @@ export class AccountHandler {
     return {};
   }
 
+  async metricsOpt(request: AuthRequest) {
+    this.log.begin('Account.metricsOpt', request);
+
+    const { uid } = request.auth.credentials as { uid: string };
+    const { state } = request.payload as { state: 'in' | 'out' };
+    const account = await this.db.account(uid);
+    const email = account.primaryEmail?.email;
+
+    await this.customs.checkAuthenticated(
+      request,
+      uid,
+      email,
+      'metricsOpt'
+    );
+
+    await Account.setMetricsOpt(uid, state);
+    await this.profileClient.deleteCache(uid);
+    await this.log.notifyAttachedServices('profileDataChange', request, {
+      uid,
+    });
+
+    return {};
+  }
+
   async getAccount(request: AuthRequest) {
     this.log.begin('Account.get', request);
 
-    const { uid } = request.auth.credentials;
+    const { uid } = request.auth.credentials as { uid: string };
 
+    // Fetch all data in parallel for better performance
+    const [
+      accountRecord,
+      emails,
+      linkedAccountsResult,
+      totpResult,
+      backupCodesResult,
+      recoveryKeyResult,
+      recoveryPhoneResult,
+      securityEventsResult,
+      devicesResult,
+      authorizedClientsResult,
+    ] = await Promise.allSettled([
+      this.db.account(uid),
+      this.db.accountEmails(uid),
+      this.db.getLinkedAccounts(uid),
+      this.db.totpToken(uid),
+      Container.get(BackupCodeManager).getCountForUserId(uid),
+      this.db.getRecoveryKeyRecordWithHint(uid),
+      Container.get(RecoveryPhoneService).hasConfirmed(uid),
+      this.db.securityEventsByUid({ uid }),
+      this.db.devices(uid),
+      listAuthorizedClients(uid),
+    ]);
+
+    // Check if recovery phone feature is enabled globally (region check requires geo context)
+    const recoveryPhoneAvailable = this.config.recoveryPhone?.enabled ?? false;
+
+    // Account record is required
+    if (accountRecord.status === 'rejected') {
+      throw accountRecord.reason;
+    }
+    const account = accountRecord.value;
+
+    // Format emails
+    const formattedEmails = emails.status === 'fulfilled'
+      ? emails.value.map((email: any) => ({
+          email: email.email,
+          isPrimary: email.isPrimary,
+          verified: email.isVerified,
+        }))
+      : [];
+
+    // Format linked accounts
+    const linkedAccounts = linkedAccountsResult.status === 'fulfilled'
+      ? linkedAccountsResult.value.map((la: any) => ({
+          providerId: la.providerId,
+          authAt: la.authAt,
+          enabled: la.enabled,
+        }))
+      : [];
+
+    // Format TOTP status
+    const totp = totpResult.status === 'fulfilled' && totpResult.value
+      ? { exists: true, verified: !!totpResult.value.verified }
+      : { exists: false, verified: false };
+
+    // Format backup codes status
+    const backupCodes = backupCodesResult.status === 'fulfilled'
+      ? backupCodesResult.value
+      : { hasBackupCodes: false, count: 0 };
+
+    // Calculate estimated sync device count (for recovery key promo eligibility)
+    const devicesCount = devicesResult.status === 'fulfilled' ? devicesResult.value.length : 0;
+    const authorizedClients = authorizedClientsResult.status === 'fulfilled' ? authorizedClientsResult.value : [];
+    const syncOAuthClientsCount = authorizedClients.filter(
+      (client: any) => client.scope && client.scope.includes(OAUTH_SCOPE_OLD_SYNC)
+    ).length;
+    const estimatedSyncDeviceCount = Math.max(devicesCount, syncOAuthClientsCount);
+
+    // Format recovery key status
+    const recoveryKey = recoveryKeyResult.status === 'fulfilled' && recoveryKeyResult.value
+      ? { exists: true, estimatedSyncDeviceCount }
+      : { exists: false, estimatedSyncDeviceCount };
+
+    // Format recovery phone status
+    const recoveryPhoneData = recoveryPhoneResult.status === 'fulfilled'
+      ? recoveryPhoneResult.value
+      : { exists: false, phoneNumber: null };
+    const recoveryPhone = {
+      ...recoveryPhoneData,
+      available: recoveryPhoneAvailable,
+    };
+
+    // Format security events
+    const securityEvents = securityEventsResult.status === 'fulfilled'
+      ? securityEventsResult.value.map((e: any) => ({
+          name: e.name,
+          createdAt: e.createdAt,
+          verified: e.verified,
+        }))
+      : [];
+
+    // Fetch subscriptions (separate block due to complexity)
     let webSubscriptions: Awaited<WebSubscription[]> = [];
     let iapGooglePlaySubscriptions: Awaited<PlayStoreSubscription[]> = [];
     let iapAppStoreSubscriptions: Awaited<AppStoreSubscription[]> = [];
@@ -2258,6 +2441,23 @@ export class AccountHandler {
     }
 
     return {
+      // Account metadata
+      createdAt: account.createdAt,
+      passwordCreatedAt: account.verifierSetAt,
+      metricsOptOutAt: account.metricsOptOutAt,
+      hasPassword: account.verifierSetAt > 0,
+      // Emails
+      emails: formattedEmails,
+      // Linked accounts
+      linkedAccounts,
+      // 2FA status
+      totp,
+      backupCodes,
+      recoveryKey,
+      recoveryPhone,
+      // Security events
+      securityEvents,
+      // Subscriptions
       subscriptions: [
         ...iapGooglePlaySubscriptions,
         ...iapAppStoreSubscriptions,
@@ -2585,6 +2785,25 @@ export const accountRoutes = (
         accountHandler.accountStatusCheck(request),
     },
     {
+      method: 'POST',
+      path: '/account/email_bounce_status',
+      options: {
+        ...ACCOUNT_DOCS.ACCOUNT_EMAIL_BOUNCE_STATUS_POST,
+        validate: {
+          payload: isA.object({
+            email: validators.email().required(),
+          }),
+        },
+        response: {
+          schema: isA.object({
+            hasHardBounce: isA.boolean().required(),
+          }),
+        },
+      },
+      handler: (request: AuthRequest) =>
+        accountHandler.emailBounceStatus(request),
+    },
+    {
       method: 'GET',
       path: '/account/profile',
       options: {
@@ -2776,6 +2995,22 @@ export const accountRoutes = (
         accountHandler.getCredentialsStatus(request),
     },
     {
+      method: 'POST',
+      path: '/account/metrics_opt',
+      options: {
+        ...ACCOUNT_DOCS.ACCOUNT_METRICS_OPT_POST,
+        auth: {
+          strategy: 'sessionToken',
+        },
+        validate: {
+          payload: isA.object({
+            state: isA.string().valid('in', 'out').required(),
+          }),
+        },
+      },
+      handler: (request: AuthRequest) => accountHandler.metricsOpt(request),
+    },
+    {
       method: 'GET',
       path: '/account',
       options: {
@@ -2792,6 +3027,66 @@ export const accountRoutes = (
             // backend. Discussion in:
             //
             // https://github.com/mozilla/fxa/issues/1808
+            createdAt: isA.number().optional(),
+            passwordCreatedAt: isA.number().optional(),
+            metricsOptOutAt: isA.number().allow(null).optional(),
+            hasPassword: isA.boolean().optional(),
+            emails: isA
+              .array()
+              .items(
+                isA.object({
+                  email: isA.string().required(),
+                  isPrimary: isA.boolean().required(),
+                  verified: isA.boolean().required(),
+                })
+              )
+              .optional(),
+            linkedAccounts: isA
+              .array()
+              .items(
+                isA.object({
+                  providerId: isA.number().required(),
+                  authAt: isA.number().required(),
+                  enabled: isA.boolean().required(),
+                })
+              )
+              .optional(),
+            totp: isA
+              .object({
+                exists: isA.boolean().required(),
+                verified: isA.boolean().required(),
+              })
+              .optional(),
+            backupCodes: isA
+              .object({
+                hasBackupCodes: isA.boolean().required(),
+                count: isA.number().required(),
+              })
+              .optional(),
+            recoveryKey: isA
+              .object({
+                exists: isA.boolean().required(),
+                estimatedSyncDeviceCount: isA.number().optional(),
+              })
+              .optional(),
+            recoveryPhone: isA
+              .object({
+                exists: isA.boolean().required(),
+                phoneNumber: isA.string().allow(null).optional(),
+                nationalFormat: isA.string().allow(null).optional(),
+                available: isA.boolean().required(),
+              })
+              .optional(),
+            securityEvents: isA
+              .array()
+              .items(
+                isA.object({
+                  name: isA.string().required(),
+                  createdAt: isA.number().required(),
+                  verified: isA.boolean().required(),
+                })
+              )
+              .optional(),
             subscriptions: isA
               .array()
               .items(

--- a/packages/fxa-auth-server/test/local/bounces.js
+++ b/packages/fxa-auth-server/test/local/bounces.js
@@ -23,10 +23,14 @@ describe('bounces', () => {
     const db = {
       emailBounces: sinon.spy(() => Promise.resolve([])),
     };
+    const aliasCheckEnabled = !!config.smtp?.bounces?.aliasCheckEnabled;
+    // When aliasCheckEnabled is true, emailBounces is called twice
+    // (once for normalized email, once for wildcard pattern)
+    const expectedCallCount = aliasCheckEnabled ? 2 : 1;
     return createBounces(config, db)
       .check(EMAIL)
       .then(() => {
-        assert.equal(db.emailBounces.callCount, 1);
+        assert.equal(db.emailBounces.callCount, expectedCallCount);
       });
   });
 

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -138,6 +138,7 @@ const makeRoutes = function (options = {}, requireMocks = {}) {
     ...(requireMocks || {}),
     'fxa-shared/db/models/auth': {
       getAccountCustomerByUid: mockGetAccountCustomerByUid,
+      ...((requireMocks || {})['fxa-shared/db/models/auth'] || {}),
     },
   });
   const signupUtils =
@@ -4733,6 +4734,7 @@ describe('/account', () => {
         },
       },
       log,
+      db: mocks.mockDB({ email, uid }),
       stripeHelper: mockStripeHelper,
     });
     return getRoute(accountRoutes, '/account');
@@ -4811,9 +4813,7 @@ describe('/account', () => {
           mockStripeHelper.subscriptionsToResponse,
           mockCustomer.subscriptions
         );
-        assert.deepEqual(result, {
-          subscriptions: mockWebSubscriptionsResponse,
-        });
+        assert.deepEqual(result.subscriptions, mockWebSubscriptionsResponse);
       });
     });
 
@@ -4823,9 +4823,7 @@ describe('/account', () => {
       });
 
       return runTest(buildRoute(), request, (result) => {
-        assert.deepEqual(result, {
-          subscriptions: [],
-        });
+        assert.deepEqual(result.subscriptions, []);
         assert.equal(log.begin.callCount, 1);
         assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
         assert.equal(mockStripeHelper.subscriptionsToResponse.callCount, 0);
@@ -4850,9 +4848,7 @@ describe('/account', () => {
 
     it('should not return stripe.customer result when subscriptions are disabled', () => {
       return runTest(buildRoute(false), request, (result) => {
-        assert.deepEqual(result, {
-          subscriptions: [],
-        });
+        assert.deepEqual(result.subscriptions, []);
 
         assert.equal(log.begin.callCount, 1);
         assert.equal(mockStripeHelper.fetchCustomer.callCount, 0);
@@ -4939,9 +4935,7 @@ describe('/account', () => {
             mockPlaySubscriptions.getSubscriptions,
             uid
           );
-          assert.deepEqual(result, {
-            subscriptions: [mockFormattedPlayStoreSubscription],
-          });
+          assert.deepEqual(result.subscriptions, [mockFormattedPlayStoreSubscription]);
         }
       );
     });
@@ -4966,12 +4960,10 @@ describe('/account', () => {
           assert.equal(log.begin.callCount, 1);
           assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
           assert.equal(mockPlaySubscriptions.getSubscriptions.callCount, 1);
-          assert.deepEqual(result, {
-            subscriptions: [
-              ...[mockFormattedPlayStoreSubscription],
-              ...mockWebSubscriptionsResponse,
-            ],
-          });
+          assert.deepEqual(result.subscriptions, [
+            ...[mockFormattedPlayStoreSubscription],
+            ...mockWebSubscriptionsResponse,
+          ]);
         }
       );
     });
@@ -4986,9 +4978,7 @@ describe('/account', () => {
           assert.equal(log.begin.callCount, 1);
           assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
           assert.equal(mockPlaySubscriptions.getSubscriptions.callCount, 1);
-          assert.deepEqual(result, {
-            subscriptions: [],
-          });
+          assert.deepEqual(result.subscriptions, []);
         }
       );
     });
@@ -5014,9 +5004,7 @@ describe('/account', () => {
           assert.equal(log.begin.callCount, 1);
           assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
           assert.equal(mockPlaySubscriptions.getSubscriptions.callCount, 0);
-          assert.deepEqual(result, {
-            subscriptions: mockWebSubscriptionsResponse,
-          });
+          assert.deepEqual(result.subscriptions, mockWebSubscriptionsResponse);
         }
       );
     });
@@ -5089,9 +5077,7 @@ describe('/account', () => {
             mockAppStoreSubscriptions.getSubscriptions,
             uid
           );
-          assert.deepEqual(result, {
-            subscriptions: [mockFormattedAppStoreSubscription],
-          });
+          assert.deepEqual(result.subscriptions, [mockFormattedAppStoreSubscription]);
         }
       );
     });
@@ -5116,12 +5102,10 @@ describe('/account', () => {
           assert.equal(log.begin.callCount, 1);
           assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
           assert.equal(mockAppStoreSubscriptions.getSubscriptions.callCount, 1);
-          assert.deepEqual(result, {
-            subscriptions: [
-              ...[mockFormattedAppStoreSubscription],
-              ...mockWebSubscriptionsResponse,
-            ],
-          });
+          assert.deepEqual(result.subscriptions, [
+            ...[mockFormattedAppStoreSubscription],
+            ...mockWebSubscriptionsResponse,
+          ]);
         }
       );
     });
@@ -5136,9 +5120,7 @@ describe('/account', () => {
           assert.equal(log.begin.callCount, 1);
           assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
           assert.equal(mockAppStoreSubscriptions.getSubscriptions.callCount, 1);
-          assert.deepEqual(result, {
-            subscriptions: [],
-          });
+          assert.deepEqual(result.subscriptions, []);
         }
       );
     });
@@ -5164,11 +5146,146 @@ describe('/account', () => {
           assert.equal(log.begin.callCount, 1);
           assert.equal(mockStripeHelper.fetchCustomer.callCount, 1);
           assert.equal(mockAppStoreSubscriptions.getSubscriptions.callCount, 0);
-          assert.deepEqual(result, {
-            subscriptions: mockWebSubscriptionsResponse,
-          });
+          assert.deepEqual(result.subscriptions, mockWebSubscriptionsResponse);
         }
       );
+    });
+  });
+
+  describe('expanded account data fields', () => {
+    it('should return account metadata and 2FA status', () => {
+      return runTest(buildRoute(), request, (result) => {
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'createdAt'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'passwordCreatedAt'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'hasPassword'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'emails'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'totp'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'backupCodes'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'recoveryKey'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'recoveryPhone'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'securityEvents'));
+        assert.ok(Object.prototype.hasOwnProperty.call(result, 'linkedAccounts'));
+        assert.isArray(result.emails);
+        assert.isArray(result.securityEvents);
+        assert.isArray(result.linkedAccounts);
+      });
+    });
+  });
+});
+
+describe('/account/email_bounce_status', () => {
+  let log, mockDB;
+
+  const email = 'test@example.com';
+
+  function buildRoute(dbOverrides = {}) {
+    log = mocks.mockLog();
+    mockDB = {
+      emailBounces: sinon.spy(() => Promise.resolve([])),
+      ...dbOverrides,
+    };
+    const accountRoutes = makeRoutes({
+      config: { smtp: { bounces: {} } },
+      log,
+      db: mockDB,
+      customs: {
+        check: sinon.spy(() => Promise.resolve()),
+        checkAuthenticated: sinon.spy(() => Promise.resolve()),
+      },
+    });
+    return getRoute(accountRoutes, '/account/email_bounce_status');
+  }
+
+  it('should return hasHardBounce: false when no bounces exist', () => {
+    const request = mocks.mockRequest({ payload: { email } });
+    return runTest(buildRoute(), request, (result) => {
+      assert.deepEqual(result, { hasHardBounce: false });
+    });
+  });
+
+  it('should return hasHardBounce: true when a hard bounce exists', () => {
+    const request = mocks.mockRequest({ payload: { email } });
+    const route = buildRoute({
+      emailBounces: sinon.spy(() =>
+        Promise.resolve([{ bounceType: 1, email, createdAt: Date.now() }])
+      ),
+    });
+    return runTest(route, request, (result) => {
+      assert.deepEqual(result, { hasHardBounce: true });
+    });
+  });
+
+  it('should return hasHardBounce: false on db error', () => {
+    const request = mocks.mockRequest({ payload: { email } });
+    const route = buildRoute({
+      emailBounces: sinon.spy(() => Promise.reject(new Error('db error'))),
+    });
+    return runTest(route, request, (result) => {
+      assert.deepEqual(result, { hasHardBounce: false });
+    });
+  });
+});
+
+describe('/account/metrics_opt', () => {
+  let log, mockDB, mockCustoms;
+
+  const uid = 'abc123';
+  const email = 'test@example.com';
+
+  function buildRoute(setMetricsOptStub) {
+    log = mocks.mockLog();
+    mockCustoms = {
+      check: sinon.spy(() => Promise.resolve()),
+      checkAuthenticated: sinon.spy(() => Promise.resolve()),
+    };
+    mockDB = mocks.mockDB({ email, uid });
+    // Reset the shared profile mock's deleteCache spy
+    profile.deleteCache.resetHistory();
+    const accountRoutes = makeRoutes(
+      {
+        log,
+        db: mockDB,
+        customs: mockCustoms,
+      },
+      {
+        'fxa-shared/db/models/auth': {
+          Account: { setMetricsOpt: setMetricsOptStub },
+          getAccountCustomerByUid: mockGetAccountCustomerByUid,
+        },
+      }
+    );
+    return getRoute(accountRoutes, '/account/metrics_opt');
+  }
+
+  it('should call setMetricsOpt and notify services on opt-out', () => {
+    const setMetricsOptStub = sinon.stub().resolves();
+    const route = buildRoute(setMetricsOptStub);
+    const request = mocks.mockRequest({
+      credentials: { uid, email },
+      payload: { state: 'out' },
+      log,
+    });
+    return runTest(route, request, (result) => {
+      assert.deepEqual(result, {});
+      assert.calledOnce(setMetricsOptStub);
+      assert.calledWith(setMetricsOptStub, uid, 'out');
+      assert.calledOnce(mockCustoms.checkAuthenticated);
+      assert.calledOnce(profile.deleteCache);
+    });
+  });
+
+  it('should call setMetricsOpt and notify services on opt-in', () => {
+    const setMetricsOptStub = sinon.stub().resolves();
+    const route = buildRoute(setMetricsOptStub);
+    const request = mocks.mockRequest({
+      credentials: { uid, email },
+      payload: { state: 'in' },
+      log,
+    });
+    return runTest(route, request, (result) => {
+      assert.deepEqual(result, {});
+      assert.calledOnce(setMetricsOptStub);
+      assert.calledWith(setMetricsOptStub, uid, 'in');
     });
   });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -743,6 +743,10 @@ function mockDB(data, errors) {
         enabled: false,
       });
     }),
+    getLinkedAccounts: sinon.spy((uid) => {
+      assert.ok(typeof uid === 'string');
+      return Promise.resolve(data.linkedAccounts || []);
+    }),
   });
 }
 

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -17,7 +17,7 @@ const {
 const {
   AppStoreSubscriptions,
 } = require('../../lib/payments/iap/apple-app-store/subscriptions');
-import jwt from '../../lib/oauth/jwt';
+const jwt = require('../../lib/oauth/jwt');
 
 // Note, intentionally not indenting for code review.
 [{ version: '' }, { version: 'V2' }].forEach((testOptions) => {
@@ -44,6 +44,8 @@ import jwt from '../../lib/oauth/jwt';
 
       Container.set(PlaySubscriptions, {});
       Container.set(AppStoreSubscriptions, {});
+      mocks.mockPriceManager();
+      mocks.mockProductConfigurationManager();
 
       server = await TestServer.start(config, false, {
         authServerMockDependencies: {

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -73,13 +73,35 @@ const DEFAULTS = _.extend(
     verificationMethod: undefined,
     verificationReason: undefined,
     totpVerified: undefined,
+    recoveryKey: undefined,
   },
   PERSISTENT
 );
 
 const ALLOWED_KEYS = Object.keys(DEFAULTS);
 const ALLOWED_PERSISTENT_KEYS = Object.keys(PERSISTENT);
-const DEPRECATED_KEYS = ['ecosystemAnonId', 'needsOptedInToMarketingEmail'];
+const DEPRECATED_KEYS = [
+  'ecosystemAnonId',
+  'needsOptedInToMarketingEmail',
+  // The following are transient UI state from fxa-settings (should not be persisted)
+  'sessionVerified',
+  'loadingFields',
+  'isLoading',
+  'error',
+  // The following are fxa-settings extended account data (ignored by content-server)
+  'avatar',
+  'accountCreated',
+  'passwordCreated',
+  'emails',
+  'totp',
+  'backupCodes',
+  // Note: 'recoveryKey' is NOT deprecated - it contains estimatedSyncDeviceCount needed by fxa-settings
+  'recoveryPhone',
+  'attachedClients',
+  'linkedAccounts',
+  'subscriptions',
+  'securityEvents',
+];
 
 const CONTENT_SERVER_OAUTH_SCOPE = 'profile profile:write clients:write';
 


### PR DESCRIPTION
 ## Because                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                             
 - The `fxa-graphql-api` server is being removed, and `fxa-settings` needs direct REST API equivalents for data it currently fetches via GraphQL                                                                                            
 - The `/account` endpoint returned only subscription data, but `fxa-settings` needs account metadata, 2FA status, recovery key info, linked accounts, and security events in a single call                                                  
                                                                                                                                                                                                                                             
 ## This pull request                                                                                                                                                                                                                        
                                                                                                                                                                                                                                             
 - Adds [`/account/email_bounce_status`](https://github.com/mozilla/fxa/blob/FXA-12993/packages/fxa-auth-server/lib/routes/account.ts) endpoint to check for hard email bounces (with alias normalization support)                           
 - Adds [`/account/metrics_opt`](https://github.com/mozilla/fxa/blob/FXA-12993/packages/fxa-auth-server/lib/routes/account.ts) endpoint to set metrics opt-in/opt-out state                                                                  
 - Expands [`GET /account`](https://github.com/mozilla/fxa/blob/FXA-12993/packages/fxa-auth-server/lib/routes/account.ts) to return `createdAt`, `passwordCreatedAt`, `hasPassword`, `emails`, `linkedAccounts`, `totp`, `backupCodes`,      
 `recoveryKey`, `recoveryPhone`, `securityEvents`, and `metricsOptOutAt`                                                                                                                                                                     
 - Adds corresponding client methods (`emailBounceStatus`, `metricsOpt`) to [`fxa-auth-client`](https://github.com/mozilla/fxa/blob/FXA-12993/packages/fxa-auth-client/lib/client.ts)                                                        
 - Adds `emailBounceStatusCheck` rate limit rule to [`rate-limit-rules.txt`](https://github.com/mozilla/fxa/blob/FXA-12993/packages/fxa-auth-server/config/rate-limit-rules.txt)                                                             
 - Updates [`fxa-content-server` account model](https://github.com/mozilla/fxa/blob/FXA-12993/packages/fxa-content-server/app/scripts/models/account.js) to handle new fields via deprecated keys list                                       
                                                                                                                                                                                                                                             
 ## Issue                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                             
 Closes: https://mozilla-hub.atlassian.net/browse/FXA-12993                                                                                                                                                                                  
                                                                                                                                                                                                                                             
 ## Checklist                                                                                                                                                                                                                                
                                                                                                                                                                                                                                             
 - [x] My commit is GPG signed                                                                                                                                                                                                               
 - [x] Tests pass locally (if applicable)                                                                                                                                                                                                    
 - [ ] Documentation updated (if applicable)                                                                                                                                                                                                 
 - [ ] RTL rendering verified (if UI changed)                                                                                                                                                                                                
                                                                                                                                                                                                                                             
 ## Other Information                                                                                                                                                                                                                        
                                                                                                                                                                                                                                             


