### PR TITLE
feat(settings): create passkey unit row and sub row components

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ButtonIcon/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ButtonIcon/index.tsx
@@ -12,12 +12,12 @@ type ButtonIconProps = {
   icon: [
     FunctionComponent<SVGProps<SVGSVGElement & { title?: string }>>,
     number,
-    number
+    number,
   ];
   classNames?: string;
   disabled?: boolean;
   gleanDataAttrs?: GleanClickEventDataAttrs;
-  onClick?: () => void;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   testId?: string;
 };
 

--- a/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
@@ -38,3 +38,26 @@ tfa-row-backup-phone-description-v2 = This is the easiest recovery method if you
 # into transferring a victim's phone number to their own SIM card, enabling access to accounts secured
 # with SMS-based two-factor authentication.
 tfa-row-backup-phone-sim-swap-risk-link = Learn about SIM swap risk
+
+# This is a string that shows when the user's passkey was created.
+# Variables:
+#   $createdDate (String) - a localized date string
+passkey-sub-row-created-date = Created: { $createdDate }
+
+# This is a string that shows when the user's passkey was last used.
+# Variables:
+#   $lastUsedDate (String) - a localized date string
+passkey-sub-row-last-used-date = Last used: { $lastUsedDate }
+
+# These two sentences are referring to the passkey
+passkey-sub-row-sign-in-only = Sign in only. Can’t be used to sync.
+
+passkey-sub-row-delete-title = Delete passkey
+passkey-delete-modal-heading = Delete your passkey?
+passkey-delete-modal-content = This passkey will be removed from your account. You’ll need to sign in using a different way.
+passkey-delete-modal-cancel-button = Cancel
+passkey-delete-modal-confirm-button = Delete passkey
+passkey-delete-success = Passkey deleted
+passkey-delete-error = There was a problem deleting your passkey. Try again in a few minutes.
+
+##

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
@@ -4,25 +4,38 @@
 
 import React from 'react';
 import { Meta, StoryFn } from '@storybook/react';
-import SubRow, { BackupCodesSubRow, BackupPhoneSubRow } from './index';
+import SubRow, {
+  BackupCodesSubRow,
+  BackupPhoneSubRow,
+  PasskeySubRow,
+} from './index';
 import { action } from '@storybook/addon-actions';
-import { withLocalization } from 'fxa-react/lib/storybooks';
+import { withLocalization, withLocation } from 'fxa-react/lib/storybooks';
 import { CodeIcon } from '../../Icons';
 import { MOCK_NATIONAL_FORMAT_PHONE_NUMBER } from '../../../pages/mocks';
