### PR TITLE
feat(fxa-auth-server): Migrate more auth-server unit tests to jest

### DIFF
--- a/packages/fxa-auth-server/jest.config.js
+++ b/packages/fxa-auth-server/jest.config.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   testTimeout: 10000,
   clearMocks: true,
-  setupFiles: ['<rootDir>/jest.setup.js'],
+  setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/jest.setup-proxyquire.js'],
   testPathIgnorePatterns: ['/node_modules/'],
   // Coverage configuration (enabled via --coverage flag)
   collectCoverageFrom: [

--- a/packages/fxa-auth-server/jest.setup-proxyquire.js
+++ b/packages/fxa-auth-server/jest.setup-proxyquire.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Fix for proxyquire not finding .ts files under Jest/ts-jest.
+ * proxyquire uses resolve.sync() which defaults to only .js extensions.
+ * This patches resolve.sync to also look for .ts files.
+ */
+
+const resolve = require('resolve');
+const originalSync = resolve.sync;
+resolve.sync = function(id, opts) {
+  opts = opts || {};
+  if (!opts.extensions || opts.extensions.length === 0) {
+    opts.extensions = ['.ts', '.tsx', '.js', '.json', '.node'];
+  }
+  return originalSync.call(this, id, opts);
+};

--- a/packages/fxa-auth-server/lib/devices.spec.ts
+++ b/packages/fxa-auth-server/lib/devices.spec.ts
@@ -1,0 +1,771 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+import sinon from 'sinon';
+
+const crypto = require('crypto');
+const mocks = require('../test/mocks');
+const { AppError: error } = require('@fxa/accounts/errors');
+const uuid = require('uuid');
+
+jest.mock('./oauth/db', () => ({
+  getRefreshToken: jest.fn(),
+  removeRefreshToken: jest.fn(),
+}));
+
+const oauthDB = require('./oauth/db');
+const devicesModule = require('./devices');
+
+interface DestroyResult {
+  sessionTokenId: string | null;
+  refreshTokenId: string | null;
+}
+
+interface DevicesModule {
+  isSpuriousUpdate(
+    payload: Record<string, unknown>,
+    token: Record<string, unknown>
+  ): boolean;
+  upsert(
+    request: unknown,
+    credentials: unknown,
+    device: unknown
+  ): Promise<Record<string, unknown>>;
+  destroy(request: unknown, deviceId: string): Promise<DestroyResult>;
+  synthesizeName(info: Record<string, string | undefined>): string;
+}
+
+describe('lib/devices:', () => {
+  describe('instantiate:', () => {
+    let log: ReturnType<typeof mocks.mockLog>,
+      deviceCreatedAt: number,
+      deviceId: string,
+      device: Record<string, unknown>,
+      db: ReturnType<typeof mocks.mockDB>,
+      push: ReturnType<typeof mocks.mockPush>,
+      devices: DevicesModule,
+      pushbox: ReturnType<typeof mocks.mockPushbox>;
+
+    beforeEach(() => {
+      log = mocks.mockLog();
+      deviceCreatedAt = Date.now();
+      deviceId = crypto.randomBytes(16).toString('hex');
+      device = {
+        name: 'foo',
+        type: 'bar',
+      };
+      db = mocks.mockDB({
+        device: device,
+        deviceCreatedAt: deviceCreatedAt,
+        deviceId: deviceId,
+      });
+      push = mocks.mockPush();
+      pushbox = mocks.mockPushbox();
+      oauthDB.getRefreshToken.mockReset();
+      oauthDB.removeRefreshToken.mockReset();
+      devices = devicesModule(log, db, push, pushbox);
+    });
+
+    it('returns the expected interface', () => {
+      expect(typeof devices).toBe('object');
+      expect(Object.keys(devices).length).toBe(4);
+
+      expect(typeof devices.isSpuriousUpdate).toBe('function');
+      expect(devices.isSpuriousUpdate.length).toBe(2);
+
+      expect(typeof devices.upsert).toBe('function');
+      expect(devices.upsert.length).toBe(3);
+
+      expect(typeof devices.destroy).toBe('function');
+      expect(devices.destroy.length).toBe(2);
+
+      expect(typeof devices.synthesizeName).toBe('function');
+      expect(devices.synthesizeName.length).toBe(1);
+    });
+
+    describe('isSpuriousUpdate:', () => {
+      it('returns false when token has no device record', () => {
+        expect(devices.isSpuriousUpdate({}, {})).toBe(false);
+      });
+
+      it('returns false when token has different device id', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo' },
+            { deviceId: 'bar' }
+          )
+        ).toBe(false);
+      });
+
+      it('returns true when ids match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo' },
+            { deviceId: 'foo' }
+          )
+        ).toBe(true);
+      });
+
+      it('returns false when token has different device name', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', name: 'foo' },
+            { deviceId: 'foo', deviceName: 'bar' }
+          )
+        ).toBe(false);
+      });
+
+      it('returns true when ids and names match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', name: 'foo' },
+            { deviceId: 'foo', deviceName: 'foo' }
+          )
+        ).toBe(true);
+      });
+
+      it('returns false when token has different device type', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', type: 'foo' },
+            { deviceId: 'foo', deviceType: 'bar' }
+          )
+        ).toBe(false);
+      });
+
+      it('returns true when ids and types match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', type: 'foo' },
+            { deviceId: 'foo', deviceType: 'foo' }
+          )
+        ).toBe(true);
+      });
+
+      it('returns false when token has different device callback URL', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', pushCallback: 'foo' },
+            { deviceId: 'foo', deviceCallbackURL: 'bar' }
+          )
+        ).toBe(false);
+      });
+
+      it('returns true when ids and callback URLs match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', pushCallback: 'foo' },
+            { deviceId: 'foo', deviceCallbackURL: 'foo' }
+          )
+        ).toBe(true);
+      });
+
+      it('returns false when token has different device callback public key', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', pushPublicKey: 'foo' },
+            { deviceId: 'foo', deviceCallbackPublicKey: 'bar' }
+          )
+        ).toBe(false);
+      });
+
+      it('returns true when ids and callback public keys match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            { id: 'foo', pushPublicKey: 'foo' },
+            { deviceId: 'foo', deviceCallbackPublicKey: 'foo' }
+          )
+        ).toBe(true);
+      });
+
+      it('returns false when payload has different available commands', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            {
+              id: 'foo',
+              availableCommands: { foo: 'bar', baz: 'qux' },
+            },
+            {
+              deviceId: 'foo',
+              deviceAvailableCommands: { foo: 'bar' },
+            }
+          )
+        ).toBe(false);
+      });
+
+      it('returns false when token has different device available commands', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            {
+              id: 'foo',
+              availableCommands: { foo: 'bar' },
+            },
+            {
+              deviceId: 'foo',
+              deviceAvailableCommands: { foo: 'bar', baz: 'qux' },
+            }
+          )
+        ).toBe(false);
+      });
+
+      it('returns true when ids and available commands match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            {
+              id: 'foo',
+              availableCommands: { foo: 'bar' },
+            },
+            {
+              deviceId: 'foo',
+              deviceAvailableCommands: { foo: 'bar' },
+            }
+          )
+        ).toBe(true);
+      });
+
+      it('returns true when all properties match', () => {
+        expect(
+          devices.isSpuriousUpdate(
+            {
+              id: 'foo',
+              name: 'bar',
+              type: 'baz',
+              pushCallback: 'wibble',
+              pushPublicKey: 'blee',
+              availableCommands: {
+                frop: 'punv',
+                thib: 'blap',
+              },
+            },
+            {
+              deviceId: 'foo',
+              deviceName: 'bar',
+              deviceType: 'baz',
+              deviceCallbackURL: 'wibble',
+              deviceCallbackPublicKey: 'blee',
+              deviceAvailableCommands: {
+                frop: 'punv',
+                thib: 'blap',
+              },
+            }
+          )
+        ).toBe(true);
+      });
+    });
+
+    describe('upsert:', () => {
+      let request: ReturnType<typeof mocks.mockRequest>;
+      let credentials: { id: string; uid: string; tokenVerified: boolean };
+
+      beforeEach(() => {
+        request = mocks.mockRequest({
+          log: log,
+        });
+        credentials = {
+          id: crypto.randomBytes(16).toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+          tokenVerified: true,
+        };
+      });
+
+      it('should create', () => {
+        return devices.upsert(request, credentials, device).then((result) => {
+          expect(result).toEqual({
+            id: deviceId,
+            name: device.name,
+            type: device.type,
+            createdAt: deviceCreatedAt,
+          });
+
+          expect(db.updateDevice.callCount).toBe(0);
+
+          expect(db.createDevice.callCount).toBe(1);
+          let args = db.createDevice.args[0];
+          expect(args.length).toBe(2);
+          expect(args[0]).toEqual(credentials.uid);
+          expect(args[1]).toBe(device);
+
+          expect(log.activityEvent.callCount).toBe(1);
+          args = log.activityEvent.args[0];
+          expect(args.length).toBe(1);
+          expect(args[0]).toEqual({
+            country: 'United States',
+            event: 'device.created',
+            region: 'California',
+            service: undefined,
+            userAgent: 'test user-agent',
+            sigsciRequestId: 'test-sigsci-id',
+            clientJa4: 'test-ja4',
+            uid: credentials.uid,
+            device_id: deviceId,
+            is_placeholder: false,
+          });
+
+          expect(log.notifyAttachedServices.callCount).toBe(1);
+          args = log.notifyAttachedServices.args[0];
+          expect(args.length).toBe(3);
+          expect(args[0]).toBe('device:create');
+          expect(args[1]).toBe(request);
+          expect(args[2]).toEqual({
+            uid: credentials.uid,
+            id: deviceId,
+            type: device.type,
+            timestamp: deviceCreatedAt,
+            isPlaceholder: false,
+          });
+
+          expect(push.notifyDeviceConnected.callCount).toBe(1);
+          args = push.notifyDeviceConnected.args[0];
+          expect(args.length).toBe(3);
+          expect(args[0]).toBe(credentials.uid);
+          expect(Array.isArray(args[1])).toBeTruthy();
+          expect(args[2]).toBe(device.name);
+        });
+      });
+
+      it('should not call notifyDeviceConnected with unverified token', () => {
+        credentials.tokenVerified = false;
+        device.name = 'device with an unverified sessionToken';
+        return devices.upsert(request, credentials, device).then(() => {
+          expect(push.notifyDeviceConnected.callCount).toBe(0);
+          credentials.tokenVerified = true;
+        });
+      });
+
+      it('should create placeholders', () => {
+        delete device.name;
+        return devices
+          .upsert(request, credentials, { uaBrowser: 'Firefox' })
+          .then(() => {
+            expect(db.updateDevice.callCount).toBe(0);
+            expect(db.createDevice.callCount).toBe(1);
+
+            expect(log.activityEvent.callCount).toBe(1);
+            expect(log.activityEvent.args[0][0].is_placeholder).toBe(true);
+
+            expect(log.notifyAttachedServices.callCount).toBe(1);
+            expect(log.notifyAttachedServices.args[0][2].isPlaceholder).toBe(true);
+
+            expect(push.notifyDeviceConnected.callCount).toBe(1);
+            expect(push.notifyDeviceConnected.args[0][0]).toBe(credentials.uid);
+            expect(push.notifyDeviceConnected.args[0][2]).toBe('Firefox');
+          });
+      });
+
+      it('should update', () => {
+        const deviceInfo = {
+          id: deviceId,
+          name: device.name,
+          type: device.type,
+        };
+        return devices
+          .upsert(request, credentials, deviceInfo)
+          .then((result) => {
+            expect(result).toBe(deviceInfo);
+
+            expect(db.createDevice.callCount).toBe(0);
+
+            expect(db.updateDevice.callCount).toBe(1);
+            let args = db.updateDevice.args[0];
+            expect(args.length).toBe(2);
+            expect(args[0]).toEqual(credentials.uid);
+            expect(args[1]).toEqual({
+              id: deviceId,
+              name: device.name,
+              type: device.type,
+            });
+
+            expect(log.activityEvent.callCount).toBe(1);
+            args = log.activityEvent.args[0];
+            expect(args.length).toBe(1);
+            expect(args[0]).toEqual({
+              country: 'United States',
+              event: 'device.updated',
+              region: 'California',
+              service: undefined,
+              userAgent: 'test user-agent',
+              sigsciRequestId: 'test-sigsci-id',
+              clientJa4: 'test-ja4',
+              uid: credentials.uid,
+              device_id: deviceId,
+              is_placeholder: false,
+            });
+
+            expect(log.notifyAttachedServices.callCount).toBe(0);
+            expect(push.notifyDeviceConnected.callCount).toBe(0);
+          });
+      });
+    });
+
+    describe('upsert with refreshToken:', () => {
+      let request: ReturnType<typeof mocks.mockRequest>;
+      let credentials: { refreshTokenId: string; uid: string; tokenVerified: boolean };
+
+      beforeEach(() => {
+        request = mocks.mockRequest({
+          log: log,
+        });
+        credentials = {
+          refreshTokenId: crypto.randomBytes(16).toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+          tokenVerified: true,
+        };
+      });
+
+      it('should create', () => {
+        return devices.upsert(request, credentials, device).then((result) => {
+          expect(result).toEqual({
+            id: deviceId,
+            name: device.name,
+            type: device.type,
+            createdAt: deviceCreatedAt,
+          });
+
+          expect(db.updateDevice.callCount).toBe(0);
+
+          expect(db.createDevice.callCount).toBe(1);
+          let args = db.createDevice.args[0];
+          expect(args.length).toBe(2);
+          expect(args[0]).toEqual(credentials.uid);
+          expect(args[1]).toBe(device);
+
+          expect(log.activityEvent.callCount).toBe(1);
+          args = log.activityEvent.args[0];
+          expect(args.length).toBe(1);
+          expect(args[0]).toEqual({
+            country: 'United States',
+            event: 'device.created',
+            region: 'California',
+            service: undefined,
+            userAgent: 'test user-agent',
+            sigsciRequestId: 'test-sigsci-id',
+            clientJa4: 'test-ja4',
+            uid: credentials.uid,
+            device_id: deviceId,
+            is_placeholder: false,
+          });
+
+          expect(log.notifyAttachedServices.callCount).toBe(1);
+          args = log.notifyAttachedServices.args[0];
+          expect(args.length).toBe(3);
+          expect(args[0]).toBe('device:create');
+          expect(args[1]).toBe(request);
+          expect(args[2]).toEqual({
+            uid: credentials.uid,
+            id: deviceId,
+            type: device.type,
+            timestamp: deviceCreatedAt,
+            isPlaceholder: false,
+          });
+
+          expect(push.notifyDeviceConnected.callCount).toBe(1);
+          args = push.notifyDeviceConnected.args[0];
+          expect(args.length).toBe(3);
+          expect(args[0]).toBe(credentials.uid);
+          expect(Array.isArray(args[1])).toBeTruthy();
+          expect(args[2]).toBe(device.name);
+        });
+      });
+
+      it('should create placeholders', () => {
+        delete device.name;
+        return devices
+          .upsert(request, credentials, { uaBrowser: 'Firefox' })
+          .then(() => {
+            expect(db.updateDevice.callCount).toBe(0);
+            expect(db.createDevice.callCount).toBe(1);
+
+            expect(log.activityEvent.callCount).toBe(1);
+            expect(log.activityEvent.args[0][0].is_placeholder).toBe(true);
+
+            expect(log.notifyAttachedServices.callCount).toBe(1);
+            expect(log.notifyAttachedServices.args[0][2].isPlaceholder).toBe(true);
+
+            expect(push.notifyDeviceConnected.callCount).toBe(1);
+            expect(push.notifyDeviceConnected.args[0][0]).toBe(credentials.uid);
+            expect(push.notifyDeviceConnected.args[0][2]).toBe('Firefox');
+          });
+      });
+
+      it('should update', () => {
+        const deviceInfo = {
+          id: deviceId,
+          name: device.name,
+          type: device.type,
+        };
+        return devices
+          .upsert(request, credentials, deviceInfo)
+          .then((result) => {
+            expect(result).toBe(deviceInfo);
+
+            expect(db.createDevice.callCount).toBe(0);
+
+            expect(db.updateDevice.callCount).toBe(1);
+            let args = db.updateDevice.args[0];
+            expect(args.length).toBe(2);
+            expect(args[0]).toEqual(credentials.uid);
+            expect(args[1]).toEqual({
+              id: deviceId,
+              name: device.name,
+              type: device.type,
+            });
+
+            expect(log.activityEvent.callCount).toBe(1);
+            args = log.activityEvent.args[0];
+            expect(args.length).toBe(1);
+            expect(args[0]).toEqual({
+              country: 'United States',
+              event: 'device.updated',
+              region: 'California',
+              service: undefined,
+              userAgent: 'test user-agent',
+              sigsciRequestId: 'test-sigsci-id',
+              clientJa4: 'test-ja4',
+              uid: credentials.uid,
+              device_id: deviceId,
+              is_placeholder: false,
+            });
+
+            expect(log.notifyAttachedServices.callCount).toBe(0);
+            expect(push.notifyDeviceConnected.callCount).toBe(0);
+          });
+      });
+    });
+
+    describe('destroy:', () => {
+      let request: ReturnType<typeof mocks.mockRequest>,
+        credentials: { id: string; uid: string; tokenVerified: boolean },
+        deviceId2: string,
+        sessionTokenId: string,
+        refreshTokenId: string;
+
+      beforeEach(() => {
+        deviceId2 = crypto.randomBytes(16).toString('hex');
+        sessionTokenId = crypto.randomBytes(32).toString('hex');
+        refreshTokenId = crypto.randomBytes(32).toString('hex');
+        credentials = {
+          id: crypto.randomBytes(16).toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+          tokenVerified: true,
+        };
+        request = mocks.mockRequest({
+          log: log,
+          devices: [deviceId, deviceId2],
+          credentials,
+        });
+        db.deleteDevice = sinon.spy(async () => {
+          return device;
+        });
+      });
+
+      it('should destroy the device record', async () => {
+        db.deleteDevice = sinon.spy(async () => {
+          return { sessionTokenId, refreshTokenId: null };
+        });
+        device.sessionTokenId = sessionTokenId;
+
+        const result = await devices.destroy(request, deviceId);
+        expect(result.sessionTokenId).toBe(sessionTokenId);
+        expect(result.refreshTokenId).toBeNull();
+
+        expect(db.deleteDevice.callCount).toBe(1);
+        expect(
+          db.deleteDevice.calledBefore(push.notifyDeviceDisconnected)
+        ).toBeTruthy();
+        expect(pushbox.deleteDevice.callCount).toBe(1);
+        expect(pushbox.deleteDevice.firstCall.args).toEqual([
+          request.auth.credentials.uid,
+          deviceId,
+        ]);
+        expect(push.notifyDeviceDisconnected.callCount).toBe(1);
+        expect(push.notifyDeviceDisconnected.firstCall.args[0]).toBe(
+          request.auth.credentials.uid
+        );
+        expect(push.notifyDeviceDisconnected.firstCall.args[1]).toEqual([
+          deviceId,
+          deviceId2,
+        ]);
+        expect(push.notifyDeviceDisconnected.firstCall.args[2]).toBe(deviceId);
+
+        expect(oauthDB.removeRefreshToken).not.toHaveBeenCalled();
+
+        expect(log.activityEvent.callCount).toBe(1);
+        let args = log.activityEvent.args[0];
+        expect(args.length).toBe(1);
+        expect(args[0]).toEqual({
+          country: 'United States',
+          event: 'device.deleted',
+          region: 'California',
+          service: undefined,
+          userAgent: 'test user-agent',
+          sigsciRequestId: 'test-sigsci-id',
+          clientJa4: 'test-ja4',
+          uid: request.auth.credentials.uid,
+          device_id: deviceId,
+        });
+
+        expect(log.notifyAttachedServices.callCount).toBe(1);
+        args = log.notifyAttachedServices.args[0];
+        expect(args.length).toBe(3);
+        expect(args[0]).toBe('device:delete');
+        expect(args[1]).toBe(request);
+        const details = args[2];
+        expect(details.uid).toBe(request.auth.credentials.uid);
+        expect(details.id).toBe(deviceId);
+        expect(Date.now() - details.timestamp).toBeLessThan(100);
+      });
+
+      it('should revoke the refreshToken if present', async () => {
+        oauthDB.removeRefreshToken.mockResolvedValue({});
+        device.refreshTokenId = refreshTokenId;
+
+        const result = await devices.destroy(request, deviceId);
+        expect(result.sessionTokenId).toBeFalsy();
+        expect(result.refreshTokenId).toBe(refreshTokenId);
+
+        expect(db.deleteDevice.callCount).toBe(1);
+        expect(oauthDB.getRefreshToken).toHaveBeenCalledWith(refreshTokenId);
+        expect(log.error.callCount).toBe(0);
+        expect(log.notifyAttachedServices.callCount).toBe(1);
+      });
+
+      it('should ignore missing tokens when deleting the refreshToken', async () => {
+        oauthDB.removeRefreshToken.mockRejectedValue(error.invalidToken());
+        device.refreshTokenId = refreshTokenId;
+
+        const result = await devices.destroy(request, deviceId);
+        expect(result.sessionTokenId).toBeFalsy();
+        expect(result.refreshTokenId).toBe(refreshTokenId);
+
+        expect(db.deleteDevice.callCount).toBe(1);
+        expect(oauthDB.getRefreshToken).toHaveBeenCalledWith(refreshTokenId);
+        expect(log.error.callCount).toBe(0);
+        expect(log.notifyAttachedServices.callCount).toBe(1);
+      });
+
+      it('should log other errors when deleting the refreshToken, without failing', async () => {
+        oauthDB.removeRefreshToken.mockRejectedValue(error.unexpectedError());
+        device.refreshTokenId = refreshTokenId;
+
+        const result = await devices.destroy(request, deviceId);
+        expect(result.sessionTokenId).toBeFalsy();
+        expect(result.refreshTokenId).toBe(refreshTokenId);
+
+        expect(db.deleteDevice.callCount).toBe(1);
+        expect(oauthDB.getRefreshToken).toHaveBeenCalledWith(refreshTokenId);
+        expect(log.notifyAttachedServices.callCount).toBe(1);
+        expect(
+          log.error.calledOnceWith('deviceDestroy.revokeRefreshTokenById.error')
+        ).toBe(true);
+      });
+    });
+
+    it('should synthesizeName', () => {
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'foo',
+          uaBrowserVersion: 'bar.bar',
+          uaOS: 'baz',
+          uaOSVersion: 'qux',
+          uaFormFactor: 'wibble',
+        })
+      ).toBe('foo bar, wibble');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowserVersion: 'foo.foo',
+          uaOS: 'bar',
+          uaOSVersion: 'baz',
+          uaFormFactor: 'wibble',
+        })
+      ).toBe('wibble');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'foo',
+          uaOS: 'bar',
+          uaOSVersion: 'baz',
+          uaFormFactor: 'wibble',
+        })
+      ).toBe('foo, wibble');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'foo',
+          uaBrowserVersion: 'bar.bar',
+          uaOSVersion: 'baz',
+          uaFormFactor: 'wibble',
+        })
+      ).toBe('foo bar, wibble');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'foo',
+          uaBrowserVersion: 'bar.bar',
+          uaOS: 'baz',
+          uaFormFactor: 'wibble',
+        })
+      ).toBe('foo bar, wibble');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'foo',
+          uaBrowserVersion: 'bar.bar',
+          uaOS: 'baz',
+          uaOSVersion: 'qux',
+        })
+      ).toBe('foo bar, baz qux');
+
+      expect(
+        devices.synthesizeName({
+          uaOS: 'bar',
+          uaFormFactor: 'wibble',
+        })
+      ).toBe('wibble');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'wibble',
+          uaBrowserVersion: 'blee.blee',
+          uaOSVersion: 'qux',
+        })
+      ).toBe('wibble blee');
+
+      expect(
+        devices.synthesizeName({
+          uaBrowser: 'foo',
+          uaBrowserVersion: 'bar.bar',
+          uaOS: 'baz',
+        })
+      ).toBe('foo bar, baz');
+
+      expect(
+        devices.synthesizeName({
+          uaOS: 'foo',
+        })
+      ).toBe('foo');
+
+      expect(
+        devices.synthesizeName({
+          uaFormFactor: 'bar',
+        })
+      ).toBe('bar');
+
+      expect(
+        devices.synthesizeName({
+          uaOS: 'foo',
+          uaOSVersion: 'bar',
+        })
+      ).toBe('foo bar');
+
+      expect(
+        devices.synthesizeName({
+          uaOSVersion: 'foo',
+        })
+      ).toBe('');
+    });
+  });
+});

