### PR TITLE
fix(auth): Pass correct client/service name to mailer

### DIFF
--- a/packages/fxa-auth-server/scripts/delete-account.ts
+++ b/packages/fxa-auth-server/scripts/delete-account.ts
@@ -73,6 +73,10 @@ const profile = new ProfileClient(log, statsd, {
   serviceName: 'subhub',
 });
 Container.set(ProfileClient, profile);
+Container.set({
+  id: OAuthClientInfoServiceName,
+  factory: () => oauthClientInfo(log, config),
+});
 
 DB.connect(config).then(async (db: any) => {
   // Bypass customs checks.
@@ -139,11 +143,6 @@ DB.connect(config).then(async (db: any) => {
 
   const accountTasks = DeleteAccountTasksFactory(config, statsd);
   Container.set(DeleteAccountTasks, accountTasks);
-
-  Container.set({
-    id: OAuthClientInfoServiceName,
-    factory: () => oauthClientInfo(log, config),
-  });
 
   // mailer lib setup
   const bounces = new Bounces(config.smtp.bounces, {

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -365,6 +365,7 @@ describe('/recovery_email/status', () => {
   });
   const stripeHelper = mocks.mockStripeHelper();
   stripeHelper.hasActiveSubscription = sinon.fake.resolves(false);
+  mocks.mockOAuthClientInfo();
   const accountRoutes = makeRoutes({
     config: config,
     db: mockDB,
@@ -382,6 +383,7 @@ describe('/recovery_email/status', () => {
   describe('invalid email', () => {
     let mockRequest;
     beforeEach(() => {
+      mocks.mockOAuthClientInfo();
       mockRequest = mocks.mockRequest({
         credentials: {
           email: TEST_EMAIL_INVALID,
@@ -580,6 +582,9 @@ describe('/recovery_email/resend_code', () => {
     return Promise.resolve();
   });
   const mockMailer = mocks.mockMailer();
+  mocks.mockOAuthClientInfo({
+    fetch: sinon.stub().resolves({ name: 'Firefox' }),
+  });
   const mockFxaMailer = mocks.mockFxaMailer();
   const mockMetricsContext = mocks.mockMetricsContext();
   const accountRoutes = makeRoutes({
@@ -750,6 +755,7 @@ describe('/recovery_email/verify_code', () => {
   };
   const mockDB = mocks.mockDB(dbData, dbErrors);
   const mockMailer = mocks.mockMailer();
+  mocks.mockOAuthClientInfo();
   const mockFxaMailer = mocks.mockFxaMailer();
   const mockPush = mocks.mockPush();
   const mockCustoms = mocks.mockCustoms();
@@ -1132,6 +1138,7 @@ describe('/recovery_email', () => {
   const mockCustoms = mocks.mockCustoms();
 
   beforeEach(() => {
+    mocks.mockOAuthClientInfo();
     mockRequest = mocks.mockRequest({
       credentials: {
         uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
@@ -1196,6 +1203,7 @@ describe('/recovery_email', () => {
 describe('/mfa/recovery_email/secondary/resend_code', () => {
   let fxaMailer;
   beforeEach(() => {
+    mocks.mockOAuthClientInfo();
     fxaMailer = mocks.mockFxaMailer();
   });
   afterEach(() => {

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -73,6 +73,7 @@ describe('/password', () => {
     // mailer mock must be done before route creation/require
     // otherwise it won't pickup the mock we define because
     // of module caching
+    mocks.mockOAuthClientInfo();
     mockFxaMailer = mocks.mockFxaMailer();
     mockAccountEventsManager = mocks.mockAccountEventsManager();
     glean.resetPassword.emailSent.reset();

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -1215,7 +1215,7 @@ function mockFxaMailer(overrides) {
 
 function mockOAuthClientInfo(overrides) {
   const mock = {
-    fetch: sinon.stub().resolves('sync'),
+    fetch: sinon.stub().resolves({ name: 'sync' }),
     ...overrides,
   };
   Container.set(OAuthClientInfoServiceName, mock);


### PR DESCRIPTION
Because:
 - The old mailer would internally call to oauth_info_service

This Commit:
 - Fixes a few places that were missed to call oauth_info_service and pass the correct clientName to the templates
 - verifyLogin, and verifyLoginCode email templates are fixed

Closes: FXA-13055

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="392" height="685" alt="image" src="https://github.com/user-attachments/assets/788c0e0c-564f-4b36-9c96-677c1d3581a4" />

## Other information (Optional)

Any other information that is important to this pull request.
