### PR TITLE
fix(payments-next): Missing `Manage` CTA on SubMan page when no payment method

### DIFF
--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -155,7 +155,7 @@ export default async function Manage({
 
       {isStripeCustomer &&
         !defaultPaymentMethod &&
-        subscriptions.length > 0 && (
+        (subscriptions.length > 0 || trialSubscriptions.length > 0) && (
           <Banner variant={BannerVariant.Warning}>
             <div className="leading-6 text-base">
               <p className="font-bold">
@@ -418,7 +418,7 @@ export default async function Manage({
               )}
 
             {isStripeCustomer &&
-              (defaultPaymentMethod || subscriptions.length > 0) && (
+              (defaultPaymentMethod || subscriptions.length > 0 || trialSubscriptions.length > 0) && (
                 <>
                   <div
                     className="border-none h-px bg-grey-100 my-5 tablet:my-8"


### PR DESCRIPTION
## Because

* When a user is missing a payment method on the subscription management page, they should be shown a warning prompt informing them of this issue, and they should see an option to add a payment method.

## This pull request

* Updates existing functionality for a user with free trials.

## Issue that this pull request solves

Closes #[PAY-3638](https://mozilla-hub.atlassian.net/browse/PAY-3638)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="861" height="790" alt="image" src="https://github.com/user-attachments/assets/4311501b-10f2-4456-8bdd-a65ce53ebd60" />


## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3638]: https://mozilla-hub.atlassian.net/browse/PAY-3638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