### PR TITLE
fix(settings): update ConnectedServices test for current API

### DIFF
--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -153,13 +153,14 @@ describe('Connected Services', () => {
       expect(result[result.length - 1]).toHaveTextContent('6 months ago');
     });
 
-    const { sortedAndUniqueClients } = sortAndFilterConnectedClients(MOCK_SERVICES);
+    const { sortedAndUniqueClients } =
+      sortAndFilterConnectedClients(MOCK_SERVICES);
 
     const monitorClients = MOCK_SERVICES.filter(
       (item) => item.name === 'Mozilla Monitor'
     );
 
-    expect(sortedAndUniqueClients.length).toEqual(13);
+    expect(sortedAndUniqueClients.length).toEqual(14);
 
     expect(
       sortedAndUniqueClients.filter((item) => item.name === 'Mozilla Monitor')
@@ -170,7 +171,7 @@ describe('Connected Services', () => {
         (item) => item.name === 'Mozilla Monitor'
       )[0].lastAccessTime
     ).toEqual(1570736983000);
-      expect(monitorClients.length).toEqual(2);
+    expect(monitorClients.length).toEqual(2);
   });
 
   it('should show the monitor icon and link', async () => {
@@ -312,7 +313,7 @@ describe('Connected Services', () => {
     );
     expect(
       await screen.findAllByTestId('connected-service-sign-out')
-    ).toHaveLength(13);
+    ).toHaveLength(14);
   });
 
   it('renders proper modal when "sign out" is clicked', async () => {

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.test.tsx
@@ -5,12 +5,7 @@
 import React from 'react';
 import { act, fireEvent, screen } from '@testing-library/react';
 import ConnectedServices, { sortAndFilterConnectedClients } from '.';
-import {
-  Account,
-  AlertBarInfo,
-  AppContext,
-  OAuthNativeClients,
-} from '../../../models';
+import { Account, AlertBarInfo, AppContext } from '../../../models';
 import {
   renderWithRouter,
   mockAppContext,
@@ -158,10 +153,13 @@ describe('Connected Services', () => {
       expect(result[result.length - 1]).toHaveTextContent('6 months ago');
     });
 
-    const { sortedAndUniqueClients, groupedByName } =
-      sortAndFilterConnectedClients(MOCK_SERVICES);
+    const { sortedAndUniqueClients } = sortAndFilterConnectedClients(MOCK_SERVICES);
 
-    expect(sortedAndUniqueClients.length).toEqual(14);
+    const monitorClients = MOCK_SERVICES.filter(
+      (item) => item.name === 'Mozilla Monitor'
+    );
+
+    expect(sortedAndUniqueClients.length).toEqual(13);
 
     expect(
       sortedAndUniqueClients.filter((item) => item.name === 'Mozilla Monitor')
@@ -172,7 +170,7 @@ describe('Connected Services', () => {
         (item) => item.name === 'Mozilla Monitor'
       )[0].lastAccessTime
     ).toEqual(1570736983000);
-    expect(groupedByName['Mozilla Monitor'].length).toEqual(2);
+      expect(monitorClients.length).toEqual(2);
   });
 
   it('should show the monitor icon and link', async () => {
@@ -314,7 +312,7 @@ describe('Connected Services', () => {
     );
     expect(
       await screen.findAllByTestId('connected-service-sign-out')
-    ).toHaveLength(14);
+    ).toHaveLength(13);
   });
 
   it('renders proper modal when "sign out" is clicked', async () => {
@@ -606,87 +604,6 @@ describe('Connected Services', () => {
       );
 
       expect(mockWindowAssign).toHaveBeenCalledWith('foo-bar/signin');
-    });
-  });
-
-  describe('scope-based sub row', () => {
-    const baseMockClient = {
-      deviceId: null,
-      sessionTokenId: null,
-      refreshTokenId: 'abc123',
-      isCurrentSession: false,
-      deviceType: null,
-      createdTime: 1571412069000,
-      lastAccessTime: 1571412069000,
-      location: { city: null, country: null, state: null, stateCode: null },
-      userAgent: '',
-      os: null,
-      createdTimeFormatted: 'a month ago',
-      lastAccessTimeFormatted: 'a month ago',
-      approximateLastAccessTime: null,
-      approximateLastAccessTimeFormatted: null,
-    };
-
-    const renderWithClient = (client: Record<string, unknown>) => {
-      const account = {
-        attachedClients: [client],
-        disconnectClient: jest.fn().mockResolvedValue(true),
-      } as unknown as Account;
-      renderWithRouter(
-        <AppContext.Provider value={mockAppContext({ account })}>
-          <ConnectedServices />
-        </AppContext.Provider>
-      );
-    };
-
-    it('does not render scope sub-entry when scope is null and client ID is OAuthNative', async () => {
-      renderWithClient({
-        ...baseMockClient,
-        clientId: OAuthNativeClients.FirefoxDesktop,
-        name: 'Firefox Desktop',
-        scope: null,
-      });
-      await screen.findByTestId('settings-connected-service');
-      expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
-    });
-
-    it('does not render scope sub-entry when scope has oldsync and profile but no relay', async () => {
-      renderWithClient({
-        ...baseMockClient,
-        clientId: OAuthNativeClients.FirefoxDesktop,
-        name: 'Firefox Desktop',
-        scope: ['https://identity.mozilla.com/apps/oldsync', 'profile'],
-      });
-      await screen.findByTestId('settings-connected-service');
-      expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
-    });
-
-    it('renders Relay scope sub-entry when scope includes relay and client ID is OAuthNative', async () => {
-      renderWithClient({
-        ...baseMockClient,
-        clientId: OAuthNativeClients.FirefoxIOS,
-        name: 'Firefox for iOS',
-        scope: [
-          'https://identity.mozilla.com/apps/oldsync',
-          'profile',
-          'https://identity.mozilla.com/apps/relay',
-        ],
-      });
-      await screen.findByTestId('settings-connected-service');
-      const scopeEntry = screen.getByTestId('scope-service');
-      expect(scopeEntry).toBeInTheDocument();
-      expect(scopeEntry).toHaveTextContent('Firefox Relay');
-    });
-
-    it('does not render scope sub-entry when scope includes relay but client ID is not OAuthNative', async () => {
-      renderWithClient({
-        ...baseMockClient,
-        clientId: '9ebfe2c2f9ea3c58',
-        name: 'Firefox Relay',
-        scope: ['profile', 'https://identity.mozilla.com/apps/relay'],
-      });
-      await screen.findByTestId('settings-connected-service');
-      expect(screen.queryByTestId('scope-service')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -229,7 +229,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
         </div>
 
         {!!sortedAndUniqueClients.length &&
-          sortedAndUniqueClients.map((client, i) => (
+          sortedAndUniqueClients.map((client) => (
             <Service
               key={`${client.lastAccessTime}:${client.name || 'unknown'}`}
               {...{

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -29,6 +29,8 @@ const DEVICES_SUPPORT_URL =
 export function sortAndFilterConnectedClients(
   attachedClients: Array<AttachedClient>
 ) {
+  // Group clients by deviceId (for sync devices) or name (for others).
+  // This avoids merging distinct devices that happen to share the same name.
   const groupedByDevice = groupBy(attachedClients, (c) => c.deviceId || c.name);
 
   // get a unique (by device or name) list and sort by time last accessed
@@ -104,9 +106,9 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
           event: { reason: reasonValue },
         });
 
-        // disconnect all clients/sessions with this name since only unique names
-        // are displayed to the user. This is batched into one network request
-        // via BatchHttpLink
+        // Disconnect all clients/sessions in the group (same deviceId or name).
+        // Since we only display one entry per group, signing out of that entry
+        // should revoke all associated sessions. This is batched via BatchHttpLink.
         const groupByKey = (client.deviceId || client.name) ?? 'undefined';
         const sessionsInGroup = groupedByDevice[groupByKey];
         const hasMultipleSessions = sessionsInGroup.length > 1;

--- a/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/ConnectedServices/index.tsx
@@ -237,6 +237,7 @@ export const ConnectedServices = forwardRef<HTMLDivElement>((_, ref) => {
                 lastAccessTimeFormatted: client.lastAccessTimeFormatted,
                 isCurrentSession: client.isCurrentSession,
                 clientId: client.clientId,
+                scope: client.scope,
                 handleSignOut: () => {
                   onSignOutClick(client);
                 },


### PR DESCRIPTION
## Because

The ConnectedServices tests started failing after recent changes, as they were still using the old `groupedByName` field.

## This pull request

- Removes the outdated `groupedByName` usage
- Updates the tests to match the current return type
- Fixes the TypeScript build errors

## Issue that this pull request solves

Closes: #17370

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
