### PR TITLE
chore(payments-next): improve error messaging for missing cart ids for debugging

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/errors.ts
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/errors.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseError } from '@fxa/shared/error';
+
+class UpgradeCartError extends BaseError {
+  constructor(message: string, info: Record<string, any>) {
+    super(message, { info });
+    this.name = 'UpgradeCartError';
+  }
+}
+
+export class UpgradeCartFromOfferingConfigIdMissingError extends UpgradeCartError {
+  constructor(cartId: string) {
+    super(`fromOfferingConfigId not present for upgrade cart: ${cartId}`, {
+      cartId,
+    });
+    this.name = 'UpgradeCartFromOfferingConfigIdMissingError';
+  }
+}
+
+export class UpgradeCartFromPriceMissingError extends UpgradeCartError {
+  constructor(cartId: string) {
+    super(`fromPrice not present for upgrade cart: ${cartId}`, { cartId });
+    this.name = 'UpgradeCartFromPriceMissingError';
+  }
+}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/layout.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import assert from 'assert';
 import { headers } from 'next/headers';
 import { Header, MetricsWrapper } from '@fxa/payments/ui';
 import { fetchCMSData, getCartAction } from '@fxa/payments/ui/actions';
@@ -16,6 +15,10 @@ import {
 } from '@fxa/payments/ui/server';
 import { config } from 'apps/payments/next/config';
 import { auth } from 'apps/payments/next/auth';
+import {
+  UpgradeCartFromOfferingConfigIdMissingError,
+  UpgradeCartFromPriceMissingError,
+} from './errors';
 
 export default async function UpgradeLayout({
   children,
@@ -41,8 +44,12 @@ export default async function UpgradeLayout({
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;
 
-  assert(cart.fromOfferingConfigId, 'fromOfferingConfigId is missing in cart');
-  assert(cart.fromPrice, 'fromPrice is missing in cart');
+  if (!cart.fromOfferingConfigId) {
+    throw new UpgradeCartFromOfferingConfigIdMissingError(resolvedParams.cartId);
+  }
+  if (!cart.fromPrice) {
+    throw new UpgradeCartFromPriceMissingError(resolvedParams.cartId);
+  }
   const currentCmsDataPromise = fetchCMSData(cart.fromOfferingConfigId, locale);
   const currentCms = await currentCmsDataPromise;
   const currentPurchaseDetails =


### PR DESCRIPTION
## Because

- We want more information in Sentry when this occurs

## This pull request

- Adds the cart id to the error messaging so that we can debug

## Issue that this pull request solves

Closes PAY-3599