### PR TITLE
chore(fxa): Add passkey functional test example

### DIFF
--- a/packages/functional-tests/lib/fixtures/standard.ts
+++ b/packages/functional-tests/lib/fixtures/standard.ts
@@ -15,6 +15,7 @@ import { create as createPages } from '../../pages';
 import { ServerTarget, TargetName, create } from '../targets';
 import { BaseTarget } from '../targets/base';
 import { TestAccountTracker } from '../testAccountTracker';
+import { PasskeyPage } from '../../pages/passkey';
 import { existsSync, readFileSync } from 'fs';
 import { join, dirname, basename } from 'path';
 
@@ -47,6 +48,12 @@ export const test = base.extend<TestOptions, WorkerOptions>({
   pages: async ({ target, page }, use) => {
     const pages = createPages(page, target);
     await use(pages);
+    // Cleanup passkey CDP sessions from any page that used them
+    for (const pageInstance of Object.values(pages)) {
+      if (pageInstance instanceof PasskeyPage) {
+        await pageInstance.cleanupPasskeys();
+      }
+    }
   },
 
   syncBrowserPages: async ({ target }, use, testInfo) => {

--- a/packages/functional-tests/lib/passkeyVirtualAuthenticator.ts
+++ b/packages/functional-tests/lib/passkeyVirtualAuthenticator.ts
@@ -1,0 +1,224 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as pwCore from 'playwright-core/types/protocol';
+import { CDPSession } from '@playwright/test';
+
+const DEFAULT_OPTS: pwCore.Protocol.WebAuthn.VirtualAuthenticatorOptions = {
+  protocol: 'ctap2',
+  transport: 'internal',
+  hasResidentKey: true,
+  hasUserVerification: true,
+  isUserVerified: true,
+  automaticPresenceSimulation: false,
+};
+
+type Trigger = () => Promise<void>;
+type PostCheck = () => Promise<void>;
+
+export class PasskeyVirtualAuthenticator {
+  private authenticatorId = '';
+
+  constructor(
+    private readonly client: CDPSession,
+    private readonly opts: pwCore.Protocol.WebAuthn.VirtualAuthenticatorOptions = DEFAULT_OPTS
+  ) {}
+
+  /**
+   * Creates the virtual authenticator in the browser via CDP.
+   *
+   * Be sure to call this before using any other methods.
+   * @param overrides
+   * @returns
+   */
+  async create(
+    overrides?: Partial<pwCore.Protocol.WebAuthn.VirtualAuthenticatorOptions>
+  ) {
+    await this.client.send('WebAuthn.enable');
+
+    const { authenticatorId } = await this.client.send(
+      'WebAuthn.addVirtualAuthenticator',
+      {
+        options: {
+          ...this.opts,
+          ...overrides,
+          automaticPresenceSimulation: false,
+        },
+      }
+    );
+
+    this.authenticatorId = authenticatorId;
+    return authenticatorId;
+  }
+
+  /**
+   * Removes the virtual authenticator from the browser via CDP.
+   * @returns
+   */
+  async dispose() {
+    if (!this.authenticatorId) return;
+    await this.client.send('WebAuthn.removeVirtualAuthenticator', {
+      authenticatorId: this.authenticatorId,
+    });
+    this.authenticatorId = '';
+  }
+
+  /**
+   * Cleanup the virtual authenticator and detach the CDP session.
+   * Safe to call even if not initialized - will silently skip.
+   */
+  async cleanup() {
+    await this.dispose();
+    try {
+      await this.client.send('WebAuthn.disable');
+    } catch {
+      // Ignore errors if already disabled
+    }
+    await this.client.detach();
+  }
+
+  /**
+   * Check how many credentials are stored in the virtual authenticator.
+   *
+   * Useful for verifying that a credential was created during registration,
+   * or testing multiple registered credential flows.
+   * @returns
+   */
+  async getCredentials() {
+    this.assertInit();
+    const result = await this.client.send('WebAuthn.getCredentials', {
+      authenticatorId: this.authenticatorId,
+    });
+    return result.credentials;
+  }
+
+  /**
+   * Simulate a *successful* passkey operation.
+   *
+   * Example:
+   * ```ts
+   * await passkeyAuth.success(async () => {
+   *   // Action that would show the Passkey prompt - this should return a promise
+   *   return signInPage.signinWithPasskey();
+   *   // event listener will resolve when operation completes
+   *   }
+   * });
+   * // then test asserts we're signed in or other success condition
+   * ```
+   * @param trigger
+   */
+  async success(trigger: Trigger) {
+    this.assertInit();
+
+    // Enable presence simulation FIRST, before anything else
+    // This gives the browser maximum time to activate it
+    await this.client.send('WebAuthn.setAutomaticPresenceSimulation', {
+      authenticatorId: this.authenticatorId,
+      enabled: true,
+    });
+
+    const operationCompleted = this.waitForOneOf([
+      'WebAuthn.credentialAdded',
+      'WebAuthn.credentialAsserted',
+    ]);
+
+    await this.client.send('WebAuthn.setUserVerified', {
+      authenticatorId: this.authenticatorId,
+      isUserVerified: true,
+    });
+
+    // Wait to ensure presence simulation is fully active
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    try {
+      await trigger();
+      await operationCompleted;
+    } finally {
+      await this.client.send('WebAuthn.setAutomaticPresenceSimulation', {
+        authenticatorId: this.authenticatorId,
+        enabled: false,
+      });
+    }
+  }
+
+  /**
+   * Simulate a *failed/cancelled* passkey operation.
+   * There’s no CDP event for failure, so you must provide a post-check or use a small timeout.
+   *
+   * Example:
+   * ```ts
+   * await passkeyAuth.fail(async () => {
+   *   // Same as `success`, trigger an action that
+   *   // would show the Passkey prompt - this should return a promise
+   *   return signInPage.signinWithPasskey();
+   * }, async () => {
+   *   // Return a promise that will resolve after the 'cancellation' is processed.
+   *   // This could be a small timeout, or an assertion that an error message is shown.
+   *   return expect(page.locator('#error-message')).toBeVisible();
+   * });
+   * // then test asserts we're still signed out or other failure condition
+   * // or check the `getCredentials()` to verify no new credentials were created
+   * ```
+   */
+  async fail(trigger: Trigger, postCheck: PostCheck) {
+    this.assertInit();
+
+    // Enable presence simulation FIRST, before anything else
+    await this.client.send('WebAuthn.setAutomaticPresenceSimulation', {
+      authenticatorId: this.authenticatorId,
+      enabled: true,
+    });
+
+    await this.client.send('WebAuthn.setUserVerified', {
+      authenticatorId: this.authenticatorId,
+      isUserVerified: false,
+    });
+
+    // Wait to ensure presence simulation is fully active
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    try {
+      await trigger();
+      await postCheck();
+    } finally {
+      await this.client.send('WebAuthn.setAutomaticPresenceSimulation', {
+        authenticatorId: this.authenticatorId,
+        enabled: false,
+      });
+    }
+  }
+
+  private waitForOneOf(
+    events: Array<'WebAuthn.credentialAdded' | 'WebAuthn.credentialAsserted'>
+  ) {
+    return new Promise<void>((resolve) => {
+      let done = false;
+
+      const handlers = events.map(() => {
+        const handler = () => {
+          if (done) return;
+          done = true;
+          // remove all handlers when one fires
+          for (let i = 0; i < events.length; i++) {
+            this.client.off(events[i], handlers[i]);
+          }
+          resolve();
+        };
+        return handler;
+      });
+
+      for (let i = 0; i < events.length; i++) {
+        this.client.on(events[i], handlers[i]);
+      }
+    });
+  }
+
+  private assertInit() {
+    if (!this.authenticatorId) {
+      throw new Error(
+        'PasskeyVirtualAuthenticator not initialized. Call init() first.'
+      );
+    }
+  }
+}

--- a/packages/functional-tests/pages/index.ts
+++ b/packages/functional-tests/pages/index.ts
@@ -37,6 +37,9 @@ import { TotpPage } from './settings/totp';
 import { InlineRecoveryKey } from './inlineRecoveryKey';
 import { SignupConfirmedSyncPage } from './signupConfirmedSync';
 import { InlineTotpSetupPage } from './inlineTotpSetup';
+import { PasskeyExamplePage } from './passkey';
+
+export { PasskeyPage } from './passkey';
 
 export function create(page: Page, target: BaseTarget) {
   return {
@@ -74,5 +77,6 @@ export function create(page: Page, target: BaseTarget) {
     signupConfirmedSync: new SignupConfirmedSyncPage(page, target),
     termsOfService: new TermsOfService(page, target),
     totp: new TotpPage(page, target),
+    passkeysExample: new PasskeyExamplePage(page, target),
   };
 }

--- a/packages/functional-tests/pages/passkey.ts
+++ b/packages/functional-tests/pages/passkey.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Page } from '@playwright/test';
+import { BaseLayout } from './layout';
+import { PasskeyVirtualAuthenticator } from '../lib/passkeyVirtualAuthenticator';
+
+/**
+ * Abstract base class for page objects that use PasskeyVirtualAuthenticator.
+ * Provides common initialization and cleanup patterns.
+ */
+export abstract class PasskeyPage extends BaseLayout {
+  protected passkeyVirtualAuth?: PasskeyVirtualAuthenticator;
+
+  /**
+   * Initialize the PasskeyVirtualAuthenticator with a CDP session.
+   * Call this before using passkey functionality.
+   */
+  async initPasskeys(page: Page) {
+    const client = await page.context().newCDPSession(page);
+    this.passkeyVirtualAuth = new PasskeyVirtualAuthenticator(client);
+    await this.passkeyVirtualAuth.create();
+  }
+
+  /**
+   * Cleanup the virtual authenticator and CDP session if initialized.
+   * Safe to call even if passkeys were never used.
+   */
+  async cleanupPasskeys() {
+    if (this.passkeyVirtualAuth) {
+      await this.passkeyVirtualAuth.cleanup();
+      this.passkeyVirtualAuth = undefined;
+    }
+  }
+
+  /**
+   * Check if passkeys have been initialized.
+   */
+  get hasPasskeysInitialized(): boolean {
+    return !!this.passkeyVirtualAuth;
+  }
+
+  /**
+   * Exposes the PasskeyVirtualAuthenticator.
+   * Must call initPasskeys() first.
+   */
+  get passkeyAuth() {
+    if (!this.passkeyVirtualAuth) {
+      throw new Error(
+        'PasskeyVirtualAuthenticator not initialized. Call initPasskeys() first.'
+      );
+    }
+    return this.passkeyVirtualAuth;
+  }
+}
+
+/**
+ * Page object for interacting with Passkeys in tests.
+ *
+ * Just an example, and will be removed once passkey tests are integrated elsewhere.
+ */
+export class PasskeyExamplePage extends PasskeyPage {
+  get path(): string {
+    return 'https://passkeys.eu'; // test page URL for passkeys
+  }
+}

--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -3,12 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect } from '@playwright/test';
-import { BaseLayout } from './layout';
 import { getReactFeatureFlagUrl } from '../lib/react-flag';
 import { Credentials } from '../lib/targets';
+import { PasskeyPage } from './passkey';
 
-export class SigninPage extends BaseLayout {
+export class SigninPage extends PasskeyPage {
   readonly path = 'signin';
+
   get authenticationFormHeading() {
     return this.page.getByRole('heading', {
       name: /^Enter (?:authentication|security) code/,

--- a/packages/functional-tests/playwright.config.ts
+++ b/packages/functional-tests/playwright.config.ts
@@ -94,6 +94,18 @@ export default defineConfig<PlaywrightTestConfig<TestOptions, WorkerOptions>>({
           },
         }) as Project
     ),
+    ...(TargetNames.map((name) => ({
+      name: `${name}-chromium`,
+      use: {
+        browserName: 'chromium',
+        targetName: name,
+        launchOptions: {
+          headless: !DEBUG,
+          slowMo: SLOWMO,
+        },
+        trace: 'retain-on-failure',
+      },
+    })) as Project[]),
   ],
   reporter: CI
     ? [

--- a/packages/functional-tests/tests/passkeys/passkeys.spec.ts
+++ b/packages/functional-tests/tests/passkeys/passkeys.spec.ts
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect, test } from '../../lib/fixtures/standard';
+
+/**
+ * These tests use a demo site at https://passkeys.eu which is a simple
+ * webauthn/passkeys registration and authentication demo.
+ *
+ * The site allows any origin to register and authenticate passkeys, making it
+ * suitable for testing purposes and making sure the `PasskeyVirtualAuthenticator`
+ * wrapper works as expected. Much of the logic and complexity here can be moved
+ * into the signIn/signUp pages, but for now this keeps things simple and readable
+ */
+
+test.describe('severity-1 #smoke', () => {
+  // Skip all tests in this suite because they cannot run in CI (third party site blocks us).
+  // But, leaving here for reference until we implement Passkey support and tests in our own app.
+  test.skip(true, 'Tests use a demo site and are not part of smoke suite');
+  /**
+   * Passkeys have a potential to collide with other tests due to the use of
+   * CDP sessions and virtual authenticators. To avoid this, we run all passkey
+   * tests in serial.
+   */
+  test.describe.configure({ mode: 'serial' });
+
+  test.describe('Passkeys chromium happy path', () => {
+    test('can register a passkey on the demo site', async ({
+      pages: { page, passkeysExample: passkeys },
+      testAccountTracker,
+    }) => {
+      const browserName = page.context().browser()?.browserType().name();
+      test.skip(
+        browserName !== 'chromium',
+        'Passkeys tests run on chromium only'
+      );
+      // initialize to tell the browser we have the ability to send passkey commands
+      // before we navigate to the page, that way, if the page checks for the ability
+      // it's already configured!
+      await passkeys.initPasskeys(page);
+
+      await page.goto('https://passkeys.eu');
+
+      const email = testAccountTracker.generateEmail();
+      // wait for and email field, fill it
+      const emailField = page.getByLabel('Email address');
+      await expect(emailField).toBeVisible();
+      await emailField.fill(email);
+
+      // 'submits' the form that then triggers the passkey creation
+      // as soon as this happens, the would prompt for the passkey creation
+      // Used in the success() wrapper below will auto 'complete' the prompt
+      // and continue the flow
+      const initiatePasskey = () =>
+        page.getByRole('button', { name: 'Continue' }).click();
+
+      await passkeys.passkeyAuth.success(initiatePasskey);
+
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+        'Passkeys demo'
+      );
+
+      // Optional "extra confidence": at least one credential exists now
+      const creds = await passkeys.passkeyAuth.getCredentials();
+      expect(creds?.length).toEqual(1);
+    });
+
+    test('does not register a passkey on demo site if user cancels', async ({
+      pages: { page, passkeysExample: pk },
+      testAccountTracker,
+    }) => {
+      const browserName = page.context().browser()?.browserType().name();
+      test.skip(
+        browserName !== 'chromium',
+        'Passkeys tests run on chromium only'
+      );
+
+      await pk.initPasskeys(page);
+
+      await page.goto('https://passkeys.eu');
+
+      const email = testAccountTracker.generateEmail();
+
+      // wait for and email field, fill it
+      const emailField = page.getByLabel('Email address');
+      await expect(emailField).toBeVisible();
+      await emailField.fill(email);
+
+      const initiatePasskey = () =>
+        page.getByRole('button', { name: 'Continue' }).click();
+
+      // expectation that will ensure the failure path was taken
+      const somethingWentWrong = () =>
+        expect(page.getByText('Something went wrong...')).toBeVisible();
+
+      await pk.passkeyAuth.fail(initiatePasskey, somethingWentWrong);
+
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText(
+        'Passkeys demo'
+      );
+
+      // Optional "extra confidence": NO credentials should exist
+      const creds = await pk.passkeyAuth.getCredentials();
+      expect(creds?.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Because:
 - We want to enable some kind of functional tests with passkey flows

This Commit:
 - Creates a new PageObject that other pages can inherit from, exposing
   the setup and functions needed for interacting with passkey flows
 - Updates README with usage and examples
 - Adds example test that can be run locally
 - Adds new target for running tests specifically in Chromium browsers
   when running passkey tests

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
