### PR TITLE
fix(sentry): Register SentryGlobalFilter via dependency injection

### DIFF
--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -27,7 +27,6 @@ import { EventLoggingModule } from './event-logging/event-logging.module';
 import { GqlModule } from './gql/gql.module';
 import { NewslettersModule } from './newsletters/newsletters.module';
 import { SubscriptionModule } from './subscriptions/subscriptions.module';
-import { LOGGER_PROVIDER } from '@fxa/shared/log';
 
 const version = getVersionInfo(__dirname);
 

--- a/packages/fxa-event-broker/src/app.module.ts
+++ b/packages/fxa-event-broker/src/app.module.ts
@@ -2,11 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ConfigModule } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { HealthModule } from 'fxa-shared/nestjs/health/health.module';
 import { LoggerModule } from 'fxa-shared/nestjs/logger/logger.module';
-import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { MetricsFactory } from 'fxa-shared/nestjs/metrics.service';
 import { getVersionInfo } from 'fxa-shared/nestjs/version';
 

--- a/packages/fxa-event-broker/src/main.ts
+++ b/packages/fxa-event-broker/src/main.ts
@@ -11,7 +11,7 @@ import { SentryGlobalFilter } from '@sentry/nestjs/setup';
 
 import { NestApplicationOptions } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { NestFactory } from '@nestjs/core';
+import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import mozLog from 'mozlog';
 
 import { initTracing } from 'fxa-shared/tracing/node-tracing';
@@ -34,7 +34,9 @@ async function bootstrap() {
   const config: ConfigService<AppConfig> = app.get(ConfigService);
   const proxyConfig = config.get('proxy') as AppConfig['proxy'];
 
-  app.useGlobalFilters(new SentryGlobalFilter());
+  // Register Sentry exception filter with proper HttpAdapterHost
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new SentryGlobalFilter(httpAdapter));
 
   // Starts listening for shutdown hooks
   app.enableShutdownHooks();

--- a/packages/fxa-graphql-api/src/app.module.ts
+++ b/packages/fxa-graphql-api/src/app.module.ts
@@ -52,7 +52,7 @@ const version = getVersionInfo(__dirname);
         extraHealthData: () => db.dbHealthCheck(),
       }),
     }),
-    CustomsModule
+    CustomsModule,
   ],
   controllers: [],
   providers: [

--- a/packages/fxa-graphql-api/src/main.ts
+++ b/packages/fxa-graphql-api/src/main.ts
@@ -16,7 +16,7 @@ import { StatsDService } from '@fxa/shared/metrics/statsd';
 import helmet from 'helmet';
 
 import { NestApplicationOptions } from '@nestjs/common';
-import { NestFactory } from '@nestjs/core';
+import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
 import { AppModule } from './app.module';
@@ -34,8 +34,9 @@ async function bootstrap() {
     nestConfig
   );
 
-  // As of sentry v9, this should handle both regular requests and graphql requests.
-  app.useGlobalFilters(new SentryGlobalFilter());
+  // Register Sentry exception filter with proper HttpAdapterHost
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new SentryGlobalFilter(httpAdapter));
 
   // Configure allowlisting of gql queries
   app.use(bodyParser.json());


### PR DESCRIPTION
## Because

  * Manual instantiation of SentryGlobalFilter bypassed NestJS dependency injection
  * This caused applicationRef to be undefined, crashing the exception filter
  * Crashed filter left requests hanging indefinitely (RP event distribution delays spiked to 2.31 days)

## This pull request

  * Registers SentryGlobalFilter as APP_FILTER provider in AppModule for fxa-graphql-api, fxa-event-broker, and fxa-admin-server
  * Removes manual app.useGlobalFilters(new SentryGlobalFilter()) calls from main.ts
  * Ensures filter receives HttpAdapterHost via dependency injection
## Issue that this pull request solves

Closes: FXA-13031

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
