### PR TITLE
feat(fxa): Add rate limit rules for passkeys

### DIFF
--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -156,3 +156,27 @@ mfaOtpCodeVerifyForEmail               : uid              : 5           : 5 minu
 mfaOtpCodeVerifyFor2fa                 : uid              : 5           : 5 minutes       : 15 minutes   : block
 mfaOtpCodeVerifyForPassword            : uid              : 5           : 5 minutes       : 15 minutes   : block
 mfaOtpCodeVerifyForRecoveryKey         : uid              : 5           : 5 minutes       : 15 minutes   : block
+
+#
+# Passkey Registration
+# MFA-protected endpoints for registering new passkeys. Moderate limits since these require existing auth.
+#
+passkeyRegisterStart                   : ip_uid            : 10           : 10 minutes      : 10 minutes  : block
+passkeyRegisterFinish                  : ip_uid            : 10           : 10 minutes      : 10 minutes  : block
+
+#
+# Passkey Authentication
+# More lenient than passwords - passkeys cannot be credential-stuffed or brute-forced.
+# Rate limits are primarily for DoS prevention.
+#
+passkeyAuthenticationStart             : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
+passkeyAuthenticationVerify            : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
+passkeyLogin                           : ip_uid            : 15          : 15 minutes      : 15 minutes  : block
+
+#
+# Passkey Management
+# Relaxed limits for normal usage. All endpoints require verifiedSessionToken or MFA JWT.
+#
+passkeysList                           : ip_uid            : 100         : 15 minutes      : 15 minutes  : block
+passkeysRename                         : ip_uid            : 100         : 15 minutes      : 15 minutes  : block
+passkeyDelete                          : ip_uid            : 100         : 15 minutes      : 15 minutes  : block


### PR DESCRIPTION
Because:
 - We will be adding new Passkey management api routes to FxA

This Commit:
 - Adds ratelimit rules to the prod fxa config for limiting passkey

Closes: FXA-12904

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Sister webservices-infra pr: https://github.com/mozilla/webservices-infra/pull/9550