--- a/packages/fxa-auth-server/lib/notifier.spec.ts
+++ b/packages/fxa-auth-server/lib/notifier.spec.ts
@@ -1,0 +1,175 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+import sinon from 'sinon';
+
+interface NotifierInstance {
+  send(event: Record<string, unknown>, cb?: () => void): void;
+  __sns: { publish: sinon.SinonSpy };
+}
+
+type SnsPublishCallback = (err: null, data: Record<string, unknown>) => void;
+
+function mockConfigWithArn(arn: string): void {
+  jest.doMock('../config', () => ({
+    config: {
+      get: (key: string) => {
+        if (key === 'snsTopicArn') {
+          return arn;
+        }
+        return undefined;
+      },
+    },
+  }));
+}
+
+function stubSnsPublish(notifier: NotifierInstance): void {
+  notifier.__sns.publish = sinon.spy(
+    (event: Record<string, unknown>, cb: SnsPublishCallback) => {
+      cb(null, event);
+    }
+  );
+}
+
+describe('notifier', () => {
+  const log = {
+    error: sinon.spy(),
+    trace: sinon.spy(),
+  };
+
+  beforeEach(() => {
+    log.error.resetHistory();
+    log.trace.resetHistory();
+    jest.resetModules();
+  });
+
+  describe('with sns configuration', () => {
+    let notifier: NotifierInstance;
+
+    beforeEach(() => {
+      mockConfigWithArn('arn:aws:sns:us-west-2:927034868275:foo');
+      const notifierModule = require('./notifier');
+      notifier = notifierModule(log);
+      stubSnsPublish(notifier);
+    });
+
+    it('publishes a correctly-formatted message', () => {
+      notifier.send({
+        event: 'stuff',
+      });
+
+      expect(log.trace.args[0][0]).toBe('Notifier.publish');
+      expect(log.trace.args[0][1]).toEqual({
+        data: {
+          TopicArn: 'arn:aws:sns:us-west-2:927034868275:foo',
+          Message: '{"event":"stuff"}',
+          MessageAttributes: {
+            event_type: {
+              DataType: 'String',
+              StringValue: 'stuff',
+            },
+          },
+        },
+        success: true,
+      });
+      expect(log.error.called).toBe(false);
+    });
+
+    it('flattens additional data into the message body', () => {
+      notifier.send({
+        event: 'stuff-with-data',
+        data: {
+          cool: 'stuff',
+          more: 'stuff',
+        },
+      });
+
+      expect(log.trace.args[0][0]).toBe('Notifier.publish');
+      expect(log.trace.args[0][1]).toEqual({
+        data: {
+          TopicArn: 'arn:aws:sns:us-west-2:927034868275:foo',
+          Message: '{"cool":"stuff","more":"stuff","event":"stuff-with-data"}',
+          MessageAttributes: {
+            event_type: {
+              DataType: 'String',
+              StringValue: 'stuff-with-data',
+            },
+          },
+        },
+        success: true,
+      });
+      expect(log.error.called).toBe(false);
+    });
+
+    it('includes email domain in message attributes', () => {
+      notifier.send({
+        event: 'email-change',
+        data: {
+          email: 'testme@example.com',
+        },
+      });
+
+      expect(log.trace.args[0][0]).toBe('Notifier.publish');
+      expect(log.trace.args[0][1]).toEqual({
+        data: {
+          TopicArn: 'arn:aws:sns:us-west-2:927034868275:foo',
+          Message: '{"email":"testme@example.com","event":"email-change"}',
+          MessageAttributes: {
+            email_domain: {
+              DataType: 'String',
+              StringValue: 'example.com',
+            },
+            event_type: {
+              DataType: 'String',
+              StringValue: 'email-change',
+            },
+          },
+        },
+        success: true,
+      });
+      expect(log.error.called).toBe(false);
+    });
+
+    it('captures perf stats with statsd when it is present', () => {
+      const statsd = { timing: sinon.stub() };
+
+      mockConfigWithArn('arn:aws:sns:us-west-2:927034868275:foo');
+      jest.resetModules();
+      const notifierModule = require('./notifier');
+      notifier = notifierModule(log, statsd);
+      stubSnsPublish(notifier);
+      notifier.send({
+        event: 'testo',
+      });
+      expect(statsd.timing.calledOnce).toBe(true);
+      expect(statsd.timing.args[0][0]).toBe('notifier.publish');
+      expect(typeof statsd.timing.args[0][1]).toBe('number');
+    });
+  });
+
+  it('works with disabled configuration', () => {
+    mockConfigWithArn('disabled');
+    const notifierModule = require('./notifier');
+    const notifier = notifierModule(log);
+
+    notifier.send(
+      {
+        event: 'stuff',
+      },
+      () => {
+        expect(log.trace.args[0][0]).toBe('Notifier.publish');
+        expect(log.trace.args[0][1]).toEqual({
+          data: {
+            disabled: true,
+          },
+          success: true,
+        });
+        expect(log.trace.args[0][1].data.disabled).toBe(true);
+        expect(log.error.called).toBe(false);
+      }
+    );
+  });
+});

