### PR TITLE
fix(payments-api): add missing glean service

### DIFF
--- a/apps/payments/api/src/app/app.module.ts
+++ b/apps/payments/api/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { ProductConfigurationManager, StrapiClient } from '@fxa/shared/cms';
 import {
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
+  PaymentsGleanService,
 } from '@fxa/payments/metrics';
 import { PaymentsGleanFactory } from '@fxa/payments/metrics/provider';
 import { PaymentsEmitterService } from '@fxa/payments/events';
@@ -64,6 +65,7 @@ import { NimbusClient, NimbusClientConfig } from '@fxa/shared/experiments';
     SubscriptionEventsService,
     PaymentsGleanFactory,
     PaymentsGleanManager,
+    PaymentsGleanService,
     PaymentsEmitterService,
     PriceManager,
     FirestoreProvider,


### PR DESCRIPTION
## Because

- The payments-api service was failing to start due to missing the PaymentsGleanService module dependency.

## This pull request

- Adds PaymentsGleanService to `payments-api`

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
