### PR TITLE
bug(settings): Redirect to root/signin if session status fails

### DIFF
--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -27,7 +27,11 @@ const mockAccountState = {
   email: 'johndoe@example.com',
   metricsEnabled: true,
   verified: true,
-  primaryEmail: { email: 'johndoe@example.com', isPrimary: true, verified: true },
+  primaryEmail: {
+    email: 'johndoe@example.com',
+    isPrimary: true,
+    verified: true,
+  },
   displayName: null,
   avatar: null,
   emails: [],
@@ -120,7 +124,11 @@ describe('Settings App', () => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
     // Reset account state mock to default values
-    (useAccountState as jest.Mock).mockReturnValue({ ...mockAccountState, isLoading: false, error: null });
+    (useAccountState as jest.Mock).mockReturnValue({
+      ...mockAccountState,
+      isLoading: false,
+      error: null,
+    });
     mockUseAccountData.mockReturnValue({
       isLoading: false,
       error: null,
@@ -238,6 +246,29 @@ describe('Settings App', () => {
       <AppContext.Provider
         value={mockAppContext({ session: unverifiedSession })}
       >
+        <Subject />
+      </AppContext.Provider>,
+      { route: SETTINGS_PATH }
+    );
+
+    await waitFor(() => {
+      expect(mockNavigateWithQuery).toHaveBeenCalledWith('/');
+    });
+    warnSpy.mockRestore();
+  });
+
+  it('redirects to root when sessionStatus call fails', async () => {
+    // this warning is expected, so we don't want to see it in the test output
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation((msg) => {
+      if (
+        msg === 'Account or email verification is require to access /settings!'
+      )
+        return;
+    });
+    mockSessionStatus.mockRejectedValue(new Error('Session status failed'));
+
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext()}>
         <Subject />
       </AppContext.Provider>,
       { route: SETTINGS_PATH }

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -7,12 +7,11 @@ import * as Sentry from '@sentry/browser';
 import SettingsLayout from './SettingsLayout';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import AppErrorDialog from 'fxa-react/components/AppErrorDialog';
+import { useAccount, useAuthClient, useSession } from '../../models';
 import {
-  useAccount,
-  useAuthClient,
-  useSession,
-} from '../../models';
-import { useAccountData, InvalidTokenError } from '../../lib/hooks/useAccountData';
+  useAccountData,
+  InvalidTokenError,
+} from '../../lib/hooks/useAccountData';
 import {
   Redirect,
   Router,
@@ -117,11 +116,16 @@ export const Settings = ({
       ) {
         return;
       }
-      const { details } = await authClient.sessionStatus(sessionToken()!);
-      setSessionVerified(details.sessionVerified);
-      setSessionVerificationMeetsAAL(
-        details.sessionVerificationMeetsMinimumAAL
-      );
+      try {
+        const { details } = await authClient.sessionStatus(sessionToken()!);
+        setSessionVerified(details.sessionVerified);
+        setSessionVerificationMeetsAAL(
+          details.sessionVerificationMeetsMinimumAAL
+        );
+      } catch (error) {
+        setSessionVerified(false);
+        setSessionVerificationMeetsAAL(false);
+      }
     })();
   }, [authClient, sessionVerified, sessionVerificationMeetsAAL]);
 


### PR DESCRIPTION


## Because

- Seeing elevated 401s on stage
- Seeing unhandled errors when calling session status on stage

## This pull request

- Handles error
- Set state as unverified resulting in redirect to signin

## Issue that this pull request solves

Closes: FXA-13110

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
