### PR TITLE
fix(webchannel): Send 'can_link_account' on email-first for isSync/isFirefoxNonSync when fxa_status resolves

### DIFF
--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.tsx
@@ -41,7 +41,7 @@ export function useFxAStatus(integration: FxAStatusIntegration) {
   const [supportsKeysOptionalLogin, setSupportsKeysOptionalLogin] =
     useState<boolean>(false);
   const [supportsCanLinkAccountUid, setSupportsCanLinkAccountUid] =
-    useState<boolean>(false);
+    useState<boolean | undefined>(undefined);
 
   useEffect(() => {
     // This sends a web channel message to the browser to prompt a response

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/mocks.tsx
@@ -7,11 +7,11 @@ import { getSyncEngineIds, syncEngineConfigs } from '../../sync-engines';
 export function mockUseFxAStatus({
   offeredSyncEnginesOverride,
   supportsKeysOptionalLogin = false,
-  supportsCanLinkAccountUid = false,
+  supportsCanLinkAccountUid,
 }: {
   offeredSyncEnginesOverride?: ReturnType<typeof getSyncEngineIds>;
   supportsKeysOptionalLogin?: boolean;
-  supportsCanLinkAccountUid?: boolean;
+  supportsCanLinkAccountUid?: boolean | undefined;
 } = {}) {
   const offeredSyncEngineConfigs = syncEngineConfigs;
   const offeredSyncEngines =


### PR DESCRIPTION
Because:
* On email-first, we are sending 'can_link_account' before the fxa_status result has resolved, which tells us whether that Firefox supports sending the UID in can_link_account. This is problematic because we should NOT be sending the merge warning at this point if Firefox does support the UID capability

This commit:
* Sets the default of 'supportsCanLinkAccountUid' to 'undefined' until fxa_status is received, and does not auto-submit the email on email-first if 'supportsCanLinkAccountUid' is undefined

fixes FXA-13002

---

Please reproduce first in Nightly, then switch into my branch and test in Nightly and in Release. You shouldn't see the merge warning for either Firefox when signing into the same account.