### PR TITLE
fix(payments-next): Display correct error message when subscription expires

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/error/page.tsx
@@ -59,18 +59,12 @@ export default async function LoyaltyDiscountStaySubscribedErrorPage({
     notFound();
   }
 
-  const staySubscribedContent = pageContent.staySubscribedContent;
-
-  if (staySubscribedContent.flowType !== 'stay_subscribed') {
-    notFound();
-  }
-
   return (
     <ChurnError
       cmsOfferingContent={cmsOfferingContent}
       locale={locale}
       reason={reason}
-      pageContent={staySubscribedContent}
+      pageContent={pageContent.staySubscribedContent}
       subscriptionId={subscriptionId}
     />
   );


### PR DESCRIPTION
## This pull request

- Displays "This discount is only available to current <product> subscribers" if subscription is not active

## Issue that this pull request solves

Closes: PAY-3514

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.