### PR TITLE
feat(payments-next): Update email reminder logic

### DIFF
--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.mjml
@@ -18,7 +18,7 @@
       </span>
     </mj-text>
 
-    <% if (locals.hadDiscount) { %>
+    <% if (locals.discountEnding) { %>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionRenewalReminder-content-discount-ending">
         Because a previous discount has ended, your subscription will renew at the standard price.

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.stories.ts
@@ -18,7 +18,7 @@ const data = {
   reminderLength: '7',
   subscriptionSupportUrl: 'http://localhost:3030/support',
   updateBillingUrl: 'http://localhost:3030/subscriptions',
-  hadDiscount: false,
+  discountEnding: false,
   hasDifferentDiscount: false,
 };
 
@@ -36,7 +36,7 @@ export const MonthlyPlanNoDiscount = createStory(
 
 export const MonthlyPlanDiscountEnding = createStory(
   {
-    hadDiscount: true,
+    discountEnding: true,
   },
   'Monthly Plan - Discount Ending'
 );
@@ -47,7 +47,7 @@ export const YearlyPlanNoDiscount = createStory(
     planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$199.99',
-    hadDiscount: false,
+    discountEnding: false,
   },
   'Yearly Plan - No Discount'
 );
@@ -58,7 +58,7 @@ export const YearlyPlanDiscountEnding = createStory(
     planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$199.99',
-    hadDiscount: true,
+    discountEnding: true,
     hasDifferentDiscount: false,
   },
   'Yearly Plan - Discount Ending'
@@ -66,7 +66,7 @@ export const YearlyPlanDiscountEnding = createStory(
 
 export const MonthlyPlanDiscountChanging = createStory(
   {
-    hadDiscount: true,
+    discountEnding: true,
     hasDifferentDiscount: true,
     invoiceTotal: '$14.00',
   },
@@ -79,7 +79,7 @@ export const YearlyPlanDiscountChanging = createStory(
     planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$139.99',
-    hadDiscount: true,
+    discountEnding: true,
     hasDifferentDiscount: true,
   },
   'Yearly Plan - Discount Changing'

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.ts
@@ -14,7 +14,7 @@ export type TemplateData = SubscriptionSupportContactTemplateData &
     reminderLength: string;
     subscriptionSupportUrl: string;
     updateBillingUrl: string;
-    hadDiscount?: boolean;
+    discountEnding?: boolean;
     hasDifferentDiscount?: boolean;
   };
 

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.txt
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/index.txt
@@ -6,7 +6,7 @@ subscriptionRenewalReminder-content-greeting = "Dear <%- productName %> customer
 
 subscriptionRenewalReminder-content-intro = "Your current subscription is set to automatically renew in <%- reminderLength %> days."
 
-<% if (locals.hadDiscount) { %>
+<% if (locals.discountEnding) { %>
 subscriptionRenewalReminder-content-discount-ending = "Because a previous discount has ended, your subscription will renew at the standard price."
 <% } else if (locals.hasDifferentDiscount) { %>
 subscriptionRenewalReminder-content-discount-change = "Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied."

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -3252,7 +3252,7 @@ module.exports = function (log, config, bounces, statsd) {
           message.invoiceTotalCurrency,
           message.acceptLanguage
         ),
-        hadDiscount: message.hadDiscount || false,
+        discountEnding: message.discountEnding || false,
         hasDifferentDiscount: message.hasDifferentDiscount || false,
       },
     });

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.mjml
@@ -18,7 +18,7 @@
       </span>
     </mj-text>
 
-    <% if (hadDiscount) { %>
+    <% if (discountEnding) { %>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionRenewalReminder-content-discount-ending">
         Because a previous discount has ended, your subscription will renew at the standard price.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.stories.ts
@@ -20,7 +20,7 @@ const createStory = subplatStoryWithProps(
     reminderLength: '7',
     subscriptionSupportUrl: 'http://localhost:3030/support',
     updateBillingUrl: 'http://localhost:3030/subscriptions',
-    hadDiscount: false,
+    discountEnding: false,
     hasDifferentDiscount: false,
   }
 );
@@ -32,7 +32,7 @@ export const MonthlyPlanNoDiscount = createStory(
 
 export const MonthlyPlanDiscountEnding = createStory(
   {
-    hadDiscount: true,
+    discountEnding: true,
   },
   'Monthly Plan - Discount Ending'
 );
@@ -43,7 +43,7 @@ export const YearlyPlanNoDiscount = createStory(
     planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$199.99',
-    hadDiscount: false,
+    discountEnding: false,
   },
   'Yearly Plan - No Discount'
 );
@@ -54,7 +54,7 @@ export const YearlyPlanDiscountEnding = createStory(
     planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$199.99',
-    hadDiscount: true,
+    discountEnding: true,
     hasDifferentDiscount: false,
   },
   'Yearly Plan - Discount Ending'
@@ -62,7 +62,7 @@ export const YearlyPlanDiscountEnding = createStory(
 
 export const MonthlyPlanDiscountChanging = createStory(
   {
-    hadDiscount: true,
+    discountEnding: true,
     hasDifferentDiscount: true,
     invoiceTotal: '$14.00',
   },
@@ -75,7 +75,7 @@ export const YearlyPlanDiscountChanging = createStory(
     planIntervalCount: '1',
     reminderLength: '15',
     invoiceTotal: '$139.99',
-    hadDiscount: true,
+    discountEnding: true,
     hasDifferentDiscount: true,
   },
   'Yearly Plan - Discount Changing'

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/index.txt
@@ -6,7 +6,7 @@ subscriptionRenewalReminder-content-greeting = "Dear <%- productName %> customer
 
 subscriptionRenewalReminder-content-intro = "Your current subscription is set to automatically renew in <%- reminderLength %> days."
 
-<% if (hadDiscount) { %>
+<% if (discountEnding) { %>
 subscriptionRenewalReminder-content-discount-ending = "Because a previous discount has ended, your subscription will renew at the standard price."
 <% } else if (hasDifferentDiscount) { %>
 subscriptionRenewalReminder-content-discount-change = "Your next invoice reflects a change in pricing, as a previous discount has ended and a new discount has been applied."

--- a/packages/fxa-auth-server/scripts/subscription-reminders.ts
+++ b/packages/fxa-auth-server/scripts/subscription-reminders.ts
@@ -37,7 +37,7 @@ async function init() {
       DEFAULT_PLAN_LENGTH.toString()
     )
     .option(
-      '-r, --reminder-length [days]',
+      '-r, --monthly-renewal-reminder-length [days]',
       'Reminder length in days before the renewal date to send the reminder email for monthly plans. Defaults to 7.',
       DEFAULT_REMINDER_LENGTH.toString()
     )

--- a/packages/fxa-auth-server/test/local/senders/emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/emails.ts
@@ -3921,7 +3921,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       updateTemplateValues: (x) => ({
         ...x,
         productName: MESSAGE.subscription.productName,
-        hadDiscount: true,
+        discountEnding: true,
         hasDifferentDiscount: false,
       }),
     },
@@ -4067,7 +4067,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       updateTemplateValues: (x) => ({
         ...x,
         productName: MESSAGE.subscription.productName,
-        hadDiscount: false,
+        discountEnding: false,
         hasDifferentDiscount: true,
       }),
     },


### PR DESCRIPTION
Because:

* We need to send emails at 15 days prior to billing for annual plans
* We need to send emails at 7 days prior to billing for monthly plans that have an ending discount and are returning to full price

This commit:

* Updates the logic to check whether a customer has an persisting discount for a monthly plan, and does not send email reminders for those plans
* Renames the `hadDiscount` variable to `discountEnding` to better reflect its purpose

Closes #PAY-2291 (to follow after merge of PR in webservices-infra)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


