### PR TITLE
feat(email): add templates for passwordless

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
+++ b/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
@@ -6450,6 +6450,824 @@ exports[`FxA Email Renderer should render renderPasswordResetWithRecoveryKeyProm
   </body></html>"
 `;
 
+exports[`FxA Email Renderer should render renderPasswordlessSigninOtp: matches full email snapshot 1`] = `
+"<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
+    <title>Use 96318398 to finish sign in</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+  </head>
+  <body style="word-spacing:normal;">
+    
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Code expires in 10 minutes</div>
+  
+    
+      <div aria-label="Use 96318398 to finish sign in" aria-roledescription="email" style="" role="article" lang="und" dir="auto">
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="body-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="body" style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="mozilla-logo" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:120px;" data-l10n-id="fxa-header-mozilla-logo"><img alt="Mozilla logo" src="https://cdn.accounts.firefox.com/product-icons/mozilla-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="120" height="auto" data-l10n-name="mozilla-logo"></td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-header" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-title">Finish your sign in</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-request">
+        This email was used to sign in from:
+      </span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-grey" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="device-all" data-l10n-args="{&quot;uaBrowser&quot;:&quot;Firefox&quot;,&quot;uaOS&quot;:&quot;Windows&quot;,&quot;uaOSVersion&quot;:&quot;100&quot;}">Firefox on Windows 100</span>
+      
+    
+  
+
+        <br>
+      
+      
+        
+
+
+  
+    
+      <span data-l10n-id="location-all" data-l10n-args="{&quot;city&quot;:&quot;San Francisco&quot;,&quot;stateCode&quot;:&quot;CA&quot;,&quot;country&quot;:&quot;US&quot;}">San Francisco, CA, US (estimated)</span>
+    
+  
+
+        <br>
+      
+      
+        Jan 1, 2024
+        <br>
+      
+      
+        12:00 PM
+        <br></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-code">
+        Use this confirmation code:
+      </span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="code-large" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">96318398</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-expiry-notice" data-l10n-args="{&quot;codeExpiryMinutes&quot;: 10}">It expires in 10 minutes.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-subtext" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><mj-section>
+  <mj-column>
+    <mj-text css-class="text-footer-automatedEmail">
+      <span data-l10n-id="automated-email-no-action">This is an automated email. If you received it by mistake, you don’t need to do anything. For more info, visit <a class="link-blue" href="http://localhost:3030/support" data-l10n-name="supportLink">Mozilla Support</a>.</span>
+    </mj-text>
+  </mj-column>
+</mj-section></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="http://localhost:3030/privacy">Mozilla Accounts Privacy Notice</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-terms-url" href="https://www.mozilla.org/about/legal/terms/services/">Mozilla Accounts Terms of Service</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  
+
+  </body></html>"
+`;
+
+exports[`FxA Email Renderer should render renderPasswordlessSignupOtp: matches full email snapshot 1`] = `
+"<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
+    <title>Use 96318398 to finish sign up</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+  </head>
+  <body style="word-spacing:normal;">
+    
+    <div style="display:none;font-size:1px;color:#ffffff;line-height:1px;max-height:0px;max-width:0px;opacity:0;overflow:hidden;">Code expires in 10 minutes</div>
+  
+    
+      <div aria-label="Use 96318398 to finish sign up" aria-roledescription="email" style="" role="article" lang="und" dir="auto">
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="body-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="body" style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="mozilla-logo" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:120px;" data-l10n-id="fxa-header-mozilla-logo"><img alt="Mozilla logo" src="https://cdn.accounts.firefox.com/product-icons/mozilla-logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="120" height="auto" data-l10n-name="mozilla-logo"></td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-header" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-title">Finish your sign up</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-request">
+        An account was created using this email address from:
+      </span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-grey" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="device-all" data-l10n-args="{&quot;uaBrowser&quot;:&quot;Firefox&quot;,&quot;uaOS&quot;:&quot;Windows&quot;,&quot;uaOSVersion&quot;:&quot;100&quot;}">Firefox on Windows 100</span>
+      
+    
+  
+
+        <br>
+      
+      
+        
+
+
+  
+    
+      <span data-l10n-id="location-all" data-l10n-args="{&quot;city&quot;:&quot;San Francisco&quot;,&quot;stateCode&quot;:&quot;CA&quot;,&quot;country&quot;:&quot;US&quot;}">San Francisco, CA, US (estimated)</span>
+    
+  
+
+        <br>
+      
+      
+        Jan 1, 2024
+        <br>
+      
+      
+        12:00 PM
+        <br></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-code">
+        Use this confirmation code:
+      </span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="code-large" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">96318398</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-expiry-notice" data-l10n-args="{&quot;codeExpiryMinutes&quot;: 10}">It expires in 10 minutes.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-subtext" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><mj-section>
+  <mj-column>
+    <mj-text css-class="text-footer-automatedEmail">
+      <span data-l10n-id="automated-email-no-action">This is an automated email. If you received it by mistake, you don’t need to do anything. For more info, visit <a class="link-blue" href="http://localhost:3030/support" data-l10n-name="supportLink">Mozilla Support</a>.</span>
+    </mj-text>
+  </mj-column>
+</mj-section></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="http://localhost:3030/privacy">Mozilla Accounts Privacy Notice</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-terms-url" href="https://www.mozilla.org/about/legal/terms/services/">Mozilla Accounts Terms of Service</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  
+
+  </body></html>"
+`;
+
 exports[`FxA Email Renderer should render renderPostAddAccountRecovery: matches full email snapshot 1`] = `
 "<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
     <title>New account recovery key created</title>

--- a/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
@@ -198,6 +198,34 @@ describe('FxA Email Renderer', () => {
     expect(email.html).toMatchSnapshot('matches full email snapshot');
   });
 
+  it('should render renderPasswordlessSigninOtp', async () => {
+    const email = await renderer.renderPasswordlessSigninOtp({
+      code: '96318398',
+      codeExpiryMinutes: 10,
+      date: 'Jan 1, 2024',
+      time: '12:00 PM',
+      device: mockDevice,
+      location: mockLocation,
+      ...defaultLayoutTemplateValues,
+    });
+    expect(email).toBeDefined();
+    expect(email.html).toMatchSnapshot('matches full email snapshot');
+  });
+
+  it('should render renderPasswordlessSignupOtp', async () => {
+    const email = await renderer.renderPasswordlessSignupOtp({
+      code: '96318398',
+      codeExpiryMinutes: 10,
+      date: 'Jan 1, 2024',
+      time: '12:00 PM',
+      device: mockDevice,
+      location: mockLocation,
+      ...defaultLayoutTemplateValues,
+    });
+    expect(email).toBeDefined();
+    expect(email.html).toMatchSnapshot('matches full email snapshot');
+  });
+
   it('should render renderPasswordReset', async () => {
     const email = await renderer.renderPasswordReset({
       date: 'Jan 1, 2024',

--- a/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.ts
+++ b/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.ts
@@ -16,6 +16,8 @@ import * as NewDeviceLogin from '../templates/newDeviceLogin';
 import * as PasswordChanged from '../templates/passwordChanged';
 import * as PasswordChangeRequired from '../templates/passwordChangeRequired';
 import * as PasswordForgotOtp from '../templates/passwordForgotOtp';
+import * as PasswordlessSigninOtp from '../templates/passwordlessSigninOtp';
+import * as PasswordlessSignupOtp from '../templates/passwordlessSignupOtp';
 import * as PasswordReset from '../templates/passwordReset';
 import * as PasswordResetAccountRecovery from '../templates/passwordResetAccountRecovery';
 import * as PasswordResetRecoveryPhone from '../templates/passwordResetRecoveryPhone';
@@ -195,6 +197,30 @@ export class FxaEmailRenderer extends EmailRenderer {
       version: PasswordForgotOtp.version,
       layout: PasswordForgotOtp.layout,
       includes: PasswordForgotOtp.includes,
+      ...opts,
+    });
+  }
+
+  async renderPasswordlessSigninOtp(
+    opts: WithFxaLayouts<PasswordlessSigninOtp.TemplateData>
+  ) {
+    return this.renderEmail({
+      template: PasswordlessSigninOtp.template,
+      version: PasswordlessSigninOtp.version,
+      layout: PasswordlessSigninOtp.layout,
+      includes: PasswordlessSigninOtp.includes,
+      ...opts,
+    });
+  }
+
+  async renderPasswordlessSignupOtp(
+    opts: WithFxaLayouts<PasswordlessSignupOtp.TemplateData>
+  ) {
+    return this.renderEmail({
+      template: PasswordlessSignupOtp.template,
+      version: PasswordlessSignupOtp.version,
+      layout: PasswordlessSignupOtp.layout,
+      includes: PasswordlessSignupOtp.includes,
       ...opts,
     });
   }

--- a/libs/accounts/email-renderer/src/templates/index.ts
+++ b/libs/accounts/email-renderer/src/templates/index.ts
@@ -14,6 +14,8 @@ export * as passwordReset from './passwordReset';
 export * as passwordChanged from './passwordChanged';
 export * as passwordChangeRequired from './passwordChangeRequired';
 export * as passwordForgotOtp from './passwordForgotOtp';
+export * as passwordlessSigninOtp from './passwordlessSigninOtp';
+export * as passwordlessSignupOtp from './passwordlessSignupOtp';
 export * as passwordResetAccountRecovery from './passwordResetAccountRecovery';
 export * as passwordResetRecoveryPhone from './passwordResetRecoveryPhone';
 export * as passwordResetWithRecoveryKeyPrompt from './passwordResetWithRecoveryKeyPrompt';

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/en.ftl
@@ -1,0 +1,9 @@
+# Variables:
+#  $code (String) - The confirmation code for sign-in
+#  $codeExpiryMinutes (Number) - Number of minutes until the code expires
+passwordless-signin-otp-subject = Use { $code } to finish sign in
+passwordless-signin-otp-preview = Code expires in { $codeExpiryMinutes } minutes
+passwordless-signin-otp-title = Finish your sign in 
+passwordless-signin-otp-request = This email was used to sign in from:
+passwordless-signin-otp-code = Use this confirmation code:
+passwordless-signin-otp-expiry-notice = It expires in { $codeExpiryMinutes } minutes.

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.mjml
@@ -1,0 +1,44 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public #
+License, v. 2.0. If a copy of the MPL was not distributed with this # file, You
+can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="passwordless-signin-otp-title">Finish your sign in</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordless-signin-otp-request">
+        This email was used to sign in from:
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/userInfo/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordless-signin-otp-code">
+        Use this confirmation code:
+      </span>
+    </mj-text>
+
+    <mj-text css-class="code-large"><%- code %></mj-text>
+
+    <mj-text css-class="text-body-no-margin">
+      <span data-l10n-id="passwordless-signin-otp-expiry-notice" data-l10n-args='{"codeExpiryMinutes": <%- codeExpiryMinutes %>}'>It expires in <%- codeExpiryMinutes %> minutes.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body-subtext">
+      <%- include('/partials/automatedEmailNoAction/index.mjml') %>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.stories.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_USER_INFO } from '../../partials/userInfo/mocks';
+import { storyWithProps } from '../../storybook-email';
+import { includes, TemplateData } from './index';
+
+export default {
+  title: 'FxA Emails/Templates/passwordlessSigninOtp',
+} as Meta;
+
+const data = {
+  ...MOCK_USER_INFO,
+  code: '96318398',
+  codeExpiryMinutes: 10,
+  supportUrl: 'https://support.mozilla.org',
+};
+
+const createStory = storyWithProps<TemplateData>(
+  'passwordlessSigninOtp',
+  'OTP sent to user for passwordless sign-in.',
+  data,
+  includes
+);
+
+export const PasswordlessSigninOtp = createStory();

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    code: string;
+    codeExpiryMinutes: number;
+    time: string;
+    date: string;
+  };
+
+export const template = 'passwordlessSigninOtp';
+export const version = 1;
+export const layout = 'fxa';
+export const includes = {
+  subject: {
+    id: 'passwordless-signin-otp-subject',
+    message: 'Use <%- code %> to finish sign in',
+  },
+  preview: {
+    id: 'passwordless-signin-otp-preview',
+    message: 'Code expires in <%- codeExpiryMinutes %> minutes',
+  },
+};

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.txt
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.txt
@@ -1,0 +1,13 @@
+passwordless-signin-otp-title = "Finish your sign in"
+
+passwordless-signin-otp-request = "This email was used to sign in from:"
+
+<%- include('/partials/userInfo/index.txt') %>
+
+passwordless-signin-otp-code = "Use this confirmation code:"
+
+<%- code %>
+
+passwordless-signin-otp-expiry-notice = "It expires in <%- codeExpiryMinutes %> minutes."
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/en.ftl
@@ -1,0 +1,9 @@
+# Variables:
+#  $code (String) - The confirmation code for sign-up
+#  $codeExpiryMinutes (Number) - Number of minutes until the code expires
+passwordless-signup-otp-subject = Use { $code } to finish sign up
+passwordless-signup-otp-preview = Code expires in { $codeExpiryMinutes } minutes
+passwordless-signup-otp-title = Finish your sign up
+passwordless-signup-otp-request = An account was created using this email address from:
+passwordless-signup-otp-code = Use this confirmation code:
+passwordless-signup-otp-expiry-notice = It expires in { $codeExpiryMinutes } minutes.

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.mjml
@@ -1,0 +1,44 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public #
+License, v. 2.0. If a copy of the MPL was not distributed with this # file, You
+can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="passwordless-signup-otp-title">Finish your sign up</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordless-signup-otp-request">
+        An account was created using this email address from:
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/userInfo/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordless-signup-otp-code">
+        Use this confirmation code:
+      </span>
+    </mj-text>
+
+    <mj-text css-class="code-large"><%- code %></mj-text>
+
+    <mj-text css-class="text-body-no-margin">
+      <span data-l10n-id="passwordless-signup-otp-expiry-notice" data-l10n-args='{"codeExpiryMinutes": <%- codeExpiryMinutes %>}'>It expires in <%- codeExpiryMinutes %> minutes.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body-subtext">
+      <%- include('/partials/automatedEmailNoAction/index.mjml') %>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.stories.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_USER_INFO } from '../../partials/userInfo/mocks';
+import { storyWithProps } from '../../storybook-email';
+import { includes, TemplateData } from './index';
+
+export default {
+  title: 'FxA Emails/Templates/passwordlessSignupOtp',
+} as Meta;
+
+const data = {
+  ...MOCK_USER_INFO,
+  code: '96318398',
+  codeExpiryMinutes: 10,
+  supportUrl: 'https://support.mozilla.org',
+};
+
+const createStory = storyWithProps<TemplateData>(
+  'passwordlessSignupOtp',
+  'OTP sent to user for passwordless sign-up.',
+  data,
+  includes
+);
+
+export const PasswordlessSignupOtp = createStory();

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
+
+export type TemplateData = AutomatedEmailNoActionTemplateData &
+  UserInfoTemplateData & {
+    code: string;
+    codeExpiryMinutes: number;
+    time: string;
+    date: string;
+  };
+
+export const template = 'passwordlessSignupOtp';
+export const version = 1;
+export const layout = 'fxa';
+export const includes = {
+  subject: {
+    id: 'passwordless-signup-otp-subject',
+    message: 'Use <%- code %> to finish sign up',
+  },
+  preview: {
+    id: 'passwordless-signup-otp-preview',
+    message: 'Code expires in <%- codeExpiryMinutes %> minutes',
+  },
+};

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.txt
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.txt
@@ -1,0 +1,13 @@
+passwordless-signup-otp-title = "Finish your sign up"
+
+passwordless-signup-otp-request = "An account was created using this email address from:"
+
+<%- include('/partials/userInfo/index.txt') %>
+
+passwordless-signup-otp-code = "Use this confirmation code:"
+
+<%- code %>
+
+passwordless-signup-otp-expiry-notice = "It expires in <%- codeExpiryMinutes %> minutes."
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/packages/fxa-auth-server/jest.config.js
+++ b/packages/fxa-auth-server/jest.config.js
@@ -6,17 +6,12 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   rootDir: '.',
-  testMatch: [
-    '<rootDir>/lib/**/*.spec.ts',
-    '<rootDir>/config/**/*.spec.ts',
-  ],
+  testMatch: ['<rootDir>/lib/**/*.spec.ts', '<rootDir>/config/**/*.spec.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: {
     '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: { isolatedModules: true } }],
   },
-  transformIgnorePatterns: [
-    '/node_modules/(?!(@fxa|fxa-shared)/)',
-  ],
+  transformIgnorePatterns: ['/node_modules/(?!(@fxa|fxa-shared)/)'],
   moduleNameMapper: {
     '^@fxa/shared/(.*)$': '<rootDir>/../../libs/shared/$1/src',
     '^@fxa/accounts/(.*)$': '<rootDir>/../../libs/accounts/$1/src',
@@ -26,6 +21,7 @@ module.exports = {
   },
   testTimeout: 10000,
   clearMocks: true,
+  workerIdleMemoryLimit: '512MB',
   setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/jest.setup-proxyquire.js'],
   testPathIgnorePatterns: ['/node_modules/'],
   // Coverage configuration (enabled via --coverage flag)

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -9,6 +9,8 @@ import {
   WithFxaLayouts,
   recovery,
   passwordForgotOtp,
+  passwordlessSigninOtp,
+  passwordlessSignupOtp,
   postVerifySecondary,
   postChangePrimary,
   postAddLinkedAccount,
@@ -186,6 +188,72 @@ export class FxaMailer extends FxaEmailRenderer {
       opts
     );
     const rendered = await this.renderPasswordForgotOtp({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered, true);
+  }
+
+  /**
+   * Renders and sends the passwordless sign-in OTP email.
+   * @param opts
+   * @returns
+   */
+  async sendPasswordlessSigninOtpEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<WithFxaLayouts<passwordlessSigninOtp.TemplateData>>
+  ) {
+    const { template, version } = passwordlessSigninOtp;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'x-passwordless-signin-otp': opts.code },
+      opts
+    );
+    const rendered = await this.renderPasswordlessSigninOtp({
+      ...opts,
+      ...links,
+    });
+    return this.sendEmail(opts, headers, rendered, true);
+  }
+
+  /**
+   * Renders and sends the passwordless sign-up OTP email.
+   * @param opts
+   * @returns
+   */
+  async sendPasswordlessSignupOtpEmail(
+    opts: EmailSenderOpts &
+      EmailFlowParams &
+      OmitCommonLinks<WithFxaLayouts<passwordlessSignupOtp.TemplateData>>
+  ) {
+    const { template, version } = passwordlessSignupOtp;
+    const { metricsEnabled } = opts;
+    const links = {
+      privacyUrl: this.linkBuilder.buildPrivacyLink(template, metricsEnabled),
+      supportUrl: this.linkBuilder.buildSupportLink(template, metricsEnabled),
+      passwordChangeLink: this.linkBuilder.buildPasswordChangeLink(
+        template,
+        metricsEnabled,
+        { email: opts.to }
+      ),
+    };
+    const headers = this.buildHeaders(
+      { template, version },
+      { 'x-passwordless-signup-otp': opts.code },
+      opts
+    );
+    const rendered = await this.renderPasswordlessSignupOtp({
       ...opts,
       ...links,
     });


### PR DESCRIPTION
## Because

- Need new email templates for passwordless signin and signup otp

## This pull request

- Adds passwordlessSigninOtp email template
- Adds passwordlessSignupOtp email template

## Issue that this pull request solves

Closes: # FXA-13016

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="922" height="741" alt="image" src="https://github.com/user-attachments/assets/4d639d95-ac30-4bec-89bb-c59e52b7318e" />

<img width="922" height="741" alt="image" src="https://github.com/user-attachments/assets/eaecf78c-d38b-40ad-9011-d62be2f32d2d" />
