### PR TITLE
fix(oauth): Always skip session token lookup for refresh token exchange

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1408,7 +1408,12 @@ const convictConf = convict({
       allowedClientIds: {
         doc: 'Client IDs allowed to perform token exchange (only Firefox mobile clients as of FXA-12925)',
         format: Array,
-        default: ['1b1a3e44c54fbb58', '3332a18d142636cb', 'a2270f727f45f648'],
+        default: [
+          '1b1a3e44c54fbb58',
+          '3332a18d142636cb',
+          'a2270f727f45f648',
+          '3c49430b43dfba77',
+        ],
         env: 'OAUTH_TOKEN_EXCHANGE_CLIENT_IDS',
       },
       allowedScopes: {

--- a/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.js
@@ -137,7 +137,7 @@ const MOCK_CODE_CHALLENGE = 'YPhkZqm08uTfwjNSiYcx80-NPT9Zn94kHboQW97KyV0';
         });
         assert.fail('should have thrown');
       } catch (err) {
-        assert.equal(err.errno, error.ERRNO.UNKNOWN_AUTHORIZATION_CODE);
+        assert.equal(err.errno, error.ERRNO.INVALID_TOKEN);
       }
     });
 

--- a/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-native-integration.ts
@@ -38,6 +38,8 @@ export enum OAuthNativeClients {
   FirefoxDesktop = '5882386c6d801776',
   Fenix = 'a2270f727f45f648',
   Fennec = '3332a18d142636cb',
+  // For Android testing
+  ReferenceBrowser = '3c49430b43dfba77',
   // TODO: handle Thunderbird case better, FXA-10848
   Thunderbird = '8269bacd7bbc7f80',
 }
@@ -119,7 +121,8 @@ export class OAuthNativeIntegration extends OAuthWebIntegration {
     return (
       this.clientInfo?.clientId === OAuthNativeClients.FirefoxIOS ||
       this.clientInfo?.clientId === OAuthNativeClients.Fenix ||
-      this.clientInfo?.clientId === OAuthNativeClients.Fennec
+      this.clientInfo?.clientId === OAuthNativeClients.Fennec ||
+      this.clientInfo?.clientId === OAuthNativeClients.ReferenceBrowser
     );
   }
 

--- a/packages/fxa-shared/oauth/constants.ts
+++ b/packages/fxa-shared/oauth/constants.ts
@@ -6,6 +6,7 @@ export const OAUTH_SCOPE_SUBSCRIPTIONS =
   'https://identity.mozilla.com/account/subscriptions';
 
 export const OAUTH_SCOPE_OLD_SYNC = 'https://identity.mozilla.com/apps/oldsync';
+export const OAUTH_SCOPE_RELAY = 'https://identity.mozilla.com/apps/relay';
 export const OAUTH_SCOPE_SESSION_TOKEN =
   'https://identity.mozilla.com/tokens/session';
 export const OAUTH_SCOPE_NEWSLETTERS =
@@ -18,6 +19,7 @@ export const MAX_NEW_ACCOUNT_AGE = 1000 * 60 * 60 * 24;
 
 export const OauthConsts = {
   OAUTH_SCOPE_OLD_SYNC,
+  OAUTH_SCOPE_RELAY,
   OAUTH_SCOPE_SESSION_TOKEN,
   OAUTH_SCOPE_NEWSLETTERS,
   OAUTH_SCOPE_SUBSCRIPTIONS,


### PR DESCRIPTION
Because:
* If the refresh token has the "session" scope, we try to create a new session token. We do not want this for our new 'silent' upgrade options, e.g. token-exchange with a refresh token and scope upgrade, and our session token to refresh token migration

This commit:
* Skips the session token lookup and creation if the request is a refresh token upgrade or token migration
* Adds Android reference browser to the allowlist of clients that can upgrade their existing refresh token and adds support for our front-end
* Updates error message when the session token isn't found, as the existing try/catch error message is misleading

closes FXA-13037

--

Jonathan will likely be testing this locally, I will hold off on merge until this has been verified.