### PR TITLE
feat(payments-next): subscriptionRenewalReminder-content-charge uses hard-coded English values for subscription interval

### DIFF
--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/en.ftl
@@ -11,11 +11,22 @@ subscriptionRenewalReminder-content-intro = Your current subscription is set to 
 subscriptionRenewalReminder-content-discount-change = Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied.
 subscriptionRenewalReminder-content-discount-ending = Because a previous discount has ended, your subscription will renew at the standard price.
 # Variables
+#   $invoiceTotalExcludingTax (String) - The amount of the subscription invoice before tax, including currency, e.g. $10.00
+#   $invoiceTax (String) - The tax amount of the subscription invoice, including currency, e.g. $1.29
+subscriptionRenewalReminder-content-charge-with-tax-day = At that time, { -brand-mozilla } will renew your daily subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-week = At that time, { -brand-mozilla } will renew your weekly subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-month = At that time, { -brand-mozilla } will renew your monthly subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-halfyear = At that time, { -brand-mozilla } will renew your six-month subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-year = At that time, { -brand-mozilla } will renew your yearly subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-default = At that time, { -brand-mozilla } will renew your subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+# Variables
 #   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
-#   $planIntervalCount (String) - The interval count of subscription plan, e.g. 2
-#   $planInterval (String) - The interval of time of the subscription plan, e.g. week
-# Tells the customer that their subscription price will change at the end of the current billing cycle
-subscriptionRenewalReminder-content-charge = At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-day = At that time, { -brand-mozilla } will renew your daily subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-week = At that time, { -brand-mozilla } will renew your weekly subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-month = At that time, { -brand-mozilla } will renew your monthly subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-halfyear = At that time, { -brand-mozilla } will renew your six-month subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-year = At that time, { -brand-mozilla } will renew your yearly subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-default = At that time, { -brand-mozilla } will renew your subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
 subscriptionRenewalReminder-content-closing = Sincerely,
 # Variables
 #   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.mjml
@@ -33,9 +33,59 @@
     <% } %>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionRenewalReminder-content-charge" data-l10n-args="<%= JSON.stringify({invoiceTotal, planInterval, planIntervalCount}) %>">
