### PR TITLE
feat(passkeys): show max-limit banner and disable Create button when passkey limit reached

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -93,6 +93,9 @@ const settingsConfig = {
     count: config.get('recovery_codes.count'),
     length: config.get('recovery_codes.length'),
   },
+  passkeys: {
+    maxPerUser: config.get('passkeys.maxPerUser'),
+  },
   mfa: {
     otp: {
       expiresInMinutes: config.get('mfa.otp.expiresInMinutes'),

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -272,6 +272,14 @@ const conf = (module.exports = convict({
       env: 'PASSWORDLESS_SIGNUP_ENABLED',
     },
   },
+  passkeys: {
+    maxPerUser: {
+      default: 10,
+      doc: 'Maximum number of passkeys a single user account may register. Must stay in sync with auth-server PASSKEYS__MAX_PASSKEYS_PER_USER.',
+      format: Number,
+      env: 'PASSKEYS__MAX_PASSKEYS_PER_USER',
+    },
+  },
   darkMode: {
     enabled: {
       default: false,

--- a/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
+++ b/packages/fxa-content-server/server/lib/routes/react-app/route-definition-index.js
@@ -64,6 +64,7 @@ function getIndexRouteDefinition(config) {
   const FEATURE_FLAGS_PASSKEY_AUTHENTICATION_ENABLED = config.get(
     'featureFlags.passkeyAuthenticationEnabled'
   );
+  const PASSKEYS_MAX_PER_USER = config.get('passkeys.maxPerUser');
   const DARK_MODE_ENABLED = config.get('darkMode.enabled');
   const GLEAN_ENABLED = config.get('glean.enabled');
   const GLEAN_APPLICATION_ID = config.get('glean.applicationId');
@@ -142,6 +143,9 @@ function getIndexRouteDefinition(config) {
     cms: {
       enabled: CMS_ENABLED,
       l10nEnabled: CMS_L10N_ENABLED,
+    },
+    passkeys: {
+      maxPerUser: PASSKEYS_MAX_PER_USER,
     },
     nimbus: {
       enabled: NIMBUS_ENABLED,

--- a/packages/fxa-settings/src/components/Banner/index.tsx
+++ b/packages/fxa-settings/src/components/Banner/index.tsx
@@ -27,6 +27,7 @@ export const Banner = ({
   link,
   isFancy,
   bannerId,
+  className,
   textAlignClassName = 'text-start',
   iconAlignClassName = 'self-center',
 }: BannerProps) => {
@@ -36,6 +37,7 @@ export const Banner = ({
       id={bannerId || ''}
       className={classNames(
         'my-4 flex flex-row no-wrap items-center px-4 py-3 gap-3.5 rounded-md border border-transparent text-sm text-grey-700',
+        className,
         textAlignClassName,
         textAlignClassName === 'text-center' && 'justify-center',
         type === 'error' && 'bg-red-100',

--- a/packages/fxa-settings/src/components/Banner/interfaces.ts
+++ b/packages/fxa-settings/src/components/Banner/interfaces.ts
@@ -15,6 +15,7 @@ import { NotificationType } from '../../models';
  * @property {Animation} [animation] - Optional animation settings for the banner.
  * @property {DismissButtonProps} [dismissButton] - Optional properties for a dismiss button.
  * @property {BannerLinkProps} [link] - Optional properties for a link within the banner.
+ * @property {string} [className] - Optional CSS class overrides, e.g. to adjust the default vertical margin.
  */
 export type BannerProps = {
   type: NotificationType;
@@ -25,6 +26,7 @@ export type BannerProps = {
   link?: BannerLinkProps;
   isFancy?: boolean;
   bannerId?: string;
+  className?: string;
   iconAlignClassName?: 'self-start' | 'self-center';
   textAlignClassName?: 'text-start' | 'text-center';
 };

--- a/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/SubRow/en.ftl
@@ -49,9 +49,6 @@ passkey-sub-row-created-date = Created: { $createdDate }
 #   $lastUsedDate (String) - a localized date string
 passkey-sub-row-last-used-date = Last used: { $lastUsedDate }
 
-# These two sentences are referring to the passkey
-passkey-sub-row-sign-in-only = Sign in only. Can’t be used to sync.
-
 passkey-sub-row-delete-title = Delete passkey
 passkey-delete-modal-heading = Delete your passkey?
 passkey-delete-modal-content = This passkey will be removed from your account. You’ll need to sign in using a different way.

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.stories.tsx
@@ -139,7 +139,7 @@ export const PasskeyWithSync: StoryFn = () => (
       name: 'MacBook Pro',
       createdAt: new Date('2026-01-01').getTime(),
       lastUsed: new Date('2026-02-01').getTime(),
-      canSync: true,
+      prfEnabled: true,
     }}
   />
 );
@@ -151,7 +151,7 @@ export const PasskeyWithoutSync: StoryFn = () => (
       name: 'iPhone 14 Pro',
       createdAt: new Date('2025-12-01').getTime(),
       lastUsed: new Date('2026-01-31').getTime(),
-      canSync: false,
+      prfEnabled: false,
     }}
   />
 );
@@ -162,7 +162,7 @@ export const PasskeyNeverUsed: StoryFn = () => (
       id: '3',
       name: 'Windows PC',
       createdAt: new Date('2025-11-01').getTime(),
-      canSync: true,
+      prfEnabled: true,
     }}
   />
 );

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.test.tsx
@@ -15,7 +15,7 @@ import {
   MOCK_MASKED_NATIONAL_FORMAT_PHONE_NUMBER,
   MOCK_MASKED_PHONE_NUMBER_WITH_COPY,
 } from '../../../pages/mocks';
-import { Passkey } from '../UnitRowPasskey';
+import { PasskeyRowData } from '.';
 import { AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
 import { mockAuthClient } from './mock';
@@ -273,7 +273,7 @@ describe('PasskeySubRow', () => {
     name: 'MacBook Pro',
     createdAt: new Date('2026-01-01').getTime(),
     lastUsed: new Date('2026-02-01').getTime(),
-    canSync: true,
+    prfEnabled: true,
   };
 
   const mockDeletePasskey = jest.fn();
@@ -285,7 +285,7 @@ describe('PasskeySubRow', () => {
   });
 
   const renderPasskeySubRow = (
-    passkey: Passkey = mockPasskey,
+    passkey: PasskeyRowData = mockPasskey,
     deletePasskey = mockDeletePasskey
   ) => {
     return render(
@@ -310,21 +310,6 @@ describe('PasskeySubRow', () => {
     const passkeyWithoutLastUsed = { ...mockPasskey, lastUsed: undefined };
     renderPasskeySubRow(passkeyWithoutLastUsed);
     expect(screen.queryByText(/Last used:/)).not.toBeInTheDocument();
-  });
-
-  it('renders message when canSync is false', () => {
-    const passkeyWithoutSync = { ...mockPasskey, canSync: false };
-    renderPasskeySubRow(passkeyWithoutSync);
-    expect(
-      screen.queryByText('Sign in only. Can’t be used to sync.')
-    ).toBeInTheDocument();
-  });
-
-  it('does not render message when canSync is true', () => {
-    renderPasskeySubRow();
-    expect(
-      screen.queryByText('Sign in only. Can’t be used to sync.')
-    ).not.toBeInTheDocument();
   });
 
   it('opens modal when delete button is clicked', async () => {

--- a/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/SubRow/index.tsx
@@ -99,7 +99,7 @@ const SubRow = ({
   return (
     <div
       className={classNames(
-        'flex flex-col w-full max-w-full mt-8 p-4 @mobileLandscape/unitRow:mt-4 @mobileLandscape/unitRow:rounded-lg border items-start text-sm gap-2',
+        'flex flex-col w-full max-w-full mt-4 px-4 py-3 @mobileLandscape/unitRow:rounded-lg border items-start text-sm gap-2',
         {
           'bg-grey-10 dark:bg-grey-700 border-transparent': !border,
           'bg-white dark:bg-grey-700 border-grey-100 dark:border-grey-500':
@@ -131,7 +131,7 @@ const SubRow = ({
               linkExternalProps && <ExtraInfoLink />}
           </div>
           {localizedDescription && (
-            <p className="text-sm w-full mx-2 mt-2">
+            <p className="text-sm w-full mt-1">
               {localizedDescription}{' '}
               {!localizedInfoMessage && linkExternalProps && <ExtraInfoLink />}
             </p>
@@ -342,17 +342,16 @@ export const BackupPhoneSubRow = ({
   );
 };
 
-// TODO: replace with actual Passkey type when available
-type Passkey = {
+export type PasskeyRowData = {
   id: string;
   name: string;
   createdAt: number;
   lastUsed?: number;
-  canSync: boolean;
+  prfEnabled: boolean;
 };
 
 export type PasskeySubRowProps = {
-  passkey: Passkey;
+  passkey: PasskeyRowData;
   // passing in as a prop for the sake of mocking.
   // TODO: replace with actual auth client API call
   deletePasskey?: (passkeyId: string) => Promise<void>;
@@ -440,19 +439,10 @@ export const PasskeySubRow = ({
     <>
       <SubRow
         idPrefix="passkey"
-        icon={
-          <PasskeyIcon ariaHidden className="h-8 w-5 ms-2 text-purple-600" />
-        }
+        icon={<PasskeyIcon ariaHidden className="h-8 w-5 text-purple-600" />}
         localizedRowTitle={passkey.name}
         localizedDescription={localizedDescription}
-        {...(!passkey.canSync && {
-          statusIcon: 'alert',
-          message: (
-            <FtlMsg id="passkey-sub-row-sign-in-only">
-              <p>Sign in only. Can’t be used to sync.</p>
-            </FtlMsg>
-          ),
-        })}
+        // TODO (passkeys phase 2): show upgrade prompt when passkey.prfEnabled
         onDeleteClick={(event) => {
           event.stopPropagation();
           revealDeleteModal();

--- a/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRow/index.tsx
@@ -209,7 +209,7 @@ export const UnitRow = ({
             secondaryCtaRoute ||
             revealSecondaryModal) && (
             <div className="unit-row-actions @mobileLandscape/unitRow:flex-1 @mobileLandscape/unitRow:flex @mobileLandscape/unitRow:justify-end ">
-              <div className="flex items-center h-8 gap-2 mt-2 @mobileLandscape/unitRow:mt-0 ">
+              <div className="flex items-center h-8 gap-2 mt-4 @mobileLandscape/unitRow:mt-0 ">
                 {/* Primary Action */}
                 {!hideCtaText &&
                   ctaText &&

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/en.ftl
@@ -5,7 +5,16 @@ passkey-row-enabled = Enabled
 passkey-row-not-set = Not set
 passkey-row-action-create = Create
 passkey-row-description = Make sign in easier and more secure by using your phone or other supported device to get into your account.
-# External link to a support article. "This" refers to passkeys.
-passkey-row-info-link = How this protects your account
+# External link to a support article about passkeys.
+passkey-row-info-link-2 = Learn more
+# Shown as a warning banner when the user has registered the maximum number of passkeys.
+# Variables:
+#   $count (Number) - the maximum number of passkeys allowed (defaults to 10 allowed)
+passkey-row-max-limit-banner =
+    { $count ->
+       *[other] You’ve used all { $count } passkeys. Delete a passkey to create a new one.
+    }
+# Tooltip shown on the disabled Create button when the passkey limit is reached
+passkey-row-max-limit-disabled-reason = You’ve reached the maximum number of passkeys.
 
 ##

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import { LocationProvider } from '@reach/router';
-import UnitRowPasskey, { Passkey } from '.';
+import UnitRowPasskey from '.';
+import { PasskeyRowData } from '../SubRow';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/mocks';
 import { initLocalAccount, mockAuthClient } from '../SubRow/mock';
@@ -23,25 +24,25 @@ const mockPasskeys = [
     name: 'MacBook Pro',
     createdAt: new Date('2026-01-01').getTime(),
     lastUsed: new Date('2026-02-01').getTime(),
-    canSync: false,
+    prfEnabled: false,
   },
   {
     id: 'passkey-2',
     name: 'iPhone 15',
     createdAt: new Date('2025-12-01').getTime(),
     lastUsed: new Date('2026-01-31').getTime(),
-    canSync: true,
+    prfEnabled: true,
   },
   {
     id: 'passkey-3',
     name: 'Work Laptop',
     createdAt: new Date('2025-11-01').getTime(),
     lastUsed: undefined,
-    canSync: false,
+    prfEnabled: false,
   },
 ];
 
-const storyWithPasskeys = (passkeys: Passkey[]) => {
+const storyWithPasskeys = (passkeys: PasskeyRowData[]) => {
   const story = () => {
     initLocalAccount();
     return (
@@ -59,10 +60,18 @@ const storyWithPasskeys = (passkeys: Passkey[]) => {
 
 export const NoPasskeys = storyWithPasskeys([]);
 
-export const WithPasskeys = storyWithPasskeys(mockPasskeys);
-
 export const SinglePasskey = storyWithPasskeys([mockPasskeys[0]]);
 
 export const WithNeverUsedPasskey = storyWithPasskeys([mockPasskeys[2]]);
 
 export const MultiplePasskeys = storyWithPasskeys(mockPasskeys);
+
+export const AtMaxPasskeys = storyWithPasskeys(
+  Array.from({ length: 10 }, (_, i) => ({
+    id: `passkey-${i + 1}`,
+    name: `Passkey ${i + 1}`,
+    createdAt: new Date('2026-01-01').getTime(),
+    lastUsed: new Date('2026-02-01').getTime(),
+    prfEnabled: i % 2 === 0,
+  }))
+);

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
@@ -5,7 +5,8 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import { LocationProvider } from '@reach/router';
-import UnitRowPasskey, { Passkey } from './index';
+import UnitRowPasskey from './index';
+import { PasskeyRowData } from '../SubRow';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 
 const mockJwtState = {};
@@ -23,20 +24,20 @@ jest.mock('../../../lib/cache', () => ({
 }));
 
 describe('UnitRowPasskey', () => {
-  const mockPasskeys: Passkey[] = [
+  const mockPasskeys: PasskeyRowData[] = [
     {
       id: 'passkey-1',
       name: 'MacBook Pro',
       createdAt: new Date('2026-01-01').getTime(),
       lastUsed: new Date('2026-02-01').getTime(),
-      canSync: true,
+      prfEnabled: true,
     },
     {
       id: 'passkey-2',
       name: 'iPhone 15',
       createdAt: new Date('2025-12-01').getTime(),
       lastUsed: new Date('2026-01-31').getTime(),
-      canSync: false,
+      prfEnabled: false,
     },
   ];
 
@@ -44,7 +45,7 @@ describe('UnitRowPasskey', () => {
     jest.clearAllMocks();
   });
 
-  const renderUnitRowPasskey = (passkeys: Passkey[] = mockPasskeys) => {
+  const renderUnitRowPasskey = (passkeys: PasskeyRowData[] = mockPasskeys) => {
     return renderWithLocalizationProvider(
       <LocationProvider>
         <UnitRowPasskey passkeys={passkeys} />
@@ -60,9 +61,7 @@ describe('UnitRowPasskey', () => {
         'Make sign in easier and more secure by using your phone or other supported device to get into your account.'
       )
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: /How this protects your account/ })
-    ).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /Learn more/ })).toHaveAttribute(
       'href',
       'https://support.mozilla.org/kb/placeholder-article'
     );
@@ -86,5 +85,26 @@ describe('UnitRowPasskey', () => {
     renderUnitRowPasskey();
     expect(screen.getByText('MacBook Pro')).toBeInTheDocument();
     expect(screen.getByText('iPhone 15')).toBeInTheDocument();
+  });
+
+  it('does not show banner and Create is a link when below max', () => {
+    renderUnitRowPasskey(mockPasskeys);
+    expect(screen.queryByText(/You’ve used all/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Create' })).toBeInTheDocument();
+  });
+
+  it('shows warning banner and disabled Create button when at max passkeys', () => {
+    const atMaxPasskeys: PasskeyRowData[] = Array.from(
+      { length: 10 },
+      (_, i) => ({
+        id: `passkey-${i}`,
+        name: `Passkey ${i}`,
+        createdAt: new Date('2026-01-01').getTime(),
+        prfEnabled: false,
+      })
+    );
+    renderUnitRowPasskey(atMaxPasskeys);
+    expect(screen.getByText(/You’ve used all 10 passkeys/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
   });
 });

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
@@ -4,27 +4,22 @@
 
 import React from 'react';
 import UnitRow, { UnitRowProps } from '../UnitRow';
-import { useFtlMsgResolver } from '../../../models';
+import { useFtlMsgResolver, useConfig } from '../../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
-import { PasskeySubRow } from '../SubRow';
-
-// TODO: Update with actual passkey data types when available
-export type Passkey = {
-  id: string;
-  name: string;
-  createdAt: number;
-  lastUsed?: number;
-  canSync: boolean;
-};
+import { PasskeySubRow, PasskeyRowData } from '../SubRow';
+import { Banner } from '../../Banner';
 
 export type UnitRowPasskeyProps = {
-  passkeys?: Passkey[];
+  passkeys?: PasskeyRowData[];
 };
 
 export const UnitRowPasskey = ({ passkeys = [] }: UnitRowPasskeyProps) => {
   const ftlMsgResolver = useFtlMsgResolver();
+  const config = useConfig();
+  const maxPasskeys = config.passkeys.maxPerUser;
   const hasPasskeys = passkeys.length > 0;
+  const isAtLimit = passkeys.length >= maxPasskeys;
 
   const conditionalUnitRowProps: Partial<UnitRowProps> = hasPasskeys
     ? {
@@ -39,19 +34,34 @@ export const UnitRowPasskey = ({ passkeys = [] }: UnitRowPasskeyProps) => {
         ),
       };
 
-  const getSubRows = () => {
-    return passkeys.map((passkey) => (
-      <PasskeySubRow key={passkey.id} passkey={passkey} />
-    ));
-  };
+  const getSubRows = () => (
+    <>
+      {isAtLimit && (
+        <Banner
+          type="warning"
+          className="mb-2"
+          content={{
+            localizedDescription: ftlMsgResolver.getMsg(
+              'passkey-row-max-limit-banner',
+              `You’ve used all ${maxPasskeys} passkeys. Delete a passkey to create a new one.`,
+              { count: maxPasskeys }
+            ),
+          }}
+        />
+      )}
+      {passkeys.map((passkey) => (
+        <PasskeySubRow key={passkey.id} passkey={passkey} />
+      ))}
+    </>
+  );
 
   const learnMoreLink = (
-    <FtlMsg id="passkey-row-info-link">
+    <FtlMsg id="passkey-row-info-link-2">
       <LinkExternal
         href="https://support.mozilla.org/kb/placeholder-article" // TODO: Update with actual support article link
         className="link-blue text-sm"
       >
-        How this protects your account
+        Learn more
       </LinkExternal>
     </FtlMsg>
   );
@@ -64,6 +74,11 @@ export const UnitRowPasskey = ({ passkeys = [] }: UnitRowPasskeyProps) => {
         prefixDataTestId="passkey"
         ctaText={ftlMsgResolver.getMsg('passkey-row-action-create', 'Create')}
         route="/settings/passkeys/add"
+        disabled={isAtLimit}
+        disabledReason={ftlMsgResolver.getMsg(
+          'passkey-row-max-limit-disabled-reason',
+          "You've reached the maximum number of passkeys."
+        )}
         {...conditionalUnitRowProps}
         subRows={getSubRows()}
       >

--- a/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowSecondaryEmail/index.tsx
@@ -162,7 +162,7 @@ export const UnitRowSecondaryEmail = () => {
               l10n.getString(
                 'se-verify-session-3',
                 null,
-                "You'll need to confirm your current session to perform this action"
+                'You’ll need to confirm your current session to perform this action'
               )
             );
           }}

--- a/packages/fxa-settings/src/lib/config.test.ts
+++ b/packages/fxa-settings/src/lib/config.test.ts
@@ -159,6 +159,31 @@ describe('reset', () => {
   });
 });
 
+describe('passkeys', () => {
+  it('can parse passkeys.maxPerUser from server config', () => {
+    const data = {
+      passkeys: {
+        maxPerUser: 5,
+      },
+    };
+
+    readConfigMeta(() => {
+      return {
+        getAttribute() {
+          return encodeURIComponent(JSON.stringify(data));
+        },
+      };
+    });
+
+    expect(config.passkeys).toBeDefined();
+    expect(config.passkeys.maxPerUser).toBe(5);
+  });
+
+  it('defaults passkeys.maxPerUser to 10', () => {
+    expect(config.passkeys.maxPerUser).toBe(10);
+  });
+});
+
 describe('featureFlags', () => {
   it('can parse passkeysEnabled feature flag', () => {
     const data = {

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -62,6 +62,9 @@ export interface Config {
     count: number;
     length: number;
   };
+  passkeys: {
+    maxPerUser: number;
+  };
   version: string;
   googleAuthConfig: {
     enabled: boolean;
@@ -171,6 +174,9 @@ export function getDefault() {
     recoveryCodes: {
       count: 8,
       length: 10,
+    },
+    passkeys: {
+      maxPerUser: 10,
     },
     googleAuthConfig: {
       enabled: false,


### PR DESCRIPTION
## Because

* Users need clear feedback when they've reached the passkey limit and should not be able to attempt creating another one.

## This pull request

* Threads `passkeys.maxPerUser` config from content-server to fxa-settings using the same `PASSKEYS__MAX_PASSKEYS_PER_USER` env var as auth-server
* Renders a warning Banner in the passkeys row when the limit is reached
* Passes disabled/disabledReason to `UnitRow` to gray out the Create button 

Additional tweaks to align with latest UX designs:
* Renames canSync → prfEnabled on the Passkey type (no phase-1 UI; needed for the phase-2 passwordless-sync upgrade flow)
* Removes the sign-in-only SubRow badge (not shown in phase 1)
* Updates link copy to "Learn more"
* Tightens SubRow padding and UnitRow action-button top margin
* Adds className prop to Banner to allow margin overrides

## Issue that this pull request solves

Closes: FXA-13369

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

Compare with [UX designs on Figma](https://www.figma.com/design/4ToDEuz5HU1HyBrFCIZe4v/Passkeys?node-id=3002-27595)
Check out the storybook for passkey unit row

## Screenshots (Optional)

<img width="830" height="503" alt="image" src="https://github.com/user-attachments/assets/21367337-2502-4599-a135-d63d5e7c61a7" />

## Other information (Optional)

Any other information that is important to this pull request.
