### PR TITLE
fix(fxa-mailer): Extract email address when formatting CMS sender names

### DIFF
--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -1689,8 +1689,16 @@ export class FxaMailer extends FxaEmailRenderer {
     rendered: RenderedTemplate
   ) {
     const { cmsRpFromName, to, cc } = opts;
+    // Extract just the email address from the sender config (e.g., "Name <email@example.com>" -> "email@example.com")
+    const senderEmail =
+      this.mailerConfig.sender.indexOf('<') >= 0
+        ? this.mailerConfig.sender.substring(
+            this.mailerConfig.sender.indexOf('<') + 1,
+            this.mailerConfig.sender.indexOf('>')
+          )
+        : this.mailerConfig.sender;
     const from = cmsRpFromName
-      ? `${cmsRpFromName} <${this.mailerConfig.sender}>`
+      ? `${cmsRpFromName} <${senderEmail}>`
       : this.mailerConfig.sender;
 
     return this.emailSender.send({

--- a/packages/fxa-auth-server/test/local/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/test/local/senders/fxa-mailer.ts
@@ -1,0 +1,259 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const ROOT_DIR = '../../..';
+
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { FxaMailer } from '../../../lib/senders/fxa-mailer';
+import { EmailSender } from '@fxa/accounts/email-sender';
+import {
+  EmailLinkBuilder,
+  NodeRendererBindings,
+} from '@fxa/accounts/email-renderer';
+
+describe('lib/senders/fxa-mailer', () => {
+  let fxaMailer: FxaMailer;
+  let mockEmailSender: sinon.SinonStubbedInstance<EmailSender>;
+  let mockLinkBuilder: sinon.SinonStubbedInstance<EmailLinkBuilder>;
+  let mockBindings: NodeRendererBindings;
+  let mockConfig: any;
+
+  beforeEach(() => {
+    mockEmailSender = {
+      send: sinon.stub().resolves({
+        sent: true,
+        messageId: 'test-message-id',
+        message: 'Email sent',
+        response: '250 OK',
+      }),
+      buildHeaders: sinon.stub().returns({}),
+    } as any;
+
+    mockLinkBuilder = {
+      buildPrivacyLink: sinon.stub().returns('https://privacy.link'),
+      buildSupportLink: sinon.stub().returns('https://support.link'),
+      buildPasswordChangeLink: sinon.stub().returns('https://password.link'),
+      buildAccountSettingsLink: sinon.stub().returns('https://settings.link'),
+      buildMozillaSupportUrl: sinon.stub().returns('https://mozilla.support'),
+    } as any;
+
+    mockBindings = {} as any;
+
+    mockConfig = {
+      sender: 'Firefox Accounts <accounts@firefox.com>',
+      fxaMailerDisableSend: [],
+    };
+
+    fxaMailer = new FxaMailer(
+      mockEmailSender as any,
+      mockLinkBuilder as any,
+      mockConfig,
+      mockBindings
+    );
+  });
+
+  describe('sendNewDeviceLoginEmail', () => {
+    describe('with cmsRpFromName', () => {
+      it('should extract email address from sender config', async () => {
+        const opts = {
+          to: 'user@example.com',
+          uid: 'test-uid',
+          metricsEnabled: true,
+          acceptLanguage: 'en',
+          timeZone: 'America/New_York',
+          cmsRpFromName: 'Mozilla AI',
+          clientName: 'Test Client',
+          device: 'Firefox on Mac',
+          time: '10:00 AM',
+          date: 'January 1, 2026',
+          location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
+          showBannerWarning: false,
+        };
+
+        // Mock the rendering method
+        sinon.stub(fxaMailer as any, 'renderNewDeviceLogin').resolves({
+          subject: 'New sign-in to Test Client',
+          html: '<html>test</html>',
+          text: 'test',
+          preview: 'test preview',
+        });
+
+        await fxaMailer.sendNewDeviceLoginEmail(opts);
+
+        assert.isTrue(mockEmailSender.send.calledOnce);
+        const sendArgs = mockEmailSender.send.getCall(0).args[0];
+
+        // Should be "Mozilla AI <accounts@firefox.com>" not "Mozilla AI <Firefox Accounts <accounts@firefox.com>>"
+        assert.equal(sendArgs.from, 'Mozilla AI <accounts@firefox.com>');
+        assert.equal(sendArgs.to, 'user@example.com');
+      });
+
+      it('should work with Firefox relying party name', async () => {
+        const opts = {
+          to: 'user@example.com',
+          uid: 'test-uid',
+          metricsEnabled: true,
+          acceptLanguage: 'en',
+          timeZone: 'America/New_York',
+          cmsRpFromName: 'Firefox',
+          clientName: 'Test Client',
+          device: 'Firefox on Mac',
+          time: '10:00 AM',
+          date: 'January 1, 2026',
+          location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
+          showBannerWarning: false,
+        };
+
+        sinon.stub(fxaMailer as any, 'renderNewDeviceLogin').resolves({
+          subject: 'New sign-in to Test Client',
+          html: '<html>test</html>',
+          text: 'test',
+          preview: 'test preview',
+        });
+
+        await fxaMailer.sendNewDeviceLoginEmail(opts);
+
+        assert.isTrue(mockEmailSender.send.calledOnce);
+        const sendArgs = mockEmailSender.send.getCall(0).args[0];
+        assert.equal(sendArgs.from, 'Firefox <accounts@firefox.com>');
+      });
+
+      it('should work with Mozilla VPN relying party name', async () => {
+        const opts = {
+          to: 'user@example.com',
+          uid: 'test-uid',
+          metricsEnabled: true,
+          acceptLanguage: 'en',
+          timeZone: 'America/New_York',
+          cmsRpFromName: 'Mozilla VPN',
+          clientName: 'Test Client',
+          device: 'Firefox on Mac',
+          time: '10:00 AM',
+          date: 'January 1, 2026',
+          location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
+          showBannerWarning: false,
+        };
+
+        sinon.stub(fxaMailer as any, 'renderNewDeviceLogin').resolves({
+          subject: 'New sign-in to Test Client',
+          html: '<html>test</html>',
+          text: 'test',
+          preview: 'test preview',
+        });
+
+        await fxaMailer.sendNewDeviceLoginEmail(opts);
+
+        assert.isTrue(mockEmailSender.send.calledOnce);
+        const sendArgs = mockEmailSender.send.getCall(0).args[0];
+        assert.equal(sendArgs.from, 'Mozilla VPN <accounts@firefox.com>');
+      });
+    });
+
+    describe('without cmsRpFromName', () => {
+      it('should use full sender config', async () => {
+        const opts = {
+          to: 'user@example.com',
+          uid: 'test-uid',
+          metricsEnabled: true,
+          acceptLanguage: 'en',
+          timeZone: 'America/New_York',
+          clientName: 'Test Client',
+          device: 'Firefox on Mac',
+          time: '10:00 AM',
+          date: 'January 1, 2026',
+          location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
+          showBannerWarning: false,
+        };
+
+        sinon.stub(fxaMailer as any, 'renderNewDeviceLogin').resolves({
+          subject: 'New sign-in to Test Client',
+          html: '<html>test</html>',
+          text: 'test',
+          preview: 'test preview',
+        });
+
+        await fxaMailer.sendNewDeviceLoginEmail(opts);
+
+        assert.isTrue(mockEmailSender.send.calledOnce);
+        const sendArgs = mockEmailSender.send.getCall(0).args[0];
+        // Should use the full configured sender
+        assert.equal(sendArgs.from, 'Firefox Accounts <accounts@firefox.com>');
+      });
+    });
+
+    describe('with sender config without angle brackets', () => {
+      it('should handle plain email address sender', async () => {
+        // Test when sender is just an email address without a display name
+        mockConfig.sender = 'noreply@firefox.com';
+        fxaMailer = new FxaMailer(
+          mockEmailSender as any,
+          mockLinkBuilder as any,
+          mockConfig,
+          mockBindings
+        );
+
+        const opts = {
+          to: 'user@example.com',
+          uid: 'test-uid',
+          metricsEnabled: true,
+          acceptLanguage: 'en',
+          timeZone: 'America/New_York',
+          cmsRpFromName: 'Mozilla Monitor',
+          clientName: 'Test Client',
+          device: 'Firefox on Mac',
+          time: '10:00 AM',
+          date: 'January 1, 2026',
+          location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
+          showBannerWarning: false,
+        };
+
+        sinon.stub(fxaMailer as any, 'renderNewDeviceLogin').resolves({
+          subject: 'New sign-in to Test Client',
+          html: '<html>test</html>',
+          text: 'test',
+          preview: 'test preview',
+        });
+
+        await fxaMailer.sendNewDeviceLoginEmail(opts);
+
+        assert.isTrue(mockEmailSender.send.calledOnce);
+        const sendArgs = mockEmailSender.send.getCall(0).args[0];
+        // Should be "Mozilla Monitor <noreply@firefox.com>"
+        assert.equal(sendArgs.from, 'Mozilla Monitor <noreply@firefox.com>');
+      });
+    });
+  });
+
+  describe('canSend', () => {
+    it('should return true when template is not in disable list', () => {
+      assert.isTrue(fxaMailer.canSend('newDeviceLogin'));
+    });
+
+    it('should return false when template is in disable list', () => {
+      mockConfig.fxaMailerDisableSend = ['newDeviceLogin'];
+      fxaMailer = new FxaMailer(
+        mockEmailSender as any,
+        mockLinkBuilder as any,
+        mockConfig,
+        mockBindings
+      );
+
+      assert.isFalse(fxaMailer.canSend('newDeviceLogin'));
+    });
+
+    it('should return true for different template when one is disabled', () => {
+      mockConfig.fxaMailerDisableSend = ['verifyLogin'];
+      fxaMailer = new FxaMailer(
+        mockEmailSender as any,
+        mockLinkBuilder as any,
+        mockConfig,
+        mockBindings
+      );
+
+      assert.isFalse(fxaMailer.canSend('verifyLogin'));
+      assert.isTrue(fxaMailer.canSend('newDeviceLogin'));
+    });
+  });
+});


### PR DESCRIPTION
## Because

  * When sending newDeviceLogin emails with CMS-configured relying party names (cmsRpFromName), the sender was constructed as "Mozilla AI <Firefox Accounts <accounts@firefox.com>>" with nested angle brackets
  * Email clients parsed this incorrectly, displaying sender names like "Mozilla AI>" or "Firefox>" with a stray ">" character
  * This affected all CMS-configured relying parties including Mozilla AI, Firefox, Mozilla VPN, etc.

## This pull request

  * Extracts just the email address portion from the configured sender before constructing the from field with cmsRpFromName
  * Uses the same email extraction logic as the legacy email.js mailer
  * Results in properly formatted sender addresses like "Mozilla AI <accounts@firefox.com>"
  * Adds comprehensive test coverage for the sender formatting logic including edge cases

## Issue that this pull request solves

Closes: FXA-13029

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Examples with local customization, emails viewed with maildev

Before
<img width="580" height="246" alt="image" src="https://github.com/user-attachments/assets/a25d7214-c7fa-40a2-a355-bfac95c4f12a" />

After
<img width="504" height="234" alt="image" src="https://github.com/user-attachments/assets/b8fac46c-4517-4d3b-8de6-6a6bea2b3318" />


## Other information (Optional)

Requirements to test:
- need to run fxa-strapi locally and add a customization for:
  - entrypoint: fxa_avatar_menu
  - client_id: 5882386c6d801776
  - Make sure to set a custom `emailFromName`
- use dev-launcher to start a local instance of Firefox
- create an account with sync (make sure customization is loaded)
- sign out
- sign in to sync with the account and look for the New device sign in email

Expected result:
On main, the custom email sender shows up with a stray `>`
In this branch, there is no stray `>`