-        At that time, Mozilla will renew your <%- planIntervalCount%> <%- planInterval%> subscription and a charge of <%- invoiceTotal%> will be applied to the payment method on your account.
-      </span>
+      <% if (showTax) { %>
+        <% if (planInterval === 'day') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-day" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'week') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-week" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'month') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-month" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'halfyear') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-halfyear" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'year') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-year" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-default" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } %>
+      <% } else { %>
+        <% if (planInterval === 'day') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-day" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'week') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-week" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'month') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-month" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'halfyear') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-halfyear" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'year') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-year" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-default" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } %>
+      <% } %>
     </mj-text>
 
     <%- include ('/partials/subscriptionUpdateBillingEnsure/index.mjml') %>

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.stories.ts
@@ -12,9 +12,11 @@ export default {
 
 const data = {
   productName: 'Firefox Fortress',
+  showTax: true,
+  invoiceTotalExcludingTax: '$18.71',
+  invoiceTax: '$1.29',
   invoiceTotal: '$20.00',
   planInterval: 'month',
-  planIntervalCount: '1',
   reminderLength: '7',
   subscriptionSupportUrl: 'http://localhost:3030/support',
   updateBillingUrl: 'http://localhost:3030/subscriptions',
@@ -44,8 +46,9 @@ export const MonthlyPlanDiscountEnding = createStory(
 export const YearlyPlanNoDiscount = createStory(
   {
     planInterval: 'year',
-    planIntervalCount: '1',
     reminderLength: '15',
+    invoiceTotalExcludingTax: '$186.90',
+    invoiceTax: '$13.09',
     invoiceTotal: '$199.99',
     discountEnding: false,
   },
@@ -55,8 +58,9 @@ export const YearlyPlanNoDiscount = createStory(
 export const YearlyPlanDiscountEnding = createStory(
   {
     planInterval: 'year',
-    planIntervalCount: '1',
     reminderLength: '15',
+    invoiceTotalExcludingTax: '$186.90',
+    invoiceTax: '$13.09',
     invoiceTotal: '$199.99',
     discountEnding: true,
     hasDifferentDiscount: false,
@@ -83,4 +87,14 @@ export const YearlyPlanDiscountChanging = createStory(
     hasDifferentDiscount: true,
   },
   'Yearly Plan - Discount Changing'
+);
+
+export const MonthlyPlanNoTax = createStory(
+  {
+    showTax: false,
+    invoiceTotalExcludingTax: undefined,
+    invoiceTax: undefined,
+    invoiceTotal: '$20.00',
+  },
+  'Monthly Plan - No Tax'
 );

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.ts
@@ -8,9 +8,11 @@ import { TemplateData as SubscriptionUpdateBillingEnsureTemplateData } from '../
 export type TemplateData = SubscriptionSupportContactTemplateData &
   SubscriptionUpdateBillingEnsureTemplateData & {
     productName: string;
+    showTax: boolean;
+    invoiceTotalExcludingTax?: string;
+    invoiceTax?: string;
     invoiceTotal: string;
     planInterval: string;
-    planIntervalCount: string;
     reminderLength: string;
     subscriptionSupportUrl: string;
     updateBillingUrl: string;

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.txt
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.txt
@@ -12,7 +12,35 @@ subscriptionRenewalReminder-content-discount-ending = "Because a previous discou
 subscriptionRenewalReminder-content-discount-change = "Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied."
 <% } %>
 
-subscriptionRenewalReminder-content-charge = "At that time, Mozilla will renew your <%- planIntervalCount %> <%- planInterval %> subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% if (showTax) { %>
+<% if (planInterval === 'day') { %>
+subscriptionRenewalReminder-content-charge-with-tax-day = "At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'week') { %>
+subscriptionRenewalReminder-content-charge-with-tax-week = "At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'month') { %>
+subscriptionRenewalReminder-content-charge-with-tax-month = "At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'halfyear') { %>
+subscriptionRenewalReminder-content-charge-with-tax-halfyear = "At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'year') { %>
+subscriptionRenewalReminder-content-charge-with-tax-year = "At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else { %>
+subscriptionRenewalReminder-content-charge-with-tax-default = "At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } %>
+<% } else { %>
+<% if (planInterval === 'day') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-day = "At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'week') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-week = "At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'month') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-month = "At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'halfyear') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-halfyear = "At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'year') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-year = "At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else { %>
+subscriptionRenewalReminder-content-charge-invoice-total-default = "At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } %>
+<% } %>
 
 <%- include ('/partials/subscriptionUpdateBillingEnsure/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -384,6 +384,13 @@ export class SubscriptionReminders {
         reminderLength: effectiveReminderDuration.as('days'),
       });
 
+      let planInterval;
+      if (interval === 'month' && interval_count === 6) {
+        planInterval = 'halfyear';
+      } else {
+        planInterval = interval;
+      }
+
       await this.mailer.sendSubscriptionRenewalReminderEmail(
         account.emails,
         account,
@@ -393,9 +400,11 @@ export class SubscriptionReminders {
           acceptLanguage: account.locale,
           subscription: formattedSubscription,
           reminderLength: effectiveReminderDuration.as('days'),
-          planIntervalCount: interval_count,
-          planInterval: interval,
+          planInterval,
           // Using invoice prefix instead of plan to accommodate `yarn write-emails`.
+          showTax: (invoicePreview.tax ?? 0) > 0,
+          invoiceTotalExcludingTaxInCents: invoicePreview.total_excluding_tax,
+          invoiceTaxInCents: invoicePreview.tax,
           invoiceTotalInCents: invoicePreview.total,
           invoiceTotalCurrency: invoicePreview.currency,
           productMetadata: formattedSubscription.productMetadata,

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -3245,8 +3245,22 @@ module.exports = function (log, config, bounces, statsd) {
         email,
         productName,
         reminderLength: message.reminderLength,
-        planIntervalCount: message.planIntervalCount,
         planInterval: message.planInterval,
+        showTax: message.showTax,
+        invoiceTotalExcludingTax:
+          message.invoiceTotalExcludingTaxInCents &&
+          this._getLocalizedCurrencyString(
+            message.invoiceTotalExcludingTaxInCents,
+            message.invoiceTotalCurrency,
+            message.acceptLanguage
+          ),
+        invoiceTax:
+          message.invoiceTaxInCents &&
+          this._getLocalizedCurrencyString(
+            message.invoiceTaxInCents,
+            message.invoiceTotalCurrency,
+            message.acceptLanguage
+          ),
         invoiceTotal: this._getLocalizedCurrencyString(
           message.invoiceTotalInCents,
           message.invoiceTotalCurrency,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
@@ -11,11 +11,22 @@ subscriptionRenewalReminder-content-intro = Your current subscription is set to 
 subscriptionRenewalReminder-content-discount-change = Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied.
 subscriptionRenewalReminder-content-discount-ending = Because a previous discount has ended, your subscription will renew at the standard price.
 # Variables
+#   $invoiceTotalExcludingTax (String) - The amount of the subscription invoice before tax, including currency, e.g. $10.00
+#   $invoiceTax (String) - The tax amount of the subscription invoice, including currency, e.g. $1.29
+subscriptionRenewalReminder-content-charge-with-tax-day = At that time, { -brand-mozilla } will renew your daily subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-week = At that time, { -brand-mozilla } will renew your weekly subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-month = At that time, { -brand-mozilla } will renew your monthly subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-halfyear = At that time, { -brand-mozilla } will renew your six-month subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-year = At that time, { -brand-mozilla } will renew your yearly subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-with-tax-default = At that time, { -brand-mozilla } will renew your subscription and a charge of { $invoiceTotalExcludingTax } + { $invoiceTax } tax will be applied to the payment method on your account.
+# Variables
 #   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
-#   $planIntervalCount (String) - The interval count of subscription plan, e.g. 2
-#   $planInterval (String) - The interval of time of the subscription plan, e.g. week
-# Tells the customer that their subscription price will change at the end of the current billing cycle
-subscriptionRenewalReminder-content-charge = At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-day = At that time, { -brand-mozilla } will renew your daily subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-week = At that time, { -brand-mozilla } will renew your weekly subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-month = At that time, { -brand-mozilla } will renew your monthly subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-halfyear = At that time, { -brand-mozilla } will renew your six-month subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-year = At that time, { -brand-mozilla } will renew your yearly subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+subscriptionRenewalReminder-content-charge-invoice-total-default = At that time, { -brand-mozilla } will renew your subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
 subscriptionRenewalReminder-content-closing = Sincerely,
 # Variables
 #   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.mjml
@@ -33,9 +33,59 @@
     <% } %>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionRenewalReminder-content-charge" data-l10n-args="<%= JSON.stringify({invoiceTotal, planInterval, planIntervalCount}) %>">
-        At that time, Mozilla will renew your <%- planIntervalCount%> <%- planInterval%> subscription and a charge of <%- invoiceTotal%> will be applied to the payment method on your account.
-      </span>
+      <% if (showTax) { %>
+        <% if (planInterval === 'day') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-day" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'week') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-week" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'month') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-month" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'halfyear') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-halfyear" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'year') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-year" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } else { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-with-tax-default" data-l10n-args="<%= JSON.stringify({invoiceTotalExcludingTax, invoiceTax}) %>">
+          At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account.
+        </span>
+        <% } %>
+      <% } else { %>
+        <% if (planInterval === 'day') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-day" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'week') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-week" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'month') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-month" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'halfyear') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-halfyear" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else if (planInterval === 'year') { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-year" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } else { %>
+        <span data-l10n-id="subscriptionRenewalReminder-content-charge-invoice-total-default" data-l10n-args="<%= JSON.stringify({invoiceTotal}) %>">
+          At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account.
+        </span>
+        <% } %>
+      <% } %>
     </mj-text>
 
     <%- include ('/partials/subscriptionUpdateBillingEnsure/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
@@ -16,12 +16,13 @@ const createStory = subplatStoryWithProps(
     productName: 'Firefox Fortress',
     invoiceTotal: '$20.00',
     planInterval: 'month',
-    planIntervalCount: '1',
     reminderLength: '7',
     subscriptionSupportUrl: 'http://localhost:3030/support',
     updateBillingUrl: 'http://localhost:3030/subscriptions',
     discountEnding: false,
     hasDifferentDiscount: false,
+    invoiceTax: undefined,
+    showTax: false,
   }
 );
 
@@ -40,7 +41,6 @@ export const MonthlyPlanDiscountEnding = createStory(
 export const YearlyPlanNoDiscount = createStory(
   {
     planInterval: 'year',
-    planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$199.99',
     discountEnding: false,
@@ -51,7 +51,6 @@ export const YearlyPlanNoDiscount = createStory(
 export const YearlyPlanDiscountEnding = createStory(
   {
     planInterval: 'year',
-    planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$199.99',
     discountEnding: true,
@@ -79,4 +78,14 @@ export const YearlyPlanDiscountChanging = createStory(
     hasDifferentDiscount: true,
   },
   'Yearly Plan - Discount Changing'
+);
+
+export const MonthlyPlanWithTax = createStory(
+  {
+    showTax: true,
+    invoiceTotalExcludingTax: '$20.00',
+    invoiceTax: '$2.60',
+    invoiceTotal: '$22.60',
+  },
+  'Monthly Plan - With Tax'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.txt
@@ -12,7 +12,35 @@ subscriptionRenewalReminder-content-discount-ending = "Because a previous discou
 subscriptionRenewalReminder-content-discount-change = "Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied."
 <% } %>
 
-subscriptionRenewalReminder-content-charge = "At that time, Mozilla will renew your <%- planIntervalCount %> <%- planInterval %> subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% if (showTax) { %>
+<% if (planInterval === 'day') { %>
+subscriptionRenewalReminder-content-charge-with-tax-day = "At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'week') { %>
+subscriptionRenewalReminder-content-charge-with-tax-week = "At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'month') { %>
+subscriptionRenewalReminder-content-charge-with-tax-month = "At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'halfyear') { %>
+subscriptionRenewalReminder-content-charge-with-tax-halfyear = "At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else if (planInterval === 'year') { %>
+subscriptionRenewalReminder-content-charge-with-tax-year = "At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } else { %>
+subscriptionRenewalReminder-content-charge-with-tax-default = "At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotalExcludingTax %> + <%- invoiceTax %> tax will be applied to the payment method on your account."
+<% } %>
+<% } else { %>
+<% if (planInterval === 'day') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-day = "At that time, Mozilla will renew your daily subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'week') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-week = "At that time, Mozilla will renew your weekly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'month') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-month = "At that time, Mozilla will renew your monthly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'halfyear') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-halfyear = "At that time, Mozilla will renew your six-month subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else if (planInterval === 'year') { %>
+subscriptionRenewalReminder-content-charge-invoice-total-year = "At that time, Mozilla will renew your yearly subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } else { %>
+subscriptionRenewalReminder-content-charge-invoice-total-default = "At that time, Mozilla will renew your subscription and a charge of <%- invoiceTotal %> will be applied to the payment method on your account."
+<% } %>
+<% } %>
 
 <%- include ('/partials/subscriptionUpdateBillingEnsure/index.txt') %>
 

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -123,7 +123,6 @@ function sendMail(mailer, messageToSend) {
     planEmailIconURL: planConfig.urls.emailIcon,
     planSuccessActionButtonURL: planConfig.urls.download,
     planInterval: 'week',
-    planIntervalCount: 4,
     playStoreLink: 'https://example.com/play-store',
     invoiceNumber: '8675309',
     cardType: 'MasterCard',
@@ -137,6 +136,9 @@ function sendMail(mailer, messageToSend) {
     productNameNew: 'Product B',
     invoiceLink:
       'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
+    showTax: true,
+    invoiceTotalExcludingTaxInCents: 869565.1,
+    invoiceTaxInCents: 130434.8,
     invoiceTotalInCents: 999999.9,
     invoiceTotalCurrency: 'eur',
     paymentAmountOldInCents: 9999099.9,

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -90,6 +90,7 @@ const MESSAGE = {
   invoiceNumber: '8675309',
   invoiceTotalInCents: 999999.9,
   invoiceSubtotalInCents: 1000200.0,
+  invoiceTotalExcludingTaxInCents: 999951.9,
   invoiceDiscountAmountInCents: -200,
   invoiceTaxAmountInCents: 48,
   invoiceTotalCurrency: 'eur',
@@ -109,7 +110,6 @@ const MESSAGE = {
   planSuccessActionButtonURL: 'http://getfirefox.com/',
   planId: 'plan-example',
   planInterval: 'day',
-  planIntervalCount: 2,
   playStoreLink: 'https://example.com/play-store',
   productIconURLNew:
     'https://cdn.accounts.firefox.com/product-icons/mozilla-vpn-email.png',
@@ -164,6 +164,7 @@ const MESSAGE_FORMATTED = {
   invoiceAmountDue2: '£32.10',
   invoiceAmountDue3: '€0.00',
   invoiceSubtotal: '€10,002.00',
+  invoiceTotalExcludingTax: '€9,999.52',
   invoiceDiscountAmount: '-€2.00',
   invoiceTaxAmount: '€0.48',
 };
@@ -3735,7 +3736,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
           },
           {
             test: 'include',
-            expected: `At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
           },
           { test: 'include', expected: 'Sincerely,' },
           {
@@ -3762,7 +3763,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
           },
           {
             test: 'include',
-            expected: `At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
           },
           { test: 'include', expected: 'Sincerely,' },
           {
@@ -3871,7 +3872,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
           },
           {
             test: 'include',
-            expected: `At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
           },
           { test: 'include', expected: 'Sincerely,' },
           {
@@ -3906,7 +3907,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
           },
           {
             test: 'include',
-            expected: `At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
           },
           { test: 'include', expected: 'Sincerely,' },
           {
@@ -4017,7 +4018,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
           },
           {
             test: 'include',
-            expected: `At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
           },
           { test: 'include', expected: 'Sincerely,' },
           {
@@ -4052,7 +4053,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
           },
           {
             test: 'include',
-            expected: `At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
           },
           { test: 'include', expected: 'Sincerely,' },
           {
@@ -4069,6 +4070,465 @@ const TESTS: [string, any, Record<string, any>?][] = [
         productName: MESSAGE.subscription.productName,
         discountEnding: false,
         hasDifferentDiscount: true,
+      }),
+    },
+  ],
+
+  [
+    'subscriptionRenewalReminderEmail',
+    new Map<string, Test | any>([
+      [
+        'subject',
+        {
+          test: 'equal',
+          expected: `${MESSAGE.subscription.productName} automatic renewal notice`,
+        },
+      ],
+      [
+        'headers',
+        new Map([
+          [
+            'X-SES-MESSAGE-TAGS',
+            {
+              test: 'equal',
+              expected: sesMessageTagsHeaderValue(
+                'subscriptionRenewalReminder'
+              ),
+            },
+          ],
+          [
+            'X-Template-Name',
+            { test: 'equal', expected: 'subscriptionRenewalReminder' },
+          ],
+          [
+            'X-Template-Version',
+            {
+              test: 'equal',
+              expected: TEMPLATE_VERSIONS.subscriptionRenewalReminder,
+            },
+          ],
+        ]),
+      ],
+      [
+        'html',
+        [
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionTermsUrl',
+                'subscription-renewal-reminder',
+                'subscription-terms'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionSettingsUrl',
+                'subscription-renewal-reminder',
+                'update-billing',
+                'plan_id',
+                'product_id',
+                'uid',
+                'email'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionSupportUrl',
+                'subscription-renewal-reminder',
+                'subscription-support'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: `Dear ${MESSAGE.subscription.productName} customer`,
+          },
+          {
+            test: 'include',
+            expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days.`,
+          },
+          {
+            test: 'include',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotalExcludingTax} + ${MESSAGE_FORMATTED.invoiceTaxAmount} tax will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+          },
+          { test: 'include', expected: 'Sincerely,' },
+          {
+            test: 'include',
+            expected: `The ${MESSAGE.subscription.productName} team`,
+          },
+          { test: 'notInclude', expected: 'utm_source=email' },
+        ],
+      ],
+      [
+        'text',
+        [
+          {
+            test: 'include',
+            expected: `${MESSAGE.subscription.productName} automatic renewal notice`,
+          },
+          {
+            test: 'include',
+            expected: `Dear ${MESSAGE.subscription.productName} customer`,
+          },
+          {
+            test: 'include',
+            expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days.`,
+          },
+          {
+            test: 'include',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotalExcludingTax} + ${MESSAGE_FORMATTED.invoiceTaxAmount} tax will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'include',
+            expected: 'Sincerely,'
+          },
+          {
+            test: 'include',
+            expected: `The ${MESSAGE.subscription.productName} team`,
+          },
+          { test: 'notInclude', expected: 'utm_source=email' },
+        ],
+      ],
+    ]),
+    {
+      updateTemplateValues: (x) => ({
+        ...x,
+        productName: MESSAGE.subscription.productName,
+        showTax: true,
+        invoiceTaxInCents: MESSAGE.invoiceTaxAmountInCents,
+        invoiceTotalExcludingTaxInCents:
+          MESSAGE.invoiceTotalExcludingTaxInCents,
+      }),
+    },
+  ],
+
+  [
+    'subscriptionRenewalReminderEmail',
+    new Map<string, Test | any>([
+      [
+        'subject',
+        {
+          test: 'equal',
+          expected: `${MESSAGE.subscription.productName} automatic renewal notice`,
+        },
+      ],
+      [
+        'headers',
+        new Map([
+          [
+            'X-SES-MESSAGE-TAGS',
+            {
+              test: 'equal',
+              expected: sesMessageTagsHeaderValue(
+                'subscriptionRenewalReminder'
+              ),
+            },
+          ],
+          [
+            'X-Template-Name',
+            { test: 'equal', expected: 'subscriptionRenewalReminder' },
+          ],
+          [
+            'X-Template-Version',
+            {
+              test: 'equal',
+              expected: TEMPLATE_VERSIONS.subscriptionRenewalReminder,
+            },
+          ],
+        ]),
+      ],
+      [
+        'html',
+        [
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionTermsUrl',
+                'subscription-renewal-reminder',
+                'subscription-terms'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionSettingsUrl',
+                'subscription-renewal-reminder',
+                'update-billing',
+                'plan_id',
+                'product_id',
+                'uid',
+                'email'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionSupportUrl',
+                'subscription-renewal-reminder',
+                'subscription-support'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: `Dear ${MESSAGE.subscription.productName} customer`,
+          },
+          {
+            test: 'include',
+            expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days.`,
+          },
+          {
+            test: 'include',
+            expected: `Because a previous discount has ended, your subscription will renew at the standard price.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied.`,
+          },
+          {
+            test: 'include',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotalExcludingTax} + ${MESSAGE_FORMATTED.invoiceTaxAmount} tax will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+          },
+          { test: 'include', expected: 'Sincerely,' },
+          {
+            test: 'include',
+            expected: `The ${MESSAGE.subscription.productName} team`,
+          },
+          { test: 'notInclude', expected: 'utm_source=email' },
+        ],
+      ],
+      [
+        'text',
+        [
+          {
+            test: 'include',
+            expected: `${MESSAGE.subscription.productName} automatic renewal notice`,
+          },
+          {
+            test: 'include',
+            expected: `Dear ${MESSAGE.subscription.productName} customer`,
+          },
+          {
+            test: 'include',
+            expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days.`,
+          },
+          {
+            test: 'include',
+            expected: `Because a previous discount has ended, your subscription will renew at the standard price.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied.`,
+          },
+          {
+            test: 'include',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotalExcludingTax} + ${MESSAGE_FORMATTED.invoiceTaxAmount} tax will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+          },
+          { test: 'include', expected: 'Sincerely,' },
+          {
+            test: 'include',
+            expected: `The ${MESSAGE.subscription.productName} team`,
+          },
+          { test: 'notInclude', expected: 'utm_source=email' },
+        ],
+      ],
+    ]),
+    {
+      updateTemplateValues: (x) => ({
+        ...x,
+        productName: MESSAGE.subscription.productName,
+        showTax: true,
+        discountEnding: true,
+        hasDifferentDiscount: false,
+        invoiceTaxInCents: MESSAGE.invoiceTaxAmountInCents,
+        invoiceTotalExcludingTaxInCents:
+          MESSAGE.invoiceTotalExcludingTaxInCents,
+      }),
+    },
+  ],
+
+  [
+    'subscriptionRenewalReminderEmail',
+    new Map<string, Test | any>([
+      [
+        'subject',
+        {
+          test: 'equal',
+          expected: `${MESSAGE.subscription.productName} automatic renewal notice`,
+        },
+      ],
+      [
+        'headers',
+        new Map([
+          [
+            'X-SES-MESSAGE-TAGS',
+            {
+              test: 'equal',
+              expected: sesMessageTagsHeaderValue(
+                'subscriptionRenewalReminder'
+              ),
+            },
+          ],
+          [
+            'X-Template-Name',
+            { test: 'equal', expected: 'subscriptionRenewalReminder' },
+          ],
+          [
+            'X-Template-Version',
+            {
+              test: 'equal',
+              expected: TEMPLATE_VERSIONS.subscriptionRenewalReminder,
+            },
+          ],
+        ]),
+      ],
+      [
+        'html',
+        [
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionTermsUrl',
+                'subscription-renewal-reminder',
+                'subscription-terms'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionSettingsUrl',
+                'subscription-renewal-reminder',
+                'update-billing',
+                'plan_id',
+                'product_id',
+                'uid',
+                'email'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: decodeUrl(
+              configHref(
+                'subscriptionSupportUrl',
+                'subscription-renewal-reminder',
+                'subscription-support'
+              )
+            ),
+          },
+          {
+            test: 'include',
+            expected: `Dear ${MESSAGE.subscription.productName} customer`,
+          },
+          {
+            test: 'include',
+            expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days.`,
+          },
+          {
+            test: 'include',
+            expected: `Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `Because a previous discount has ended, your subscription will renew at the standard price.`,
+          },
+          {
+            test: 'include',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotalExcludingTax} + ${MESSAGE_FORMATTED.invoiceTaxAmount} tax will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+          },
+          { test: 'include', expected: 'Sincerely,' },
+          {
+            test: 'include',
+            expected: `The ${MESSAGE.subscription.productName} team`,
+          },
+          { test: 'notInclude', expected: 'utm_source=email' },
+        ],
+      ],
+      [
+        'text',
+        [
+          {
+            test: 'include',
+            expected: `${MESSAGE.subscription.productName} automatic renewal notice`,
+          },
+          {
+            test: 'include',
+            expected: `Dear ${MESSAGE.subscription.productName} customer`,
+          },
+          {
+            test: 'include',
+            expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days.`,
+          },
+          {
+            test: 'include',
+            expected: `Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `Because a previous discount has ended, your subscription will renew at the standard price.`,
+          },
+          {
+            test: 'include',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotalExcludingTax} + ${MESSAGE_FORMATTED.invoiceTaxAmount} tax will be applied to the payment method on your account.`,
+          },
+          {
+            test: 'notInclude',
+            expected: `At that time, Mozilla will renew your daily subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.`,
+          },
+          { test: 'include', expected: 'Sincerely,' },
+          {
+            test: 'include',
+            expected: `The ${MESSAGE.subscription.productName} team`,
+          },
+          { test: 'notInclude', expected: 'utm_source=email' },
+        ],
+      ],
+    ]),
+    {
+      updateTemplateValues: (x) => ({
+        ...x,
+        productName: MESSAGE.subscription.productName,
+        showTax: true,
+        discountEnding: false,
+        hasDifferentDiscount: true,
+        invoiceTaxInCents: MESSAGE.invoiceTaxAmountInCents,
+        invoiceTotalExcludingTaxInCents:
+          MESSAGE.invoiceTotalExcludingTaxInCents,
       }),
     },
   ],


### PR DESCRIPTION
## Because

- The subscriptionRenewalReminder-content-charge fluent string has a variable hardcoded in English, so a localized string will display with a mix of English and translated text.

## This pull request

- Updates the string for proper localization and to match existing subscription plan lengths (daily, weekly, monthly, halfyearly (6-monthly), yearly.
- Updates the string to break out the charge to show the tax amount (where applicable).

## Issue that this pull request solves

Closes: #[PAY-3497](https://mozilla-hub.atlassian.net/browse/PAY-3497)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
With tax: 
<img width="1475" height="723" alt="image" src="https://github.com/user-attachments/assets/66f25b39-dcce-4852-a6e4-65ee622e58e5" />

No Tax:
<img width="1451" height="581" alt="image" src="https://github.com/user-attachments/assets/1dedadaf-e206-4ac3-8244-56624f1d9864" />



## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3497]: https://mozilla-hub.atlassian.net/browse/PAY-3497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