### PR TITLE
fix(subscription-reminders): Fix misconfigured subscription reminder args

### DIFF
--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -40,6 +40,7 @@ interface EndingRemindersOptions {
 }
 
 interface RenewalRemindersOptions {
+  monthlyReminderDays?: number;
   yearlyReminderDays?: number;
 }
 
@@ -81,6 +82,11 @@ export class SubscriptionReminders {
     this.statsd = statsd;
     this.planDuration = Duration.fromObject({ days: planLength });
     this.reminderDuration = Duration.fromObject({ days: reminderLength });
+    if (renewalRemindersOptions.monthlyReminderDays) {
+      this.reminderDuration = Duration.fromObject({
+        days: renewalRemindersOptions.monthlyReminderDays,
+      });
+    }
     if (renewalRemindersOptions.yearlyReminderDays) {
       this.yearlyRenewalReminderDuration = Duration.fromObject({
         days: renewalRemindersOptions.yearlyReminderDays,

--- a/packages/fxa-auth-server/scripts/subscription-reminders.ts
+++ b/packages/fxa-auth-server/scripts/subscription-reminders.ts
@@ -87,7 +87,7 @@ async function init() {
   const subscriptionReminders = new SubscriptionReminders(
     log,
     parseInt(program.planLength),
-    parseInt(program.reminderLength),
+    parseInt(program.monthlyRenewalReminderLength),
     {
       enabled: parseBooleanArg(program.enableEndingReminders),
       paymentsNextUrl: config.smtp.subscriptionSettingsUrl,
@@ -96,6 +96,7 @@ async function init() {
       yearlyReminderDays: parseInt(program.endingReminderYearlyLength),
     },
     {
+      monthlyReminderDays: parseInt(program.monthlyRenewalReminderLength),
       yearlyReminderDays: parseInt(program.yearlyRenewalReminderLength),
     },
     database,


### PR DESCRIPTION
 Because:

* the code to autogenerate the variable names changed, but the references did not

commit:

* Updates the references to the autogenerated variables, and includes an explicit check for these values

Closes #N/A

## Checklist

_Put an `x` in the boxes that apply_

- [] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
