### PR TITLE
fix(auth): emit notifyAttachedServices for passwordless and linked-accounts

### DIFF
--- a/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.spec.ts
@@ -285,6 +285,25 @@ describe('/linked_account', () => {
           glean.thirdPartyAuth.googleRegComplete,
           mockRequest
         );
+
+        // Should emit SNS verified + login + profileDataChange events so
+        // Basket/Braze learn about the new account.
+        const notifyEvents = mockLog.notifyAttachedServices.args.map(
+          (call: any[]) => call[0]
+        );
+        expect(notifyEvents).toContain('verified');
+        expect(notifyEvents).toContain('login');
+        expect(notifyEvents).toContain('profileDataChange');
+        sinon.assert.calledWithMatch(
+          mockLog.notifyAttachedServices,
+          'verified',
+          mockRequest,
+          sinon.match({
+            email: mockGoogleUser.email,
+            uid: UID,
+            service: 'sync',
+          })
+        );
       });
 
       it('should link existing fxa account and new google account and return session', async () => {
@@ -315,6 +334,15 @@ describe('/linked_account', () => {
           mockRequest,
           { reason: 'linking' }
         );
+
+        // Should emit SNS login + profileDataChange but NOT verified
+        // (the account already existed).
+        const notifyEvents = mockLog.notifyAttachedServices.args.map(
+          (call: any[]) => call[0]
+        );
+        expect(notifyEvents).not.toContain('verified');
+        expect(notifyEvents).toContain('login');
+        expect(notifyEvents).toContain('profileDataChange');
       });
 
       it('should return session with valid google id token', async () => {
@@ -338,6 +366,12 @@ describe('/linked_account', () => {
         expect(mockDB.createSessionToken.calledOnce).toBe(true);
         expect(result.uid).toBe(UID);
         expect(result.sessionToken).toBeTruthy();
+
+        // Re-login: login event only, no verified, no profileDataChange.
+        const notifyEvents = mockLog.notifyAttachedServices.args.map(
+          (call: any[]) => call[0]
+        );
+        expect(notifyEvents).toEqual(['login']);
         sinon.assert.calledOnceWithExactly(
           glean.thirdPartyAuth.googleLoginComplete,
           mockRequest
@@ -516,6 +550,14 @@ describe('/linked_account', () => {
           glean.thirdPartyAuth.appleRegComplete,
           mockRequest
         );
+
+        // Should emit SNS verified + login + profileDataChange events.
+        const notifyEvents = mockLog.notifyAttachedServices.args.map(
+          (call: any[]) => call[0]
+        );
+        expect(notifyEvents).toContain('verified');
+        expect(notifyEvents).toContain('login');
+        expect(notifyEvents).toContain('profileDataChange');
       });
 
       it('should link existing fxa account and new apple account and return session', async () => {
@@ -544,6 +586,14 @@ describe('/linked_account', () => {
           mockRequest,
           { reason: 'linking' }
         );
+
+        // New link on existing account: login + profileDataChange, no verified.
+        const notifyEvents = mockLog.notifyAttachedServices.args.map(
+          (call: any[]) => call[0]
+        );
+        expect(notifyEvents).not.toContain('verified');
+        expect(notifyEvents).toContain('login');
+        expect(notifyEvents).toContain('profileDataChange');
       });
 
       it('should return session with valid apple id token', async () => {
@@ -571,6 +621,12 @@ describe('/linked_account', () => {
           glean.thirdPartyAuth.appleLoginComplete,
           mockRequest
         );
+
+        // Re-login: login event only.
+        const notifyEvents = mockLog.notifyAttachedServices.args.map(
+          (call: any[]) => call[0]
+        );
+        expect(notifyEvents).toEqual(['login']);
       });
     });
   });
@@ -912,11 +968,7 @@ describe('/linked_account', () => {
         mockLog.debug,
         'Revoked 1 third party sessions for user fxauid'
       );
-      sinon.assert.calledWithExactly(
-        mockDB.deleteLinkedAccount,
-        UID,
-        'google'
-      );
+      sinon.assert.calledWithExactly(mockDB.deleteLinkedAccount, UID, 'google');
     });
 
     it('handles credentials changed event', async () => {
@@ -967,11 +1019,7 @@ describe('/linked_account', () => {
         mockLog.debug,
         'Revoked 1 third party sessions for user fxauid'
       );
-      sinon.assert.calledWithExactly(
-        mockDB.deleteLinkedAccount,
-        UID,
-        'google'
-      );
+      sinon.assert.calledWithExactly(mockDB.deleteLinkedAccount, UID, 'google');
     });
 
     it('handles account enabled event', async () => {
@@ -1204,9 +1252,7 @@ describe('/linked_account', () => {
           },
         ],
       });
-      mockDB.getLinkedAccount = sinon.spy(() =>
-        Promise.resolve({ uid: UID })
-      );
+      mockDB.getLinkedAccount = sinon.spy(() => Promise.resolve({ uid: UID }));
       const mockConfig = {
         appleAuthConfig: { clientId: 'OooOoo', teamId: 'teamId' },
       };
@@ -1288,11 +1334,7 @@ describe('/linked_account', () => {
         mockLog.debug,
         'Revoked 1 third party sessions for user fxauid'
       );
-      sinon.assert.calledWithExactly(
-        mockDB.deleteLinkedAccount,
-        UID,
-        'apple'
-      );
+      sinon.assert.calledWithExactly(mockDB.deleteLinkedAccount, UID, 'apple');
       sinon.assert.calledWithExactly(
         statsd.increment,
         'handleAppleSET.processed.consent-revoked'
@@ -1319,11 +1361,7 @@ describe('/linked_account', () => {
         mockLog.debug,
         'Revoked 1 third party sessions for user fxauid'
       );
-      sinon.assert.calledWithExactly(
-        mockDB.deleteLinkedAccount,
-        UID,
-        'apple'
-      );
+      sinon.assert.calledWithExactly(mockDB.deleteLinkedAccount, UID, 'apple');
       sinon.assert.calledWithExactly(
         statsd.increment,
         'handleAppleSET.processed.account-delete'

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -19,6 +19,7 @@ import isA from 'joi';
 import DESCRIPTION from '../../docs/swagger/shared/descriptions';
 import { AppError as error } from '@fxa/accounts/errors';
 import { schema as METRICS_CONTEXT_SCHEMA } from '../metrics/context';
+import { notifyAttachedServicesForAccountSession } from './utils/account';
 import {
   getGooglePublicKey,
   getApplePublicKey,
@@ -351,6 +352,13 @@ export class LinkedAccountHandler {
     const name = idToken.name;
 
     let accountRecord;
+    // Tracks which of the three third-party auth paths we took so the
+    // SNS notification block after the if/else can emit the right events.
+    let linkedAccountFlow:
+      | 'new-link-existing-account'
+      | 'new-account'
+      | 'existing-linked-account'
+      | undefined;
     const linkedAccountRecord = await this.db.getLinkedAccount(
       userid,
       provider
@@ -433,6 +441,7 @@ export class LinkedAccountHandler {
           flowBeginTime,
           service,
         });
+        linkedAccountFlow = 'new-link-existing-account';
       } catch (err) {
         this.log.trace(
           'Account.login.sendPostAddLinkedAccountNotification.error',
@@ -503,6 +512,7 @@ export class LinkedAccountHandler {
           uid: accountRecord.uid,
           reason: provider === 'google' ? 'google' : 'apple',
         });
+        linkedAccountFlow = 'new-account';
       }
     } else {
       // This is an existing user and existing FxA user
@@ -531,6 +541,7 @@ export class LinkedAccountHandler {
         uid: accountRecord.uid,
         reason: provider === 'google' ? 'google' : 'apple',
       });
+      linkedAccountFlow = 'existing-linked-account';
     }
 
     let verificationMethod,
@@ -561,6 +572,29 @@ export class LinkedAccountHandler {
     };
 
     const sessionToken = await this.db.createSessionToken(sessionTokenOptions);
+
+    // Mirror the SNS notifications that AccountHandler.createAccount
+    // fires. Placed after createSessionToken so db.sessions already
+    // includes the new session. A new third-party link on an existing
+    // account counts as a profile change (the link was added).
+    const isNewAccount = linkedAccountFlow === 'new-account';
+    const deviceCount = isNewAccount
+      ? 1
+      : (await this.db.sessions(accountRecord.uid)).length;
+    await notifyAttachedServicesForAccountSession({
+      log: this.log,
+      request,
+      account: {
+        uid: accountRecord.uid,
+        email: accountRecord.primaryEmail.email,
+        locale: accountRecord.locale,
+      },
+      service,
+      deviceCount,
+      isNewAccount,
+      emailVerified: true,
+      profileChanged: linkedAccountFlow === 'new-link-existing-account',
+    });
 
     return {
       uid: sessionToken.uid,

--- a/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.spec.ts
@@ -79,10 +79,14 @@ jest.mock('./utils/security-event', () => ({
 // we simply reassign the stub per-test.
 let getOptionalCmsEmailConfigStub: sinon.SinonStub;
 
-jest.mock('./utils/account', () => ({
-  getOptionalCmsEmailConfig: (...args: any[]) =>
-    getOptionalCmsEmailConfigStub(...args),
-}));
+jest.mock('./utils/account', () => {
+  const actual = jest.requireActual('./utils/account');
+  return {
+    ...actual,
+    getOptionalCmsEmailConfig: (...args: any[]) =>
+      getOptionalCmsEmailConfigStub(...args),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Route factory (mirrors the Mocha `makeRoutes`)
@@ -142,11 +146,7 @@ function makeRoutes(options: any = {}) {
   return passwordlessRoutes(log, db, config, customs, glean, statsd, redis);
 }
 
-function runTest(
-  route: any,
-  request: any,
-  assertions?: (result: any) => void
-) {
+function runTest(route: any, request: any, assertions?: (result: any) => void) {
   return new Promise((resolve, reject) => {
     try {
       return route.handler(request).then(resolve, reject);
@@ -382,9 +382,7 @@ describe('/account/passwordless/confirm_code', () => {
 
       expect(mockCustoms.check.callCount).toBe(2);
       expect(mockCustoms.check.args[0][2]).toBe('passwordlessVerifyOtp');
-      expect(mockCustoms.check.args[1][2]).toBe(
-        'passwordlessVerifyOtpPerDay'
-      );
+      expect(mockCustoms.check.args[1][2]).toBe('passwordlessVerifyOtpPerDay');
 
       expect(mockOtpManagerIsValid.callCount).toBe(1);
       expect(mockOtpManagerIsValid.args[0][0]).toBe(TEST_EMAIL);
@@ -406,6 +404,22 @@ describe('/account/passwordless/confirm_code', () => {
       expect(result.verified).toBe(true);
       expect(result.authAt).toBe(1234567890);
       expect(result.isNewAccount).toBe(true);
+
+      // Should emit SNS verified + login + profileDataChange events so
+      // Basket/Braze learn about the new passwordless account. Missing
+      // these calls was the root cause of the basket regression (FXA-13416).
+      const notifyEvents = mockLog.notifyAttachedServices.args.map(
+        (call: any[]) => call[0]
+      );
+      expect(notifyEvents).toContain('verified');
+      expect(notifyEvents).toContain('login');
+      expect(notifyEvents).toContain('profileDataChange');
+      sinon.assert.calledWithMatch(
+        mockLog.notifyAttachedServices,
+        'verified',
+        mockRequest,
+        sinon.match({ email: TEST_EMAIL, uid })
+      );
     });
   });
 
@@ -426,6 +440,7 @@ describe('/account/passwordless/confirm_code', () => {
         lastAuthAt: () => 1234567890,
       })
     );
+    mockDB.sessions = sinon.spy(() => Promise.resolve([{}, {}, {}]));
 
     return runTest(route, mockRequest, (result) => {
       expect(mockOtpManagerIsValid.callCount).toBe(1);
@@ -441,6 +456,19 @@ describe('/account/passwordless/confirm_code', () => {
 
       expect(result.uid).toBe(uid);
       expect(result.isNewAccount).toBe(false);
+
+      // Existing account: login event only, no verified, no
+      // profileDataChange. deviceCount should come from db.sessions.
+      const notifyEvents = mockLog.notifyAttachedServices.args.map(
+        (call: any[]) => call[0]
+      );
+      expect(notifyEvents).toEqual(['login']);
+      sinon.assert.calledWithMatch(
+        mockLog.notifyAttachedServices,
+        'login',
+        mockRequest,
+        sinon.match({ email: TEST_EMAIL, uid, deviceCount: 3 })
+      );
     });
   });
 
@@ -1876,11 +1904,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
           },
         },
       });
-      const route = getRoute(
-        routes,
-        '/account/passwordless/send_code',
-        'POST'
-      );
+      const route = getRoute(routes, '/account/passwordless/send_code', 'POST');
       mockDB.accountRecord = sinon.spy(() =>
         Promise.resolve({
           uid,
@@ -1910,11 +1934,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
           },
         },
       });
-      const route = getRoute(
-        routes,
-        '/account/passwordless/send_code',
-        'POST'
-      );
+      const route = getRoute(routes, '/account/passwordless/send_code', 'POST');
       mockDB.accountRecord = sinon.spy(() =>
         Promise.resolve({
           uid,
@@ -1944,11 +1964,7 @@ describe('existing passwordless accounts bypass flag and allowlist', () => {
           },
         },
       });
-      const route = getRoute(
-        routes,
-        '/account/passwordless/send_code',
-        'POST'
-      );
+      const route = getRoute(routes, '/account/passwordless/send_code', 'POST');
       mockDB.accountRecord = sinon.spy(() =>
         Promise.reject(error.unknownAccount())
       );

--- a/packages/fxa-auth-server/lib/routes/passwordless.ts
+++ b/packages/fxa-auth-server/lib/routes/passwordless.ts
@@ -30,7 +30,10 @@ import {
   isPasswordlessEligible,
 } from './utils/passwordless';
 import { RelyingPartyConfigurationManager } from '@fxa/shared/cms';
-import { getOptionalCmsEmailConfig } from './utils/account';
+import {
+  getOptionalCmsEmailConfig,
+  notifyAttachedServicesForAccountSession,
+} from './utils/account';
 import { FxaMailerFormat } from '../senders/fxa-mailer-format';
 import { getClientServiceTags } from '../metrics/client-tags';
 
@@ -304,6 +307,27 @@ class PasswordlessHandler {
       db: this.db,
       request,
       account: { uid: account.uid },
+    });
+
+    // Mirror the SNS notifications that AccountHandler.createAccount
+    // fires, since passwordless bypasses that path. This runs after
+    // createSessionToken so db.sessions already includes the new session.
+    const deviceCount = isNewAccount
+      ? 1
+      : (await this.db.sessions(account.uid)).length;
+    await notifyAttachedServicesForAccountSession({
+      log: this.log,
+      request,
+      account: {
+        uid: account.uid,
+        email: account.email,
+        locale: account.locale,
+      },
+      service,
+      deviceCount,
+      isNewAccount,
+      emailVerified: true,
+      profileChanged: false,
     });
 
     const response: {

--- a/packages/fxa-auth-server/lib/routes/utils/account.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/account.ts
@@ -80,6 +80,91 @@ export const fetchRpCmsData = async (
   return null;
 };
 
+/**
+ * Emit SNS notifications to attached services (Basket, etc.) for
+ * account creation / login events.
+ *
+ * Mirrors the set of notifications `AccountHandler.createAccount` in
+ * `routes/account.ts` fires, so that flows that bypass that handler
+ * (passwordless OTP, Google/Apple third-party auth) deliver the same
+ * events to downstream subscribers.
+ *
+ * - `isNewAccount && emailVerified`      → fires `verified` (Basket creates the user)
+ * - always                               → fires `login`    (session/device tracking)
+ * - `isNewAccount` or `profileChanged`   → fires `profileDataChange`
+ *
+ * `emailVerified` is independent of `isNewAccount` to match the gate in
+ * `AccountHandler.createAccount`, which only fires `verified` when the
+ * account is email-verified at creation time. Password-based signups
+ * create unverified accounts and fire `verified` later from
+ * `signupUtils.verifyAccount`; passwordless and third-party auth create
+ * already-verified accounts and should fire it immediately.
+ */
+export async function notifyAttachedServicesForAccountSession(options: {
+  log: AuthLogger;
+  request: AuthRequest;
+  account: { uid: string; email: string; locale?: string };
+  service: string | undefined;
+  deviceCount: number;
+  isNewAccount: boolean;
+  emailVerified: boolean;
+  profileChanged: boolean;
+}): Promise<void> {
+  const {
+    log,
+    request,
+    account,
+    service,
+    deviceCount,
+    isNewAccount,
+    emailVerified,
+    profileChanged,
+  } = options;
+
+  const geoData = request.app.geo;
+  const country = geoData.location && geoData.location.country;
+  const countryCode = geoData.location && geoData.location.countryCode;
+  const userAgent = request.headers['user-agent'];
+
+  const notifications: Promise<void>[] = [];
+
+  if (isNewAccount && emailVerified) {
+    notifications.push(
+      log.notifyAttachedServices('verified', request, {
+        country,
+        countryCode,
+        email: account.email,
+        locale: account.locale,
+        service,
+        uid: account.uid,
+        userAgent,
+      })
+    );
+  }
+
+  notifications.push(
+    log.notifyAttachedServices('login', request, {
+      country,
+      countryCode,
+      deviceCount,
+      email: account.email,
+      service,
+      uid: account.uid,
+      userAgent,
+    })
+  );
+
+  if (isNewAccount || profileChanged) {
+    notifications.push(
+      log.notifyAttachedServices('profileDataChange', request, {
+        uid: account.uid,
+      })
+    );
+  }
+
+  await Promise.all(notifications);
+}
+
 export async function getOptionalCmsEmailConfig(
   emailOptions,
   { request, cmsManager, log, emailTemplate }


### PR DESCRIPTION
  ## Because

  - Basket / Braze stopped receiving user records for `accounts.firefox.com` signups once passwordless OTP was enabled in production for the Settings client
  - Passwordless (`/account/passwordless/confirm_code`) and Google/Apple third-party auth (`/linked_account/login`) both created new FxA accounts via `db.createAccount` without calling `log.notifyAttachedServices`, so the SNS topic that Basket subscribes to never saw a `verified` event for these signups

  ## This pull request

  - Adds `notifyAttachedServicesForAccountSession` helper to `routes/utils/account.ts`
  - Updates `passwordless.ts` `confirmCode` to call the helper, passing `deviceCount: 1` for new signups and `db.sessions(uid).length` for existing-account logins
  - Updates `linked-accounts.ts` `loginOrCreateAccount` to track which of its three paths was taken via a `linkedAccountFlow` flag, then calls the helper with the matching `isNewAccount` + `profileChanged` flags (new-account, new-link-on-existing-account, or existing-linked-account re-login)

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13416

  ## Checklist

  - [x] My commit is GPG signed.                                                                                                                                                                                                                                                                                                                                        
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).                                                                                                                                                                                                                                                                                                          
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.                                                                                                                                                                                                                                                                                                                 
                                                   
  ## Other information                                                                                                                                                                                                                                                                                                                                                  
                                            
This will be a bit hard to verify until it gets to stage/production