### PR TITLE
polish(payments-api): Remove root accessor and default api path prefix

### DIFF
--- a/apps/payments/api/src/app/app.controller.spec.ts
+++ b/apps/payments/api/src/app/app.controller.spec.ts
@@ -12,13 +12,6 @@ describe('AppController', () => {
     }).compile();
   });
 
-  describe('getData', () => {
-    it('should return "Hello world"', () => {
-      const appController = app.get<AppController>(AppController);
-      expect(appController.getData()).toEqual({ message: 'Hello world' });
-    });
-  });
-
   describe('service status endpoints', () => {
     it('__heartbeat__ should return empty object', () => {
       const appController = app.get<AppController>(AppController);

--- a/apps/payments/api/src/app/app.controller.ts
+++ b/apps/payments/api/src/app/app.controller.ts
@@ -5,11 +5,6 @@ import { AppService } from './app.service';
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  @Get()
-  getData() {
-    return this.appService.getData();
-  }
-
   @Get('__lbheartbeat__')
   __lbheartbeat__() {
     return this.appService.__lbheartbeat__();

--- a/apps/payments/api/src/app/app.service.spec.ts
+++ b/apps/payments/api/src/app/app.service.spec.ts
@@ -12,12 +12,6 @@ describe('AppService', () => {
     service = app.get<AppService>(AppService);
   });
 
-  describe('getData', () => {
-    it('should return "Hello API"', () => {
-      expect(service.getData()).toEqual({ message: 'Hello API' });
-    });
-  });
-
   describe('service status endpoints', () => {
     it('__heartbeat__ should return empty object', () => {
       expect(service.__heartbeat__()).toEqual({});

--- a/apps/payments/api/src/app/app.service.ts
+++ b/apps/payments/api/src/app/app.service.ts
@@ -4,12 +4,6 @@ import { Injectable } from '@nestjs/common';
 export class AppService {
   constructor() {}
 
-  getData() {
-    return {
-      message: 'Hello world',
-    };
-  }
-
   __heartbeat__() {
     return {};
   }

--- a/apps/payments/api/src/main.ts
+++ b/apps/payments/api/src/main.ts
@@ -11,12 +11,10 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     rawBody: true,
   });
-  const globalPrefix = 'api';
-  app.setGlobalPrefix(globalPrefix);
-  const port = process.env.PORT || 3000;
+  const port = process.env.PORT || 3037;
   await app.listen(port);
   Logger.log(
-    `🚀 Application is running on: http://localhost:${port}/${globalPrefix}`
+    `🚀 Application is running on: http://localhost:${port}`
   );
 }
 


### PR DESCRIPTION
Because:

* Payments API shares code and services with other applications in the fxa ecosystem, but came with a default /api/ base path prefix for all routes
* This prefix causes some confusion for the service health checks, which expect all heartbeat and version endpoints to be off of the root path for all services

This commit:

* Removes the /api/ base prefix, as it is not required by internal or external stakeholders, and appears to be an inherited default value
* removes the root ('/') endpoint, as its purpose is not yet defined

Closes #N/A (relates to SVCSE-4181)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
