### PR TITLE
fix(webchannel): Send 'can_link_account' during signin_unblock

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -638,7 +638,12 @@ const AuthAndAccountSetupRoutes = ({
       />
       <SigninUnblockContainer
         path="/signin_unblock/*"
-        {...{ integration, flowQueryParams, setCurrentSplitLayout }}
+        {...{
+          integration,
+          flowQueryParams,
+          setCurrentSplitLayout,
+          useFxAStatusResult,
+        }}
       />
       <InlineRecoveryKeySetupContainer
         path="/inline_recovery_key_setup/*"

--- a/packages/fxa-settings/src/pages/Signin/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.tsx
@@ -312,7 +312,7 @@ const SigninContainer = ({
   const beginSigninHandler: BeginSigninHandler = useCallback(
     async (email: string, password: string) => {
       // - If the user came from email-first WITHOUT a linked third‑party account, Index already showed
-      //   the merge prompt.
+      //   the merge prompt for old firefox versions (supportsCanLinkAccountUid=false).
       // - If the user HAS a linked third‑party account, Index deferred the prompt to avoid duplicates,
       //   so we must prompt here instead.
       // Note: the browser will repond {ok} if the email matches stored data or the user accepts the merge.


### PR DESCRIPTION
Because:
* Users can keep 'canceling' the login when they see the merge warning until they get rate limited, and then they can bypass the merge warning by going through signin_unblock

This commit:
* Sends the 'can_link_account' command on this screen after unblock

fixes FXA-13009

--

See [this doc](https://docs.google.com/document/d/1LmeXqPR0ccTl4oN1NB1GEtg82QxyXHV39bT7-8IqA5Y/) - `signin_unblock` wasn't listed on places to add this check for the MVP, an oversight.

Since we need the `uid`, we have to wait until the user is at least partially authenticated with password before we can send this web channel message up. However, for `signin_unblock`, we don't get back the user's `uid` after password entry, we must wait until they are verified. So now, users in this flow will see the merge warning after the successful unblock, but they'll be redirected to email-first once they hit "cancel".

**I will file an issue for this**: one thing that would make this flow much better because users would get "blocked" much earlier in the flow, would be the non-MVP cases shown in that doc - e.g., user has an entry in local storage and therefore as soon as we know the email they're trying to sign in with and it matches what's in local storage, use the UID there to send `can_link_account`. However, there is an edge case where if a user deleted their account on another device and recreated it, we'd be sending the wrong UID up. This is probably OK, but I think that should be a separate task. 
edit: [here's that ticket](https://mozilla-hub.atlassian.net/browse/FXA-13012)