### PR TITLE
feat(settings): create password fallback page for Sync

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/content-server-routes.js
@@ -74,6 +74,8 @@ const FRONTEND_ROUTES = [
   'signin_recovery_choice',
   'signin_recovery_phone',
   'signin_confirmed',
+  // TODO: FXA-13100 - Uncomment when passkey fallback is fully implemented
+  // 'signin_passkey_fallback',
   'signin_permissions',
   'signin_reported',
   'signin_unblock',

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -105,6 +105,9 @@ const SigninBounced = lazy(() => import('../../pages/Signin/SigninBounced'));
 const SigninConfirmed = lazy(
   () => import('../../pages/Signin/SigninConfirmed')
 );
+const SigninPasskeyFallback = lazy(
+  () => import('../../pages/Signin/SigninPasskeyFallback')
+);
 const SigninRecoveryCodeContainer = lazy(
   () => import('../../pages/Signin/SigninRecoveryCode/container')
 );
@@ -309,7 +312,8 @@ export const App = ({
         recoveryKey: data.account.recoveryKey?.exists ?? false,
         hasSecondaryVerifiedEmail:
           data.account.emails.length > 1 && data.account.emails[1].verified,
-        totpActive: (data.account.totp?.exists && data.account.totp?.verified) ?? false,
+        totpActive:
+          (data.account.totp?.exists && data.account.totp?.verified) ?? false,
       });
     }
   }, [
@@ -610,6 +614,7 @@ const AuthAndAccountSetupRoutes = ({
         path="/signin_confirmed/*"
         {...{ isSignedIn, serviceName, integration }}
       />
+      <SigninPasskeyFallback path="/signin_passkey_fallback/*" />
       <SigninRecoveryChoiceContainer
         path="/signin_recovery_choice/*"
         {...{ integration }}

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/__snapshots__/index.test.tsx.snap
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SigninPasskeyFallback renders as expected 1`] = `
+<div>
+  <div
+    class="flex min-h-screen flex-col items-center"
+    data-testid="app"
+  >
+    <div
+      class="w-full hidden mobileLandscape:block"
+      id="body-top"
+    />
+    <header
+      class="w-full px-6 py-4 mobileLandscape:py-6"
+    >
+      <a
+        class="mobileLandscape:inline-block"
+        data-testid="link-external"
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        rel="author"
+        target="_blank"
+      >
+        <img
+          alt="Mozilla logo"
+          class="h-auto w-[140px] mx-0"
+          src="moz-logo-bw-rgb.svg"
+        />
+        <span
+          class="sr-only"
+        >
+          Opens in new window
+        </span>
+      </a>
+    </header>
+    <main
+      class="flex mobileLandscape:items-center flex-1"
+    >
+      <section>
+        <div
+          class="card"
+        >
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-passkey-fallback-header"
+          >
+            <p
+              class="text-sm text-grey-500 mb-2"
+            >
+              Finish sign in
+            </p>
+          </span>
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-passkey-fallback-heading"
+          >
+            <h1
+              class="card-header mb-4"
+            >
+              Enter your password to sync
+            </h1>
+          </span>
+          <span
+            data-testid="ftlmsg-mock"
+            id="signin-passkey-fallback-body"
+          >
+            <p
+              class="text-sm mb-6"
+            >
+              To keep your data safe, you need to enter your password when you use this passkey.
+            </p>
+          </span>
+          <form>
+            <span
+              data-testid="ftlmsg-mock"
+              id="signin-passkey-fallback-password-label"
+            >
+              <div
+                class="relative"
+              >
+                <label
+                  class="flex text-start rounded transition-all duration-100 ease-in-out border relative outline-none border-grey-200 bg-white mb-6"
+                  data-testid="password-input-container"
+                >
+                  <span
+                    class="block flex-auto"
+                  >
+                    <span
+                      class="px-3 w-full cursor-text absolute ltr:origin-top-left rtl:origin-top-right text-sm transition-all duration-100 ease-in-out truncate font-body text-grey-900 mt-3 pt-px"
+                      data-testid="password-input-label"
+                    >
+                      Password
+                    </span>
+                    <input
+                      autocomplete="off"
+                      class="pb-1 pt-5 px-3 font-body rounded text-start w-[90%]"
+                      data-testid="password-input-field"
+                      name="password"
+                      spellcheck="false"
+                      type="password"
+                      value=""
+                    />
+                  </span>
+                </label>
+                <button
+                  aria-label="Your password is currently hidden."
+                  aria-pressed="false"
+                  class="absolute end-0 inset-y-0 my-auto mx-2 px-2 text-grey-500 box-content focus-visible-default rounded"
+                  data-testid="password-visibility-toggle"
+                  title="Show password"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="stroke-current"
+                    height="18"
+                    width="24"
+                  >
+                    eye-open.svg
+                  </svg>
+                </button>
+              </div>
+            </span>
+            <div
+              class="flex flex-col tablet:flex-row gap-4"
+            >
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-passkey-fallback-go-to-settings"
+              >
+                <button
+                  class="cta-neutral cta-base-p tablet:flex-1"
+                  data-testid="go-to-settings-button"
+                  type="button"
+                >
+                  Go to settings
+                </button>
+              </span>
+              <span
+                data-testid="ftlmsg-mock"
+                id="signin-passkey-fallback-continue"
+              >
+                <button
+                  class="cta-primary cta-base-p tablet:flex-1"
+                  data-testid="continue-button"
+                  type="submit"
+                >
+                  Continue
+                </button>
+              </span>
+            </div>
+          </form>
+        </div>
+      </section>
+    </main>
+  </div>
+  <div
+    class="w-full block mobileLandscape:hidden"
+    id="body-bottom"
+  />
+</div>
+`;

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/en.ftl
@@ -1,0 +1,9 @@
+## SigninPasskeyFallback page
+## Users who authenticate with a passkey to access Sync must also enter their password.
+
+signin-passkey-fallback-header = Finish sign-in
+signin-passkey-fallback-heading = Enter your password to sync
+signin-passkey-fallback-body = To keep your data safe, you need to enter your password when you use this passkey.
+signin-passkey-fallback-password-label = Password
+signin-passkey-fallback-go-to-settings = Go to settings
+signin-passkey-fallback-continue = Continue

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.stories.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import SigninPasskeyFallback from '.';
+import { LocationProvider } from '@reach/router';
+import { Meta } from '@storybook/react';
+import { withLocalization } from 'fxa-react/lib/storybooks';
+
+export default {
+  title: 'Pages/Signin/SigninPasskeyFallback',
+  component: SigninPasskeyFallback,
+  decorators: [withLocalization],
+} as Meta;
+
+export const Default = () => (
+  <LocationProvider>
+    <SigninPasskeyFallback />
+  </LocationProvider>
+);

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.test.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '../../../models/mocks';
+import SigninPasskeyFallback from '.';
+
+describe('SigninPasskeyFallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders as expected', () => {
+    const { container } = renderWithRouter(<SigninPasskeyFallback />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('clears password error text on input change', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(<SigninPasskeyFallback />);
+    const passwordInput = screen.getByLabelText('Password');
+
+    await user.type(passwordInput, 'newpassword');
+
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasskeyFallback/index.tsx
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState } from 'react';
+import { RouteComponentProps } from '@reach/router';
+import { useForm } from 'react-hook-form';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import AppLayout from '../../../components/AppLayout';
+import InputPassword from '../../../components/InputPassword';
+
+export type SigninPasskeyFallbackProps = {};
+
+type FormData = {
+  password: string;
+};
+
+export const viewName = 'signin-passkey-fallback';
+
+const SigninPasskeyFallback = (
+  _props: SigninPasskeyFallbackProps & RouteComponentProps
+) => {
+  // State
+  const [passwordErrorText, setPasswordErrorText] = useState('');
+
+  // Form
+  const { handleSubmit, register } = useForm<FormData>({
+    mode: 'onTouched',
+    criteriaMode: 'all',
+    defaultValues: { password: '' },
+  });
+
+  // Handlers
+  const onContinue = useCallback(async (data: FormData) => {
+    // TODO: FXA-13100 - Hook up password verification when container is added
+  }, []);
+
+  const onGoToSettings = useCallback(() => {
+    // TODO: FXA-13100 - Hook up navigation when container is added
+  }, []);
+
+  return (
+    <AppLayout>
+      <FtlMsg id="signin-passkey-fallback-header">
+        <p className="text-sm text-grey-500 mb-2">Finish sign in</p>
+      </FtlMsg>
+
+      <FtlMsg id="signin-passkey-fallback-heading">
+        <h1 className="card-header mb-4">Enter your password to sync</h1>
+      </FtlMsg>
+
+      <FtlMsg id="signin-passkey-fallback-body">
+        <p className="text-sm mb-6">
+          To keep your data safe, you need to enter your password when you use
+          this passkey.
+        </p>
+      </FtlMsg>
+
+      <form onSubmit={handleSubmit(onContinue)}>
+        <FtlMsg
+          id="signin-passkey-fallback-password-label"
+          attrs={{ label: true }}
+        >
+          <InputPassword
+            name="password"
+            label="Password"
+            className="mb-6"
+            errorText={passwordErrorText}
+            anchorPosition="start"
+            autoFocus
+            onChange={() => setPasswordErrorText('')}
+            inputRef={register({ required: true })}
+            prefixDataTestId="password"
+          />
+        </FtlMsg>
+
+        {/* TODO: FXA-13100 - Add disabled={isSubmitting} while the password is submitting. */}
+        <div className="flex flex-col tablet:flex-row gap-4">
+          <FtlMsg id="signin-passkey-fallback-go-to-settings">
+            <button
+              type="button"
+              className="cta-neutral cta-base-p tablet:flex-1"
+              onClick={onGoToSettings}
+              data-testid="go-to-settings-button"
+            >
+              Go to settings
+            </button>
+          </FtlMsg>
+
+          <FtlMsg id="signin-passkey-fallback-continue">
+            <button
+              type="submit"
+              className="cta-primary cta-base-p tablet:flex-1"
+              data-testid="continue-button"
+            >
+              Continue
+            </button>
+          </FtlMsg>
+        </div>
+      </form>
+    </AppLayout>
+  );
+};
+
+export default SigninPasskeyFallback;


### PR DESCRIPTION
## Because

- We want a "create password entry page" for Sync users after passkey authentication

## This pull request

- adds the page design at `/signin_passkey_fallback` (navigation/interaction hookups not included) 

## Issue that this pull request solves

Closes: FXA-12909

## Screenshots (Optional)
https://mozilla.github.io/fxa/storybooks/pr-20066/fxa-settings/iframe.html?args=&id=pages-signin-signinpasskeyfallback--default

<img width="562" height="422" alt="Screenshot 2026-02-18 at 10 58 52 AM" src="https://github.com/user-attachments/assets/d5630c01-c836-41fb-8662-fbcd4cb792fb" />


## Other information (Optional)

- original ticket suggests the path `/signin/passkey/fallback`, however these changes use `/signin_passkey_fallback` for convention with other routes/components
