### PR TITLE
set email input type to email to stop autocapitalize on mobile

### DIFF
--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -49,6 +49,7 @@ export type InputTextProps = {
   tooltipPosition?: 'top' | 'bottom';
   isPasswordInput?: boolean;
   ariaDescribedBy?: string;
+  autocapitalize?: 'off' | 'sentences' | 'words' | 'characters';
 };
 
 export const InputText = ({
@@ -82,6 +83,7 @@ export const InputText = ({
   tooltipPosition,
   isPasswordInput = false,
   ariaDescribedBy,
+  autocapitalize,
 }: InputTextProps) => {
   const [focused, setFocused] = useState<boolean>(false);
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);

--- a/packages/fxa-settings/src/pages/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Index/index.tsx
@@ -166,6 +166,7 @@ export const Index = ({
             autoFocus
             errorText={tooltipErrorMessage}
             onChange={handleInputChange}
+            autocapitalize="off"
           />
         </FtlMsg>
         <div className="flex mt-5">


### PR DESCRIPTION
## Because

- first character of email field gets autocapitalized on mobile

## This pull request

- set autocapitalize to off on the email input

## Issue that this pull request solves

Closes: FXA-13050

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

See comments for screenshots from Xcode testing (thanks @LZoog)

## Other information (Optional)

Also tested using `type="email"` but this changed error handling behaviour and caused test failures. Decided to stick with a targeted change instead.
