### PR TITLE
fix(functional-tests): harden tests against sign-out race condition

### DIFF
--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -86,8 +86,13 @@ export abstract class SettingsLayout extends BaseLayout {
 
   async signOut() {
     await this.avatarDropDownMenuToggle.click();
-    await this.avatarMenuSignOut.click();
 
-    await expect(this.page).not.toHaveURL(/settings/);
+    // Wait for the hard navigation (window.location.assign) to complete.
+    // SPA redirects during sign-out can change the URL before the real
+    // page load fires, so we wait for the actual 'load' event.
+    await Promise.all([
+      this.page.waitForEvent('load'),
+      this.avatarMenuSignOut.click(),
+    ]);
   }
 }

--- a/packages/functional-tests/pages/signin.ts
+++ b/packages/functional-tests/pages/signin.ts
@@ -142,6 +142,8 @@ export class SigninPage extends PasskeyPage {
   }
 
   async fillOutEmailFirstForm(email: string) {
+    // Ensure the page is ready after a hard navigation.
+    await expect(this.emailTextbox).toBeVisible();
     await this.emailTextbox.fill(email);
     await this.emailFirstSubmitButton.click();
   }


### PR DESCRIPTION
## Because

- There is a race condition on the sign out, while we investigate the fix, we can hard the tests a bit

## This pull request

- Uses `waitForEvent` to make sure the page is settle before checking for headers
- Uses playwright `expect` that is a little more robust since it keeps checking on page.goto

## Issue that this pull request solves

Closes: (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1427" height="222" alt="Screenshot 2026-02-13 at 9 18 24 AM" src="https://github.com/user-attachments/assets/5a8f0e53-0415-4ad5-993e-226612ec150a" />

The last failure is because I'm rate limited from Fastly.