+import { AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
+import { initLocalAccount, mockAuthClient } from './mock';
 
 export default {
   title: 'Components/Settings/SubRow',
   component: SubRow,
   decorators: [
     withLocalization,
+    withLocation(),
     (Story) => {
+      initLocalAccount();
       return (
-        // @container/unitRow on the container div allows sub row to adjust based on the size of the parent container
-        // instead of the viewport. This fixes issues with the subrow and CTAs overflowing their parent container in mobileLandscape
-        // and tablet portrait views.
-        <div className="@container/unitRow">
-          <Story />
-        </div>
+        <AppContext.Provider
+          value={mockAppContext({ authClient: mockAuthClient } as any)}
+        >
+          {/* @container/unitRow on the container div allows sub row to adjust based on the size of the parent container
+          instead of the viewport. This fixes issues with the subrow and CTAs overflowing their parent container in mobileLandscape
+          and tablet portrait views. */}
+          <div className="@container/unitRow">
+            <Story />
+          </div>
+        </AppContext.Provider>
       );
     },
   ],
@@ -35,7 +48,7 @@ export const GenericSubRow: StoryFn = () => (
     ctaTestId="cta-button"
     icon={<CodeIcon className="my-0" />}
     idPrefix="example"
-    isEnabled
+    statusIcon="checkmark"
     localizedInfoMessage="Row description"
     localizedRowTitle="Sub row title"
     message={<div>Status message goes here</div>}
@@ -50,7 +63,7 @@ export const GenericSubRowWithDescription: StoryFn = () => (
     ctaTestId="cta-button"
     icon={<CodeIcon className="my-0" />}
     idPrefix="example"
-    isEnabled
+    statusIcon="checkmark"
     localizedInfoMessage="Row description"
     localizedRowTitle="Sub row title"
     message={<div>Status message goes here</div>}
@@ -116,5 +129,40 @@ export const BackupPhoneAvailableNoDelete: StoryFn = () => (
   <BackupPhoneSubRow
     onCtaClick={action('Change recovery phone')}
     phoneNumber={MOCK_NATIONAL_FORMAT_PHONE_NUMBER}
+  />
+);
+
+export const PasskeyWithSync: StoryFn = () => (
+  <PasskeySubRow
+    passkey={{
+      id: '1',
+      name: 'MacBook Pro',
+      createdAt: new Date('2026-01-01').getTime(),
+      lastUsed: new Date('2026-02-01').getTime(),
+      canSync: true,
+    }}
+  />
+);
+
+export const PasskeyWithoutSync: StoryFn = () => (
+  <PasskeySubRow
+    passkey={{
+      id: '2',
+      name: 'iPhone 14 Pro',
+      createdAt: new Date('2025-12-01').getTime(),
+      lastUsed: new Date('2026-01-31').getTime(),
+      canSync: false,
+    }}
+  />
+);
+
+export const PasskeyNeverUsed: StoryFn = () => (
+  <PasskeySubRow
+    passkey={{
+      id: '3',
+      name: 'Windows PC',
+      createdAt: new Date('2025-11-01').getTime(),
+      canSync: true,
+    }}
   />
 );

--- a/packages/fxa-settings/src/components/Settings/SubRow/mock.ts
+++ b/packages/fxa-settings/src/components/Settings/SubRow/mock.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AuthClient from 'fxa-auth-client';
+
+/// mock localStorage state to allow MfaGuard to work in stories
+export function initLocalAccount() {
+  const uid = 'abc123';
+  const accounts = {
+    [uid]: {
+      uid,
+      sessionToken: 'sessionToken',
+      email: 'user@example.com',
+      verified: true,
+      lastLogin: Date.now(),
+    },
+  };
+  window.localStorage.setItem(
+    `__fxa_storage.accounts`,
+    JSON.stringify(accounts)
+  );
+  window.localStorage.setItem(
+    `__fxa_storage.currentAccountUid`,
+    JSON.stringify(uid)
+  );
+}
+
+/// mock AuthClient to allow MfaGuard to work in stories
+export const mockAuthClient = {
+  mfaRequestOtp: async (st: string, sc: string) => {
+    return undefined;
+  },
+  mfaOtpVerify: async (st: string, code: string, sc: string) => {
+    return { accessToken: 'storybook-jwt' } as any;
+  },
+} as unknown as AuthClient;

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/en.ftl
@@ -1,0 +1,11 @@
+## UnitRowPasskey
+
+passkey-row-header = Passkeys
+passkey-row-enabled = Enabled
+passkey-row-not-set = Not Set
+passkey-row-action-create = Create
+passkey-row-description = Make sign in easier and more secure by using your phone or other supported device to get into your account.
+# External link to a support article. "This" refers to passkeys.
+passkey-row-info-link = How this protects your account
+
+##

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+import { LocationProvider } from '@reach/router';
+import UnitRowPasskey, { Passkey } from '.';
+import { AppContext } from 'fxa-settings/src/models';
+import { mockAppContext } from 'fxa-settings/src/models/mocks';
+import { initLocalAccount, mockAuthClient } from '../SubRow/mock';
+
+export default {
+  title: 'Components/Settings/UnitRowPasskey',
+  component: UnitRowPasskey,
+  decorators: [withLocalization],
+} as Meta;
+
+const mockPasskeys = [
+  {
+    id: 'passkey-1',
+    name: 'MacBook Pro',
+    createdAt: new Date('2026-01-01').getTime(),
+    lastUsed: new Date('2026-02-01').getTime(),
+    canSync: false,
+  },
+  {
+    id: 'passkey-2',
+    name: 'iPhone 15',
+    createdAt: new Date('2025-12-01').getTime(),
+    lastUsed: new Date('2026-01-31').getTime(),
+    canSync: true,
+  },
+  {
+    id: 'passkey-3',
+    name: 'Work Laptop',
+    createdAt: new Date('2025-11-01').getTime(),
+    lastUsed: undefined,
+    canSync: false,
+  },
+];
+
+const storyWithPasskeys = (passkeys: Passkey[]) => {
+  const story = () => {
+    initLocalAccount();
+    return (
+      <LocationProvider>
+        <AppContext.Provider
+          value={mockAppContext({ authClient: mockAuthClient } as any)}
+        >
+          <UnitRowPasskey passkeys={passkeys} />
+        </AppContext.Provider>
+      </LocationProvider>
+    );
+  };
+  return story;
+};
+
+export const NoPasskeys = storyWithPasskeys([]);
+
+export const WithPasskeys = storyWithPasskeys(mockPasskeys);
+
+export const SinglePasskey = storyWithPasskeys([mockPasskeys[0]]);
+
+export const WithNeverUsedPasskey = storyWithPasskeys([mockPasskeys[2]]);
+
+export const MultiplePasskeys = storyWithPasskeys(mockPasskeys);

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { LocationProvider } from '@reach/router';
+import UnitRowPasskey, { Passkey } from './index';
+import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
+
+const mockJwtState = {};
+
+jest.mock('../../../lib/cache', () => ({
+  ...jest.requireActual('../../../lib/cache'),
+  JwtTokenCache: {
+    hasToken: jest.fn(() => true),
+    subscribe: jest.fn((listener) => {
+      return () => {}; // unsubscribe function
+    }),
+    getSnapshot: jest.fn(() => mockJwtState),
+  },
+  sessionToken: jest.fn(() => 'session-123'),
+}));
+
+describe('UnitRowPasskey', () => {
+  const mockPasskeys: Passkey[] = [
+    {
+      id: 'passkey-1',
+      name: 'MacBook Pro',
+      createdAt: new Date('2026-01-01').getTime(),
+      lastUsed: new Date('2026-02-01').getTime(),
+      canSync: true,
+    },
+    {
+      id: 'passkey-2',
+      name: 'iPhone 15',
+      createdAt: new Date('2025-12-01').getTime(),
+      lastUsed: new Date('2026-01-31').getTime(),
+      canSync: false,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderUnitRowPasskey = (passkeys: Passkey[] = mockPasskeys) => {
+    return renderWithLocalizationProvider(
+      <LocationProvider>
+        <UnitRowPasskey passkeys={passkeys} />
+      </LocationProvider>
+    );
+  };
+
+  it('renders as expected', () => {
+    renderUnitRowPasskey();
+    expect(screen.getByText('Passkeys')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Make sign in easier and more secure by using your phone or other supported device to get into your account.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /How this protects your account/ })
+    ).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/placeholder-article'
+    );
+    expect(screen.getByRole('link', { name: 'Create' })).toHaveAttribute(
+      'href',
+      '/settings/passkeys/add'
+    );
+  });
+
+  it('displays "Enabled" when passkeys exist', () => {
+    renderUnitRowPasskey();
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  it('displays "Not Set" when no passkeys exist', () => {
+    renderUnitRowPasskey([]);
+    expect(screen.getByText('Not Set')).toBeInTheDocument();
+  });
+
+  it('renders all passkey sub-rows', () => {
+    renderUnitRowPasskey();
+    expect(screen.getByText('MacBook Pro')).toBeInTheDocument();
+    expect(screen.getByText('iPhone 15')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import UnitRow, { UnitRowProps } from '../UnitRow';
+import { useFtlMsgResolver } from '../../../models';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { PasskeySubRow } from '../SubRow';
+
+// TODO: Update with actual passkey data types when available
+export type Passkey = {
+  id: string;
+  name: string;
+  createdAt: number;
+  lastUsed?: number;
+  canSync: boolean;
+};
+
+export type UnitRowPasskeyProps = {
+  passkeys?: Passkey[];
+};
+
+export const UnitRowPasskey = ({ passkeys = [] }: UnitRowPasskeyProps) => {
+  const ftlMsgResolver = useFtlMsgResolver();
+  const hasPasskeys = passkeys.length > 0;
+
+  const conditionalUnitRowProps: Partial<UnitRowProps> = hasPasskeys
+    ? {
+        statusIcon: 'checkmark',
+        headerValue: ftlMsgResolver.getMsg('passkey-row-enabled', 'Enabled'),
+      }
+    : {
+        statusIcon: 'alert',
+        defaultHeaderValueText: ftlMsgResolver.getMsg(
+          'passkey-row-not-set',
+          'Not Set'
+        ),
+      };
+
+  const getSubRows = () => {
+    return passkeys.map((passkey) => (
+      <PasskeySubRow key={passkey.id} passkey={passkey} />
+    ));
+  };
+
+  const learnMoreLink = (
+    <FtlMsg id="passkey-row-info-link">
+      <LinkExternal
+        href="https://support.mozilla.org/kb/placeholder-article" // TODO: Update with actual support article link
+        className="link-blue text-sm"
+      >
+        How this protects your account
+      </LinkExternal>
+    </FtlMsg>
+  );
+
+  return (
+    <>
+      <UnitRow
+        header={ftlMsgResolver.getMsg('passkey-row-header', 'Passkeys')}
+        headerId="passkeys"
+        prefixDataTestId="passkey"
+        ctaText={ftlMsgResolver.getMsg('passkey-row-action-create', 'Create')}
+        route="/settings/passkeys/add"
+        {...conditionalUnitRowProps}
+        subRows={getSubRows()}
+      >
+        <FtlMsg id="passkey-row-description">
+          <p className="text-sm my-2">
+            Make sign in easier and more secure by using your phone or other
+            supported device to get into your account.
+          </p>
+        </FtlMsg>
+        {learnMoreLink}
+      </UnitRow>
+    </>
+  );
+};
+
+export default UnitRowPasskey;

--- a/packages/fxa-settings/src/models/contexts/AppContext.ts
+++ b/packages/fxa-settings/src/models/contexts/AppContext.ts
@@ -126,6 +126,7 @@ export function defaultAppContext(context?: AppContextValue) {
     metricsEnabled: true,
     attachedClients: [],
     subscriptions: [],
+    email: 'johndope@example.com',
     primaryEmail: {
       email: 'johndope@example.com',
       isPrimary: true,


### PR DESCRIPTION
## Because

- we need passkey in settings

## This pull request

- creates passkey unit row and sub row components

## Issue that this pull request solves

Closes: FXA-12908

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="943" height="486" alt="image" src="https://github.com/user-attachments/assets/2bd65536-5bf4-4549-a5e2-0ba6c9386091" />

<img width="542" height="339" alt="image" src="https://github.com/user-attachments/assets/0ec914ae-8405-424b-92a0-0efd887844a1" />

## Other information (Optional)

Any other information that is important to this pull request.
