### PR TITLE
feat(auth): add passwordless email otp routes

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1211,12 +1211,67 @@ export default class AuthClient {
 
   async accountStatusByEmail(
     email: string,
-    options: { thirdPartyAuthStatus?: boolean } = {},
+    options: { thirdPartyAuthStatus?: boolean; clientId?: string } = {},
     headers?: Headers
   ) {
     return this.request(
       'POST',
       '/account/status',
+      { email, ...options },
+      headers
+    );
+  }
+
+  /**
+   * Send a passwordless OTP code to the user's email
+   */
+  async passwordlessSendCode(
+    email: string,
+    options: { service?: string; metricsContext?: MetricsContext } = {},
+    headers?: Headers
+  ): Promise<{}> {
+    return this.request(
+      'POST',
+      '/account/passwordless/send_code',
+      { email, ...options },
+      headers
+    );
+  }
+
+  /**
+   * Confirm a passwordless OTP code and get a session token
+   */
+  async passwordlessConfirmCode(
+    email: string,
+    code: string,
+    options: { service?: string; metricsContext?: MetricsContext } = {},
+    headers?: Headers
+  ): Promise<{
+    uid: string;
+    sessionToken: string;
+    verified: boolean;
+    authAt: number;
+    isNewAccount: boolean;
+  }> {
+    return this.request(
+      'POST',
+      '/account/passwordless/confirm_code',
+      { email, code, ...options },
+      headers
+    );
+  }
+
+  /**
+   * Resend a passwordless OTP code
+   */
+  async passwordlessResendCode(
+    email: string,
+    options: { service?: string; metricsContext?: MetricsContext } = {},
+    headers?: Headers
+  ): Promise<{}> {
+    return this.request(
+      'POST',
+      '/account/passwordless/resend_code',
       { email, ...options },
       headers
     );
@@ -1907,11 +1962,17 @@ export default class AuthClient {
     return this.sessionGet('/account/sessions', sessionToken, headers);
   }
 
-  async securityEvents(sessionToken: hexstring, headers?: Headers): Promise<SecurityEvent[]> {
+  async securityEvents(
+    sessionToken: hexstring,
+    headers?: Headers
+  ): Promise<SecurityEvent[]> {
     return this.sessionGet('/securityEvents', sessionToken, headers);
   }
 
-  async attachedClients(sessionToken: hexstring, headers?: Headers): Promise<AttachedClient[]> {
+  async attachedClients(
+    sessionToken: hexstring,
+    headers?: Headers
+  ): Promise<AttachedClient[]> {
     return this.sessionGet('/account/attached_clients', sessionToken, headers);
   }
 

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2166,6 +2166,38 @@ const convictConf = convict({
       env: 'OTP_SIGNUP_DIGIT',
     },
   },
+  passwordlessOtp: {
+    enabled: {
+      doc: 'Enable passwordless authentication feature',
+      default: false,
+      format: Boolean,
+      env: 'PASSWORDLESS_ENABLED',
+    },
+    forcedEmailAddresses: {
+      doc: 'Force passwordless flow for email addresses matching this regex (for testing)',
+      format: RegExp,
+      default: /^passwordless.*@restmail\.net$/,
+      env: 'PASSWORDLESS_FORCED_EMAIL_REGEX',
+    },
+    allowedClientIds: {
+      doc: 'Array of clients ids allowed to use passwordless authentication. Empty array means all services allowed.',
+      format: Array,
+      default: [],
+      env: 'PASSWORDLESS_ALLOWED_SERVICES',
+    },
+    digits: {
+      doc: 'Number of digits in passwordless OTP code',
+      default: 8,
+      format: 'nat',
+      env: 'OTP_PASSWORDLESS_DIGITS',
+    },
+    ttl: {
+      doc: 'Duration in seconds when the passwordless OTP is valid',
+      default: 10 * 60,
+      format: 'nat',
+      env: 'OTP_PASSWORDLESS_TTL',
+    },
+  },
   accountDestroy: {
     requireVerifiedAccount: {
       doc: 'Whether or not the account must be verified in order to destroy it.',

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -180,3 +180,19 @@ passkeyLogin                           : ip_uid            : 15          : 15 mi
 passkeysList                           : ip_uid            : 100         : 15 minutes      : 15 minutes  : block
 passkeysRename                         : ip_uid            : 100         : 15 minutes      : 15 minutes  : block
 passkeyDelete                          : ip_uid            : 100         : 15 minutes      : 15 minutes  : block
+
+#
+# Passwordless Authentication OTP Limits
+# Controls the rate at which passwordless OTP codes can be sent and verified
+#
+passwordlessSendOtp                    : email            : 2           : 15 minutes      : 15 minutes   : block
+passwordlessSendOtp                    : email            : 5           : 24 hours        : 12 hours     : block
+passwordlessSendOtp                    : ip               : 50          : 24 hours        : 12 hours     : block
+passwordlessSendOtp                    : ip               : 20          : 15 minutes      : 30 minutes   : block
+passwordlessSendOtp                    : ip               : 100         : 24 hours        : 15 minutes   : ban
+
+# Passwordless OTP Verification Limits
+passwordlessVerifyOtp                  : ip_email         : 5           : 10 minutes      : 15 minutes   : block
+passwordlessVerifyOtp                  : ip               : 100         : 24 hours        : 15 minutes   : ban
+passwordlessVerifyOtpPerDay            : ip_email         : 10          : 24 hours        : 24 hours     : block
+passwordlessVerifyOtpPerDay            : ip               : 100         : 24 hours        : 15 minutes   : ban

--- a/packages/fxa-auth-server/docs/swagger/passwordless-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passwordless-api.ts
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import dedent from 'dedent';
+import TAGS from './swagger-tags';
+
+const TAGS_PASSWORDLESS = {
+  tags: TAGS.PASSWORDLESS,
+};
+
+const PASSWORDLESS_SEND_CODE_POST = {
+  ...TAGS_PASSWORDLESS,
+  description: '/account/passwordless/send_code',
+  notes: [
+    dedent`
+      Send a one-time password (OTP) code to the user's email for passwordless authentication.
+
+      This endpoint can be used for both:
+      - New user registration (account doesn't exist)
+      - Login for existing passwordless accounts (accounts without a password)
+
+      Accounts with passwords set cannot use this endpoint.
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - \`errno: 148\` - Account has a password set, use standard login flow
+          `,
+        },
+        429: {
+          description: 'Rate limit exceeded',
+        },
+      },
+    },
+  },
+};
+
+const PASSWORDLESS_CONFIRM_CODE_POST = {
+  ...TAGS_PASSWORDLESS,
+  description: '/account/passwordless/confirm_code',
+  notes: [
+    dedent`
+      Confirm the OTP code sent via \`/account/passwordless/send_code\`.
+
+      On success:
+      - For new users: Creates a new account and returns a session token
+      - For existing users: Returns a session token for the existing account
+
+      The \`isNewAccount\` field in the response indicates whether a new account was created.
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - \`errno: 183\` - Invalid OTP code
+            - \`errno: 148\` - Account has a password set
+          `,
+        },
+        429: {
+          description: 'Rate limit exceeded',
+        },
+      },
+    },
+  },
+};
+
+const PASSWORDLESS_RESEND_CODE_POST = {
+  ...TAGS_PASSWORDLESS,
+  description: '/account/passwordless/resend_code',
+  notes: [
+    dedent`
+      Resend the OTP code for passwordless authentication.
+
+      This invalidates any previously sent code and sends a new one.
+      Subject to the same rate limits as \`/account/passwordless/send_code\`.
+    `,
+  ],
+  plugins: {
+    'hapi-swagger': {
+      responses: {
+        400: {
+          description: dedent`
+            Failing requests may be caused by the following errors:
+            - \`errno: 148\` - Account has a password set
+          `,
+        },
+        429: {
+          description: 'Rate limit exceeded',
+        },
+      },
+    },
+  },
+};
+
+export default {
+  PASSWORDLESS_SEND_CODE_POST,
+  PASSWORDLESS_CONFIRM_CODE_POST,
+  PASSWORDLESS_RESEND_CODE_POST,
+};

