### PR TITLE
feat(settings): Display refresh token OAuthNative client IDs Relay scope in connected services

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -73,6 +73,7 @@ export interface AttachedClient {
   os: string | null;
   sessionTokenId: string | null;
   refreshTokenId: string | null;
+  scope: string[] | null;
 }
 
 export interface RecoveryKeyData {

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -5,7 +5,12 @@
 import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import ConnectedServices, { sortAndFilterConnectedClients } from '.';
-import { Account, AlertBarInfo, AppContext } from '../../../models';
+import {
+  Account,
+  AlertBarInfo,
+  AppContext,
+  OAuthNativeClients,
+} from '../../../models';
 import {
   renderWithRouter,
   mockAppContext,
@@ -156,7 +161,7 @@ describe('Connected Services', () => {
     const { sortedAndUniqueClients, groupedByName } =
       sortAndFilterConnectedClients(MOCK_SERVICES);
 
-    expect(sortedAndUniqueClients.length).toEqual(13);
+    expect(sortedAndUniqueClients.length).toEqual(14);
 
     expect(
       sortedAndUniqueClients.filter((item) => item.name === 'Mozilla Monitor')
@@ -309,7 +314,7 @@ describe('Connected Services', () => {
     );
     expect(
       await screen.findAllByTestId('connected-service-sign-out')
-    ).toHaveLength(13);
+    ).toHaveLength(14);
   });
 
   it('renders proper modal when "sign out" is clicked', async () => {
@@ -601,6 +606,87 @@ describe('Connected Services', () => {
       );
 
       expect(mockWindowAssign).toHaveBeenCalledWith('foo-bar/signin');
+    });
+  });
+
+  describe('scope-based sub row', () => {
+    const baseMockClient = {
+      deviceId: null,
+      sessionTokenId: null,
+      refreshTokenId: 'abc123',
+      isCurrentSession: false,
+      deviceType: null,
+      createdTime: 1571412069000,
+      lastAccessTime: 1571412069000,
+      location: { city: null, country: null, state: null, stateCode: null },
+      userAgent: '',
+      os: null,
+      createdTimeFormatted: 'a month ago',
+      lastAccessTimeFormatted: 'a month ago',
+      approximateLastAccessTime: null,
+      approximateLastAccessTimeFormatted: null,
+    };
+
+    const renderWithClient = (client: Record<string, unknown>) => {
+      const account = {
+        attachedClients: [client],
+        disconnectClient: jest.fn().mockResolvedValue(true),
+      } as unknown as Account;
+      renderWithRouter(
+        <AppContext.Provider value={mockAppContext({ account })}>
+          <ConnectedServices />
+        </AppContext.Provider>
+      );
+    };
+
+    it('does not render scope sub-entry when scope is null and client ID is OAuthNative', async () => {
+      renderWithClient({
+        ...baseMockClient,
+        clientId: OAuthNativeClients.FirefoxDesktop,
+        name: 'Firefox Desktop',
+        scope: null,
+      });
+      await screen.findByTestId('settings-connected-service');
+      expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
+    });
+
+    it('does not render scope sub-entry when scope has oldsync and profile but no relay', async () => {
+      renderWithClient({
+        ...baseMockClient,
+        clientId: OAuthNativeClients.FirefoxDesktop,
+        name: 'Firefox Desktop',
+        scope: ['https://identity.mozilla.com/apps/oldsync', 'profile'],
+      });
+      await screen.findByTestId('settings-connected-service');
+      expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
+    });
+
+    it('renders Relay scope sub-entry when scope includes relay and client ID is OAuthNative', async () => {
+      renderWithClient({
+        ...baseMockClient,
+        clientId: OAuthNativeClients.FirefoxIOS,
+        name: 'Firefox for iOS',
+        scope: [
+          'https://identity.mozilla.com/apps/oldsync',
+          'profile',
+          'https://identity.mozilla.com/apps/relay',
+        ],
+      });
+      await screen.findByTestId('settings-connected-service');
+      const scopeEntry = screen.getByTestId('scope-service');
+      expect(scopeEntry).toBeInTheDocument();
+      expect(scopeEntry).toHaveTextContent('Firefox Relay');
+    });
+
+    it('does not render scope sub-entry when scope includes relay but client ID is not OAuthNative', async () => {
+      renderWithClient({
+        ...baseMockClient,
+        clientId: '9ebfe2c2f9ea3c58',
+        name: 'Firefox Relay',
+        scope: ['profile', 'https://identity.mozilla.com/apps/relay'],
+      });
+      await screen.findByTestId('settings-connected-service');
+      expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -238,6 +238,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
                 lastAccessTimeFormatted: client.lastAccessTimeFormatted,
                 isCurrentSession: client.isCurrentSession,
                 clientId: client.clientId,
+                scope: client.scope,
                 handleSignOut: () => {
                   onSignOutClick(client);
                 },

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/mocks.ts
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/mocks.ts
@@ -22,6 +22,7 @@ export const DESKTOP_SYNC_MOCKS = [
     },
     userAgent: '',
     os: null,
+    scope: null,
     createdTimeFormatted: 'a month ago',
     lastAccessTimeFormatted: 'a month ago',
     approximateLastAccessTime: null,
@@ -95,6 +96,7 @@ const OAUTH_SERVICE_MOCKS = [
     name: 'Firefox Private Network',
     createdTime: 1571412069000,
     lastAccessTime: 1571412069000,
+    scope: null,
     location: {
       city: null,
       country: null,
@@ -119,6 +121,7 @@ const OAUTH_SERVICE_MOCKS = [
     name: 'Mozilla Monitor',
     createdTime: 1570736983000,
     lastAccessTime: 1570736983000,
+    scope: null,
     location: {
       city: null,
       country: null,
@@ -192,7 +195,7 @@ const OAUTH_SERVICE_MOCKS = [
     name: 'Firefox Relay',
     createdTime: 1556745521000,
     lastAccessTime: 1556745521000,
-    scope: ['profile'],
+    scope: ['profile', 'https://identity.mozilla.com/apps/relay'],
     location: {
       city: null,
       country: null,
@@ -321,6 +324,35 @@ const MOBILE_SYNC_SERVICE_MOCKS = [
     createdTime: 1570221396000,
     lastAccessTime: 1570221396619,
     scope: ['https://identity.mozilla.com/apps/oldsync', 'profile'],
+    location: {
+      city: null,
+      country: null,
+      state: null,
+      stateCode: null,
+    },
+    userAgent: '',
+    os: null,
+    createdTimeFormatted: 'a month ago',
+    lastAccessTimeFormatted: 'a month ago',
+    approximateLastAccessTime: null,
+    approximateLastAccessTimeFormatted: null,
+  },
+  {
+    clientId: '1b1a3e44c54fbb58',
+    deviceId: 'a91cc4d7b8e4495fa3c6e2edf8c5132b',
+    sessionTokenId: null,
+    refreshTokenId:
+      'c4a8f3b2d1e6a9507f2c4e8b3d1a6f9072e5c8b4a3d7f1e6920b5c8a4d3f7e1',
+    isCurrentSession: false,
+    deviceType: 'mobile',
+    name: 'Firefox for iOS',
+    createdTime: 1570100000000,
+    lastAccessTime: 1570100000000,
+    scope: [
+      'https://identity.mozilla.com/apps/oldsync',
+      'profile',
+      'https://identity.mozilla.com/apps/relay',
+    ],
     location: {
       city: null,
       country: null,

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -128,6 +128,7 @@ export function mapAttachedClient(c: RawAttachedClient): AttachedClient {
     os: c.os,
     sessionTokenId: c.sessionTokenId,
     refreshTokenId: c.refreshTokenId,
+    scope: c.scope,
   };
 }
 
@@ -148,6 +149,7 @@ export interface AttachedClient {
   os: string | null;
   sessionTokenId: string | null;
   refreshTokenId: string | null;
+  scope: string[] | null;
 }
 
 interface Subscription {


### PR DESCRIPTION
~This PR was branched from #19981 and that needs to be merged first. I'll open this as a draft until then. Please check out the 2nd commit.~

---

Because:
* FxA should display refresh token scopes underneath the login for transparency

This commit:
* Displays only refresh tokens that match the OAuthNative client IDs that have a Relay scope, in connected services. Revoking and displaying other services will come in follow ups

closes FXA-12928

---

<img width="700" height="130" alt="image" src="https://github.com/user-attachments/assets/8ce44772-1bb5-4e2f-8581-1920aa63897b" />
