### PR TITLE
fix(l10n): Localize subscription renewal intervals

### DIFF
--- a/libs/accounts/email-renderer/gruntfile.js
+++ b/libs/accounts/email-renderer/gruntfile.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- module.exports = function(grunt) {
+module.exports = function (grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
   });
@@ -110,7 +110,7 @@
         // 'src/templates/subscriptionPaymentFailed/en.ftl',
         // 'src/templates/subscriptionPaymentProviderCancelled/en.ftl',
         // 'src/templates/subscriptionReactivation/en.ftl',
-        // 'src/templates/subscriptionRenewalReminder/en.ftl',
+        'src/templates/subscriptionRenewalReminder/en.ftl',
         // 'src/templates/subscriptionReplaced/en.ftl',
         // 'src/templates/subscriptionSubsequentInvoice/en.ftl',
         // 'src/templates/subscriptionUpgrade/en.ftl',
@@ -134,9 +134,7 @@
 
   grunt.config('watch', {
     ftl: {
-      files: [
-        'src/**/en.ftl'
-      ],
+      files: ['src/**/en.ftl'],
       tasks: ['l10n-merge'],
       options: {
         interrupt: true,
@@ -150,4 +148,4 @@
 
   grunt.registerTask('l10n-watch', ['watch:ftl']);
   grunt.registerTask('l10n-merge', ['copy:branding-ftl', 'concat:emails-ftl']);
- }
+};

--- a/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/subscriptionRenewalReminder/en.ftl
@@ -15,7 +15,20 @@ subscriptionRenewalReminder-content-discount-ending = Because a previous discoun
 #   $planIntervalCount (String) - The interval count of subscription plan, e.g. 2
 #   $planInterval (String) - The interval of time of the subscription plan, e.g. week
 # Tells the customer that their subscription price will change at the end of the current billing cycle
-subscriptionRenewalReminder-content-charge = At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+# Localized subscription intervals
+subscription-interval-day = day
+subscription-interval-week = week
+subscription-interval-month = month
+subscription-interval-year = year
+
+# Tells the customer that their subscription price will change at the end of the current billing cycle
+subscriptionRenewalReminder-content-charge = At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval ->
+        [day] { subscription-interval-day }
+        [week] { subscription-interval-week }
+        [month] { subscription-interval-month }
+        [year] { subscription-interval-year }
+        *[other] { $planInterval }
+    } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
 subscriptionRenewalReminder-content-closing = Sincerely,
 # Variables
 #   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionRenewalReminder/en.ftl
@@ -15,7 +15,20 @@ subscriptionRenewalReminder-content-discount-ending = Because a previous discoun
 #   $planIntervalCount (String) - The interval count of subscription plan, e.g. 2
 #   $planInterval (String) - The interval of time of the subscription plan, e.g. week
 # Tells the customer that their subscription price will change at the end of the current billing cycle
-subscriptionRenewalReminder-content-charge = At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
+# Localized subscription intervals
+subscription-interval-day = day
+subscription-interval-week = week
+subscription-interval-month = month
+subscription-interval-year = year
+
+# Tells the customer that their subscription price will change at the end of the current billing cycle
+subscriptionRenewalReminder-content-charge = At that time, { -brand-mozilla } will renew your { $planIntervalCount } { $planInterval ->
+        [day] { subscription-interval-day }
+        [week] { subscription-interval-week }
+        [month] { subscription-interval-month }
+        [year] { subscription-interval-year }
+        *[other] { $planInterval }
+    } subscription and a charge of { $invoiceTotal } will be applied to the payment method on your account.
 subscriptionRenewalReminder-content-closing = Sincerely,
 # Variables
 #   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN


### PR DESCRIPTION
This enables proper localization for subscription intervals in the renewal reminder email.

Previously, the email template used hardcoded English strings (e.g., "month", "year") that were passed directly from the backend. This resulted in mixed-language content for non-English users (e.g., seeing "1 month subscription" inside an Italian email).

### Changes
- Updated `subscriptionRenewalReminder` to map the interval to specific Fluent keys (`subscription-interval-day`, `period-week`, etc.) instead of using the raw string.
- Added the necessary interval terms to `en.ftl` to support this mapping.
- Enabled the template in `email-renderer/gruntfile.js` so it's included in the l10n build process.

This allows translators to define the correct word and pluralization rules for each language while keeping the English output consistent. Reference issue #19956.