### PR TITLE
fix(payments-next): The “Resubscribe and save x%” button link from the "Stay Subscribed" email offer is losing some parameters if the user is not signed in on the account.

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/error/page.tsx
@@ -36,6 +36,10 @@ export default async function LoyaltyDiscountCancelErrorPage({
       `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
     );
     redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirectToUrl.searchParams.set(
+      'redirect_to',
+      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/cancel/error`
+    );
     redirect(redirectToUrl.href);
   }
 

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/page.tsx
@@ -31,6 +31,10 @@ export default async function LoyaltyDiscountCancelPage({
       `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
     );
     redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirectToUrl.searchParams.set(
+      'redirect_to',
+      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/cancel`
+    );
     redirect(redirectToUrl.href);
   }
 

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/error/page.tsx
@@ -32,6 +32,10 @@ export default async function LoyaltyDiscountStaySubscribedErrorPage({
       `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
     );
     redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirectToUrl.searchParams.set(
+      'redirect_to',
+      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/stay-subscribed/error`
+    );
     redirect(redirectToUrl.href);
   }
 

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/page.tsx
@@ -31,6 +31,10 @@ export default async function LoyaltyDiscountStaySubscribedPage({
       `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
     );
     redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirectToUrl.searchParams.set(
+      'redirect_to',
+      `/${locale}/subscriptions/${subscriptionId}/loyalty-discount/stay-subscribed`
+    );
     redirect(redirectToUrl.href);
   }
 

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/error/page.tsx
@@ -34,6 +34,10 @@ export default async function InterstitialOfferErrorPage({
       `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
     );
     redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirectToUrl.searchParams.set(
+      'redirect_to',
+      `/${locale}/subscriptions/${subscriptionId}/offer/error`
+    );
     redirect(redirectToUrl.href);
   }
 

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/page.tsx
@@ -35,6 +35,10 @@ export default async function InterstitialOfferPage({
       `${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`
     );
     redirectToUrl.search = new URLSearchParams(searchParams).toString();
+    redirectToUrl.searchParams.set(
+      'redirect_to',
+      `/${locale}/subscriptions/${subscriptionId}/offer`
+    );
     redirect(redirectToUrl.href);
   }
 

--- a/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
+++ b/apps/payments/next/app/[locale]/subscriptions/landing/route.ts
@@ -17,8 +17,16 @@ export async function GET(
   const requestSearchParams = request.nextUrl.searchParams;
   const { locale } = params;
 
+  const redirectToParam = requestSearchParams.get('redirect_to');
+  requestSearchParams.delete('redirect_to');
+
+  const redirectToPath =
+    redirectToParam && redirectToParam.startsWith('/')
+      ? redirectToParam
+      : `/${locale}/subscriptions/manage`;
+
   const redirectToUrl = new URL(
-    `${config.paymentsNextHostedUrl}/${locale}/subscriptions/manage`
+    `${config.paymentsNextHostedUrl}${redirectToPath}`
   );
   redirectToUrl.search = requestSearchParams.toString();
 


### PR DESCRIPTION
## Because

- If the user is not signed in and clicks on the promotion link from the email, after they sign in they are taken to the SubManage page instead of the loyalty-discount page.

## This pull request

- Fixes the above and implements a similar fix for other churn pages as well (stay subscribed, stay subscribed error, cancel, cancel error, offer, offer error)

## Issue that this pull request solves

Closes: #[PAY-3507](https://mozilla-hub.atlassian.net/browse/PAY-3507)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

https://github.com/user-attachments/assets/b22c3a82-09eb-4136-9d21-6be6f1d42c72

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3507]: https://mozilla-hub.atlassian.net/browse/PAY-3507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