### PR TITLE
PART2: feat(settings): Add account local storage state management components

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1689,7 +1689,7 @@ export class AccountHandler {
         // Combine and dedupe bounces by email and createdAt
         const seen = new Set<string>();
         bounces = [...normalizedBounces, ...wildcardBounces].filter(
-          (bounce: any) => {
+          (bounce: { email: string; createdAt: number }) => {
             const key = `${bounce.email}:${bounce.createdAt}`;
             if (seen.has(key)) return false;
             seen.add(key);
@@ -2364,7 +2364,7 @@ export class AccountHandler {
 
     // Format emails
     const formattedEmails = emails.status === 'fulfilled'
-      ? emails.value.map((email: any) => ({
+      ? emails.value.map((email: { email: string; isPrimary: boolean; isVerified: boolean }) => ({
           email: email.email,
           isPrimary: email.isPrimary,
           verified: email.isVerified,
@@ -2373,7 +2373,7 @@ export class AccountHandler {
 
     // Format linked accounts
     const linkedAccounts = linkedAccountsResult.status === 'fulfilled'
-      ? linkedAccountsResult.value.map((la: any) => ({
+      ? linkedAccountsResult.value.map((la: { providerId: number; authAt: number; enabled: boolean }) => ({
           providerId: la.providerId,
           authAt: la.authAt,
           enabled: la.enabled,
@@ -2394,7 +2394,7 @@ export class AccountHandler {
     const devicesCount = devicesResult.status === 'fulfilled' ? devicesResult.value.length : 0;
     const authorizedClients = authorizedClientsResult.status === 'fulfilled' ? authorizedClientsResult.value : [];
     const syncOAuthClientsCount = authorizedClients.filter(
-      (client: any) => client.scope && client.scope.includes(OAUTH_SCOPE_OLD_SYNC)
+      (client: { scope?: string }) => client.scope && client.scope.includes(OAUTH_SCOPE_OLD_SYNC)
     ).length;
     const estimatedSyncDeviceCount = Math.max(devicesCount, syncOAuthClientsCount);
 
@@ -2414,7 +2414,7 @@ export class AccountHandler {
 
     // Format security events
     const securityEvents = securityEventsResult.status === 'fulfilled'
-      ? securityEventsResult.value.map((e: any) => ({
+      ? securityEventsResult.value.map((e: { name: string; createdAt: number; verified?: boolean }) => ({
           name: e.name,
           createdAt: e.createdAt,
           verified: e.verified,

--- a/packages/fxa-settings/src/lib/account-storage.test.ts
+++ b/packages/fxa-settings/src/lib/account-storage.test.ts
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// jest.mock must precede imports because account-storage.ts calls
+// Storage.factory() at module load time — the mock must be in place first.
+// eslint-disable-next-line import/first
+import {
+  getAccountData,
+  updateAccountData,
+  getCurrentAccountUid,
+  setCurrentAccountUid,
+  removeAccount,
+  clearExtendedAccountState,
+  isSignedIn,
+  getSessionVerified,
+  setSessionVerified,
+  getFullAccountData,
+  UnifiedAccountData,
+} from './account-storage';
+import Storage from './storage';
+
+jest.mock('./storage');
+
+const UID = 'abc123';
+const EMAIL = 'test@example.com';
+const base = {
+  uid: UID,
+  email: EMAIL,
+  verified: true,
+  metricsEnabled: true,
+  sessionVerified: true,
+  sessionToken: 'tok',
+};
+const store = {
+  get: jest.fn(),
+  set: jest.fn(),
+  remove: jest.fn(),
+};
+
+function mockStore(
+  accounts: Record<string, Partial<UnifiedAccountData>>,
+  currentUid: string | null = UID
+) {
+  store.get.mockImplementation((key: string) => {
+    if (key === 'currentAccountUid') return currentUid;
+    if (key === 'accounts') return accounts;
+    return null;
+  });
+}
+
+/** Returns the account object from the most recent store.set('accounts', ...) call. */
+function savedAccount() {
+  const calls = store.set.mock.calls.filter((c: [string, unknown]) => c[0] === 'accounts');
+  return calls[calls.length - 1][1][UID];
+}
+
+describe('account-storage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Storage.factory as jest.Mock).mockReturnValue(store);
+  });
+
+  it('getCurrentAccountUid reads from storage', () => {
+    store.get.mockReturnValue(UID);
+    expect(getCurrentAccountUid()).toBe(UID);
+    store.get.mockReturnValue(null);
+    expect(getCurrentAccountUid()).toBeNull();
+  });
+
+  it('setCurrentAccountUid writes and dispatches event', () => {
+    const spy = jest.spyOn(window, 'dispatchEvent');
+    setCurrentAccountUid(UID);
+    expect(store.set).toHaveBeenCalledWith('currentAccountUid', UID);
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'localStorageChange' })
+    );
+    spy.mockRestore();
+  });
+
+  describe('getAccountData', () => {
+    it('returns null when no uid or no account', () => {
+      store.get.mockReturnValue(null);
+      expect(getAccountData()).toBeNull();
+
+      mockStore({});
+      expect(getAccountData()).toBeNull();
+    });
+
+    it('fills defaults for missing fields', () => {
+      mockStore({ [UID]: base });
+      const result = getAccountData(UID)!;
+      expect(result.uid).toBe(UID);
+      expect(result.emails).toEqual([]);
+      expect(result.totp).toBeNull();
+      expect(result.hasPassword).toBe(true);
+    });
+
+    it('migrates legacy accountState_{uid} data', () => {
+      store.get.mockImplementation((key: string) => {
+        if (key === `accountState_${UID}`) return { displayName: 'Migrated' };
+        if (key === 'accounts') return { [UID]: base };
+        return null;
+      });
+      getAccountData(UID);
+      expect(savedAccount().displayName).toBe('Migrated');
+      expect(store.remove).toHaveBeenCalledWith(`accountState_${UID}`);
+    });
+  });
+
+  describe('updateAccountData', () => {
+    it('merges updates and filters transient fields', () => {
+      mockStore({ [UID]: base });
+      updateAccountData({
+        displayName: 'X',
+        isLoading: true,
+        loadingFields: ['a'],
+        error: { message: 'e', name: 'E' },
+      } as Partial<UnifiedAccountData>);
+      const saved = savedAccount();
+      expect(saved.displayName).toBe('X');
+      expect(saved.isLoading).toBeUndefined();
+      expect(saved.loadingFields).toBeUndefined();
+      expect(saved.error).toBeUndefined();
+    });
+
+    it('dispatches localStorageChange event', () => {
+      const spy = jest.spyOn(window, 'dispatchEvent');
+      mockStore({ [UID]: base });
+      updateAccountData({ displayName: 'Y' });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'localStorageChange' })
+      );
+      spy.mockRestore();
+    });
+  });
+
+  it('removeAccount deletes account and clears currentAccountUid', () => {
+    mockStore({ [UID]: base });
+    removeAccount(UID);
+    expect(store.set).toHaveBeenCalledWith('accounts', {});
+    expect(store.remove).toHaveBeenCalledWith('currentAccountUid');
+  });
+
+  it('clearExtendedAccountState resets extended data, keeps identity', () => {
+    mockStore({
+      [UID]: { ...base, displayName: 'Old', totp: { exists: true, verified: true } },
+    });
+    clearExtendedAccountState(UID);
+    const saved = savedAccount();
+    expect(saved.uid).toBe(UID);
+    expect(saved.sessionToken).toBe('tok');
+    expect(saved.displayName).toBeNull();
+    expect(saved.totp).toBeNull();
+  });
+
+  it('isSignedIn checks sessionToken presence', () => {
+    mockStore({ [UID]: base });
+    expect(isSignedIn()).toBe(true);
+    store.get.mockReturnValue(null);
+    expect(isSignedIn()).toBe(false);
+  });
+
+  it('getSessionVerified / setSessionVerified read and write', () => {
+    mockStore({ [UID]: { ...base, sessionVerified: true } });
+    expect(getSessionVerified(UID)).toBe(true);
+
+    mockStore({ [UID]: base });
+    setSessionVerified(false);
+    expect(savedAccount().sessionVerified).toBe(false);
+  });
+
+  it('getFullAccountData derives primaryEmail', () => {
+    const emails = [{ email: EMAIL, isPrimary: true, verified: true }];
+    mockStore({ [UID]: { ...base, emails } });
+    expect(getFullAccountData(UID)!.primaryEmail).toEqual(emails[0]);
+
+    store.get.mockReturnValue(null);
+    expect(getFullAccountData()).toBeNull();
+  });
+});

--- a/packages/fxa-settings/src/lib/account-storage.ts
+++ b/packages/fxa-settings/src/lib/account-storage.ts
@@ -1,0 +1,401 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/** Unified account storage - all data in `accounts[uid]` in localStorage. */
+
+import { AccountAvatar, AccountTotp, AccountBackupCodes } from './interfaces';
+import {
+  Email,
+  AttachedClient,
+  LinkedAccount,
+  SecurityEvent,
+} from '../models/Account';
+import { lazy } from './test-utils';
+import Storage from './storage';
+
+const storage = lazy<Storage>(() => Storage.factory('localStorage'));
+
+export interface UnifiedAccountData {
+  // Core identity
+  uid: string;
+  email: string;
+  sessionToken?: string;
+  verified: boolean;
+  metricsEnabled: boolean;
+  sessionVerified: boolean;
+
+  // Profile data
+  displayName: string | null;
+  avatar: (AccountAvatar & { isDefault?: boolean }) | null;
+  profileImageId?: string;
+  profileImageUrl?: string;
+  profileImageUrlDefault?: boolean;
+
+  // Account metadata
+  accountCreated: number | null;
+  passwordCreated: number | null;
+  hasPassword: boolean;
+  lastLogin?: number;
+  alertText?: string;
+
+  // Email addresses
+  emails: Email[];
+
+  // Security features
+  totp: AccountTotp | null;
+  backupCodes: AccountBackupCodes | null;
+  recoveryKey: { exists: boolean; estimatedSyncDeviceCount?: number } | null;
+  recoveryPhone: {
+    exists: boolean;
+    phoneNumber: string | null;
+    nationalFormat?: string | null;
+    available: boolean;
+  } | null;
+
+  // Connected services
+  attachedClients: AttachedClient[];
+  linkedAccounts: LinkedAccount[];
+  subscriptions: { created: number; productName: string }[];
+  securityEvents: SecurityEvent[];
+
+  // UI state (transient)
+  isLoading: boolean;
+  loadingFields: string[];
+  error: { message: string; name: string } | null;
+
+  // Legacy content-server fields (preserved for compatibility)
+  sessionTokenContext?: string;
+  permissions?: Record<string, string[]>;
+  grantedPermissions?: Record<string, string[]>;
+  hadProfileImageSetBefore?: boolean;
+  originalLoginEmail?: string;
+  accountResetToken?: string;
+  recoveryKeyId?: string;
+  providerUid?: string;
+}
+
+export type ExtendedAccountState = Pick<
+  UnifiedAccountData,
+  | 'displayName'
+  | 'avatar'
+  | 'accountCreated'
+  | 'passwordCreated'
+  | 'hasPassword'
+  | 'emails'
+  | 'totp'
+  | 'backupCodes'
+  | 'recoveryKey'
+  | 'recoveryPhone'
+  | 'attachedClients'
+  | 'linkedAccounts'
+  | 'subscriptions'
+  | 'securityEvents'
+  | 'isLoading'
+  | 'loadingFields'
+  | 'error'
+>;
+
+const defaultExtendedState: ExtendedAccountState = {
+  displayName: null,
+  avatar: null,
+  accountCreated: null,
+  passwordCreated: null,
+  hasPassword: true,
+  emails: [],
+  totp: null,
+  backupCodes: null,
+  recoveryKey: null,
+  recoveryPhone: null,
+  attachedClients: [],
+  linkedAccounts: [],
+  subscriptions: [],
+  securityEvents: [],
+  isLoading: false,
+  loadingFields: [],
+  error: null,
+};
+
+const defaultAccountData: Omit<UnifiedAccountData, 'uid' | 'email'> = {
+  ...defaultExtendedState,
+  sessionToken: undefined,
+  verified: false,
+  metricsEnabled: true,
+  sessionVerified: false,
+};
+
+function getLegacyExtendedStateKey(uid: string): string {
+  return `accountState_${uid}`;
+}
+
+function dispatchStorageEvent(): void {
+  window.dispatchEvent(
+    new CustomEvent('localStorageChange', { detail: { key: 'accounts' } })
+  );
+}
+
+/** Migrate legacy accountState_{uid} data into unified accounts structure. */
+function migrateLegacyAccountState(uid: string): void {
+  const legacyKey = getLegacyExtendedStateKey(uid);
+  const legacyData = storage().get(legacyKey);
+
+  if (!legacyData) {
+    return;
+  }
+
+  const accounts = storage().get('accounts') || {};
+  const currentAccount = accounts[uid];
+
+  if (!currentAccount) {
+    storage().remove(legacyKey);
+    return;
+  }
+
+  const { isLoading, loadingFields, error, ...persistableLegacyData } =
+    legacyData;
+  accounts[uid] = { ...currentAccount, ...persistableLegacyData };
+  storage().set('accounts', accounts);
+  storage().remove(legacyKey);
+}
+
+export function getCurrentAccountUid(): string | null {
+  return storage().get('currentAccountUid') || null;
+}
+
+export function getAccountData(uid?: string): UnifiedAccountData | null {
+  const accountUid = uid || getCurrentAccountUid();
+  if (!accountUid) return null;
+
+  migrateLegacyAccountState(accountUid);
+
+  const accounts = storage().get('accounts') || {};
+  const account = accounts[accountUid];
+  if (!account) return null;
+
+  return {
+    ...defaultAccountData,
+    ...account,
+    uid: account.uid,
+    email: account.email || '',
+    loadingFields: account.loadingFields || [],
+    error: account.error || null,
+  };
+}
+
+export function getBasicAccountData(uid?: string): {
+  uid: string;
+  email: string;
+  metricsEnabled: boolean;
+  verified: boolean;
+  sessionToken?: string;
+  sessionVerified: boolean;
+} | null {
+  const account = getAccountData(uid);
+  if (!account) return null;
+
+  return {
+    uid: account.uid,
+    email: account.email,
+    metricsEnabled: account.metricsEnabled,
+    verified: account.verified,
+    sessionToken: account.sessionToken,
+    sessionVerified: account.sessionVerified,
+  };
+}
+
+export function isSignedIn(): boolean {
+  const account = getAccountData();
+  return !!(account && account.sessionToken);
+}
+
+export function getSessionVerified(uid?: string): boolean {
+  const account = getAccountData(uid);
+  return account?.sessionVerified ?? false;
+}
+
+export function setSessionVerified(verified: boolean, uid?: string): void {
+  updateAccountData({ sessionVerified: verified }, uid);
+}
+
+export function getExtendedAccountState(uid?: string): ExtendedAccountState {
+  const account = getAccountData(uid);
+  if (!account) {
+    return { ...defaultExtendedState };
+  }
+
+  return {
+    displayName: account.displayName,
+    avatar: account.avatar,
+    accountCreated: account.accountCreated,
+    passwordCreated: account.passwordCreated,
+    hasPassword: account.hasPassword,
+    emails: account.emails,
+    totp: account.totp,
+    backupCodes: account.backupCodes,
+    recoveryKey: account.recoveryKey,
+    recoveryPhone: account.recoveryPhone,
+    attachedClients: account.attachedClients,
+    linkedAccounts: account.linkedAccounts,
+    subscriptions: account.subscriptions,
+    securityEvents: account.securityEvents,
+    isLoading: account.isLoading,
+    loadingFields: account.loadingFields,
+    error: account.error,
+  };
+}
+
+/** Update account data (transient UI state is filtered out). */
+export function updateAccountData(
+  updates: Partial<UnifiedAccountData>,
+  uid?: string
+): void {
+  const accountUid = uid || getCurrentAccountUid();
+  if (!accountUid) return;
+
+  const accounts = storage().get('accounts') || {};
+  const currentAccount = accounts[accountUid] || { uid: accountUid };
+  const { isLoading, loadingFields, error, ...persistableUpdates } = updates;
+  const updatedAccount = {
+    ...currentAccount,
+    ...persistableUpdates,
+  };
+  delete updatedAccount.isLoading;
+  delete updatedAccount.loadingFields;
+  delete updatedAccount.error;
+
+  accounts[accountUid] = updatedAccount;
+  storage().set('accounts', accounts);
+  dispatchStorageEvent();
+}
+
+export function updateExtendedAccountState(
+  updates: Partial<ExtendedAccountState>,
+  uid?: string
+): void {
+  updateAccountData(updates as Partial<UnifiedAccountData>, uid);
+}
+
+export function updateAccountField<K extends keyof UnifiedAccountData>(
+  field: K,
+  value: UnifiedAccountData[K],
+  uid?: string
+): void {
+  updateAccountData({ [field]: value } as Partial<UnifiedAccountData>, uid);
+}
+
+export function updateBasicAccountData(
+  updates: Partial<{
+    email: string;
+    metricsEnabled: boolean;
+    verified: boolean;
+    displayName: string;
+    sessionToken: string;
+    sessionVerified: boolean;
+  }>,
+  uid?: string
+): void {
+  updateAccountData(updates, uid);
+}
+
+export function getFullAccountData(uid?: string): {
+  uid: string | null;
+  email: string | null;
+  metricsEnabled: boolean;
+  verified: boolean;
+  displayName: string | null;
+  avatar: (AccountAvatar & { isDefault?: boolean }) | null;
+  accountCreated: number | null;
+  passwordCreated: number | null;
+  hasPassword: boolean;
+  emails: Email[];
+  primaryEmail: Email | null;
+  totp: AccountTotp | null;
+  backupCodes: AccountBackupCodes | null;
+  recoveryKey: { exists: boolean; estimatedSyncDeviceCount?: number } | null;
+  recoveryPhone: {
+    exists: boolean;
+    phoneNumber: string | null;
+    nationalFormat?: string | null;
+    available: boolean;
+  } | null;
+  attachedClients: AttachedClient[];
+  linkedAccounts: LinkedAccount[];
+  subscriptions: { created: number; productName: string }[];
+  securityEvents: SecurityEvent[];
+} | null {
+  const account = getAccountData(uid);
+  if (!account) return null;
+
+  const emails = account.emails || [];
+
+  return {
+    uid: account.uid,
+    email: account.email,
+    metricsEnabled: account.metricsEnabled,
+    verified: account.verified,
+    displayName: account.displayName,
+    avatar: account.avatar,
+    accountCreated: account.accountCreated,
+    passwordCreated: account.passwordCreated,
+    hasPassword: account.hasPassword,
+    emails,
+    primaryEmail: emails.find((e) => e.isPrimary) || null,
+    totp: account.totp,
+    backupCodes: account.backupCodes,
+    recoveryKey: account.recoveryKey,
+    recoveryPhone: account.recoveryPhone,
+    attachedClients: account.attachedClients,
+    linkedAccounts: account.linkedAccounts,
+    subscriptions: account.subscriptions,
+    securityEvents: account.securityEvents,
+  };
+}
+
+/** Clear extended data (keeps basic identity). */
+export function clearExtendedAccountState(uid?: string): void {
+  const accountUid = uid || getCurrentAccountUid();
+  if (!accountUid) return;
+
+  const accounts = storage().get('accounts') || {};
+  const currentAccount = accounts[accountUid];
+  if (!currentAccount) return;
+
+  accounts[accountUid] = {
+    uid: currentAccount.uid,
+    email: currentAccount.email,
+    sessionToken: currentAccount.sessionToken,
+    verified: currentAccount.verified,
+    metricsEnabled: currentAccount.metricsEnabled,
+    sessionVerified: currentAccount.sessionVerified,
+    lastLogin: currentAccount.lastLogin,
+    ...defaultExtendedState,
+  };
+
+  storage().set('accounts', accounts);
+  storage().remove(getLegacyExtendedStateKey(accountUid));
+  dispatchStorageEvent();
+}
+
+export function removeAccount(uid?: string): void {
+  const accountUid = uid || getCurrentAccountUid();
+  if (!accountUid) return;
+
+  const accounts = storage().get('accounts') || {};
+  delete accounts[accountUid];
+  storage().set('accounts', accounts);
+
+  if (getCurrentAccountUid() === accountUid) {
+    storage().remove('currentAccountUid');
+  }
+  storage().remove(getLegacyExtendedStateKey(accountUid));
+  dispatchStorageEvent();
+}
+
+export function setCurrentAccountUid(uid: string): void {
+  storage().set('currentAccountUid', uid);
+  window.dispatchEvent(
+    new CustomEvent('localStorageChange', {
+      detail: { key: 'currentAccountUid' },
+    })
+  );
+}

--- a/packages/fxa-settings/src/lib/hooks/useAccountData.ts
+++ b/packages/fxa-settings/src/lib/hooks/useAccountData.ts
@@ -1,0 +1,353 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useCallback, useEffect, useRef } from 'react';
+import AuthClient from 'fxa-auth-client/browser';
+import { sessionToken as getSessionToken } from '../cache';
+import {
+  AccountState,
+  RecoveryKeyStatus,
+  RecoveryPhoneStatus,
+  useAccountState,
+} from '../../models/contexts/AccountStateContext';
+import { Email, AttachedClient, LinkedAccount, SecurityEvent } from '../../models/Account';
+import { AccountTotp, AccountBackupCodes, AccountAvatar } from '../interfaces';
+import config from '../config';
+import { ERRNO } from '@fxa/accounts/errors';
+import * as Sentry from '@sentry/browser';
+
+/** OAuth token TTL in seconds for profile server requests */
+const PROFILE_OAUTH_TOKEN_TTL_SECONDS = 300;
+
+/**
+ * Error thrown when the session token is invalid (errno 110).
+ * Indicates the user needs to sign in again.
+ */
+export class InvalidTokenError extends Error {
+  constructor() {
+    super('Invalid session token');
+    this.name = 'InvalidTokenError';
+  }
+}
+
+/**
+ * Check if an error has INVALID_TOKEN errno (110).
+ * These errors indicate the session token is no longer valid.
+ */
+function isInvalidTokenError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'errno' in error &&
+    error.errno === ERRNO.INVALID_TOKEN
+  );
+}
+
+interface UseAccountDataOptions {
+  authClient: AuthClient;
+  onError?: (error: Error) => void;
+}
+
+interface AccountDataResult {
+  data: AccountState;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+  refetchField: (field: keyof AccountState) => Promise<void>;
+}
+
+/** Shape returned by the consolidated /account auth-server endpoint. */
+interface AccountResponse {
+  emails?: Array<{ email: string; isPrimary: boolean; verified: boolean }>;
+  linkedAccounts?: Array<{ providerId: number; authAt: number; enabled: boolean }>;
+  subscriptions?: Array<{ created?: number; createdAt?: number; productName?: string; product_name?: string }>;
+  totp?: { exists?: boolean; verified?: boolean };
+  backupCodes?: { hasBackupCodes?: boolean; count?: number };
+  recoveryKey?: { exists?: boolean; estimatedSyncDeviceCount?: number };
+  recoveryPhone?: { exists?: boolean; phoneNumber?: string; available?: boolean };
+  securityEvents?: Array<{ name: string; createdAt: number; verified?: boolean }>;
+  metricsOptOutAt?: number | null;
+  createdAt?: number;
+  passwordCreatedAt?: number;
+  hasPassword?: boolean;
+}
+
+/** Transform the consolidated /account endpoint response to AccountState format. */
+function transformAccountResponse(response: AccountResponse): Partial<AccountState> {
+  const emails: Email[] = (response.emails || []).map((e) => ({
+    email: e.email,
+    isPrimary: e.isPrimary,
+    verified: e.verified,
+  }));
+
+  const linkedAccounts: LinkedAccount[] = (response.linkedAccounts || []).map(
+    (la) => ({
+      providerId: la.providerId,
+      authAt: la.authAt,
+      enabled: la.enabled,
+    })
+  );
+
+  const subscriptions = (response.subscriptions || []).map((s) => ({
+    created: s.created ?? s.createdAt ?? 0,
+    productName: s.productName || s.product_name || '',
+  }));
+
+  const totp: AccountTotp = {
+    exists: response.totp?.exists ?? false,
+    verified: response.totp?.verified ?? false,
+  };
+
+  const backupCodes: AccountBackupCodes = {
+    hasBackupCodes: response.backupCodes?.hasBackupCodes ?? false,
+    count: response.backupCodes?.count ?? 0,
+  };
+
+  const recoveryKey: RecoveryKeyStatus = {
+    exists: response.recoveryKey?.exists ?? false,
+    estimatedSyncDeviceCount: response.recoveryKey?.estimatedSyncDeviceCount,
+  };
+
+  const recoveryPhone: RecoveryPhoneStatus = {
+    exists: response.recoveryPhone?.exists ?? false,
+    phoneNumber: response.recoveryPhone?.phoneNumber ?? null,
+    nationalFormat: null, // Not returned by consolidated endpoint
+    available: response.recoveryPhone?.available ?? false,
+  };
+
+  const securityEvents: SecurityEvent[] = (response.securityEvents || []).map(
+    (e) => ({
+      name: e.name,
+      createdAt: e.createdAt,
+      verified: e.verified,
+    })
+  );
+
+  return {
+    emails,
+    linkedAccounts,
+    subscriptions,
+    metricsEnabled: !response.metricsOptOutAt,
+    accountCreated: response.createdAt ?? null,
+    passwordCreated: response.passwordCreatedAt ?? null,
+    hasPassword: response.hasPassword ?? true,
+    totp,
+    backupCodes,
+    recoveryKey,
+    recoveryPhone,
+    securityEvents,
+  };
+}
+
+/** Fetch profile data from the profile server (requires OAuth token). */
+async function fetchProfileData(
+  authClient: AuthClient,
+  sessionToken: string
+): Promise<{ displayName: string | null; avatar: AccountAvatar | null }> {
+  try {
+    const { access_token } = await authClient.createOAuthToken(
+      sessionToken,
+      config.oauth.clientId,
+      { scope: 'profile', ttl: PROFILE_OAUTH_TOKEN_TTL_SECONDS }
+    );
+
+    const response = await fetch(`${config.servers.profile.url}/v1/profile`, {
+      headers: { Authorization: `Bearer ${access_token}` },
+    });
+
+    if (!response.ok) {
+      return { displayName: null, avatar: null };
+    }
+
+    const profile = await response.json();
+    return {
+      displayName: profile.displayName || null,
+      avatar: profile.avatar
+        ? { id: profile.avatarId || 'default', url: profile.avatar }
+        : null,
+    };
+  } catch (error) {
+    // Re-throw invalid token errors to trigger sign-in redirect
+    if (isInvalidTokenError(error)) {
+      throw error;
+    }
+    console.error('Failed to fetch profile:', error);
+    return { displayName: null, avatar: null };
+  }
+}
+
+/** Shape of a single entry from the /account/attached_clients endpoint. */
+interface RawAttachedClient {
+  clientId: string;
+  isCurrentSession: boolean;
+  userAgent: string;
+  deviceType: string | null;
+  deviceId: string | null;
+  name: string;
+  lastAccessTime: number;
+  lastAccessTimeFormatted: string;
+  approximateLastAccessTime: number;
+  approximateLastAccessTimeFormatted: string;
+  location?: { city?: string; country?: string; state?: string; stateCode?: string };
+  os: string;
+  sessionTokenId: string | null;
+  refreshTokenId: string | null;
+}
+
+/** Maps raw attached clients response to normalized AttachedClient objects. */
+function transformAttachedClientsResponse(response: RawAttachedClient[]): AttachedClient[] {
+  return response.map((client) => ({
+    clientId: client.clientId,
+    isCurrentSession: client.isCurrentSession,
+    userAgent: client.userAgent,
+    deviceType: client.deviceType,
+    deviceId: client.deviceId,
+    name: client.name,
+    lastAccessTime: client.lastAccessTime,
+    lastAccessTimeFormatted: client.lastAccessTimeFormatted,
+    approximateLastAccessTime: client.approximateLastAccessTime,
+    approximateLastAccessTimeFormatted: client.approximateLastAccessTimeFormatted,
+    location: {
+      city: client.location?.city || null,
+      country: client.location?.country || null,
+      state: client.location?.state || null,
+      stateCode: client.location?.stateCode || null,
+    },
+    os: client.os,
+    sessionTokenId: client.sessionTokenId,
+    refreshTokenId: client.refreshTokenId,
+  }));
+}
+
+/**
+ * Hook for fetching account data from auth-server, profile server, and attached clients.
+ * @throws {InvalidTokenError} When the session token is invalid
+ */
+export function useAccountData({
+  authClient,
+  onError,
+}: UseAccountDataOptions): AccountDataResult {
+  // Ref prevents infinite re-render from unstable onError callback
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const accountState = useAccountState();
+  const {
+    setAccountData,
+    setLoading,
+    setError,
+    isLoading,
+    error,
+    ...stateData
+  } = accountState;
+
+  const fetchAccountData = useCallback(async () => {
+    const token = getSessionToken();
+    if (!token) {
+      setError(new Error('No session token available'));
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      // allSettled (not .all) so a single failure doesn't discard other results
+      const [accountResult, profileResult, attachedClientsResult] =
+        await Promise.allSettled([
+          authClient.account(token),
+          fetchProfileData(authClient, token),
+          authClient.attachedClients(token),
+        ]);
+
+      // Check for invalid token errors - user needs to sign in again
+      const rejectedResults = [accountResult, profileResult, attachedClientsResult]
+        .filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (rejectedResults.some((r) => isInvalidTokenError(r.reason))) {
+        throw new InvalidTokenError();
+      }
+
+      let accountData: Partial<AccountState> = {};
+
+      if (accountResult.status === 'fulfilled') {
+        accountData = { ...accountData, ...transformAccountResponse(accountResult.value) };
+      } else {
+        Sentry.captureMessage(`Failed to fetch account: ${accountResult.reason}`);
+      }
+
+      if (profileResult.status === 'fulfilled') {
+        const { displayName, avatar } = profileResult.value;
+        if (displayName !== null) accountData.displayName = displayName;
+        if (avatar !== null) accountData.avatar = avatar;
+      } else {
+        Sentry.captureMessage(`Failed to fetch profile: ${profileResult.reason}`);  
+      }
+
+      if (attachedClientsResult.status === 'fulfilled') {
+        accountData.attachedClients = transformAttachedClientsResponse(
+          attachedClientsResult.value
+        );
+      } else {
+        Sentry.captureMessage(`Failed to fetch attached clients: ${attachedClientsResult.reason}`);  
+        accountData.attachedClients = [];
+      }
+
+      setAccountData(accountData);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error('Unknown error');
+      setError(error);
+      onErrorRef.current?.(error);
+    } finally {
+      setLoading(false);
+    }
+  }, [authClient, setAccountData, setLoading, setError]);
+
+  const refetchField = useCallback(
+    async (field: keyof AccountState) => {
+      const token = getSessionToken();
+      if (!token) return;
+
+      try {
+        let fieldData: Partial<AccountState> = {};
+
+        switch (field) {
+          case 'attachedClients': {
+            const clients = await authClient.attachedClients(token);
+            fieldData.attachedClients = transformAttachedClientsResponse(clients);
+            break;
+          }
+          case 'displayName':
+          case 'avatar': {
+            const { displayName, avatar } = await fetchProfileData(authClient, token);
+            if (displayName !== null) fieldData.displayName = displayName;
+            if (avatar !== null) fieldData.avatar = avatar;
+            break;
+          }
+          default: {
+            const account = await authClient.account(token);
+            fieldData = { ...fieldData, ...transformAccountResponse(account) };
+            break;
+          }
+        }
+
+        setAccountData(fieldData);
+      } catch (err) {
+        console.error(`Failed to refetch ${field}:`, err);
+      }
+    },
+    [authClient, setAccountData]
+  );
+
+  useEffect(() => {
+    fetchAccountData();
+  }, [fetchAccountData]);
+
+  return {
+    data: { ...stateData, isLoading, error } as AccountState,
+    isLoading,
+    error,
+    refetch: fetchAccountData,
+    refetchField,
+  };
+}

--- a/packages/fxa-settings/src/lib/reactive-var.test.ts
+++ b/packages/fxa-settings/src/lib/reactive-var.test.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { renderHook, act } from '@testing-library/react';
+import { makeVar, useReactiveVar } from './reactive-var';
+
+describe('makeVar', () => {
+  it('reads initial value and updates on set', () => {
+    const rv = makeVar(0);
+    expect(rv()).toBe(0);
+    expect(rv(42)).toBe(42);
+    expect(rv()).toBe(42);
+  });
+
+  it('notifies subscribers and supports unsubscribe', () => {
+    const rv = makeVar('a');
+    const fn = jest.fn();
+    const unsub = rv.subscribe(fn);
+
+    rv('b');
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    unsub();
+    rv('c');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useReactiveVar', () => {
+  it('returns current value and re-renders on change', () => {
+    const rv = makeVar(0);
+    const { result } = renderHook(() => useReactiveVar(rv));
+    expect(result.current).toBe(0);
+
+    act(() => rv(5));
+    expect(result.current).toBe(5);
+  });
+});

--- a/packages/fxa-settings/src/lib/reactive-var.ts
+++ b/packages/fxa-settings/src/lib/reactive-var.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useReducer } from 'react';
+
+/**
+ * A lightweight reactive variable that replaces Apollo's makeVar/useReactiveVar.
+ * Holds a value and notifies subscribers when it changes.
+ */
+export interface ReactiveVar<T> {
+  (): T;
+  (newValue: T): T;
+  subscribe(listener: () => void): () => void;
+}
+
+export function makeVar<T>(initialValue: T): ReactiveVar<T> {
+  let value = initialValue;
+  const listeners = new Set<() => void>();
+
+  function variable(newValue?: T): T {
+    if (arguments.length > 0) {
+      value = newValue as T;
+      listeners.forEach((l) => l());
+    }
+    return value;
+  }
+
+  variable.subscribe = (listener: () => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return variable as ReactiveVar<T>;
+}
+
+export function useReactiveVar<T>(rv: ReactiveVar<T>): T {
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  useEffect(() => rv.subscribe(forceUpdate), [rv]);
+  return rv();
+}

--- a/packages/fxa-settings/src/lib/test-utils.ts
+++ b/packages/fxa-settings/src/lib/test-utils.ts
@@ -23,3 +23,18 @@ export const typeByLabelText = (labelText: string) => async (x: string) => {
     });
   });
 };
+
+/**
+ * Creates an instance of type T lazily. This can be useful for mocking.
+ * @param factory Produces instance of T
+ * @returns Single instance of type T
+ */
+export function lazy<T>(factory: () => T): () => T {
+  let value: T | undefined;
+  return () => {
+    if (value === undefined) {
+      value = factory();
+    }
+    return value;
+  };
+}

--- a/packages/fxa-settings/src/models/contexts/AccountStateContext.test.tsx
+++ b/packages/fxa-settings/src/models/contexts/AccountStateContext.test.tsx
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import {
+  AccountStateProvider,
+  useAccountState,
+} from './AccountStateContext';
+import * as storage from '../../lib/account-storage';
+
+jest.mock('../../lib/account-storage');
+jest.mock('../../lib/hooks/useLocalStorageSync', () => ({
+  useLocalStorageSync: jest.fn(() => undefined),
+}));
+
+const UID = 'uid-123';
+const EMAIL = 'test@example.com';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AccountStateProvider>{children}</AccountStateProvider>
+);
+
+function mockAccount(overrides: Record<string, any> = {}) {
+  (storage.getAccountData as jest.Mock).mockReturnValue({
+    uid: UID, email: EMAIL, verified: true, metricsEnabled: true,
+    sessionVerified: false, displayName: null, avatar: null,
+    accountCreated: null, passwordCreated: null, hasPassword: true,
+    emails: [], totp: null, backupCodes: null, recoveryKey: null,
+    recoveryPhone: null, attachedClients: [], linkedAccounts: [],
+    subscriptions: [], securityEvents: [], isLoading: false,
+    loadingFields: [], error: null,
+    ...overrides,
+  });
+}
+
+describe('AccountStateContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (storage.getAccountData as jest.Mock).mockReturnValue(null);
+    (storage.getCurrentAccountUid as jest.Mock).mockReturnValue(UID);
+  });
+
+  it('throws outside provider', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useAccountState())).toThrow(
+      'useAccountState must be used within an AccountStateProvider'
+    );
+  });
+
+  it('provides default state when no account data', () => {
+    const { result } = renderHook(() => useAccountState(), { wrapper });
+    expect(result.current.uid).toBeNull();
+    expect(result.current.emails).toEqual([]);
+    expect(result.current.metricsEnabled).toBe(true);
+  });
+
+  it('reads account data from storage and derives primaryEmail', () => {
+    const primary = { email: EMAIL, isPrimary: true, verified: true };
+    mockAccount({ displayName: 'Test', emails: [primary] });
+
+    const { result } = renderHook(() => useAccountState(), { wrapper });
+    expect(result.current.uid).toBe(UID);
+    expect(result.current.displayName).toBe('Test');
+    expect(result.current.primaryEmail).toEqual(primary);
+  });
+
+  it('setAccountData delegates to storage', () => {
+    const { result } = renderHook(() => useAccountState(), { wrapper });
+    act(() => result.current.setAccountData({ displayName: 'New' }));
+    expect(storage.updateAccountData).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'New' }), UID
+    );
+  });
+
+  it('clearAccount delegates to storage', () => {
+    const { result } = renderHook(() => useAccountState(), { wrapper });
+    act(() => result.current.clearAccount());
+    expect(storage.clearExtendedAccountState).toHaveBeenCalledWith(UID);
+  });
+
+});

--- a/packages/fxa-settings/src/models/contexts/AccountStateContext.tsx
+++ b/packages/fxa-settings/src/models/contexts/AccountStateContext.tsx
@@ -1,0 +1,292 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  createContext,
+  useContext,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from 'react';
+import {
+  AccountAvatar,
+  AccountTotp,
+  AccountBackupCodes,
+} from '../../lib/interfaces';
+import {
+  Email,
+  AttachedClient,
+  LinkedAccount,
+  SecurityEvent,
+} from '../Account';
+import { useLocalStorageSync } from '../../lib/hooks/useLocalStorageSync';
+import {
+  getAccountData,
+  updateAccountData,
+  clearExtendedAccountState,
+  getCurrentAccountUid,
+  UnifiedAccountData,
+} from '../../lib/account-storage';
+
+export interface RecoveryKeyStatus {
+  exists: boolean;
+  estimatedSyncDeviceCount?: number;
+}
+
+export interface RecoveryPhoneStatus {
+  exists: boolean;
+  phoneNumber: string | null;
+  nationalFormat?: string | null;
+  available: boolean;
+}
+
+export interface Subscription {
+  created: number;
+  productName: string;
+}
+
+export interface ExtendedAccountState {
+  displayName: string | null;
+  avatar: (AccountAvatar & { isDefault?: boolean }) | null;
+  accountCreated: number | null;
+  passwordCreated: number | null;
+  hasPassword: boolean;
+  emails: Email[];
+  totp: AccountTotp | null;
+  backupCodes: AccountBackupCodes | null;
+  recoveryKey: RecoveryKeyStatus | null;
+  recoveryPhone: RecoveryPhoneStatus | null;
+  attachedClients: AttachedClient[];
+  linkedAccounts: LinkedAccount[];
+  subscriptions: Subscription[];
+  securityEvents: SecurityEvent[];
+}
+
+export interface AccountState extends ExtendedAccountState {
+  uid: string | null;
+  email: string | null;
+  metricsEnabled: boolean;
+  verified: boolean;
+  primaryEmail: Email | null;
+  isLoading: boolean;
+  loadingFields: Set<string>;
+  error: Error | null;
+}
+
+export interface AccountStateActions {
+  setAccountData: (data: Partial<AccountState>) => void;
+  updateField: <K extends keyof AccountState>(
+    field: K,
+    value: AccountState[K]
+  ) => void;
+  setLoading: (loading: boolean) => void;
+  setFieldLoading: (field: string, loading: boolean) => void;
+  setError: (error: Error | null) => void;
+  clearAccount: () => void;
+}
+
+export type AccountStateContextValue = AccountState & AccountStateActions;
+
+const defaultAccountState: AccountState = {
+  uid: null,
+  email: null,
+  metricsEnabled: true,
+  verified: false,
+  primaryEmail: null,
+  displayName: null,
+  avatar: null,
+  accountCreated: null,
+  passwordCreated: null,
+  hasPassword: true,
+  emails: [],
+  totp: null,
+  backupCodes: null,
+  recoveryKey: null,
+  recoveryPhone: null,
+  attachedClients: [],
+  linkedAccounts: [],
+  subscriptions: [],
+  securityEvents: [],
+  isLoading: false,
+  loadingFields: new Set(),
+  error: null,
+};
+
+export const AccountStateContext =
+  createContext<AccountStateContextValue | null>(null);
+
+export interface AccountStateProviderProps {
+  children: ReactNode;
+  initialState?: Partial<AccountState>;
+}
+
+/** Convert localStorage data to AccountState (deserializes Error and Set). */
+function unifiedToAccountState(
+  data: UnifiedAccountData | null,
+  initialState?: Partial<AccountState>
+): AccountState {
+  if (!data) {
+    return {
+      ...defaultAccountState,
+      ...(initialState || {}),
+    };
+  }
+
+  const emails = data.emails || [];
+  const loadingFields = new Set(data.loadingFields || []);
+  let error: Error | null = null;
+  if (data.error) {
+    error = new Error(data.error.message);
+    error.name = data.error.name;
+  }
+
+  return {
+    uid: data.uid,
+    email: data.email,
+    metricsEnabled: data.metricsEnabled,
+    verified: data.verified,
+    displayName: data.displayName,
+    avatar: data.avatar,
+    accountCreated: data.accountCreated,
+    passwordCreated: data.passwordCreated,
+    hasPassword: data.hasPassword,
+    emails,
+    primaryEmail: emails.find((e) => e.isPrimary) || null,
+    totp: data.totp,
+    backupCodes: data.backupCodes,
+    recoveryKey: data.recoveryKey,
+    recoveryPhone: data.recoveryPhone,
+    attachedClients: data.attachedClients,
+    linkedAccounts: data.linkedAccounts,
+    subscriptions: data.subscriptions,
+    securityEvents: data.securityEvents,
+    isLoading: data.isLoading,
+    loadingFields,
+    error,
+    ...(initialState || {}),
+  };
+}
+
+export function AccountStateProvider({
+  children,
+  initialState,
+}: AccountStateProviderProps) {
+  // useLocalStorageSync triggers re-renders on storage changes;
+  // we read from getAccountData() rather than the return value directly
+  useLocalStorageSync('accounts');
+  const currentAccountUid = useLocalStorageSync('currentAccountUid') as string | undefined;
+
+  const accountState = unifiedToAccountState(
+    getAccountData(currentAccountUid),
+    initialState
+  );
+
+  // Serialize AccountState -> UnifiedAccountData for localStorage:
+  // Set -> Array, Error -> {message,name}, exclude derived 'primaryEmail'
+  const setAccountDataCallback = useCallback((data: Partial<AccountState>) => {
+    const uid = getCurrentAccountUid();
+    if (!uid) return;
+
+    const { uid: dataUid, email: dataEmail, primaryEmail, ...rest } = data;
+    const storageData: Partial<UnifiedAccountData> = {
+      ...rest,
+      ...(dataUid !== undefined && { uid: dataUid ?? undefined }),
+      ...(dataEmail !== undefined && { email: dataEmail ?? undefined }),
+      loadingFields: data.loadingFields ? Array.from(data.loadingFields) : undefined,
+      error: data.error ? { message: data.error.message, name: data.error.name } : undefined,
+    };
+    updateAccountData(storageData, uid);
+  }, []);
+
+  const updateField = useCallback(
+    <K extends keyof AccountState>(field: K, value: AccountState[K]) => {
+      const uid = getCurrentAccountUid();
+      if (!uid || field === 'primaryEmail') return;
+
+      let storageValue: UnifiedAccountData[keyof UnifiedAccountData] = value as UnifiedAccountData[keyof UnifiedAccountData];
+      if (field === 'loadingFields' && value instanceof Set) {
+        storageValue = Array.from(value);
+      }
+      if (field === 'error' && value instanceof Error) {
+        storageValue = { message: value.message, name: value.name };
+      }
+      updateAccountData({ [field]: storageValue } as Partial<UnifiedAccountData>, uid);
+    },
+    []
+  );
+
+  const setLoading = useCallback((loading: boolean) => {
+    const uid = getCurrentAccountUid();
+    if (!uid) return;
+    updateAccountData({ isLoading: loading }, uid);
+  }, []);
+
+  const setFieldLoading = useCallback((field: string, loading: boolean) => {
+    const uid = getCurrentAccountUid();
+    if (!uid) return;
+
+    const currentData = getAccountData(uid);
+    const currentLoadingFields = new Set(currentData?.loadingFields || []);
+
+    if (loading) {
+      currentLoadingFields.add(field);
+    } else {
+      currentLoadingFields.delete(field);
+    }
+
+    updateAccountData({ loadingFields: Array.from(currentLoadingFields) }, uid);
+  }, []);
+
+  const setError = useCallback((error: Error | null) => {
+    const uid = getCurrentAccountUid();
+    if (!uid) return;
+    updateAccountData({
+      error: error ? { message: error.message, name: error.name } : null,
+    }, uid);
+  }, []);
+
+  const clearAccount = useCallback(() => {
+    const uid = getCurrentAccountUid();
+    if (!uid) return;
+    clearExtendedAccountState(uid);
+  }, []);
+
+  // Memoize context value to prevent all consumers from re-rendering on every provider render
+  const value = useMemo<AccountStateContextValue>(
+    () => ({
+      ...accountState,
+      setAccountData: setAccountDataCallback,
+      updateField,
+      setLoading,
+      setFieldLoading,
+      setError,
+      clearAccount,
+    }),
+    [
+      accountState,
+      setAccountDataCallback,
+      updateField,
+      setLoading,
+      setFieldLoading,
+      setError,
+      clearAccount,
+    ]
+  );
+
+  return (
+    <AccountStateContext.Provider value={value}>
+      {children}
+    </AccountStateContext.Provider>
+  );
+}
+
+export function useAccountState(): AccountStateContextValue {
+  const context = useContext(AccountStateContext);
+  if (!context) {
+    throw new Error(
+      'useAccountState must be used within an AccountStateProvider'
+    );
+  }
+  return context;
+}

--- a/packages/fxa-settings/src/models/contexts/AuthStateContext.test.tsx
+++ b/packages/fxa-settings/src/models/contexts/AuthStateContext.test.tsx
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import {
+  AuthStateProvider,
+  useAuthState,
+} from './AuthStateContext';
+
+jest.mock('../../lib/cache', () => ({ sessionToken: jest.fn(() => null) }));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthStateProvider>{children}</AuthStateProvider>
+);
+
+const signedInWrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthStateProvider initialState={{ isSignedIn: true, sessionToken: 'tok', sessionVerified: true }}>
+    {children}
+  </AuthStateProvider>
+);
+
+describe('AuthStateContext', () => {
+  it('throws outside provider', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useAuthState())).toThrow(
+      'useAuthState must be used within an AuthStateProvider'
+    );
+  });
+
+  it('provides default state', () => {
+    const { result } = renderHook(() => useAuthState(), { wrapper });
+    expect(result.current).toMatchObject({ isSignedIn: false, sessionToken: null, sessionVerified: false });
+  });
+
+  it('accepts initial state', () => {
+    const { result } = renderHook(() => useAuthState(), { wrapper: signedInWrapper });
+    expect(result.current).toMatchObject({ isSignedIn: true, sessionToken: 'tok', sessionVerified: true });
+  });
+
+  it('setSessionToken updates token and sets signed in', () => {
+    const { result } = renderHook(() => useAuthState(), { wrapper });
+    act(() => result.current.setSessionToken('new'));
+    expect(result.current.sessionToken).toBe('new');
+    expect(result.current.isSignedIn).toBe(true);
+  });
+
+  it('signOut resets all state', () => {
+    const { result } = renderHook(() => useAuthState(), { wrapper: signedInWrapper });
+    act(() => result.current.signOut());
+    expect(result.current).toMatchObject({ isSignedIn: false, sessionToken: null, sessionVerified: false });
+  });
+
+});

