### PR TITLE
feat(payments-next): Add healthcheck payments-api local start script

### DIFF
--- a/apps/payments/api/project.json
+++ b/apps/payments/api/project.json
@@ -70,13 +70,13 @@
       }
     },
     "start": {
-      "command": "pm2 start apps/payments/api/pm2.config.js",
+      "command": "pm2 start apps/payments/api/pm2.config.js && yarn check:url localhost:3037/__heartbeat__"
     },
     "stop": {
       "command": "pm2 stop apps/payments/api/pm2.config.js"
     },
     "restart": {
-      "command": "pm2 restart apps/payments/api/pm2.config.js",
+      "command": "pm2 restart apps/payments/api/pm2.config.js"
     },
     "delete": {
       "command": "pm2 delete apps/payments/api/pm2.config.js"


### PR DESCRIPTION
## Because

- We want to ensure that payments-api starts up successfully on stack startup.

## This pull request

-  Adds a check health to the project.json start script to check if payments-api has started successfully on stack startup.

## Issue that this pull request solves

Closes: #PAY-3528

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
