### PR TITLE
polish(auth): Use defaults for NodeRenderBindings

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -10,7 +10,6 @@ const Sentry = require('@sentry/node');
 
 const { config } = require('../config');
 const Redis = require('ioredis');
-const { join } = require('node:path');
 const { CapabilityManager } = require('@fxa/payments/capability');
 const { EligibilityManager } = require('@fxa/payments/eligibility');
 const {
@@ -377,15 +376,7 @@ async function run(config) {
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings({
-      translations: {
-        // TODO: Once this PR, https://github.com/mozilla/fxa-content-server-l10n/pull/989, is finalized we can:
-        //  - switch this to point libs/accounts/public/locales or ../public/locales (either is probably fine...)
-        //  - switch to using emails.ftl, since all email specific strings will have been migrated over
-        basePath: join(__dirname, '../public/locales'),
-        ftlFileName: 'auth.ftl',
-      },
-    })
+    new NodeRendererBindings()
   );
   Container.set(FxaMailer, fxaMailer);
 

--- a/packages/fxa-auth-server/scripts/delete-account.ts
+++ b/packages/fxa-auth-server/scripts/delete-account.ts
@@ -20,7 +20,6 @@
 import { StatsD } from 'hot-shots';
 import readline from 'readline';
 import { Container } from 'typedi';
-import { join } from 'path';
 
 import { PayPalClient } from '@fxa/payments/paypal';
 
@@ -162,12 +161,7 @@ DB.connect(config).then(async (db: any) => {
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings({
-      translations: {
-        basePath: join(__dirname, '../public/locales'),
-        ftlFileName: 'auth.ftl',
-      },
-    })
+    new NodeRendererBindings()
   );
   Container.set(FxaMailer, fxaMailer);
 

--- a/packages/fxa-auth-server/scripts/recorded-future/check-and-reset.ts
+++ b/packages/fxa-auth-server/scripts/recorded-future/check-and-reset.ts
@@ -23,7 +23,6 @@
 
 import crypto from 'crypto';
 import { promisify } from 'util';
-import { join } from 'path';
 
 import { Command } from 'commander';
 import { Container } from 'typedi';
@@ -317,12 +316,7 @@ async function resetAccounts(
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings({
-      translations: {
-        basePath: join(__dirname, '../../public/locales'),
-        ftlFileName: 'auth.ftl',
-      },
-    })
+    new NodeRendererBindings()
   );
 
   for (const acct of accountsToReset) {

--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -40,7 +40,6 @@ const {
 } = require('@fxa/accounts/email-renderer');
 const { FxaMailer } = require('../lib/senders/fxa-mailer');
 const { FxaMailerFormat } = require('../lib/senders/fxa-mailer-format');
-const { join } = require('path');
 const { StatsD } = require('hot-shots');
 
 Sentry.init({});
@@ -111,15 +110,7 @@ async function run() {
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings({
-      translations: {
-        // TODO: Once this PR, https://github.com/mozilla/fxa-content-server-l10n/pull/989, is finalized we can:
-        //  - switch this to point libs/accounts/public/locales or ../public/locales (either is probably fine...)
-        //  - switch to using emails.ftl, since all email specific strings will have been migrated over
-        basePath: join(__dirname, '../public/locales'),
-        ftlFileName: 'auth.ftl',
-      },
-    })
+    new NodeRendererBindings()
   );
 
   // since these are sent via a scheduled job, we need to fabricate a request object


### PR DESCRIPTION
## Because

- We can now target `emails.ftl` for email translations

## This pull request

- Removes override configs that were targeting `auth.ftl`

## Issue that this pull request solves

Closes: FXA-12947 (*Partially, other PRs were also needed to close)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
