### PR TITLE
Use RecoveryPhoneService.available in /account endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -2335,6 +2335,7 @@ export class AccountHandler {
       backupCodesResult,
       recoveryKeyResult,
       recoveryPhoneResult,
+      recoveryPhoneAvailableResult,
       securityEventsResult,
       devicesResult,
       authorizedClientsResult,
@@ -2346,13 +2347,17 @@ export class AccountHandler {
       Container.get(BackupCodeManager).getCountForUserId(uid),
       this.db.getRecoveryKeyRecordWithHint(uid),
       Container.get(RecoveryPhoneService).hasConfirmed(uid),
+      request.app.geo?.location?.countryCode
+        ? Container.get(RecoveryPhoneService).available(uid, request.app.geo.location.countryCode)
+        : Promise.resolve(false),
       this.db.securityEventsByUid({ uid }),
       this.db.devices(uid),
       listAuthorizedClients(uid),
     ]);
 
-    // Check if recovery phone feature is enabled globally (region check requires geo context)
-    const recoveryPhoneAvailable = this.config.recoveryPhone?.enabled ?? false;
+    const recoveryPhoneAvailable = recoveryPhoneAvailableResult.status === 'fulfilled'
+      ? recoveryPhoneAvailableResult.value
+      : false;
 
     // Account record is required
     if (accountRecord.status === 'rejected') {


### PR DESCRIPTION
## Because

- We should be using the actual recovery phone service availble value...

## This pull request

- Uses the value

## Issue that this pull request solves

Closes: FXA-13078

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
