### PR TITLE
fix(fxa): Use provider for name mapping in linked account email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -388,7 +388,7 @@ export class LinkedAccountHandler {
             ...FxaMailerFormat.location(request),
             ...FxaMailerFormat.device(request),
             ...FxaMailerFormat.sync(service),
-            providerName: PROVIDER_NAME[name],
+            providerName: PROVIDER_NAME[provider],
           });
         } else {
           const emailOptions = {


### PR DESCRIPTION
Because:
 - We're passing the users name to the provider_name mapping
 - Which causes the template to display incorrectly

This Commit:
 - Uses the correct item for the map

Closes: FXA-13093

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.

<img width="356" height="528" alt="image" src="https://github.com/user-attachments/assets/27e4ee4d-1263-4176-8c14-3906101694b9" />