--- a/packages/fxa-auth-server/docs/swagger/swagger-tags.ts
+++ b/packages/fxa-auth-server/docs/swagger/swagger-tags.ts
@@ -11,6 +11,7 @@ const TAGS = {
   OAUTH: ['api', 'Oauth'],
   OAUTH_SERVER: ['api', 'OAuth Server API Overview'],
   PASSWORD: ['api', 'Password'],
+  PASSWORDLESS: ['api', 'Passwordless'],
   RECOVERY_PHONE: ['api', 'Recovery phone'],
   RECOVERY_CODES: ['api', 'Backup authentication codes'],
   RECOVERY_KEY: ['api', 'Account recovery key'],

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -241,6 +241,17 @@ module.exports = function (
   const { mfaRoutes } = require('./mfa');
   const mfa = mfaRoutes(customs, db, log, mailer, statsd, config);
 
+  const { passwordlessRoutes } = require('./passwordless');
+  const passwordless = passwordlessRoutes(
+    log,
+    db,
+    config,
+    customs,
+    glean,
+    statsd,
+    authServerCacheRedis
+  );
+
   let basePath = url.parse(config.publicUrl).path;
   if (basePath === '/') {
     basePath = '';
@@ -253,6 +264,7 @@ module.exports = function (
     attachedClients,
     emails,
     password,
+    passwordless,
     recoveryCodes,
     recoveryPhone,
     securityEvents,

--- a/packages/fxa-auth-server/lib/routes/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.ts
@@ -1,0 +1,560 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Redis } from 'ioredis';
+import * as isA from 'joi';
+import { StatsD } from 'hot-shots';
+import * as uuid from 'uuid';
+import Container from 'typedi';
+
+import { OtpManager, OtpStorage } from '@fxa/shared/otp';
+import { AppError as error } from '@fxa/accounts/errors';
+import {
+  constructLocalTimeAndDateStrings,
+  splitEmails,
+} from '@fxa/accounts/email-renderer';
+
+import { ConfigType } from '../../config';
+import PASSWORDLESS_DOCS from '../../docs/swagger/passwordless-api';
+import DESCRIPTION from '../../docs/swagger/shared/descriptions';
+import * as random from '../crypto/random';
+import { schema as METRICS_CONTEXT_SCHEMA } from '../metrics/context';
+import { gleanMetrics } from '../metrics/glean';
+import { AuthLogger, AuthRequest } from '../types';
+import { recordSecurityEvent } from './utils/security-event';
+import * as validators from './validators';
+import { FxaMailer } from '../senders/fxa-mailer';
+import { formatUserAgentInfo } from 'fxa-shared/lib/user-agent';
+import { formatGeoData } from 'fxa-shared/lib/geo-data';
+import type { DB } from '../db';
+import { isClientAllowedForPasswordless, isPasswordlessEligible } from './utils/passwordless';
+
+/**
+ * Redis adapter for OTP storage
+ */
+class OtpRedisAdapter implements OtpStorage {
+  constructor(
+    private redis: Redis,
+    private ttl: number
+  ) {}
+
+  async set(key: string, value: string) {
+    await this.redis.set(key, value, 'EX', this.ttl);
+  }
+
+  async get(key: string) {
+    return this.redis.get(key);
+  }
+
+  async del(key: string) {
+    await this.redis.del(key);
+  }
+}
+
+/**
+ * Handler class for passwordless authentication endpoints
+ */
+class PasswordlessHandler {
+  private otpManager: OtpManager;
+  private fxaMailer: FxaMailer;
+  private otpUtils: any;
+
+  constructor(
+    private log: AuthLogger,
+    private db: DB,
+    private config: ConfigType,
+    private customs: any,
+    private glean: ReturnType<typeof gleanMetrics>,
+    private statsd: StatsD,
+    authServerCacheRedis: Redis
+  ) {
+    const otpRedisAdapter = new OtpRedisAdapter(
+      authServerCacheRedis,
+      config.passwordlessOtp.ttl
+    );
+    this.otpManager = new OtpManager(
+      { kind: 'passwordless', digits: config.passwordlessOtp.digits },
+      otpRedisAdapter
+    );
+    this.fxaMailer = Container.get(FxaMailer);
+    // For checking if account has TOTP enabled
+    this.otpUtils = require('./utils/otp').default(db, statsd);
+  }
+
+  /**
+   * Send OTP code for passwordless authentication
+   */
+  async sendCode(request: AuthRequest) {
+    this.log.begin('Passwordless.sendCode', request);
+
+    const { email, clientId } = request.payload as {
+      email: string;
+      clientId?: string;
+    };
+
+    // Check if clientId is allowed to use passwordless
+    if (
+      !isClientAllowedForPasswordless(
+        this.config.passwordlessOtp.allowedClientIds as string[],
+        clientId
+      )
+    ) {
+      this.log.error('passwordless.sendCode.clientIdNotAllowed', {
+        clientId,
+      });
+      throw error.featureNotEnabled();
+    }
+
+    // Rate limiting
+    await this.customs.check(request, email, 'passwordlessSendOtp');
+
+    // Check if account exists and is eligible
+    let account: any = null;
+    let isNewAccount = true;
+
+    try {
+      account = await this.db.accountRecord(email);
+      isNewAccount = false;
+    } catch (err: any) {
+      if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
+        throw err;
+      }
+      // Account doesn't exist - this is a new registration
+    }
+
+    // Check eligibility
+    if (
+      !isPasswordlessEligible(
+        account,
+        email,
+        this.config.passwordlessOtp.forcedEmailAddresses as RegExp
+      )
+    ) {
+      throw error.cannotCreatePassword(); // Account has a password, use standard flow
+    }
+
+    return this.generateAndSendOtp(request, email, account, isNewAccount);
+  }
+
+  /**
+   * Confirm OTP code and create session
+   */
+  async confirmCode(request: AuthRequest) {
+    this.log.begin('Passwordless.confirmCode', request);
+
+    const { email, code, clientId } = request.payload as {
+      email: string;
+      code: string;
+      clientId?: string;
+    };
+
+    // Check if clientId is allowed to use passwordless
+    if (
+      !isClientAllowedForPasswordless(
+        this.config.passwordlessOtp.allowedClientIds as string[],
+        clientId
+      )
+    ) {
+      this.log.error('passwordless.confirmCode.clientIdNotAllowed', {
+        clientId,
+      });
+      throw error.featureNotEnabled();
+    }
+
+    // Rate limiting
+    await this.customs.check(request, email, 'passwordlessVerifyOtp');
+
+    // Daily limit
+    if (this.customs.v2Enabled()) {
+      await this.customs.check(request, email, 'passwordlessVerifyOtpPerDay');
+    }
+
+    // Check if account exists
+    let account: any = null;
+    let isNewAccount = true;
+
+    try {
+      account = await this.db.accountRecord(email);
+      isNewAccount = false;
+    } catch (err: any) {
+      if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
+        throw err;
+      }
+    }
+
+    // Check eligibility
+    if (
+      account &&
+      !isPasswordlessEligible(
+        account,
+        email,
+        this.config.passwordlessOtp.forcedEmailAddresses as RegExp
+      )
+    ) {
+      throw error.cannotCreatePassword();
+    }
+
+    // Check if account has 2FA (TOTP) enabled
+    // Accounts with 2FA must use the password + TOTP flow for security
+    if (account) {
+      const hasTotpToken = await this.otpUtils.hasTotpToken(account);
+      if (hasTotpToken) {
+        this.log.info('passwordless.confirmCode.totpRequired', {
+          uid: account.uid,
+        });
+        throw error.totpRequired();
+      }
+    }
+
+    // Verify OTP
+    const otpKey = account ? account.uid : email;
+    const isValidCode = await this.otpManager.isValid(otpKey, code);
+
+    if (!isValidCode) {
+      this.statsd.increment('passwordless.confirmCode.invalid');
+      await recordSecurityEvent('account.passwordless_login_otp_failed', {
+        db: this.db,
+        request,
+        account: account ? { uid: account.uid } : undefined,
+      });
+      throw error.invalidVerificationCode();
+    }
+
+    // Delete OTP (single use)
+    await this.otpManager.delete(otpKey);
+
+    // Create account if new
+    if (isNewAccount) {
+      account = await this.createPasswordlessAccount(email, request);
+      this.statsd.increment('passwordless.registration.success');
+
+      await recordSecurityEvent('account.passwordless_registration_complete', {
+        db: this.db,
+        request,
+        account: { uid: account.uid },
+      });
+    }
+
+    // Create session token
+    const sessionToken = await this.createSessionToken(account, request);
+
+    this.statsd.increment('passwordless.confirmCode.success');
+
+    await recordSecurityEvent('account.passwordless_login_otp_verified', {
+      db: this.db,
+      request,
+      account: { uid: account.uid },
+    });
+
+    return {
+      uid: account.uid,
+      sessionToken: sessionToken.data,
+      verified: sessionToken.emailVerified && sessionToken.tokenVerified,
+      authAt: sessionToken.lastAuthAt(),
+      isNewAccount,
+    };
+  }
+
+  /**
+   * Resend OTP code
+   */
+  async resendCode(request: AuthRequest) {
+    this.log.begin('Passwordless.resendCode', request);
+
+    const { email, clientId } = request.payload as {
+      email: string;
+      clientId?: string;
+    };
+
+    // Check if clientId is allowed to use passwordless
+    if (
+      !isClientAllowedForPasswordless(
+        this.config.passwordlessOtp.allowedClientIds as string[],
+        clientId
+      )
+    ) {
+      this.log.error('passwordless.resendCode.clientIdNotAllowed', {
+        clientId,
+      });
+      throw error.featureNotEnabled();
+    }
+
+    // Rate limiting
+    await this.customs.check(request, email, 'passwordlessSendOtp');
+
+    // Check if account exists and is eligible
+    let account: any = null;
+    let isNewAccount = true;
+
+    try {
+      account = await this.db.accountRecord(email);
+      isNewAccount = false;
+    } catch (err: any) {
+      if (err.errno !== error.ERRNO.ACCOUNT_UNKNOWN) {
+        throw err;
+      }
+      // Account doesn't exist - this is a new registration
+    }
+
+    // Check eligibility
+    if (
+      !isPasswordlessEligible(
+        account,
+        email,
+        this.config.passwordlessOtp.forcedEmailAddresses as RegExp
+      )
+    ) {
+      throw error.cannotCreatePassword(); // Account has a password, use standard flow
+    }
+
+    // Delete existing code first
+    const otpKey = account ? account.uid : email;
+    await this.otpManager.delete(otpKey);
+
+    return this.generateAndSendOtp(request, email, account, isNewAccount);
+  }
+
+  /**
+   * Generate OTP code and send email
+   * NOTE: This method does NOT perform rate limiting or eligibility checks.
+   * Callers must do those checks before calling this method.
+   */
+  private async generateAndSendOtp(
+    request: AuthRequest,
+    email: string,
+    account: any,
+    isNewAccount: boolean
+  ) {
+    // Generate OTP code
+    // For new accounts, use email as the key; for existing accounts, use uid
+    const otpKey = account ? account.uid : email;
+    const code = await this.otpManager.create(otpKey);
+
+    // Send OTP email
+    const geoData = request.app.geo;
+    const { browser, os, osVersion } = request.app.ua;
+    const { deviceId, flowId, flowBeginTime } =
+      await request.app.metricsContext;
+
+    const { time, date, acceptLanguage, timeZone } =
+      constructLocalTimeAndDateStrings(
+        request.app.acceptLanguage,
+        geoData.timeZone
+      );
+
+    const commonArgs = {
+      code,
+      deviceId,
+      flowId,
+      flowBeginTime,
+      time,
+      date,
+      acceptLanguage,
+      timeZone,
+      sync: false,
+      device: formatUserAgentInfo({ browser, os, osVersion }),
+      location: formatGeoData(geoData.location),
+      codeExpiryMinutes: this.config.passwordlessOtp.ttl / 60,
+    };
+
+    if (isNewAccount) {
+      const metricsEnabled =
+        this.config.gleanMetrics.enabled &&
+        (await request.app.isMetricsEnabled);
+
+      await this.fxaMailer.sendPasswordlessSignupOtpEmail({
+        ...commonArgs,
+        to: email,
+        cc: [],
+        metricsEnabled,
+      });
+    } else {
+      const emailAddresses = splitEmails(account.emails);
+      await this.fxaMailer.sendPasswordlessSigninOtpEmail({
+        ...commonArgs,
+        to: emailAddresses.to,
+        cc: emailAddresses.cc,
+        uid: account.uid,
+        metricsEnabled: account.metricsEnabled,
+      });
+    }
+
+    this.statsd.increment('passwordless.sendCode.success');
+
+    // Record security event
+    await recordSecurityEvent('account.passwordless_login_otp_sent', {
+      db: this.db,
+      request,
+      account: account ? { uid: account.uid } : undefined,
+    });
+
+    return {};
+  }
+
+  /**
+   * Create a new passwordless account
+   */
+  private async createPasswordlessAccount(
+    email: string,
+    request: AuthRequest
+  ): Promise<any> {
+    const emailCode = await random.hex(16);
+    const authSalt = await random.hex(32);
+    const [kA, wrapWrapKb, wrapWrapKbVersion2] = await random.hex(32, 32, 32);
+
+    const account = await this.db.createAccount({
+      uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+      createdAt: Date.now(),
+      email,
+      emailCode,
+      emailVerified: true, // Verified via OTP
+      kA,
+      wrapWrapKb,
+      wrapWrapKbVersion2,
+      authSalt,
+      clientSalt: undefined,
+      verifierVersion: this.config.verifierVersion,
+      verifyHash: Buffer.alloc(32).toString('hex'),
+      verifyHashVersion2: Buffer.alloc(32).toString('hex'),
+      verifierSetAt: 0, // No password set
+      locale: request.app.acceptLanguage,
+    });
+
+    return account;
+  }
+
+  /**
+   * Create a session token for the account
+   */
+  private async createSessionToken(
+    account: any,
+    request: AuthRequest
+  ): Promise<any> {
+    const sessionTokenOptions = {
+      uid: account.uid,
+      email: account.email,
+      emailCode: account.emailCode,
+      emailVerified: true,
+      verifierSetAt: account.verifierSetAt,
+      mustVerify: false,
+      tokenVerificationId: null, // Already verified via OTP
+      uaBrowser: request.app.ua.browser,
+      uaBrowserVersion: request.app.ua.browserVersion,
+      uaOS: request.app.ua.os,
+      uaOSVersion: request.app.ua.osVersion,
+      uaDeviceType: request.app.ua.deviceType,
+      uaFormFactor: request.app.ua.formFactor,
+    };
+
+    return this.db.createSessionToken(sessionTokenOptions);
+  }
+}
+
+/**
+ * Export routes factory function
+ */
+export function passwordlessRoutes(
+  log: AuthLogger,
+  db: any,
+  config: ConfigType,
+  customs: any,
+  glean: ReturnType<typeof gleanMetrics>,
+  statsd: StatsD,
+  authServerCacheRedis: Redis
+) {
+  // Feature flag check
+  // Routes are available if either:
+  // 1. The feature is globally enabled
+  if (!config.passwordlessOtp.enabled) {
+    return [];
+  }
+
+  const handler = new PasswordlessHandler(
+    log,
+    db,
+    config,
+    customs,
+    glean,
+    statsd,
+    authServerCacheRedis
+  );
+
+  return [
+    {
+      method: 'POST',
+      path: '/account/passwordless/send_code',
+      options: {
+        ...PASSWORDLESS_DOCS.PASSWORDLESS_SEND_CODE_POST,
+        auth: false,
+        validate: {
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            clientId: validators.clientId
+              .optional()
+              .description(DESCRIPTION.clientId),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
+        },
+        response: {
+          schema: isA.object({}),
+        },
+      },
+      handler: (request: AuthRequest) => handler.sendCode(request),
+    },
+    {
+      method: 'POST',
+      path: '/account/passwordless/confirm_code',
+      options: {
+        ...PASSWORDLESS_DOCS.PASSWORDLESS_CONFIRM_CODE_POST,
+        auth: false,
+        validate: {
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            code: isA
+              .string()
+              .length(config.passwordlessOtp.digits)
+              .regex(validators.DIGITS)
+              .required()
+              .description('The OTP code sent to the user email'),
+            clientId: validators.clientId
+              .optional()
+              .description(DESCRIPTION.clientId),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
+        },
+        response: {
+          schema: isA.object({
+            uid: isA.string().required(),
+            sessionToken: isA.string().required(),
+            verified: isA.boolean().required(),
+            authAt: isA.number().required(),
+            isNewAccount: isA.boolean().required(),
+          }),
+        },
+      },
+      handler: (request: AuthRequest) => handler.confirmCode(request),
+    },
+    {
+      method: 'POST',
+      path: '/account/passwordless/resend_code',
+      options: {
+        ...PASSWORDLESS_DOCS.PASSWORDLESS_RESEND_CODE_POST,
+        auth: false,
+        validate: {
+          payload: isA.object({
+            email: validators.email().required().description(DESCRIPTION.email),
+            clientId: validators.clientId
+              .optional()
+              .description(DESCRIPTION.clientId),
+            metricsContext: METRICS_CONTEXT_SCHEMA,
+          }),
+        },
+        response: {
+          schema: isA.object({}),
+        },
+      },
+      handler: (request: AuthRequest) => handler.resendCode(request),
+    },
+  ];
+}

--- a/packages/fxa-auth-server/lib/routes/utils/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/passwordless.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Check if a clientId is allowed to use passwordless authentication
+ * @param allowedClientIds - Array of allowed client IDs. Empty array means no clients are allowed.
+ * @param clientId - The client ID to check (optional)
+ * @returns true if the clientId is allowed, false otherwise
+ */
+export function isClientAllowedForPasswordless(
+  allowedClientIds: string[],
+  clientId?: string
+): boolean {
+  // If allowedClientIds is empty, no clients are allowed
+  if (!allowedClientIds || allowedClientIds.length === 0) {
+    return false;
+  }
+
+  // If no clientId specified, deny
+  if (!clientId) {
+    return false;
+  }
+
+  // Check if clientId is in the allowed list
+  return allowedClientIds.includes(clientId);
+}
+
+/**
+ * Check if an account is eligible for passwordless authentication
+ * An account is eligible if:
+ * - It doesn't exist (new registration)
+ * - The email matches the forcedEmailAddress regex (for testing)
+ * - It exists but has no password set (verifierSetAt === 0)
+ * 
+ * @param account - The account object (null if account doesn't exist)
+ * @param email - The email address
+ * @param forcedEmailRegex - Regex pattern to force passwordless for specific emails (optional)
+ * @returns true if the account is eligible for passwordless, false otherwise
+ */
+export function isPasswordlessEligible(
+  account: { verifierSetAt: number } | null,
+  email: string,
+  forcedEmailRegex?: RegExp
+): boolean {
+  // New account (doesn't exist) - eligible
+  if (!account) {
+    return true;
+  }
+
+  // Check if email matches forced regex (for testing)
+  if (forcedEmailRegex && forcedEmailRegex.test(email)) {
+    return true;
+  }
+
+  // Existing account must not have a password set
+  return account.verifierSetAt === 0;
+}

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -209,11 +209,6 @@ export class FxaMailer extends FxaEmailRenderer {
     const links = {
       privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
       supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
-      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
-        template,
-        metricsEnabled,
-        { email: opts.to }
-      ),
     };
     const headers = this.buildHeaders(
       { template, version },
@@ -233,7 +228,7 @@ export class FxaMailer extends FxaEmailRenderer {
    * @returns
    */
   async sendPasswordlessSignupOtpEmail(
-    opts: EmailSenderOpts &
+    opts: Omit<EmailSenderOpts, 'uid'> &
       EmailFlowParams &
       OmitCommonLinks<WithFxaLayouts<passwordlessSignupOtp.TemplateData>>
   ) {
@@ -242,11 +237,6 @@ export class FxaMailer extends FxaEmailRenderer {
     const links = {
       privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
       supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
-      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
-        template,
-        metricsEnabled,
-        { email: opts.to }
-      ),
     };
     const headers = this.buildHeaders(
       { template, version },

--- a/packages/fxa-auth-server/test/local/routes/passwordless.js
+++ b/packages/fxa-auth-server/test/local/routes/passwordless.js
@@ -1,0 +1,933 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const mocks = require('../../mocks');
+const getRoute = require('../../routes_helpers').getRoute;
+const proxyquire = require('proxyquire');
+const uuid = require('uuid');
+const crypto = require('crypto');
+const { AppError: error } = require('@fxa/accounts/errors');
+
+function hexString(bytes) {
+  return crypto.randomBytes(bytes).toString('hex');
+}
+
+const TEST_EMAIL = 'test@example.com';
+const FORCED_EMAIL = 'forcepasswordless@example.com';
+
+let mockOtpManager;
+let mockOtpManagerCreate;
+let mockOtpManagerIsValid;
+let mockOtpManagerDelete;
+
+const makeRoutes = function (options = {}, requireMocks = {}) {
+  const config = options.config || {};
+  config.passwordlessOtp = config.passwordlessOtp || {
+    enabled: true,
+    ttl: 300,
+    digits: 6,
+    forcedEmailAddresses: /forcepasswordless@example.com/,
+    allowedClientIds: [],
+  };
+  config.verifierVersion = config.verifierVersion || 0;
+  config.gleanMetrics = config.gleanMetrics || {
+    enabled: true,
+  };
+
+  const log = options.log || mocks.mockLog();
+  const db = options.db || mocks.mockDB();
+  const customs = options.customs || {
+    check: () => Promise.resolve(true),
+    v2Enabled: () => true,
+  };
+  const glean = options.glean || mocks.mockGlean();
+  const statsd = options.statsd || mocks.mockStatsd();
+  const redis = options.authServerCacheRedis || {
+    get: async () => null,
+    set: async () => 'OK',
+    del: async () => 0,
+  };
+
+  // Mock OtpManager
+  mockOtpManagerCreate = sinon.stub().resolves('123456');
+  mockOtpManagerIsValid = sinon.stub().resolves(true);
+  mockOtpManagerDelete = sinon.stub().resolves();
+
+  mockOtpManager = {
+    create: mockOtpManagerCreate,
+    isValid: mockOtpManagerIsValid,
+    delete: mockOtpManagerDelete,
+  };
+
+  mocks.mockFxaMailer();
+
+  const { passwordlessRoutes } = proxyquire(
+    '../../../lib/routes/passwordless',
+    {
+      '@fxa/shared/otp': {
+        OtpManager: sinon.stub().returns(mockOtpManager),
+      },
+      './utils/otp': {
+        default: () => ({
+          hasTotpToken: options.hasTotpToken || sinon.stub().resolves(false),
+        }),
+      },
+      './utils/security-event': {
+        recordSecurityEvent:
+          options.recordSecurityEvent || sinon.stub().resolves(),
+      },
+      ...requireMocks,
+    }
+  );
+
+  return passwordlessRoutes(log, db, config, customs, glean, statsd, redis);
+};
+
+function runTest(route, request, assertions) {
+  return new Promise((resolve, reject) => {
+    try {
+      return route.handler(request).then(resolve, reject);
+    } catch (err) {
+      reject(err);
+    }
+  }).then(assertions);
+}
+
+describe('/account/passwordless/send_code', () => {
+  let uid, mockLog, mockRequest, mockDB, mockCustoms, route, routes;
+
+  beforeEach(() => {
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
+    mockLog = mocks.mockLog();
+    mockDB = mocks.mockDB({
+      uid,
+      email: TEST_EMAIL,
+      emailVerified: true,
+      verifierSetAt: 0,
+    });
+    mockCustoms = {
+      check: sinon.spy(() => Promise.resolve()),
+      v2Enabled: () => true,
+    };
+    mockRequest = mocks.mockRequest({
+      log: mockLog,
+      payload: {
+        email: TEST_EMAIL,
+        clientId: 'test-client-id',
+        metricsContext: {
+          deviceId: 'device123',
+          flowId: 'flow123',
+          flowBeginTime: Date.now(),
+        },
+      },
+    });
+
+    routes = makeRoutes({
+      log: mockLog,
+      db: mockDB,
+      customs: mockCustoms,
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+          forcedEmailAddresses: /forcepasswordless@example.com/,
+          allowedClientIds: ['test-client-id'],
+        },
+      },
+    });
+    route = getRoute(routes, '/account/passwordless/send_code', 'POST');
+  });
+
+  afterEach(() => {
+    mockOtpManagerCreate.resetHistory();
+    mockOtpManagerIsValid.resetHistory();
+    mockOtpManagerDelete.resetHistory();
+  });
+
+  it('should send OTP for new account', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.reject(error.unknownAccount())
+    );
+
+    return runTest(route, mockRequest, (result) => {
+      assert.equal(mockCustoms.check.callCount, 1, 'customs.check was called');
+      assert.equal(
+        mockCustoms.check.args[0][1],
+        TEST_EMAIL,
+        'customs.check called with email'
+      );
+      assert.equal(
+        mockCustoms.check.args[0][2],
+        'passwordlessSendOtp',
+        'customs.check called with correct action'
+      );
+
+      assert.equal(
+        mockOtpManagerCreate.callCount,
+        1,
+        'otpManager.create was called'
+      );
+      assert.equal(
+        mockOtpManagerCreate.args[0][0],
+        TEST_EMAIL,
+        'otpManager.create called with email for new account'
+      );
+
+      assert.deepEqual(result, {}, 'response is empty object');
+    });
+  });
+
+  it('should send OTP for existing passwordless account', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: 0,
+        emails: [{ email: TEST_EMAIL, isPrimary: true }],
+      })
+    );
+
+    return runTest(route, mockRequest, (result) => {
+      assert.equal(mockDB.accountRecord.callCount, 1);
+      assert.equal(mockOtpManagerCreate.callCount, 1);
+      assert.equal(
+        mockOtpManagerCreate.args[0][0],
+        uid,
+        'otpManager.create called with uid for existing account'
+      );
+      assert.deepEqual(result, {});
+    });
+  });
+
+  it('should send OTP for forcedEmailAddress', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: FORCED_EMAIL,
+        verifierSetAt: Date.now(),
+        emails: [{ email: FORCED_EMAIL, isPrimary: true }],
+      })
+    );
+    mockRequest = mocks.mockRequest({
+      log: mockLog,
+      payload: {
+        email: FORCED_EMAIL,
+        clientId: 'test-client-id',
+        metricsContext: {
+          deviceId: 'device123',
+          flowId: 'flow123',
+          flowBeginTime: Date.now(),
+        },
+      },
+    });
+
+    return runTest(route, mockRequest, (result) => {
+      assert.equal(mockDB.accountRecord.callCount, 1);
+      assert.equal(mockOtpManagerCreate.callCount, 1);
+      assert.equal(
+        mockOtpManagerCreate.args[0][0],
+        uid,
+        'otpManager.create called with uid for existing account'
+      );
+      assert.deepEqual(result, {});
+    });
+  });
+
+  it('should reject account with password', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: Date.now(),
+      })
+    );
+
+    return runTest(route, mockRequest).then(
+      () => assert.fail('should have thrown'),
+      (err) => {
+        assert.equal(mockDB.accountRecord.callCount, 1);
+        assert.equal(mockOtpManagerCreate.callCount, 0);
+        assert.equal(err.errno, 206);
+      }
+    );
+  });
+
+  it('should apply rate limiting', () => {
+    mockCustoms.check = sinon.spy(() =>
+      Promise.reject(error.tooManyRequests())
+    );
+
+    return runTest(route, mockRequest).then(
+      () => assert.fail('should have thrown'),
+      (err) => {
+        assert.equal(mockCustoms.check.callCount, 1);
+        assert.equal(err.errno, error.ERRNO.THROTTLED);
+      }
+    );
+  });
+});
+
+describe('/account/passwordless/confirm_code', () => {
+  let uid, mockLog, mockRequest, mockDB, mockCustoms, route, routes;
+
+  beforeEach(() => {
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
+    mockLog = mocks.mockLog();
+    mockDB = mocks.mockDB({
+      uid,
+      email: TEST_EMAIL,
+      emailCode: hexString(16),
+      emailVerified: true,
+      verifierSetAt: 0,
+    });
+    mockCustoms = {
+      check: sinon.spy(() => Promise.resolve()),
+      v2Enabled: () => true,
+    };
+    mockRequest = mocks.mockRequest({
+      log: mockLog,
+      payload: {
+        email: TEST_EMAIL,
+        code: '123456',
+        clientId: 'test-client-id',
+        metricsContext: {
+          deviceId: 'device123',
+          flowId: 'flow123',
+          flowBeginTime: Date.now(),
+        },
+      },
+    });
+
+    routes = makeRoutes({
+      log: mockLog,
+      db: mockDB,
+      customs: mockCustoms,
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+          forcedEmailAddresses: /forcepasswordless@example.com/,
+          allowedClientIds: ['test-client-id'],
+        },
+      },
+    });
+    route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
+  });
+
+  afterEach(() => {
+    mockOtpManagerCreate.resetHistory();
+    mockOtpManagerIsValid.resetHistory();
+    mockOtpManagerDelete.resetHistory();
+  });
+
+  it('should create new account and session for valid code', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.reject(error.unknownAccount())
+    );
+    mockDB.createAccount = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        emailCode: hexString(16),
+        verifierSetAt: 0,
+      })
+    );
+    mockDB.createSessionToken = sinon.spy(() =>
+      Promise.resolve({
+        data: 'sessiontoken123',
+        emailVerified: true,
+        tokenVerified: true,
+        lastAuthAt: () => 1234567890,
+      })
+    );
+
+    return runTest(route, mockRequest, (result) => {
+      assert.equal(
+        mockCustoms.check.callCount,
+        2,
+        'customs.check called twice'
+      );
+      assert.equal(
+        mockCustoms.check.args[0][2],
+        'passwordlessVerifyOtp',
+        'first check is for verify'
+      );
+      assert.equal(
+        mockCustoms.check.args[1][2],
+        'passwordlessVerifyOtpPerDay',
+        'second check is for daily limit'
+      );
+
+      assert.equal(mockOtpManagerIsValid.callCount, 1);
+      assert.equal(mockOtpManagerIsValid.args[0][0], TEST_EMAIL);
+      assert.equal(mockOtpManagerIsValid.args[0][1], '123456');
+
+      assert.equal(mockOtpManagerDelete.callCount, 1);
+      assert.equal(mockOtpManagerDelete.args[0][0], TEST_EMAIL);
+
+      assert.equal(mockDB.createAccount.callCount, 1);
+      const accountArgs = mockDB.createAccount.args[0][0];
+      assert.equal(accountArgs.email, TEST_EMAIL);
+      assert.equal(accountArgs.emailVerified, true);
+      assert.equal(accountArgs.verifierSetAt, 0);
+
+      assert.equal(mockDB.createSessionToken.callCount, 1);
+
+      assert.equal(result.uid, uid);
+      assert.equal(result.sessionToken, 'sessiontoken123');
+      assert.equal(result.verified, true);
+      assert.equal(result.authAt, 1234567890);
+      assert.equal(result.isNewAccount, true);
+    });
+  });
+
+  it('should create session for existing account with valid code', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        emailCode: hexString(16),
+        verifierSetAt: 0,
+      })
+    );
+    mockDB.createSessionToken = sinon.spy(() =>
+      Promise.resolve({
+        data: 'sessiontoken123',
+        emailVerified: true,
+        tokenVerified: true,
+        lastAuthAt: () => 1234567890,
+      })
+    );
+
+    return runTest(route, mockRequest, (result) => {
+      assert.equal(mockOtpManagerIsValid.callCount, 1);
+      assert.equal(mockOtpManagerIsValid.args[0][0], uid);
+
+      assert.equal(mockDB.createAccount.callCount, 0);
+      assert.equal(mockDB.createSessionToken.callCount, 1);
+
+      assert.equal(result.uid, uid);
+      assert.equal(result.isNewAccount, false);
+    });
+  });
+
+  it('should reject invalid OTP code', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: 0,
+      })
+    );
+    mockOtpManagerIsValid.resolves(false);
+
+    return runTest(route, mockRequest).then(
+      () => assert.fail('should have thrown'),
+      (err) => {
+        assert.equal(mockOtpManagerIsValid.callCount, 1);
+        assert.equal(mockOtpManagerDelete.callCount, 0);
+        assert.equal(err.errno, 105);
+      }
+    );
+  });
+
+  it('should reject account with TOTP enabled', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: 0,
+      })
+    );
+
+    const hasTotpToken = sinon.stub().resolves(true);
+    routes = makeRoutes({
+      log: mockLog,
+      db: mockDB,
+      customs: mockCustoms,
+      hasTotpToken,
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+          forcedEmailAddresses: /forcepasswordless@example.com/,
+          allowedClientIds: ['test-client-id'],
+        },
+      },
+    });
+    route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
+
+    return runTest(route, mockRequest).then(
+      () => assert.fail('should have thrown'),
+      (err) => {
+        assert.equal(hasTotpToken.callCount, 1);
+        assert.equal(mockOtpManagerIsValid.callCount, 0);
+        assert.equal(err.errno, 160);
+      }
+    );
+  });
+
+  it('should reject account with password set', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: Date.now(),
+      })
+    );
+
+    return runTest(route, mockRequest).then(
+      () => assert.fail('should have thrown'),
+      (err) => {
+        assert.equal(mockDB.accountRecord.callCount, 1);
+        assert.equal(err.errno, 206);
+      }
+    );
+  });
+
+  it('should include user agent info in session token', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        emailCode: hexString(16),
+        verifierSetAt: 0,
+      })
+    );
+    mockDB.createSessionToken = sinon.spy(() =>
+      Promise.resolve({
+        data: 'sessiontoken123',
+        emailVerified: true,
+        tokenVerified: true,
+        lastAuthAt: () => 1234567890,
+      })
+    );
+    mockRequest.app.ua = {
+      browser: 'Firefox',
+      browserVersion: '100',
+      os: 'Linux',
+      osVersion: '5.15',
+      deviceType: 'desktop',
+      formFactor: 'desktop',
+    };
+
+    return runTest(route, mockRequest, () => {
+      assert.equal(mockDB.createSessionToken.callCount, 1);
+      const sessionOpts = mockDB.createSessionToken.args[0][0];
+      assert.equal(sessionOpts.uaBrowser, 'Firefox');
+      assert.equal(sessionOpts.uaBrowserVersion, '100');
+      assert.equal(sessionOpts.uaOS, 'Linux');
+      assert.equal(sessionOpts.uaOSVersion, '5.15');
+      assert.equal(sessionOpts.uaDeviceType, 'desktop');
+      assert.equal(sessionOpts.uaFormFactor, 'desktop');
+      assert.equal(sessionOpts.mustVerify, false);
+      assert.equal(sessionOpts.tokenVerificationId, null);
+    });
+  });
+});
+
+describe('/account/passwordless/resend_code', () => {
+  let uid, mockLog, mockRequest, mockDB, mockCustoms, route, routes;
+
+  beforeEach(() => {
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
+    mockLog = mocks.mockLog();
+    mockDB = mocks.mockDB({
+      uid,
+      email: TEST_EMAIL,
+      emailVerified: true,
+      verifierSetAt: 0,
+    });
+    mockCustoms = {
+      check: sinon.spy(() => Promise.resolve()),
+      v2Enabled: () => true,
+    };
+    mockRequest = mocks.mockRequest({
+      log: mockLog,
+      payload: {
+        email: TEST_EMAIL,
+        clientId: 'test-client-id',
+        metricsContext: {
+          deviceId: 'device123',
+          flowId: 'flow123',
+          flowBeginTime: Date.now(),
+        },
+      },
+    });
+
+    routes = makeRoutes({
+      log: mockLog,
+      db: mockDB,
+      customs: mockCustoms,
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+          forcedEmailAddresses: /forcepasswordless@example.com/,
+          allowedClientIds: ['test-client-id'],
+        },
+      },
+    });
+    route = getRoute(routes, '/account/passwordless/resend_code', 'POST');
+  });
+
+  afterEach(() => {
+    mockOtpManagerCreate.resetHistory();
+    mockOtpManagerDelete.resetHistory();
+  });
+
+  it('should delete old code and send new one for new account', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.reject(error.unknownAccount())
+    );
+
+    return runTest(route, mockRequest, (result) => {
+      // Verify rate limiting was called
+      assert.equal(mockCustoms.check.callCount, 1);
+      assert.equal(mockCustoms.check.args[0][1], TEST_EMAIL);
+      assert.equal(mockCustoms.check.args[0][2], 'passwordlessSendOtp');
+
+      assert.equal(mockOtpManagerDelete.callCount, 1);
+      assert.equal(mockOtpManagerDelete.args[0][0], TEST_EMAIL);
+
+      assert.equal(mockOtpManagerCreate.callCount, 1);
+      assert.equal(mockOtpManagerCreate.args[0][0], TEST_EMAIL);
+
+      assert.deepEqual(result, {});
+    });
+  });
+
+  it('should delete old code and send new one for existing account', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: 0,
+        emails: [{ email: TEST_EMAIL, isPrimary: true }],
+      })
+    );
+
+    return runTest(route, mockRequest, (result) => {
+      // Verify rate limiting was called
+      assert.equal(mockCustoms.check.callCount, 1);
+      assert.equal(mockCustoms.check.args[0][1], TEST_EMAIL);
+      assert.equal(mockCustoms.check.args[0][2], 'passwordlessSendOtp');
+
+      assert.equal(mockOtpManagerDelete.callCount, 1);
+      assert.equal(mockOtpManagerDelete.args[0][0], uid);
+
+      assert.equal(mockOtpManagerCreate.callCount, 1);
+      assert.equal(mockOtpManagerCreate.args[0][0], uid);
+
+      assert.deepEqual(result, {});
+    });
+  });
+
+  it('should reject account with password', () => {
+    mockDB.accountRecord = sinon.spy(() =>
+      Promise.resolve({
+        uid,
+        email: TEST_EMAIL,
+        verifierSetAt: Date.now(),
+      })
+    );
+
+    return runTest(route, mockRequest).then(
+      () => assert.fail('should have thrown'),
+      (err) => {
+        assert.equal(mockDB.accountRecord.callCount, 1);
+        assert.equal(mockOtpManagerDelete.callCount, 0);
+        assert.equal(mockOtpManagerCreate.callCount, 0);
+        assert.equal(err.errno, 206);
+      }
+    );
+  });
+});
+
+describe('passwordless routes feature flags', () => {
+  it('should return empty array when feature disabled', () => {
+    const routes = makeRoutes({
+      config: {
+        passwordlessOtp: {
+          enabled: false,
+          forcedEmailAddresses: /^$/,
+        },
+      },
+    });
+
+    assert.equal(routes.length, 0);
+  });
+
+  it('should return routes when feature enabled', () => {
+    const routes = makeRoutes({
+      config: {
+        passwordlessOtp: {
+          enabled: true,
+          ttl: 300,
+          digits: 6,
+        },
+      },
+    });
+
+    assert.equal(routes.length, 3);
+    assert.equal(routes[0].path, '/account/passwordless/send_code');
+    assert.equal(routes[0].method, 'POST');
+    assert.equal(routes[1].path, '/account/passwordless/confirm_code');
+    assert.equal(routes[1].method, 'POST');
+    assert.equal(routes[2].path, '/account/passwordless/resend_code');
+    assert.equal(routes[2].method, 'POST');
+  });
+});
+
+describe('passwordless service validation', () => {
+  let uid, mockLog, mockDB, mockCustoms, mockRequest, routes, route;
+
+  beforeEach(() => {
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
+    mockLog = mocks.mockLog();
+    mockDB = mocks.mockDB({
+      uid,
+      email: TEST_EMAIL,
+      emailVerified: true,
+      verifierSetAt: 0,
+    });
+    mockCustoms = {
+      check: sinon.spy(() => Promise.resolve()),
+      v2Enabled: () => true,
+    };
+    mockRequest = mocks.mockRequest({
+      log: mockLog,
+      payload: {
+        email: TEST_EMAIL,
+        metricsContext: {
+          deviceId: 'device123',
+          flowId: 'flow123',
+          flowBeginTime: Date.now(),
+        },
+      },
+    });
+  });
+
+  describe('when allowedClientIds is empty', () => {
+    beforeEach(() => {
+      routes = makeRoutes({
+        log: mockLog,
+        db: mockDB,
+        customs: mockCustoms,
+        config: {
+          passwordlessOtp: {
+            enabled: true,
+            ttl: 300,
+            digits: 6,
+            allowedClientIds: [],
+          },
+        },
+      });
+      route = getRoute(routes, '/account/passwordless/send_code', 'POST');
+      mockDB.accountRecord = sinon.spy(() =>
+        Promise.reject(error.unknownAccount())
+      );
+    });
+
+    it('should reject requests without clientId', () => {
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+          assert.equal(mockOtpManagerCreate.callCount, 0);
+        }
+      );
+    });
+
+    it('should reject requests with any clientId', () => {
+      mockRequest.payload.clientId = 'ea3ca969f8c6bb0d';
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+          assert.equal(mockOtpManagerCreate.callCount, 0);
+        }
+      );
+    });
+  });
+
+  describe('when allowedClientIds is configured', () => {
+    beforeEach(() => {
+      routes = makeRoutes({
+        log: mockLog,
+        db: mockDB,
+        customs: mockCustoms,
+        config: {
+          passwordlessOtp: {
+            enabled: true,
+            ttl: 300,
+            digits: 6,
+            allowedClientIds: ['ea3ca969f8c6bb0d', 'dcdb5ae7add825d2'],
+          },
+        },
+      });
+      route = getRoute(routes, '/account/passwordless/send_code', 'POST');
+      mockDB.accountRecord = sinon.spy(() =>
+        Promise.reject(error.unknownAccount())
+      );
+    });
+
+    it('should reject requests without clientId', () => {
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+          assert.equal(mockOtpManagerCreate.callCount, 0);
+        }
+      );
+    });
+
+    it('should reject requests with disallowed clientId', () => {
+      mockRequest.payload.clientId = 'not-allowed-client';
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+          assert.equal(mockOtpManagerCreate.callCount, 0);
+        }
+      );
+    });
+
+    it('should allow requests with allowed clientId (ea3ca969f8c6bb0d)', () => {
+      mockRequest.payload.clientId = 'ea3ca969f8c6bb0d';
+      return runTest(route, mockRequest, () => {
+        assert.equal(mockCustoms.check.callCount, 1);
+        assert.equal(mockOtpManagerCreate.callCount, 1);
+      });
+    });
+
+    it('should allow requests with allowed clientId (dcdb5ae7add825d2)', () => {
+      mockRequest.payload.clientId = 'dcdb5ae7add825d2';
+      return runTest(route, mockRequest, () => {
+        assert.equal(mockCustoms.check.callCount, 1);
+        assert.equal(mockOtpManagerCreate.callCount, 1);
+      });
+    });
+  });
+
+  describe('confirm_code clientId validation', () => {
+    beforeEach(() => {
+      routes = makeRoutes({
+        log: mockLog,
+        db: mockDB,
+        customs: mockCustoms,
+        config: {
+          passwordlessOtp: {
+            enabled: true,
+            ttl: 300,
+            digits: 6,
+            allowedClientIds: ['ea3ca969f8c6bb0d'],
+          },
+        },
+      });
+      route = getRoute(routes, '/account/passwordless/confirm_code', 'POST');
+      mockRequest.payload.code = '123456';
+      mockDB.accountRecord = sinon.spy(() => ({
+        uid,
+        email: TEST_EMAIL,
+        emailVerified: true,
+        verifierSetAt: 0,
+      }));
+    });
+
+    it('should reject confirm_code without clientId', () => {
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+        }
+      );
+    });
+
+    it('should reject confirm_code with disallowed clientId', () => {
+      mockRequest.payload.clientId = 'not-allowed-client';
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+        }
+      );
+    });
+
+    it('should allow confirm_code with allowed clientId', () => {
+      mockRequest.payload.clientId = 'ea3ca969f8c6bb0d';
+      return runTest(route, mockRequest, (result) => {
+        assert.equal(mockCustoms.check.callCount, 2);
+        assert.isString(result.uid);
+        assert.isString(result.sessionToken);
+      });
+    });
+  });
+
+  describe('resend_code clientId validation', () => {
+    beforeEach(() => {
+      routes = makeRoutes({
+        log: mockLog,
+        db: mockDB,
+        customs: mockCustoms,
+        config: {
+          passwordlessOtp: {
+            enabled: true,
+            ttl: 300,
+            digits: 6,
+            allowedClientIds: ['ea3ca969f8c6bb0d'],
+          },
+        },
+      });
+      route = getRoute(routes, '/account/passwordless/resend_code', 'POST');
+      mockDB.accountRecord = sinon.spy(() =>
+        Promise.reject(error.unknownAccount())
+      );
+    });
+
+    it('should reject resend_code without clientId', () => {
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+        }
+      );
+    });
+
+    it('should reject resend_code with disallowed clientId', () => {
+      mockRequest.payload.clientId = 'not-allowed-client';
+      return route.handler(mockRequest).then(
+        () => assert.fail('should have thrown'),
+        (err) => {
+          assert.equal(err.errno, error.ERRNO.FEATURE_NOT_ENABLED);
+          assert.equal(mockCustoms.check.callCount, 0);
+        }
+      );
+    });
+
+    it('should allow resend_code with allowed clientId', () => {
+      mockRequest.payload.clientId = 'ea3ca969f8c6bb0d';
+      return runTest(route, mockRequest, () => {
+        assert.equal(mockCustoms.check.callCount, 1);
+        assert.equal(mockOtpManagerDelete.callCount, 1);
+        assert.equal(mockOtpManagerCreate.callCount, 1);
+      });
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -1168,6 +1168,8 @@ function mockFxaMailer(overrides) {
     canSend: sinon.stub().returns(true),
     sendRecoveryEmail: sinon.stub().resolves(),
     sendPasswordForgotOtpEmail: sinon.stub().resolves(),
+    sendPasswordlessSigninOtpEmail: sinon.stub().resolves(),
+    sendPasswordlessSignupOtpEmail: sinon.stub().resolves(),
     sendPostVerifySecondaryEmail: sinon.stub().resolves(),
     sendPostChangePrimaryEmail: sinon.stub().resolves(),
     sendPostRemoveSecondaryEmail: sinon.stub().resolves(),


### PR DESCRIPTION
## Because

- Add necessary backend changes to enable passwordless signup and signin with email OTP.

## This pull request

- Adds PasswordlessHandler route handler
- Adds passworldess send/resend/confirm routes
- Adds tests for PasswordlessHandler

## Issue that this pull request solves

Closes: # FXA-13014, # FXA-13015

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
