### PR TITLE
fix(oauth): Prevent validation errors from orphaned client tokens

### DIFF
--- a/packages/fxa-shared/connected-services/factories.ts
+++ b/packages/fxa-shared/connected-services/factories.ts
@@ -257,7 +257,7 @@ export class ConnectedServicesFactory {
       // We fill in a default device name from the OAuth client name,
       // but individual clients can override this in their device record registration.
       if (!client.name) {
-        client.name = oauthClient.client_name;
+        client.name = oauthClient.client_name ?? null;
       }
       // For now we assume that all oauth clients that register a device record are mobile apps.
       // Ref https://github.com/mozilla/fxa/issues/449
@@ -277,7 +277,7 @@ export class ConnectedServicesFactory {
         refreshTokenId: null,
         deviceId: device.id,
         deviceType: device.type,
-        name: device.name,
+        name: device.name ?? null,
         createdTime: device.createdAt,
         lastAccessTime: device.lastAccessTime,
       };
@@ -292,6 +292,6 @@ export class ConnectedServicesFactory {
   }
 
   protected getDefaultClientFields(): AttachedClient {
-    return attachedClientsDefaults;
+    return { ...attachedClientsDefaults };
   }
 }

--- a/packages/fxa-shared/test/connected-services/factories.ts
+++ b/packages/fxa-shared/test/connected-services/factories.ts
@@ -193,5 +193,44 @@ describe('connected-services/factories', () => {
       Sinon.assert.calledOnce(bStubbed.oauthClients);
       Sinon.assert.calledOnce(bStubbed.sessions);
     });
+
+    it('coerces undefined device name to null', async () => {
+      deviceList = [
+        {
+          id: 'test-device',
+          sessionTokenId: 'test',
+          name: undefined as any, // Simulate undefined from database
+          pushEndpointExpired: false,
+          availableCommands: {},
+          location: {},
+        } as AttachedDevice,
+      ];
+      oauthClients = [];
+      sessions = [];
+
+      const results = await factory.build('1234', 'en');
+
+      assert.strictEqual(results[0].name, null);
+    });
+
+    it('coerces undefined client_name to null', async () => {
+      oauthClients = [
+        {
+          refresh_token_id: 'test-oauth',
+          created_time: Date.now(),
+          last_access_time: Date.now(),
+          client_name: undefined as any, // Simulate undefined from database
+          client_id: null as any,
+          scope: null as any,
+        } as AttachedOAuthClient,
+      ];
+      deviceList = [];
+      sessions = [];
+
+      const results = await factory.build('1234', 'en');
+
+      // Verify name is null, not undefined (required for validation)
+      assert.strictEqual(results[0].name, null);
+    });
   });
 });


### PR DESCRIPTION
## Because

* Sentry showed ValidationError: "[0].name" is required
* OAuth token queries use LEFT OUTER JOIN with clients table
* When a client is deleted but tokens remain (orphaned), the JOIN returns NULL
* This may be converted to undefined, which fails Joi validation

## This pull request

* Add nullish coalescing in factories.ts when merging OAuth client names
* Fix shared reference bug in getDefaultClientFields() to return copy of defaults
* Add regression test for undefined client_name handling

## Issue that this pull request solves

Closes: FXA-13132

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
