### PR TITLE
fix(settings): missing signin token code title

### DIFF
--- a/packages/fxa-settings/src/components/CardHeader/index.test.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.test.tsx
@@ -87,6 +87,15 @@ describe('CardHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('falls back to default heading when cmsHeadline is null (Strapi unset field)', () => {
+    renderWithLocalizationProvider(
+      <CardHeader headingText={MOCK_HEADING} cmsHeadline={null} />
+    );
+    expect(
+      screen.getByRole('heading', { name: MOCK_HEADING })
+    ).toBeInTheDocument();
+  });
+
   it('falls back to default heading when only description is provided (no headline)', () => {
     renderWithLocalizationProvider(
       <CardHeader
@@ -113,7 +122,9 @@ describe('CardHeader', () => {
     expect(
       screen.getByRole('heading', { name: MOCK_HEADING })
     ).toBeInTheDocument();
-    expect(screen.queryByAltText(MOCK_CMS_LOGO_ALT_TEXT)).not.toBeInTheDocument();
+    expect(
+      screen.queryByAltText(MOCK_CMS_LOGO_ALT_TEXT)
+    ).not.toBeInTheDocument();
   });
 
   it('renders CMS header with default font size', () => {

--- a/packages/fxa-settings/src/components/CardHeader/index.tsx
+++ b/packages/fxa-settings/src/components/CardHeader/index.tsx
@@ -51,7 +51,7 @@ interface CardHeaderBasicWithDefaultSubheadingProps
 interface CardHeaderCmsProps extends CardHeaderRequiredProps {
   cmsLogoUrl?: string;
   cmsLogoAltText?: string;
-  cmsHeadline?: string;
+  cmsHeadline?: string | null;
   cmsDescription?: string;
   cmsHeadlineFontSize?: HeadlineFontSize | string | null;
   cmsHeadlineTextColor?: string | null;
@@ -111,7 +111,7 @@ function isDefaultService(
 }
 
 function isCmsHeader(props: CardHeaderProps): props is CardHeaderCmsProps {
-  return (props as CardHeaderCmsProps).cmsHeadline !== undefined;
+  return !!(props as CardHeaderCmsProps).cmsHeadline;
 }
 
 function isBasicWithCustomSubheading(
@@ -215,9 +215,7 @@ const CardHeader = (props: CardHeaderProps) => {
         >
           {cmsHeadline}
         </h1>
-        {cmsDescription && (
-          <p className="card-subheader">{cmsDescription}</p>
-        )}
+        {cmsDescription && <p className="card-subheader">{cmsDescription}</p>}
       </>
     );
   }


### PR DESCRIPTION
## Because

- When a CMS client (Smart Window) has a page in Strapi with splitLayout but no headline, Strapi returns null for that field
- `CardHeader.isCmsHeader` checked `cmsHeadline !== undefined`, which is `true` for `null`, causing the CMS heading to render an empty `<h1>` page heading

## This pull request

- Fixes `isCmsHeader` to use a truthy check (!!) so `undefined` _and_ `null` get a fallback
- Updates the cmsHeadline prop type from `string | undefined` to `string | null` to better reflect what Strapi returns
- Adds a regression test for the null case

## Issue that this pull request solves

Closes: FXA-13240

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

I tested this by running the test case with and without the fix:
`cd packages/fxa-settings && SKIP_PREFLIGHT_CHECK=true node scripts/test.js --watchAll=false --testPathPattern=src/components/CardHeader/index.test.tsx`

I wasn't able to follow the steps to reproduce given in the bug ticket – bonus if you're able to confirm fix that way!

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This fix is in CardHeader and should apply to all pages that use it with CMS data.
