### PR TITLE
feat(auth): include credentials for certain fetch requests

### DIFF
--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -45,15 +45,11 @@
   },
   "author": "",
   "license": "MPL-2.0",
-  "dependencies": {
-    "node-fetch": "^2.6.7"
-  },
   "devDependencies": {
     "@types/assert": "^1.5.4",
     "@types/fast-text-encoding": "^1",
     "@types/mocha": "^10",
     "@types/node": "^22.13.5",
-    "@types/node-fetch": "^2.5.7",
     "@types/prettier": "^2",
     "esbuild": "^0.17.15",
     "esbuild-register": "^3.5.0",

--- a/packages/fxa-auth-client/server.ts
+++ b/packages/fxa-auth-client/server.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 import https from 'https';
-import fetch, { Headers } from 'node-fetch';
 import AuthClient from './lib/client';
 
 http.globalAgent = new http.Agent({
@@ -9,11 +8,6 @@ http.globalAgent = new http.Agent({
 https.globalAgent = new https.Agent({
   keepAlive: true,
 });
-
-// @ts-ignore
-global.fetch = fetch;
-// @ts-ignore
-global.Headers = Headers;
 
 export default AuthClient;
 export * from './lib/client';

--- a/packages/fxa-auth-client/tsconfig.base.json
+++ b/packages/fxa-auth-client/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "types": ["mocha"]
+    "types": ["mocha", "node"]
   },
   "include": ["./lib/**/*", "./server.ts"],
   "exclude": ["dist", "node_modules"]

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -417,8 +417,7 @@ export class AccountHandler {
               service: form.service || query.service,
             });
           } else {
-            console.debug('falling back')
-            const sent = await this.mailer.sendVerifyEmail([], account, {
+            await this.mailer.sendVerifyEmail([], account, {
               code: account.emailCode,
               service: form.service || query.service,
               redirectTo: form.redirectTo,
@@ -440,7 +439,6 @@ export class AccountHandler {
               uaDeviceType: sessionToken.uaDeviceType,
               uid: sessionToken.uid,
             });
-            console.debug('falling back sent!', sent);
           }
         }
       }
@@ -2321,12 +2319,21 @@ export const accountRoutes = (
     statsd,
     authServerCacheRedis
   );
+
+  // Enable CORS credentials only when using explicit origins (not wildcard, per CORS spec)
+  const enableCredentials = config.corsOrigin && config.corsOrigin[0] !== '*';
+
   const routes = [
     {
       method: 'POST',
       path: '/account/create',
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_CREATE_POST,
+        ...(enableCredentials && {
+          cors: {
+            credentials: true,
+          },
+        }),
         validate: {
           query: isA.object({
             keys: isA.boolean().optional().description(DESCRIPTION.keys),

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -79,6 +79,9 @@ module.exports = function (
       : db.updatePasswordForgotToken(passwordForgotToken);
   }
 
+  // Enable CORS credentials only when using explicit origins (not wildcard, per CORS spec)
+  const enableCredentials = config.corsOrigin && config.corsOrigin[0] !== '*';
+
   const routes = [
     {
       method: 'POST',
@@ -995,6 +998,11 @@ module.exports = function (
       path: '/password/forgot/send_otp',
       options: {
         ...PASSWORD_DOCS.PASSWORD_FORGOT_SEND_OTP_POST,
+        ...(enableCredentials && {
+          cors: {
+            credentials: true,
+          },
+        }),
         validate: {
           query: isA.object({
             service: validators.service.description(DESCRIPTION.serviceRP),

--- a/yarn.lock
+++ b/yarn.lock
@@ -22944,7 +22944,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.5.7, @types/node-fetch@npm:^2.6.1, @types/node-fetch@npm:^2.6.4":
+"@types/node-fetch@npm:^2.6.1, @types/node-fetch@npm:^2.6.4":
   version: 2.6.12
   resolution: "@types/node-fetch@npm:2.6.12"
   dependencies:
@@ -35436,7 +35436,6 @@ __metadata:
     "@types/fast-text-encoding": "npm:^1"
     "@types/mocha": "npm:^10"
     "@types/node": "npm:^22.13.5"
-    "@types/node-fetch": "npm:^2.5.7"
     "@types/prettier": "npm:^2"
     esbuild: "npm:^0.17.15"
     esbuild-register: "npm:^3.5.0"
@@ -35444,7 +35443,6 @@ __metadata:
     eslint-config-react-app: "npm:^7.0.1"
     fast-text-encoding: "npm:^1.0.4"
     mocha: "npm:^10.4.0"
-    node-fetch: "npm:^2.6.7"
     prettier: "npm:^3.5.3"
     typescript: "npm:5.5.3"
   languageName: unknown


### PR DESCRIPTION
## Because

- WAF challenge cookies are not forwarded cross-domain

## This pull request

- sets the "include credentials" flag to enable cross-domain cookies for certain endpoints

## Issue that this pull request solves

Closes: FXA-12977

## Notes
The global polyfill node-fetch was involved with test failures, possibly due to credentials handling.  Rather than try to an obsolete dependency work, I replaced it with native fetch, available since node 18.  

A nice-to-have might be to expose the WAF-challenge endpoints as a var.  Maybe this can be prioritized in the future if more endpoints are added.