### PR TITLE
polish(emails): Doctor l10n strings

### DIFF
--- a/libs/accounts/email-renderer/gruntfile.js
+++ b/libs/accounts/email-renderer/gruntfile.js
@@ -28,7 +28,7 @@
         // 'src/**/en.ftl',
 
         'src/layouts/fxa/en.ftl',
-        // 'src/subscription/fxa/en.ftl',
+        // 'src/layouts/subscription/en.ftl',
 
         'src/partials/accountDeletionInfoBlock/en.ftl',
         'src/partials/appBadges/en.ftl',
@@ -60,7 +60,8 @@
         'src/partials/userLocation/en.ftl',
         // 'src/partials/viewInvoice/en.ftl',
 
-        'src/templates/adminResetAccounts/en.ftl',
+        // Skip translation. Internal FxA email. Not user facing.
+        // 'src/templates/adminResetAccounts/en.ftl',
         'src/templates/cadReminderFirst/en.ftl',
         'src/templates/cadReminderSecond/en.ftl',
         // 'src/templates/downloadSubscription/en.ftl',

--- a/packages/fxa-auth-server/grunttasks/ftl.js
+++ b/packages/fxa-auth-server/grunttasks/ftl.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
         // 'lib/senders/emails/**/en.ftl',
 
         // 'lib/senders/emails/layouts/fxa/en.ftl',
-        'lib/senders/emails/subscription/fxa/en.ftl',
+        'lib/senders/emails/layouts/subscription/en.ftl',
 
         // 'lib/senders/emails/partials/accountDeletionInfoBlock/en.ftl',
         // 'lib/senders/emails/partials/appBadges/en.ftl',


### PR DESCRIPTION
## Because

- During the l10n migration process, we don't want any 'new' strings showing up
- The adminAccountReset strings were newly added
- These emails are only used internally anyway, so it's alright to skip translation for now.
- The subscription layout path was incorrect.

## This pull request

- Excluded adminAccountReset l10n strings
- Fix subscription layout path

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
