### PR TITLE
fxa-12622: Migrate 24 Mocha integration tests to Jest

### DIFF
--- a/packages/fxa-auth-server/jest.integration.config.js
+++ b/packages/fxa-auth-server/jest.integration.config.js
@@ -20,6 +20,7 @@ module.exports = {
   ],
 
   testTimeout: 120000,
+  maxWorkers: '50%',
 
   globalSetup: '<rootDir>/test/support/jest-global-setup.ts',
   globalTeardown: '<rootDir>/test/support/jest-global-teardown.ts',

--- a/packages/fxa-auth-server/test/remote/account_create.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_create.in.spec.ts
@@ -1,0 +1,723 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import crypto from 'crypto';
+
+interface AuthServerError extends Error {
+  errno: number;
+  code: number;
+  email: string;
+}
+
+interface TestConfig extends Record<string, unknown> {
+  smtp: { syncUrl: string };
+  publicUrl: string;
+}
+
+const Client = require('../client')();
+const mocks = require('../mocks');
+
+let server: TestServerInstance;
+let config: TestConfig;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      subscriptions: { enabled: false },
+    },
+  });
+  config = server.config as TestConfig;
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account create',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('unverified account fail when getting keys', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      expect(client.authAt).toBeTruthy();
+
+      try {
+        await client.keys();
+        fail('got keys before verifying email');
+      } catch (err: unknown) {
+        const error = err as AuthServerError;
+        expect(error.errno).toBe(104);
+        expect(error.message).toBe('Unconfirmed account');
+      }
+    });
+
+    it('create and verify sync account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        service: 'sync',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-mailer']).toBeUndefined();
+      expect(emailData.headers['x-template-name']).toBe('verify');
+
+      const verifyCode = emailData.headers['x-verify-code'];
+      await client.verifyEmail(verifyCode, { service: 'sync' });
+
+      const postVerifyEmail = await server.mailbox.waitForEmail(email);
+      expect(postVerifyEmail.headers['x-link']).toMatch(new RegExp(`^${config.smtp.syncUrl}`));
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+    });
+
+    it('create account with service identifier and resume', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        service: 'abcdef',
+        resume: 'foo',
+      });
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-service-id']).toBe('abcdef');
+      expect(emailData.headers['x-link']).toContain('resume=foo');
+    });
+
+    it('create account allows localization of emails', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      let client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.text).toContain('Confirm account');
+
+      const code = emailData.headers['x-verify-code'];
+      await client.verifyEmail(code, {});
+      await client.destroyAccount();
+
+      client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        lang: 'pt-br',
+      });
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.text).not.toContain('Confirm email');
+
+      const code2 = emailData.headers['x-verify-code'];
+      await client.verifyEmail(code2, {});
+      await client.destroyAccount();
+    });
+
+    it('Unknown account should not exist', async () => {
+      const client = new Client(server.publicUrl, testOptions);
+      client.email = server.uniqueEmail();
+      client.authPW = crypto.randomBytes(32);
+      client.authPWVersion2 = crypto.randomBytes(32);
+
+      try {
+        await client.auth();
+        fail('account should not exist');
+      } catch (err: unknown) {
+        const error = err as AuthServerError;
+        expect(error.errno).toBe(102);
+      }
+    });
+
+    it('stubs account and finishes setup', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(server.publicUrl, testOptions);
+      await client.setupCredentials(email, password);
+
+      if (testOptions.version === 'V2') {
+        await client.setupCredentialsV2(email, password);
+      }
+
+      const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
+
+      const jwt = require('../../lib/oauth/jwt');
+      const setupToken = jwt.sign(
+        { uid: stubResponse.uid, iat: Date.now() },
+        { header: { typ: 'fin+JWT' } }
+      );
+
+      const response = await client.finishAccountSetup(setupToken);
+      expect(response.uid).toBeDefined();
+      expect(response.sessionToken).toBeDefined();
+      expect(response.verified).toBe(false);
+
+      const client2 = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      expect(client2.sessionToken).toBeDefined();
+    });
+
+    it('can re-stub an unverified account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+
+      const stub = async () => {
+        const client = new Client(server.publicUrl, testOptions);
+        await client.setupCredentials(email, password);
+
+        if (testOptions.version === 'V2') {
+          await client.setupCredentialsV2(email, password);
+        }
+
+        return client.stubAccount('dcdb5ae7add825d2');
+      };
+
+      const first = await stub();
+      expect(first.uid).toBeDefined();
+
+      const second = await stub();
+      expect(second.uid).toBeDefined();
+      expect(second.uid).not.toBe(first.uid);
+    });
+
+    it('fails to create account with a corrupt setup token', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(server.publicUrl, testOptions);
+      await client.setupCredentials(email, password);
+
+      if (testOptions.version === 'V2') {
+        await client.setupCredentialsV2(email, password);
+      }
+
+      await client.stubAccount('dcdb5ae7add825d2');
+      await expect(client.finishAccountSetup('invalid-token')).rejects.toBeDefined();
+    });
+
+    it('fails to call finish setup again', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(server.publicUrl, testOptions);
+      await client.setupCredentials(email, password);
+
+      if (testOptions.version === 'V2') {
+        await client.setupCredentialsV2(email, password);
+      }
+
+      const stubResponse = await client.stubAccount('dcdb5ae7add825d2');
+
+      const jwt = require('../../lib/oauth/jwt');
+      const setupToken = jwt.sign(
+        {
+          uid: stubResponse.uid,
+          iat: Date.now(),
+        },
+        { header: { typ: 'fin+JWT' } }
+      );
+
+      await client.finishAccountSetup(setupToken);
+      await expect(client.finishAccountSetup(setupToken)).rejects.toBeDefined();
+    });
+
+    it('/account/create works with proper data', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+      expect(client.uid).toBeTruthy();
+
+      await client.login();
+      expect(client.sessionToken).toBeTruthy();
+    });
+
+    it('/account/create returns a sessionToken', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(server.publicUrl, testOptions);
+
+      await client.setupCredentials(email, password);
+      const response = await client.api.accountCreate(client.email, client.authPW);
+
+      expect(response.sessionToken).toBeTruthy();
+      expect(response.keyFetchToken).toBeUndefined();
+    });
+
+    it('/account/create returns a keyFetchToken when keys=true', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = new Client(server.publicUrl, testOptions);
+
+      await client.setupCredentials(email, password);
+      const response = await client.api.accountCreate(client.email, client.authPW, {
+        keys: true,
+      });
+
+      expect(response.sessionToken).toBeTruthy();
+      expect(response.keyFetchToken).toBeTruthy();
+    });
+
+    it('signup with same email, different case', async () => {
+      const email = server.uniqueEmail();
+      const email2 = email.toUpperCase();
+      const password = 'abcdef';
+
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.create(server.publicUrl, email2, password, testOptions);
+        fail('should have thrown');
+      } catch (err: unknown) {
+        const error = err as AuthServerError;
+        expect(error.code).toBe(400);
+        expect(error.errno).toBe(101);
+        expect(error.email).toBe(email);
+      }
+    });
+
+    it('re-signup against an unverified email', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+
+      await Client.create(server.publicUrl, email, password, testOptions);
+      await server.mailbox.waitForEmail(email);
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+      expect(client.uid).toBeTruthy();
+    });
+
+    it('invalid redirectTo', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        redirectTo: 'http://accounts.firefox.com.evil.us',
+      };
+
+      try {
+        await api.accountCreate(email, authPW, options);
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(107);
+      }
+    });
+
+    it('another invalid redirectTo', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        redirectTo: 'https://www.fake.com/.firefox.com',
+      };
+
+      try {
+        await api.accountCreate(email, authPW, options);
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(107);
+      }
+    });
+
+    it('valid metricsContext', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: 'foo',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'bar',
+          utmContent: 'baz',
+          utmMedium: 'qux',
+          utmSource: 'wibble',
+          utmTerm: 'blee',
+        },
+      };
+
+      await api.accountCreate(email, authPW, options);
+    });
+
+    it('empty metricsContext', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {},
+      };
+
+      await api.accountCreate(email, authPW, options);
+    });
+
+    it('invalid entrypoint', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const email = server.uniqueEmail();
+      const authPW =
+        '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+      const options = {
+        ...testOptions,
+        metricsContext: {
+          entrypoint: ';',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
+          utmCampaign: 'foo',
+          utmContent: 'bar',
+          utmMedium: 'baz',
+          utmSource: 'qux',
+          utmTerm: 'wibble',
+        },
+      };
+
+      try {
+        await api.accountCreate(email, authPW, options);
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(107);
+      }
+    });
+
+    it('create account with service query parameter', async () => {
+      const email = server.uniqueEmail();
+
+      await Client.create(server.publicUrl, email, 'foo', {
+        ...testOptions,
+        serviceQuery: 'bar',
+      });
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-service-id']).toBe('bar');
+    });
+
+    it('account creation works with unicode email address', async () => {
+      const email = server.uniqueUnicodeEmail();
+
+      const client = await Client.create(
+        server.publicUrl,
+        email,
+        'foo',
+        testOptions
+      );
+      expect(client).toBeTruthy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData).toBeTruthy();
+    });
+
+    it('account creation fails with invalid metricsContext flowId', async () => {
+      const email = server.uniqueEmail();
+
+      try {
+        await Client.create(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId: 'deadbeefbaadf00ddeadbeefbaadf00d',
+            flowBeginTime: 1,
+          },
+        });
+        fail('account creation should have failed');
+      } catch (err) {
+        expect(err).toBeTruthy();
+      }
+    });
+
+    it('account creation fails with invalid metricsContext flowBeginTime', async () => {
+      const email = server.uniqueEmail();
+
+      try {
+        await Client.create(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId:
+              'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+            flowBeginTime: 0,
+          },
+        });
+        fail('account creation should have failed');
+      } catch (err) {
+        expect(err).toBeTruthy();
+      }
+    });
+
+    it('account creation works with maximal metricsContext metadata', async () => {
+      const email = server.uniqueEmail();
+      const options = {
+        ...testOptions,
+        metricsContext: mocks.generateMetricsContext(),
+      };
+
+      const client = await Client.create(server.publicUrl, email, 'foo', options);
+      expect(client).toBeTruthy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-flow-begin-time']).toBe(
+        String(options.metricsContext.flowBeginTime)
+      );
+      expect(emailData.headers['x-flow-id']).toBe(options.metricsContext.flowId);
+    });
+
+    it('account creation works with empty metricsContext metadata', async () => {
+      const email = server.uniqueEmail();
+
+      const client = await Client.create(server.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {},
+      });
+      expect(client).toBeTruthy();
+    });
+
+    it('account creation fails with missing flowBeginTime', async () => {
+      const email = server.uniqueEmail();
+
+      try {
+        await Client.create(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId:
+              'deadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00ddeadbeefbaadf00d',
+          },
+        });
+        fail('account creation should have failed');
+      } catch (err) {
+        expect(err).toBeTruthy();
+      }
+    });
+
+    it('account creation fails with missing flowId', async () => {
+      const email = server.uniqueEmail();
+
+      try {
+        await Client.create(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowBeginTime: Date.now(),
+          },
+        });
+        fail('account creation should have failed');
+      } catch (err) {
+        expect(err).toBeTruthy();
+      }
+    });
+
+    it('create account for non-sync service, gets generic sign-up email', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      expect(client).toBeTruthy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verify');
+
+      const verifyCode = emailData.headers['x-verify-code'];
+      await client.verifyEmail(verifyCode, { service: 'testpilot' });
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      expect(code).toBeTruthy();
+    });
+
+    it('create account for unspecified service does not get sync email', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      expect(client).toBeTruthy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verify');
+
+      const verifyCode = emailData.headers['x-verify-code'];
+      await client.verifyEmail(verifyCode, {});
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      expect(code).toBeTruthy();
+    });
+
+    it('create account and subscribe to newsletters', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        service: 'sync',
+      });
+      expect(client).toBeTruthy();
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      const verifyCode = emailData.headers['x-verify-code'];
+
+      await client.verifyEmail(verifyCode, {
+        service: 'sync',
+        newsletters: ['test-pilot'],
+      });
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('postVerify');
+    });
+
+    if (version === 'V2') {
+      it('maintains single kB value for account create with V1 & V2 credentials', async () => {
+        const email = server.uniqueEmail();
+        const password = 'F00BAR';
+
+        const client = await Client.createAndVerify(
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          {
+            ...testOptions,
+            keys: true,
+            service: 'sync',
+          }
+        );
+
+        await client.getKeysV1();
+        await client.getKeysV2();
+        const originalKb = client.kB;
+        const clientSalt = await client.getClientSalt();
+
+        const login = async (loginEmail: string, loginPassword: string, loginVersion = '') => {
+          return await Client.login(server.publicUrl, loginEmail, loginPassword, {
+            ...testOptions,
+            version: loginVersion,
+            keys: true,
+            service: 'sync',
+          });
+        };
+
+        const clientV1 = await login(email, password, '');
+        await clientV1.getKeysV1();
+        const kB1 = clientV1.kB;
+
+        const clientV2 = await login(email, password, 'V2');
+        await clientV2.getKeysV2();
+        const kB2 = clientV2.kB;
+
+        expect(originalKb).toBeDefined();
+        expect(
+          clientSalt.startsWith('identity.mozilla.com/picl/v1/quickStretchV2:')
+        ).toBe(true);
+        expect(kB1).toBe(originalKb);
+        expect(kB2).toBe(originalKb);
+      });
+
+      it('maintains single kB value after account password upgrade from V1 to V2', async () => {
+        const email = server.uniqueEmail();
+        const password = 'F00BAR';
+
+        const client = await Client.createAndVerify(
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          {
+            ...testOptions,
+            keys: true,
+            service: 'sync',
+          }
+        );
+
+        await client.keys();
+        const originalKb = client.getState().kB;
+        await client.upgradeCredentials(password);
+
+        const login = async (loginEmail: string, loginPassword: string, loginVersion = '') => {
+          return await Client.login(server.publicUrl, loginEmail, loginPassword, {
+            ...testOptions,
+            version: loginVersion,
+            keys: true,
+            service: 'sync',
+          });
+        };
+
+        const clientV1 = await login(email, password, '');
+        await clientV1.getKeysV1();
+        const kB1 = clientV1.kB;
+
+        const clientV2 = await login(email, password, 'V2');
+        await clientV2.getKeysV2();
+        const kB2 = clientV2.kB;
+
+        expect(originalKb).toBeDefined();
+        expect(kB1).toBe(originalKb);
+        expect(kB2).toBe(originalKb);
+      });
+    }
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_create_with_code.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code.in.spec.ts
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+const otplib = require('otplib');
+
+interface AuthServerError extends Error {
+  code: number;
+  errno: number;
+}
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account create with sign-up code',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    const password = '4L6prUdlLNfxGIoj';
+
+    it('create and verify sync account', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        service: 'sync',
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(false);
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.verifyShortCodeEmail(
+        emailData.headers['x-verify-short-code'],
+        { service: 'sync' }
+      );
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-link']).toContain(
+        (server.config as any).smtp.syncUrl
+      );
+
+      emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(true);
+    });
+
+    it('create and verify account', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.verifyShortCodeEmail(
+        emailData.headers['x-verify-short-code']
+      );
+
+      emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(true);
+
+      // It's hard to test for "an email didn't arrive".
+      // Instead trigger sending of another email and test
+      // that there wasn't anything in the queue before it.
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      expect(code).toBeTruthy();
+    });
+
+    it('throws for expired code', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.requestVerifyEmail();
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verify');
+
+      const secret = emailData.headers['x-verify-code'];
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
+      futureAuthenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        (server.config as any).otp,
+        { secret, epoch: Date.now() / 1000 - 60 * 60 } // Code 60mins old
+      );
+      const expiredCode = futureAuthenticator.generate();
+
+      await expect(
+        client.verifyShortCodeEmail(expiredCode)
+      ).rejects.toMatchObject({ code: 400, errno: 183 });
+    });
+
+    it('throws for invalid code', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      const invalidCode = emailData.headers['x-verify-short-code'] + 1;
+
+      await expect(
+        client.verifyShortCodeEmail(invalidCode)
+      ).rejects.toMatchObject({ code: 400, errno: 183 });
+    });
+
+    it('create and resend authentication code', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      const originalMessageId = emailData['messageId'];
+      const originalCode = emailData.headers['x-verify-short-code'];
+
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.resendVerifyShortCodeEmail();
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+      expect(emailData['messageId']).not.toBe(originalMessageId);
+      expect(emailData.headers['x-verify-short-code']).toBe(originalCode);
+    });
+
+    it('should verify code from previous code window', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.requestVerifyEmail();
+      emailData = await server.mailbox.waitForEmail(email);
+
+      // Each code window is 10 minutes
+      const secret = emailData.headers['x-verify-code'];
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
+      futureAuthenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        (server.config as any).otp,
+        { secret, epoch: Date.now() / 1000 - 60 * 10 } // Code 10mins old
+      );
+
+      const previousWindowCode = futureAuthenticator.generate(secret);
+      const response = await client.verifyShortCodeEmail(previousWindowCode);
+      expect(response).toBeTruthy();
+    });
+
+    it('should not verify code from future code window', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.requestVerifyEmail();
+      emailData = await server.mailbox.waitForEmail(email);
+
+      // Each code window is 10 minutes
+      const secret = emailData.headers['x-verify-code'];
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
+      futureAuthenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        (server.config as any).otp,
+        { secret, epoch: Date.now() / 1000 + 60 * 30 } // Code 30mins in future
+      );
+
+      const futureWindowCode = futureAuthenticator.generate(secret);
+
+      await expect(
+        client.verifyShortCodeEmail(futureWindowCode)
+      ).rejects.toMatchObject({ code: 400, errno: 183 });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_destroy.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_destroy.in.spec.ts
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import crypto from 'crypto';
+import { AppError } from '@fxa/accounts/errors';
+const otplib = require('otplib');
+
+interface AuthServerError extends Error {
+  code: number;
+  errno: number;
+  message: string;
+}
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account destroy',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('can delete account by providing short code', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      await client.resendVerifyShortCodeEmail();
+      const emailData = await server.mailbox.waitForEmail(email);
+      let code: string | undefined;
+      for (let i = 0; i < emailData.length; i++) {
+        if (emailData[i].headers['x-verify-short-code']) {
+          code = emailData[i].headers['x-verify-short-code'];
+        }
+      }
+      expect(code).toBeDefined();
+      await client.verifyShortCodeEmail(code);
+
+      // Should not throw
+      await client.destroyAccount();
+    });
+
+    it('can delete account by providing verify code', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const code = emailData[emailData.length - 1].headers['x-verify-code'];
+      await client.verifyEmail(code);
+
+      // Should not throw
+      await client.destroyAccount();
+    });
+
+    it('cannot delete account with invalid authPW', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      const c = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      c.authPW = Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      );
+      c.authPWVersion2 = Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      );
+
+      try {
+        await c.destroyAccount();
+        fail('should not be able to destroy account with invalid password');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(103);
+      }
+    });
+
+    it('cannot delete account without verifying TOTP', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+
+      await Client.createAndVerifyAndTOTP(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+
+      // Create a new unverified session
+      const client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      const res = await client.emailStatus();
+      expect(res.sessionVerified).toBe(false);
+
+      try {
+        await client.destroyAccount();
+        fail('Should not be able to destroy account without verifying totp');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(
+          AppError.ERRNO.INSUFFICIENT_AAL
+        );
+      }
+    });
+
+    it('cannot delete account with TOTP by supplying email otp code', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      let client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      await client.resendVerifyShortCodeEmail();
+      const emailData = await server.mailbox.waitForEmail(email);
+      let code: string | undefined;
+      for (let i = 0; i < emailData.length; i++) {
+        if (emailData[i].headers['x-verify-short-code']) {
+          code = emailData[i].headers['x-verify-short-code'];
+        }
+      }
+      expect(code).toBeDefined();
+      await client.verifyShortCodeEmail(code);
+
+      // Add totp to account.
+      client.totpAuthenticator = new otplib.authenticator.Authenticator();
+      const totpTokenResult = await client.createTotpToken();
+      expect(totpTokenResult).toBeDefined();
+      client.totpAuthenticator.options = {
+        secret: totpTokenResult.secret,
+        crypto: crypto,
+      };
+      const totpCode = client.totpAuthenticator.generate();
+      await client.verifyTotpSetupCode(totpCode);
+      await client.completeTotpSetup();
+
+      // Log in again. This creates a new unverified session
+      client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      const res = await client.emailStatus();
+      expect(res.sessionVerified).toBe(false);
+
+      // Try verifying the session with a short code. This should
+      // not be enough to bypass 2FA.
+      await client.verifyShortCodeEmail(code);
+      expect((await client.emailStatus()).sessionVerified).toBe(true);
+
+      // Destroying the account should not work. Despite the session being 'verified',
+      // totp has not been provided.
+      try {
+        await client.destroyAccount();
+        fail('Should not be able to destroy account without verifying totp');
+      } catch (error: unknown) {
+        expect((error as AuthServerError).errno).toBe(
+          AppError.ERRNO.INSUFFICIENT_AAL
+        );
+      }
+    });
+
+    it('cannot delete without verifying session', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      // Login again requiring email-2fa for session verification.
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+      });
+
+      try {
+        await client.destroyAccount();
+        fail('Should not be able allowed to destroy account.');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).message).toBe('Unconfirmed session');
+      }
+    });
+
+    it('cannot delete without verifying account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      const client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      try {
+        await client.destroyAccount();
+        fail('Should not be able allowed to destroy account.');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).message).toBe('Unconfirmed session');
+      }
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_locale.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_locale.in.spec.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      redis: { sessionTokens: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account locale',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('a really long (invalid) locale', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        lang: Buffer.alloc(128).toString('hex'),
+      });
+      const response = await client.api.accountStatus(
+        client.uid,
+        client.sessionToken
+      );
+      expect(response.locale).toBeFalsy();
+    });
+
+    it('a really long (valid) locale', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        lang: `en-US,en;q=0.8,${Buffer.alloc(128).toString('hex')}`,
+      });
+      const response = await client.api.accountStatus(
+        client.uid,
+        client.sessionToken
+      );
+      expect(response.locale).toBe('en-US,en;q=0.8');
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_login.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_login.in.spec.ts
@@ -1,0 +1,353 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import crypto from 'crypto';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      securityHistory: { ipProfiling: { allowedRecency: 0 } },
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account login',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('the email is returned in the error on Incorrect password errors', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(
+          server.publicUrl,
+          email,
+          `${password}x`,
+          testOptions
+        );
+        fail('should have thrown');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(103);
+        expect(err.email).toBe(email);
+      }
+    });
+
+    it('the email is returned in the error on Incorrect email case errors with correct password', async () => {
+      if (version === 'V2') {
+        // V2 passwords do not use the user's email as salt,
+        // and therefore are not affected by this edge case.
+        return;
+      }
+
+      const signupEmail = server.uniqueEmail();
+      const loginEmail = signupEmail.toUpperCase();
+      const password = 'abcdef';
+      await Client.createAndVerify(
+        server.publicUrl,
+        signupEmail,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(
+          server.publicUrl,
+          loginEmail,
+          password,
+          testOptions
+        );
+        fail('should have thrown');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(120);
+        expect(err.email).toBe(signupEmail);
+      }
+    });
+
+    it('Unknown account should not exist', async () => {
+      const client = new Client(server.publicUrl, testOptions);
+      client.email = server.uniqueEmail();
+      client.authPW = crypto.randomBytes(32);
+      client.authPWVersion2 = crypto.randomBytes(32);
+
+      try {
+        await client.login();
+        fail('account should not exist');
+      } catch (err: any) {
+        expect(err.errno).toBe(102);
+      }
+    });
+
+    it('No keyFetchToken without keys=true', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      const c = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: false,
+      });
+      expect(c.keyFetchToken).toBeNull();
+    });
+
+    it('login works with unicode email address', async () => {
+      const email = server.uniqueUnicodeEmail();
+      const password = 'wibble';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      const client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      expect(client).toBeTruthy();
+    });
+
+    it('account login works with minimal metricsContext metadata', async () => {
+      const email = server.uniqueEmail();
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        'foo',
+        server.mailbox,
+        testOptions
+      );
+
+      const client = await Client.login(server.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {
+          flowId:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          flowBeginTime: Date.now(),
+        },
+      });
+      expect(client).toBeTruthy();
+    });
+
+    it('account login fails with invalid metricsContext flowId', async () => {
+      const email = server.uniqueEmail();
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        'foo',
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0',
+            flowBeginTime: Date.now(),
+          },
+        });
+        fail('account login should have failed');
+      } catch (err: any) {
+        expect(err).toBeTruthy();
+      }
+    });
+
+    it('account login fails with invalid metricsContext flowBeginTime', async () => {
+      const email = server.uniqueEmail();
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        'foo',
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            flowBeginTime: 'wibble',
+          },
+        });
+        fail('account login should have failed');
+      } catch (err: any) {
+        expect(err).toBeTruthy();
+      }
+    });
+
+    describe('can use verificationMethod', () => {
+      let email: string;
+      const password = 'foo';
+
+      beforeEach(async () => {
+        email = server.uniqueEmail('@mozilla.com');
+        await Client.createAndVerify(
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          testOptions
+        );
+      });
+
+      it('fails with invalid verification method', async () => {
+        try {
+          await Client.login(server.publicUrl, email, password, {
+            ...testOptions,
+            verificationMethod: 'notvalid',
+            keys: true,
+          });
+          fail('should not have succeeded');
+        } catch (err: any) {
+          expect(err.errno).toBe(107);
+        }
+      });
+
+      it('can use `email` verification', async () => {
+        const client = await Client.login(
+          server.publicUrl,
+          email,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'email',
+            keys: true,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('email');
+
+        let status = await client.emailStatus();
+        expect(status.verified).toBe(false);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+
+        const emailData = await server.mailbox.waitForEmail(email);
+        const singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+        expect(singleEmail.headers['x-template-name']).toBe('verifyLogin');
+        const code = singleEmail.headers['x-verify-code'];
+        expect(code).toBeTruthy();
+
+        await client.verifyEmail(code);
+
+        status = await client.emailStatus();
+        expect(status.verified).toBe(true);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(true);
+      });
+
+      it('can use `email-2fa` verification', async () => {
+        const client = await Client.login(
+          server.publicUrl,
+          email,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'email-2fa',
+            keys: true,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('email-2fa');
+
+        const status = await client.emailStatus();
+        expect(status.verified).toBe(false);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+
+        const emailData = await server.mailbox.waitForEmail(email);
+        const singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+        expect(singleEmail.headers['x-template-name']).toBe('verifyLoginCode');
+        const code = singleEmail.headers['x-signin-verify-code'];
+        expect(code).toBeTruthy();
+      });
+
+      it('can use `totp-2fa` verification', async () => {
+        const totpEmail = server.uniqueEmail();
+        await Client.createAndVerifyAndTOTP(
+          server.publicUrl,
+          totpEmail,
+          password,
+          server.mailbox,
+          { ...testOptions, keys: true }
+        );
+
+        const client = await Client.login(
+          server.publicUrl,
+          totpEmail,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'totp-2fa',
+            keys: true,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('totp-2fa');
+
+        const status = await client.emailStatus();
+        expect(status.verified).toBe(false);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+      });
+
+      it('should include verificationMethod if session is unverified', async () => {
+        const client = await Client.login(
+          server.publicUrl,
+          email,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'email',
+            keys: false,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('email');
+
+        const status = await client.emailStatus();
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+      });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_profile.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_profile.in.spec.ts
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+let CLIENT_ID: string;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      subscriptions: { enabled: false },
+    },
+  });
+  const config = server.config as any;
+  CLIENT_ID = config.oauthServer.clients.find(
+    (c: any) => c.trusted && c.canGrant && c.publicClient
+  ).id;
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - fetch user profile data',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    describe('when a request is authenticated with a session token', () => {
+      let client: any;
+
+      beforeEach(async () => {
+        client = await Client.create(
+          server.publicUrl,
+          server.uniqueEmail(),
+          'password',
+          { ...testOptions, lang: 'en-US' }
+        );
+      });
+
+      it('returns the profile data', async () => {
+        const response = await client.accountProfile();
+
+        expect(response.email).toBeTruthy();
+        expect(response.locale).toBe('en-US');
+        expect(response.authenticationMethods).toEqual(['pwd', 'email']);
+        expect(response.authenticatorAssuranceLevel).toBe(1);
+        expect(response.profileChangedAt).toBeTruthy();
+      });
+    });
+
+    describe('when a request is authenticated with a valid oauth token', () => {
+      let client: any;
+      let token: string;
+
+      async function initialize(scope: string) {
+        const email = server.uniqueEmail();
+        const password = 'test password';
+        client = await Client.createAndVerify(
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          { ...testOptions, lang: 'en-US' }
+        );
+
+        const tokenResponse =
+          await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: CLIENT_ID,
+            access_type: 'offline',
+            scope: scope,
+          });
+
+        token = tokenResponse.access_token;
+      }
+
+      it('returns the profile data', async () => {
+        await initialize('profile');
+        const response = await client.accountProfile(token);
+
+        expect(response.email).toBeTruthy();
+        expect(response.locale).toBe('en-US');
+        expect(response.authenticationMethods).toEqual(['pwd', 'email']);
+        expect(response.authenticatorAssuranceLevel).toBe(1);
+        expect(response.profileChangedAt).toBeTruthy();
+      });
+
+      describe('scopes are applied to profile data returned', () => {
+        describe('scope does not authorize profile data', () => {
+          it('returns no profile data', async () => {
+            await initialize('preadinglist payments');
+            const response = await client.accountProfile(token);
+
+            expect(response).toEqual({});
+          });
+        });
+
+        describe('limited oauth scopes for profile data', () => {
+          it('returns only email for email only token', async () => {
+            await initialize('profile:email');
+            const response = await client.accountProfile(token);
+
+            expect(response.email).toBeTruthy();
+            expect(response.locale).toBeFalsy();
+            expect(response.profileChangedAt).toBeTruthy();
+          });
+
+          it('returns only locale for locale only token', async () => {
+            await initialize('profile:locale');
+            const response = await client.accountProfile(token);
+            expect(response.email).toBeFalsy();
+            expect(response.locale).toBe('en-US');
+            expect(response.profileChangedAt).toBeTruthy();
+          });
+        });
+
+        describe('profile authenticated with :write scopes', () => {
+          describe('profile:write', () => {
+            it('returns profile data', async () => {
+              await initialize('profile:write');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeTruthy();
+              expect(response.locale).toBeTruthy();
+              expect(response.authenticationMethods).toBeTruthy();
+              expect(response.authenticatorAssuranceLevel).toBeTruthy();
+              expect(response.profileChangedAt).toBeTruthy();
+            });
+          });
+
+          describe('profile:locale:write readinglist', () => {
+            it('returns limited profile data', async () => {
+              await initialize('profile:locale:write readinglist');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeFalsy();
+              expect(response.locale).toBeTruthy();
+              expect(response.authenticationMethods).toBeFalsy();
+              expect(response.authenticatorAssuranceLevel).toBeFalsy();
+            });
+          });
+
+          describe('profile:email:write storage', () => {
+            it('returns limited profile data', async () => {
+              await initialize('profile:email:write storage');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeTruthy();
+              expect(response.locale).toBeFalsy();
+              expect(response.authenticationMethods).toBeFalsy();
+              expect(response.authenticatorAssuranceLevel).toBeFalsy();
+            });
+          });
+
+          describe('profile:email:write profile:amr', () => {
+            it('returns limited profile data', async () => {
+              await initialize('profile:email:write profile:amr');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeTruthy();
+              expect(response.locale).toBeFalsy();
+              expect(response.authenticationMethods).toBeTruthy();
+              expect(response.authenticatorAssuranceLevel).toBeTruthy();
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the profile data is not default', () => {
+      describe('when the email address is unicode', () => {
+        it('returns the email address correctly with the profile data', async () => {
+          const email = server.uniqueUnicodeEmail();
+          const client = await Client.create(
+            server.publicUrl,
+            email,
+            'password',
+            testOptions
+          );
+          const response = await client.accountProfile();
+          expect(response.email).toBe(email);
+        });
+      });
+
+      describe('when the account has TOTP', () => {
+        it('returns correct TOTP status in profile data', async () => {
+          const client = await Client.createAndVerifyAndTOTP(
+            server.publicUrl,
+            server.uniqueEmail(),
+            'password',
+            server.mailbox,
+            { ...testOptions, lang: 'en-US' }
+          );
+
+          const res = await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: CLIENT_ID,
+            access_type: 'offline',
+            scope: 'profile',
+          });
+
+          const response = await client.accountProfile(res.access_token);
+          expect(response.email).toBeTruthy();
+          expect(response.locale).toBe('en-US');
+          expect(response.authenticationMethods).toEqual([
+            'pwd',
+            'email',
+            'otp',
+          ]);
+          expect(response.authenticatorAssuranceLevel).toBe(2);
+        });
+      });
+
+      describe('when the locale is empty', () => {
+        it('returns the profile data successfully', async () => {
+          const email = server.uniqueEmail();
+          const password = 'test password';
+          const client = await Client.createAndVerify(
+            server.publicUrl,
+            email,
+            password,
+            server.mailbox,
+            testOptions
+          );
+
+          const res = await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: CLIENT_ID,
+            scope: 'profile:locale',
+          });
+
+          const response = await client.accountProfile(res.access_token);
+          expect(response.locale).toBeUndefined();
+        });
+      });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_reset.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_reset.in.spec.ts
@@ -1,0 +1,239 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import url from 'url';
+
+interface AuthServerError extends Error {
+  code: number;
+  errno: number;
+}
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: { skipForNewAccounts: { enabled: true } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+async function resetPassword(
+  client: any,
+  otpCode: string,
+  newPassword: string,
+  options?: any
+) {
+  const result = await client.verifyPasswordForgotOtp(otpCode);
+  await client.verifyPasswordResetCode(result.code);
+  return await client.resetPassword(newPassword, {}, options);
+}
+
+describe.each(testVersions)(
+  '#integration$tag - remote account reset',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('account reset w/o sessionToken', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      let client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+      const keys1 = await client.keys();
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      const response = await resetPassword(client, code, newPassword, {
+        sessionToken: false,
+      });
+      expect(response.sessionToken).toBeFalsy();
+      expect(response.keyFetchToken).toBeFalsy();
+      expect(response.verified).toBeFalsy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const link = emailData.headers['x-link'];
+      const query = url.parse(link, true).query;
+      expect(query.email).toBeTruthy();
+
+      if (testOptions.version === 'V2') {
+        const newClient = await Client.login(
+          server.publicUrl,
+          email,
+          newPassword,
+          { version: '', keys: true }
+        );
+        await newClient.upgradeCredentials(newPassword);
+      }
+
+      client = await Client.login(server.publicUrl, email, newPassword, {
+        ...testOptions,
+        keys: true,
+      });
+      const keys2 = await client.keys();
+      expect(keys1.wrapKb).not.toBe(keys2.wrapKb);
+      expect(keys1.kA).toBe(keys2.kA);
+      expect(typeof client.getState().kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+
+    it('account reset with keys', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      let client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+      const keys1 = await client.keys();
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      const response = await resetPassword(client, code, newPassword, {
+        keys: true,
+      });
+      expect(response.sessionToken).toBeTruthy();
+      expect(response.keyFetchToken).toBeTruthy();
+      expect(response.emailVerified).toBe(true);
+      expect(response.sessionVerified).toBe(true);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const link = emailData.headers['x-link'];
+      const query = url.parse(link, true).query;
+      expect(query.email).toBeTruthy();
+
+      if (testOptions.version === 'V2') {
+        const newClient = await Client.login(
+          server.publicUrl,
+          email,
+          newPassword,
+          { version: '', keys: true }
+        );
+        const status = await newClient.getCredentialsStatus(email);
+        expect(status.upgradeNeeded).toBeTruthy();
+        await newClient.upgradeCredentials(newPassword);
+      }
+
+      client = await Client.login(server.publicUrl, email, newPassword, {
+        ...testOptions,
+        keys: true,
+      });
+      const keys2 = await client.keys();
+      expect(keys1.wrapKb).not.toBe(keys2.wrapKb);
+      expect(keys1.kA).toBe(keys2.kA);
+      expect(typeof client.getState().kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+
+    it('account reset w/o keys, with sessionToken', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      const response = await resetPassword(client, code, newPassword);
+      expect(response.sessionToken).toBeTruthy();
+      expect(response.keyFetchToken).toBeFalsy();
+      expect(response.emailVerified).toBe(true);
+      expect(response.sessionVerified).toBe(true);
+    });
+
+    it('account reset deletes tokens', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+      const options = { ...testOptions, keys: true };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        options
+      );
+
+      await client.forgotPassword();
+      const originalCode = await server.mailbox.waitForCode(email);
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      await resetPassword(client, code, newPassword, undefined);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const templateName = emailData.headers['x-template-name'];
+      expect(templateName).toBe('passwordReset');
+
+      try {
+        await resetPassword(client, originalCode, newPassword, undefined);
+        fail('Should not have succeeded password reset');
+      } catch (err: unknown) {
+        const error = err as AuthServerError;
+        expect(error.code).toBe(400);
+        expect(error.errno).toBe(105);
+      }
+    });
+
+    it('account reset updates keysChangedAt', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+
+      const profileBefore = await client.accountProfile();
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await resetPassword(client, code, newPassword);
+      await server.mailbox.waitForEmail(email);
+
+      const profileAfter = await client.accountProfile();
+
+      expect(profileBefore['keysChangedAt']).toBeLessThan(
+        profileAfter['keysChangedAt']
+      );
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_signin_verification.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification.in.spec.ts
@@ -1,0 +1,373 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import crypto from 'crypto';
+
+const Client = require('../client')();
+const mocks = require('../mocks');
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      redis: { sessionTokens: { enabled: false } },
+      securityHistory: { ipProfiling: { allowedRecency: 0 } },
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account signin verification',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('account signin with keys does set challenge', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+      expect(client.authAt).toBeTruthy();
+
+      const status = await client.emailStatus();
+      expect(status.emailVerified).toBe(true);
+
+      const response = await client.login({ keys: true });
+      expect(response.verificationMethod).toBe('email');
+      expect(response.verificationReason).toBe('login');
+      expect(response.sessionVerified).toBe(false);
+    });
+
+    it('account can verify new sign-in from email', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const loginOpts = {
+        keys: true,
+        metricsContext: mocks.generateMetricsContext(),
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+      expect(client.authAt).toBeTruthy();
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+
+      const response = await client.login(loginOpts);
+      expect(response.verificationMethod).toBe('email');
+      expect(response.verificationReason).toBe('login');
+      expect(response.sessionVerified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      const uid = singleEmail.headers['x-uid'];
+      const code = singleEmail.headers['x-verify-code'];
+      expect(singleEmail.subject).toBe('Confirm sign-in');
+      expect(uid).toBeTruthy();
+      expect(code).toBeTruthy();
+      expect(singleEmail.headers['x-flow-begin-time']).toBe(
+        String(loginOpts.metricsContext.flowBeginTime)
+      );
+      expect(singleEmail.headers['x-flow-id']).toBe(
+        loginOpts.metricsContext.flowId
+      );
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+
+      await client.verifyEmail(code);
+
+      status = await client.emailStatus();
+      expect(status.emailVerified).toBe(true);
+      expect(status.verificationMethod).toBeFalsy();
+      expect(status.verificationReason).toBeFalsy();
+    });
+
+    it('Account verification links still work after session verification', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      let singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      expect(singleEmail.subject).toBe('Finish creating your account');
+      const emailCode = singleEmail.headers['x-verify-code'];
+      expect(emailCode).toBeTruthy();
+
+      await client.verifyEmail(emailCode);
+
+      await client.login({ keys: true });
+
+      emailData = await server.mailbox.waitForEmail(email);
+      singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      const tokenCode = singleEmail.headers['x-verify-code'];
+      expect(singleEmail.subject).toBe('Confirm sign-in');
+      expect(singleEmail.headers['x-uid']).toBeTruthy();
+      expect(tokenCode).toBeTruthy();
+      expect(tokenCode).not.toBe(emailCode);
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.sessionVerified).toBe(false);
+
+      // Attempt to verify account reusing original email code
+      await client.verifyEmail(emailCode);
+    });
+
+    it('sign-in verification email link', async () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      const config = server.config as any;
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}`,
+        service: 'sync',
+        resume: 'resumeToken',
+        keys: true,
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        options
+      );
+
+      await client.login(options);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      const link = singleEmail.headers['x-link'];
+      const query = new URL(link).searchParams;
+      expect(query.get('uid')).toBeTruthy();
+      expect(query.get('code')).toBeTruthy();
+      expect(query.get('service')).toBe(options.service);
+      expect(query.get('resume')).toBe(options.resume);
+      expect(singleEmail.subject).toBe('Confirm sign-in');
+    });
+
+    it('sign-in verification from different client', async () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      const config = server.config as any;
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}`,
+        service: 'sync',
+        resume: 'resumeToken',
+        keys: true,
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        options
+      );
+
+      await client.login(options);
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      let singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      const link = singleEmail.headers['x-link'];
+      const query = new URL(link).searchParams;
+      expect(query.get('uid')).toBeTruthy();
+      expect(query.get('code')).toBeTruthy();
+      expect(query.get('service')).toBe(options.service);
+      expect(query.get('resume')).toBe(options.resume);
+      expect(singleEmail.subject).toBe('Confirm sign-in');
+
+      // Attempt to login from new location
+      const client2 = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        options
+      );
+
+      // Clears inbox of new signin email
+      await server.mailbox.waitForEmail(email);
+
+      await client2.login(options);
+
+      const code = await server.mailbox.waitForCode(email);
+
+      // Verify account from client2
+      await client2.verifyEmail(code, options);
+
+      let status = await client2.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(false);
+    });
+
+    it('account keys, return keys on verified account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: true,
+      });
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.emailVerified).toBe(false);
+      expect(status.sessionVerified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      expect(singleEmail.subject).toBe('Finish creating your account');
+      const tokenCode = singleEmail.headers['x-verify-code'];
+      expect(tokenCode).toBeTruthy();
+
+      // Unverified accounts can not retrieve keys
+      try {
+        await client.keys();
+        fail('should have thrown');
+      } catch (err: any) {
+        expect(err.errno).toBe(104);
+        expect(err.code).toBe(400);
+        expect(err.message).toBe('Unconfirmed account');
+      }
+
+      // Verify the account
+      await client.verifyEmail(tokenCode);
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      // Once verified, keys can be returned
+      const keys = await client.keys();
+      expect(keys.kA).toBeTruthy();
+      expect(keys.kB).toBeTruthy();
+      expect(keys.wrapKb).toBeTruthy();
+    });
+
+    it('account keys, return keys on verified login', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      let client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+
+      // Trigger confirm sign-in
+      client = await client.login({ keys: true });
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      expect(singleEmail.subject).toBe('Confirm sign-in');
+      const tokenCode = singleEmail.headers['x-verify-code'];
+      expect(tokenCode).toBeTruthy();
+
+      // Because of unverified sign-in, requests for keys will fail
+      try {
+        await client.keys();
+        fail('should have thrown');
+      } catch (err: any) {
+        expect(err.errno).toBe(104);
+        expect(err.code).toBe(400);
+        expect(err.message).toBe('Unconfirmed account');
+      }
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(false);
+
+      // Verify the sign-in
+      await client.verifyEmail(tokenCode);
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      // Can retrieve keys now that account tokens verified
+      const keys = await client.keys();
+      expect(keys.kA).toBeTruthy();
+      expect(keys.kB).toBeTruthy();
+      expect(keys.wrapKb).toBeTruthy();
+    });
+
+    it('unverified account is verified on sign-in confirmation', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      let client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: true,
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      let singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      expect(singleEmail.headers['x-template-name']).toBe('verify');
+      const tokenCode = singleEmail.headers['x-verify-code'];
+      expect(tokenCode).toBeTruthy();
+
+      client = await client.login({ keys: true });
+
+      emailData = await server.mailbox.waitForEmail(email);
+      singleEmail = Array.isArray(emailData) ? emailData[0] : emailData;
+      expect(singleEmail.headers['x-template-name']).toBe('verify');
+      const signinToken = singleEmail.headers['x-verify-code'];
+      expect(tokenCode).not.toBe(signinToken);
+
+      await client.verifyEmail(signinToken);
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      // Can retrieve keys now that account tokens verified
+      const keys = await client.keys();
+      expect(keys.kA).toBeTruthy();
+      expect(keys.kB).toBeTruthy();
+      expect(keys.wrapKb).toBeTruthy();
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_status.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_status.in.spec.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+interface AuthServerError extends Error {
+  code: number;
+  errno: number;
+  message: string;
+}
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account status',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('account status with existing account', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      const response = await c.api.accountStatus(c.uid);
+      expect(response.exists).toBeTruthy();
+    });
+
+    it('account status includes locale when authenticated', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        { ...testOptions, lang: 'en-US' }
+      );
+      const response = await c.api.accountStatus(c.uid, c.sessionToken);
+      expect(response.locale).toBe('en-US');
+    });
+
+    it('account status does not include locale when unauthenticated', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        { ...testOptions, lang: 'en-US' }
+      );
+      const response = await c.api.accountStatus(c.uid);
+      expect(response.locale).toBeFalsy();
+    });
+
+    it('account status unauthenticated with no uid returns an error', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        { ...testOptions, lang: 'en-US' }
+      );
+      try {
+        await c.api.accountStatus();
+        fail('should get an error');
+      } catch (e: unknown) {
+        const err = e as AuthServerError;
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(108);
+      }
+    });
+
+    it('account status with non-existing account', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const response = await api.accountStatus(
+        '0123456789ABCDEF0123456789ABCDEF'
+      );
+      expect(response.exists).toBeFalsy();
+    });
+
+    it('account status by email with existing account', async () => {
+      const email = server.uniqueEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      const response = await c.api.accountStatusByEmail(email);
+      expect(response.exists).toBeTruthy();
+    });
+
+    it('account status by email with non-existing account', async () => {
+      const email = server.uniqueEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      const nonExistEmail = server.uniqueEmail();
+      const response = await c.api.accountStatusByEmail(nonExistEmail);
+      expect(response.exists).toBeFalsy();
+    });
+
+    it('account status by email with an invalid email', async () => {
+      const email = server.uniqueEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      try {
+        await c.api.accountStatusByEmail('notAnEmail');
+        fail('should not have successful request');
+      } catch (e: unknown) {
+        const err = e as AuthServerError;
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(107);
+        expect(err.message).toBe('Invalid parameter in request body');
+      }
+    });
+
+    it('account status by email works with unicode email address', async () => {
+      const email = server.uniqueUnicodeEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      const response = await c.api.accountStatusByEmail(email);
+      expect(response.exists).toBeTruthy();
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_unlock.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_unlock.in.spec.ts
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+interface AuthServerError extends Error {
+  code: number;
+  errno: number;
+}
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account unlock',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('/account/lock is no longer supported', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      try {
+        await c.lockAccount();
+        fail('should get an error');
+      } catch (e: unknown) {
+        expect((e as AuthServerError).code).toBe(410);
+      }
+    });
+
+    it('/account/unlock/resend_code is no longer supported', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      try {
+        await c.resendAccountUnlockCode('en');
+        fail('should get an error');
+      } catch (e: unknown) {
+        expect((e as AuthServerError).code).toBe(410);
+      }
+    });
+
+    it('/account/unlock/verify_code is no longer supported', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      try {
+        await c.verifyAccountUnlockCode('bigscaryuid', 'bigscarycode');
+        fail('should get an error');
+      } catch (e: unknown) {
+        expect((e as AuthServerError).code).toBe(410);
+      }
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/attached_clients_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/attached_clients_tests.in.spec.ts
@@ -1,0 +1,232 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const hashRefreshToken = require('fxa-shared/auth/encrypt').hash;
+
+const buf = (v: any) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
+const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
+
+let server: TestServerInstance;
+let oauthServerDb: any;
+let tokens: any;
+
+beforeAll(async () => {
+  server = await createTestServer();
+
+  const config = require('../../config').default.getProperties();
+  tokens = require('../../lib/tokens')({ trace: () => {} }, config);
+  oauthServerDb = require('../../lib/oauth/db');
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - attached clients listing',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('correctly lists a variety of attached clients', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+      const mySessionTokenId = (
+        await tokens.SessionToken.fromHex(client.sessionToken)
+      ).id;
+      const deviceInfo = {
+        name: 'test device \ud83c\udf53\ud83d\udd25\u5728\ud834\udf06',
+        type: 'mobile',
+        availableCommands: { foo: 'bar' },
+        pushCallback: '',
+        pushPublicKey: '',
+        pushAuthKey: '',
+      };
+
+      let allClients = await client.attachedClients();
+      expect(allClients.length).toBe(1);
+      expect(allClients[0].sessionTokenId).toBe(mySessionTokenId);
+      expect(allClients[0].deviceId).toBeNull();
+      expect(allClients[0].lastAccessTimeFormatted).toBe('a few seconds ago');
+
+      const device = await client.updateDevice(deviceInfo);
+
+      allClients = await client.attachedClients();
+      expect(allClients.length).toBe(1);
+      expect(allClients[0].sessionTokenId).toBe(mySessionTokenId);
+      expect(allClients[0].deviceId).toBe(device.id);
+      expect(allClients[0].name).toBe(deviceInfo.name);
+
+      const refreshToken = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: ScopeSet.fromArray([
+          'profile',
+          'https://identity.mozilla.com/apps/oldsync',
+        ]),
+      });
+      const refreshTokenId = hashRefreshToken(refreshToken.token).toString('hex');
+
+      allClients = await client.attachedClients();
+      expect(allClients.length).toBe(2);
+      expect(allClients[0].sessionTokenId).toBe(mySessionTokenId);
+      expect(allClients[1].sessionTokenId).toBeNull();
+      expect(allClients[1].refreshTokenId).toBe(refreshTokenId);
+      expect(allClients[1].lastAccessTimeFormatted).toBe('a few seconds ago');
+      expect(allClients[1].name).toBe('Android Components Reference Browser');
+
+      const device2 = await client.updateDeviceWithRefreshToken(
+        refreshToken.token.toString('hex'),
+        { name: 'test device', type: 'mobile' }
+      );
+
+      allClients = await client.attachedClients();
+      expect(allClients.length).toBe(2);
+      const one = allClients.findIndex((c: any) => c.name === 'test device');
+      const zero = (one + 1) % allClients.length;
+      expect(allClients[zero].sessionTokenId).toBe(mySessionTokenId);
+      expect(allClients[zero].deviceId).toBe(device.id);
+      expect(allClients[one].refreshTokenId).toBe(refreshTokenId);
+      expect(allClients[one].deviceId).toBe(device2.id);
+      expect(allClients[one].name).toBe('test device');
+    });
+
+    it('correctly deletes by device id', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+      const mySessionTokenId = (
+        await tokens.SessionToken.fromHex(client.sessionToken)
+      ).id;
+
+      const client2 = await Client.login(server.publicUrl, email, password, testOptions);
+      const device = await client2.updateDevice({ name: 'test', type: 'desktop' });
+
+      let allClients = await client.attachedClients();
+      expect(allClients.length).toBe(2);
+
+      await client.destroyAttachedClient({ deviceId: device.id });
+
+      allClients = await client.attachedClients();
+      expect(allClients.length).toBe(1);
+      expect(allClients[0].sessionTokenId).toBe(mySessionTokenId);
+    });
+
+    it('correctly deletes by sessionTokenId', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+      const mySessionTokenId = (
+        await tokens.SessionToken.fromHex(client.sessionToken)
+      ).id;
+
+      const client2 = await Client.login(server.publicUrl, email, password, testOptions);
+      const otherSessionTokenId = (
+        await tokens.SessionToken.fromHex(client2.sessionToken)
+      ).id;
+
+      let allClients = await client.attachedClients();
+      expect(allClients.length).toBe(2);
+
+      await client.destroyAttachedClient({ sessionTokenId: otherSessionTokenId });
+
+      allClients = await client.attachedClients();
+      expect(allClients.length).toBe(1);
+      expect(allClients[0].sessionTokenId).toBe(mySessionTokenId);
+    });
+
+    it('correctly deletes by refreshTokenId', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+      const mySessionTokenId = (
+        await tokens.SessionToken.fromHex(client.sessionToken)
+      ).id;
+
+      const refreshToken = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: ScopeSet.fromArray([
+          'profile',
+          'https://identity.mozilla.com/apps/oldsync',
+        ]),
+      });
+      const refreshTokenId = hashRefreshToken(refreshToken.token).toString('hex');
+
+      let allClients = await client.attachedClients();
+      expect(allClients.length).toBe(2);
+
+      await client.destroyAttachedClient({
+        refreshTokenId,
+        clientId: PUBLIC_CLIENT_ID,
+      });
+
+      allClients = await client.attachedClients();
+      expect(allClients.length).toBe(1);
+      expect(allClients[0].sessionTokenId).toBe(mySessionTokenId);
+      expect(allClients[0].refreshTokenId).toBeNull();
+    });
+
+    it('correctly lists a unique list of clientIds for refresh tokens', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+
+      let oauthClients = await client.attachedOAuthClients();
+      expect(oauthClients.length).toBe(0);
+
+      const clientId = buf(PUBLIC_CLIENT_ID);
+      const userId = buf(client.uid);
+      const scope = ScopeSet.fromArray([
+        'profile',
+        'https://identity.mozilla.com/apps/oldsync',
+      ]);
+
+      await oauthServerDb.generateRefreshToken({
+        clientId, userId, email: client.email, scope,
+      });
+
+      const refreshToken2 = await oauthServerDb.generateRefreshToken({
+        clientId, userId, email: client.email, scope,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const newerTimestamp = new Date(Date.now() + 5000);
+      await oauthServerDb.mysql._touchRefreshToken(
+        refreshToken2.tokenId,
+        newerTimestamp
+      );
+
+      oauthClients = await client.attachedOAuthClients();
+      expect(oauthClients.length).toBe(1);
+      expect(oauthClients[0].clientId).toBe(PUBLIC_CLIENT_ID);
+      const timeDiff = Math.abs(
+        oauthClients[0].lastAccessTime - newerTimestamp.getTime()
+      );
+      expect(timeDiff).toBeLessThan(1000);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/base_path.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/base_path.in.spec.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+let serverPort: number;
+
+beforeAll(async () => {
+  server = await createTestServer();
+  const url = new URL(server.publicUrl);
+  serverPort = parseInt(url.port, 10);
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote base path',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('base path account creation', async () => {
+      const email = `${Math.random()}@example.com`;
+      const password = 'ok';
+      // if this doesn't crash, we're all good
+      await Client.create(server.publicUrl, email, password, testOptions);
+    });
+
+    it('.well-known did not move', async () => {
+      const res = await fetch(
+        `http://localhost:${serverPort}/.well-known/browserid`
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.authentication).toBe(
+        '/.well-known/browserid/nonexistent.html'
+      );
+    });
+
+    // The version routes (/, /__version__) require the server to be started
+    // with a non-root base path (e.g. /auth). The child-process TestServer
+    // does not yet support custom base paths, so these are skipped for now.
+    // The original Mocha test configured publicUrl = 'http://localhost:9000/auth'.
+    it.todo('"/" returns valid version information');
+    it.todo('"/__version__" returns valid version information');
+  }
+);

--- a/packages/fxa-auth-server/test/remote/concurrent.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/concurrent.in.spec.ts
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      verifierVersion: 1,
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote concurrent',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('concurrent create requests', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      // Two shall enter, only one shall survive!
+      const r1 = Client.create(server.publicUrl, email, password, testOptions);
+      const r2 = Client.create(server.publicUrl, email, password, testOptions);
+      const results = await Promise.allSettled([r1, r2]);
+      const rejected = results.filter((p) => p.status === 'rejected');
+      expect(rejected.length).toBe(1);
+      await server.mailbox.waitForEmail(email);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/db.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/db.in.spec.ts
@@ -1,0 +1,919 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import crypto from 'crypto';
+
+const base64url = require('base64url');
+const config = require('../../config').default.getProperties();
+const sinon = require('sinon');
+const UnblockCode = require('../../lib/crypto/random').base32(
+  config.signinUnblock.codeLength
+);
+const uuid = require('uuid');
+const { normalizeEmail } = require('fxa-shared').email.helpers;
+const ioredis = require('ioredis');
+
+const log = { debug() {}, trace() {}, info() {}, error() {} };
+
+const lastAccessTimeUpdates = {
+  enabled: true,
+  sampleRate: 1,
+};
+const Token = require('../../lib/tokens')(log, {
+  lastAccessTimeUpdates: lastAccessTimeUpdates,
+  tokenLifetimes: {
+    sessionTokenWithoutDevice: 2419200000,
+  },
+});
+
+const tokenPruning = {
+  enabled: true,
+  maxAge: 1000 * 60 * 60,
+};
+const { createDB } = require('../../lib/db');
+const DB = createDB(
+  {
+    lastAccessTimeUpdates,
+    signinCodeSize: config.signinCodeSize,
+    redis: {
+      enabled: true,
+      ...config.redis,
+      ...config.redis.sessionTokens,
+    },
+    securityHistory: {
+      ipHmacKey: 'test',
+    },
+    tokenLifetimes: {},
+    tokenPruning,
+    totp: {
+      recoveryCodes: {
+        length: 10,
+      },
+    },
+  },
+  log,
+  Token,
+  UnblockCode
+);
+
+const zeroBuffer16 = Buffer.from(
+  '00000000000000000000000000000000',
+  'hex'
+).toString('hex');
+const zeroBuffer32 = Buffer.from(
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  'hex'
+).toString('hex');
+
+let server: TestServerInstance;
+let account: any;
+let secondEmail: string;
+let db: any;
+let redis: any;
+
+beforeAll(async () => {
+  redis = ioredis.createClient({
+    host: config.redis.host,
+    port: config.redis.port,
+    password: config.redis.password,
+    prefix: config.redis.sessionTokens.prefix,
+    enable_offline_queue: false,
+  });
+  server = await createTestServer();
+  db = await DB.connect(config);
+}, 120000);
+
+afterAll(async () => {
+  await db.close();
+  await redis.quit();
+  await server.stop();
+});
+
+beforeEach(async () => {
+  account = {
+    uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+    email: server.uniqueEmail(),
+    emailCode: zeroBuffer16,
+    emailVerified: false,
+    verifierVersion: 1,
+    verifyHash: zeroBuffer32,
+    authSalt: zeroBuffer32,
+    kA: zeroBuffer32,
+    wrapWrapKb: zeroBuffer32,
+    tokenVerificationId: zeroBuffer16,
+  };
+
+  const createdAccount = await db.createAccount(account);
+  expect(createdAccount.uid).toEqual(account.uid);
+
+  secondEmail = server.uniqueEmail();
+  const emailData = {
+    email: secondEmail,
+    emailCode: crypto.randomBytes(16).toString('hex'),
+    normalizedEmail: normalizeEmail(secondEmail),
+    isVerified: true,
+    isPrimary: false,
+    uid: account.uid,
+  };
+  await db.createEmail(account.uid, emailData);
+
+  // Ensure redis is empty for the uid
+  await redis.del(account.uid);
+});
+
+describe('#integration - remote db', () => {
+  it('ping', async () => {
+    await db.ping();
+  });
+
+  it('account creation', async () => {
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBeTruthy();
+
+    const acct = await db.account(account.uid);
+    expect(acct.uid).toEqual(account.uid);
+    expect(acct.email).toBe(account.email);
+    expect(acct.emailCode).toEqual(account.emailCode);
+    expect(acct.emailVerified).toBe(account.emailVerified);
+    expect(acct.kA).toEqual(account.kA);
+    expect(acct.wrapWrapKb).toEqual(account.wrapWrapKb);
+    expect(acct.verifyHash).toBeFalsy();
+    expect(acct.authSalt).toEqual(account.authSalt);
+    expect(acct.verifierVersion).toBe(account.verifierVersion);
+    expect(acct.createdAt).toBeTruthy();
+  });
+
+  it('session token handling', async () => {
+    // Fetch all sessions for the account
+    let sessions = await db.sessions(account.uid);
+    expect(Array.isArray(sessions)).toBe(true);
+    expect(sessions.length).toBe(0);
+
+    // Fetch the email record
+    let emailRecord = await db.emailRecord(account.email);
+    emailRecord.createdAt = Date.now() - 1000;
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Mac OS X';
+    emailRecord.uaOSVersion = '10.10';
+    emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+
+    // Create a session token
+    const sessionToken = await db.createSessionToken(emailRecord);
+    expect(sessionToken.uid).toEqual(account.uid);
+    const tokenId = sessionToken.id;
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(typeof sessions[0].id).toBe('string');
+    expect(sessions[0].uid).toBe(account.uid);
+    expect(sessions[0].createdAt >= account.createdAt).toBe(true);
+    expect(sessions[0].uaBrowser).toBe('Firefox');
+    expect(sessions[0].uaBrowserVersion).toBe('41');
+    expect(sessions[0].uaOS).toBe('Mac OS X');
+    expect(sessions[0].uaOSVersion).toBe('10.10');
+    expect(sessions[0].uaDeviceType).toBeNull();
+    expect(sessions[0].uaFormFactor).toBeNull();
+    expect(sessions[0].lastAccessTime).toBe(sessions[0].createdAt);
+    expect(sessions[0].authAt).toBe(sessions[0].createdAt);
+    expect(sessions[0].location).toBeUndefined();
+    expect(sessions[0].deviceId).toBeNull();
+    expect(sessions[0].deviceAvailableCommands).toBeNull();
+
+    // Fetch the session token
+    let fetchedToken = await db.sessionToken(tokenId);
+    expect(fetchedToken.id).toBe(tokenId);
+    expect(fetchedToken.uaBrowser).toBe('Firefox');
+    expect(fetchedToken.uaBrowserVersion).toBe('41');
+    expect(fetchedToken.uaOS).toBe('Mac OS X');
+    expect(fetchedToken.uaOSVersion).toBe('10.10');
+    expect(fetchedToken.uaDeviceType).toBeNull();
+    expect(fetchedToken.lastAccessTime).toBe(fetchedToken.createdAt);
+    expect(fetchedToken.uid).toBe(account.uid);
+    expect(fetchedToken.email).toBe(account.email);
+    expect(fetchedToken.emailCode).toBe(account.emailCode);
+    expect(fetchedToken.emailVerified).toBe(account.emailVerified);
+    expect(fetchedToken.lifetime < Infinity).toBe(true);
+
+    // Disable session token updates
+    lastAccessTimeUpdates.enabled = false;
+
+    // Attempt to update the session token
+    const result = await db.touchSessionToken(fetchedToken, {});
+    expect(result).toBeUndefined();
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uid).toBe(account.uid);
+    expect(sessions[0].lastAccessTime == null).toBe(true);
+    expect(sessions[0].location == null).toBe(true);
+
+    // Re-enable session token updates
+    lastAccessTimeUpdates.enabled = true;
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Update the session token
+    await db.touchSessionToken(
+      Object.assign({}, fetchedToken, {
+        lastAccessTime: Date.now(),
+      }),
+      {
+        location: {
+          city: 'Bournemouth',
+          country: 'United Kingdom',
+          countryCode: 'GB',
+          state: 'England',
+          stateCode: 'EN',
+        },
+        timeZone: 'Europe/London',
+      }
+    );
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uid).toBe(account.uid);
+    expect(sessions[0].lastAccessTime > sessions[0].createdAt).toBe(true);
+    expect(sessions[0].location.city).toBe('Bournemouth');
+    expect(sessions[0].location.country).toBe('United Kingdom');
+    expect(sessions[0].location.countryCode).toBe('GB');
+    expect(sessions[0].location.state).toBe('England');
+    expect(sessions[0].location.stateCode).toBe('EN');
+    expect(sessions[0].location.timeZone).toBeUndefined();
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Update the session token with new UA
+    await db.touchSessionToken(
+      Object.assign({}, fetchedToken, {
+        uaBrowser: 'Firefox Mobile',
+        uaBrowserVersion: '42',
+        uaOS: 'Android',
+        uaOSVersion: '4.4',
+        uaDeviceType: 'mobile',
+        uaFormFactor: null,
+      }),
+      {}
+    );
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uaBrowser).toBe('Firefox Mobile');
+    expect(sessions[0].uaBrowserVersion).toBe('42');
+    expect(sessions[0].uaOS).toBe('Android');
+    expect(sessions[0].uaOSVersion).toBe('4.4');
+    expect(sessions[0].uaDeviceType).toBe('mobile');
+    expect(sessions[0].uaFormFactor).toBeNull();
+    expect(sessions[0].location.country).toBe('United Kingdom');
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+    // this returns previously stored data since sessionToken doesn't read from cache
+    expect(fetchedToken.uaBrowser).toBe('Firefox');
+    expect(fetchedToken.uaBrowserVersion).toBe('41');
+    expect(fetchedToken.uaOS).toBe('Mac OS X');
+    expect(fetchedToken.uaOSVersion).toBe('10.10');
+    expect(fetchedToken.lastAccessTime).toBe(fetchedToken.createdAt);
+
+    // Attempt to prune a session token that is younger than maxAge
+    fetchedToken.createdAt = Date.now() - tokenPruning.maxAge + 10000;
+    await db.pruneSessionTokens(account.uid, [fetchedToken]);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uaBrowser).toBe('Firefox Mobile');
+    expect(sessions[0].uaBrowserVersion).toBe('42');
+    expect(sessions[0].uaOS).toBe('Android');
+    expect(sessions[0].uaOSVersion).toBe('4.4');
+    expect(sessions[0].uaDeviceType).toBe('mobile');
+    expect(sessions[0].uaFormFactor).toBeNull();
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Prune a session token that is older than maxAge
+    fetchedToken.createdAt = Date.now() - tokenPruning.maxAge - 1;
+    await db.pruneSessionTokens(account.uid, [fetchedToken]);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uaBrowser).toBe('Firefox');
+    expect(sessions[0].uaBrowserVersion).toBe('41');
+    expect(sessions[0].uaOS).toBe('Mac OS X');
+    expect(sessions[0].uaOSVersion).toBe('10.10');
+    expect(sessions[0].uaDeviceType).toBeNull();
+    expect(sessions[0].uaFormFactor).toBeNull();
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Delete the session token
+    await db.deleteSessionToken(fetchedToken);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(0);
+
+    // Attempt to fetch the deleted session token
+    try {
+      await db.sessionToken(tokenId);
+      fail('db.sessionToken should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+
+    // Fetch the email record again
+    emailRecord = await db.emailRecord(account.email);
+    emailRecord.createdAt = Date.now() - 1000;
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Mac OS X';
+    emailRecord.uaOSVersion = '10.10';
+    emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+
+    // Create a session token with the same data as the deleted token
+    await db.createSessionToken(emailRecord);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    // Make sure that the data got deleted from redis too
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].lastAccessTime).toBe(sessions[0].createdAt);
+    expect(sessions[0].location).toBeUndefined();
+
+    // Delete the session token again
+    await db.deleteSessionToken(sessions[0]);
+
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+  });
+
+  it('device registration', async () => {
+    let sessionToken: any;
+    let anotherSessionToken: any;
+    const deviceInfo: any = {
+      id: crypto.randomBytes(16).toString('hex'),
+      name: '',
+      type: 'mobile',
+      availableCommands: { foo: 'bar', wibble: 'wobble' },
+      pushCallback: 'https://foo/bar',
+      pushPublicKey: base64url(
+        Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])
+      ),
+      pushAuthKey: base64url(crypto.randomBytes(16)),
+    };
+    const conflictingDeviceInfo: any = {
+      id: crypto.randomBytes(16).toString('hex'),
+      name: 'wibble',
+    };
+
+    let emailRecord = await db.emailRecord(account.email);
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox Mobile';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Android';
+    emailRecord.uaOSVersion = '4.4';
+    emailRecord.uaDeviceType = 'mobile';
+    emailRecord.uaFormFactor = null;
+
+    // Create a session token
+    sessionToken = await db.createSessionToken(emailRecord);
+    deviceInfo.sessionTokenId = sessionToken.id;
+
+    // Attempt to update a non-existent device
+    try {
+      await db.updateDevice(account.uid, deviceInfo);
+      fail('updating a non-existent device should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(123);
+    }
+
+    // Attempt to delete a non-existent device
+    try {
+      await db.deleteDevice(account.uid, deviceInfo.id);
+      fail('deleting a non-existent device should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(123);
+    }
+
+    // Fetch all of the devices for the account
+    let devices = await db.devices(account.uid);
+    expect(Array.isArray(devices)).toBe(true);
+    expect(devices.length).toBe(0);
+
+    // Create a device
+    const device = await db.createDevice(account.uid, deviceInfo);
+    expect(device.id).toBeTruthy();
+    expect(device.createdAt > 0).toBe(true);
+    expect(device.name).toBe(deviceInfo.name);
+    expect(device.type).toBe(deviceInfo.type);
+    expect(device.availableCommands).toEqual(deviceInfo.availableCommands);
+    expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(device.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+    expect(device.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+    expect(device.pushEndpointExpired).toBe(false);
+
+    // Fetch the session token
+    sessionToken = await db.sessionToken(sessionToken.id);
+    expect(sessionToken.lifetime).toBe(Infinity);
+    conflictingDeviceInfo.sessionTokenId = sessionToken.id;
+
+    // Attempt to create a device with a duplicate session token
+    try {
+      await db.createDevice(account.uid, conflictingDeviceInfo);
+      fail('adding a device with a duplicate session token should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(124);
+      expect(err.output.payload.deviceId).toBe(deviceInfo.id);
+    }
+
+    // Fetch all of the devices for the account
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(1);
+    let fetchedDevice = devices[0];
+
+    expect(fetchedDevice.id).toBeTruthy();
+    expect(fetchedDevice.lastAccessTime > 0).toBe(true);
+    expect(fetchedDevice.name).toBe(deviceInfo.name);
+    expect(fetchedDevice.type).toBe(deviceInfo.type);
+    expect(fetchedDevice.availableCommands).toEqual(
+      deviceInfo.availableCommands
+    );
+    expect(fetchedDevice.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(fetchedDevice.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+    expect(fetchedDevice.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+    expect(fetchedDevice.pushEndpointExpired).toBe(false);
+    expect(fetchedDevice.uaBrowser).toBe('Firefox Mobile');
+    expect(fetchedDevice.uaBrowserVersion).toBe('41');
+    expect(fetchedDevice.uaOS).toBe('Android');
+    expect(fetchedDevice.uaOSVersion).toBe('4.4');
+    expect(fetchedDevice.uaDeviceType).toBe('mobile');
+    expect(fetchedDevice.uaFormFactor).toBeNull();
+    expect(fetchedDevice.location).toBeUndefined();
+
+    deviceInfo.id = fetchedDevice.id;
+    deviceInfo.name = 'wibble';
+    deviceInfo.type = 'desktop';
+    deviceInfo.availableCommands = {};
+    deviceInfo.pushCallback = '';
+    deviceInfo.pushPublicKey = '';
+    deviceInfo.pushAuthKey = '';
+    deviceInfo.sessionTokenId = sessionToken.id;
+    sessionToken.lastAccessTime = 42;
+    sessionToken.uaBrowser = 'Firefox';
+    sessionToken.uaBrowserVersion = '44';
+    sessionToken.uaOS = 'Mac OS X';
+    sessionToken.uaOSVersion = '10.10';
+    sessionToken.uaFormFactor = null;
+
+    // Update the device and the session token
+    await Promise.all([
+      db.updateDevice(account.uid, deviceInfo),
+      db.touchSessionToken(sessionToken, {
+        location: {
+          city: 'Mountain View',
+          country: 'United States',
+          countryCode: 'US',
+          state: 'California',
+          stateCode: 'CA',
+        },
+        timeZone: 'America/Los_Angeles',
+      }),
+    ]);
+
+    // Create another session token
+    anotherSessionToken = await db.createSessionToken(sessionToken);
+    conflictingDeviceInfo.sessionTokenId = anotherSessionToken.id;
+
+    // Create another device
+    await db.createDevice(account.uid, conflictingDeviceInfo);
+
+    // Attempt to update a device with a duplicate session token
+    deviceInfo.sessionTokenId = anotherSessionToken.id;
+    try {
+      await db.updateDevice(account.uid, deviceInfo);
+      fail(
+        'updating a device with a duplicate session token should have failed'
+      );
+    } catch (err: any) {
+      expect(err.errno).toBe(124);
+      expect(err.output.payload.deviceId).toBe(conflictingDeviceInfo.id);
+    }
+
+    // Fetch all of the devices for the account
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(2);
+
+    fetchedDevice =
+      devices[0].id === deviceInfo.id ? devices[0] : devices[1];
+
+    // Fetch a single device
+    const singleDevice = await db.device(account.uid, fetchedDevice.id);
+    expect(singleDevice).toEqual(fetchedDevice);
+
+    expect(fetchedDevice.lastAccessTime).toBe(42);
+    expect(fetchedDevice.name).toBe(deviceInfo.name);
+    expect(fetchedDevice.type).toBe(deviceInfo.type);
+    expect(fetchedDevice.availableCommands).toEqual(
+      deviceInfo.availableCommands
+    );
+    expect(fetchedDevice.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(fetchedDevice.pushPublicKey).toBe('');
+    expect(fetchedDevice.pushAuthKey).toBe('');
+    expect(fetchedDevice.pushEndpointExpired).toBe(false);
+    expect(fetchedDevice.uaBrowser).toBe('Firefox');
+    expect(fetchedDevice.uaBrowserVersion).toBe('44');
+    expect(fetchedDevice.uaOS).toBe('Mac OS X');
+    expect(fetchedDevice.uaOSVersion).toBe('10.10');
+    expect(fetchedDevice.uaDeviceType).toBe('mobile');
+    expect(fetchedDevice.uaFormFactor).toBeNull();
+    expect(fetchedDevice.location.city).toBe('Mountain View');
+    expect(fetchedDevice.location.country).toBe('United States');
+    expect(fetchedDevice.location.countryCode).toBe('US');
+    expect(fetchedDevice.location.state).toBe('California');
+    expect(fetchedDevice.location.stateCode).toBe('CA');
+
+    // Disable session token updates
+    lastAccessTimeUpdates.enabled = false;
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(2);
+    expect(devices[0].lastAccessTime).toBeUndefined();
+    expect(devices[1].lastAccessTime).toBeUndefined();
+
+    // Re-enable session token updates
+    lastAccessTimeUpdates.enabled = true;
+
+    // Delete the devices
+    await db.deleteDevice(account.uid, deviceInfo.id);
+    // Deleting these serially ensures there's no Redis WATCH conflict for account.uid
+    await db.deleteDevice(account.uid, conflictingDeviceInfo.id);
+
+    // Deleting the devices should also have cleared the data from Redis
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+
+    // Fetch all of the devices for the account
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(0);
+
+    // Delete the account
+    await db.deleteAccount(account);
+  });
+
+  it('keyfetch token handling', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const keyFetchToken = await db.createKeyFetchToken({
+      uid: emailRecord.uid,
+      kA: emailRecord.kA,
+      wrapKb: account.wrapWrapKb,
+    });
+
+    expect(keyFetchToken.uid).toEqual(account.uid);
+    const tokenId = keyFetchToken.id;
+
+    const fetched = await db.keyFetchToken(tokenId);
+    expect(fetched.id).toEqual(tokenId);
+    expect(fetched.uid).toEqual(account.uid);
+    expect(fetched.emailVerified).toBe(account.emailVerified);
+
+    await db.deleteKeyFetchToken(fetched);
+
+    try {
+      await db.keyFetchToken(tokenId);
+      fail('keyFetchToken() should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+  });
+
+  it('reset token handling', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const passwordForgotToken = await db.createPasswordForgotToken(emailRecord);
+    const accountResetToken =
+      await db.forgotPasswordVerified(passwordForgotToken);
+
+    expect(accountResetToken.createdAt >= passwordForgotToken.createdAt).toBe(
+      true
+    );
+    expect(accountResetToken.uid).toEqual(account.uid);
+    const tokenId = accountResetToken.id;
+
+    const fetched = await db.accountResetToken(tokenId);
+    expect(fetched.id).toEqual(tokenId);
+    expect(fetched.uid).toEqual(account.uid);
+
+    await db.deleteAccountResetToken(fetched);
+
+    try {
+      await db.accountResetToken(tokenId);
+      fail('accountResetToken() should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+  });
+
+  it('forgotpwd token handling', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const token1 = await db.createPasswordForgotToken(emailRecord);
+
+    expect(token1.uid).toEqual(account.uid);
+    const token1tries = token1.tries;
+
+    let fetched = await db.passwordForgotToken(token1.id);
+    expect(fetched.id).toEqual(token1.id);
+    expect(fetched.uid).toEqual(token1.uid);
+
+    fetched.tries -= 1;
+    await db.updatePasswordForgotToken(fetched);
+
+    fetched = await db.passwordForgotToken(token1.id);
+    expect(fetched.id).toEqual(token1.id);
+    expect(fetched.tries).toBe(token1tries - 1);
+
+    await db.deletePasswordForgotToken(fetched);
+
+    try {
+      await db.passwordForgotToken(token1.id);
+      fail('passwordForgotToken() should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+  });
+
+  it('email verification', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    await db.verifyEmail(emailRecord, emailRecord.emailCode);
+
+    const acct = await db.account(account.uid);
+    expect(acct.emailVerified).toBeTruthy();
+  });
+
+  it('db.forgotPasswordVerified', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const passwordForgotToken =
+      await db.createPasswordForgotToken(emailRecord);
+    const accountResetToken =
+      await db.forgotPasswordVerified(passwordForgotToken);
+
+    expect(accountResetToken.uid).toEqual(account.uid);
+
+    const fetched = await db.accountResetToken(accountResetToken.id);
+    expect(fetched.uid).toEqual(account.uid);
+
+    await db.deleteAccountResetToken(accountResetToken);
+  });
+
+  it('db.resetAccount', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Mac OS X';
+    emailRecord.uaOSVersion = '10.10';
+    emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+
+    const sessionToken = await db.createSessionToken(emailRecord);
+    const accountResetToken =
+      await db.forgotPasswordVerified(sessionToken);
+    await db.resetAccount(accountResetToken, account);
+
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+
+    // account should STILL exist for this email address
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBe(true);
+  });
+
+  it('db.securityEvents', async () => {
+    await db.securityEvent({
+      ipAddr: '127.0.0.1',
+      name: 'account.create',
+      uid: account.uid,
+    });
+
+    const events = await db.securityEvents({
+      ipAddr: '127.0.0.1',
+      uid: account.uid,
+    });
+    expect(events.length).toBe(1);
+  });
+
+  it('db.securityEventsByUid', async () => {
+    await db.securityEvent({
+      ipAddr: '127.0.0.1',
+      name: 'account.create',
+      uid: account.uid,
+    });
+
+    const events = await db.securityEventsByUid({
+      uid: account.uid,
+    });
+    expect(events.length).toBe(1);
+  });
+
+  it('unblock code', async () => {
+    const unblockCode = await db.createUnblockCode(account.uid);
+    expect(unblockCode).toBeTruthy();
+
+    // Consume with invalid code
+    try {
+      await db.consumeUnblockCode(account.uid, 'NOTREAL');
+      fail('consumeUnblockCode() with an invalid unblock code should not succeed');
+    } catch (err: any) {
+      expect(err.errno).toBe(127);
+      expect(`${err}`).toBe('Error: Invalid unblock code');
+    }
+
+    // Consume with valid code
+    await db.consumeUnblockCode(account.uid, unblockCode);
+
+    // re-use unblock code, no longer valid
+    try {
+      await db.consumeUnblockCode(account.uid, unblockCode);
+      fail('consumeUnblockCode() with a used unblock code should not succeed');
+    } catch (err: any) {
+      expect(err.errno).toBe(127);
+      expect(`${err}`).toBe('Error: Invalid unblock code');
+    }
+  });
+
+  it('signinCodes', async () => {
+    const flowId = crypto.randomBytes(32).toString('hex');
+
+    // Create a signinCode without a flowId
+    const previousCode = await db.createSigninCode(account.uid);
+    expect(typeof previousCode).toBe('string');
+    expect(Buffer.from(previousCode, 'hex').length).toBe(
+      config.signinCodeSize
+    );
+
+    // Stub crypto.randomBytes to return a duplicate code
+    const stub = sinon
+      .stub(crypto, 'randomBytes')
+      .callsFake((size: number, callback?: any) => {
+        if (!callback) {
+          return previousCode;
+        }
+        callback(null, previousCode);
+      });
+
+    // Create a signinCode with crypto.randomBytes rigged to return a duplicate
+    const code = await db.createSigninCode(account.uid, flowId);
+    stub.restore();
+    expect(typeof code).toBe('string');
+    expect(code).not.toBe(previousCode);
+    expect(Buffer.from(code, 'hex').length).toBe(config.signinCodeSize);
+
+    // Consume both signinCodes
+    const results = await Promise.all([
+      db.consumeSigninCode(previousCode),
+      db.consumeSigninCode(code),
+    ]);
+    expect(results[0].email).toBe(account.email);
+    expect(results[1].email).toBe(account.email);
+    if (results[1].flowId) {
+      // This assertion is conditional so that tests pass regardless of db version
+      expect(results[1].flowId).toBe(flowId);
+    }
+
+    // Attempt to consume a consumed signinCode
+    try {
+      await db.consumeSigninCode(previousCode);
+      fail('db.consumeSigninCode should have failed');
+    } catch (err: any) {
+      expect(err.errno).toBe(146);
+      expect(err.message).toBe('Invalid signin code');
+      expect(err.output.statusCode).toBe(400);
+    }
+  });
+
+  it('account deletion', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    expect(emailRecord.uid).toEqual(account.uid);
+
+    await db.deleteAccount(emailRecord);
+
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBe(false);
+
+    const deletedAccount = await db.deletedAccount(account.uid);
+    expect(deletedAccount.uid).toBe(account.uid);
+  });
+
+  it('should create and delete linked account', async () => {
+    const googleId = `goog_${Math.random().toString().substr(2)}`;
+    await db.createLinkedAccount(account.uid, googleId, 'google');
+
+    let records = await db.getLinkedAccounts(account.uid);
+    expect(records.length).toBe(1);
+    const record = records[0];
+    expect(record.uid).toBe(account.uid);
+    expect(record.providerId).toBe(1);
+    expect(record.enabled).toBe(true);
+    expect(record.id).toBe(googleId);
+
+    await db.deleteAccount({ ...account });
+
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBe(false);
+
+    records = await db.getLinkedAccounts(account.uid);
+    expect(records.length).toBe(0);
+  });
+
+  describe('account record', () => {
+    it('can retrieve account from account email', async () => {
+      const [emailRecord, accountRecord] = await Promise.all([
+        db.emailRecord(account.email),
+        db.accountRecord(account.email),
+      ]);
+      expect(emailRecord.email).toBe(accountRecord.email);
+      expect(emailRecord.emails).toEqual(accountRecord.emails);
+      expect(emailRecord.primaryEmail).toEqual(accountRecord.primaryEmail);
+    });
+
+    it('can retrieve account from secondary email', async () => {
+      const [accountRecord, accountRecordFromSecondEmail] = await Promise.all([
+        db.accountRecord(account.email),
+        db.accountRecord(secondEmail),
+      ]);
+      expect(accountRecordFromSecondEmail.email).toBe(accountRecord.email);
+      expect(accountRecordFromSecondEmail.emails).toEqual(
+        accountRecord.emails
+      );
+      expect(accountRecordFromSecondEmail.primaryEmail).toEqual(
+        accountRecord.primaryEmail
+      );
+    });
+
+    it('can retrieve linked account', async () => {
+      const googleId = `goog_${Math.random().toString().substr(2)}`;
+      const linkedAccount = await db.createLinkedAccount(
+        account.uid,
+        googleId,
+        'google'
+      );
+      // linkedAccount UID comes back as a buffer but we want a hex string
+      if (linkedAccount.uid instanceof Buffer) {
+        linkedAccount.uid = linkedAccount.uid.toString('hex');
+      }
+
+      const accountRecord = await db.accountRecord(account.email, {
+        linkedAccounts: true,
+      });
+      expect(accountRecord.linkedAccounts[0]).toEqual(linkedAccount);
+    });
+
+    it('does not retrieve linked account without option specified', async () => {
+      const googleId = `goog_${Math.random().toString().substr(2)}`;
+      await db.createLinkedAccount(account.uid, googleId, 'google');
+      const accountRecord = await db.accountRecord(account.email);
+      expect(accountRecord.linkedAccounts).toBeUndefined();
+    });
+
+    it('returns unknown account', async () => {
+      try {
+        await db.accountRecord('idontexist@email.com');
+        fail('should not have retrieved non-existent account');
+      } catch (err: any) {
+        expect(err.errno).toBe(102);
+      }
+    });
+  });
+
+  describe('set primary email', () => {
+    it('can set primary email address', async () => {
+      await db.setPrimaryEmail(account.uid, secondEmail);
+      const acct = await db.accountRecord(secondEmail);
+      expect(acct.primaryEmail.email).toBe(secondEmail);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/remote/device_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/device_tests.in.spec.ts
@@ -1,0 +1,464 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+import base64url from 'base64url';
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+const mocks = require('../mocks');
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote device',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('device registration after account creation', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device \ud83c\udf53\ud83d\udd25\u5728\ud834\udf06',
+        type: 'mobile',
+        availableCommands: { foo: 'bar' },
+        pushCallback: '',
+        pushPublicKey: '',
+        pushAuthKey: '',
+      };
+
+      let devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceInfo.name);
+      expect(device.type).toBe(deviceInfo.type);
+      expect(device.availableCommands).toEqual(deviceInfo.availableCommands);
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+      expect(device.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+      expect(device.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+      expect(device.pushEndpointExpired).toBe(false);
+
+      devices = await client.devices();
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(deviceInfo.name);
+      expect(devices[0].type).toBe(deviceInfo.type);
+      expect(devices[0].availableCommands).toEqual(deviceInfo.availableCommands);
+      expect(devices[0].pushCallback).toBe('');
+      expect(devices[0].pushPublicKey).toBe('');
+      expect(devices[0].pushAuthKey).toBe('');
+      expect(devices[0].pushEndpointExpired).toBeFalsy();
+
+      await client.destroyDevice(devices[0].id);
+    });
+
+    it('device registration without optional parameters', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+      };
+
+      let devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceInfo.name);
+      expect(device.type).toBe(deviceInfo.type);
+      expect(device.pushCallback == null).toBe(true);
+      expect(device.pushPublicKey == null).toBe(true);
+      expect(device.pushAuthKey == null).toBe(true);
+      expect(device.pushEndpointExpired).toBe(false);
+
+      devices = await client.devices();
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(deviceInfo.name);
+      expect(devices[0].type).toBe(deviceInfo.type);
+      expect(devices[0].pushCallback == null).toBe(true);
+      expect(devices[0].pushPublicKey == null).toBe(true);
+      expect(devices[0].pushAuthKey == null).toBe(true);
+      expect(devices[0].pushEndpointExpired).toBe(false);
+
+      await client.destroyDevice(devices[0].id);
+    });
+
+    it('device registration with unicode characters in the name', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'Firefox \u5728 \u03b2 test\ufffd',
+        type: 'desktop',
+      };
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceInfo.name);
+
+      const devices = await client.devices();
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(deviceInfo.name);
+    });
+
+    it('device registration without required name parameter', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const device = await client.updateDevice({ type: 'mobile' });
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe('');
+      expect(device.type).toBe('mobile');
+    });
+
+    it('device registration without required type parameter', async () => {
+      const email = server.uniqueEmail();
+      const deviceName = 'test device';
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const device = await client.updateDevice({ name: 'test device' });
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceName);
+    });
+
+    it('update device fails with bad callbackUrl', async () => {
+      const badPushCallback =
+        'https://updates.push.services.mozilla.com.different-push-server.technology';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const deviceInfo = {
+        id: crypto.randomBytes(16).toString('hex'),
+        name: 'test device',
+        type: 'desktop',
+        availableCommands: {},
+        pushCallback: badPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+      try {
+        await client.updateDevice(deviceInfo);
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(107);
+        expect(err.validation.keys[0]).toBe('pushCallback');
+      }
+    });
+
+    it('update device fails with non-normalized callbackUrl', async () => {
+      const badPushCallback =
+        'https://updates.push.services.mozilla.com/invalid/\u010D/char';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const deviceInfo = {
+        id: crypto.randomBytes(16).toString('hex'),
+        name: 'test device',
+        type: 'desktop',
+        availableCommands: {},
+        pushCallback: badPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+      try {
+        await client.updateDevice(deviceInfo);
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(107);
+        expect(err.validation.keys[0]).toBe('pushCallback');
+      }
+    });
+
+    it('update device works with stage servers', async () => {
+      const goodPushCallback = 'https://updates-autopush.stage.mozaws.net';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+        availableCommands: {},
+        pushCallback: goodPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    });
+
+    it('update device works with dev servers', async () => {
+      const goodPushCallback = 'https://updates-autopush.dev.mozaws.net';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+        pushCallback: goodPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    });
+
+    it('update device works with callback urls that :443 as a port', async () => {
+      const goodPushCallback =
+        'https://updates.push.services.mozilla.com:443/wpush/v1/gAAAAABbkq0Eafe6IANS4OV3pmoQ5Z8AhqFSGKtozz5FIvu0CfrTGmcv07CYziPaysTv_9dgisB0yr3UjEIlGEyoprRFX1WU5VA4nG-9tofPdA3FYREPf6xh3JL1qBhTa9mEFS2dSn--';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+        pushCallback: goodPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    });
+
+    it('update device works with callback urls that :4430 as a port', async () => {
+      const goodPushCallback = 'https://updates.push.services.mozilla.com:4430';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+        pushCallback: goodPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    });
+
+    it('update device works with callback urls that a custom port', async () => {
+      const goodPushCallback =
+        'https://updates.push.services.mozilla.com:10332';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+        pushCallback: goodPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    });
+
+    it('update device fails with bad dev callbackUrl', async () => {
+      const badPushCallback = 'https://evil.mozaws.net';
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const deviceInfo = {
+        id: crypto.randomBytes(16).toString('hex'),
+        name: 'test device',
+        type: 'desktop',
+        pushCallback: badPushCallback,
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+      try {
+        await client.updateDevice(deviceInfo);
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(107);
+        expect(err.validation.keys[0]).toBe('pushCallback');
+      }
+    });
+
+    it('device registration ignores deprecated "capabilities" field', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+      const deviceInfo = {
+        name: 'a very capable device',
+        type: 'desktop',
+        capabilities: [],
+      };
+
+      const device = await client.updateDevice(deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceInfo.name);
+      expect(device.capabilities).toBeFalsy();
+    });
+
+    it('device registration from a different session', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const deviceInfo = [
+        { name: 'first device', type: 'mobile' },
+        { name: 'second device', type: 'desktop' },
+      ];
+
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+
+      const secondClient = await Client.login(server.publicUrl, email, password, testOptions);
+      await secondClient.updateDevice(deviceInfo[0]);
+
+      let devices = await client.devices();
+      expect(devices.length).toBe(1);
+      expect(devices[0].isCurrentDevice).toBe(false);
+      expect(devices[0].name).toBe(deviceInfo[0].name);
+      expect(devices[0].type).toBe(deviceInfo[0].type);
+
+      await client.updateDevice(deviceInfo[1]);
+      devices = await client.devices();
+      expect(devices.length).toBe(2);
+
+      if (devices[0].name === deviceInfo[1].name) {
+        const swap: any = {};
+        Object.keys(devices[0]).forEach((key: string) => {
+          swap[key] = devices[0][key];
+          devices[0][key] = devices[1][key];
+          devices[1][key] = swap[key];
+        });
+      }
+
+      expect(devices[0].isCurrentDevice).toBe(false);
+      expect(devices[0].name).toBe(deviceInfo[0].name);
+      expect(devices[0].type).toBe(deviceInfo[0].type);
+      expect(devices[1].isCurrentDevice).toBe(true);
+      expect(devices[1].name).toBe(deviceInfo[1].name);
+      expect(devices[1].type).toBe(deviceInfo[1].type);
+
+      await Promise.all([
+        client.destroyDevice(devices[0].id),
+        client.destroyDevice(devices[1].id),
+      ]);
+    });
+
+    it('ensures all device push fields appear together', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const deviceInfo = {
+        name: 'test device',
+        type: 'desktop',
+        pushCallback: 'https://updates.push.services.mozilla.com/qux',
+        pushPublicKey: mocks.MOCK_PUSH_KEY,
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const client = await Client.create(server.publicUrl, email, password, testOptions);
+      await client.updateDevice(deviceInfo);
+
+      const devices = await client.devices();
+      expect(devices[0].pushCallback).toBe(deviceInfo.pushCallback);
+      expect(devices[0].pushPublicKey).toBe(deviceInfo.pushPublicKey);
+      expect(devices[0].pushAuthKey).toBe(deviceInfo.pushAuthKey);
+      expect(devices[0].pushEndpointExpired).toBe(false);
+
+      try {
+        await client.updateDevice({
+          id: client.device.id,
+          pushCallback: 'https://updates.push.services.mozilla.com/foo',
+        });
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        expect(err.errno).toBe(107);
+        expect(err.message).toBe('Invalid parameter in request body');
+      }
+    });
+
+    it('invalid public keys are cleanly rejected', async () => {
+      const email = server.uniqueEmail();
+      const password = 'test password';
+      const invalidPublicKey = Buffer.alloc(65);
+      invalidPublicKey.fill('\0');
+      const deviceInfo = {
+        name: 'test device',
+        type: 'desktop',
+        pushCallback: 'https://updates.push.services.mozilla.com/qux',
+        pushPublicKey: base64url(invalidPublicKey),
+        pushAuthKey: base64url(crypto.randomBytes(16)),
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+
+      try {
+        await client.updateDevice(deviceInfo);
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(107);
+      }
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.in.spec.ts
@@ -1,0 +1,364 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+const encrypt = require('fxa-shared/auth/encrypt');
+
+const buf = (v: any) => (Buffer.isBuffer(v) ? v : Buffer.from(v, 'hex'));
+
+const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
+const NON_PUBLIC_CLIENT_ID = 'dcdb5ae7add825d2';
+const OAUTH_CLIENT_NAME = 'Android Components Reference Browser';
+const UNKNOWN_REFRESH_TOKEN =
+  'B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78';
+
+let server: TestServerInstance;
+let oauthServerDb: any;
+let db: any;
+
+beforeAll(async () => {
+  server = await createTestServer();
+
+  const log = { trace() {}, info() {}, error() {}, debug() {}, warn() {} };
+  const config = require('../../config').default.getProperties();
+  const lastAccessTimeUpdates = {
+    enabled: true,
+    sampleRate: 1,
+    earliestSaneTimestamp: config.lastAccessTimeUpdates.earliestSaneTimestamp,
+  };
+  const Token = require('../../lib/tokens')(log, {
+    lastAccessTimeUpdates,
+    tokenLifetimes: { sessionTokenWithoutDevice: 2419200000 },
+  });
+  const { createDB } = require('../../lib/db');
+  const DB = createDB(config, log, Token);
+  db = await DB.connect(config);
+  oauthServerDb = require('../../lib/oauth/db');
+}, 120000);
+
+afterAll(async () => {
+  await db.close();
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote device with refresh tokens',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    let client: any;
+    let email: string;
+    let password: string;
+    let refreshToken: string;
+
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      password = 'test password';
+      client = await Client.create(server.publicUrl, email, password, testOptions);
+    });
+
+    it('device registration with unknown refresh token', async () => {
+      const deviceInfo = {
+        name: 'test device \ud83c\udf53\ud83d\udd25\u5728\ud834\udf06',
+        type: 'mobile',
+        availableCommands: { foo: 'bar' },
+        pushCallback: '',
+        pushPublicKey: '',
+        pushAuthKey: '',
+      };
+
+      try {
+        await client.updateDeviceWithRefreshToken(UNKNOWN_REFRESH_TOKEN, deviceInfo);
+        throw new Error('should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
+      }
+    });
+
+    it('devicesWithRefreshToken fails with unknown refresh token', async () => {
+      try {
+        await client.devicesWithRefreshToken(UNKNOWN_REFRESH_TOKEN);
+        throw new Error('should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
+      }
+    });
+
+    it('destroyDeviceWithRefreshToken fails with unknown refresh token', async () => {
+      try {
+        await client.destroyDeviceWithRefreshToken(UNKNOWN_REFRESH_TOKEN, '1');
+        throw new Error('should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
+      }
+    });
+
+    it('deviceCommandsWithRefreshToken fails with unknown refresh token', async () => {
+      try {
+        await client.deviceCommandsWithRefreshToken(UNKNOWN_REFRESH_TOKEN, 0, 50);
+        throw new Error('should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
+      }
+    });
+
+    it('devicesInvokeCommandWithRefreshToken fails with unknown refresh token', async () => {
+      try {
+        await client.devicesInvokeCommandWithRefreshToken(
+          UNKNOWN_REFRESH_TOKEN, 'target', 'command', {}, 5
+        );
+        throw new Error('should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
+      }
+    });
+
+    it('devicesNotifyWithRefreshToken fails with unknown refresh token', async () => {
+      try {
+        await client.devicesNotifyWithRefreshToken(UNKNOWN_REFRESH_TOKEN, '123');
+        throw new Error('should have failed');
+      } catch (err: any) {
+        expect(err.code).toBe(401);
+        expect(err.errno).toBe(110);
+      }
+    });
+
+    it('device registration after account creation', async () => {
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      refreshToken = refresh.token.toString('hex');
+
+      const deviceInfo = {
+        name: 'test device \ud83c\udf53\ud83d\udd25\u5728\ud834\udf06',
+        type: 'mobile',
+        availableCommands: { foo: 'bar' },
+        pushCallback: '',
+        pushPublicKey: '',
+        pushAuthKey: '',
+      };
+
+      let devices = await client.devicesWithRefreshToken(refreshToken);
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDeviceWithRefreshToken(refreshToken, deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceInfo.name);
+      expect(device.type).toBe(deviceInfo.type);
+      expect(device.availableCommands).toEqual(deviceInfo.availableCommands);
+      expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+      expect(device.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+      expect(device.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+      expect(device.pushEndpointExpired).toBe(false);
+
+      devices = await client.devicesWithRefreshToken(refreshToken);
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(deviceInfo.name);
+      expect(devices[0].type).toBe(deviceInfo.type);
+      expect(devices[0].availableCommands).toEqual(deviceInfo.availableCommands);
+      expect(devices[0].pushCallback).toBe(deviceInfo.pushCallback);
+      expect(devices[0].pushPublicKey).toBe(deviceInfo.pushPublicKey);
+      expect(devices[0].pushAuthKey).toBe(deviceInfo.pushAuthKey);
+      expect(devices[0].pushEndpointExpired).toBeFalsy();
+
+      await client.destroyDeviceWithRefreshToken(refreshToken, devices[0].id);
+    });
+
+    it('device registration without optional parameters', async () => {
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      refreshToken = refresh.token.toString('hex');
+
+      const deviceInfo = {
+        name: 'test device',
+        type: 'mobile',
+      };
+
+      let devices = await client.devicesWithRefreshToken(refreshToken);
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDeviceWithRefreshToken(refreshToken, deviceInfo);
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(deviceInfo.name);
+      expect(device.type).toBe(deviceInfo.type);
+      expect(device.pushCallback == null).toBe(true);
+      expect(device.pushPublicKey == null).toBe(true);
+      expect(device.pushAuthKey == null).toBe(true);
+      expect(device.pushEndpointExpired).toBe(false);
+
+      devices = await client.devicesWithRefreshToken(refreshToken);
+      const deviceId = devices[0].id;
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(deviceInfo.name);
+      expect(devices[0].type).toBe(deviceInfo.type);
+      expect(devices[0].pushCallback == null).toBe(true);
+      expect(devices[0].pushPublicKey == null).toBe(true);
+      expect(devices[0].pushAuthKey == null).toBe(true);
+      expect(devices[0].pushEndpointExpired).toBe(false);
+
+      const tokenObj = await oauthServerDb.getRefreshToken(encrypt.hash(refreshToken));
+      expect(tokenObj).toBeTruthy();
+
+      await client.destroyDeviceWithRefreshToken(refreshToken, deviceId);
+
+      const tokenObjAfter = await oauthServerDb.getRefreshToken(encrypt.hash(refreshToken));
+      expect(tokenObjAfter).toBeFalsy();
+    });
+
+    it('device registration using oauth client name', async () => {
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      refreshToken = refresh.token.toString('hex');
+
+      const refresh2 = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      const refreshToken2 = refresh2.token.toString('hex');
+
+      let devices = await client.devicesWithRefreshToken(refreshToken);
+      expect(devices.length).toBe(0);
+
+      const device = await client.updateDeviceWithRefreshToken(refreshToken, {});
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(OAUTH_CLIENT_NAME);
+      expect(device.type).toBe('mobile');
+      expect(device.pushCallback).toBeUndefined();
+      expect(device.pushPublicKey).toBeUndefined();
+      expect(device.pushAuthKey).toBeUndefined();
+      expect(device.pushEndpointExpired).toBe(false);
+
+      devices = await client.devicesWithRefreshToken(refreshToken2);
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(OAUTH_CLIENT_NAME);
+      expect(devices[0].type).toBe('mobile');
+    });
+
+    it('device registration without required name parameter', async () => {
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      refreshToken = refresh.token.toString('hex');
+
+      const device = await client.updateDeviceWithRefreshToken(refreshToken, {
+        type: 'mobile',
+      });
+      expect(device.id).toBeTruthy();
+      expect(device.createdAt).toBeGreaterThan(0);
+      expect(device.name).toBe(OAUTH_CLIENT_NAME);
+      expect(device.type).toBe('mobile');
+    });
+
+    it('sets isCurrentDevice correctly', async () => {
+      const generateTokenInfo = {
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      };
+
+      const rt1 = await oauthServerDb.generateRefreshToken(generateTokenInfo);
+      const rt2 = await oauthServerDb.generateRefreshToken(generateTokenInfo);
+
+      await client.updateDeviceWithRefreshToken(rt1.token.toString('hex'), {
+        name: 'first device',
+      });
+      await client.updateDeviceWithRefreshToken(rt2.token.toString('hex'), {
+        name: 'second device',
+      });
+
+      const devices = await client.devicesWithRefreshToken(rt1.token.toString('hex'));
+      expect(devices.length).toBe(2);
+
+      if (devices[0].name === 'first device') {
+        const swap: any = {};
+        Object.keys(devices[0]).forEach((key: string) => {
+          swap[key] = devices[0][key];
+          devices[0][key] = devices[1][key];
+          devices[1][key] = swap[key];
+        });
+      }
+
+      expect(devices[0].isCurrentDevice).toBe(false);
+      expect(devices[0].name).toBe('second device');
+      expect(devices[1].isCurrentDevice).toBe(true);
+      expect(devices[1].name).toBe('first device');
+    });
+
+    it('does not allow non-public clients', async () => {
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(NON_PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      refreshToken = refresh.token.toString('hex');
+
+      try {
+        await client.updateDeviceWithRefreshToken(refreshToken, { type: 'mobile' });
+        throw new Error('must fail');
+      } catch (err: any) {
+        expect(err.message).toBe('Not a public client');
+        expect(err.errno).toBe(166);
+      }
+    });
+
+    it('throws conflicting device errors', async () => {
+      const conflictingDeviceInfo: any = {
+        id: crypto.randomBytes(16).toString('hex'),
+        name: 'Device',
+      };
+
+      const refresh = await oauthServerDb.generateRefreshToken({
+        clientId: buf(PUBLIC_CLIENT_ID),
+        userId: buf(client.uid),
+        email: client.email,
+        scope: 'profile https://identity.mozilla.com/apps/oldsync',
+      });
+      refreshToken = refresh.token.toString('hex');
+      conflictingDeviceInfo.refreshTokenId = refreshToken;
+
+      await db.createDevice(client.uid, conflictingDeviceInfo);
+
+      conflictingDeviceInfo.id = crypto.randomBytes(16).toString('hex');
+      try {
+        await db.createDevice(client.uid, conflictingDeviceInfo);
+        throw new Error('must fail');
+      } catch (err: any) {
+        expect(err.message).toBe('Session already registered by another device');
+      }
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/email_validity.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/email_validity.in.spec.ts
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+interface AuthServerError extends Error {
+  code: number;
+}
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      accountDestroy: {
+        requireVerifiedAccount: false,
+        requireVerifiedSession: false,
+      },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote email validity',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('/account/create with a variety of malformed email addresses', async () => {
+      const pwd = '123456';
+
+      const emails = [
+        'notAnEmailAddress',
+        '\n@example.com',
+        'me@hello world.com',
+        'me@hello+world.com',
+        'me@.example',
+        'me@example',
+        'me@example.com-',
+        'me@example..com',
+        'me@example-.com',
+        'me@example.-com',
+        '\uD83D\uDCA9@unicodepooforyou.com',
+      ];
+
+      const results = await Promise.all(
+        emails.map((email) =>
+          Client.create(server.publicUrl, email, pwd, testOptions).then(
+            () => {
+              throw new Error(`Email ${email} should have been rejected`);
+            },
+            (err: AuthServerError) => {
+              expect(err.code).toBe(400);
+            }
+          )
+        )
+      );
+    });
+
+    it('/account/create with a variety of unusual but valid email addresses', async () => {
+      const pwd = '123456';
+
+      const emails = [
+        'tim@tim-example.net',
+        'a+b+c@example.com',
+        '#!?-@t-e-s-assert.c-o-m',
+        `${String.fromCharCode(1234)}@example.com`,
+        `test@${String.fromCharCode(5678)}.com`,
+      ];
+
+      await Promise.all(
+        emails.map((email) =>
+          Client.create(server.publicUrl, email, pwd, testOptions).then(
+            (c: any) => c.destroyAccount(),
+            () => {
+              fail(
+                `Email address ${email} should have been allowed, but it wasn't`
+              );
+            }
+          )
+        )
+      );
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/flow.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/flow.in.spec.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: { skipForNewAccounts: { enabled: true } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote flow',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    let email1: string;
+
+    beforeAll(() => {
+      email1 = server.uniqueEmail();
+    });
+
+    it('Create account flow', async () => {
+      const email = email1;
+      const password = 'allyourbasearebelongtous';
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+      const keys = await client.keys();
+      expect(typeof keys.kA).toBe('string');
+      expect(typeof keys.wrapKb).toBe('string');
+      expect(typeof keys.kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+
+    it('Login flow', async () => {
+      const email = email1;
+      const password = 'allyourbasearebelongtous';
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: true,
+      });
+      expect(client.authAt).toBeTruthy();
+      expect(client.uid).toBeTruthy();
+      const keys = await client.keys();
+      expect(typeof keys.kA).toBe('string');
+      expect(typeof keys.wrapKb).toBe('string');
+      expect(typeof keys.kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/misc_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/misc_tests.in.spec.ts
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import http from 'http';
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+const packageJson = require('../../package.json');
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+// Simple HTTP GET using Node's built-in http module.
+// Avoids superagent's circular references (which crash Jest workers)
+// and fetch's behavioral quirks with certain hapi routes.
+function httpGet(
+  url: string,
+  options?: { headers?: Record<string, string> }
+): Promise<{ statusCode: number; headers: http.IncomingHttpHeaders; body: string; json: () => any }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const req = http.get(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        headers: options?.headers || {},
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode!,
+            headers: res.headers,
+            body: data,
+            json: () => JSON.parse(data),
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+  });
+}
+
+function httpPost(
+  url: string,
+  payload: any,
+  headers?: Record<string, string>
+): Promise<{ statusCode: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const body = JSON.stringify(payload);
+    const req = http.request(
+      {
+        method: 'POST',
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          ...headers,
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk) => { data += chunk; });
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode!,
+            headers: res.headers,
+            body: data,
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+describe.each(testVersions)(
+  '#integration$tag - remote misc',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('unsupported api version', async () => {
+      const res = await httpGet(`${server.publicUrl}/v0/account/create`);
+      expect(res.statusCode).toBe(410);
+    });
+
+    it('/__heartbeat__ returns a 200 OK', async () => {
+      const res = await httpGet(`${server.publicUrl}/__heartbeat__`);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('/__lbheartbeat__ returns a 200 OK', async () => {
+      const res = await httpGet(`${server.publicUrl}/__lbheartbeat__`);
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('/ returns version, git hash and source repo', async () => {
+      const res = await httpGet(server.publicUrl + '/');
+      const json = res.json();
+      expect(Object.keys(json)).toEqual(['version', 'commit', 'source']);
+      expect(json.version).toBe(packageJson.version);
+      expect(json.source && json.source !== 'unknown').toBeTruthy();
+      expect(json.commit).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    it('/__version__ returns version, git hash and source repo', async () => {
+      const res = await httpGet(server.publicUrl + '/__version__');
+      const json = res.json();
+      expect(Object.keys(json)).toEqual(['version', 'commit', 'source']);
+      expect(json.version).toBe(packageJson.version);
+      expect(json.source && json.source !== 'unknown').toBeTruthy();
+      expect(json.commit).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    it('returns correct CORS headers', async () => {
+      // The default corsOrigin config is ['*'], which sets Hapi CORS to 'ignore'
+      // mode. In this mode Access-Control-Allow-Origin: * is returned on all
+      // responses regardless of whether an Origin header was sent.
+      const res = await httpGet(`${server.publicUrl}/`);
+      expect(res.headers['access-control-allow-origin']).toBe('*');
+    });
+
+    it('/verify_email redirects', async () => {
+      const path = '/v1/verify_email?code=0000&uid=0000';
+      const res = await httpGet(server.publicUrl + path);
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('/complete_reset_password redirects', async () => {
+      const path =
+        '/v1/complete_reset_password?code=0000&email=a@b.c&token=0000';
+      const res = await httpGet(server.publicUrl + path);
+      expect(res.statusCode).toBe(302);
+    });
+
+    it('timestamp header', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+
+      await client.login();
+      const url = `${client.api.baseURL}/account/keys`;
+      const token = await client.api.Token.KeyFetchToken.fromHex(
+        client.getState().keyFetchToken
+      );
+
+      const res = await httpGet(url, {
+        headers: { 'Authorization': `Hawk id="${token.id}"` },
+      });
+      const now = +new Date() / 1000;
+      expect(Number(res.headers.timestamp)).toBeGreaterThan(now - 60);
+      expect(Number(res.headers.timestamp)).toBeLessThan(now + 60);
+    });
+
+    it('Strict-Transport-Security header', async () => {
+      const res = await httpGet(`${server.publicUrl}/`);
+      expect(res.headers['strict-transport-security']).toBe(
+        'max-age=31536000; includeSubDomains'
+      );
+    });
+
+    it('oversized payload', async () => {
+      const client = new Client(server.publicUrl, testOptions);
+      try {
+        await client.api.doRequest(
+          'POST',
+          `${client.api.baseURL}/get_random_bytes`,
+          null,
+          { big: Buffer.alloc(8192).toString('hex') }
+        );
+        throw new Error('request should have failed');
+      } catch (err: any) {
+        if (err.errno) {
+          expect(err.errno).toBe(113);
+        } else {
+          expect(/413 Request Entity Too Large/.test(err)).toBeTruthy();
+        }
+      }
+    });
+
+    it('random bytes', async () => {
+      const client = new Client(server.publicUrl, testOptions);
+      const x = await client.api.getRandomBytes();
+      expect(x.data.length).toBe(64);
+    });
+
+    it('fetch /.well-known/browserid support document', async () => {
+      const client = new Client(server.publicUrl, testOptions);
+      const doc = await client.api.doRequest(
+        'GET',
+        server.publicUrl + '/.well-known/browserid'
+      );
+      expect(doc.hasOwnProperty('public-key')).toBe(true);
+      expect(/^[0-9]+$/.test(doc['public-key'].n)).toBe(true);
+      expect(/^[0-9]+$/.test(doc['public-key'].e)).toBe(true);
+      expect(doc.hasOwnProperty('authentication')).toBe(true);
+      expect(doc.hasOwnProperty('provisioning')).toBe(true);
+      expect(doc.keys.length).toBe(1);
+    });
+
+    it('ignores fail on hawk payload mismatch', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+
+      const token = await client.api.Token.SessionToken.fromHex(client.sessionToken);
+      const url = `${client.api.baseURL}/account/device`;
+      const payload: any = {
+        name: 'my cool device',
+        type: 'desktop',
+      };
+
+      payload.name = 'my stealthily-changed device name';
+      const res = await httpPost(url, payload, {
+        'Authorization': `Hawk id="${token.id}"`,
+      });
+      expect(res.statusCode).toBe(200);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_session_token_scope_tests.in.spec.ts
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+const {
+  OAUTH_SCOPE_SESSION_TOKEN,
+  OAUTH_SCOPE_OLD_SYNC,
+} = require('fxa-shared/oauth/constants');
+const { AppError: error } = require('@fxa/accounts/errors');
+
+const OAUTH_CLIENT_NAME = 'Android Components Reference Browser';
+const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
+const MOCK_CODE_VERIFIER = 'abababababababababababababababababababababa';
+const MOCK_CODE_CHALLENGE = 'YPhkZqm08uTfwjNSiYcx80-NPT9Zn94kHboQW97KyV0';
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - /oauth/ session token scope',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    let client: any;
+    let email: string;
+    let password: string;
+
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      password = 'test password';
+      client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+    });
+
+    it('provides a session token using the session token scope', async () => {
+      const SCOPE = OAUTH_SCOPE_SESSION_TOKEN;
+      const res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        scope: SCOPE,
+        state: 'xyz',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+      });
+      expect(res.redirect).toBeTruthy();
+      expect(res.code).toBeTruthy();
+      expect(res.state).toBe('xyz');
+
+      const tokenRes = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      expect(tokenRes.access_token).toBeTruthy();
+      expect(tokenRes.session_token).toBeTruthy();
+      expect(tokenRes.session_token).not.toBe(client.sessionToken);
+      expect(tokenRes.session_token_id).toBeFalsy();
+      expect(tokenRes.scope).toBe(SCOPE);
+      expect(tokenRes.auth_at).toBeTruthy();
+      expect(tokenRes.expires_in).toBeTruthy();
+      expect(tokenRes.token_type).toBeTruthy();
+    });
+
+    it('works with oldsync and session token scopes', async () => {
+      const SCOPE = `${OAUTH_SCOPE_SESSION_TOKEN} ${OAUTH_SCOPE_OLD_SYNC}`;
+      const res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        scope: SCOPE,
+        state: 'xyz',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        access_type: 'offline',
+      });
+
+      const tokenRes = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      expect(tokenRes.access_token).toBeTruthy();
+      expect(tokenRes.session_token).toBeTruthy();
+      expect(tokenRes.refresh_token).toBeTruthy();
+
+      const allClients = await client.attachedClients();
+      expect(allClients.length).toBe(2);
+      expect(allClients[0].sessionTokenId).toBeTruthy();
+      expect(allClients[0].name).toBe(OAUTH_CLIENT_NAME);
+      expect(allClients[1].sessionTokenId).toBeTruthy();
+      expect(allClients[0].isCurrentSession).toBe(false);
+      expect(allClients[1].isCurrentSession).toBe(true);
+      expect(allClients[0].sessionTokenId).not.toBe(allClients[1].sessionTokenId);
+    });
+
+    it('rejects invalid sessionToken', async () => {
+      const res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        scope: OAUTH_SCOPE_SESSION_TOKEN,
+        state: 'xyz',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+      });
+
+      await client.destroySession();
+      try {
+        await client.grantOAuthTokens({
+          client_id: PUBLIC_CLIENT_ID,
+          code: res.code,
+          code_verifier: MOCK_CODE_VERIFIER,
+        });
+        throw new Error('should have thrown');
+      } catch (err: any) {
+        expect(err.errno).toBe(error.ERRNO.INVALID_TOKEN);
+      }
+    });
+
+    it('contains no token when scopes is not set', async () => {
+      const res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        scope: 'profile',
+        state: 'xyz',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+      });
+
+      const tokenRes = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      expect(tokenRes.access_token).toBeTruthy();
+      expect(tokenRes.session_token).toBeFalsy();
+      expect(tokenRes.session_token_id).toBeFalsy();
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/oauth_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.in.spec.ts
@@ -1,0 +1,535 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+const { OAUTH_SCOPE_OLD_SYNC } = require('fxa-shared/oauth/constants');
+const { AppError: error } = require('@fxa/accounts/errors');
+const testUtils = require('../lib/util');
+
+const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
+const OAUTH_CLIENT_NAME = 'Android Components Reference Browser';
+const MOCK_CODE_VERIFIER = 'abababababababababababababababababababababa';
+const MOCK_CODE_CHALLENGE = 'YPhkZqm08uTfwjNSiYcx80-NPT9Zn94kHboQW97KyV0';
+
+const JWT_ACCESS_TOKEN_CLIENT_ID = '325b4083e32fe8e7';
+const JWT_ACCESS_TOKEN_SECRET =
+  'a084f4c36501ea1eb2de33258421af97b2e67ffbe107d2812f4a14f3579900ef';
+
+const FIREFOX_IOS_CLIENT_ID = '1b1a3e44c54fbb58';
+const RELAY_SCOPE = 'https://identity.mozilla.com/apps/relay';
+const GRANT_TOKEN_EXCHANGE = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const SUBJECT_TOKEN_TYPE_REFRESH =
+  'urn:ietf:params:oauth:token-type:refresh_token';
+
+const { decodeJWT } = testUtils;
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - /oauth/ routes',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    let client: any;
+    let email: string;
+    let password: string;
+
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      password = 'test password';
+      client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+    });
+
+    it('successfully grants an authorization code', async () => {
+      const res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        scope: 'abc',
+        state: 'xyz',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+      });
+      expect(res.redirect).toBeTruthy();
+      expect(res.code).toBeTruthy();
+      expect(res.state).toBe('xyz');
+    });
+
+    it('rejects `assertion` parameter in /authorization request', async () => {
+      try {
+        await client.createAuthorizationCode({
+          client_id: PUBLIC_CLIENT_ID,
+          state: 'xyz',
+          assertion: 'a~b',
+        });
+        throw new Error('should have thrown');
+      } catch (err: any) {
+        expect(err.errno).toBe(error.ERRNO.INVALID_PARAMETER);
+        expect(err.validation.keys[0]).toBe('assertion');
+      }
+    });
+
+    it('rejects `resource` parameter in /authorization request', async () => {
+      try {
+        await client.createAuthorizationCode({
+          client_id: PUBLIC_CLIENT_ID,
+          state: 'xyz',
+          code_challenge: MOCK_CODE_CHALLENGE,
+          code_challenge_method: 'S256',
+          resource: 'https://resource.server.com',
+        });
+        throw new Error('should have thrown');
+      } catch (err: any) {
+        expect(err.errno).toBe(error.ERRNO.INVALID_PARAMETER);
+        expect(err.validation.keys[0]).toBe('resource');
+      }
+    });
+
+    it('successfully grants tokens from sessionToken and notifies user', async () => {
+      const SCOPE = OAUTH_SCOPE_OLD_SYNC;
+
+      let devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      const res = await client.grantOAuthTokensFromSessionToken({
+        grant_type: 'fxa-credentials',
+        client_id: PUBLIC_CLIENT_ID,
+        access_type: 'offline',
+        scope: SCOPE,
+      });
+
+      expect(res.access_token).toBeTruthy();
+      expect(res.refresh_token).toBeTruthy();
+      expect(res.scope).toBe(SCOPE);
+      expect(res.auth_at).toBeTruthy();
+      expect(res.expires_in).toBeTruthy();
+      expect(res.token_type).toBeTruthy();
+
+      devices = await client.devicesWithRefreshToken(res.refresh_token);
+      expect(devices.length).toBe(1);
+      expect(devices[0].name).toBe(OAUTH_CLIENT_NAME);
+    });
+
+    it('successfully grants tokens via authentication code flow, and refresh token flow', async () => {
+      const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
+
+      let devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      let res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        state: 'abc',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: SCOPE,
+        access_type: 'offline',
+      });
+      expect(res.code).toBeTruthy();
+
+      devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      res = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      expect(res.access_token).toBeTruthy();
+      expect(res.refresh_token).toBeTruthy();
+      expect(res.id_token).toBeTruthy();
+      expect(res.scope).toBe(SCOPE);
+      expect(res.auth_at).toBeTruthy();
+      expect(res.expires_in).toBeTruthy();
+      expect(res.token_type).toBeTruthy();
+
+      const idToken = decodeJWT(res.id_token);
+      expect(idToken.claims.aud).toBe(PUBLIC_CLIENT_ID);
+
+      devices = await client.devices();
+      expect(devices.length).toBe(1);
+
+      const res2 = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: res.refresh_token,
+      });
+      expect(res2.access_token).toBeTruthy();
+      expect(res2.id_token).toBeFalsy();
+      expect(res2.scope).toBe(OAUTH_SCOPE_OLD_SYNC);
+      expect(res2.expires_in).toBeTruthy();
+      expect(res2.token_type).toBeTruthy();
+      expect(res.access_token).not.toBe(res2.access_token);
+
+      devices = await client.devices();
+      expect(devices.length).toBe(1);
+    });
+
+    it('successfully propagates `resource` and `clientId` in the ID token `aud` claim', async () => {
+      const SCOPE = `${OAUTH_SCOPE_OLD_SYNC} openid`;
+
+      let devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      let res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        state: 'abc',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: SCOPE,
+        access_type: 'offline',
+      });
+      expect(res.code).toBeTruthy();
+
+      devices = await client.devices();
+      expect(devices.length).toBe(0);
+
+      res = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+        resource: 'https://resource.server.com',
+      });
+      expect(res.access_token).toBeTruthy();
+      expect(res.refresh_token).toBeTruthy();
+      expect(res.id_token).toBeTruthy();
+      expect(res.scope).toBe(SCOPE);
+      expect(res.auth_at).toBeTruthy();
+      expect(res.expires_in).toBeTruthy();
+      expect(res.token_type).toBeTruthy();
+
+      const idToken = decodeJWT(res.id_token);
+      expect(idToken.claims.aud).toEqual([
+        PUBLIC_CLIENT_ID,
+        'https://resource.server.com',
+      ]);
+    });
+
+    it('successfully grants JWT access tokens via authentication code flow, and refresh token flow', async () => {
+      const SCOPE = 'openid';
+
+      const codeRes = await client.createAuthorizationCode({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        state: 'abc',
+        scope: SCOPE,
+        access_type: 'offline',
+      });
+      expect(codeRes.code).toBeTruthy();
+
+      const tokenRes = await client.grantOAuthTokens({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        code: codeRes.code,
+        ppid_seed: 100,
+      });
+      expect(tokenRes.access_token).toBeTruthy();
+      expect(tokenRes.refresh_token).toBeTruthy();
+      expect(tokenRes.id_token).toBeTruthy();
+      expect(tokenRes.scope).toBe(SCOPE);
+      expect(tokenRes.auth_at).toBeTruthy();
+      expect(tokenRes.expires_in).toBeTruthy();
+      expect(tokenRes.token_type).toBeTruthy();
+
+      const tokenJWT = decodeJWT(tokenRes.access_token);
+      expect(tokenJWT.claims.sub).toBeTruthy();
+      expect(tokenJWT.claims.aud).toBe(JWT_ACCESS_TOKEN_CLIENT_ID);
+
+      const refreshTokenRes = await client.grantOAuthTokens({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        refresh_token: tokenRes.refresh_token,
+        grant_type: 'refresh_token',
+        ppid_seed: 100,
+        resource: 'https://resource.server1.com',
+        scope: SCOPE,
+      });
+      expect(refreshTokenRes.access_token).toBeTruthy();
+      expect(refreshTokenRes.id_token).toBeFalsy();
+      expect(refreshTokenRes.scope).toBe('');
+      expect(refreshTokenRes.expires_in).toBeTruthy();
+      expect(refreshTokenRes.token_type).toBeTruthy();
+
+      const refreshTokenJWT = decodeJWT(refreshTokenRes.access_token);
+      expect(tokenJWT.claims.sub).toBe(refreshTokenJWT.claims.sub);
+      expect(refreshTokenJWT.claims.aud).toEqual([
+        JWT_ACCESS_TOKEN_CLIENT_ID,
+        'https://resource.server1.com',
+      ]);
+
+      const clientRotatedRes = await client.grantOAuthTokens({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        refresh_token: tokenRes.refresh_token,
+        grant_type: 'refresh_token',
+        ppid_seed: 101,
+        scope: SCOPE,
+      });
+      expect(clientRotatedRes.access_token).toBeTruthy();
+      expect(clientRotatedRes.id_token).toBeFalsy();
+      expect(clientRotatedRes.scope).toBe('');
+      expect(clientRotatedRes.expires_in).toBeTruthy();
+      expect(clientRotatedRes.token_type).toBeTruthy();
+
+      const clientRotatedJWT = decodeJWT(clientRotatedRes.access_token);
+      expect(tokenJWT.claims.sub).not.toBe(clientRotatedJWT.claims.sub);
+    });
+
+    it('successfully revokes access tokens, and refresh tokens', async () => {
+      let res = await client.createAuthorizationCode({
+        client_id: PUBLIC_CLIENT_ID,
+        state: 'abc',
+        code_challenge: MOCK_CODE_CHALLENGE,
+        code_challenge_method: 'S256',
+        scope: 'profile openid',
+        access_type: 'offline',
+      });
+      expect(res.code).toBeTruthy();
+
+      res = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        code: res.code,
+        code_verifier: MOCK_CODE_VERIFIER,
+      });
+      expect(res.access_token).toBeTruthy();
+      expect(res.refresh_token).toBeTruthy();
+
+      let tokenStatus = await client.api.introspect(res.access_token);
+      expect(tokenStatus.active).toBe(true);
+
+      await client.revokeOAuthToken({
+        client_id: PUBLIC_CLIENT_ID,
+        token: res.access_token,
+      });
+
+      tokenStatus = await client.api.introspect(res.access_token);
+      expect(tokenStatus.active).toBe(false);
+
+      const res2 = await client.grantOAuthTokens({
+        client_id: PUBLIC_CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: res.refresh_token,
+      });
+      expect(res2.access_token).toBeTruthy();
+      expect(res2.refresh_token).toBeFalsy();
+
+      tokenStatus = await client.api.introspect(res.refresh_token);
+      expect(tokenStatus.active).toBe(true);
+
+      await client.revokeOAuthToken({
+        client_id: PUBLIC_CLIENT_ID,
+        token: res.refresh_token,
+      });
+
+      try {
+        await client.grantOAuthTokens({
+          client_id: PUBLIC_CLIENT_ID,
+          grant_type: 'refresh_token',
+          refresh_token: res.refresh_token,
+        });
+        throw new Error('should have thrown');
+      } catch (err: any) {
+        expect(err.errno).toBe(error.ERRNO.INVALID_TOKEN);
+      }
+    });
+
+    it('successfully revokes JWT access tokens', async () => {
+      const codeRes = await client.createAuthorizationCode({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        state: 'abc',
+        scope: 'openid',
+      });
+      expect(codeRes.code).toBeTruthy();
+
+      const token = (
+        await client.grantOAuthTokens({
+          client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+          client_secret: JWT_ACCESS_TOKEN_SECRET,
+          code: codeRes.code,
+          ppid_seed: 100,
+        })
+      ).access_token;
+      expect(token).toBeTruthy();
+
+      const tokenJWT = decodeJWT(token);
+      expect(tokenJWT.claims.sub).toBeTruthy();
+
+      await client.revokeOAuthToken({
+        client_id: JWT_ACCESS_TOKEN_CLIENT_ID,
+        client_secret: JWT_ACCESS_TOKEN_SECRET,
+        token,
+      });
+    });
+
+    it('sees correct keyRotationTimestamp after password change and password reset', async () => {
+      const keyData1 = (
+        await client.getScopedKeyData({
+          client_id: PUBLIC_CLIENT_ID,
+          scope: OAUTH_SCOPE_OLD_SYNC,
+        })
+      )[OAUTH_SCOPE_OLD_SYNC];
+
+      await client.changePassword('new password', undefined, client.sessionToken);
+      await server.mailbox.waitForEmail(email);
+
+      client = await Client.login(server.publicUrl, email, 'new password', testOptions);
+      await server.mailbox.waitForEmail(email);
+
+      const keyData2 = (
+        await client.getScopedKeyData({
+          client_id: PUBLIC_CLIENT_ID,
+          scope: OAUTH_SCOPE_OLD_SYNC,
+        })
+      )[OAUTH_SCOPE_OLD_SYNC];
+
+      expect(keyData1.keyRotationTimestamp).toBe(keyData2.keyRotationTimestamp);
+
+      await client.forgotPassword();
+      const otpCode = await server.mailbox.waitForCode(email);
+      const result = await client.verifyPasswordForgotOtp(otpCode);
+      await client.verifyPasswordResetCode(result.code);
+      await client.resetPassword(password, {});
+      await server.mailbox.waitForEmail(email);
+
+      const keyData3 = (
+        await client.getScopedKeyData({
+          client_id: PUBLIC_CLIENT_ID,
+          scope: OAUTH_SCOPE_OLD_SYNC,
+        })
+      )[OAUTH_SCOPE_OLD_SYNC];
+
+      expect(keyData2.keyRotationTimestamp).toBeLessThan(keyData3.keyRotationTimestamp);
+    });
+  }
+);
+
+describe.each(testVersions)(
+  '#integration$tag - /oauth/token token exchange',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    let client: any;
+    let email: string;
+    let password: string;
+
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      password = 'test password';
+      client = await Client.createAndVerify(
+        server.publicUrl, email, password, server.mailbox, testOptions
+      );
+    });
+
+    it('successfully exchanges a refresh token for a new token with additional scope', async () => {
+      const initialTokens = await client.grantOAuthTokensFromSessionToken({
+        grant_type: 'fxa-credentials',
+        client_id: FIREFOX_IOS_CLIENT_ID,
+        access_type: 'offline',
+        scope: OAUTH_SCOPE_OLD_SYNC,
+      });
+
+      expect(initialTokens.access_token).toBeTruthy();
+      expect(initialTokens.refresh_token).toBeTruthy();
+      expect(initialTokens.scope).toBe(OAUTH_SCOPE_OLD_SYNC);
+
+      const clientsBefore = await client.attachedClients();
+      const oauthClientBefore = clientsBefore.find(
+        (c: any) => c.refreshTokenId !== null
+      );
+      expect(oauthClientBefore).toBeTruthy();
+      const originalDeviceId = oauthClientBefore.deviceId;
+
+      const exchangedTokens = await client.grantOAuthTokens({
+        grant_type: GRANT_TOKEN_EXCHANGE,
+        subject_token: initialTokens.refresh_token,
+        subject_token_type: SUBJECT_TOKEN_TYPE_REFRESH,
+        scope: RELAY_SCOPE,
+      });
+
+      expect(exchangedTokens.access_token).toBeTruthy();
+      expect(exchangedTokens.refresh_token).toBeTruthy();
+      expect(exchangedTokens.scope).toContain(OAUTH_SCOPE_OLD_SYNC);
+      expect(exchangedTokens.scope).toContain(RELAY_SCOPE);
+      expect(exchangedTokens.expires_in).toBeTruthy();
+      expect(exchangedTokens.token_type).toBe('bearer');
+      expect(exchangedTokens._clientId).toBeUndefined();
+      expect(exchangedTokens._existingDeviceId).toBeUndefined();
+
+      const clientsAfter = await client.attachedClients();
+      const oauthClientAfter = clientsAfter.find(
+        (c: any) => c.refreshTokenId !== null
+      );
+      expect(oauthClientAfter).toBeTruthy();
+      expect(oauthClientAfter.deviceId).toBe(originalDeviceId);
+
+      try {
+        await client.grantOAuthTokens({
+          grant_type: 'refresh_token',
+          client_id: FIREFOX_IOS_CLIENT_ID,
+          refresh_token: initialTokens.refresh_token,
+        });
+        throw new Error('should have thrown - original token should be revoked');
+      } catch (err: any) {
+        expect(err.errno).toBe(110);
+      }
+    });
+  }
+);
+
+describe('#integrationV2 - /oauth/token fxa-credentials with reason', () => {
+  const testOptions = { version: 'V2' };
+  let client: any;
+  let email: string;
+  let password: string;
+
+  beforeEach(async () => {
+    email = server.uniqueEmail();
+    password = 'test password';
+    client = await Client.createAndVerify(
+      server.publicUrl, email, password, server.mailbox, testOptions
+    );
+  });
+
+  it('grants tokens with reason=token_migration and links to existing device', async () => {
+    const deviceInfo = {
+      name: 'Test Device',
+      type: 'desktop',
+    };
+    const device = await client.updateDevice(deviceInfo);
+    expect(device.id).toBeTruthy();
+
+    const clientsBefore = await client.attachedClients();
+    expect(clientsBefore.length).toBe(1);
+    expect(clientsBefore[0].deviceId).toBe(device.id);
+    expect(clientsBefore[0].refreshTokenId).toBeNull();
+
+    const tokens = await client.grantOAuthTokensFromSessionToken({
+      grant_type: 'fxa-credentials',
+      client_id: FIREFOX_IOS_CLIENT_ID,
+      access_type: 'offline',
+      scope: OAUTH_SCOPE_OLD_SYNC,
+      reason: 'token_migration',
+    });
+
+    expect(tokens.access_token).toBeTruthy();
+    expect(tokens.refresh_token).toBeTruthy();
+    expect(tokens.scope).toBe(OAUTH_SCOPE_OLD_SYNC);
+
+    const clientsAfter = await client.attachedClients();
+    expect(clientsAfter.length).toBe(1);
+    expect(clientsAfter[0].deviceId).toBe(device.id);
+    expect(clientsAfter[0].refreshTokenId).toBeTruthy();
+  });
+});

--- a/packages/fxa-auth-server/test/remote/push_db_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.in.spec.ts
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+import base64url from 'base64url';
+import * as uuid from 'uuid';
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const log = { trace() {}, info() {}, error() {}, debug() {}, warn() {} };
+const config = require('../../config').default.getProperties();
+const Token = require('../../lib/tokens')(log);
+const { createDB } = require('../../lib/db');
+const mockStatsD = { increment: () => {} };
+const DB = createDB(config, log, Token);
+
+const zeroBuffer16 = Buffer.from(
+  '00000000000000000000000000000000',
+  'hex'
+).toString('hex');
+const zeroBuffer32 = Buffer.from(
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  'hex'
+).toString('hex');
+
+const SESSION_TOKEN_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0';
+const ACCOUNT = {
+  uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+  email: `push${Math.random()}@bar.com`,
+  emailCode: zeroBuffer16,
+  emailVerified: false,
+  verifierVersion: 1,
+  verifyHash: zeroBuffer32,
+  authSalt: zeroBuffer32,
+  kA: zeroBuffer32,
+  wrapWrapKb: zeroBuffer32,
+  tokenVerificationId: zeroBuffer16,
+};
+const mockLog2 = {
+  debug() {},
+  error() {},
+  warn() {},
+  increment() {},
+  trace() {},
+  info() {},
+};
+
+let server: TestServerInstance;
+let db: any;
+
+beforeAll(async () => {
+  server = await createTestServer();
+  db = await DB.connect(config);
+}, 120000);
+
+afterAll(async () => {
+  await db.close();
+  await server.stop();
+});
+
+describe('#integration - remote push db', () => {
+  it('push db tests', async () => {
+    const deviceInfo: any = {
+      id: crypto.randomBytes(16).toString('hex'),
+      name: 'my push device',
+      type: 'mobile',
+      availableCommands: { foo: 'bar' },
+      pushCallback: 'https://foo/bar',
+      pushPublicKey: base64url(
+        Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])
+      ),
+      pushAuthKey: base64url(crypto.randomBytes(16)),
+      pushEndpointExpired: false,
+    };
+
+    await db.createAccount(ACCOUNT);
+    const emailRecord = await db.emailRecord(ACCOUNT.email);
+    emailRecord.createdAt = Date.now();
+    const sessionToken = await db.createSessionToken(emailRecord, SESSION_TOKEN_UA);
+
+    deviceInfo.sessionTokenId = sessionToken.id;
+    const device = await db.createDevice(ACCOUNT.uid, deviceInfo);
+    expect(device.name).toBe(deviceInfo.name);
+    expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(device.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+    expect(device.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+
+    let devices = await db.devices(ACCOUNT.uid);
+
+    // First: unknown 400 level error — device push info should stay the same
+    jest.resetModules();
+    jest.doMock('web-push', () => ({
+      sendNotification() {
+        const err: any = new Error('Failed 429 level');
+        err.statusCode = 429;
+        return Promise.reject(err);
+      },
+    }));
+    const pushWithUnknown400 = require('../../lib/push')(
+      mockLog2, db, {}, mockStatsD
+    );
+    await pushWithUnknown400.sendPush(ACCOUNT.uid, devices, 'accountVerify');
+
+    devices = await db.devices(ACCOUNT.uid);
+    let d = devices[0];
+    expect(d.name).toBe(deviceInfo.name);
+    expect(d.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(d.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+    expect(d.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+    expect(d.pushEndpointExpired).toBe(deviceInfo.pushEndpointExpired);
+
+    // Second: known 400 error (410) — device endpoint should be marked expired
+    jest.resetModules();
+    jest.doMock('web-push', () => ({
+      sendNotification() {
+        const err: any = new Error('Failed 400 level');
+        err.statusCode = 410;
+        return Promise.reject(err);
+      },
+    }));
+    const pushWithKnown400 = require('../../lib/push')(
+      mockLog2, db, {}, mockStatsD
+    );
+    await pushWithKnown400.sendPush(ACCOUNT.uid, devices, 'accountVerify');
+
+    devices = await db.devices(ACCOUNT.uid);
+    d = devices[0];
+    expect(d.name).toBe(deviceInfo.name);
+    expect(d.pushEndpointExpired).toBe(true);
+  });
+});

--- a/packages/fxa-auth-server/test/remote/pushbox_db.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/pushbox_db.in.spec.ts
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import base64url from 'base64url';
+import sinon from 'sinon';
+import { StatsD } from 'hot-shots';
+
+import PushboxDB from '../../lib/pushbox/db';
+
+const sandbox = sinon.createSandbox();
+const config = require('../../config').default.getProperties();
+const statsd = {
+  increment: sandbox.stub(),
+  timing: sandbox.stub(),
+} as unknown as StatsD;
+const log = {
+  info: sandbox.stub(),
+  trace: sandbox.stub(),
+  warn: sandbox.stub(),
+  error: sandbox.stub(),
+  debug: sandbox.stub(),
+};
+
+const pushboxDb = new PushboxDB({
+  config: config.pushbox.database,
+  log,
+  statsd,
+});
+
+const data = base64url.encode(JSON.stringify({ wibble: 'quux' }));
+const r = {
+  uid: 'xyz',
+  deviceId: 'ff9000',
+  data,
+  ttl: 999999,
+};
+let insertIdx: number;
+
+describe('#integration - pushbox db', () => {
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('store', () => {
+    it('returns the inserted record', async () => {
+      const record = await pushboxDb.store(r);
+      expect(record.user_id).toBe(r.uid);
+      expect(record.device_id).toBe(r.deviceId);
+      expect(record.data.toString()).toBe(data);
+      expect(record.ttl).toBe(999999);
+
+      insertIdx = record.idx;
+    });
+  });
+
+  describe('retrieve', () => {
+    it('found no record', async () => {
+      const results = await pushboxDb.retrieve({
+        uid: 'nope',
+        deviceId: 'pdp-11',
+        limit: 10,
+      });
+      expect(results).toEqual({ last: true, index: 0, messages: [] });
+    });
+
+    it('fetches up to max index', async () => {
+      sandbox.stub(Date, 'now').returns(111111000);
+      const currentClientSideIdx = insertIdx;
+      const insertUpTo = insertIdx + 3;
+      while (insertIdx < insertUpTo) {
+        const record = await pushboxDb.store(r);
+        insertIdx = record.idx;
+      }
+      const result = await pushboxDb.retrieve({
+        uid: r.uid,
+        deviceId: r.deviceId,
+        limit: 10,
+        index: currentClientSideIdx,
+      });
+
+      expect(result.last).toBe(true);
+      expect(result.index).toBe(insertIdx);
+      result.messages.forEach((x: any) => {
+        expect(x.user_id).toBe(r.uid);
+        expect(x.device_id).toBe(r.deviceId);
+        expect(x.data.toString()).toBe(data);
+        expect(x.ttl).toBe(999999);
+      });
+    });
+
+    it('fetches up to less than max', async () => {
+      sandbox.stub(Date, 'now').returns(111111000);
+      const insertUpTo = insertIdx + 3;
+      while (insertIdx < insertUpTo) {
+        const record = await pushboxDb.store(r);
+        insertIdx = record.idx;
+      }
+      const result = await pushboxDb.retrieve({
+        uid: r.uid,
+        deviceId: r.deviceId,
+        limit: 2,
+        index: insertIdx - 3,
+      });
+
+      expect(result.last).toBe(false);
+      expect(result.index).toBe(insertIdx - 2);
+    });
+  });
+
+  describe('deleteDevice', () => {
+    it('deletes without error', async () => {
+      await pushboxDb.deleteDevice({ uid: r.uid, deviceId: r.deviceId });
+    });
+  });
+
+  describe('deleteAccount', () => {
+    it('deletes without error', async () => {
+      await pushboxDb.deleteAccount(r.uid);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/remote/session_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/session_tests.in.spec.ts
@@ -1,0 +1,342 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: {
+        skipForNewAccounts: { enabled: false },
+      },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote session',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    describe('destroy', () => {
+      it('deletes a valid session', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox, testOptions
+        );
+
+        await client.sessionStatus();
+        const sessionToken = client.sessionToken;
+        await client.destroySession();
+        expect(client.sessionToken).toBeNull();
+
+        client.sessionToken = sessionToken;
+        try {
+          await client.sessionStatus();
+          throw new Error('got status with destroyed session');
+        } catch (err: any) {
+          expect(err.errno).toBe(110);
+        }
+      });
+
+      it('deletes a different custom token', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+        const sessionTokenCreate = client.sessionToken;
+        const sessions = await client.api.sessions(sessionTokenCreate);
+        const tokenId = sessions[0].id;
+
+        const c = await client.login();
+        const sessionTokenLogin = c.sessionToken;
+
+        const status = await client.api.sessionStatus(sessionTokenCreate);
+        expect(status.uid).toBeTruthy();
+
+        await client.api.sessionDestroy(sessionTokenLogin, {
+          customSessionToken: tokenId,
+        });
+
+        try {
+          await client.api.sessionStatus(sessionTokenCreate);
+          throw new Error('got status with destroyed session');
+        } catch (err: any) {
+          expect(err.code).toBe(401);
+          expect(err.errno).toBe(110);
+        }
+      });
+
+      it('fails with a bad custom token', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.create(server.publicUrl, email, password, testOptions);
+
+        const sessionTokenCreate = client.sessionToken;
+        const c = await client.login();
+        const sessionTokenLogin = c.sessionToken;
+
+        await client.api.sessionStatus(sessionTokenCreate);
+
+        // In the original Mocha test, sessionDestroy may throw and the
+        // rejection propagates to the final .then(null, errHandler).
+        // With async/await we must catch errors from either call.
+        try {
+          await client.api.sessionDestroy(sessionTokenLogin, {
+            customSessionToken:
+              'eff779f59ab974f800625264145306ce53185bb22ee01fe80280964ff2766504',
+          });
+          await client.api.sessionStatus(sessionTokenCreate);
+          throw new Error('got status with destroyed session');
+        } catch (err: any) {
+          expect(err.code).toBe(401);
+          expect(err.errno).toBe(110);
+          expect(err.error).toBe('Unauthorized');
+          expect(err.message).toBe('The authentication token could not be found');
+        }
+      });
+    });
+
+    describe('duplicate', () => {
+      it('duplicates a valid session into a new, independent session', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client1 = await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox, testOptions
+        );
+
+        const client2 = await client1.duplicate();
+        expect(client1.sessionToken).not.toBe(client2.sessionToken);
+
+        await client1.api.sessionDestroy(client1.sessionToken);
+
+        try {
+          await client1.sessionStatus();
+          throw new Error('client1 session should have been destroyed');
+        } catch (err: any) {
+          expect(err.code).toBe(401);
+          expect(err.errno).toBe(110);
+        }
+
+        const status = await client2.sessionStatus();
+        expect(status).toBeTruthy();
+
+        await client2.api.sessionDestroy(client2.sessionToken);
+
+        try {
+          await client2.sessionStatus();
+          throw new Error('client2 session should have been destroyed');
+        } catch (err: any) {
+          expect(err.code).toBe(401);
+          expect(err.errno).toBe(110);
+        }
+      });
+
+      it('creates independent verification state for the new token', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client1 = await Client.create(server.publicUrl, email, password, testOptions);
+        const client2 = await client1.duplicate();
+
+        expect(client1.verified).toBeFalsy();
+        expect(client2.verified).toBeFalsy();
+
+        const code = await server.mailbox.waitForCode(email);
+        await client1.verifyEmail(code);
+
+        let status = await client1.sessionStatus();
+        expect(status.state).toBe('verified');
+
+        status = await client2.sessionStatus();
+        expect(status.state).toBe('unverified');
+
+        const client3 = await client2.duplicate();
+        await client2.requestVerifyEmail();
+        const code2 = await server.mailbox.waitForCode(email);
+        await client2.verifyEmail(code2);
+
+        status = await client2.sessionStatus();
+        expect(status.state).toBe('verified');
+
+        status = await client3.sessionStatus();
+        expect(status.state).toBeTruthy();
+      });
+    });
+
+    describe('reauth', () => {
+      it('allocates a new keyFetchToken', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox,
+          { ...testOptions, keys: true }
+        );
+
+        const keys = await client.keys();
+        const kA = keys.kA;
+        const kB = keys.kB;
+        expect(client.getState().keyFetchToken).toBeNull();
+
+        await client.reauth({ keys: true });
+        expect(client.getState().keyFetchToken).toBeTruthy();
+
+        const keys2 = await client.keys();
+        expect(keys2.kA).toBe(kA);
+        expect(keys2.kB).toBe(kB);
+        expect(client.getState().keyFetchToken).toBeNull();
+      });
+
+      it('rejects incorrect passwords', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox, testOptions
+        );
+
+        await client.setupCredentials(email, 'fiibar');
+        if (testOptions.version === 'V2') {
+          await client.setupCredentialsV2(email, 'fiibar');
+        }
+
+        try {
+          await client.reauth();
+          throw new Error('password should have been rejected');
+        } catch (err: any) {
+          expect(err.code).toBe(400);
+          expect(err.errno).toBe(103);
+        }
+      });
+
+      it('has sane account-verification behaviour', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.create(server.publicUrl, email, password, testOptions);
+        expect(client.verified).toBeFalsy();
+
+        // Clear the verification email, without verifying.
+        await server.mailbox.waitForCode(email);
+
+        await client.reauth();
+        let status = await client.sessionStatus();
+        expect(status.state).toBe('unverified');
+
+        // The reauth should have triggered a second email.
+        const code = await server.mailbox.waitForCode(email);
+        await client.verifyEmail(code);
+
+        status = await client.sessionStatus();
+        expect(status.state).toBe('verified');
+      });
+
+      it('has sane session-verification behaviour', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox,
+          { ...testOptions, keys: false }
+        );
+
+        const client = await Client.login(server.publicUrl, email, password, {
+          keys: false,
+          ...testOptions,
+        });
+
+        // Clears inbox of new signin email
+        await server.mailbox.waitForEmail(email);
+
+        let status = await client.sessionStatus();
+        expect(status.state).toBe('unverified');
+
+        let emailStatus = await client.emailStatus();
+        expect(emailStatus.verified).toBe(true);
+
+        await client.reauth({ keys: true });
+
+        status = await client.sessionStatus();
+        expect(status.state).toBe('unverified');
+
+        emailStatus = await client.emailStatus();
+        expect(emailStatus.verified).toBe(false);
+
+        // The reauth should have triggered a verification email.
+        const code = await server.mailbox.waitForCode(email);
+        await client.verifyEmail(code);
+
+        status = await client.sessionStatus();
+        expect(status.state).toBe('verified');
+
+        emailStatus = await client.emailStatus();
+        expect(emailStatus.verified).toBe(true);
+      });
+
+      it('does not send notification emails on verified sessions', async () => {
+        const email = server.uniqueEmail();
+        const password = 'foobar';
+        const client = await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox,
+          { ...testOptions, keys: true }
+        );
+
+        await client.reauth({ keys: true });
+
+        // Send some other type of email, and assert that it's the one we get back.
+        // If the above sent a "new login" notification, we would get that instead.
+        await client.forgotPassword();
+        const msg = await server.mailbox.waitForEmail(email);
+        expect(msg.headers['x-password-forgot-otp']).toBeTruthy();
+      });
+    });
+
+    describe('status', () => {
+      it('succeeds with valid token', async () => {
+        const email = server.uniqueEmail();
+        const password = 'testx';
+        const c = await Client.createAndVerify(
+          server.publicUrl, email, password, server.mailbox, testOptions
+        );
+        const uid = c.uid;
+        await c.login();
+        const x = await c.api.sessionStatus(c.sessionToken);
+
+        expect(x).toEqual({
+          state: 'unverified',
+          uid,
+          details: {
+            accountEmailVerified: true,
+            sessionVerificationMeetsMinimumAAL: true,
+            sessionVerificationMethod: null,
+            sessionVerified: false,
+            verified: false,
+          },
+        });
+      });
+
+      it('errors with invalid token', async () => {
+        const client = new Client(server.publicUrl, testOptions);
+        try {
+          await client.api.sessionStatus(
+            '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF'
+          );
+          throw new Error('should have failed');
+        } catch (err: any) {
+          expect(err.errno).toBe(110);
+        }
+      });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/sign_key_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/sign_key_tests.in.spec.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import path from 'path';
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+const superagent = require('superagent');
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      oldPublicKeyFile: path.resolve(__dirname, '../../config/public-key.json'),
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+describe('#integration - remote sign key', () => {
+  it('.well-known/browserid has keys', async () => {
+    const res = await superagent.get(
+      `${server.publicUrl}/.well-known/browserid`
+    );
+    expect(res.statusCode).toBe(200);
+    const json = res.body;
+    expect(json.authentication).toBe(
+      '/.well-known/browserid/nonexistent.html'
+    );
+    expect(json.keys.length).toBe(2);
+  });
+});

--- a/packages/fxa-auth-server/test/support/jest-global-teardown.ts
+++ b/packages/fxa-auth-server/test/support/jest-global-teardown.ts
@@ -7,6 +7,8 @@ import path from 'path';
 
 const AUTH_SERVER_ROOT = path.resolve(__dirname, '../..');
 const MAIL_HELPER_PID_FILE = path.join(AUTH_SERVER_ROOT, 'test', 'support', '.tmp', 'mail_helper.pid');
+const VERSION_JSON_PATH = path.join(AUTH_SERVER_ROOT, 'config', 'version.json');
+const VERSION_JSON_MARKER = path.join(AUTH_SERVER_ROOT, 'test', 'support', '.tmp', 'version_json_created');
 
 interface NodeError extends Error {
   code?: string;
@@ -38,5 +40,11 @@ export default async function globalTeardown(): Promise<void> {
     fs.unlinkSync(MAIL_HELPER_PID_FILE);
   } catch (err) {
     console.error('[Jest Global Teardown] Error:', err);
+  }
+
+  // Clean up version.json if we created it
+  if (fs.existsSync(VERSION_JSON_MARKER)) {
+    try { fs.unlinkSync(VERSION_JSON_PATH); } catch { /* ignore */ }
+    try { fs.unlinkSync(VERSION_JSON_MARKER); } catch { /* ignore */ }
   }
 }


### PR DESCRIPTION
Migrate all remote integration tests from Mocha (.js) to Jest (.in.spec.ts) format in fxa-auth-server/test/remote/. Adds test infrastructure including test-server helper, mailbox helper, profile-helper, global setup/teardown, and Jest integration config.

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
