### PR TITLE
feat(settings): Add passkey to MFA scopes

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2672,7 +2672,7 @@ const convictConf = convict({
       env: 'MFA__ENABLED',
     },
     actions: {
-      default: ['test', '2fa', 'email', 'recovery_key', 'password'],
+      default: ['test', '2fa', 'email', 'recovery_key', 'password', 'passkeys'],
       doc: 'Actions protected by MFA',
       format: Array,
       env: 'MFA__ACTIONS',

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -463,12 +463,11 @@ export const PasskeySubRow = ({
       />
       {deleteModalRevealed && (
         <MfaGuard
-          // TODO: replace with actual required scope and reason when available
-          requiredScope="test"
+          requiredScope="passkeys"
           onDismissCallback={async () => {
             hideDeleteModal();
           }}
-          reason={MfaReason.test}
+          reason={MfaReason.removePasskey}
         >
           <Modal
             onDismiss={hideDeleteModal}

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -36,6 +36,9 @@ export enum MfaReason {
   createBackupCodes = 'create backup codes',
   createRecoveryKey = 'create recovery key',
   removeRecoveryKey = 'remove recovery key',
+  createPasskey = 'create passkey',
+  renamePasskey = 'rename passkey',
+  removePasskey = 'remove passkey',
   test = 'test',
 }
 
@@ -92,4 +95,10 @@ export type TotpInfo = {
   secret: string;
 };
 
-export type MfaScope = 'test' | '2fa' | 'email' | 'recovery_key' | 'password';
+export type MfaScope =
+  | 'test'
+  | '2fa'
+  | 'email'
+  | 'recovery_key'
+  | 'password'
+  | 'passkeys';


### PR DESCRIPTION
## Because

- adds passkey to MFA scopes

## This pull request

- passkey operations are protected by MFA

## Issue that this pull request solves

Closes: FXA-13049

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
