### PR TITLE
fix(fxa-settings): clean up noisy test output across test suite in fxa-settings

### DIFF
--- a/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormPhoneNumber/index.test.tsx
@@ -21,21 +21,23 @@ describe('FormPhoneNumber', () => {
     });
   }
 
-  function renderWithInfoBannerProps() {
-    renderWithLocalizationProvider(
-      <FormPhoneNumber
-        localizedCTAText="Send code"
-        submitPhoneNumber={mockSubmit}
-        infoBannerContent={{
-          localizedDescription: 'This is a banner description',
-          localizedHeading: 'This is a banner heading',
-        }}
-        infoBannerLink={{
-          localizedText: 'This is a banner link',
-          path: '#',
-        }}
-      />
-    );
+  async function renderWithInfoBannerProps() {
+    await act(async () => {
+      renderWithLocalizationProvider(
+        <FormPhoneNumber
+          localizedCTAText="Send code"
+          submitPhoneNumber={mockSubmit}
+          infoBannerContent={{
+            localizedDescription: 'This is a banner description',
+            localizedHeading: 'This is a banner heading',
+          }}
+          infoBannerLink={{
+            localizedText: 'This is a banner link',
+            path: '#',
+          }}
+        />
+      );
+    });
   }
 
   function getPhoneInput() {
@@ -59,7 +61,7 @@ describe('FormPhoneNumber', () => {
   });
 
   it('renders the component with info banner', async () => {
-    renderWithInfoBannerProps();
+    await renderWithInfoBannerProps();
     await waitFor(() => {
       expect(screen.getByRole('combobox')).toBeInTheDocument();
     });

--- a/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.test.tsx
+++ b/packages/fxa-settings/src/components/RecoveryKeySetupDownload/index.test.tsx
@@ -30,7 +30,7 @@ describe('RecoveryKeySetupDownload', () => {
         const b = screen.getByRole('button', { name: 'Download and continue' });
         expect(b).toBeInTheDocument();
       },
-      { timeout: 2000 }
+      { timeout: 5000 }
     );
 
     screen.getByRole('button', {

--- a/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/FlowSetupRecoveryPhoneSubmitNumber/index.test.tsx
@@ -41,7 +41,7 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
    * @param props
    */
   async function renderWith(props = defaultProps) {
-    await act(() => {
+    await act(async () => {
       renderWithLocalizationProvider(
         <FlowSetupRecoveryPhoneSubmitNumber {...props} />
       );
@@ -85,7 +85,7 @@ describe('FlowSetupRecoveryPhoneSubmitNumber', () => {
         '1231231234'
       )
     );
-    user.click(screen.getByRole('button', { name: /Send code/i }));
+    await user.click(screen.getByRole('button', { name: /Send code/i }));
 
     await waitFor(() => expect(mockVerifyPhoneNumber).toHaveBeenCalledTimes(1));
     expect(mockNavigateForward).toHaveBeenCalledTimes(1);

--- a/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ModalMfaProtected/index.test.tsx
@@ -24,10 +24,13 @@ const defaultProps = {
 };
 
 describe('ModalMfaProtected', () => {
-  it('renders correctly', () => {
+  it('renders correctly', async () => {
     renderWithRouter(<ModalMfaProtected {...defaultProps} />);
 
-    expect(screen.getByText('Enter confirmation code')).toBeInTheDocument();
+    // Await to let react-hook-form's internal state updates settle.
+    expect(
+      await screen.findByText('Enter confirmation code')
+    ).toBeInTheDocument();
     expect(
       screen.getByText('Help us make sure it’s you changing your account info')
     ).toBeInTheDocument();
@@ -119,22 +122,22 @@ describe('ModalMfaProtected', () => {
     expect(onDismiss).toHaveBeenCalled();
   });
 
-  it('displays error banner', () => {
+  it('displays error banner', async () => {
     renderWithRouter(
       <ModalMfaProtected
         {...defaultProps}
         localizedErrorBannerMessage="error banner"
       />
     );
-    expect(screen.getByText('error banner')).toBeInTheDocument();
+    expect(await screen.findByText('error banner')).toBeInTheDocument();
   });
 
-  it('shows code resend success banner', () => {
+  it('shows code resend success banner', async () => {
     renderWithRouter(
       <ModalMfaProtected {...defaultProps} showResendSuccessBanner={true} />
     );
     expect(
-      screen.getByText('A new code was sent to your email.')
+      await screen.findByText('A new code was sent to your email.')
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageRecentActivity/index.tsx
@@ -33,8 +33,8 @@ export const PageRecentActivity = (_: RouteComponentProps) => {
         {!!securityEvents &&
           securityEvents.map((securityEvent) => (
             <SecurityEventSection
+              key={securityEvent.name + securityEvent.createdAt}
               {...{
-                key: securityEvent.name + securityEvent.createdAt,
                 name: securityEvent.name,
                 createdAt: securityEvent.createdAt,
               }}

--- a/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/ThirdPartyAuth/index.test.tsx
@@ -57,9 +57,7 @@ function renderWith(props?: any) {
 }
 
 const mockFormSubmit = jest.fn();
-// This prevents console errors when the deepLink logic is tested.
-// However, for some reason we cannot mock `requestSubmit` and we'll
-// still see errors logged for that.
+// jsdom does not implement HTMLFormElement.prototype.submit.
 HTMLFormElement.prototype.submit = mockFormSubmit;
 
 describe('ThirdPartyAuthComponent', () => {

--- a/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useFxAStatus/index.test.tsx
@@ -140,7 +140,10 @@ describe('useFxAStatus', () => {
           isSync: () => true,
           isFirefoxNonSync: () => false,
         };
-        const { result } = renderHook(() => useFxAStatus(integration));
+        const { result, waitForNextUpdate } = renderHook(() =>
+          useFxAStatus(integration)
+        );
+        await waitForNextUpdate();
         expect(result.current.supportsKeysOptionalLogin).toBe(false);
       });
     });

--- a/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks/useOAuthFlowRecovery/index.test.tsx
@@ -142,6 +142,7 @@ describe('useOAuthFlowRecovery', () => {
   });
 
   it('sets recoveryFailed when fxaOAuthFlowBegin throws', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     (firefox.fxaOAuthFlowBegin as jest.Mock).mockRejectedValue(
       new Error('WebChannel error')
     );

--- a/packages/fxa-settings/src/models/contexts/NimbusContext.test.tsx
+++ b/packages/fxa-settings/src/models/contexts/NimbusContext.test.tsx
@@ -221,11 +221,13 @@ describe('NimbusContext', () => {
 
       renderWithProviders(previewConfig);
 
-      expect(mockInitializeNimbus).toHaveBeenCalledWith(
-        'test-user-id',
-        true,
-        { language: 'en', region: 'us' }
-      );
+      await waitFor(() => {
+        expect(mockInitializeNimbus).toHaveBeenCalledWith(
+          'test-user-id',
+          true,
+          { language: 'en', region: 'us' }
+        );
+      });
     });
 
     it('handles preview mode from URL params', async () => {
@@ -236,11 +238,13 @@ describe('NimbusContext', () => {
 
       renderWithProviders();
 
-      expect(mockInitializeNimbus).toHaveBeenCalledWith(
-        'test-user-id',
-        true,
-        { language: 'en', region: 'us' }
-      );
+      await waitFor(() => {
+        expect(mockInitializeNimbus).toHaveBeenCalledWith(
+          'test-user-id',
+          true,
+          { language: 'en', region: 'us' }
+        );
+      });
     });
 
     it('cleans up on unmount', async () => {

--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -7,7 +7,7 @@ import * as IndexModule from './index';
 import * as ReactUtils from 'fxa-react/lib/utils';
 import * as cache from '../../lib/cache';
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { LocationProvider } from '@reach/router';
 import { useValidatedQueryParams } from '../../lib/hooks/useValidate';
 import { Integration, IntegrationType, WebIntegration } from '../../models';
@@ -204,7 +204,7 @@ describe('IndexContainer', () => {
     jest.resetAllMocks();
   });
 
-  it('should check query parameters', () => {
+  it('should check query parameters', async () => {
     const { container } = renderWithLocalizationProvider(
       <LocationProvider>
         <IndexContainer
@@ -217,10 +217,12 @@ describe('IndexContainer', () => {
       </LocationProvider>
     );
     expect(container).toBeDefined();
-    expect(mockUseValidatedQueryParams).toHaveBeenCalledWith(
-      IndexQueryParams,
-      false
-    );
+    await waitFor(() => {
+      expect(mockUseValidatedQueryParams).toHaveBeenCalledWith(
+        IndexQueryParams,
+        false
+      );
+    });
   });
 
   it('should render the Index component when no redirection is required', async () => {
@@ -895,7 +897,9 @@ describe('IndexContainer', () => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
         });
 
-        await currentIndexProps?.processEmailSubmission(MOCK_EMAIL);
+        await act(async () => {
+          await currentIndexProps?.processEmailSubmission(MOCK_EMAIL);
+        });
 
         await waitFor(() => {
           expect(firefox.fxaCanLinkAccount).toHaveBeenCalledTimes(1);
@@ -928,7 +932,9 @@ describe('IndexContainer', () => {
         await waitFor(() => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
         });
-        await currentIndexProps?.processEmailSubmission(MOCK_EMAIL);
+        await act(async () => {
+          await currentIndexProps?.processEmailSubmission(MOCK_EMAIL);
+        });
 
         await waitFor(() => {
           expect(firefox.fxaCanLinkAccount).toHaveBeenCalledTimes(1);
@@ -961,7 +967,9 @@ describe('IndexContainer', () => {
           expect(currentIndexProps?.processEmailSubmission).toBeDefined();
         });
 
-        await currentIndexProps?.processEmailSubmission(MOCK_EMAIL);
+        await act(async () => {
+          await currentIndexProps?.processEmailSubmission(MOCK_EMAIL);
+        });
 
         await waitFor(() => {
           expect(firefox.fxaCanLinkAccount).toHaveBeenCalled();

--- a/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
+++ b/packages/fxa-settings/src/pages/InlineRecoverySetupFlow/container.test.tsx
@@ -217,15 +217,19 @@ describe('InlineRecoverySetupContainer', () => {
       });
     });
 
-    it('redirects when there is no signin state', () => {
+    it('redirects when there is no signin state', async () => {
       render();
-      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+      });
     });
 
-    it('redirects when there is no totp token', () => {
+    it('redirects when there is no totp token', async () => {
       mockLocationState = MOCK_SIGNIN_LOCATION_STATE;
       render();
-      expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(`/signup${search}`);
+      });
     });
 
     it('redirects when totp is already active', async () => {
@@ -242,12 +246,14 @@ describe('InlineRecoverySetupContainer', () => {
       mockLocationState = MOCK_SIGNIN_RECOVERY_LOCATION_STATE;
 
       render();
-      expect(mockNavigateHook).toHaveBeenCalledWith(
-        `/signin_totp_code${search}`,
-        {
-          state: MOCK_SIGNIN_LOCATION_STATE,
-        }
-      );
+      await waitFor(() => {
+        expect(mockNavigateHook).toHaveBeenCalledWith(
+          `/signin_totp_code${search}`,
+          {
+            state: MOCK_SIGNIN_LOCATION_STATE,
+          }
+        );
+      });
     });
   });
 
@@ -324,9 +330,11 @@ describe('InlineRecoverySetupContainer', () => {
 
     it('reads data from sensitive data client', async () => {
       render();
-      expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
-        SensitiveData.Key.Auth
-      );
+      await waitFor(() => {
+        expect(mockSensitiveDataClient.getDataType).toHaveBeenCalledWith(
+          SensitiveData.Key.Auth
+        );
+      });
     });
 
     describe('callbacks', () => {

--- a/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
+++ b/packages/fxa-settings/src/pages/PostVerify/SetPassword/container.test.tsx
@@ -195,7 +195,9 @@ describe('SetPassword-container', () => {
     mockCurrentAccount(storedAccount);
 
     render();
-    expect(mockNavigate).toHaveBeenCalledWith('/signin', { replace: true });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/signin', { replace: true });
+    });
     expect(SetPasswordModule.default).not.toHaveBeenCalled();
   });
 

--- a/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
+++ b/packages/fxa-settings/src/pages/ResetPassword/CompleteResetPassword/container.tsx
@@ -208,7 +208,6 @@ const CompleteResetPasswordContainer = ({
         undefined,
         includeRecoveryKeyPrompt
       );
-    console.log('accountResetData', accountResetData);
     return accountResetData;
   };
 

--- a/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninUnblock/container.test.tsx
@@ -276,7 +276,7 @@ describe('signin unblock container', () => {
   });
 
   it('handles signin with correct code and failure when looking up credential status', async () => {
-    jest.spyOn(global.console, 'warn');
+    jest.spyOn(global.console, 'warn').mockImplementation(() => {});
 
     await render([
       {

--- a/packages/fxa-settings/src/pages/Signin/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/container.test.tsx
@@ -1000,6 +1000,7 @@ describe('signin container', () => {
       });
 
       it('handles error when starting upgrade', async () => {
+        jest.spyOn(console, 'info').mockImplementation(() => {});
         render([
           mockGqlAvatarUseQuery(),
           mockGqlCredentialStatusMutation({

--- a/packages/fxa-settings/src/pages/Signup/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signup/index.test.tsx
@@ -257,8 +257,11 @@ describe('Signup page', () => {
       />
     );
 
+    // Await to let react-hook-form's internal state updates settle.
     expect(
-      screen.queryByAltText(MOCK_CMS_INFO.SignupSetPasswordPage.logoAltText)
+      await screen.findByAltText(
+        MOCK_CMS_INFO.SignupSetPasswordPage.logoAltText
+      )
     ).toBeInTheDocument();
 
     expect(screen.queryByLabelText('Repeat password')).not.toBeInTheDocument();
@@ -286,6 +289,9 @@ describe('Signup page', () => {
         isMobile={true}
       />
     );
+
+    // Await to let react-hook-form's internal state updates settle.
+    await screen.findByRole('heading', { name: 'Create a password' });
 
     expect(
       screen.queryByAltText(MOCK_CMS_INFO.SignupSetPasswordPage.logoAltText)
@@ -318,8 +324,9 @@ describe('Signup page', () => {
         )}
       />
     );
+    // Await to let react-hook-form's internal state updates settle.
     expect(
-      screen.queryByAltText(MOCK_CMS_INFO.shared.logoAltText)
+      await screen.findByAltText(MOCK_CMS_INFO.shared.logoAltText)
     ).toBeInTheDocument();
     expect(
       screen

--- a/packages/fxa-settings/src/setupTests.tsx
+++ b/packages/fxa-settings/src/setupTests.tsx
@@ -22,6 +22,39 @@ Object.defineProperty(global, 'crypto', {
   },
 });
 
+// Suppress noisy console output during tests.
+// - Glean SDK telemetry pings and init warnings
+// - Model validation warnings from tests with intentionally invalid data
+// - Apollo cache warnings from incomplete mock data
+//
+// Set SHOW_CONSOLE_NOISE=1 to disable filtering for debugging:
+//   SHOW_CONSOLE_NOISE=1 yarn test --watchAll=false
+if (!process.env.SHOW_CONSOLE_NOISE) {
+  const wrap = <T extends (...args: any[]) => void>(
+    fn: T,
+    filter: (msg: string) => boolean
+  ): T =>
+    ((...args: any[]) => {
+      if (filter(String(args[0]))) return;
+      fn(...args);
+    }) as unknown as T;
+
+  const isGlean = (m: string) => m.includes('(Glean');
+  const isModelValidation = (m: string) =>
+    m.includes('Model Validation Errors');
+  const isMissingField = (m: string) => m.includes('Missing field');
+  // jsdom does not implement requestSubmit; this is a known limitation
+  // that produces noisy errors when clicking submit buttons in tests.
+  const isJsdomNotImplemented = (m: string) =>
+    m.includes('Not implemented: HTMLFormElement.prototype.requestSubmit');
+
+  console.info = wrap(console.info, isGlean);
+  console.warn = wrap(console.warn, (m) => isGlean(m) || isModelValidation(m));
+  console.error = wrap(console.error, (m) =>
+    isMissingField(m) || isJsdomNotImplemented(m)
+  );
+}
+
 jest.mock('fxa-react/lib/utils', () => {
   const originalModule = jest.requireActual('fxa-react/lib/utils');
 


### PR DESCRIPTION
## Because

- The fxa-settings tests were very noisy which polluted the context window making it harder to iterate and debug actual test errors
- It was annoying

## This pull request

- Fix act() warnings by using async findBy* queries, waitFor wrappers, and act() around direct async callback calls in tests affected by react-hook-form and async useEffect state updates
- Suppress jsdom requestSubmit not-implemented errors in setupTests.tsx
- Suppress expected console output in error-path tests with mockImplementation
- Fix React key-in-spread warning in PageRecentActivity component
- Remove leftover debug console.log in CompleteResetPassword container
- Use deterministic Date.now spy for MfaGuard debounce test


## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-10364

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

<img width="641" height="2895" alt="Screenshot 2026-02-05 at 9 50 36 PM" src="https://github.com/user-attachments/assets/2602613e-c104-4075-bff1-b36c23698e16" />

