### PR TITLE
fix(payments-ui): Keep success messaging after subscription update

### DIFF
--- a/libs/payments/ui/src/lib/client/components/ChurnCancel/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/ChurnCancel/index.tsx
@@ -126,10 +126,8 @@ export function ChurnCancel({
     setLoading(false);
   }
 
-  const isActiveNotCanceling = !!active && !cancelAtPeriodEnd;
-  const isOffer = reason === 'eligible' && isActiveNotCanceling;
-  const isDiscountAlreadyApplied =
-    reason === 'discount_already_applied' && isActiveNotCanceling;
+  const isOffer = reason === 'eligible' && !cancelAtPeriodEnd && active;
+  const isDiscountAlreadyApplied = reason === 'discount_already_applied';
 
   return (
     <section


### PR DESCRIPTION
## Because

- After redeeming the coupon on the cancel subscription flow, the success messaging appears briefly before redirecting to the error page

## This pull request

- Keeps success messaging displayed after subscription update

## Issue that this pull request solves

Closes: PAY-3509

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.