### PR TITLE
fix(settings): Restore pre-GraphQL session verification guard

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -151,6 +151,7 @@ export type SessionStatus = {
     accountEmailVerified: boolean;
     sessionVerificationMethod: string | null;
     sessionVerified: boolean;
+    mustVerify: boolean;
     sessionVerificationMeetsMinimumAAL: boolean;
   };
 };

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -312,6 +312,7 @@ module.exports = function (
               accountEmailVerified: isA.boolean(),
               sessionVerificationMethod: isA.string().allow(null),
               sessionVerified: isA.boolean(),
+              mustVerify: isA.boolean(),
               sessionVerificationMeetsMinimumAAL: isA.boolean(),
               verified: isA.boolean(), // Deprecated!
             }),
@@ -351,6 +352,8 @@ module.exports = function (
         // Legacy verified flag. Keep for backwards compatibility.
         const verified = accountEmailVerified && sessionVerified;
 
+        const mustVerify = !!sessionToken.mustVerify;
+
         return {
           state: sessionToken.state,
           uid: sessionToken.uid,
@@ -358,6 +361,7 @@ module.exports = function (
             accountEmailVerified,
             sessionVerificationMethod,
             sessionVerified,
+            mustVerify,
             sessionVerificationMeetsMinimumAAL,
             verified,
           },

--- a/packages/fxa-settings/src/pages/Signin/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/index.test.tsx
@@ -492,7 +492,7 @@ describe('Signin component', () => {
             });
           });
 
-          it('navigates to /signin_token_code when session unverified', async () => {
+          it('navigates to /settings when session unverified but email verified (direct web flow)', async () => {
             const beginSigninHandler = jest.fn().mockReturnValueOnce(
               createBeginSigninResponse({
                 emailVerified: true,
@@ -503,7 +503,7 @@ describe('Signin component', () => {
 
             await enterPasswordAndSubmit();
             await waitFor(() => {
-              expect(navigate).toHaveBeenCalledWith('/signin_token_code', {
+              expect(navigate).toHaveBeenCalledWith('/settings', {
                 replace: false,
                 state: {
                   email: MOCK_EMAIL,

--- a/packages/fxa-settings/src/pages/Signin/utils.ts
+++ b/packages/fxa-settings/src/pages/Signin/utils.ts
@@ -279,7 +279,17 @@ export async function handleNavigation(navigationOptions: NavigationOptions) {
     }
 
     if (navigationOptions.performNavigation !== false) {
-      performNavigation({ to, locationState });
+      // For direct web logins (non-OAuth) where the email is already verified
+      // and the session isn't TOTP-required, the session already meets the
+      // account's minimum AAL. Navigate to settings directly instead of the
+      // confirmation code page. This restores the pre-GraphQL-removal behavior
+      // where the server-side SessionTokenStrategy respected mustVerify
+      // (which was false for these non-keys, non-forced, non-TOTP cases).
+      if (navigationOptions.signinData.emailVerified) {
+        performNavigation({ to: '/settings', locationState });
+      } else {
+        performNavigation({ to, locationState });
+      }
     }
     return { error: undefined };
   }


### PR DESCRIPTION
## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
