### PR TITLE
fix(payments-next): Show pre-discount tax

### DIFF
--- a/libs/payments/customer/src/lib/invoice.manager.spec.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.spec.ts
@@ -307,7 +307,7 @@ describe('InvoiceManager', () => {
       );
       const mockPreviewUpcomingInvoice = InvoicePreviewFactory();
 
-      jest
+      const spy = jest
         .spyOn(stripeClient, 'invoicesRetrieveUpcoming')
         .mockResolvedValue(mockUpcomingInvoice);
 
@@ -320,6 +320,45 @@ describe('InvoiceManager', () => {
         subscription: mockSubscription,
       });
       expect(result).toEqual(mockPreviewUpcomingInvoice);
+      expect(spy).toHaveBeenCalledWith({
+        customer: mockCustomer.id,
+        subscription: mockSubscription.id,
+        subscription_details: {
+          cancel_at_period_end: false,
+        },
+      });
+    });
+
+    it('passes empty string discounts when excludeDiscounts is true', async () => {
+      const mockCustomer = StripeCustomerFactory({ currency: 'usd' });
+      const mockSubscription = StripeSubscriptionFactory();
+      const mockUpcomingInvoice = StripeResponseFactory(
+        StripeUpcomingInvoiceFactory()
+      );
+      const mockPreviewUpcomingInvoice = InvoicePreviewFactory();
+
+      const spy = jest
+        .spyOn(stripeClient, 'invoicesRetrieveUpcoming')
+        .mockResolvedValue(mockUpcomingInvoice);
+
+      mockedStripeInvoiceToFirstInvoicePreviewDTO.mockReturnValue(
+        mockPreviewUpcomingInvoice
+      );
+
+      const result = await invoiceManager.previewUpcomingSubscription({
+        customer: mockCustomer,
+        subscription: mockSubscription,
+        excludeDiscounts: true,
+      });
+      expect(result).toEqual(mockPreviewUpcomingInvoice);
+      expect(spy).toHaveBeenCalledWith({
+        customer: mockCustomer.id,
+        subscription: mockSubscription.id,
+        subscription_details: {
+          cancel_at_period_end: false,
+        },
+        discounts: '',
+      });
     });
   });
 

--- a/libs/payments/customer/src/lib/invoice.manager.ts
+++ b/libs/payments/customer/src/lib/invoice.manager.ts
@@ -187,9 +187,11 @@ export class InvoiceManager {
   async previewUpcomingSubscription({
     customer,
     subscription,
+    excludeDiscounts,
   }: {
     customer: StripeCustomer;
     subscription: StripeSubscription;
+    excludeDiscounts?: boolean;
   }): Promise<InvoicePreview> {
     const upcomingInvoice = await this.stripeClient.invoicesRetrieveUpcoming({
       customer: customer.id,
@@ -197,6 +199,7 @@ export class InvoiceManager {
       subscription_details: {
         cancel_at_period_end: false,
       },
+      ...(excludeDiscounts ? { discounts: '' } : {}),
     });
 
     return stripeInvoiceToInvoicePreviewDTO(upcomingInvoice);

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -459,6 +459,7 @@ export class SubscriptionManagementService {
       this.invoiceManager.previewUpcomingSubscription({
         customer,
         subscription,
+        excludeDiscounts: true,
       }),
       this.churnInterventionService.determineStaySubscribedEligibility(
         uid,
@@ -501,11 +502,12 @@ export class SubscriptionManagementService {
 
     const {
       nextInvoiceDate,
-      promotionName: nextPromotionName,
       subsequentAmount,
       subsequentAmountExcludingTax,
       subsequentTax,
     } = upcomingInvoice;
+
+    const nextPromotionName = subscription.discount?.coupon.name ?? null;
 
     const totalExclusiveTax = taxAmounts
       .filter((tax) => !tax.inclusive)
@@ -791,6 +793,7 @@ export class SubscriptionManagementService {
         await this.invoiceManager.previewUpcomingSubscription({
           customer: stripeCustomer,
           subscription,
+          excludeDiscounts: true,
         });
 
       if (!upcomingInvoice) {
@@ -912,6 +915,7 @@ export class SubscriptionManagementService {
         await this.invoiceManager.previewUpcomingSubscription({
           customer: stripeCustomer,
           subscription,
+          excludeDiscounts: true,
         });
 
       if (!upcomingInvoice) {


### PR DESCRIPTION
## Because

- the post-discount tax amount is being displayed when we caveat that a discount will be applied when we should be displaying the pre-discount tax amount

## This pull request

- Updates to display the pre-discount tax amount

## Issue that this pull request solves

Closes: PAY-3635

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)
Before
<img width="993" height="393" alt="Screenshot 2026-04-13 at 11 27 43 AM" src="https://github.com/user-attachments/assets/8b017f96-c9e3-46d8-b293-15219d2a59b5" />

After
<img width="995" height="383" alt="Screenshot 2026-04-13 at 11 26 21 AM" src="https://github.com/user-attachments/assets/7ae8437d-c0a1-4bf4-8dee-3e428b5e6413" />




