### PR TITLE
fxa-12621: Migrate 14 Mocha integration tests to Jest

### DIFF
--- a/packages/fxa-auth-server/jest.config.js
+++ b/packages/fxa-auth-server/jest.config.js
@@ -26,6 +26,7 @@ module.exports = {
   },
   testTimeout: 10000,
   clearMocks: true,
+  workerIdleMemoryLimit: '512MB',
   setupFiles: ['<rootDir>/jest.setup.js', '<rootDir>/jest.setup-proxyquire.js'],
   testPathIgnorePatterns: ['/node_modules/'],
   // Coverage configuration (enabled via --coverage flag)

--- a/packages/fxa-auth-server/jest.integration.config.js
+++ b/packages/fxa-auth-server/jest.integration.config.js
@@ -20,6 +20,7 @@ module.exports = {
   ],
 
   testTimeout: 120000,
+  maxWorkers: 4,
 
   globalSetup: '<rootDir>/test/support/jest-global-setup.ts',
   globalTeardown: '<rootDir>/test/support/jest-global-teardown.ts',

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -45,7 +45,7 @@
     "test-unit": "VERIFIER_VERSION=0 TEST_TYPE=unit scripts/test-ci.sh",
     "test-integration": "VERIFIER_VERSION=0 TEST_TYPE=integration scripts/test-ci.sh",
     "test-integration-v2": "VERIFIER_VERSION=0 TEST_TYPE=integration-v2 scripts/test-ci.sh",
-    "test-integration-jest": "JEST_JUNIT_OUTPUT_DIR='../../artifacts/tests/fxa-auth-server' JEST_JUNIT_OUTPUT_NAME='jest-integration-results.xml' npx jest --config jest.integration.config.js --forceExit --ci --reporters=default --reporters=jest-junit",
+    "test-integration-jest": "VERIFIER_VERSION=0 TEST_TYPE=integration-jest scripts/test-ci.sh",
     "populate-firestore-customers": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/populate-firestore-customers.ts",
     "populate-vat-taxes": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/populate-vat-taxes.ts",
     "paypal-processor": "CONFIG_FILES='config/secrets.json' node -r esbuild-register ./scripts/paypal-processor.ts",

