### PR TITLE
Skip client-side redirect to /signin during sign-out

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -35,7 +35,7 @@ import { SETTINGS_PATH } from '../../constants';
 import PageAvatar from './PageAvatar';
 import PageRecentActivity from './PageRecentActivity';
 import { MfaGuardPageRecoveryKeyCreate } from './PageRecoveryKeyCreate';
-import { currentAccount, sessionToken } from '../../lib/cache';
+import { currentAccount, isSigningOut, sessionToken } from '../../lib/cache';
 import { hasAccount, setCurrentAccount } from '../../lib/storage-utils';
 import GleanMetrics from '../../lib/glean';
 import Head from 'fxa-react/components/Head';
@@ -131,9 +131,12 @@ export const Settings = ({
 
   // This error check includes a network error
   if (error) {
-    // If the session token is invalid (destroyed/expired), redirect to signin
+    // If the session token is invalid, redirect to signin.
+    // Skip during sign-out to avoid racing with window.location.assign.
     if (error instanceof InvalidTokenError) {
-      navigateWithQuery('/signin');
+      if (!isSigningOut()) {
+        navigateWithQuery('/signin');
+      }
       return <LoadingSpinner fullScreen />;
     }
     Sentry.captureException(error, { tags: { source: 'settings' } });


### PR DESCRIPTION
## Because

- This was causing the page to render twice, which could cause a race condition

## This pull request

- Don't redirect if signout (gets handled in `session.destroyed`)

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
