### PR TITLE
polish(emails): Doctor l10n string exports

### DIFF
--- a/libs/accounts/email-renderer/gruntfile.js
+++ b/libs/accounts/email-renderer/gruntfile.js
@@ -28,7 +28,7 @@
         // 'src/**/en.ftl',
 
         'src/layouts/fxa/en.ftl',
-        // 'src/subscription/fxa/en.ftl',
+        // 'src/layouts/subscription/en.ftl',
 
         'src/partials/accountDeletionInfoBlock/en.ftl',
         'src/partials/appBadges/en.ftl',
@@ -42,6 +42,7 @@
         'src/partials/bannerWarning/en.ftl',
         'src/partials/brandMessaging/en.ftl',
         'src/partials/button/en.ftl',
+        // 'src/partials/cancellationSurvey/en.ftl',
         'src/partials/changePassword/en.ftl',
         // 'src/partials/icon/en.ftl',
         'src/partials/manageAccount/en.ftl',
@@ -60,7 +61,8 @@
         'src/partials/userLocation/en.ftl',
         // 'src/partials/viewInvoice/en.ftl',
 
-        'src/templates/adminResetAccounts/en.ftl',
+        // Skip translation. Internal FxA email. Not user facing.
+        // 'src/templates/adminResetAccounts/en.ftl',
         'src/templates/cadReminderFirst/en.ftl',
         'src/templates/cadReminderSecond/en.ftl',
         // 'src/templates/downloadSubscription/en.ftl',

--- a/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
+++ b/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
@@ -7799,6 +7799,14 @@ exports[`FxA Email Renderer should render renderPostAddTwoStepAuthentication wit
               </tr>
             
               <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-device-sign-out-message">To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
                 <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span></div>
@@ -8219,6 +8227,14 @@ exports[`FxA Email Renderer should render renderPostAddTwoStepAuthentication wit
               </tr>
             
               <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-device-sign-out-message">To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
                 <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span></div>
@@ -8626,6 +8642,14 @@ exports[`FxA Email Renderer should render renderPostAddTwoStepAuthentication: ma
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" href="http://localhost:3030/mock-support-link">
         <span data-l10n-id="postAddTwoStepAuthentication-how-protects-link">How this protects your account</span>
       </a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postAddTwoStepAuthentication-device-sign-out-message">To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.</span></div>
     
                 </td>
               </tr>
@@ -10127,6 +10151,14 @@ exports[`FxA Email Renderer should render renderPostChangeTwoStepAuthentication:
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" href="http://localhost:3030/mock-support-link">
         <span data-l10n-id="postChangeTwoStepAuthentication-how-protects-link">How this protects your account</span>
       </a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="postChangeTwoStepAuthentication-device-sign-out-message">To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication.</span></div>
     
                 </td>
               </tr>

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/en.ftl
@@ -11,3 +11,4 @@ postAddTwoStepAuthentication-recovery-method-codes = You also added backup authe
 postAddTwoStepAuthentication-recovery-method-phone = You also added { $maskedPhoneNumber } as your recovery phone number.
 postAddTwoStepAuthentication-how-protects-link = How this protects your account
 postAddTwoStepAuthentication-how-protects-plaintext = How this protects your account:
+postAddTwoStepAuthentication-device-sign-out-message = To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.mjml
@@ -32,6 +32,12 @@
       </a>
     </mj-text>
 
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddTwoStepAuthentication-device-sign-out-message">
+        To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication.
+      </span>
+    </mj-text>
+
     <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="postAddTwoStepAuthentication-from-device-v2">You requested this from:</span>
     </mj-text>

--- a/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.txt
+++ b/libs/accounts/email-renderer/src/templates/postAddTwoStepAuthentication/index.txt
@@ -13,6 +13,8 @@ postAddTwoStepAuthentication-recovery-method-phone = "You also added <%- maskedP
 postAddTwoStepAuthentication-how-protects-plaintext = "How this protects your account:"
 <%- twoFactorSupportLink %>
 
+postAddTwoStepAuthentication-device-sign-out-message = "To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using two-step authentication."
+
 postAddTwoStepAuthentication-from-device-v2 = "You requested this from:"
 <%- include('/partials/userInfo/index.txt') %>
 

--- a/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/en.ftl
@@ -7,3 +7,4 @@ postChangeTwoStepAuthentication-from-device = You requested this from:
 postChangeTwoStepAuthentication-action = Manage account
 postChangeTwoStepAuthentication-how-protects-link = How this protects your account
 postChangeTwoStepAuthentication-how-protects-plaintext = How this protects your account:
+postChangeTwoStepAuthentication-device-sign-out-message = To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication.

--- a/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.mjml
@@ -18,6 +18,12 @@
       </a>
     </mj-text>
 
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postChangeTwoStepAuthentication-device-sign-out-message">
+        To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication.
+      </span>
+    </mj-text>
+
     <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="postChangeTwoStepAuthentication-from-device">You requested this from:</span>
     </mj-text>

--- a/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.txt
+++ b/libs/accounts/email-renderer/src/templates/postChangeTwoStepAuthentication/index.txt
@@ -5,6 +5,8 @@ postChangeTwoStepAuthentication-use-new-account = "You now need to use the new M
 postChangeTwoStepAuthentication-how-protects-plaintext = "How this protects your account:"
 <%- twoFactorSupportLink %>
 
+postChangeTwoStepAuthentication-device-sign-out-message = "To protect all your connected devices, you should sign out everywhere youʼre using this account, and then sign back in using your new two-step authentication."
+
 postChangeTwoStepAuthentication-from-device = "You requested this from:"
 <%- include('/partials/userInfo/index.txt') %>
 

--- a/packages/fxa-auth-server/grunttasks/ftl.js
+++ b/packages/fxa-auth-server/grunttasks/ftl.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
         // 'lib/senders/emails/**/en.ftl',
 
         // 'lib/senders/emails/layouts/fxa/en.ftl',
-        'lib/senders/emails/subscription/fxa/en.ftl',
+        'lib/senders/emails/layouts/subscription/en.ftl',
 
         // 'lib/senders/emails/partials/accountDeletionInfoBlock/en.ftl',
         // 'lib/senders/emails/partials/appBadges/en.ftl',
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
         // 'lib/senders/emails/partials/bannerWarning/en.ftl',
         // 'lib/senders/emails/partials/brandMessaging/en.ftl',
         // 'lib/senders/emails/partials/button/en.ftl',
-        // 'lib/senders/emails/partials/changePassword/en.ftl',
+        'lib/senders/emails/partials/cancellationSurvey/en.ftl',
         // 'lib/senders/emails/partials/changePassword/en.ftl',
         'lib/senders/emails/partials/icon/en.ftl',
         // 'lib/senders/emails/partials/manageAccount/en.ftl',


### PR DESCRIPTION
## Because

- We are sanity checking l10 string exports
- We found a couple mismatches

## This pull request

- Fixes path for subscription layout template
- Removes adminAccountReset template (not needed internal email)
- Adds missing updates to poastChangeTwoStepAuthentication and postAddTwoStepAuthentication templates
- Add missing cancellationSurvey template

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
