### PR TITLE
fix(fxa-settings): Fix gql loading issues and set password not keeping state

### DIFF
--- a/packages/fxa-settings/src/lib/hooks/useAccountData.test.ts
+++ b/packages/fxa-settings/src/lib/hooks/useAccountData.test.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { renderHook, act } from '@testing-library/react';
+import { useAccountData } from './useAccountData';
+import { sessionToken as getSessionToken } from '../cache';
+
+const mockSetAccountData = jest.fn();
+
+jest.mock('../cache', () => ({ sessionToken: jest.fn() }));
+jest.mock('../../models/contexts/AccountStateContext', () => ({
+  useAccountState: () => ({ setAccountData: mockSetAccountData }),
+}));
+jest.mock('../config', () => ({
+  oauth: { clientId: 'test' },
+  servers: { profile: { url: 'http://localhost' } },
+}));
+jest.mock('@sentry/browser', () => ({ captureMessage: jest.fn() }));
+
+const authClient = {
+  account: jest.fn(),
+  attachedClients: jest.fn(),
+  createOAuthToken: jest.fn(),
+} as any;
+
+describe('useAccountData', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('starts with isLoading=true', () => {
+    (getSessionToken as jest.Mock).mockReturnValue('tok');
+    authClient.account.mockReturnValue(new Promise(() => {}));
+    authClient.attachedClients.mockReturnValue(new Promise(() => {}));
+    authClient.createOAuthToken.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useAccountData({ authClient }));
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('sets error when no session token', async () => {
+    (getSessionToken as jest.Mock).mockReturnValue(null);
+    let result: any;
+    await act(async () => {
+      ({ result } = renderHook(() => useAccountData({ authClient })));
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error?.message).toBe('No session token available');
+  });
+});

--- a/packages/fxa-settings/src/models/Account.test.ts
+++ b/packages/fxa-settings/src/models/Account.test.ts
@@ -2,14 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { getNextAvatar } from './Account';
+import { Account, getNextAvatar } from './Account';
+import { sessionToken, JwtTokenCache } from '../lib/cache';
+import { getFullAccountData, updateExtendedAccountState } from '../lib/account-storage';
 
 jest.mock('../lib/config', () => ({
-  servers: {
-    profile: {
-      url: 'default-url',
-    },
-  },
+  servers: { profile: { url: 'default-url' } },
+  oauth: { clientId: 'test' },
+}));
+jest.mock('../lib/cache', () => ({
+  sessionToken: jest.fn(),
+  JwtTokenCache: { hasToken: jest.fn(() => true), getToken: jest.fn() },
+  isSigningOut: jest.fn(() => false),
+}));
+jest.mock('../lib/account-storage', () => ({
+  getFullAccountData: jest.fn(),
+  updateExtendedAccountState: jest.fn(),
+  updateBasicAccountData: jest.fn(),
 }));
 
 describe('Account', () => {
@@ -52,6 +61,40 @@ describe('Account', () => {
       const avatar = getNextAvatar(undefined, undefined, '!@example.com', '@#');
       expect(avatar.id).toBe(null);
       expect(avatar.url).toBe(null);
+    });
+  });
+
+  describe('createPassword', () => {
+    let account: Account;
+    const authClient: any = {
+      createPassword: jest.fn().mockResolvedValue({ passwordCreated: 123 }),
+      createPasswordWithJwt: jest.fn().mockResolvedValue({ passwordCreated: 123 }),
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      (getFullAccountData as jest.Mock).mockReturnValue({
+        uid: 'abc',
+        emails: [{ email: 'a@b.com', isPrimary: true, verified: true }],
+        primaryEmail: { email: 'a@b.com', isPrimary: true, verified: true },
+      });
+      (sessionToken as jest.Mock).mockReturnValue('tok');
+      (JwtTokenCache.getToken as jest.Mock).mockReturnValue('jwt');
+      account = new Account(authClient);
+    });
+
+    it('sets hasPassword after createPassword', async () => {
+      await account.createPassword('pw');
+      expect(updateExtendedAccountState).toHaveBeenCalledWith(
+        expect.objectContaining({ hasPassword: true })
+      );
+    });
+
+    it('sets hasPassword after createPasswordWithJwt', async () => {
+      await account.createPasswordWithJwt('pw');
+      expect(updateExtendedAccountState).toHaveBeenCalledWith(
+        expect.objectContaining({ hasPassword: true })
+      );
     });
   });
 });

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -662,6 +662,7 @@ export class Account implements AccountData {
 
     updateExtendedAccountState({
       passwordCreated: passwordCreatedResult.passwordCreated,
+      hasPassword: true,
     });
   }
 
@@ -677,6 +678,7 @@ export class Account implements AccountData {
 
     updateExtendedAccountState({
       passwordCreated: passwordCreatedResult.passwordCreated,
+      hasPassword: true,
     });
   }
 


### PR DESCRIPTION
## Because

- You might see a flash of default state before the account loads in settings
- We didn't update local cache after setting a password

## This pull request

- Adds a loading indicator to wait for account state to get loaded before showing setting
- Updates account local storage state after setting password

## Issue that this pull request solves

Closes: https://mozilla-hub.atlassian.net/browse/FXA-13107
Closes: https://mozilla-hub.atlassian.net/browse/FXA-13109

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Its kinda hard to reproduce settings refresh issue locally (I wasn't actually able too), but this seems to be reasonable to me what might be going on.