--- a/packages/fxa-settings/src/models/contexts/AuthStateContext.tsx
+++ b/packages/fxa-settings/src/models/contexts/AuthStateContext.tsx
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from 'react';
+import { sessionToken as getSessionToken } from '../../lib/cache';
+
+export interface AuthState {
+  isSignedIn: boolean;
+  sessionToken: string | null;
+  sessionVerified: boolean;
+}
+
+export interface AuthStateActions {
+  setSignedIn: (signedIn: boolean) => void;
+  setSessionVerified: (verified: boolean) => void;
+  setSessionToken: (token: string | null) => void;
+  signOut: () => void;
+}
+
+export type AuthStateContextValue = AuthState & AuthStateActions;
+
+export const AuthStateContext =
+  createContext<AuthStateContextValue | null>(null);
+
+export interface AuthStateProviderProps {
+  children: ReactNode;
+  initialState?: Partial<AuthState>;
+}
+
+export function AuthStateProvider({
+  children,
+  initialState,
+}: AuthStateProviderProps) {
+  const [isSignedIn, setIsSignedIn] = useState(
+    initialState?.isSignedIn ?? !!getSessionToken()
+  );
+  const [sessionToken, setSessionTokenState] = useState<string | null>(
+    initialState?.sessionToken ?? getSessionToken() ?? null
+  );
+  const [sessionVerified, setSessionVerifiedState] = useState(
+    initialState?.sessionVerified ?? false
+  );
+
+  const setSessionToken = useCallback((token: string | null) => {
+    setSessionTokenState(token);
+    if (token) {
+      setIsSignedIn(true);
+    }
+  }, []);
+
+  const signOut = useCallback(() => {
+    setIsSignedIn(false);
+    setSessionTokenState(null);
+    setSessionVerifiedState(false);
+  }, []);
+
+  const value = useMemo<AuthStateContextValue>(
+    () => ({
+      isSignedIn,
+      sessionToken,
+      sessionVerified,
+      setSignedIn: setIsSignedIn,
+      setSessionVerified: setSessionVerifiedState,
+      setSessionToken,
+      signOut,
+    }),
+    [isSignedIn, sessionToken, sessionVerified, setSessionToken, signOut]
+  );
+
+  return (
+    <AuthStateContext.Provider value={value}>
+      {children}
+    </AuthStateContext.Provider>
+  );
+}
+
+export function useAuthState(): AuthStateContextValue {
+  const context = useContext(AuthStateContext);
+  if (!context) {
+    throw new Error('useAuthState must be used within an AuthStateProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## Because

- fxa-settings currently relies on Apollo Client and GraphQL for state management, which is being removed
- Need new infrastructure to fetch account data via auth-client REST APIs and manage state in localStorage

## This pull request

- Adds `account-storage.ts`, unified localStorage abstraction for all account data
- Adds `useAccountData.ts`, React hook that fetches account data from 3 sources in parallel (auth-server consolidated endpoint, profile server, attached clients)
- Adds `AccountStateContext.tsx`, React context backed by localStorage with cross-tab sync via `localStorageChange` events
- Adds `AuthStateContext.tsx`, React context for authentication state (session token, signed-in status)
- These are additive-only changes not yet wired into the application

## Issue

Closes: https://mozilla-hub.atlassian.net/browse/FXA-12994

## Checklist

- [x] My commit is GPG signed
- [x] Tests pass locally (if applicable)
- [ ] Documentation updated (if applicable)
- [ ] RTL rendering verified (if UI changed)

## Other Information

We won't be able to fully test the flow until  https://github.com/mozilla/fxa/pull/19981 lands, however this PR adds all the state management needed to support that.