--- a/packages/fxa-auth-server/lib/push.spec.ts
+++ b/packages/fxa-auth-server/lib/push.spec.ts
@@ -1,0 +1,810 @@
+export {};
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import sinon from 'sinon';
+const Ajv = require('ajv');
+const ajv = new Ajv();
+const fs = require('fs');
+const path = require('path');
+const match = sinon.match;
+
+const mocks = require('../test/mocks');
+const mockUid = 'deadbeef';
+
+const TTL = '42';
+const MS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
+
+const PUSH_PAYLOADS_SCHEMA_PATH = './pushpayloads.schema.json';
+let PUSH_PAYLOADS_SCHEMA_MATCHER: sinon.SinonMatcher | null = null;
+
+interface ExtendedMatch extends sinon.SinonMatch {
+  validPushPayload(fields: Record<string, unknown>): sinon.SinonMatcher;
+}
+
+const extMatch = match as unknown as ExtendedMatch;
+extMatch.validPushPayload = function validPushPayload(fields: Record<string, unknown>): sinon.SinonMatcher {
+  if (!PUSH_PAYLOADS_SCHEMA_MATCHER) {
+    const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
+    const schema = JSON.parse(fs.readFileSync(schemaPath));
+    PUSH_PAYLOADS_SCHEMA_MATCHER = match((value: unknown) => {
+      return ajv.validate(schema, value);
+    }, 'matches payload schema');
+  }
+  return match(fields).and(PUSH_PAYLOADS_SCHEMA_MATCHER);
+};
+
+interface MockDevice {
+  id: string;
+  isCurrentDevice: boolean;
+  lastAccessTime: number;
+  name: string;
+  type: string | null;
+  availableCommands: Record<string, string>;
+  pushCallback: string;
+  pushPublicKey: string;
+  pushAuthKey: string;
+  pushEndpointExpired: boolean;
+  uaOS?: string;
+  uaOSVersion?: string;
+  uaBrowser?: string;
+  uaBrowserVersion?: string;
+}
+
+const WINDOWS_DESKTOP_PUSH_DEFAULTS = {
+  isCurrentDevice: false,
+  name: 'My Desktop',
+  uaOS: 'Windows',
+  uaOSVersion: '10',
+  uaBrowser: 'Firefox',
+  uaBrowserVersion: '65.4',
+  type: null,
+  availableCommands: {},
+  pushCallback:
+    'https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75',
+  pushPublicKey: mocks.MOCK_PUSH_KEY,
+  pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
+  pushEndpointExpired: false,
+} as const;
+
+describe('push', () => {
+  let mockDb: ReturnType<typeof mocks.mockDB>,
+    mockLog: ReturnType<typeof mocks.mockLog>,
+    mockConfig: Record<string, unknown>,
+    mockStatsD: { increment: sinon.SinonSpy },
+    mockDevices: MockDevice[],
+    mockSendNotification: sinon.SinonSpy;
+
+  function loadMockedPushModule() {
+    jest.resetModules();
+    jest.doMock('web-push', () => ({
+      sendNotification: mockSendNotification,
+    }));
+    return require('./push')(mockLog, mockDb, mockConfig, mockStatsD);
+  }
+
+  beforeEach(() => {
+    mockDb = mocks.mockDB();
+    mockLog = mocks.mockLog();
+    mockConfig = {};
+    mockDevices = [
+      {
+        id: '0f7aa00356e5416e82b3bef7bc409eef',
+        isCurrentDevice: true,
+        lastAccessTime: Date.now(),
+        name: 'My Phone',
+        type: 'mobile',
+        availableCommands: {},
+        pushCallback:
+          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
+        pushEndpointExpired: false,
+      },
+      {
+        ...WINDOWS_DESKTOP_PUSH_DEFAULTS,
+        id: '3a45e6d0dae543qqdKyqjuvAiEupsnOd',
+        // 2 days ago, will show in statsd as < 1 week
+        lastAccessTime: Date.now() - MS_IN_ONE_DAY * 2,
+      },
+      {
+        id: '50973923bc3e4507a0aa4e285513194a',
+        isCurrentDevice: false,
+        lastAccessTime: Date.now(),
+        name: 'My Ipad',
+        type: null,
+        availableCommands: {},
+        uaOS: 'iOS',
+        pushCallback:
+          'https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a',
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
+        pushEndpointExpired: false,
+      },
+    ];
+    mockStatsD = {
+      increment: sinon.spy(),
+    };
+    mockSendNotification = sinon.spy(async () => {});
+  });
+
+  it('sendPush does not reject on empty device array', async () => {
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, [], 'accountVerify');
+    sinon.assert.callCount(mockSendNotification, 0);
+    sinon.assert.callCount(mockStatsD.increment, 0);
+  });
+
+  it('sendPush logs metrics about successful sends', async () => {
+    mockDevices.push(
+      {
+        ...WINDOWS_DESKTOP_PUSH_DEFAULTS,
+        id: '11173923bc3e4507a0aa4e285513194a',
+        // 2 weeks ago, will show in statsd as < 1 month
+        lastAccessTime: Date.now() - MS_IN_ONE_DAY * 7 * 2,
+      },
+      {
+        ...WINDOWS_DESKTOP_PUSH_DEFAULTS,
+        id: '22273923bc3e4507a0aa4e285513194a',
+        // 2 months ago, will show in statsd as < 1 year
+        lastAccessTime: Date.now() - MS_IN_ONE_DAY * 30 * 2,
+      },
+      {
+        ...WINDOWS_DESKTOP_PUSH_DEFAULTS,
+        id: '33373923bc3e4507a0aa4e285513194a',
+        // Over 1 year ago, will show in statsd as > 1 year
+        lastAccessTime: Date.now() - MS_IN_ONE_DAY * 370,
+      }
+    );
+
+    const push = loadMockedPushModule();
+    const sendErrors = await push.sendPush(
+      mockUid,
+      mockDevices,
+      'accountVerify'
+    );
+    expect(sendErrors).toEqual({});
+    sinon.assert.callCount(mockSendNotification, 5);
+
+    sinon.assert.callCount(mockStatsD.increment, 10);
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(0),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: undefined,
+        errCode: undefined,
+        lastSeen: '< 1 day',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(1),
+      'push.send.success',
+      {
+        reason: 'accountVerify',
+        uaOS: undefined,
+        errCode: undefined,
+        lastSeen: '< 1 day',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(2),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 week',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(3),
+      'push.send.success',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 week',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(4),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 month',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(5),
+      'push.send.success',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 month',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(6),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 year',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(7),
+      'push.send.success',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 year',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(8),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '> 1 year',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(9),
+      'push.send.success',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '> 1 year',
+      }
+    );
+  });
+
+  it('sendPush logs metrics about failed sends', async () => {
+    let shouldFail = false;
+    mockSendNotification = sinon.spy(async () => {
+      try {
+        if (shouldFail) {
+          throw new Error('intermittent failure');
+        }
+      } finally {
+        shouldFail = !shouldFail;
+      }
+    });
+    const push = loadMockedPushModule();
+    const sendErrors = await push.sendPush(
+      mockUid,
+      mockDevices,
+      'accountVerify'
+    );
+    sinon.assert.match(sendErrors, match.has(mockDevices[1].id, match.any));
+    sinon.assert.callCount(mockSendNotification, 2);
+
+    sinon.assert.callCount(mockStatsD.increment, 4);
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(0),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: undefined,
+        errCode: undefined,
+        lastSeen: '< 1 day',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(1),
+      'push.send.success',
+      {
+        reason: 'accountVerify',
+        uaOS: undefined,
+        errCode: undefined,
+        lastSeen: '< 1 day',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(2),
+      'push.send.attempt',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: undefined,
+        lastSeen: '< 1 week',
+      }
+    );
+    sinon.assert.calledWithExactly(
+      mockStatsD.increment.getCall(3),
+      'push.send.failure',
+      {
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: 'unknown',
+        lastSeen: '< 1 week',
+      }
+    );
+  });
+
+  it('sendPush sends notifications with a TTL of 0', async () => {
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, mockDevices, 'accountVerify');
+    sinon.assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      sinon.assert.calledWithMatch(call, match.any, null, {
+        TTL: '0',
+      });
+    }
+  });
+
+  it('sendPush sends notifications with user-defined TTL', async () => {
+    const push = loadMockedPushModule();
+    const options = { TTL: TTL };
+    await push.sendPush(mockUid, mockDevices, 'accountVerify', options);
+    sinon.assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      sinon.assert.calledWithMatch(call, match.any, null, { TTL });
+    }
+  });
+
+  it('sendPush sends data', async () => {
+    const push = loadMockedPushModule();
+    const data = { foo: 'bar' };
+    const options = { data: data };
+    await push.sendPush(mockUid, mockDevices, 'accountVerify', options);
+    sinon.assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      sinon.assert.calledWithMatch(
+        call,
+        {
+          keys: {
+            p256dh: match.defined,
+            auth: match.defined,
+          },
+        },
+        Buffer.from(JSON.stringify(data))
+      );
+    }
+  });
+
+  it("sendPush doesn't push to ios devices if it is triggered with an unsupported command", async () => {
+    const push = loadMockedPushModule();
+    const data = Buffer.from(
+      JSON.stringify({ command: 'fxaccounts:non_existent_command' })
+    );
+    const options = { data: data };
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
+    sinon.assert.callCount(mockSendNotification, 2);
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
+  });
+
+  it('sendPush pushes to all ios devices if it is triggered with a "commands received" command', async () => {
+    const push = loadMockedPushModule();
+    const data = {
+      command: 'fxaccounts:command_received',
+      data: { foo: 'bar' },
+    };
+    const options = { data: data };
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
+    sinon.assert.callCount(mockSendNotification, 3);
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(2), {
+      endpoint: mockDevices[2].pushCallback,
+    });
+  });
+
+  it('sendPush does not push to ios devices if triggered with a "collection changed" command', async () => {
+    const push = loadMockedPushModule();
+    const data = {
+      command: 'sync:collection_changed',
+      data: { collection: 'clients', reason: 'firstsync' },
+    };
+    const options = { data: data };
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
+    sinon.assert.callCount(mockSendNotification, 2);
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
+  });
+
+  it('sendPush pushes to ios devices if it is triggered with a "device connected" command', async () => {
+    const push = loadMockedPushModule();
+    const data = { command: 'fxaccounts:device_connected' };
+    const options = { data: data };
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
+    sinon.assert.callCount(mockSendNotification, 3);
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
+    sinon.assert.calledWithMatch(mockSendNotification.getCall(2), {
+      endpoint: mockDevices[2].pushCallback,
+    });
+  });
+
+  it('push fails if data is present but both keys are not present', async () => {
+    const push = loadMockedPushModule();
+    const devices = [
+      {
+        id: 'foo',
+        name: 'My Phone',
+        pushCallback:
+          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
+        pushAuthKey: 'bogus',
+        pushEndpointExpired: false,
+      },
+    ];
+    const options = { data: Buffer.from('foobar') };
+    await push.sendPush(mockUid, devices, 'deviceConnected', options);
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'deviceConnected',
+      errCode: 'noKeys',
+    });
+  });
+
+  it('push catches devices with no push callback', async () => {
+    const push = loadMockedPushModule();
+    const devices = [
+      {
+        id: 'foo',
+        name: 'My Phone',
+      },
+    ];
+    await push.sendPush(mockUid, devices, 'accountVerify');
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'noCallback',
+    });
+  });
+
+  it('push catches devices with expired callback', async () => {
+    const push = loadMockedPushModule();
+    const devices = [
+      {
+        id: 'foo',
+        name: 'My Phone',
+        pushCallback:
+          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
+        pushEndpointExpired: true,
+      },
+    ];
+    await push.sendPush(mockUid, devices, 'accountVerify');
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'expiredCallback',
+    });
+  });
+
+  it('push reports errors when web-push fails', async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error('Failed with a nasty error');
+    });
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, [mockDevices[0]], 'accountVerify');
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'unknown',
+      err: match.has('message', 'Failed with a nasty error'),
+    });
+  });
+
+  it('push logs a warning when asked to send to more than 200 devices', async () => {
+    const push = loadMockedPushModule();
+    const devices: MockDevice[] = [];
+    for (let i = 0; i < 200; i++) {
+      devices.push(mockDevices[0]);
+    }
+    await push.sendPush(mockUid, devices, 'accountVerify');
+    sinon.assert.callCount(mockLog.warn, 0);
+
+    devices.push(mockDevices[0]);
+    await push.sendPush(mockUid, devices, 'accountVerify');
+    sinon.assert.callCount(mockLog.warn, 1);
+    sinon.assert.calledWithMatch(mockLog.warn, 'push.sendPush.tooManyDevices', {
+      uid: mockUid,
+    });
+  });
+
+  it('push resets device push data when push server responds with a 400 level error', async () => {
+    mockSendNotification = sinon.spy(async () => {
+      const err: Error & { statusCode?: number } = new Error('Failed');
+      err.statusCode = 410;
+      throw err;
+    });
+    const push = loadMockedPushModule();
+    const device = JSON.parse(JSON.stringify(mockDevices[0]));
+    await push.sendPush(mockUid, [device], 'accountVerify');
+    sinon.assert.callCount(mockSendNotification, 1);
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'resetCallback',
+    });
+    sinon.assert.callCount(mockDb.updateDevice, 1);
+    sinon.assert.calledWithMatch(mockDb.updateDevice, mockUid, {
+      id: mockDevices[0].id,
+      sessionTokenId: match.falsy,
+    });
+  });
+
+  it('push resets device push data when a failure is caused by bad encryption keys', async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error('Failed');
+    });
+    const push = loadMockedPushModule();
+    const device = JSON.parse(JSON.stringify(mockDevices[0]));
+    device.pushPublicKey = `E${device.pushPublicKey.substring(1)}`;
+    await push.sendPush(mockUid, [device], 'accountVerify');
+    sinon.assert.callCount(mockSendNotification, 1);
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'resetCallback',
+    });
+    sinon.assert.callCount(mockDb.updateDevice, 1);
+    sinon.assert.calledWithMatch(mockDb.updateDevice, mockUid, {
+      id: mockDevices[0].id,
+      sessionTokenId: match.falsy,
+    });
+  });
+
+  it('push does not reset device push data after an unexpected failure', async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error('Failed unexpectedly');
+    });
+    const push = loadMockedPushModule();
+    const device = JSON.parse(JSON.stringify(mockDevices[0]));
+    await push.sendPush(mockUid, [device], 'accountVerify');
+    sinon.assert.callCount(mockSendNotification, 1);
+    sinon.assert.callCount(mockLog.debug, 1);
+    sinon.assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'unknown',
+    });
+    sinon.assert.callCount(mockLog.error, 1);
+    sinon.assert.calledWithMatch(mockLog.error, 'push.sendPush.unexpectedError', {
+      err: match.has('message', 'Failed unexpectedly'),
+    });
+    sinon.assert.callCount(mockDb.updateDevice, 0);
+  });
+
+  it('notifyCommandReceived calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    await push.notifyCommandReceived(
+      mockUid,
+      mockDevices[0],
+      'commandName',
+      'sendingDevice',
+      12,
+      'http://fetch.url',
+      42
+    );
+    sinon.assert.calledOnceWithExactly(
+      push.sendPush,
+      mockUid,
+      [mockDevices[0]],
+      'commandReceived',
+      {
+        data: extMatch.validPushPayload({
+          version: 1,
+          command: 'fxaccounts:command_received',
+          data: {
+            command: 'commandName',
+            index: 12,
+            sender: 'sendingDevice',
+            url: 'http://fetch.url',
+          },
+        }),
+        TTL: 42,
+      }
+    );
+  });
+
+  it('notifyCommandReceived re-throws errors', async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error('Failed with a nasty error');
+    });
+    const push = loadMockedPushModule();
+    try {
+      await push.notifyCommandReceived(
+        mockUid,
+        mockDevices[0],
+        'commandName',
+        'sendingDevice',
+        12,
+        'http://fetch.url',
+        42
+      );
+      throw new Error('should have thrown');
+    } catch (err) {
+      sinon.assert.match(
+        err,
+        match.has('message', 'Failed with a nasty error')
+      );
+    }
+  });
+
+  it('notifyDeviceConnected calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    const deviceName = 'My phone';
+    await push.notifyDeviceConnected(mockUid, mockDevices, deviceName);
+    sinon.assert.calledOnce(push.sendPush);
+    sinon.assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      'deviceConnected',
+      {
+        data: extMatch.validPushPayload({
+          version: 1,
+          command: 'fxaccounts:device_connected',
+          data: {
+            deviceName: deviceName,
+          },
+        }),
+        TTL: sinon.match.typeOf('undefined'),
+      }
+    );
+  });
+
+  it('notifyDeviceDisconnected calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    const idToDisconnect = mockDevices[0].id;
+    await push.notifyDeviceDisconnected(mockUid, mockDevices, idToDisconnect);
+    sinon.assert.calledOnce(push.sendPush);
+    sinon.assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      'deviceDisconnected',
+      {
+        data: extMatch.validPushPayload({
+          version: 1,
+          command: 'fxaccounts:device_disconnected',
+          data: {
+            id: idToDisconnect,
+          },
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it('notifyPasswordChanged calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    await push.notifyPasswordChanged(mockUid, mockDevices);
+    sinon.assert.calledOnce(push.sendPush);
+    sinon.assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      'passwordChange',
+      {
+        data: extMatch.validPushPayload({
+          version: 1,
+          command: 'fxaccounts:password_changed',
+          data: sinon.match.typeOf('undefined'),
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it('notifyPasswordReset calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    await push.notifyPasswordReset(mockUid, mockDevices);
+    sinon.assert.calledOnce(push.sendPush);
+    sinon.assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      'passwordReset',
+      {
+        data: extMatch.validPushPayload({
+          version: 1,
+          command: 'fxaccounts:password_reset',
+          data: sinon.match.typeOf('undefined'),
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it('notifyAccountUpdated calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    await push.notifyAccountUpdated(mockUid, mockDevices, 'deviceConnected');
+    sinon.assert.calledOnce(push.sendPush);
+    sinon.assert.calledWithExactly(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      'deviceConnected'
+    );
+  });
+
+  it('notifyAccountDestroyed calls sendPush', async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, 'sendPush');
+    await push.notifyAccountDestroyed(mockUid, mockDevices);
+    sinon.assert.calledOnce(push.sendPush);
+    sinon.assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      'accountDestroyed',
+      {
+        data: extMatch.validPushPayload({
+          version: 1,
+          command: 'fxaccounts:account_destroyed',
+          data: {
+            uid: mockUid,
+          },
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it('sendPush includes VAPID identification if it is configured', async () => {
+    mockConfig = {
+      publicUrl: 'https://example.com',
+      vapidKeysFile: path.join(__dirname, '../test/config/mock-vapid-keys.json'),
+    };
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, mockDevices, 'accountVerify');
+    sinon.assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      sinon.assert.calledWithMatch(call, match.any, null, {
+        vapidDetails: {
+          subject: mockConfig.publicUrl,
+          privateKey: 'private',
+          publicKey: 'public',
+        },
+      });
+    }
+  });
+
+  it('sendPush errors out cleanly if given an unknown reason argument', async () => {
+    const push = loadMockedPushModule();
+    try {
+      await push.sendPush(mockUid, mockDevices, 'anUnknownReasonString');
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBe('Unknown push reason: anUnknownReasonString');
+    }
+    sinon.assert.notCalled(mockSendNotification);
+  });
+});

--- a/packages/fxa-auth-server/lib/pushbox/index.spec.ts
+++ b/packages/fxa-auth-server/lib/pushbox/index.spec.ts
@@ -1,0 +1,293 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+import sinon from 'sinon';
+
+const sandbox = sinon.createSandbox();
+
+const { pushboxApi } = require('./index');
+const pushboxDbModule = require('./db');
+const { AppError: error } = require('@fxa/accounts/errors');
+const { mockLog } = require('../../test/mocks');
+let mockStatsD: { increment: sinon.SinonStub; timing: sinon.SinonStub };
+
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  pushbox: {
+    enabled: true,
+    maxTTL: 123456000,
+    database: {
+      database: 'pushbox',
+      host: 'example.local',
+      password: '',
+      port: 3306,
+      user: 'root',
+      connectionLimitMin: 2,
+      connectionLimitMax: 10,
+      acquireTimeoutMillis: 30000,
+    },
+  },
+};
+const mockDeviceIds = ['AAAA11', 'BBBB22', 'CCCC33'];
+const mockUid = 'ABCDEF';
+
+interface PushboxError extends Error {
+  errno: number;
+}
+
+interface RetrieveResult {
+  last: boolean;
+  index: number;
+  messages: Array<{ index: number; data: Record<string, string> }>;
+}
+
+describe('pushbox', () => {
+  describe('using direct Pushbox database access', () => {
+    let stubDbModule: sinon.SinonStubbedInstance<typeof pushboxDbModule.PushboxDB>;
+    let stubConstructor: sinon.SinonStub;
+
+    beforeEach(() => {
+      mockStatsD = { increment: sandbox.stub(), timing: sandbox.stub() };
+      stubDbModule = sandbox.createStubInstance(pushboxDbModule.PushboxDB);
+      stubConstructor = sandbox
+        .stub(pushboxDbModule, 'PushboxDB')
+        .returns(stubDbModule);
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('store', () => {
+      sandbox.stub(Date, 'now').returns(1000534);
+      stubDbModule.store.resolves({ idx: 12 });
+      const pushbox = pushboxApi(
+        mockLog(),
+        mockConfig,
+        mockStatsD,
+        stubConstructor
+      );
+      return pushbox
+        .store(mockUid, mockDeviceIds[0], { test: 'data' })
+        .then(({ index }: { index: number }) => {
+          sinon.assert.calledOnceWithExactly(stubDbModule.store, {
+            uid: mockUid,
+            deviceId: mockDeviceIds[0],
+            data: 'eyJ0ZXN0IjoiZGF0YSJ9',
+            ttl: 124457,
+          });
+          sinon.assert.calledOnce(mockStatsD.timing);
+          expect(mockStatsD.timing.args[0][0]).toBe(
+            'pushbox.db.store.success'
+          );
+          sinon.assert.calledOnceWithExactly(
+            mockStatsD.increment,
+            'pushbox.db.store'
+          );
+          expect(index).toBe(12);
+        });
+    });
+
+    it('store with custom ttl', () => {
+      sandbox.stub(Date, 'now').returns(1000534);
+      stubDbModule.store.resolves({ idx: 12 });
+      const pushbox = pushboxApi(
+        mockLog(),
+        mockConfig,
+        mockStatsD,
+        stubConstructor
+      );
+      return pushbox
+        .store(mockUid, mockDeviceIds[0], { test: 'data' }, 42)
+        .then(({ index }: { index: number }) => {
+          sinon.assert.calledOnceWithExactly(stubDbModule.store, {
+            uid: mockUid,
+            deviceId: mockDeviceIds[0],
+            data: 'eyJ0ZXN0IjoiZGF0YSJ9',
+            ttl: 1043,
+          });
+          expect(index).toBe(12);
+        });
+    });
+
+    it('store caps ttl at configured maximum', () => {
+      sandbox.stub(Date, 'now').returns(1000432);
+      stubDbModule.store.resolves({ idx: 12 });
+      const pushbox = pushboxApi(
+        mockLog(),
+        mockConfig,
+        mockStatsD,
+        stubConstructor
+      );
+      return pushbox
+        .store(mockUid, mockDeviceIds[0], { test: 'data' }, 999999999)
+        .then(({ index }: { index: number }) => {
+          sinon.assert.calledOnceWithExactly(stubDbModule.store, {
+            uid: mockUid,
+            deviceId: mockDeviceIds[0],
+            data: 'eyJ0ZXN0IjoiZGF0YSJ9',
+            ttl: 124457,
+          });
+          expect(index).toBe(12);
+        });
+    });
+
+    it('logs an error when failed to store', async () => {
+      stubDbModule.store.rejects(new Error('db is a mess right now'));
+      const log = mockLog();
+      const pushbox = pushboxApi(log, mockConfig, mockStatsD, stubConstructor);
+      try {
+        await pushbox.store(mockUid, mockDeviceIds[0], { test: 'data' }, 999999999);
+        throw new Error('should not happen');
+      } catch (err) {
+        expect(err).toBeTruthy();
+        expect((err as PushboxError).errno).toBe(error.ERRNO.UNEXPECTED_ERROR);
+        sinon.assert.calledOnce(log.error);
+        expect(log.error.args[0][0]).toBe('pushbox.db.store');
+        expect(log.error.args[0][1]['error']['message']).toBe(
+          'db is a mess right now'
+        );
+      }
+    });
+
+    it('retrieve', async () => {
+      stubDbModule.retrieve.resolves({
+        last: true,
+        index: 15,
+        messages: [
+          {
+            idx: 15,
+            data: 'eyJmb28iOiJiYXIiLCAiYmFyIjogImJhciJ9',
+          },
+        ],
+      });
+      const pushbox = pushboxApi(
+        mockLog(),
+        mockConfig,
+        mockStatsD,
+        stubConstructor
+      );
+      const result: RetrieveResult = await pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10);
+      expect(result).toEqual({
+        last: true,
+        index: 15,
+        messages: [
+          {
+            index: 15,
+            data: { foo: 'bar', bar: 'bar' },
+          },
+        ],
+      });
+    });
+
+    it('retrieve throws on error response', async () => {
+      stubDbModule.retrieve.rejects(new Error('db is a mess right now'));
+      const log = mockLog();
+      const pushbox = pushboxApi(log, mockConfig, mockStatsD, stubConstructor);
+      try {
+        await pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10);
+        throw new Error('should not happen');
+      } catch (err) {
+        expect(err).toBeTruthy();
+        expect((err as PushboxError).errno).toBe(error.ERRNO.UNEXPECTED_ERROR);
+        sinon.assert.calledOnce(log.error);
+        expect(log.error.args[0][0]).toBe('pushbox.db.retrieve');
+        expect(log.error.args[0][1]['error']['message']).toBe(
+          'db is a mess right now'
+        );
+      }
+    });
+
+    it('deletes records of a device', async () => {
+      stubDbModule.deleteDevice.resolves();
+      const log = mockLog();
+      const pushbox = pushboxApi(log, mockConfig, mockStatsD, stubConstructor);
+      const res = await pushbox.deleteDevice(mockUid, mockDeviceIds[0]);
+      expect(res).toBeUndefined();
+      expect(mockStatsD.timing.args[0][0]).toBe(
+        'pushbox.db.delete.device.success'
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockStatsD.increment,
+        'pushbox.db.delete.device'
+      );
+    });
+
+    it('throws error when delete device fails', async () => {
+      stubDbModule.deleteDevice.rejects(new Error('db is a mess right now'));
+      const log = mockLog();
+      const pushbox = pushboxApi(log, mockConfig, mockStatsD, stubConstructor);
+      try {
+        await pushbox.deleteDevice(mockUid, mockDeviceIds[0]);
+        throw new Error('should not happen');
+      } catch (err) {
+        expect(err).toBeTruthy();
+        expect((err as PushboxError).errno).toBe(error.ERRNO.UNEXPECTED_ERROR);
+        sinon.assert.calledOnce(log.error);
+        expect(log.error.args[0][0]).toBe('pushbox.db.delete.device');
+        expect(log.error.args[0][1]['error']['message']).toBe(
+          'db is a mess right now'
+        );
+      }
+    });
+
+    it('deletes all records for an account', async () => {
+      stubDbModule.deleteAccount.resolves();
+      const log = mockLog();
+      const pushbox = pushboxApi(log, mockConfig, mockStatsD, stubConstructor);
+      const res = await pushbox.deleteAccount(mockUid);
+      expect(res).toBeUndefined();
+      expect(mockStatsD.timing.args[0][0]).toBe(
+        'pushbox.db.delete.account.success'
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockStatsD.increment,
+        'pushbox.db.delete.account'
+      );
+    });
+
+    it('throws error when delete account fails', async () => {
+      stubDbModule.deleteAccount.rejects(
+        new Error('someone deleted the pushboxv1 table')
+      );
+      const log = mockLog();
+      const pushbox = pushboxApi(log, mockConfig, mockStatsD, stubConstructor);
+      try {
+        await pushbox.deleteAccount(mockUid);
+        throw new Error('should not happen');
+      } catch (err) {
+        expect(err).toBeTruthy();
+        expect((err as PushboxError).errno).toBe(error.ERRNO.UNEXPECTED_ERROR);
+        sinon.assert.calledOnce(log.error);
+        expect(log.error.args[0][0]).toBe('pushbox.db.delete.account');
+        expect(log.error.args[0][1]['error']['message']).toBe(
+          'someone deleted the pushboxv1 table'
+        );
+      }
+    });
+  });
+
+  it('feature disabled', async () => {
+    const config = { ...mockConfig, pushbox: { enabled: false } };
+    const pushbox = pushboxApi(mockLog(), config);
+
+    try {
+      await pushbox.store(mockUid, mockDeviceIds[0], 'sendtab', mockUid);
+      throw new Error('should not happen');
+    } catch (err) {
+      expect(err).toBeTruthy();
+      expect((err as Error).message).toBe('Feature not enabled');
+    }
+
+    try {
+      await pushbox.retrieve(mockUid, mockDeviceIds[0], 50, 10);
+      throw new Error('should not happen');
+    } catch (err) {
+      expect(err).toBeTruthy();
+      expect((err as Error).message).toBe('Feature not enabled');
+    }
+  });
+});

--- a/packages/fxa-auth-server/lib/sqs.spec.ts
+++ b/packages/fxa-auth-server/lib/sqs.spec.ts
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+import sinon from 'sinon';
+
+const log = { error: sinon.stub() };
+
+interface SQSQueue {
+  sqs: Record<string, unknown>;
+  start(): void;
+}
+
+let SQSReceiver: ReturnType<typeof require>;
+let statsd: { timing: sinon.SinonStub };
+let testQueue: SQSQueue;
+
+describe('SQSReceiver', () => {
+  beforeEach(() => {
+    statsd = { timing: sinon.stub() };
+    SQSReceiver = require('./sqs')(log, statsd);
+    testQueue = new SQSReceiver('testo', [
+      'https://sqs.testo.meows.xyz/fxa/quux',
+    ]);
+    const receiveStub = sinon.stub();
+    receiveStub.onFirstCall().callsFake(
+      (_qParams: Record<string, unknown>, cb: (err: null, data: { Messages: string[] }) => void) => {
+        cb(null, { Messages: [JSON.stringify({ Body: 'SYN' })] });
+      }
+    );
+    receiveStub.returns(null);
+    testQueue.sqs = {
+      receiveMessage: receiveStub,
+      deleteMessage: (_sParams: Record<string, unknown>, cb: (err: null) => void) => {
+        cb(null);
+      },
+    };
+  });
+
+  it('should collect perf stats with statsd when it is present', () => {
+    testQueue.start();
+    expect(statsd.timing.callCount).toBe(2);
+    expect(statsd.timing.args[0][0]).toBe('sqs.quux.receive');
+    expect(typeof statsd.timing.args[0][1]).toBe('number');
+    expect(statsd.timing.args[1][0]).toBe('sqs.quux.delete');
+    expect(typeof statsd.timing.args[1][1]).toBe('number');
+  });
+});

--- a/packages/fxa-auth-server/lib/tokens/account_reset_token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/account_reset_token.spec.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+const log = { trace() {} };
+const tokens = require('./index')(log);
+const AccountResetToken = tokens.AccountResetToken;
+
+const ACCOUNT = {
+  uid: 'xxx',
+};
+
+interface TokenLike {
+  data: Buffer;
+  id: string;
+  authKey: Buffer;
+  bundleKey: Buffer;
+  uid: string;
+}
+
+describe('account reset tokens', () => {
+  it('should re-create from tokenData', async () => {
+    const token: TokenLike = await AccountResetToken.create(ACCOUNT);
+    const token2: TokenLike = await AccountResetToken.fromHex(token.data, ACCOUNT);
+    expect(token.data).toEqual(token2.data);
+    expect(token.id).toEqual(token2.id);
+    expect(token.authKey).toEqual(token2.authKey);
+    expect(token.bundleKey).toEqual(token2.bundleKey);
+    expect(token.uid).toEqual(token2.uid);
+  });
+
+  it('should have test-vector compliant key derivations', async () => {
+    const tokenData =
+      'c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf';
+    const token: TokenLike = await AccountResetToken.fromHex(tokenData, ACCOUNT);
+    expect(token.data.toString('hex')).toBe(tokenData);
+    expect(token.id).toBe(
+      '46ec557e56e531a058620e9344ca9c75afac0d0bcbdd6f8c3c2f36055d9540cf'
+    );
+    expect(token.authKey.toString('hex')).toBe(
+      '716ebc28f5122ef48670a48209190a1605263c3188dfe45256265929d1c45e48'
+    );
+    expect(token.bundleKey.toString('hex')).toBe(
+      'aa5906d2318c6e54ecebfa52f10df4c036165c230cc78ee859f546c66ea3c126'
+    );
+  });
+});

--- a/packages/fxa-auth-server/lib/tokens/key_fetch_token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/key_fetch_token.spec.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+const crypto = require('crypto');
+const log = { trace() {}, error() {} };
+
+const tokens = require('./index')(log);
+const KeyFetchToken = tokens.KeyFetchToken;
+
+const ACCOUNT = {
+  uid: 'xxx',
+  kA: Buffer.from(
+    '0000000000000000000000000000000000000000000000000000000000000000',
+    'hex'
+  ).toString('hex'),
+  wrapKb: Buffer.from(
+    '0000000000000000000000000000000000000000000000000000000000000000',
+    'hex'
+  ).toString('hex'),
+  emailVerified: true,
+};
+
+interface KeyFetchTokenLike {
+  data: string;
+  id: string;
+  authKey: string;
+  bundleKey: string;
+  uid: string;
+  kA: string;
+  wrapKb: string;
+  emailVerified: boolean;
+  bundleKeys(kA: string | Buffer, wrapKb: string | Buffer): Promise<string>;
+  unbundleKeys(bundle: string): Promise<{ kA: string; wrapKb: string }>;
+}
+
+describe('KeyFetchToken', () => {
+  it('should re-create from tokenData', async () => {
+    const token: KeyFetchTokenLike = await KeyFetchToken.create(ACCOUNT);
+    const token2: KeyFetchTokenLike = await KeyFetchToken.fromHex(token.data, ACCOUNT);
+    expect(token.data).toEqual(token2.data);
+    expect(token.id).toEqual(token2.id);
+    expect(token.authKey).toEqual(token2.authKey);
+    expect(token.bundleKey).toEqual(token2.bundleKey);
+    expect(token.uid).toEqual(token2.uid);
+    expect(token.kA).toEqual(token2.kA);
+    expect(token.wrapKb).toEqual(token2.wrapKb);
+    expect(token.emailVerified).toBe(token2.emailVerified);
+  });
+
+  it('should re-create from id', async () => {
+    const token: KeyFetchTokenLike = await KeyFetchToken.create(ACCOUNT);
+    const token2: KeyFetchTokenLike = await KeyFetchToken.fromId(token.id, token);
+    expect(token2.id).toBe(token.id);
+    expect(token2.authKey).toBe(token.authKey);
+  });
+
+  it('should bundle / unbundle of keys', async () => {
+    const kA = crypto.randomBytes(32).toString('hex');
+    const wrapKb = crypto.randomBytes(32).toString('hex');
+    const token: KeyFetchTokenLike = await KeyFetchToken.create(ACCOUNT);
+    const bundle = await token.bundleKeys(kA, wrapKb);
+    const unbundled = await token.unbundleKeys(bundle);
+    expect(unbundled.kA).toEqual(kA);
+    expect(unbundled.wrapKb).toEqual(wrapKb);
+  });
+
+  it('should only bundle / unbundle of keys with correct token', async () => {
+    const kA = crypto.randomBytes(32).toString('hex');
+    const wrapKb = crypto.randomBytes(32).toString('hex');
+    const token1: KeyFetchTokenLike = await KeyFetchToken.create(ACCOUNT);
+    const token2: KeyFetchTokenLike = await KeyFetchToken.create(ACCOUNT);
+    const bundle = await token1.bundleKeys(kA, wrapKb);
+    try {
+      await token2.unbundleKeys(bundle);
+      throw new Error('was able to unbundle using wrong token');
+    } catch (err) {
+      expect((err as { errno: number }).errno).toBe(109);
+    }
+  });
+
+  it('should have key derivations that are test-vector compliant', async () => {
+    const tokenData =
+      '808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f';
+    const token: KeyFetchTokenLike = await KeyFetchToken.fromHex(tokenData, ACCOUNT);
+    expect(token.data).toBe(tokenData);
+    expect(token.id).toBe(
+      '3d0a7c02a15a62a2882f76e39b6494b500c022a8816e048625a495718998ba60'
+    );
+    expect(token.authKey).toBe(
+      '87b8937f61d38d0e29cd2d5600b3f4da0aa48ac41de36a0efe84bb4a9872ceb7'
+    );
+    expect(token.bundleKey).toBe(
+      '14f338a9e8c6324d9e102d4e6ee83b209796d5c74bb734a410e729e014a4a546'
+    );
+
+    const kA = Buffer.from(
+      '202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f',
+      'hex'
+    );
+    const wrapKb = Buffer.from(
+      '404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f',
+      'hex'
+    );
+    const bundle = await token.bundleKeys(kA, wrapKb);
+    expect(bundle).toBe(
+      'ee5c58845c7c9412b11bbd20920c2fddd83c33c9cd2c2de2' +
+        'd66b222613364636c2c0f8cfbb7c630472c0bd88451342c6' +
+        'c05b14ce342c5ad46ad89e84464c993c3927d30230157d08' +
+        '17a077eef4b20d976f7a97363faf3f064c003ada7d01aa70'
+    );
+  });
+});

--- a/packages/fxa-auth-server/lib/tokens/password_forgot_token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/password_forgot_token.spec.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+const log = { trace() {} };
+const timestamp = Date.now();
+
+const PasswordForgotToken = require('./index')(log).PasswordForgotToken;
+
+const ACCOUNT = {
+  uid: 'xxx',
+  email: Buffer.from('test@example.com').toString('hex'),
+};
+
+interface ForgotTokenLike {
+  data: Buffer;
+  id: string;
+  authKey: Buffer;
+  bundleKey: Buffer;
+  uid: string;
+  email: string;
+  createdAt: number;
+  tries: number;
+  ttl(asOf: number): number;
+  failAttempt(): boolean;
+}
+
+describe('PasswordForgotToken', () => {
+  it('can re-create from tokenData', async () => {
+    const token: ForgotTokenLike = await PasswordForgotToken.create(ACCOUNT);
+    const token2: ForgotTokenLike = await PasswordForgotToken.fromHex(token.data, ACCOUNT);
+    expect(token.data).toEqual(token2.data);
+    expect(token.id).toEqual(token2.id);
+    expect(token.authKey).toEqual(token2.authKey);
+    expect(token.bundleKey).toEqual(token2.bundleKey);
+    expect(token.uid).toEqual(token2.uid);
+    expect(token.email).toEqual(token2.email);
+  });
+
+  it('ttl "works"', async () => {
+    const token: ForgotTokenLike = await PasswordForgotToken.create(ACCOUNT);
+    token.createdAt = timestamp;
+    expect(token.ttl(timestamp)).toBe(900);
+    expect(token.ttl(timestamp + 1000)).toBe(899);
+    expect(token.ttl(timestamp + 2000)).toBe(898);
+  });
+
+  it('failAttempt decrements `tries`', async () => {
+    const token: ForgotTokenLike = await PasswordForgotToken.create(ACCOUNT);
+    expect(token.tries).toBe(3);
+    expect(token.failAttempt()).toBe(false);
+    expect(token.tries).toBe(2);
+    expect(token.failAttempt()).toBe(false);
+    expect(token.tries).toBe(1);
+    expect(token.failAttempt()).toBe(true);
+  });
+});

--- a/packages/fxa-auth-server/lib/tokens/session_token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/session_token.spec.ts
@@ -1,0 +1,327 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+import sinon from 'sinon';
+
+const crypto = require('crypto');
+const log = {
+  trace() {},
+  info() {},
+  error: sinon.spy(),
+};
+
+interface SessionTokenLike {
+  data: Buffer;
+  id: string;
+  authKey: string;
+  bundleKey: string | Buffer;
+  uid: string;
+  key: Buffer;
+  algorithm: string;
+  lifetime: number;
+  createdAt: number;
+  email: string;
+  emailCode: string;
+  emailVerified: boolean;
+  verifierSetAt: number;
+  locale: string;
+  tokenVerified: boolean;
+  tokenVerificationId: string | null;
+  state: string;
+  verificationMethod: number | null;
+  verificationMethodValue: string | null;
+  verifiedAt: number | null;
+  authenticationMethods: Set<string>;
+  authenticatorAssuranceLevel: number;
+  uaBrowser: string;
+  uaBrowserVersion: string;
+  uaOS: string;
+  uaOSVersion: string;
+  uaDeviceType: string;
+  uaFormFactor: string;
+  lastAccessTime: string | number;
+  lastAuthAt(): number;
+  setUserAgentInfo(info: Record<string, string>): void;
+  copyTokenState(): Promise<SessionTokenLike>;
+  ttl(asOf?: number): number;
+  expired(asOf?: number): boolean;
+}
+
+const TOKEN = {
+  createdAt: Date.now(),
+  uid: 'xxx',
+  email: Buffer.from('test@example.com').toString('hex'),
+  emailCode: '123456',
+  emailVerified: true,
+  tokenVerificationId: crypto.randomBytes(16),
+  verificationMethod: 2, // Totp verification method
+  verifiedAt: Date.now(),
+};
+
+describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
+  const MAX_AGE_WITHOUT_DEVICE = 1000 * 60 * 60 * 24 * 7 * 4;
+  const config = {
+    lastAccessTimeUpdates: {},
+    tokenLifetimes: {
+      sessionTokenWithoutDevice: MAX_AGE_WITHOUT_DEVICE,
+    },
+  };
+  const tokens = require('./index')(log, config);
+  const SessionToken = tokens.SessionToken;
+
+  it('interface is correct', async () => {
+    const token: SessionTokenLike = await SessionToken.create(TOKEN);
+    expect(typeof token.lastAuthAt).toBe('function');
+    expect(typeof token.setUserAgentInfo).toBe('function');
+    expect(typeof token.copyTokenState).toBe('function');
+    expect(
+      Object.getOwnPropertyDescriptor(token, 'state')
+    ).toBeUndefined();
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(token),
+      'state'
+    );
+    expect(descriptor).toBeDefined();
+    expect(typeof descriptor?.get).toBe('function');
+    expect(token.createdAt).not.toBe(TOKEN.createdAt);
+  });
+
+  it('re-creation from tokenData works', async () => {
+    const token: SessionTokenLike = await SessionToken.create(TOKEN);
+    const token2: SessionTokenLike = await SessionToken.fromHex(token.data, token);
+    expect(token.data).toEqual(token2.data);
+    expect(token.id).toEqual(token2.id);
+    expect(token.authKey).toEqual(token2.authKey);
+    expect(token.bundleKey).toEqual(token2.bundleKey);
+    expect(typeof token.authKey).toBe('string');
+    expect(Buffer.isBuffer(token.key)).toBe(true);
+    expect(token.key.toString('hex')).toBe(token.authKey);
+    expect(token.uid).toEqual(token2.uid);
+    expect(token.email).toBe(token2.email);
+    expect(token.emailCode).toBe(token2.emailCode);
+    expect(token.emailVerified).toBe(token2.emailVerified);
+    expect(token.createdAt).toBe(token2.createdAt);
+    expect(token.tokenVerified).toBe(token2.tokenVerified);
+    expect(token.tokenVerificationId).toBe(token2.tokenVerificationId);
+    expect(token.state).toBe(token2.state);
+    expect(token.verificationMethod).toBe(token2.verificationMethod);
+    expect(token.verificationMethodValue).toBe('totp-2fa');
+    expect(token.verifiedAt).toBe(token2.verifiedAt);
+    expect(token.authenticationMethods).toEqual(
+      token2.authenticationMethods
+    );
+    expect(token.authenticatorAssuranceLevel).toEqual(
+      token2.authenticatorAssuranceLevel
+    );
+  });
+
+  it('copy token state works', async () => {
+    (TOKEN as Record<string, unknown>).tokenVerificationId = 'bar';
+    const token: SessionTokenLike = await SessionToken.create(TOKEN);
+    const newState = await token.copyTokenState();
+    expect(token.tokenVerificationId).not.toBe(newState.tokenVerificationId);
+    expect(token.data).toBe(newState.data);
+    expect(token.id).toBe(newState.id);
+    expect(token.uid).toBe(newState.uid);
+    expect(Object.keys(token).length).toBe(Object.keys(newState).length);
+  });
+
+  it('SessionToken.fromHex creates expired token if deviceId is null and createdAt is too old', async () => {
+    const created: SessionTokenLike = await SessionToken.create(TOKEN);
+    const token: SessionTokenLike = await SessionToken.fromHex(created.data, {
+      createdAt: Date.now() - MAX_AGE_WITHOUT_DEVICE - 1,
+      deviceId: null,
+    });
+    expect(token.ttl()).toBe(0);
+    expect(token.expired()).toBe(true);
+  });
+
+  it('SessionToken.fromHex creates non-expired token if deviceId is null and createdAt is recent enough', async () => {
+    const created: SessionTokenLike = await SessionToken.create(TOKEN);
+    const token: SessionTokenLike = await SessionToken.fromHex(created.data, {
+      createdAt: Date.now() - MAX_AGE_WITHOUT_DEVICE + 10000,
+      deviceId: null,
+    });
+    expect(token.ttl() > 0).toBe(true);
+    expect(token.expired()).toBe(false);
+  });
+
+  it('SessionToken.fromHex creates non-expired token if deviceId is set and createdAt is too old', async () => {
+    const created: SessionTokenLike = await SessionToken.create(TOKEN);
+    const token: SessionTokenLike = await SessionToken.fromHex(created.data, {
+      createdAt: Date.now() - MAX_AGE_WITHOUT_DEVICE - 1,
+      deviceId: crypto.randomBytes(16),
+    });
+    expect(token.ttl() > 0).toBe(true);
+    expect(token.expired()).toBe(false);
+  });
+
+  it('create with NaN createdAt', async () => {
+    const token: SessionTokenLike = await SessionToken.create({
+      createdAt: NaN,
+      email: 'foo',
+      uid: 'bar',
+    });
+    const now = Date.now();
+    expect(token.createdAt > now - 1000 && token.createdAt <= now).toBeTruthy();
+  });
+
+  it('sessionToken key derivations are test-vector compliant', async () => {
+    const tokenData =
+      'a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf';
+    const token: SessionTokenLike = await SessionToken.fromHex(tokenData, TOKEN);
+    expect(token.data.toString('hex')).toBe(tokenData);
+    expect(token.id).toBe(
+      'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab'
+    );
+    expect(token.authKey).toBe(
+      '9d8f22998ee7f5798b887042466b72d53e56ab0c094388bf65831f702d2febc0'
+    );
+  });
+
+  it('SessionToken.setUserAgentInfo', async () => {
+    const token: SessionTokenLike = await SessionToken.create(TOKEN);
+    token.setUserAgentInfo({
+      data: 'foo',
+      id: 'foo',
+      authKey: 'foo',
+      bundleKey: 'foo',
+      algorithm: 'foo',
+      uid: 'foo',
+      lifetime: 'foo',
+      createdAt: 'foo',
+      email: 'foo',
+      emailCode: 'foo',
+      emailVerified: 'foo',
+      verifierSetAt: 'foo',
+      locale: 'foo',
+      uaBrowser: 'foo',
+      uaBrowserVersion: 'bar',
+      uaOS: 'baz',
+      uaOSVersion: 'qux',
+      uaDeviceType: 'wibble',
+      uaFormFactor: 'blee',
+      lastAccessTime: 'mnngh',
+    });
+    expect(token.data).not.toBe('foo');
+    expect(token.id).not.toBe('foo');
+    expect(token.authKey).not.toBe('foo');
+    expect(token.bundleKey).not.toBe('foo');
+    expect(token.algorithm).not.toBe('foo');
+    expect(token.uid).not.toBe('foo');
+    expect(token.lifetime).not.toBe('foo');
+    expect(token.createdAt).not.toBe('foo');
+    expect(token.email).not.toBe('foo');
+    expect(token.emailVerified).not.toBe('foo');
+    expect(token.verifierSetAt).not.toBe('foo');
+    expect(token.locale).not.toBe('foo');
+    expect(token.uaBrowser).toBe('foo');
+    expect(token.uaBrowserVersion).toBe('bar');
+    expect(token.uaOS).toBe('baz');
+    expect(token.uaOSVersion).toBe('qux');
+    expect(token.uaDeviceType).toBe('wibble');
+    expect(token.uaFormFactor).toBe('blee');
+    expect(token.lastAccessTime).toBe('mnngh');
+  });
+
+  it('SessionToken.setUserAgentInfo without lastAccessTime', async () => {
+    const token: SessionTokenLike = await SessionToken.create(TOKEN);
+    token.lastAccessTime = 'foo';
+    token.setUserAgentInfo({
+      uaBrowser: 'foo',
+      uaBrowserVersion: 'bar',
+      uaOS: 'baz',
+      uaOSVersion: 'qux',
+      uaDeviceType: 'wibble',
+      uaFormFactor: 'blee',
+    });
+    expect(token.lastAccessTime).not.toBeUndefined();
+  });
+
+  describe('state', () => {
+    it('should be unverified if token is not verified', () => {
+      const token = new SessionToken({}, {});
+      token.tokenVerified = false;
+      expect(token.state).toBe('unverified');
+    });
+
+    it('should be verified if token is verified', () => {
+      const token = new SessionToken({}, {});
+      token.tokenVerified = true;
+      expect(token.state).toBe('verified');
+    });
+  });
+
+  describe('authenticationMethods', () => {
+    it('should be [`pwd`] for unverified tokens', async () => {
+      const token: SessionTokenLike = await SessionToken.create({
+        ...TOKEN,
+        verificationMethod: null,
+        verifiedAt: null,
+      });
+      expect(Array.from(token.authenticationMethods).sort()).toEqual([
+        'pwd',
+      ]);
+    });
+
+    it('should be [`pwd`, `email`] for verified tokens', async () => {
+      const token: SessionTokenLike = await SessionToken.create({
+        ...TOKEN,
+        tokenVerificationId: null,
+        verificationMethod: null,
+        verifiedAt: null,
+      });
+      expect(Array.from(token.authenticationMethods).sort()).toEqual([
+        'email',
+        'pwd',
+      ]);
+    });
+
+    it('should be [`pwd`, `email`] for tokens verified via email-2fa', async () => {
+      const token: SessionTokenLike = await SessionToken.create({
+        ...TOKEN,
+        tokenVerificationId: null,
+        verificationMethod: 1,
+      });
+      expect(Array.from(token.authenticationMethods).sort()).toEqual([
+        'email',
+        'pwd',
+      ]);
+    });
+
+    it('should be [`pwd`, `otp`] for tokens verified via totp-2fa', async () => {
+      const token: SessionTokenLike = await SessionToken.create({
+        ...TOKEN,
+        verificationMethod: 2,
+      });
+      expect(Array.from(token.authenticationMethods).sort()).toEqual([
+        'otp',
+        'pwd',
+      ]);
+    });
+  });
+});
+
+describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice === 0', () => {
+  const config = {
+    lastAccessTimeUpdates: {},
+    tokenLifetimes: {
+      sessionTokenWithoutDevice: 0,
+    },
+  };
+  const tokens = require('./index')(log, config);
+  const SessionToken = tokens.SessionToken;
+
+  it('SessionToken.fromHex creates non-expired token if deviceId is null and createdAt is too old', async () => {
+    const created: SessionTokenLike = await SessionToken.create(TOKEN);
+    const token: SessionTokenLike = await SessionToken.fromHex(created.data, {
+      createdAt: 1,
+      deviceId: null,
+    });
+    expect(token.ttl() > 0).toBe(true);
+    expect(token.expired()).toBe(false);
+  });
+});

--- a/packages/fxa-auth-server/lib/tokens/token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/token.spec.ts
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export {};
+
+const config = require('../../config').default.getProperties();
+const mocks = require('../../test/mocks');
+const log = mocks.mockLog();
+
+interface TokenInstance {
+  createdAt: number;
+}
+
+describe('Token', () => {
+  describe('NODE_ENV=dev', () => {
+    let Token: ReturnType<typeof require>;
+    beforeAll(() => {
+      config.isProduction = false;
+      Token = require('./token')(log, config);
+    });
+
+    it('Token constructor was exported', () => {
+      expect(typeof Token).toBe('function');
+      expect(Token.name).toBe('Token');
+      expect(Token.length).toBe(2);
+    });
+
+    it('Token constructor has expected factory methods', () => {
+      expect(typeof Token.createNewToken).toBe('function');
+      expect(Token.createNewToken.length).toBe(2);
+      expect(typeof Token.createTokenFromHexData).toBe('function');
+      expect(Token.createTokenFromHexData.length).toBe(3);
+    });
+
+    it('Token constructor sets createdAt', () => {
+      const now = Date.now() - 1;
+      const token = new Token({}, { createdAt: now });
+      expect(token.createdAt).toBe(now);
+    });
+
+    it('Token constructor defaults createdAt to zero if not given a value', () => {
+      const token = new Token({}, {});
+      expect(token.createdAt).toBe(0);
+    });
+
+    it('Token.createNewToken defaults createdAt to the current time', async () => {
+      const now = Date.now();
+      const token: TokenInstance = await Token.createNewToken(Token, {});
+      expect(token.createdAt >= now && token.createdAt <= Date.now()).toBeTruthy();
+    });
+
+    it('Token.createNewToken ignores an override for createdAt', async () => {
+      const now = Date.now() - 1;
+      const token: TokenInstance = await Token.createNewToken(Token, { createdAt: now });
+      expect(token.createdAt).not.toBe(now);
+    });
+
+    it('Token.createNewToken ignores a negative value for createdAt', async () => {
+      const now = Date.now();
+      const notNow = -now;
+      const token: TokenInstance = await Token.createNewToken(Token, { createdAt: notNow });
+      expect(token.createdAt >= now && token.createdAt <= Date.now()).toBeTruthy();
+    });
+
+    it('Token.createNewToken ignores a createdAt timestamp in the future', async () => {
+      const now = Date.now();
+      const notNow = Date.now() + 1000;
+      const token: TokenInstance = await Token.createNewToken(Token, { createdAt: notNow });
+      expect(token.createdAt >= now && token.createdAt <= Date.now()).toBeTruthy();
+    });
+
+    it('Token.createTokenFromHexData accepts a value for createdAt', async () => {
+      const now = Date.now() - 20;
+      const token: TokenInstance = await Token.createTokenFromHexData(Token, 'ABCD', {
+        createdAt: now,
+      });
+      expect(token.createdAt).toBe(now);
+    });
+
+    it('Token.createTokenFromHexData defaults to zero if not given a value for createdAt', async () => {
+      const token: TokenInstance = await Token.createTokenFromHexData(Token, 'ABCD', {
+        other: 'data',
+      });
+      expect(token.createdAt).toBe(0);
+    });
+  });
+
+  describe('NODE_ENV=prod', () => {
+    let Token: ReturnType<typeof require>;
+    beforeAll(() => {
+      config.isProduction = true;
+      Token = require('./token')(log, config);
+    });
+
+    it('Token.createNewToken defaults createdAt to the current time', async () => {
+      const now = Date.now();
+      const token: TokenInstance = await Token.createNewToken(Token, {});
+      expect(token.createdAt >= now && token.createdAt <= Date.now()).toBeTruthy();
+    });
+
+    it('Token.createNewToken does not accept an override for createdAt', async () => {
+      const now = Date.now() - 1;
+      const token: TokenInstance = await Token.createNewToken(Token, { createdAt: now });
+      expect(token.createdAt > now && token.createdAt <= Date.now()).toBeTruthy();
+    });
+
+    it('Token.createTokenFromHexData accepts a value for createdAt', async () => {
+      const now = Date.now() - 20;
+      const token: TokenInstance = await Token.createTokenFromHexData(Token, 'ABCD', {
+        createdAt: now,
+      });
+      expect(token.createdAt).toBe(now);
+    });
+
+    it('Token.createTokenFromHexData defaults to zero if not given a value for createdAt', async () => {
+      const token: TokenInstance = await Token.createTokenFromHexData(Token, 'ABCD', {
+        other: 'data',
+      });
+      expect(token.createdAt).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Because                                                                                                            
                                                                             
  - The auth-server test suite is being migrated from Mocha/Chai to Jest as part of FXA-12561                           
  - Co-located `.spec.ts` files improve discoverability and align with the project's test convention                    
  - Jest provides better TypeScript integration via ts-jest, built-in coverage, and parallel execution                  
                                                                             
  ## This pull request                   

  - Adds `jest.setup-proxyquire.js` to patch `resolve.sync` for proxyquire + ts-jest compatibility
  - Migrates 5 token tests: `token.spec.ts`, `account_reset_token.spec.ts`, `password_forgot_token.spec.ts`,
  `key_fetch_token.spec.ts`, `session_token.spec.ts`
  - Migrates 3 infrastructure tests: `sqs.spec.ts`, `notifier.spec.ts`, `pushbox/index.spec.ts`
  - Migrates 2 complex tests: `push.spec.ts`, `devices.spec.ts`
  - Replaces `proxyquire` with `jest.mock()`/`jest.doMock()`, converts `assert.*` to `expect().*`, uses proper TypeScript types (zero `any` usage)

  ### Coverage Parity: Mocha (NYC) vs Jest

  All 114 tests pass with identical coverage to the original Mocha suite:

  | Source File | Metric | Mocha (NYC) | Jest | Delta |
  |---|---|---|---|---|
  | **tokens/token.js** | Stmts | 100.0% | 100.0% | 0% |
  | | Branch | 91.7% | 91.7% | 0% |
  | | Funcs | 100.0% | 100.0% | 0% |
  | **tokens/account_reset_token.js** | Stmts | 100.0% | 100.0% | 0% |
  | | Branch | 75.0% | 75.0% | 0% |
  | | Funcs | 100.0% | 100.0% | 0% |
  | **tokens/password_forgot_token.js** | Stmts | 100.0% | 100.0% | 0% |
  | | Branch | 58.3% | 58.3% | 0% |
  | | Funcs | 100.0% | 100.0% | 0% |
  | **tokens/key_fetch_token.js** | Stmts | 100.0% | 100.0% | 0% |
  | | Branch | 70.0% | 70.0% | 0% |
  | | Funcs | 100.0% | 100.0% | 0% |
  | **tokens/session_token.js** | Stmts | 98.5% | 98.5% | 0% |
  | | Branch | 89.5% | 89.5% | 0% |
  | | Funcs | 90.9% | 90.9% | 0% |
  | **sqs.js** | Stmts | 83.0% | 83.0% | 0% |
  | | Branch | 50.0% | 50.0% | 0% |
  | | Funcs | 100.0% | 100.0% | 0% |
  | **notifier.js** | Stmts | 96.3% | 96.3% | 0% |
  | | Branch | 87.5% | 87.5% | 0% |
  | | Funcs | 100.0% | 100.0% | 0% |
  | **pushbox/index.ts** | Stmts | 90.9% | 90.9% | 0% |
  | | Branch | 60.0% | 60.0% | 0% |
  | | Funcs | 84.6% | 83.3% | -1.3% |
  | **push.js** | Stmts | 97.1% | 97.1% | 0% |
  | | Branch | 97.6% | 97.6% | 0% |
  | | Funcs | 90.0% | 90.0% | 0% |
  | **devices.js** | Stmts | 93.8% | 93.8% | 0% |
  | | Branch | 92.3% | 92.3% | 0% |
  | | Funcs | 72.7% | 72.7% | 0% |
  | **Totals** | Stmts | **95.3%** | **95.3%** | **0%** |
  | | Branch | **84.6%** | **84.6%** | **0%** |
  | | Funcs | **91.6%** | **91.5%** | **-0.1%** |

  ## Issue

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-12561

  ## Checklist

  - [x] My commit is GPG signed
  - [x] Tests pass locally (if applicable)
  - [ ] Documentation updated (if applicable)
  - [ ] RTL rendering verified (if UI changed)

  ## Other Information

  **How to test:**
  ```bash
  cd packages/fxa-auth-server
  npx jest --no-coverage --forceExit lib/tokens/token.spec.ts lib/tokens/account_reset_token.spec.ts
  lib/tokens/password_forgot_token.spec.ts lib/tokens/key_fetch_token.spec.ts lib/tokens/session_token.spec.ts
  lib/sqs.spec.ts lib/notifier.spec.ts lib/pushbox/index.spec.ts lib/push.spec.ts lib/devices.spec.ts
  ```

The original Mocha test files in `test/local/` are not removed in this PR