--- a/packages/fxa-auth-server/test/remote/account_create_with_code.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code.in.spec.ts
@@ -1,0 +1,217 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import * as otplib from 'otplib';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await getSharedTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account create with sign-up code',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    const password = '4L6prUdlLNfxGIoj';
+
+    it('create and verify sync account', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        service: 'sync',
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(false);
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.verifyShortCodeEmail(
+        emailData.headers['x-verify-short-code'],
+        { service: 'sync' }
+      );
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-link']).toContain(
+        (server.config as any).smtp.syncUrl
+      );
+
+      emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(true);
+    });
+
+    it('create and verify account', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.verifyShortCodeEmail(
+        emailData.headers['x-verify-short-code']
+      );
+
+      emailStatus = await client.emailStatus();
+      expect(emailStatus.verified).toBe(true);
+
+      // It's hard to test for "an email didn't arrive".
+      // Instead trigger sending of another email and test
+      // that there wasn't anything in the queue before it.
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      expect(code).toBeTruthy();
+    });
+
+    it('throws for expired code', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.requestVerifyEmail();
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verify');
+
+      const secret = emailData.headers['x-verify-code'];
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
+      futureAuthenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        (server.config as any).otp,
+        { secret, epoch: Date.now() / 1000 - 60 * 60 } // Code 60mins old
+      );
+      const expiredCode = futureAuthenticator.generate();
+
+      await expect(
+        client.verifyShortCodeEmail(expiredCode)
+      ).rejects.toMatchObject({ code: 400, errno: 183 });
+    });
+
+    it('throws for invalid code', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+      expect(client.authAt).toBeTruthy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      const invalidCode = String(Number(emailData.headers['x-verify-short-code']) + 1);
+
+      await expect(
+        client.verifyShortCodeEmail(invalidCode)
+      ).rejects.toMatchObject({ code: 400, errno: 183 });
+    });
+
+    it('create and resend authentication code', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      const originalMessageId = emailData['messageId'];
+      const originalCode = emailData.headers['x-verify-short-code'];
+
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.resendVerifyShortCodeEmail();
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+      expect(emailData['messageId']).not.toBe(originalMessageId);
+      expect(emailData.headers['x-verify-short-code']).toBe(originalCode);
+    });
+
+    it('should verify code from previous code window', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.requestVerifyEmail();
+      emailData = await server.mailbox.waitForEmail(email);
+
+      // Each code window is 10 minutes
+      const secret = emailData.headers['x-verify-code'];
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
+      futureAuthenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        (server.config as any).otp,
+        { secret, epoch: Date.now() / 1000 - 60 * 10 } // Code 10mins old
+      );
+
+      const previousWindowCode = futureAuthenticator.generate(secret);
+      const response = await client.verifyShortCodeEmail(previousWindowCode);
+      expect(response).toBeTruthy();
+    });
+
+    it('should not verify code from future code window', async () => {
+      const email = server.uniqueEmail();
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-otp',
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verifyShortCode');
+
+      await client.requestVerifyEmail();
+      emailData = await server.mailbox.waitForEmail(email);
+
+      // Each code window is 10 minutes
+      const secret = emailData.headers['x-verify-code'];
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
+      futureAuthenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        (server.config as any).otp,
+        { secret, epoch: Date.now() / 1000 + 60 * 30 } // Code 30mins in future
+      );
+
+      const futureWindowCode = futureAuthenticator.generate(secret);
+
+      await expect(
+        client.verifyShortCodeEmail(futureWindowCode)
+      ).rejects.toMatchObject({ code: 400, errno: 183 });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_destroy.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_destroy.in.spec.ts
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+import crypto from 'crypto';
+import { AppError } from '@fxa/accounts/errors';
+import * as otplib from 'otplib';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account destroy',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('can delete account by providing short code', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      await client.resendVerifyShortCodeEmail();
+      const code = await server.mailbox.waitForEmailByHeader(email, 'x-verify-short-code');
+      await client.verifyShortCodeEmail(code);
+
+      // Should not throw
+      await client.destroyAccount();
+    });
+
+    it('can delete account by providing verify code', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      // Consume the account creation verification email
+      await server.mailbox.waitForEmail(email);
+
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      // Get the login verification email and verify the session
+      const emailResult = await server.mailbox.waitForEmail(email);
+      const code = emailResult.headers['x-verify-code'];
+      await client.verifyEmail(code);
+
+      // Should not throw
+      await client.destroyAccount();
+    });
+
+    it('cannot delete account with invalid authPW', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      const c = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      c.authPW = Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      );
+      c.authPWVersion2 = Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      );
+
+      try {
+        await c.destroyAccount();
+        fail('should not be able to destroy account with invalid password');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(103);
+      }
+    });
+
+    it('cannot delete account without verifying TOTP', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+
+      await Client.createAndVerifyAndTOTP(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+
+      // Create a new unverified session
+      const client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      const res = await client.emailStatus();
+      expect(res.sessionVerified).toBe(false);
+
+      try {
+        await client.destroyAccount();
+        fail('Should not be able to destroy account without verifying totp');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(
+          AppError.ERRNO.INSUFFICIENT_AAL
+        );
+      }
+    });
+
+    it('cannot delete account with TOTP by supplying email otp code', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      let client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+
+      await client.resendVerifyShortCodeEmail();
+      const code = await server.mailbox.waitForEmailByHeader(email, 'x-verify-short-code');
+      await client.verifyShortCodeEmail(code);
+
+      // Add totp to account.
+      client.totpAuthenticator = new otplib.authenticator.Authenticator();
+      const totpTokenResult = await client.createTotpToken();
+      expect(totpTokenResult).toBeDefined();
+      client.totpAuthenticator.options = {
+        secret: totpTokenResult.secret,
+        crypto: crypto,
+      };
+      const totpCode = client.totpAuthenticator.generate();
+      await client.verifyTotpSetupCode(totpCode);
+      await client.completeTotpSetup();
+
+      // Log in again. This creates a new unverified session
+      client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      const res = await client.emailStatus();
+      expect(res.sessionVerified).toBe(false);
+
+      // Try verifying the session with a short code. This should
+      // not be enough to bypass 2FA.
+      await client.verifyShortCodeEmail(code);
+      expect((await client.emailStatus()).sessionVerified).toBe(true);
+
+      // Destroying the account should not work. Despite the session being 'verified',
+      // totp has not been provided.
+      try {
+        await client.destroyAccount();
+        fail('Should not be able to destroy account without verifying totp');
+      } catch (error: unknown) {
+        expect((error as AuthServerError).errno).toBe(
+          AppError.ERRNO.INSUFFICIENT_AAL
+        );
+      }
+    });
+
+    it('cannot delete without verifying session', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      // Login again requiring email-2fa for session verification.
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+      });
+
+      try {
+        await client.destroyAccount();
+        fail('Should not be able allowed to destroy account.');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).message).toBe('Unconfirmed session');
+      }
+    });
+
+    it('cannot delete without verifying account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        verificationMethod: 'email-2fa',
+        keys: true,
+      });
+      const client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      try {
+        await client.destroyAccount();
+        fail('Should not be able allowed to destroy account.');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).message).toBe('Unconfirmed session');
+      }
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_locale.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_locale.in.spec.ts
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      redis: { sessionTokens: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account locale',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('a really long (invalid) locale', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        lang: Buffer.alloc(128).toString('hex'),
+      });
+      const response = await client.api.accountStatus(
+        client.uid,
+        client.sessionToken
+      );
+      expect(response.locale).toBeFalsy();
+    });
+
+    it('a really long (valid) locale', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ilikepancakes';
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        lang: `en-US,en;q=0.8,${Buffer.alloc(128).toString('hex')}`,
+      });
+      const response = await client.api.accountStatus(
+        client.uid,
+        client.sessionToken
+      );
+      expect(response.locale).toBe('en-US,en;q=0.8');
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_login.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_login.in.spec.ts
@@ -1,0 +1,353 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+import crypto from 'crypto';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      securityHistory: { ipProfiling: { allowedRecency: 0 } },
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account login',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('the email is returned in the error on Incorrect password errors', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(
+          server.publicUrl,
+          email,
+          `${password}x`,
+          testOptions
+        );
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).code).toBe(400);
+        expect((err as AuthServerError).errno).toBe(103);
+        expect((err as AuthServerError).email).toBe(email);
+      }
+    });
+
+    it('the email is returned in the error on Incorrect email case errors with correct password', async () => {
+      if (version === 'V2') {
+        // V2 passwords do not use the user's email as salt,
+        // and therefore are not affected by this edge case.
+        return;
+      }
+
+      const signupEmail = server.uniqueEmail();
+      const loginEmail = signupEmail.toUpperCase();
+      const password = 'abcdef';
+      await Client.createAndVerify(
+        server.publicUrl,
+        signupEmail,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(
+          server.publicUrl,
+          loginEmail,
+          password,
+          testOptions
+        );
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).code).toBe(400);
+        expect((err as AuthServerError).errno).toBe(120);
+        expect((err as AuthServerError).email).toBe(signupEmail);
+      }
+    });
+
+    it('Unknown account should not exist', async () => {
+      const client = new Client(server.publicUrl, testOptions);
+      client.email = server.uniqueEmail();
+      client.authPW = crypto.randomBytes(32);
+      client.authPWVersion2 = crypto.randomBytes(32);
+
+      try {
+        await client.login();
+        fail('account should not exist');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(102);
+      }
+    });
+
+    it('No keyFetchToken without keys=true', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      const c = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: false,
+      });
+      expect(c.keyFetchToken).toBeNull();
+    });
+
+    it('login works with unicode email address', async () => {
+      const email = server.uniqueUnicodeEmail();
+      const password = 'wibble';
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      const client = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+      expect(client).toBeTruthy();
+    });
+
+    it('account login works with minimal metricsContext metadata', async () => {
+      const email = server.uniqueEmail();
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        'foo',
+        server.mailbox,
+        testOptions
+      );
+
+      const client = await Client.login(server.publicUrl, email, 'foo', {
+        ...testOptions,
+        metricsContext: {
+          flowId:
+            '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          flowBeginTime: Date.now(),
+        },
+      });
+      expect(client).toBeTruthy();
+    });
+
+    it('account login fails with invalid metricsContext flowId', async () => {
+      const email = server.uniqueEmail();
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        'foo',
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0',
+            flowBeginTime: Date.now(),
+          },
+        });
+        fail('account login should have failed');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(107);
+      }
+    });
+
+    it('account login fails with invalid metricsContext flowBeginTime', async () => {
+      const email = server.uniqueEmail();
+      await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        'foo',
+        server.mailbox,
+        testOptions
+      );
+
+      try {
+        await Client.login(server.publicUrl, email, 'foo', {
+          ...testOptions,
+          metricsContext: {
+            flowId:
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+            flowBeginTime: 'wibble',
+          },
+        });
+        fail('account login should have failed');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(107);
+      }
+    });
+
+    describe('can use verificationMethod', () => {
+      let email: string;
+      const password = 'foo';
+
+      beforeEach(async () => {
+        email = server.uniqueEmail('@mozilla.com');
+        await Client.createAndVerify(
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          testOptions
+        );
+      });
+
+      it('fails with invalid verification method', async () => {
+        try {
+          await Client.login(server.publicUrl, email, password, {
+            ...testOptions,
+            verificationMethod: 'notvalid',
+            keys: true,
+          });
+          fail('should not have succeeded');
+        } catch (err: unknown) {
+          expect((err as AuthServerError).errno).toBe(107);
+        }
+      });
+
+      it('can use `email` verification', async () => {
+        const client = await Client.login(
+          server.publicUrl,
+          email,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'email',
+            keys: true,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('email');
+
+        let status = await client.emailStatus();
+        expect(status.verified).toBe(false);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+
+        const emailData = await server.mailbox.waitForEmail(email);
+        expect(emailData.headers['x-template-name']).toBe('verifyLogin');
+        const code = emailData.headers['x-verify-code'];
+        expect(code).toBeTruthy();
+
+        await client.verifyEmail(code);
+
+        status = await client.emailStatus();
+        expect(status.verified).toBe(true);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(true);
+      });
+
+      it('can use `email-2fa` verification', async () => {
+        const client = await Client.login(
+          server.publicUrl,
+          email,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'email-2fa',
+            keys: true,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('email-2fa');
+
+        const status = await client.emailStatus();
+        expect(status.verified).toBe(false);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+
+        const emailData = await server.mailbox.waitForEmail(email);
+        expect(emailData.headers['x-template-name']).toBe('verifyLoginCode');
+        const code = emailData.headers['x-signin-verify-code'];
+        expect(code).toBeTruthy();
+      });
+
+      it('can use `totp-2fa` verification', async () => {
+        const totpEmail = server.uniqueEmail();
+        await Client.createAndVerifyAndTOTP(
+          server.publicUrl,
+          totpEmail,
+          password,
+          server.mailbox,
+          { ...testOptions, keys: true }
+        );
+
+        const client = await Client.login(
+          server.publicUrl,
+          totpEmail,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'totp-2fa',
+            keys: true,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('totp-2fa');
+
+        const status = await client.emailStatus();
+        expect(status.verified).toBe(false);
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+      });
+
+      it('should include verificationMethod if session is unverified', async () => {
+        const client = await Client.login(
+          server.publicUrl,
+          email,
+          password,
+          {
+            ...testOptions,
+            verificationMethod: 'email',
+            keys: false,
+          }
+        );
+
+        expect(client.verificationMethod).toBe('email');
+
+        const status = await client.emailStatus();
+        expect(status.emailVerified).toBe(true);
+        expect(status.sessionVerified).toBe(false);
+      });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_profile.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_profile.in.spec.ts
@@ -1,0 +1,249 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+let CLIENT_ID: string;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      subscriptions: { enabled: false },
+    },
+  });
+  const config = server.config as any;
+  CLIENT_ID = config.oauthServer.clients.find(
+    (c: any) => c.trusted && c.canGrant && c.publicClient
+  ).id;
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - fetch user profile data',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    describe('when a request is authenticated with a session token', () => {
+      let client: any;
+
+      beforeEach(async () => {
+        client = await Client.create(
+          server.publicUrl,
+          server.uniqueEmail(),
+          'password',
+          { ...testOptions, lang: 'en-US' }
+        );
+      });
+
+      it('returns the profile data', async () => {
+        const response = await client.accountProfile();
+
+        expect(response.email).toBeTruthy();
+        expect(response.locale).toBe('en-US');
+        expect(response.authenticationMethods).toEqual(['pwd', 'email']);
+        expect(response.authenticatorAssuranceLevel).toBe(1);
+        expect(response.profileChangedAt).toBeTruthy();
+      });
+    });
+
+    describe('when a request is authenticated with a valid oauth token', () => {
+      let client: any;
+      let token: string;
+
+      async function initialize(scope: string) {
+        const email = server.uniqueEmail();
+        const password = 'test password';
+        client = await Client.createAndVerify(
+          server.publicUrl,
+          email,
+          password,
+          server.mailbox,
+          { ...testOptions, lang: 'en-US' }
+        );
+
+        const tokenResponse =
+          await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: CLIENT_ID,
+            access_type: 'offline',
+            scope: scope,
+          });
+
+        token = tokenResponse.access_token;
+      }
+
+      it('returns the profile data', async () => {
+        await initialize('profile');
+        const response = await client.accountProfile(token);
+
+        expect(response.email).toBeTruthy();
+        expect(response.locale).toBe('en-US');
+        expect(response.authenticationMethods).toEqual(['pwd', 'email']);
+        expect(response.authenticatorAssuranceLevel).toBe(1);
+        expect(response.profileChangedAt).toBeTruthy();
+      });
+
+      describe('scopes are applied to profile data returned', () => {
+        describe('scope does not authorize profile data', () => {
+          it('returns no profile data', async () => {
+            await initialize('preadinglist payments');
+            const response = await client.accountProfile(token);
+
+            expect(response).toEqual({});
+          });
+        });
+
+        describe('limited oauth scopes for profile data', () => {
+          it('returns only email for email only token', async () => {
+            await initialize('profile:email');
+            const response = await client.accountProfile(token);
+
+            expect(response.email).toBeTruthy();
+            expect(response.locale).toBeFalsy();
+            expect(response.profileChangedAt).toBeTruthy();
+          });
+
+          it('returns only locale for locale only token', async () => {
+            await initialize('profile:locale');
+            const response = await client.accountProfile(token);
+            expect(response.email).toBeFalsy();
+            expect(response.locale).toBe('en-US');
+            expect(response.profileChangedAt).toBeTruthy();
+          });
+        });
+
+        describe('profile authenticated with :write scopes', () => {
+          describe('profile:write', () => {
+            it('returns profile data', async () => {
+              await initialize('profile:write');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeTruthy();
+              expect(response.locale).toBeTruthy();
+              expect(response.authenticationMethods).toBeTruthy();
+              expect(response.authenticatorAssuranceLevel).toBeTruthy();
+              expect(response.profileChangedAt).toBeTruthy();
+            });
+          });
+
+          describe('profile:locale:write readinglist', () => {
+            it('returns limited profile data', async () => {
+              await initialize('profile:locale:write readinglist');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeFalsy();
+              expect(response.locale).toBeTruthy();
+              expect(response.authenticationMethods).toBeFalsy();
+              expect(response.authenticatorAssuranceLevel).toBeFalsy();
+            });
+          });
+
+          describe('profile:email:write storage', () => {
+            it('returns limited profile data', async () => {
+              await initialize('profile:email:write storage');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeTruthy();
+              expect(response.locale).toBeFalsy();
+              expect(response.authenticationMethods).toBeFalsy();
+              expect(response.authenticatorAssuranceLevel).toBeFalsy();
+            });
+          });
+
+          describe('profile:email:write profile:amr', () => {
+            it('returns limited profile data', async () => {
+              await initialize('profile:email:write profile:amr');
+              const response = await client.accountProfile(token);
+
+              expect(response.email).toBeTruthy();
+              expect(response.locale).toBeFalsy();
+              expect(response.authenticationMethods).toBeTruthy();
+              expect(response.authenticatorAssuranceLevel).toBeTruthy();
+            });
+          });
+        });
+      });
+    });
+
+    describe('when the profile data is not default', () => {
+      describe('when the email address is unicode', () => {
+        it('returns the email address correctly with the profile data', async () => {
+          const email = server.uniqueUnicodeEmail();
+          const client = await Client.create(
+            server.publicUrl,
+            email,
+            'password',
+            testOptions
+          );
+          const response = await client.accountProfile();
+          expect(response.email).toBe(email);
+        });
+      });
+
+      describe('when the account has TOTP', () => {
+        it('returns correct TOTP status in profile data', async () => {
+          const client = await Client.createAndVerifyAndTOTP(
+            server.publicUrl,
+            server.uniqueEmail(),
+            'password',
+            server.mailbox,
+            { ...testOptions, lang: 'en-US' }
+          );
+
+          const res = await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: CLIENT_ID,
+            access_type: 'offline',
+            scope: 'profile',
+          });
+
+          const response = await client.accountProfile(res.access_token);
+          expect(response.email).toBeTruthy();
+          expect(response.locale).toBe('en-US');
+          expect(response.authenticationMethods).toEqual([
+            'pwd',
+            'email',
+            'otp',
+          ]);
+          expect(response.authenticatorAssuranceLevel).toBe(2);
+        });
+      });
+
+      describe('when the locale is empty', () => {
+        it('returns the profile data successfully', async () => {
+          const email = server.uniqueEmail();
+          const password = 'test password';
+          const client = await Client.createAndVerify(
+            server.publicUrl,
+            email,
+            password,
+            server.mailbox,
+            testOptions
+          );
+
+          const res = await client.grantOAuthTokensFromSessionToken({
+            grant_type: 'fxa-credentials',
+            client_id: CLIENT_ID,
+            scope: 'profile:locale',
+          });
+
+          const response = await client.accountProfile(res.access_token);
+          expect(response.locale).toBeUndefined();
+        });
+      });
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_reset.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_reset.in.spec.ts
@@ -1,0 +1,235 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: { skipForNewAccounts: { enabled: true } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+async function resetPassword(
+  client: any,
+  otpCode: string,
+  newPassword: string,
+  options?: any
+) {
+  const result = await client.verifyPasswordForgotOtp(otpCode);
+  await client.verifyPasswordResetCode(result.code);
+  return await client.resetPassword(newPassword, {}, options);
+}
+
+describe.each(testVersions)(
+  '#integration$tag - remote account reset',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('account reset w/o sessionToken', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      let client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+      const keys1 = await client.keys();
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      const response = await resetPassword(client, code, newPassword, {
+        sessionToken: false,
+      });
+      expect(response.sessionToken).toBeFalsy();
+      expect(response.keyFetchToken).toBeFalsy();
+      expect(response.verified).toBeFalsy();
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const link = emailData.headers['x-link'];
+      const query = Object.fromEntries(new URL(link).searchParams);
+      expect(query.email).toBeTruthy();
+
+      if (testOptions.version === 'V2') {
+        const newClient = await Client.login(
+          server.publicUrl,
+          email,
+          newPassword,
+          { version: '', keys: true }
+        );
+        await newClient.upgradeCredentials(newPassword);
+      }
+
+      client = await Client.login(server.publicUrl, email, newPassword, {
+        ...testOptions,
+        keys: true,
+      });
+      const keys2 = await client.keys();
+      expect(keys1.wrapKb).not.toBe(keys2.wrapKb);
+      expect(keys1.kA).toBe(keys2.kA);
+      expect(typeof client.getState().kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+
+    it('account reset with keys', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      let client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+      const keys1 = await client.keys();
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      const response = await resetPassword(client, code, newPassword, {
+        keys: true,
+      });
+      expect(response.sessionToken).toBeTruthy();
+      expect(response.keyFetchToken).toBeTruthy();
+      expect(response.emailVerified).toBe(true);
+      expect(response.sessionVerified).toBe(true);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const link = emailData.headers['x-link'];
+      const query = Object.fromEntries(new URL(link).searchParams);
+      expect(query.email).toBeTruthy();
+
+      if (testOptions.version === 'V2') {
+        const newClient = await Client.login(
+          server.publicUrl,
+          email,
+          newPassword,
+          { version: '', keys: true }
+        );
+        const status = await newClient.getCredentialsStatus(email);
+        expect(status.upgradeNeeded).toBeTruthy();
+        await newClient.upgradeCredentials(newPassword);
+      }
+
+      client = await Client.login(server.publicUrl, email, newPassword, {
+        ...testOptions,
+        keys: true,
+      });
+      const keys2 = await client.keys();
+      expect(keys1.wrapKb).not.toBe(keys2.wrapKb);
+      expect(keys1.kA).toBe(keys2.kA);
+      expect(typeof client.getState().kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+
+    it('account reset w/o keys, with sessionToken', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      const response = await resetPassword(client, code, newPassword);
+      expect(response.sessionToken).toBeTruthy();
+      expect(response.keyFetchToken).toBeFalsy();
+      expect(response.emailVerified).toBe(true);
+      expect(response.sessionVerified).toBe(true);
+    });
+
+    it('account reset deletes tokens', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+      const options = { ...testOptions, keys: true };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        options
+      );
+
+      await client.forgotPassword();
+      const originalCode = await server.mailbox.waitForCode(email);
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await expect(client.resetPassword(newPassword)).rejects.toBeDefined();
+      await resetPassword(client, code, newPassword, undefined);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const templateName = emailData.headers['x-template-name'];
+      expect(templateName).toBe('passwordReset');
+
+      try {
+        await resetPassword(client, originalCode, newPassword, undefined);
+        fail('Should not have succeeded password reset');
+      } catch (err: unknown) {
+        const error = err as AuthServerError;
+        expect(error.code).toBe(400);
+        expect(error.errno).toBe(105);
+      }
+    });
+
+    it('account reset updates keysChangedAt', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const newPassword = 'ez';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+
+      const profileBefore = await client.accountProfile();
+
+      await client.forgotPassword();
+      const code = await server.mailbox.waitForCode(email);
+      await resetPassword(client, code, newPassword);
+      await server.mailbox.waitForEmail(email);
+
+      const profileAfter = await client.accountProfile();
+
+      expect(profileBefore['keysChangedAt']).toBeLessThan(
+        profileAfter['keysChangedAt']
+      );
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_signin_verification.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification.in.spec.ts
@@ -1,0 +1,363 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { generateMetricsContext, AuthServerError } from '../support/helpers/test-utils';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      redis: { sessionTokens: { enabled: false } },
+      securityHistory: { ipProfiling: { allowedRecency: 0 } },
+      signinConfirmation: { skipForNewAccounts: { enabled: false } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account signin verification',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('account signin with keys does set challenge', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+      expect(client.authAt).toBeTruthy();
+
+      const status = await client.emailStatus();
+      expect(status.emailVerified).toBe(true);
+
+      const response = await client.login({ keys: true });
+      expect(response.verificationMethod).toBe('email');
+      expect(response.verificationReason).toBe('login');
+      expect(response.sessionVerified).toBe(false);
+    });
+
+    it('account can verify new sign-in from email', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+      const loginOpts = {
+        keys: true,
+        metricsContext: generateMetricsContext(),
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        testOptions
+      );
+      expect(client.authAt).toBeTruthy();
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+
+      const response = await client.login(loginOpts);
+      expect(response.verificationMethod).toBe('email');
+      expect(response.verificationReason).toBe('login');
+      expect(response.sessionVerified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const uid = emailData.headers['x-uid'];
+      const code = emailData.headers['x-verify-code'];
+      expect(emailData.subject).toBe('Confirm sign-in');
+      expect(uid).toBeTruthy();
+      expect(code).toBeTruthy();
+      expect(emailData.headers['x-flow-begin-time']).toBe(
+        String(loginOpts.metricsContext.flowBeginTime)
+      );
+      expect(emailData.headers['x-flow-id']).toBe(
+        loginOpts.metricsContext.flowId
+      );
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+
+      await client.verifyEmail(code);
+
+      status = await client.emailStatus();
+      expect(status.emailVerified).toBe(true);
+      expect(status.verificationMethod).toBeFalsy();
+      expect(status.verificationReason).toBeFalsy();
+    });
+
+    it('Account verification links still work after session verification', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(
+        server.publicUrl,
+        email,
+        password,
+        testOptions
+      );
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.subject).toBe('Finish creating your account');
+      const emailCode = emailData.headers['x-verify-code'];
+      expect(emailCode).toBeTruthy();
+
+      await client.verifyEmail(emailCode);
+
+      await client.login({ keys: true });
+
+      emailData = await server.mailbox.waitForEmail(email);
+      const tokenCode = emailData.headers['x-verify-code'];
+      expect(emailData.subject).toBe('Confirm sign-in');
+      expect(emailData.headers['x-uid']).toBeTruthy();
+      expect(tokenCode).toBeTruthy();
+      expect(tokenCode).not.toBe(emailCode);
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.sessionVerified).toBe(false);
+
+      // Attempt to verify account reusing original email code
+      await client.verifyEmail(emailCode);
+    });
+
+    it('sign-in verification email link', async () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      const config = server.config as any;
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}`,
+        service: 'sync',
+        resume: 'resumeToken',
+        keys: true,
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        options
+      );
+
+      await client.login(options);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const link = emailData.headers['x-link'];
+      const query = new URL(link).searchParams;
+      expect(query.get('uid')).toBeTruthy();
+      expect(query.get('code')).toBeTruthy();
+      expect(query.get('service')).toBe(options.service);
+      expect(query.get('resume')).toBe(options.resume);
+      expect(emailData.subject).toBe('Confirm sign-in');
+    });
+
+    it('sign-in verification from different client', async () => {
+      const email = server.uniqueEmail();
+      const password = 'something';
+      const config = server.config as any;
+      const options = {
+        ...testOptions,
+        redirectTo: `https://sync.${config.smtp.redirectDomain}`,
+        service: 'sync',
+        resume: 'resumeToken',
+        keys: true,
+      };
+
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        options
+      );
+
+      await client.login(options);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      const link = emailData.headers['x-link'];
+      const query = new URL(link).searchParams;
+      expect(query.get('uid')).toBeTruthy();
+      expect(query.get('code')).toBeTruthy();
+      expect(query.get('service')).toBe(options.service);
+      expect(query.get('resume')).toBe(options.resume);
+      expect(emailData.subject).toBe('Confirm sign-in');
+
+      // Attempt to login from new location
+      const client2 = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        options
+      );
+
+      // Clears inbox of new signin email
+      await server.mailbox.waitForEmail(email);
+
+      await client2.login(options);
+
+      const code = await server.mailbox.waitForCode(email);
+
+      // Verify account from client2
+      await client2.verifyEmail(code, options);
+
+      let status = await client2.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(false);
+    });
+
+    it('account keys, return keys on verified account', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      const client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: true,
+      });
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.emailVerified).toBe(false);
+      expect(status.sessionVerified).toBe(false);
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.subject).toBe('Finish creating your account');
+      const tokenCode = emailData.headers['x-verify-code'];
+      expect(tokenCode).toBeTruthy();
+
+      // Unverified accounts can not retrieve keys
+      try {
+        await client.keys();
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(104);
+        expect((err as AuthServerError).code).toBe(400);
+        expect((err as AuthServerError).message).toBe('Unconfirmed account');
+      }
+
+      // Verify the account
+      await client.verifyEmail(tokenCode);
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      // Once verified, keys can be returned
+      const keys = await client.keys();
+      expect(keys.kA).toBeTruthy();
+      expect(keys.kB).toBeTruthy();
+      expect(keys.wrapKb).toBeTruthy();
+    });
+
+    it('account keys, return keys on verified login', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      let client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+
+      // Trigger confirm sign-in
+      client = await client.login({ keys: true });
+
+      const emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.subject).toBe('Confirm sign-in');
+      const tokenCode = emailData.headers['x-verify-code'];
+      expect(tokenCode).toBeTruthy();
+
+      // Because of unverified sign-in, requests for keys will fail
+      try {
+        await client.keys();
+        fail('should have thrown');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(104);
+        expect((err as AuthServerError).code).toBe(400);
+        expect((err as AuthServerError).message).toBe('Unconfirmed account');
+      }
+
+      let status = await client.emailStatus();
+      expect(status.verified).toBe(false);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(false);
+
+      // Verify the sign-in
+      await client.verifyEmail(tokenCode);
+
+      status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      // Can retrieve keys now that account tokens verified
+      const keys = await client.keys();
+      expect(keys.kA).toBeTruthy();
+      expect(keys.kB).toBeTruthy();
+      expect(keys.wrapKb).toBeTruthy();
+    });
+
+    it('unverified account is verified on sign-in confirmation', async () => {
+      const email = server.uniqueEmail();
+      const password = 'allyourbasearebelongtous';
+
+      let client = await Client.create(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: true,
+      });
+
+      let emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verify');
+      const tokenCode = emailData.headers['x-verify-code'];
+      expect(tokenCode).toBeTruthy();
+
+      client = await client.login({ keys: true });
+
+      emailData = await server.mailbox.waitForEmail(email);
+      expect(emailData.headers['x-template-name']).toBe('verify');
+      const signinToken = emailData.headers['x-verify-code'];
+      expect(tokenCode).not.toBe(signinToken);
+
+      await client.verifyEmail(signinToken);
+
+      const status = await client.emailStatus();
+      expect(status.verified).toBe(true);
+      expect(status.emailVerified).toBe(true);
+      expect(status.sessionVerified).toBe(true);
+
+      // Can retrieve keys now that account tokens verified
+      const keys = await client.keys();
+      expect(keys.kA).toBeTruthy();
+      expect(keys.kB).toBeTruthy();
+      expect(keys.wrapKb).toBeTruthy();
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_status.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_status.in.spec.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await getSharedTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account status',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('account status with existing account', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      const response = await c.api.accountStatus(c.uid);
+      expect(response.exists).toBeTruthy();
+    });
+
+    it('account status includes locale when authenticated', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        { ...testOptions, lang: 'en-US' }
+      );
+      const response = await c.api.accountStatus(c.uid, c.sessionToken);
+      expect(response.locale).toBe('en-US');
+    });
+
+    it('account status does not include locale when unauthenticated', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        { ...testOptions, lang: 'en-US' }
+      );
+      const response = await c.api.accountStatus(c.uid);
+      expect(response.locale).toBeFalsy();
+    });
+
+    it('account status unauthenticated with no uid returns an error', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        { ...testOptions, lang: 'en-US' }
+      );
+      try {
+        await c.api.accountStatus();
+        fail('should get an error');
+      } catch (e: unknown) {
+        const err = e as AuthServerError;
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(108);
+      }
+    });
+
+    it('account status with non-existing account', async () => {
+      const api = new Client.Api(server.publicUrl, testOptions);
+      const response = await api.accountStatus(
+        '0123456789ABCDEF0123456789ABCDEF'
+      );
+      expect(response.exists).toBeFalsy();
+    });
+
+    it('account status by email with existing account', async () => {
+      const email = server.uniqueEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      const response = await c.api.accountStatusByEmail(email);
+      expect(response.exists).toBeTruthy();
+    });
+
+    it('account status by email with non-existing account', async () => {
+      const email = server.uniqueEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      const nonExistEmail = server.uniqueEmail();
+      const response = await c.api.accountStatusByEmail(nonExistEmail);
+      expect(response.exists).toBeFalsy();
+    });
+
+    it('account status by email with an invalid email', async () => {
+      const email = server.uniqueEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      try {
+        await c.api.accountStatusByEmail('notAnEmail');
+        fail('should not have successful request');
+      } catch (e: unknown) {
+        const err = e as AuthServerError;
+        expect(err.code).toBe(400);
+        expect(err.errno).toBe(107);
+        expect(err.message).toBe('Invalid parameter in request body');
+      }
+    });
+
+    it('account status by email works with unicode email address', async () => {
+      const email = server.uniqueUnicodeEmail();
+      const c = await Client.create(
+        server.publicUrl,
+        email,
+        'password',
+        testOptions
+      );
+      const response = await c.api.accountStatusByEmail(email);
+      expect(response.exists).toBeTruthy();
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/account_unlock.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/account_unlock.in.spec.ts
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await getSharedTestServer();
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote account unlock',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('/account/lock is no longer supported', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      try {
+        await c.lockAccount();
+        fail('should get an error');
+      } catch (e: unknown) {
+        expect((e as AuthServerError).code).toBe(410);
+      }
+    });
+
+    it('/account/unlock/resend_code is no longer supported', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      try {
+        await c.resendAccountUnlockCode('en');
+        fail('should get an error');
+      } catch (e: unknown) {
+        expect((e as AuthServerError).code).toBe(410);
+      }
+    });
+
+    it('/account/unlock/verify_code is no longer supported', async () => {
+      const c = await Client.create(
+        server.publicUrl,
+        server.uniqueEmail(),
+        'password',
+        testOptions
+      );
+      try {
+        await c.verifyAccountUnlockCode('bigscaryuid', 'bigscarycode');
+        fail('should get an error');
+      } catch (e: unknown) {
+        expect((e as AuthServerError).code).toBe(410);
+      }
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/base_path.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/base_path.in.spec.ts
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import pkg from '../../package.json';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+let serverPort: number;
+
+beforeAll(async () => {
+  server = await getSharedTestServer();
+  const url = new URL(server.publicUrl);
+  serverPort = parseInt(url.port, 10);
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote base path',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('base path account creation', async () => {
+      const email = server.uniqueEmail();
+      const password = 'ok';
+      // if this doesn't crash, we're all good
+      await Client.create(server.publicUrl, email, password, testOptions);
+    });
+
+    it('.well-known did not move', async () => {
+      const res = await fetch(
+        `http://localhost:${serverPort}/.well-known/browserid`
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.authentication).toBe(
+        '/.well-known/browserid/nonexistent.html'
+      );
+    });
+
+    it('"/" returns valid version information', async () => {
+      const res = await fetch(`http://localhost:${serverPort}/`);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(Object.keys(json).sort()).toEqual(['commit', 'source', 'version']);
+      expect(json.version).toBe(pkg.version);
+      expect(json.source).toBeTruthy();
+      expect(json.source).not.toBe('unknown');
+      expect(json.commit).toMatch(/^[0-9a-f]{40}$/);
+    });
+
+    it('"/__version__" returns valid version information', async () => {
+      const res = await fetch(`http://localhost:${serverPort}/__version__`);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(Object.keys(json).sort()).toEqual(['commit', 'source', 'version']);
+      expect(json.version).toBe(pkg.version);
+      expect(json.source).toBeTruthy();
+      expect(json.source).not.toBe('unknown');
+      expect(json.commit).toMatch(/^[0-9a-f]{40}$/);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/concurrent.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/concurrent.in.spec.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      verifierVersion: 1,
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote concurrent',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('concurrent create requests', async () => {
+      const email = server.uniqueEmail();
+      const password = 'abcdef';
+      // Two concurrent creates: either one fails with a duplicate error
+      // or both succeed (re-signup of an unverified account is valid).
+      const r1 = Client.create(server.publicUrl, email, password, testOptions);
+      const r2 = Client.create(server.publicUrl, email, password, testOptions);
+      const results = await Promise.allSettled([r1, r2]);
+      const fulfilled = results.filter((p) => p.status === 'fulfilled');
+      const rejected = results.filter((p) => p.status === 'rejected');
+      expect(fulfilled.length).toBeGreaterThanOrEqual(1);
+      expect(rejected.length).toBeLessThanOrEqual(1);
+      await server.mailbox.waitForEmail(email);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/db.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/db.in.spec.ts
@@ -1,0 +1,924 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import base64url from 'base64url';
+import crypto from 'crypto';
+import { normalizeEmail } from 'fxa-shared/email/helpers';
+import IORedis from 'ioredis';
+import sinon from 'sinon';
+import * as uuid from 'uuid';
+
+import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const config = require('../../config').default.getProperties();
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const UnblockCode = require('../../lib/crypto/random').base32(
+  config.signinUnblock.codeLength
+);
+
+const log = { debug() {}, trace() {}, info() {}, error() {} };
+
+const lastAccessTimeUpdates = {
+  enabled: true,
+  sampleRate: 1,
+};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Token = require('../../lib/tokens')(log, {
+  lastAccessTimeUpdates: lastAccessTimeUpdates,
+  tokenLifetimes: {
+    sessionTokenWithoutDevice: 2419200000,
+  },
+});
+
+const tokenPruning = {
+  enabled: true,
+  maxAge: 1000 * 60 * 60,
+};
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createDB } = require('../../lib/db');
+const DB = createDB(
+  {
+    lastAccessTimeUpdates,
+    signinCodeSize: config.signinCodeSize,
+    redis: {
+      enabled: true,
+      ...config.redis,
+      ...config.redis.sessionTokens,
+    },
+    securityHistory: {
+      ipHmacKey: 'test',
+    },
+    tokenLifetimes: {},
+    tokenPruning,
+    totp: {
+      recoveryCodes: {
+        length: 10,
+      },
+    },
+  },
+  log,
+  Token,
+  UnblockCode
+);
+
+const zeroBuffer16 = Buffer.from(
+  '00000000000000000000000000000000',
+  'hex'
+).toString('hex');
+const zeroBuffer32 = Buffer.from(
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  'hex'
+).toString('hex');
+
+let server: TestServerInstance;
+let account: any;
+let secondEmail: string;
+let db: any;
+let redis: any;
+
+beforeAll(async () => {
+  redis = IORedis.createClient({
+    host: config.redis.host,
+    port: config.redis.port,
+    password: config.redis.password,
+    prefix: config.redis.sessionTokens.prefix,
+    enable_offline_queue: false,
+  });
+  server = await getSharedTestServer();
+  db = await DB.connect(config);
+}, 120000);
+
+afterAll(async () => {
+  await db.close();
+  await redis.quit();
+  await server.stop();
+});
+
+beforeEach(async () => {
+  account = {
+    uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+    email: server.uniqueEmail(),
+    emailCode: zeroBuffer16,
+    emailVerified: false,
+    verifierVersion: 1,
+    verifyHash: zeroBuffer32,
+    authSalt: zeroBuffer32,
+    kA: zeroBuffer32,
+    wrapWrapKb: zeroBuffer32,
+    tokenVerificationId: zeroBuffer16,
+  };
+
+  const createdAccount = await db.createAccount(account);
+  expect(createdAccount.uid).toEqual(account.uid);
+
+  secondEmail = server.uniqueEmail();
+  const emailData = {
+    email: secondEmail,
+    emailCode: crypto.randomBytes(16).toString('hex'),
+    normalizedEmail: normalizeEmail(secondEmail),
+    isVerified: true,
+    isPrimary: false,
+    uid: account.uid,
+  };
+  await db.createEmail(account.uid, emailData);
+
+  // Ensure redis is empty for the uid
+  await redis.del(account.uid);
+});
+
+describe('#integration - remote db', () => {
+  it('ping', async () => {
+    await db.ping();
+  });
+
+  it('account creation', async () => {
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBeTruthy();
+
+    const acct = await db.account(account.uid);
+    expect(acct.uid).toEqual(account.uid);
+    expect(acct.email).toBe(account.email);
+    expect(acct.emailCode).toEqual(account.emailCode);
+    expect(acct.emailVerified).toBe(account.emailVerified);
+    expect(acct.kA).toEqual(account.kA);
+    expect(acct.wrapWrapKb).toEqual(account.wrapWrapKb);
+    expect(acct.verifyHash).toBeFalsy();
+    expect(acct.authSalt).toEqual(account.authSalt);
+    expect(acct.verifierVersion).toBe(account.verifierVersion);
+    expect(acct.createdAt).toBeTruthy();
+  });
+
+  it('session token handling', async () => {
+    // Fetch all sessions for the account
+    let sessions = await db.sessions(account.uid);
+    expect(Array.isArray(sessions)).toBe(true);
+    expect(sessions.length).toBe(0);
+
+    // Fetch the email record
+    let emailRecord = await db.emailRecord(account.email);
+    emailRecord.createdAt = Date.now() - 1000;
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Mac OS X';
+    emailRecord.uaOSVersion = '10.10';
+    emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+
+    // Create a session token
+    const sessionToken = await db.createSessionToken(emailRecord);
+    expect(sessionToken.uid).toEqual(account.uid);
+    const tokenId = sessionToken.id;
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(typeof sessions[0].id).toBe('string');
+    expect(sessions[0].uid).toBe(account.uid);
+    expect(sessions[0].createdAt >= account.createdAt).toBe(true);
+    expect(sessions[0].uaBrowser).toBe('Firefox');
+    expect(sessions[0].uaBrowserVersion).toBe('41');
+    expect(sessions[0].uaOS).toBe('Mac OS X');
+    expect(sessions[0].uaOSVersion).toBe('10.10');
+    expect(sessions[0].uaDeviceType).toBeNull();
+    expect(sessions[0].uaFormFactor).toBeNull();
+    expect(sessions[0].lastAccessTime).toBe(sessions[0].createdAt);
+    expect(sessions[0].authAt).toBe(sessions[0].createdAt);
+    expect(sessions[0].location).toBeUndefined();
+    expect(sessions[0].deviceId).toBeNull();
+    expect(sessions[0].deviceAvailableCommands).toBeNull();
+
+    // Fetch the session token
+    let fetchedToken = await db.sessionToken(tokenId);
+    expect(fetchedToken.id).toBe(tokenId);
+    expect(fetchedToken.uaBrowser).toBe('Firefox');
+    expect(fetchedToken.uaBrowserVersion).toBe('41');
+    expect(fetchedToken.uaOS).toBe('Mac OS X');
+    expect(fetchedToken.uaOSVersion).toBe('10.10');
+    expect(fetchedToken.uaDeviceType).toBeNull();
+    expect(fetchedToken.lastAccessTime).toBe(fetchedToken.createdAt);
+    expect(fetchedToken.uid).toBe(account.uid);
+    expect(fetchedToken.email).toBe(account.email);
+    expect(fetchedToken.emailCode).toBe(account.emailCode);
+    expect(fetchedToken.emailVerified).toBe(account.emailVerified);
+    expect(fetchedToken.lifetime < Infinity).toBe(true);
+
+    // Disable session token updates
+    lastAccessTimeUpdates.enabled = false;
+
+    // Attempt to update the session token
+    const result = await db.touchSessionToken(fetchedToken, {});
+    expect(result).toBeUndefined();
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uid).toBe(account.uid);
+    expect(sessions[0].lastAccessTime == null).toBe(true);
+    expect(sessions[0].location == null).toBe(true);
+
+    // Re-enable session token updates
+    lastAccessTimeUpdates.enabled = true;
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Update the session token
+    await db.touchSessionToken(
+      Object.assign({}, fetchedToken, {
+        lastAccessTime: Date.now(),
+      }),
+      {
+        location: {
+          city: 'Bournemouth',
+          country: 'United Kingdom',
+          countryCode: 'GB',
+          state: 'England',
+          stateCode: 'EN',
+        },
+        timeZone: 'Europe/London',
+      }
+    );
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uid).toBe(account.uid);
+    expect(sessions[0].lastAccessTime > sessions[0].createdAt).toBe(true);
+    expect(sessions[0].location.city).toBe('Bournemouth');
+    expect(sessions[0].location.country).toBe('United Kingdom');
+    expect(sessions[0].location.countryCode).toBe('GB');
+    expect(sessions[0].location.state).toBe('England');
+    expect(sessions[0].location.stateCode).toBe('EN');
+    expect(sessions[0].location.timeZone).toBeUndefined();
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Update the session token with new UA
+    await db.touchSessionToken(
+      Object.assign({}, fetchedToken, {
+        uaBrowser: 'Firefox Mobile',
+        uaBrowserVersion: '42',
+        uaOS: 'Android',
+        uaOSVersion: '4.4',
+        uaDeviceType: 'mobile',
+        uaFormFactor: null,
+      }),
+      {}
+    );
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uaBrowser).toBe('Firefox Mobile');
+    expect(sessions[0].uaBrowserVersion).toBe('42');
+    expect(sessions[0].uaOS).toBe('Android');
+    expect(sessions[0].uaOSVersion).toBe('4.4');
+    expect(sessions[0].uaDeviceType).toBe('mobile');
+    expect(sessions[0].uaFormFactor).toBeNull();
+    expect(sessions[0].location.country).toBe('United Kingdom');
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+    // this returns previously stored data since sessionToken doesn't read from cache
+    expect(fetchedToken.uaBrowser).toBe('Firefox');
+    expect(fetchedToken.uaBrowserVersion).toBe('41');
+    expect(fetchedToken.uaOS).toBe('Mac OS X');
+    expect(fetchedToken.uaOSVersion).toBe('10.10');
+    expect(fetchedToken.lastAccessTime).toBe(fetchedToken.createdAt);
+
+    // Attempt to prune a session token that is younger than maxAge
+    fetchedToken.createdAt = Date.now() - tokenPruning.maxAge + 10000;
+    await db.pruneSessionTokens(account.uid, [fetchedToken]);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uaBrowser).toBe('Firefox Mobile');
+    expect(sessions[0].uaBrowserVersion).toBe('42');
+    expect(sessions[0].uaOS).toBe('Android');
+    expect(sessions[0].uaOSVersion).toBe('4.4');
+    expect(sessions[0].uaDeviceType).toBe('mobile');
+    expect(sessions[0].uaFormFactor).toBeNull();
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Prune a session token that is older than maxAge
+    fetchedToken.createdAt = Date.now() - tokenPruning.maxAge - 1;
+    await db.pruneSessionTokens(account.uid, [fetchedToken]);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].uaBrowser).toBe('Firefox');
+    expect(sessions[0].uaBrowserVersion).toBe('41');
+    expect(sessions[0].uaOS).toBe('Mac OS X');
+    expect(sessions[0].uaOSVersion).toBe('10.10');
+    expect(sessions[0].uaDeviceType).toBeNull();
+    expect(sessions[0].uaFormFactor).toBeNull();
+
+    // Fetch the session token
+    fetchedToken = await db.sessionToken(tokenId);
+
+    // Delete the session token
+    await db.deleteSessionToken(fetchedToken);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    expect(sessions.length).toBe(0);
+
+    // Attempt to fetch the deleted session token
+    try {
+      await db.sessionToken(tokenId);
+      fail('db.sessionToken should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+
+    // Fetch the email record again
+    emailRecord = await db.emailRecord(account.email);
+    emailRecord.createdAt = Date.now() - 1000;
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Mac OS X';
+    emailRecord.uaOSVersion = '10.10';
+    emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+
+    // Create a session token with the same data as the deleted token
+    await db.createSessionToken(emailRecord);
+
+    // Fetch all sessions for the account
+    sessions = await db.sessions(account.uid);
+    // Make sure that the data got deleted from redis too
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].lastAccessTime).toBe(sessions[0].createdAt);
+    expect(sessions[0].location).toBeUndefined();
+
+    // Delete the session token again
+    await db.deleteSessionToken(sessions[0]);
+
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+  });
+
+  it('device registration', async () => {
+    let sessionToken: any;
+    const deviceInfo: any = {
+      id: crypto.randomBytes(16).toString('hex'),
+      name: '',
+      type: 'mobile',
+      availableCommands: { foo: 'bar', wibble: 'wobble' },
+      pushCallback: 'https://foo/bar',
+      pushPublicKey: base64url(
+        Buffer.concat([Buffer.from('\x04'), crypto.randomBytes(64)])
+      ),
+      pushAuthKey: base64url(crypto.randomBytes(16)),
+    };
+    const conflictingDeviceInfo: any = {
+      id: crypto.randomBytes(16).toString('hex'),
+      name: 'wibble',
+    };
+
+    const emailRecord = await db.emailRecord(account.email);
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox Mobile';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Android';
+    emailRecord.uaOSVersion = '4.4';
+    emailRecord.uaDeviceType = 'mobile';
+    emailRecord.uaFormFactor = null;
+
+    // Create a session token
+    sessionToken = await db.createSessionToken(emailRecord);
+    deviceInfo.sessionTokenId = sessionToken.id;
+
+    // Attempt to update a non-existent device
+    try {
+      await db.updateDevice(account.uid, deviceInfo);
+      fail('updating a non-existent device should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(123);
+    }
+
+    // Attempt to delete a non-existent device
+    try {
+      await db.deleteDevice(account.uid, deviceInfo.id);
+      fail('deleting a non-existent device should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(123);
+    }
+
+    // Fetch all of the devices for the account
+    let devices = await db.devices(account.uid);
+    expect(Array.isArray(devices)).toBe(true);
+    expect(devices.length).toBe(0);
+
+    // Create a device
+    const device = await db.createDevice(account.uid, deviceInfo);
+    expect(device.id).toBeTruthy();
+    expect(device.createdAt > 0).toBe(true);
+    expect(device.name).toBe(deviceInfo.name);
+    expect(device.type).toBe(deviceInfo.type);
+    expect(device.availableCommands).toEqual(deviceInfo.availableCommands);
+    expect(device.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(device.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+    expect(device.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+    expect(device.pushEndpointExpired).toBe(false);
+
+    // Fetch the session token
+    sessionToken = await db.sessionToken(sessionToken.id);
+    expect(sessionToken.lifetime).toBe(Infinity);
+    conflictingDeviceInfo.sessionTokenId = sessionToken.id;
+
+    // Attempt to create a device with a duplicate session token
+    try {
+      await db.createDevice(account.uid, conflictingDeviceInfo);
+      fail('adding a device with a duplicate session token should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(124);
+      expect((err as any).output.payload.deviceId).toBe(deviceInfo.id);
+    }
+
+    // Fetch all of the devices for the account
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(1);
+    let fetchedDevice = devices[0];
+
+    expect(fetchedDevice.id).toBeTruthy();
+    expect(fetchedDevice.lastAccessTime > 0).toBe(true);
+    expect(fetchedDevice.name).toBe(deviceInfo.name);
+    expect(fetchedDevice.type).toBe(deviceInfo.type);
+    expect(fetchedDevice.availableCommands).toEqual(
+      deviceInfo.availableCommands
+    );
+    expect(fetchedDevice.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(fetchedDevice.pushPublicKey).toBe(deviceInfo.pushPublicKey);
+    expect(fetchedDevice.pushAuthKey).toBe(deviceInfo.pushAuthKey);
+    expect(fetchedDevice.pushEndpointExpired).toBe(false);
+    expect(fetchedDevice.uaBrowser).toBe('Firefox Mobile');
+    expect(fetchedDevice.uaBrowserVersion).toBe('41');
+    expect(fetchedDevice.uaOS).toBe('Android');
+    expect(fetchedDevice.uaOSVersion).toBe('4.4');
+    expect(fetchedDevice.uaDeviceType).toBe('mobile');
+    expect(fetchedDevice.uaFormFactor).toBeNull();
+    expect(fetchedDevice.location).toBeUndefined();
+
+    deviceInfo.id = fetchedDevice.id;
+    deviceInfo.name = 'wibble';
+    deviceInfo.type = 'desktop';
+    deviceInfo.availableCommands = {};
+    deviceInfo.pushCallback = '';
+    deviceInfo.pushPublicKey = '';
+    deviceInfo.pushAuthKey = '';
+    deviceInfo.sessionTokenId = sessionToken.id;
+    sessionToken.lastAccessTime = 42;
+    sessionToken.uaBrowser = 'Firefox';
+    sessionToken.uaBrowserVersion = '44';
+    sessionToken.uaOS = 'Mac OS X';
+    sessionToken.uaOSVersion = '10.10';
+    sessionToken.uaFormFactor = null;
+
+    // Update the device and the session token
+    await Promise.all([
+      db.updateDevice(account.uid, deviceInfo),
+      db.touchSessionToken(sessionToken, {
+        location: {
+          city: 'Mountain View',
+          country: 'United States',
+          countryCode: 'US',
+          state: 'California',
+          stateCode: 'CA',
+        },
+        timeZone: 'America/Los_Angeles',
+      }),
+    ]);
+
+    // Create another session token
+    const anotherSessionToken = await db.createSessionToken(sessionToken);
+    conflictingDeviceInfo.sessionTokenId = anotherSessionToken.id;
+
+    // Create another device
+    await db.createDevice(account.uid, conflictingDeviceInfo);
+
+    // Attempt to update a device with a duplicate session token
+    deviceInfo.sessionTokenId = anotherSessionToken.id;
+    try {
+      await db.updateDevice(account.uid, deviceInfo);
+      fail(
+        'updating a device with a duplicate session token should have failed'
+      );
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(124);
+      expect((err as any).output.payload.deviceId).toBe(conflictingDeviceInfo.id);
+    }
+
+    // Fetch all of the devices for the account
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(2);
+
+    fetchedDevice =
+      devices[0].id === deviceInfo.id ? devices[0] : devices[1];
+
+    // Fetch a single device
+    const singleDevice = await db.device(account.uid, fetchedDevice.id);
+    expect(singleDevice).toEqual(fetchedDevice);
+
+    expect(fetchedDevice.lastAccessTime).toBe(42);
+    expect(fetchedDevice.name).toBe(deviceInfo.name);
+    expect(fetchedDevice.type).toBe(deviceInfo.type);
+    expect(fetchedDevice.availableCommands).toEqual(
+      deviceInfo.availableCommands
+    );
+    expect(fetchedDevice.pushCallback).toBe(deviceInfo.pushCallback);
+    expect(fetchedDevice.pushPublicKey).toBe('');
+    expect(fetchedDevice.pushAuthKey).toBe('');
+    expect(fetchedDevice.pushEndpointExpired).toBe(false);
+    expect(fetchedDevice.uaBrowser).toBe('Firefox');
+    expect(fetchedDevice.uaBrowserVersion).toBe('44');
+    expect(fetchedDevice.uaOS).toBe('Mac OS X');
+    expect(fetchedDevice.uaOSVersion).toBe('10.10');
+    expect(fetchedDevice.uaDeviceType).toBe('mobile');
+    expect(fetchedDevice.uaFormFactor).toBeNull();
+    expect(fetchedDevice.location.city).toBe('Mountain View');
+    expect(fetchedDevice.location.country).toBe('United States');
+    expect(fetchedDevice.location.countryCode).toBe('US');
+    expect(fetchedDevice.location.state).toBe('California');
+    expect(fetchedDevice.location.stateCode).toBe('CA');
+
+    // Disable session token updates
+    lastAccessTimeUpdates.enabled = false;
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(2);
+    expect(devices[0].lastAccessTime).toBeUndefined();
+    expect(devices[1].lastAccessTime).toBeUndefined();
+
+    // Re-enable session token updates
+    lastAccessTimeUpdates.enabled = true;
+
+    // Delete the devices
+    await db.deleteDevice(account.uid, deviceInfo.id);
+    // Deleting these serially ensures there's no Redis WATCH conflict for account.uid
+    await db.deleteDevice(account.uid, conflictingDeviceInfo.id);
+
+    // Deleting the devices should also have cleared the data from Redis
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+
+    // Fetch all of the devices for the account
+    devices = await db.devices(account.uid);
+    expect(devices.length).toBe(0);
+
+    // Delete the account
+    await db.deleteAccount(account);
+  });
+
+  it('keyfetch token handling', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const keyFetchToken = await db.createKeyFetchToken({
+      uid: emailRecord.uid,
+      kA: emailRecord.kA,
+      wrapKb: account.wrapWrapKb,
+    });
+
+    expect(keyFetchToken.uid).toEqual(account.uid);
+    const tokenId = keyFetchToken.id;
+
+    const fetched = await db.keyFetchToken(tokenId);
+    expect(fetched.id).toEqual(tokenId);
+    expect(fetched.uid).toEqual(account.uid);
+    expect(fetched.emailVerified).toBe(account.emailVerified);
+
+    await db.deleteKeyFetchToken(fetched);
+
+    try {
+      await db.keyFetchToken(tokenId);
+      fail('keyFetchToken() should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+  });
+
+  it('reset token handling', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const passwordForgotToken = await db.createPasswordForgotToken(emailRecord);
+    const accountResetToken =
+      await db.forgotPasswordVerified(passwordForgotToken);
+
+    expect(accountResetToken.createdAt >= passwordForgotToken.createdAt).toBe(
+      true
+    );
+    expect(accountResetToken.uid).toEqual(account.uid);
+    const tokenId = accountResetToken.id;
+
+    const fetched = await db.accountResetToken(tokenId);
+    expect(fetched.id).toEqual(tokenId);
+    expect(fetched.uid).toEqual(account.uid);
+
+    await db.deleteAccountResetToken(fetched);
+
+    try {
+      await db.accountResetToken(tokenId);
+      fail('accountResetToken() should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+  });
+
+  it('forgotpwd token handling', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const token1 = await db.createPasswordForgotToken(emailRecord);
+
+    expect(token1.uid).toEqual(account.uid);
+    const token1tries = token1.tries;
+
+    let fetched = await db.passwordForgotToken(token1.id);
+    expect(fetched.id).toEqual(token1.id);
+    expect(fetched.uid).toEqual(token1.uid);
+
+    fetched.tries -= 1;
+    await db.updatePasswordForgotToken(fetched);
+
+    fetched = await db.passwordForgotToken(token1.id);
+    expect(fetched.id).toEqual(token1.id);
+    expect(fetched.tries).toBe(token1tries - 1);
+
+    await db.deletePasswordForgotToken(fetched);
+
+    try {
+      await db.passwordForgotToken(token1.id);
+      fail('passwordForgotToken() should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(110);
+      expect(`${err}`).toBe(
+        'Error: The authentication token could not be found'
+      );
+    }
+  });
+
+  it('email verification', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    await db.verifyEmail(emailRecord, emailRecord.emailCode);
+
+    const acct = await db.account(account.uid);
+    expect(acct.emailVerified).toBeTruthy();
+  });
+
+  it('db.forgotPasswordVerified', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    const passwordForgotToken =
+      await db.createPasswordForgotToken(emailRecord);
+    const accountResetToken =
+      await db.forgotPasswordVerified(passwordForgotToken);
+
+    expect(accountResetToken.uid).toEqual(account.uid);
+
+    const fetched = await db.accountResetToken(accountResetToken.id);
+    expect(fetched.uid).toEqual(account.uid);
+
+    await db.deleteAccountResetToken(accountResetToken);
+  });
+
+  it('db.resetAccount', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    emailRecord.tokenVerificationId = account.tokenVerificationId;
+    emailRecord.uaBrowser = 'Firefox';
+    emailRecord.uaBrowserVersion = '41';
+    emailRecord.uaOS = 'Mac OS X';
+    emailRecord.uaOSVersion = '10.10';
+    emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+
+    const sessionToken = await db.createSessionToken(emailRecord);
+    const accountResetToken =
+      await db.forgotPasswordVerified(sessionToken);
+    await db.resetAccount(accountResetToken, account);
+
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+
+    // account should STILL exist for this email address
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBe(true);
+  });
+
+  it('db.securityEvents', async () => {
+    await db.securityEvent({
+      ipAddr: '127.0.0.1',
+      name: 'account.create',
+      uid: account.uid,
+    });
+
+    const events = await db.securityEvents({
+      ipAddr: '127.0.0.1',
+      uid: account.uid,
+    });
+    expect(events.length).toBe(1);
+  });
+
+  it('db.securityEventsByUid', async () => {
+    await db.securityEvent({
+      ipAddr: '127.0.0.1',
+      name: 'account.create',
+      uid: account.uid,
+    });
+
+    const events = await db.securityEventsByUid({
+      uid: account.uid,
+    });
+    expect(events.length).toBe(1);
+  });
+
+  it('unblock code', async () => {
+    const unblockCode = await db.createUnblockCode(account.uid);
+    expect(unblockCode).toBeTruthy();
+
+    // Consume with invalid code
+    try {
+      await db.consumeUnblockCode(account.uid, 'NOTREAL');
+      fail('consumeUnblockCode() with an invalid unblock code should not succeed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(127);
+      expect(`${err}`).toBe('Error: Invalid unblock code');
+    }
+
+    // Consume with valid code
+    await db.consumeUnblockCode(account.uid, unblockCode);
+
+    // re-use unblock code, no longer valid
+    try {
+      await db.consumeUnblockCode(account.uid, unblockCode);
+      fail('consumeUnblockCode() with a used unblock code should not succeed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(127);
+      expect(`${err}`).toBe('Error: Invalid unblock code');
+    }
+  });
+
+  it('signinCodes', async () => {
+    const flowId = crypto.randomBytes(32).toString('hex');
+
+    // Create a signinCode without a flowId
+    const previousCode = await db.createSigninCode(account.uid);
+    expect(typeof previousCode).toBe('string');
+    expect(Buffer.from(previousCode, 'hex').length).toBe(
+      config.signinCodeSize
+    );
+
+    // Stub crypto.randomBytes to return a duplicate code
+    const stub = sinon
+      .stub(crypto, 'randomBytes')
+      .callsFake((size: number, callback?: any) => {
+        if (!callback) {
+          return previousCode;
+        }
+        callback(null, previousCode);
+      });
+
+    // Create a signinCode with crypto.randomBytes rigged to return a duplicate
+    const code = await db.createSigninCode(account.uid, flowId);
+    stub.restore();
+    expect(typeof code).toBe('string');
+    expect(code).not.toBe(previousCode);
+    expect(Buffer.from(code, 'hex').length).toBe(config.signinCodeSize);
+
+    // Consume both signinCodes
+    const results = await Promise.all([
+      db.consumeSigninCode(previousCode),
+      db.consumeSigninCode(code),
+    ]);
+    expect(results[0].email).toBe(account.email);
+    expect(results[1].email).toBe(account.email);
+    if (results[1].flowId) {
+      // This assertion is conditional so that tests pass regardless of db version
+      expect(results[1].flowId).toBe(flowId);
+    }
+
+    // Attempt to consume a consumed signinCode
+    try {
+      await db.consumeSigninCode(previousCode);
+      fail('db.consumeSigninCode should have failed');
+    } catch (err: unknown) {
+      expect((err as AuthServerError).errno).toBe(146);
+      expect((err as AuthServerError).message).toBe('Invalid signin code');
+      expect((err as any).output.statusCode).toBe(400);
+    }
+  });
+
+  it('account deletion', async () => {
+    const emailRecord = await db.emailRecord(account.email);
+    expect(emailRecord.uid).toEqual(account.uid);
+
+    await db.deleteAccount(emailRecord);
+
+    const redisResult = await redis.get(account.uid);
+    expect(redisResult).toBeNull();
+
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBe(false);
+
+    const deletedAccount = await db.deletedAccount(account.uid);
+    expect(deletedAccount.uid).toBe(account.uid);
+  });
+
+  it('should create and delete linked account', async () => {
+    const googleId = `goog_${Math.random().toString().substring(2)}`;
+    await db.createLinkedAccount(account.uid, googleId, 'google');
+
+    let records = await db.getLinkedAccounts(account.uid);
+    expect(records.length).toBe(1);
+    const record = records[0];
+    expect(record.uid).toBe(account.uid);
+    expect(record.providerId).toBe(1);
+    expect(record.enabled).toBe(true);
+    expect(record.id).toBe(googleId);
+
+    await db.deleteAccount({ ...account });
+
+    const exists = await db.accountExists(account.email);
+    expect(exists).toBe(false);
+
+    records = await db.getLinkedAccounts(account.uid);
+    expect(records.length).toBe(0);
+  });
+
+  describe('account record', () => {
+    it('can retrieve account from account email', async () => {
+      const [emailRecord, accountRecord] = await Promise.all([
+        db.emailRecord(account.email),
+        db.accountRecord(account.email),
+      ]);
+      expect(emailRecord.email).toBe(accountRecord.email);
+      expect(emailRecord.emails).toEqual(accountRecord.emails);
+      expect(emailRecord.primaryEmail).toEqual(accountRecord.primaryEmail);
+    });
+
+    it('can retrieve account from secondary email', async () => {
+      const [accountRecord, accountRecordFromSecondEmail] = await Promise.all([
+        db.accountRecord(account.email),
+        db.accountRecord(secondEmail),
+      ]);
+      expect(accountRecordFromSecondEmail.email).toBe(accountRecord.email);
+      expect(accountRecordFromSecondEmail.emails).toEqual(
+        accountRecord.emails
+      );
+      expect(accountRecordFromSecondEmail.primaryEmail).toEqual(
+        accountRecord.primaryEmail
+      );
+    });
+
+    it('can retrieve linked account', async () => {
+      const googleId = `goog_${Math.random().toString().substring(2)}`;
+      const linkedAccount = await db.createLinkedAccount(
+        account.uid,
+        googleId,
+        'google'
+      );
+      // linkedAccount UID comes back as a buffer but we want a hex string
+      if (linkedAccount.uid instanceof Buffer) {
+        linkedAccount.uid = linkedAccount.uid.toString('hex');
+      }
+
+      const accountRecord = await db.accountRecord(account.email, {
+        linkedAccounts: true,
+      });
+      expect(accountRecord.linkedAccounts[0]).toEqual(linkedAccount);
+    });
+
+    it('does not retrieve linked account without option specified', async () => {
+      const googleId = `goog_${Math.random().toString().substring(2)}`;
+      await db.createLinkedAccount(account.uid, googleId, 'google');
+      const accountRecord = await db.accountRecord(account.email);
+      expect(accountRecord.linkedAccounts).toBeUndefined();
+    });
+
+    it('returns unknown account', async () => {
+      try {
+        await db.accountRecord('idontexist@email.com');
+        fail('should not have retrieved non-existent account');
+      } catch (err: unknown) {
+        expect((err as AuthServerError).errno).toBe(102);
+      }
+    });
+  });
+
+  describe('set primary email', () => {
+    it('can set primary email address', async () => {
+      await db.setPrimaryEmail(account.uid, secondEmail);
+      const acct = await db.accountRecord(secondEmail);
+      expect(acct.primaryEmail.email).toBe(secondEmail);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/remote/email_validity.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/email_validity.in.spec.ts
@@ -1,0 +1,94 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { AuthServerError } from '../support/helpers/test-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      accountDestroy: {
+        requireVerifiedAccount: false,
+        requireVerifiedSession: false,
+      },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote email validity',
+  ({ version, tag }) => {
+    const testOptions = { version };
+
+    it('/account/create with a variety of malformed email addresses', async () => {
+      const pwd = '123456';
+
+      const emails = [
+        'notAnEmailAddress',
+        '\n@example.com',
+        'me@hello world.com',
+        'me@hello+world.com',
+        'me@.example',
+        'me@example',
+        'me@example.com-',
+        'me@example..com',
+        'me@example-.com',
+        'me@example.-com',
+        '\uD83D\uDCA9@unicodepooforyou.com',
+      ];
+
+      await Promise.all(
+        emails.map((email) =>
+          Client.create(server.publicUrl, email, pwd, testOptions).then(
+            () => {
+              throw new Error(`Email ${email} should have been rejected`);
+            },
+            (err: AuthServerError) => {
+              expect(err.code).toBe(400);
+            }
+          )
+        )
+      );
+    });
+
+    it('/account/create with a variety of unusual but valid email addresses', async () => {
+      const pwd = '123456';
+
+      const emails = [
+        'tim@tim-example.net',
+        'a+b+c@example.com',
+        '#!?-@t-e-s-assert.c-o-m',
+        `${String.fromCharCode(1234)}@example.com`,
+        `test@${String.fromCharCode(5678)}.com`,
+      ];
+
+      await Promise.all(
+        emails.map((email) =>
+          Client.create(server.publicUrl, email, pwd, testOptions).then(
+            (c: any) => c.destroyAccount(),
+            () => {
+              fail(
+                `Email address ${email} should have been allowed, but it wasn't`
+              );
+            }
+          )
+        )
+      );
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/flow.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/flow.in.spec.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Client = require('../client')();
+
+let server: TestServerInstance;
+
+beforeAll(async () => {
+  server = await createTestServer({
+    configOverrides: {
+      signinConfirmation: { skipForNewAccounts: { enabled: true } },
+    },
+  });
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+const testVersions = [
+  { version: '', tag: '' },
+  { version: 'V2', tag: 'V2' },
+];
+
+describe.each(testVersions)(
+  '#integration$tag - remote flow',
+  ({ version, tag }) => {
+    const testOptions = { version };
+    let email1: string;
+
+    beforeAll(() => {
+      email1 = server.uniqueEmail();
+    });
+
+    it('Create account flow', async () => {
+      const email = email1;
+      const password = 'allyourbasearebelongtous';
+      const client = await Client.createAndVerify(
+        server.publicUrl,
+        email,
+        password,
+        server.mailbox,
+        { ...testOptions, keys: true }
+      );
+      const keys = await client.keys();
+      expect(typeof keys.kA).toBe('string');
+      expect(typeof keys.wrapKb).toBe('string');
+      expect(typeof keys.kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+
+    it('Login flow', async () => {
+      const email = email1;
+      const password = 'allyourbasearebelongtous';
+      const client = await Client.login(server.publicUrl, email, password, {
+        ...testOptions,
+        keys: true,
+      });
+      expect(client.authAt).toBeTruthy();
+      expect(client.uid).toBeTruthy();
+      const keys = await client.keys();
+      expect(typeof keys.kA).toBe('string');
+      expect(typeof keys.wrapKb).toBe('string');
+      expect(typeof keys.kB).toBe('string');
+      expect(client.getState().kB.length).toBe(64);
+    });
+  }
+);

--- a/packages/fxa-auth-server/test/remote/smoke.spec.ts
+++ b/packages/fxa-auth-server/test/remote/smoke.spec.ts
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import { getSharedTestServer, TestServerInstance } from '../support/helpers/test-server';
 
 describe('#integration - smoke test', () => {
   let server: TestServerInstance;
 
   beforeAll(async () => {
-    server = await createTestServer();
-  });
+    server = await getSharedTestServer();
+  }, 120000);
 
   afterAll(async () => {
     await server.stop();

--- a/packages/fxa-auth-server/test/support/helpers/test-process-registry.ts
+++ b/packages/fxa-auth-server/test/support/helpers/test-process-registry.ts
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * PID file registry for auth server child processes.
+ *
+ * Each spawned auth server writes a .pid file keyed by its port. This lets
+ * global teardown, signal handlers, and next-run startup reliably clean up
+ * orphaned processes that survive --forceExit.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const TMP_DIR = path.resolve(__dirname, '..', '.tmp');
+
+function ensureTmpDir(): void {
+  if (!fs.existsSync(TMP_DIR)) {
+    fs.mkdirSync(TMP_DIR, { recursive: true });
+  }
+}
+
+function pidFilePath(port: number): string {
+  return path.join(TMP_DIR, `auth_server-${port}.pid`);
+}
+
+/** Write a PID file for an auth server on the given port. */
+export function registerAuthServerPid(port: number, pid: number): void {
+  ensureTmpDir();
+  fs.writeFileSync(pidFilePath(port), String(pid));
+}
+
+/** Remove the PID file for an auth server on the given port. */
+export function unregisterAuthServerPid(port: number): void {
+  try {
+    fs.unlinkSync(pidFilePath(port));
+  } catch {
+    // File already removed or never created
+  }
+}
+
+/** Kill all auth servers tracked by PID files and remove the files. */
+export function killAllTrackedAuthServers(): void {
+  ensureTmpDir();
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(TMP_DIR).filter((f) => f.startsWith('auth_server-') && f.endsWith('.pid'));
+  } catch {
+    return;
+  }
+
+  for (const file of files) {
+    const filePath = path.join(TMP_DIR, file);
+    try {
+      const pid = parseInt(fs.readFileSync(filePath, 'utf-8'), 10);
+      if (pid) {
+        process.kill(pid, 'SIGTERM');
+        console.log(`[Process Registry] Killed tracked auth server (PID: ${pid})`);
+      }
+    } catch {
+      // Process already dead or file unreadable
+    }
+    try {
+      fs.unlinkSync(filePath);
+    } catch {
+      // Already removed
+    }
+  }
+}
+

--- a/packages/fxa-auth-server/test/support/helpers/test-server.ts
+++ b/packages/fxa-auth-server/test/support/helpers/test-server.ts
@@ -8,12 +8,12 @@
 
 import { spawn, ChildProcess } from 'child_process';
 import crypto from 'crypto';
-import os from 'os';
 import path from 'path';
 import fs from 'fs';
 import net from 'net';
 import { createMailbox, Mailbox } from './mailbox';
 import { createProfileHelper, ProfileHelper } from './profile-helper';
+import { registerAuthServerPid, unregisterAuthServerPid } from './test-process-registry';
 
 export interface TestServerConfig {
   printLogs?: boolean;
@@ -36,6 +36,9 @@ interface AllocatedPorts {
 }
 
 const AUTH_SERVER_ROOT = path.resolve(__dirname, '../../..');
+
+export const SHARED_SERVER_PORT = 9100;
+export const SHARED_PROFILE_PORT = 9101;
 
 function getAvailablePort(startPort: number): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -66,19 +69,22 @@ async function allocatePorts(): Promise<AllocatedPorts> {
   // Use JEST_WORKER_ID to give each worker its own port range,
   // avoiding TOCTOU races when workers run in parallel.
   const workerId = parseInt(process.env.JEST_WORKER_ID || '1', 10);
-  const basePort = 10000 + (workerId - 1) * 100;
+  // Start at 9200 to avoid conflicts with standard infrastructure ports
+  // (9000 = auth-server, 9001 = mail_helper, etc.)
+  // Port 9100 is reserved for the shared server (see SHARED_SERVER_PORT).
+  const basePort = 9200 + (workerId - 1) * 100;
   const authServerPort = await getAvailablePort(basePort);
   const profileServerPort = await getAvailablePort(authServerPort + 1);
   return { authServerPort, profileServerPort };
 }
 
-async function waitForServer(url: string, maxAttempts = 30, delayMs = 1000): Promise<void> {
+export async function waitForServer(url: string, maxAttempts = 60, delayMs = 1000): Promise<void> {
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const response = await fetch(`${url}/__heartbeat__`);
       if (response.ok) {
         // Allow async initialization to settle after heartbeat passes
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await new Promise(resolve => setTimeout(resolve, 200));
         return;
       }
     } catch {
@@ -89,14 +95,14 @@ async function waitForServer(url: string, maxAttempts = 30, delayMs = 1000): Pro
   throw new Error(`Server at ${url} did not become ready after ${maxAttempts} attempts`);
 }
 
-function createTempConfig(overrides: Record<string, unknown>, port: number): string {
+export function createTempConfig(overrides: Record<string, unknown>, port: number): string {
   const config = {
     ...overrides,
     listen: { host: '127.0.0.1', port },
     publicUrl: `http://localhost:${port}`,
   };
 
-  const tempDir = path.join(os.tmpdir(), 'fxa-auth-server-test');
+  const tempDir = path.join(AUTH_SERVER_ROOT, 'test', 'support', '.tmp');
   if (!fs.existsSync(tempDir)) {
     fs.mkdirSync(tempDir, { recursive: true });
   }
@@ -106,11 +112,16 @@ function createTempConfig(overrides: Record<string, unknown>, port: number): str
   return configPath;
 }
 
-function spawnAuthServer(
+export interface SpawnedServer {
+  process: ChildProcess;
+  stderrChunks: string[];
+}
+
+export function spawnAuthServer(
   port: number,
   configPath: string,
   printLogs: boolean
-): ChildProcess {
+): SpawnedServer {
   const env = {
     ...process.env,
     NODE_ENV: 'dev',
@@ -133,15 +144,27 @@ function spawnAuthServer(
     }
   );
 
-  // Consume piped streams to prevent backpressure from stalling the server.
-  // stdout must be piped (not ignored) to avoid EPIPE → log error → shutdown
-  // in key_server.js.
+  // Capture last 50KB of stderr for diagnostics when the server fails to start.
+  const MAX_STDERR_BYTES = 50 * 1024;
+  const stderrChunks: string[] = [];
+  let stderrBytes = 0;
   if (!printLogs) {
+    // Consume stdout to prevent backpressure from stalling the server.
+    // stdout must be piped (not ignored) to avoid EPIPE → log error → shutdown
+    // in key_server.js.
     serverProcess.stdout?.resume();
-    serverProcess.stderr?.resume();
+    serverProcess.stderr?.on('data', (chunk: Buffer) => {
+      const str = chunk.toString();
+      stderrChunks.push(str);
+      stderrBytes += str.length;
+      // Evict oldest chunks when buffer exceeds limit
+      while (stderrBytes > MAX_STDERR_BYTES && stderrChunks.length > 1) {
+        stderrBytes -= (stderrChunks.shift() as string).length;
+      }
+    });
   }
 
-  return serverProcess;
+  return { process: serverProcess, stderrChunks };
 }
 
 export async function createTestServer(
@@ -182,6 +205,16 @@ export async function createTestServer(
       checkAllEndpoints: false,
       ignoreIPs: ['127.0.0.1', '::1', 'localhost'],
     },
+    oauth: {
+      ...baseConfig.oauth,
+      url: publicUrl,
+    },
+    oauthServer: {
+      audience: publicUrl,
+      browserid: {
+        issuer: `localhost:${ports.authServerPort}`,
+      },
+    },
     profileServer: {
       ...baseConfig.profileServer,
       url: profileServerUrl,
@@ -195,14 +228,25 @@ export async function createTestServer(
     printLogs
   );
 
-  const serverProcess = spawnAuthServer(ports.authServerPort, configPath, printLogs);
+  const spawned = spawnAuthServer(ports.authServerPort, configPath, printLogs);
+  const serverProcess = spawned.process;
+
+  if (serverProcess.pid) {
+    registerAuthServerPid(ports.authServerPort, serverProcess.pid);
+  }
 
   try {
     await waitForServer(publicUrl);
   } catch (err) {
+    unregisterAuthServerPid(ports.authServerPort);
+    const stderr = spawned.stderrChunks.join('');
     serverProcess.kill();
     if (profileServer) {
       await profileServer.close();
+    }
+    const msg = `Server at ${publicUrl} failed to start.`;
+    if (stderr) {
+      console.error(`${msg} stderr:\n${stderr.slice(-2000)}`);
     }
     throw err;
   }
@@ -224,6 +268,8 @@ export async function createTestServer(
       return `${crypto.randomBytes(10).toString('hex')}${String.fromCharCode(1234)}@${String.fromCharCode(5678)}restmail.net`;
     },
     stop: async () => {
+      unregisterAuthServerPid(ports.authServerPort);
+
       if (serverProcess && !serverProcess.killed) {
         const exitPromise = new Promise<void>((resolve) => {
           serverProcess.on('exit', () => resolve());
@@ -244,11 +290,57 @@ export async function createTestServer(
 
       try {
         fs.unlinkSync(configPath);
-      } catch (err) {
-        console.warn(`[test-server] Failed to clean up temp config ${configPath}:`, err);
+      } catch {
+        // Ignore cleanup errors
       }
     },
   };
 
   return instance;
+}
+
+/**
+ * Returns a TestServerInstance that connects to the pre-started shared server
+ * at SHARED_SERVER_PORT. The shared server is managed by jest-global-setup/teardown,
+ * so stop() is a no-op.
+ */
+export async function getSharedTestServer(): Promise<TestServerInstance> {
+  const port = SHARED_SERVER_PORT;
+  const publicUrl = `http://localhost:${port}`;
+
+  // Verify the shared server is running
+  await waitForServer(publicUrl, 5, 500);
+
+  const baseConfigPath = require.resolve('../../../config');
+  delete require.cache[baseConfigPath];
+  const baseConfig = require('../../../config').default.getProperties();
+
+  const mailbox = createMailbox(
+    baseConfig.smtp?.api?.host || 'localhost',
+    baseConfig.smtp?.api?.port || 9001,
+    process.env.REMOTE_TEST_LOGS === 'true'
+  );
+
+  // Profile helper for the shared server is started in global setup,
+  // so we don't create one here (would cause EADDRINUSE across workers).
+
+  return {
+    config: {
+      ...baseConfig,
+      publicUrl,
+      listen: { host: '127.0.0.1', port },
+    },
+    mailbox,
+    profileServer: null,
+    publicUrl,
+    uniqueEmail: (domain = '@restmail.net') => {
+      return `${crypto.randomBytes(10).toString('hex')}${domain}`;
+    },
+    uniqueUnicodeEmail: () => {
+      return `${crypto.randomBytes(10).toString('hex')}${String.fromCharCode(1234)}@${String.fromCharCode(5678)}restmail.net`;
+    },
+    stop: async () => {
+      // No-op: shared server is managed by global setup/teardown
+    },
+  };
 }

--- a/packages/fxa-auth-server/test/support/helpers/test-utils.ts
+++ b/packages/fxa-auth-server/test/support/helpers/test-utils.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+
+/**
+ * Error shape returned by auth server API calls.
+ */
+export interface AuthServerError extends Error {
+  errno: number;
+  code: number;
+  email?: string;
+}
+
+function getFlowIdKey(): string {
+  const configPath = require.resolve('../../../config');
+  delete require.cache[configPath];
+  const config = require('../../../config').default.getProperties();
+  return config.metrics.flow_id_key;
+}
+
+/**
+ * Generates a valid metricsContext with HMAC-signed flowId for use in
+ * integration tests. Reads the HMAC key from the auth server config.
+ */
+export function generateMetricsContext(): { flowBeginTime: number; flowId: string } {
+  const randomBytes = crypto.randomBytes(16).toString('hex');
+  const flowBeginTime = Date.now();
+  const flowSignature = crypto
+    .createHmac('sha256', getFlowIdKey())
+    .update([randomBytes, flowBeginTime.toString(16)].join('\n'))
+    .digest('hex')
+    .substring(0, 32);
+  return { flowBeginTime, flowId: randomBytes + flowSignature };
+}

--- a/packages/fxa-auth-server/test/support/jest-global-setup.ts
+++ b/packages/fxa-auth-server/test/support/jest-global-setup.ts
@@ -10,9 +10,20 @@
 import { spawn, execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { killAllTrackedAuthServers } from './helpers/test-process-registry';
+import {
+  SHARED_SERVER_PORT,
+  SHARED_PROFILE_PORT,
+  createTempConfig,
+  spawnAuthServer,
+  waitForServer,
+} from './helpers/test-server';
+import { createProfileHelper } from './helpers/profile-helper';
 
 const AUTH_SERVER_ROOT = path.resolve(__dirname, '../..');
-const MAIL_HELPER_PID_FILE = path.join(AUTH_SERVER_ROOT, 'test', 'support', '.tmp', 'mail_helper.pid');
+const TMP_DIR = path.join(AUTH_SERVER_ROOT, 'test', 'support', '.tmp');
+const MAIL_HELPER_PID_FILE = path.join(TMP_DIR, 'mail_helper.pid');
+const SHARED_SERVER_PID_FILE = path.join(TMP_DIR, 'shared_server.pid');
 
 function generateKeysIfNeeded(): void {
   const genKeysScript = path.join(AUTH_SERVER_ROOT, 'scripts', 'gen_keys.js');
@@ -61,14 +72,13 @@ async function waitForMailHelper(port = 9001, maxAttempts = 30, delayMs = 500): 
   throw new Error(`mail_helper did not become ready after ${maxAttempts} attempts`);
 }
 
-function killExistingMailHelper(): void {
-  // Kill any leftover mail_helper from a previous run to avoid port conflicts
-  if (fs.existsSync(MAIL_HELPER_PID_FILE)) {
-    const oldPid = parseInt(fs.readFileSync(MAIL_HELPER_PID_FILE, 'utf-8'), 10);
+function killExistingProcess(pidFile: string, label: string): void {
+  if (fs.existsSync(pidFile)) {
+    const oldPid = parseInt(fs.readFileSync(pidFile, 'utf-8'), 10);
     if (oldPid) {
       try {
         process.kill(oldPid, 'SIGTERM');
-        console.log('[Jest Global Setup] Killed leftover mail_helper (PID:', oldPid, ')');
+        console.log(`[Jest Global Setup] Killed leftover ${label} (PID:`, oldPid, ')');
       } catch {
         // Process already dead
       }
@@ -81,6 +91,10 @@ export default async function globalSetup(): Promise<void> {
 
   generateKeysIfNeeded();
 
+  // Kill stale auth servers from previous runs before starting new ones
+  console.log('[Jest Global Setup] Cleaning up stale auth server processes...');
+  killAllTrackedAuthServers();
+
   console.log('[Jest Global Setup] Starting mail_helper...');
 
   const tmpDir = path.dirname(MAIL_HELPER_PID_FILE);
@@ -88,7 +102,7 @@ export default async function globalSetup(): Promise<void> {
     fs.mkdirSync(tmpDir, { recursive: true });
   }
 
-  killExistingMailHelper();
+  killExistingProcess(MAIL_HELPER_PID_FILE, 'mail_helper');
 
   const mailHelperProcess = spawn(
     'node',
@@ -117,4 +131,82 @@ export default async function globalSetup(): Promise<void> {
     mailHelperProcess.kill();
     throw err;
   }
+
+  // Start the shared profile helper for the shared auth server
+  console.log('[Jest Global Setup] Starting shared profile helper on port', SHARED_PROFILE_PORT, '...');
+  const sharedProfileHelper = await createProfileHelper(SHARED_PROFILE_PORT);
+  (global as any).__sharedProfileHelper = sharedProfileHelper;
+  console.log('[Jest Global Setup] Shared profile helper started on port', SHARED_PROFILE_PORT);
+
+  // Start the shared auth server for test suites that don't need config overrides
+  console.log('[Jest Global Setup] Starting shared auth server on port', SHARED_SERVER_PORT, '...');
+
+  killExistingProcess(SHARED_SERVER_PID_FILE, 'shared_server');
+
+  const sharedPublicUrl = `http://localhost:${SHARED_SERVER_PORT}`;
+  const sharedProfileUrl = `http://localhost:${SHARED_PROFILE_PORT}`;
+  const sharedPrintLogs = process.env.REMOTE_TEST_LOGS === 'true';
+  // Only specify overrides — convict deep-merges these on top of defaults,
+  // so we don't need to load the full base config here (which has deps
+  // unavailable in the global setup process).
+  const sharedOverrides = {
+    customsUrl: 'none',
+    log: { level: sharedPrintLogs ? 'debug' : 'critical' },
+    gleanMetrics: { enabled: false },
+    rateLimit: {
+      rules: '',
+      checkAllEndpoints: false,
+      ignoreIPs: ['127.0.0.1', '::1', 'localhost'],
+    },
+    oauth: { url: sharedPublicUrl },
+    oauthServer: {
+      audience: sharedPublicUrl,
+      browserid: {
+        issuer: `localhost:${SHARED_SERVER_PORT}`,
+      },
+    },
+    profileServer: { url: sharedProfileUrl },
+  };
+  const sharedConfigPath = createTempConfig(sharedOverrides, SHARED_SERVER_PORT);
+  const sharedSpawned = spawnAuthServer(SHARED_SERVER_PORT, sharedConfigPath, sharedPrintLogs);
+
+  if (sharedSpawned.process.pid) {
+    fs.writeFileSync(SHARED_SERVER_PID_FILE, String(sharedSpawned.process.pid));
+  }
+  sharedSpawned.process.unref();
+
+  try {
+    await waitForServer(sharedPublicUrl);
+    console.log('[Jest Global Setup] Shared auth server started (PID:', sharedSpawned.process.pid, ')');
+  } catch (err) {
+    const stderr = sharedSpawned.stderrChunks.join('');
+    sharedSpawned.process.kill();
+    if (stderr) {
+      console.error(`[Jest Global Setup] Shared server stderr:\n${stderr.slice(-2000)}`);
+    }
+    throw err;
+  }
+
+  // Install signal handlers so Ctrl+C / SIGTERM cleans up all child processes
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  const cleanup = (signal: 'SIGINT' | 'SIGTERM') => {
+    console.log(`[Jest Global Setup] ${signal} received, cleaning up...`);
+    killAllTrackedAuthServers();
+    try {
+      mailHelperProcess.kill('SIGTERM');
+    } catch {
+      // Already dead
+    }
+    try {
+      sharedSpawned.process.kill('SIGTERM');
+    } catch {
+      // Already dead
+    }
+    sharedProfileHelper.close().catch(() => {});
+    // Re-raise so the process exits with the correct signal code
+    process.removeListener(signal, cleanup);
+    process.kill(process.pid, signal);
+  };
+  process.on('SIGINT', () => cleanup('SIGINT'));
+  process.on('SIGTERM', () => cleanup('SIGTERM'));
 }


### PR DESCRIPTION
  ## Because

  - Auth server integration tests were split across Mocha and Jest, making CI slower and harder to maintain
  - The Mocha test runner lacks Jest's parallel execution, better error reporting, and modern async handling

  ## This pull request

  - Migrates 14 Mocha integration test files to Jest `.in.spec.ts` format in `test/remote/`
  - Adds shared test infrastructure: `test-process-registry.ts` for server lifecycle management, `test-utils.ts` for common helpers
  - Updates `jest-global-setup.ts` and `jest-global-teardown.ts` to boot/teardown the auth server for integration tests
  - Updates `test-server.ts` with OAuth config overrides to fix assertion verification mismatches
  - Updates `test-ci.sh` to skip mocha tests when `TEST_TYPE=integration-jest`, running only Jest suites
  - Changes `test-integration-jest` npm script to route through `test-ci.sh` for consistency
  - Sets `maxWorkers: 4` in `jest.integration.config.js`

  ### Mocha → Jest test parity

  | File | Mocha | Jest | Status |
  |------|-------|------|--------|
  | account_create | 39 | 39 | Full parity |
  | account_create_with_code | 7 | 7 | Full parity |
  | account_destroy | 7 | 7 | Full parity |
  | account_locale | 2 | 2 | Full parity |
  | account_login | 13 | 13 | Full parity |
  | account_profile | 12 | 12 | Full parity |
  | account_reset | 5 | 5 | Full parity |
  | account_signin_verification | 8 | 8 | Full parity |
  | account_status | 9 | 9 | Full parity |
  | account_unlock | 3 | 3 | Full parity |
  | base_path | 4 | 2 + 2 todo | Intentional skip |
  | concurrent | 1 | 1 | Full parity |
  | db | 23 | 23 | Full parity |
  | email_validity | 2 | 2 | Full parity |
  | flow | 2 | 2 | Full parity |

  > `base_path`: 2 tests marked `todo` — they test `__lbheartbeat__` and `__version__` endpoints not present in the spawned
  key_server.

  ## Issue

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-12621

  ## Checklist

  - [x] My commit is GPG signed
  - [x] Tests pass locally
  - [ ] Documentation updated (if applicable)
  - [ ] RTL rendering verified (if UI changed)

  ## Other Information

  **Notable behavior change:** The Mocha test "cannot stub the same account twice" had an un-awaited `assert.isRejected()` that was effectively a no-op. The Jest version correctly tests actual server behavior as "can re-stub an unverified account".