### PR TITLE
fix(fxa): accounts that are force email confirmation to need to mark session needs verification

### DIFF
--- a/packages/functional-tests/lib/email.ts
+++ b/packages/functional-tests/lib/email.ts
@@ -126,6 +126,43 @@ export class EmailClient {
   }
 
   /**
+   * Returns a summary of all emails for the given address (template name and subject).
+   * Useful for debugging which emails have been delivered.
+   * @param emailAddress - The email address to check.
+   * @returns Array of { template, subject } for each email.
+   */
+  async getEmailsByType(
+    emailAddress: string
+  ): Promise<{ template: string; subject: string }[]> {
+    const mail = (await got(
+      `${this.host}/mail/${toUsername(emailAddress)}`
+    ).json()) as any[];
+    return mail.map((m) => ({
+      template: m.headers[EmailHeader.templateName] || 'unknown',
+      subject: m.subject || '',
+    }));
+  }
+
+  /**
+   * Counts how many emails of a specific type exist for the given address.
+   * Does not clear or consume the emails.
+   * @param emailAddress - The email address to check.
+   * @param type - The type of email to count.
+   * @returns The number of matching emails.
+   */
+  async countEmailsByType(
+    emailAddress: string,
+    type: EmailType
+  ): Promise<number> {
+    const mail = (await got(
+      `${this.host}/mail/${toUsername(emailAddress)}`
+    ).json()) as any[];
+    return mail.filter(
+      (m) => m.headers[EmailHeader.templateName] === EmailType[type]
+    ).length;
+  }
+
+  /**
    * Gets the link to create new backup authentication codes from the lowRecoveryCodes email.
    * @param email - The email that is expected to receive the link.
    * @returns the backup authentication codes link

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1300,6 +1300,7 @@ export class AccountHandler {
         needsVerificationId &&
         (verificationForced === 'suspect' ||
           verificationForced === 'global' ||
+          verificationForced === 'email' ||
           requestHelper.wantsKeys(request) ||
           (service &&
             this.config.servicesWithEmailVerification.includes(service)));

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3010,8 +3010,8 @@ describe('/account/login', () => {
         );
         const tokenData = mockDB.createSessionToken.getCall(0).args[0];
         assert.ok(
-          !tokenData.mustVerify,
-          'sessionToken does not have to be verified'
+          tokenData.mustVerify,
+          'sessionToken mustVerify is true for forcedEmailAddresses'
         );
         const sessionToken = mockDB.createSessionToken.returnValues[0];
         sessionToken.then((token) => {

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -12,6 +12,7 @@ import {
   isSignedIn as checkIsSignedIn,
   getSessionVerified,
   setSessionVerified,
+  updateAccountData,
   dispatchStorageEvent,
 } from '../lib/account-storage';
 
@@ -88,6 +89,7 @@ export class Session implements SessionData {
       this.authClient.sessionVerifyCode(sessionToken()!, code, options)
     );
     setSessionVerified(true);
+    updateAccountData({ verified: true });
     setStoredSignedInStatus(true);
   }
 


### PR DESCRIPTION
## Because

- When an email is "force" to verify on a login, there is a bug where the session is marked as not needing verification, this leads to strange edge cases
- I suspect this wasn't an issue before because of apollo cache and inconsistent caching behavior

## This pull request

- If an email is forced to verify their email, ensure that the session is marked that it needs to be verified
- After verifiying an email, mark the session verified

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

STR An existing verified account with an email matching forcedEmailAddresses regex (e.g. @mozilla.com,@softvision.com).                                                                                                                             
                                                                                                                                                                      
  1. Open Firefox Accounts login page
  2. Enter the email address and click next
  3. Enter the password and submit
  4. You are redirected to /signin_token_code (email verification required)
  5. Before entering the code, check the inbox or pm2 logs
