### PR TITLE
fix(settings): skip recovery for fresh signin flow

### DIFF
--- a/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninTokenCode/container.tsx
@@ -69,19 +69,13 @@ const SigninTokenCodeContainer = ({
     const shouldAttemptRecovery =
       !recoveryAttempted &&
       isOAuthNativeIntegration(integration) &&
-      (!signinState || !signinState.sessionToken || oAuthKeysCheckError);
+      (!signinState || !signinState.sessionToken);
 
     if (shouldAttemptRecovery) {
       setRecoveryAttempted(true);
       attemptOAuthFlowRecovery();
     }
-  }, [
-    recoveryAttempted,
-    integration,
-    signinState,
-    oAuthKeysCheckError,
-    attemptOAuthFlowRecovery,
-  ]);
+  }, [recoveryAttempted, integration, signinState, attemptOAuthFlowRecovery]);
 
   // Handle recovery failure - navigate to signin with error message
   useEffect(() => {

--- a/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signup/ConfirmSignupCode/container.tsx
@@ -148,7 +148,7 @@ const SignupConfirmCodeContainer = ({
     const shouldAttemptRecovery =
       !recoveryAttempted &&
       isOAuthNativeIntegration(integration) &&
-      (!uid || !sessionToken || !email || oAuthKeysCheckError);
+      (!uid || !sessionToken || !email);
 
     if (shouldAttemptRecovery) {
       setRecoveryAttempted(true);
@@ -160,7 +160,6 @@ const SignupConfirmCodeContainer = ({
     uid,
     sessionToken,
     email,
-    oAuthKeysCheckError,
     attemptOAuthFlowRecovery,
   ]);
 


### PR DESCRIPTION
## Because

- Users are redirected to the signin page after entering their email verification code, instead of being taken to their final destination (e.g. /settings)

## This pull request

- Removes oAuthKeysCheckError from recovery decision because keys can be temporarily
unavailable during normal signin flows (timing, async state), causing false
positives.
- uses signin state as a more reliable indicator of fresh flow vs genuine crash/refresh.

## Issue that this pull request solves

Closes: FXA-13126