### PR TITLE
fix(emails): Fix user's locale in emails from being overwritten by an other user

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/email-helpers.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-helpers.spec.ts
@@ -136,5 +136,60 @@ describe('EmailHelpers', () => {
       expect(resultDefault).toEqual('01/15/2024');
       expect(resultEst).toEqual('01/14/2024');
     });
+
+    it('does not leak locale between concurrent calls', async () => {
+      const date = new Date('2025-03-13T12:00:00Z');
+
+      const [enResult, gbResult] = await Promise.all([
+        Promise.resolve(constructLocalDateString(undefined, 'en', date)),
+        Promise.resolve(constructLocalDateString(undefined, 'en-GB', date)),
+      ]);
+
+      expect(enResult).toEqual('03/13/2025');
+      expect(gbResult).toEqual('13/03/2025');
+    });
+
+    it('does not leak locale into subsequent calls', () => {
+      const date = new Date('2025-03-13T12:00:00Z');
+
+      constructLocalDateString(undefined, 'en-GB', date);
+      const enResult = constructLocalDateString(undefined, 'en', date);
+
+      expect(enResult).toEqual('03/13/2025');
+    });
+  });
+
+  describe('constructLocalTimeAndDateStrings - locale isolation', () => {
+    it('does not leak locale between concurrent calls', async () => {
+      const [enResult, esResult] = await Promise.all([
+        Promise.resolve(
+          constructLocalTimeAndDateStrings('America/Los_Angeles', 'en')
+        ),
+        Promise.resolve(
+          constructLocalTimeAndDateStrings('America/Los_Angeles', 'es')
+        ),
+      ]);
+
+      const enDays = [
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+        'Sunday',
+      ];
+      const esDays = [
+        'lunes',
+        'martes',
+        'miércoles',
+        'jueves',
+        'viernes',
+        'sábado',
+        'domingo',
+      ];
+      expect(enDays).toContain(enResult.date.split(',')[0]);
+      expect(esDays).toContain(esResult.date.split(',')[0]);
+    });
   });
 });

--- a/libs/accounts/email-renderer/src/renderer/email-helpers.ts
+++ b/libs/accounts/email-renderer/src/renderer/email-helpers.ts
@@ -53,15 +53,11 @@ export const constructLocalTimeAndDateStrings = (
   time: string;
   timeZone: string;
 } => {
-  moment.tz.setDefault(DEFAULT_TIMEZONE);
-
   const locale = determineLocale(acceptLanguage) || DEFAULT_LOCALE;
-  moment.locale(locale);
 
-  let timeMoment = moment(date ? date : undefined);
-  if (timeZone) {
-    timeMoment = timeMoment.tz(timeZone);
-  }
+  const timeMoment = moment(date ? date : undefined)
+    .locale(locale)
+    .tz(timeZone || DEFAULT_TIMEZONE);
 
   const formattedTime = timeMoment.format('LTS (z)');
   const formattedDate = timeMoment.format('dddd, ll');
@@ -88,15 +84,11 @@ export const constructLocalDateString = (
   date?: Date | number,
   formatString = 'L'
 ): string => {
-  moment.tz.setDefault(DEFAULT_TIMEZONE);
-
   const locale = determineLocale(acceptLanguage) || DEFAULT_LOCALE;
-  moment.locale(locale);
 
-  let time = moment(date);
-  if (timeZone) {
-    time = time.tz(timeZone);
-  }
+  const time = moment(date)
+    .locale(locale)
+    .tz(timeZone || DEFAULT_TIMEZONE);
 
   return time.format(formatString);
 };

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -23,7 +23,6 @@ const { ProductConfigurationManager } = require('@fxa/shared/cms');
 const { Container } = require('typedi');
 
 const DEFAULT_LOCALE = 'en';
-const DEFAULT_TIMEZONE = 'Etc/UTC';
 const UTM_PREFIX = 'fx-';
 
 const X_SES_CONFIGURATION_SET = 'X-SES-CONFIGURATION-SET';
@@ -186,15 +185,11 @@ module.exports = function (log, config, bounces, statsd) {
   }
 
   function constructLocalTimeString(timeZone, locale) {
-    // if no timeZone is passed, use DEFAULT_TIMEZONE
-    moment.tz.setDefault(DEFAULT_TIMEZONE);
     // if no locale is passed, use DEFAULT_LOCALE
     locale = locale || DEFAULT_LOCALE;
-    moment.locale(locale);
-    let timeMoment = moment();
-    if (timeZone) {
-      timeMoment = timeMoment.tz(timeZone);
-    }
+    const timeMoment = moment()
+      .locale(locale)
+      .tz(timeZone || 'Etc/UTC');
     // return a locale-specific time
     // if date or time is passed, return it as the current date or time
     const timeNow = timeMoment.format('LTS (z)');
@@ -208,15 +203,11 @@ module.exports = function (log, config, bounces, statsd) {
     date,
     formatString = 'L'
   ) {
-    // if no timeZone is passed, use DEFAULT_TIMEZONE
-    moment.tz.setDefault(DEFAULT_TIMEZONE);
     // if no locale is passed, use DEFAULT_LOCALE
     locale = locale || DEFAULT_LOCALE;
-    moment.locale(locale);
-    let time = moment(date);
-    if (timeZone) {
-      time = time.tz(timeZone);
-    }
+    const time = moment(date)
+      .locale(locale)
+      .tz(timeZone || 'Etc/UTC');
     // return a locale-specific date
     return time.format(formatString);
   }


### PR DESCRIPTION
## Because

- moment.tz.setDefault() and moment.locale() are global mutations
- Since Node.js processes emails concurrently (via async), one user's email could overwrite the global locale while another user's email was mid-render, causing that email to format dates with the wrong locale (e.g., MM/DD/YYYY instead of DD/MM/YYYY or vice versa)

## This pull request

- Switches to instance-level .locale (locale) so each date formatting call is self-contained and can't affect others.

## Issue that this pull request solves

Closes: PAY-3575

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.