### PR TITLE
test(auth): Mock oauth/token module in token exchange unit test

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.spec.ts
@@ -745,6 +745,9 @@ describe('/oauth/token POST', () => {
       jest.doMock('../utils/oauth', () => ({
         newTokenNotification: newTokenNotificationStub,
       }));
+      jest.doMock('../../oauth/token', () => ({
+        verify: sinon.stub().resolves({ user: UID }),
+      }));
       const routes = require('./token')({
         ...tokenRoutesArgMocks,
         db: {
@@ -827,6 +830,9 @@ describe('/oauth/token POST', () => {
       );
       jest.doMock('../utils/oauth', () => ({
         newTokenNotification: newTokenNotificationStub,
+      }));
+      jest.doMock('../../oauth/token', () => ({
+        verify: sinon.stub().resolves({ user: UID }),
       }));
       const routes = require('./token')({
         ...tokenRoutesArgMocks,


### PR DESCRIPTION
## Because

* token.verify() was not mocked in two token exchange tests
* Each jest.resetModules() creates a fresh OauthDB singleton that opens real MySQL/Redis connections; the second instantiation hangs past 10s in CI, causing an intermittent timeout
* Example failure: https://app.circleci.com/pipelines/github/mozilla/fxa/68720/workflows/fd17ddcd-5541-49fe-90c2-28cb3bdd86c7/jobs/661401

## This pull request

* Adds jest.doMock('../../oauth/token', ...) to both token exchange tests so token.verify() never hits real infrastructure in unit tests

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
