### PR TITLE
fix(passkeys): pass challenge as Buffer to simplewebauthn to fix lookup

### DIFF
--- a/libs/accounts/passkey/src/index.ts
+++ b/libs/accounts/passkey/src/index.ts
@@ -26,3 +26,4 @@ export * from './lib/passkey.config';
 export * from './lib/passkey.provider';
 export * from './lib/passkey.challenge.manager';
 export * from './lib/webauthn-adapter';
+export * from './lib/virtual-authenticator';

--- a/libs/accounts/passkey/src/lib/virtual-authenticator.ts
+++ b/libs/accounts/passkey/src/lib/virtual-authenticator.ts
@@ -1,0 +1,194 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Minimal virtual WebAuthn authenticator for tests.
+ *
+ * Builds cryptographically valid "none"-format attestation and signed
+ * assertion responses so that tests can exercise the real
+ * @simplewebauthn/server library without a browser.
+ */
+
+import {
+  createHash,
+  createSign,
+  generateKeyPairSync,
+  randomBytes,
+  type KeyObject,
+} from 'crypto';
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+
+// ---------------------------------------------------------------------------
+// Minimal CBOR encoder – just enough for attestationObject + COSE keys
+// ---------------------------------------------------------------------------
+
+function cborEncodeLength(majorType: number, length: number): Buffer {
+  const major = majorType << 5;
+  if (length < 24) return Buffer.from([major | length]);
+  if (length < 256) return Buffer.from([major | 24, length]);
+  if (length < 65536) {
+    const buf = Buffer.alloc(3);
+    buf[0] = major | 25;
+    buf.writeUInt16BE(length, 1);
+    return buf;
+  }
+  throw new Error('CBOR length > 65535 not supported');
+}
+
+function cborEncodeValue(value: unknown): Buffer {
+  if (typeof value === 'number' && Number.isInteger(value)) {
+    if (value >= 0) return cborEncodeLength(0, value);
+    return cborEncodeLength(1, -1 - value);
+  }
+  if (typeof value === 'string') {
+    const strBuf = Buffer.from(value, 'utf8');
+    return Buffer.concat([cborEncodeLength(3, strBuf.length), strBuf]);
+  }
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    const bytes = Buffer.from(value);
+    return Buffer.concat([cborEncodeLength(2, bytes.length), bytes]);
+  }
+  if (value instanceof Map) {
+    const header = cborEncodeLength(5, value.size);
+    const entries: Buffer[] = [header];
+    for (const [k, v] of value) {
+      entries.push(cborEncodeValue(k), cborEncodeValue(v));
+    }
+    return Buffer.concat(entries);
+  }
+  throw new Error(`Unsupported CBOR value: ${typeof value}`);
+}
+
+// ---------------------------------------------------------------------------
+// Virtual authenticator
+// ---------------------------------------------------------------------------
+
+export interface VirtualCredential {
+  id: Buffer;
+  privateKey: KeyObject;
+  publicKey: KeyObject;
+  signCount: number;
+}
+
+/**
+ * Test-only virtual WebAuthn authenticator.
+ *
+ * Generates ES256 key pairs and builds cryptographically valid WebAuthn
+ * attestation and assertion responses for use in tests.
+ */
+export class VirtualAuthenticator {
+  /** Create a fresh ES256 credential with a random 32-byte ID. */
+  static createCredential(): VirtualCredential {
+    const { privateKey, publicKey } = generateKeyPairSync('ec', {
+      namedCurve: 'P-256',
+    });
+    return { id: randomBytes(32), privateKey, publicKey, signCount: 0 };
+  }
+
+  /** Build a valid "none"-format attestation response for registration. */
+  static createAttestationResponse(
+    cred: VirtualCredential,
+    input: { challenge: string; origin: string; rpId: string }
+  ): RegistrationResponseJSON {
+    const jwk = cred.publicKey.export({ format: 'jwk' });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const x = Buffer.from(jwk.x!, 'base64url');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const y = Buffer.from(jwk.y!, 'base64url');
+
+    const coseKey = new Map<number, unknown>([
+      [1, 2], // kty: EC2
+      [3, -7], // alg: ES256
+      [-1, 1], // crv: P-256
+      [-2, x],
+      [-3, y],
+    ]);
+
+    const rpIdHash = createHash('sha256').update(input.rpId).digest();
+    const flags = Buffer.from([0x45]); // UP + UV + AT
+    const signCountBuf = Buffer.alloc(4);
+    const credIdLen = Buffer.alloc(2);
+    credIdLen.writeUInt16BE(cred.id.length, 0);
+
+    const authData = Buffer.concat([
+      rpIdHash,
+      flags,
+      signCountBuf,
+      Buffer.alloc(16), // aaguid (zeros)
+      credIdLen,
+      cred.id,
+      cborEncodeValue(coseKey),
+    ]);
+
+    const attestationObject = cborEncodeValue(
+      new Map<string, unknown>([
+        ['fmt', 'none'],
+        ['attStmt', new Map()],
+        ['authData', authData],
+      ])
+    );
+
+    const clientDataJSON = JSON.stringify({
+      type: 'webauthn.create',
+      challenge: input.challenge,
+      origin: input.origin,
+    });
+
+    return {
+      id: cred.id.toString('base64url'),
+      rawId: cred.id.toString('base64url'),
+      response: {
+        clientDataJSON: Buffer.from(clientDataJSON).toString('base64url'),
+        attestationObject: attestationObject.toString('base64url'),
+        transports: ['internal'],
+      },
+      type: 'public-key',
+      clientExtensionResults: {},
+      authenticatorAttachment: 'platform',
+    };
+  }
+
+  /** Build a valid signed assertion response for authentication. */
+  static createAssertionResponse(
+    cred: VirtualCredential,
+    input: { challenge: string; origin: string; rpId: string }
+  ): AuthenticationResponseJSON {
+    cred.signCount++;
+
+    const rpIdHash = createHash('sha256').update(input.rpId).digest();
+    const flags = Buffer.from([0x05]); // UP + UV
+    const signCountBuf = Buffer.alloc(4);
+    signCountBuf.writeUInt32BE(cred.signCount, 0);
+
+    const authenticatorData = Buffer.concat([rpIdHash, flags, signCountBuf]);
+
+    const clientDataJSON = Buffer.from(
+      JSON.stringify({
+        type: 'webauthn.get',
+        challenge: input.challenge,
+        origin: input.origin,
+      })
+    );
+    const clientDataHash = createHash('sha256').update(clientDataJSON).digest();
+
+    const signature = createSign('SHA256')
+      .update(Buffer.concat([authenticatorData, clientDataHash]))
+      .sign(cred.privateKey);
+
+    return {
+      id: cred.id.toString('base64url'),
+      rawId: cred.id.toString('base64url'),
+      response: {
+        clientDataJSON: clientDataJSON.toString('base64url'),
+        authenticatorData: authenticatorData.toString('base64url'),
+        signature: signature.toString('base64url'),
+      },
+      type: 'public-key',
+      clientExtensionResults: {},
+    };
+  }
+}

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.in.spec.ts
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Integration tests for the webauthn-adapter that exercise the real
+ * @simplewebauthn/server library (no mocking). A minimal virtual
+ * authenticator builds valid "none"-format attestation responses so
+ * we can verify the full challenge roundtrip through generate → verify.
+ */
+
+import { randomBytes } from 'crypto';
+import {
+  generateWebauthnRegistrationOptions,
+  verifyWebauthnRegistrationResponse,
+} from './webauthn-adapter';
+import { PasskeyConfig } from './passkey.config';
+import { VirtualAuthenticator } from './virtual-authenticator';
+
+const TEST_RP_ID = 'accounts.firefox.com';
+const TEST_ORIGIN = 'https://accounts.firefox.com';
+
+function testConfig(): PasskeyConfig {
+  return new PasskeyConfig({
+    enabled: true,
+    rpId: TEST_RP_ID,
+    allowedOrigins: [TEST_ORIGIN],
+    maxPasskeysPerUser: 10,
+    challengeTimeout: 30_000,
+    userVerification: 'required',
+    residentKey: 'required',
+  });
+}
+
+describe('webauthn-adapter (real @simplewebauthn/server)', () => {
+  const config = testConfig();
+
+  describe('challenge roundtrip', () => {
+    it('generateWebauthnRegistrationOptions returns the original base64url challenge unchanged', async () => {
+      const challenge = randomBytes(32).toString('base64url');
+
+      const options = await generateWebauthnRegistrationOptions(config, {
+        uid: Buffer.alloc(16, 0xaa),
+        email: 'test@example.com',
+        challenge,
+      });
+
+      expect(options.challenge).toBe(challenge);
+    });
+
+    it('verifyWebauthnRegistrationResponse succeeds when the challenge matches', async () => {
+      const cred = VirtualAuthenticator.createCredential();
+      const challenge = randomBytes(32).toString('base64url');
+
+      const options = await generateWebauthnRegistrationOptions(config, {
+        uid: Buffer.alloc(16, 0xaa),
+        email: 'test@example.com',
+        challenge,
+      });
+
+      const response = VirtualAuthenticator.createAttestationResponse(cred, {
+        challenge: options.challenge,
+        origin: TEST_ORIGIN,
+        rpId: TEST_RP_ID,
+      });
+
+      const result = await verifyWebauthnRegistrationResponse(config, {
+        response,
+        challenge,
+      });
+
+      expect(result.verified).toBe(true);
+      if (!result.verified) throw new Error('narrowing');
+      expect(result.data.credentialId).toBeInstanceOf(Buffer);
+      expect(result.data.publicKey).toBeInstanceOf(Buffer);
+      expect(result.data.signCount).toBe(0);
+      expect(result.data.aaguid).toBeInstanceOf(Buffer);
+      expect(result.data.aaguid.length).toBe(16);
+    });
+
+    it('verifyWebauthnRegistrationResponse rejects a mismatched challenge', async () => {
+      const cred = VirtualAuthenticator.createCredential();
+      const realChallenge = randomBytes(32).toString('base64url');
+      const wrongChallenge = randomBytes(32).toString('base64url');
+
+      const options = await generateWebauthnRegistrationOptions(config, {
+        uid: Buffer.alloc(16, 0xaa),
+        email: 'test@example.com',
+        challenge: realChallenge,
+      });
+
+      const response = VirtualAuthenticator.createAttestationResponse(cred, {
+        challenge: options.challenge,
+        origin: TEST_ORIGIN,
+        rpId: TEST_RP_ID,
+      });
+
+      // Verify with a different challenge — should fail
+      await expect(
+        verifyWebauthnRegistrationResponse(config, {
+          response,
+          challenge: wrongChallenge,
+        })
+      ).rejects.toThrow();
+    });
+
+    it('verifyWebauthnRegistrationResponse rejects a wrong origin', async () => {
+      const cred = VirtualAuthenticator.createCredential();
+      const challenge = randomBytes(32).toString('base64url');
+
+      const options = await generateWebauthnRegistrationOptions(config, {
+        uid: Buffer.alloc(16, 0xaa),
+        email: 'test@example.com',
+        challenge,
+      });
+
+      const response = VirtualAuthenticator.createAttestationResponse(cred, {
+        challenge: options.challenge,
+        origin: 'https://evil.example.com',
+        rpId: TEST_RP_ID,
+      });
+
+      await expect(
+        verifyWebauthnRegistrationResponse(config, { response, challenge })
+      ).rejects.toThrow();
+    });
+
+    it('verifyWebauthnRegistrationResponse rejects a wrong rpId', async () => {
+      const cred = VirtualAuthenticator.createCredential();
+      const challenge = randomBytes(32).toString('base64url');
+
+      const options = await generateWebauthnRegistrationOptions(config, {
+        uid: Buffer.alloc(16, 0xaa),
+        email: 'test@example.com',
+        challenge,
+      });
+
+      const response = VirtualAuthenticator.createAttestationResponse(cred, {
+        challenge: options.challenge,
+        origin: TEST_ORIGIN,
+        rpId: 'evil.example.com',
+      });
+
+      await expect(
+        verifyWebauthnRegistrationResponse(config, { response, challenge })
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('credential data extraction', () => {
+    it('extracts transports and backup flags from a verified response', async () => {
+      const cred = VirtualAuthenticator.createCredential();
+      const challenge = randomBytes(32).toString('base64url');
+
+      const options = await generateWebauthnRegistrationOptions(config, {
+        uid: Buffer.alloc(16, 0xaa),
+        email: 'test@example.com',
+        challenge,
+      });
+
+      const response = VirtualAuthenticator.createAttestationResponse(cred, {
+        challenge: options.challenge,
+        origin: TEST_ORIGIN,
+        rpId: TEST_RP_ID,
+      });
+
+      const result = await verifyWebauthnRegistrationResponse(config, {
+        response,
+        challenge,
+      });
+
+      expect(result.verified).toBe(true);
+      if (!result.verified) throw new Error('narrowing');
+      expect(result.data.credentialId.equals(cred.id)).toBe(true);
+      expect(result.data.transports).toEqual(['internal']);
+      expect(typeof result.data.backupEligible).toBe('boolean');
+      expect(typeof result.data.backupState).toBe('boolean');
+    });
+  });
+});

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type {
-  RegistrationResponseJSON,
-  AuthenticationResponseJSON,
-} from '@simplewebauthn/server';
+import { randomBytes } from 'crypto';
 import {
   generateWebauthnRegistrationOptions,
   verifyWebauthnRegistrationResponse,
@@ -14,34 +11,16 @@ import {
   uuidToBuffer,
 } from './webauthn-adapter';
 import { PasskeyConfig } from './passkey.config';
+import { VirtualAuthenticator } from './virtual-authenticator';
 
-jest.mock('@simplewebauthn/server', () => ({
-  generateRegistrationOptions: jest.fn(),
-  verifyRegistrationResponse: jest.fn(),
-  generateAuthenticationOptions: jest.fn(),
-  verifyAuthenticationResponse: jest.fn(),
-}));
+const TEST_RP_ID = 'accounts.firefox.com';
+const TEST_ORIGIN = 'https://accounts.firefox.com';
 
-const libMocks = jest.requireMock('@simplewebauthn/server') as {
-  generateRegistrationOptions: jest.MockedFunction<
-    (...args: unknown[]) => Promise<unknown>
-  >;
-  verifyRegistrationResponse: jest.MockedFunction<
-    (...args: unknown[]) => Promise<unknown>
-  >;
-  generateAuthenticationOptions: jest.MockedFunction<
-    (...args: unknown[]) => Promise<unknown>
-  >;
-  verifyAuthenticationResponse: jest.MockedFunction<
-    (...args: unknown[]) => Promise<unknown>
-  >;
-};
-
-function mockConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
+function testConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
   return new PasskeyConfig({
     enabled: true,
-    rpId: 'accounts.firefox.com',
-    allowedOrigins: ['https://accounts.firefox.com'],
+    rpId: TEST_RP_ID,
+    allowedOrigins: [TEST_ORIGIN],
     userVerification: 'required',
     residentKey: 'preferred',
     maxPasskeysPerUser: 10,
@@ -50,31 +29,34 @@ function mockConfig(overrides: Partial<PasskeyConfig> = {}): PasskeyConfig {
   });
 }
 
-function mockRegistrationResponse(): RegistrationResponseJSON {
-  return {
-    id: 'aGVsbG93b3JsZA',
-    rawId: 'aGVsbG93b3JsZA',
-    response: {
-      clientDataJSON: 'e30',
-      attestationObject: 'e30',
-    },
-    type: 'public-key',
-    clientExtensionResults: {},
-  };
-}
+/**
+ * Full registration roundtrip returning the virtual credential (retains
+ * the private key for subsequent assertions) and the stored data from
+ * verifyWebauthnRegistrationResponse.
+ */
+async function registerCredential(config: PasskeyConfig) {
+  const cred = VirtualAuthenticator.createCredential();
+  const challenge = randomBytes(32).toString('base64url');
 
-function mockAuthenticationResponse(): AuthenticationResponseJSON {
-  return {
-    id: 'aGVsbG93b3JsZA',
-    rawId: 'aGVsbG93b3JsZA',
-    response: {
-      clientDataJSON: 'e30',
-      authenticatorData: 'e30',
-      signature: 'e30',
-    },
-    type: 'public-key',
-    clientExtensionResults: {},
-  };
+  const options = await generateWebauthnRegistrationOptions(config, {
+    uid: Buffer.alloc(16, 0xaa),
+    email: 'test@example.com',
+    challenge,
+  });
+
+  const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+    challenge: options.challenge,
+    origin: config.allowedOrigins[0],
+    rpId: config.rpId,
+  });
+
+  const result = await verifyWebauthnRegistrationResponse(config, {
+    response: attestation,
+    challenge,
+  });
+
+  if (!result.verified) throw new Error('registration setup failed');
+  return { cred, stored: result.data };
 }
 
 describe('uuidToBuffer', () => {
@@ -109,369 +91,368 @@ describe('uuidToBuffer', () => {
 });
 
 describe('generateWebauthnRegistrationOptions', () => {
-  beforeEach(() => jest.clearAllMocks());
+  it('returns the original base64url challenge unchanged', async () => {
+    const challenge = randomBytes(32).toString('base64url');
 
-  it('maps config and input fields to the correct library options', async () => {
-    libMocks.generateRegistrationOptions.mockResolvedValue({
-      challenge: 'c',
+    const options = await generateWebauthnRegistrationOptions(testConfig(), {
+      uid: Buffer.alloc(16, 0xaa),
+      email: 'test@example.com',
+      challenge,
     });
-    const uid = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
 
-    await generateWebauthnRegistrationOptions(
-      mockConfig({
-        residentKey: 'required',
-        authenticatorAttachment: 'platform',
-      }),
+    expect(options.challenge).toBe(challenge);
+  });
+
+  it('sets rp info from config', async () => {
+    const options = await generateWebauthnRegistrationOptions(
+      testConfig({ rpId: 'example.com' }),
       {
-        uid,
+        uid: Buffer.alloc(16),
         email: 'alice@example.com',
-        challenge: 'test-challenge',
+        challenge: randomBytes(32).toString('base64url'),
       }
     );
 
-    expect(libMocks.generateRegistrationOptions).toHaveBeenCalledWith(
+    expect(options.rp.id).toBe('example.com');
+    expect(options.rp.name).toBe('example.com');
+  });
+
+  it('maps authenticatorSelection from config', async () => {
+    const options = await generateWebauthnRegistrationOptions(
+      testConfig({
+        residentKey: 'required',
+        userVerification: 'required',
+        authenticatorAttachment: 'platform',
+      }),
+      {
+        uid: Buffer.alloc(16),
+        email: 'alice@example.com',
+        challenge: randomBytes(32).toString('base64url'),
+      }
+    );
+
+    expect(options.authenticatorSelection).toEqual(
       expect.objectContaining({
-        rpName: 'accounts.firefox.com',
-        rpID: 'accounts.firefox.com',
-        userName: 'alice@example.com',
-        userID: uid,
-        challenge: 'test-challenge',
-        authenticatorSelection: expect.objectContaining({
-          userVerification: 'required',
-          residentKey: 'required',
-          authenticatorAttachment: 'platform',
-        }),
+        residentKey: 'required',
+        userVerification: 'required',
+        authenticatorAttachment: 'platform',
       })
     );
   });
 
-  it('returns the library result unchanged', async () => {
-    const fakeResult = { challenge: 'xyz' };
-    libMocks.generateRegistrationOptions.mockResolvedValue(fakeResult);
-
-    const result = await generateWebauthnRegistrationOptions(mockConfig(), {
-      uid: Buffer.alloc(16),
-      email: 'user@example.com',
-      challenge: 'xyz',
+  it('sets user name from email', async () => {
+    const options = await generateWebauthnRegistrationOptions(testConfig(), {
+      uid: Buffer.alloc(16, 0xbb),
+      email: 'bob@example.com',
+      challenge: randomBytes(32).toString('base64url'),
     });
 
-    expect(result).toBe(fakeResult);
+    expect(options.user.name).toBe('bob@example.com');
   });
 });
 
 describe('verifyWebauthnRegistrationResponse', () => {
-  beforeEach(() => jest.clearAllMocks());
+  const config = testConfig();
 
-  const baseInput = {
-    response: mockRegistrationResponse(),
-    challenge: 'test-challenge',
-  };
+  it('succeeds with a valid attestation and extracts credential data', async () => {
+    const cred = VirtualAuthenticator.createCredential();
+    const challenge = randomBytes(32).toString('base64url');
 
-  const successLibResult = {
-    verified: true,
-    registrationInfo: {
-      credential: {
-        id: 'aGVsbG93b3JsZA',
-        publicKey: new Uint8Array([0x04, 0xab, 0xcd, 0xef]),
-        counter: 0,
-        transports: ['internal'],
-      },
-      aaguid: 'adce0002-35bc-c60a-648b-0b25f1f05503',
-      credentialDeviceType: 'multiDevice',
-      credentialBackedUp: true,
-      authenticatorExtensionResults: { prf: { enabled: true } },
-    },
-  };
+    const options = await generateWebauthnRegistrationOptions(config, {
+      uid: Buffer.alloc(16, 0xaa),
+      email: 'test@example.com',
+      challenge,
+    });
 
-  it('returns { verified: true, data } when the library succeeds', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue(successLibResult);
+    const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: TEST_RP_ID,
+    });
 
-    const result = await verifyWebauthnRegistrationResponse(
-      mockConfig(),
-      baseInput
-    );
+    const result = await verifyWebauthnRegistrationResponse(config, {
+      response: attestation,
+      challenge,
+    });
 
     expect(result.verified).toBe(true);
     if (!result.verified) throw new Error('narrowing');
 
     expect(result.data.credentialId).toBeInstanceOf(Buffer);
+    expect(result.data.credentialId.equals(cred.id)).toBe(true);
     expect(result.data.publicKey).toBeInstanceOf(Buffer);
     expect(result.data.signCount).toBe(0);
     expect(result.data.transports).toEqual(['internal']);
     expect(result.data.aaguid).toBeInstanceOf(Buffer);
     expect(result.data.aaguid.length).toBe(16);
-    expect(result.data.backupEligible).toBe(true);
-    expect(result.data.backupState).toBe(true);
-    expect(result.data.prfEnabled).toBe(true);
-  });
-
-  it('sets prfEnabled=false when authenticatorExtensionResults is absent', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue({
-      ...successLibResult,
-      registrationInfo: {
-        ...successLibResult.registrationInfo,
-        authenticatorExtensionResults: undefined,
-      },
-    });
-
-    const result = await verifyWebauthnRegistrationResponse(
-      mockConfig(),
-      baseInput
-    );
-
-    expect(result.verified).toBe(true);
-    if (!result.verified) throw new Error('narrowing');
+    expect(result.data.aaguid.equals(Buffer.alloc(16, 0))).toBe(true);
+    expect(result.data.backupEligible).toBe(false);
+    expect(result.data.backupState).toBe(false);
     expect(result.data.prfEnabled).toBe(false);
   });
 
-  it('sets prfEnabled=false when prf extension is present but enabled=false', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue({
-      ...successLibResult,
-      registrationInfo: {
-        ...successLibResult.registrationInfo,
-        authenticatorExtensionResults: { prf: { enabled: false } },
-      },
+  it('rejects a mismatched challenge', async () => {
+    const cred = VirtualAuthenticator.createCredential();
+    const realChallenge = randomBytes(32).toString('base64url');
+    const wrongChallenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(config, {
+      uid: Buffer.alloc(16, 0xaa),
+      email: 'test@example.com',
+      challenge: realChallenge,
     });
 
-    const result = await verifyWebauthnRegistrationResponse(
-      mockConfig(),
-      baseInput
-    );
-
-    expect(result.verified).toBe(true);
-    if (!result.verified) throw new Error('narrowing');
-    expect(result.data.prfEnabled).toBe(false);
-  });
-
-  it('sets prfEnabled=false when prf key is missing from extension results', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue({
-      ...successLibResult,
-      registrationInfo: {
-        ...successLibResult.registrationInfo,
-        authenticatorExtensionResults: {},
-      },
+    const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: TEST_RP_ID,
     });
 
-    const result = await verifyWebauthnRegistrationResponse(
-      mockConfig(),
-      baseInput
-    );
-
-    expect(result.verified).toBe(true);
-    if (!result.verified) throw new Error('narrowing');
-    expect(result.data.prfEnabled).toBe(false);
-  });
-
-  it('returns { verified: false } when the library returns verified=false', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue({ verified: false });
-
-    const result = await verifyWebauthnRegistrationResponse(
-      mockConfig(),
-      baseInput
-    );
-
-    expect(result.verified).toBe(false);
-    expect((result as { data?: unknown }).data).toBeUndefined();
-  });
-
-  it('passes config and input options to the library', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue(successLibResult);
-    const config = mockConfig({
-      allowedOrigins: ['https://accounts.firefox.com', 'https://other.example'],
-    });
-
-    await verifyWebauthnRegistrationResponse(config, {
-      response: mockRegistrationResponse(),
-      challenge: 'expected-challenge-xyz',
-    });
-
-    expect(libMocks.verifyRegistrationResponse).toHaveBeenCalledWith(
-      expect.objectContaining({
-        expectedChallenge: 'expected-challenge-xyz',
-        expectedOrigin: [
-          'https://accounts.firefox.com',
-          'https://other.example',
-        ],
+    await expect(
+      verifyWebauthnRegistrationResponse(config, {
+        response: attestation,
+        challenge: wrongChallenge,
       })
-    );
+    ).rejects.toThrow();
   });
 
-  it('decodes the aaguid UUID into a 16-byte Buffer', async () => {
-    libMocks.verifyRegistrationResponse.mockResolvedValue(successLibResult);
+  it('rejects a wrong origin', async () => {
+    const cred = VirtualAuthenticator.createCredential();
+    const challenge = randomBytes(32).toString('base64url');
 
-    const result = await verifyWebauthnRegistrationResponse(
-      mockConfig(),
-      baseInput
-    );
+    const options = await generateWebauthnRegistrationOptions(config, {
+      uid: Buffer.alloc(16, 0xaa),
+      email: 'test@example.com',
+      challenge,
+    });
 
-    expect(result.data?.aaguid[0]).toBe(0xad);
+    const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: 'https://evil.example.com',
+      rpId: TEST_RP_ID,
+    });
+
+    await expect(
+      verifyWebauthnRegistrationResponse(config, {
+        response: attestation,
+        challenge,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects a wrong rpId', async () => {
+    const cred = VirtualAuthenticator.createCredential();
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(config, {
+      uid: Buffer.alloc(16, 0xaa),
+      email: 'test@example.com',
+      challenge,
+    });
+
+    const attestation = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: 'evil.example.com',
+    });
+
+    await expect(
+      verifyWebauthnRegistrationResponse(config, {
+        response: attestation,
+        challenge,
+      })
+    ).rejects.toThrow();
   });
 });
 
 describe('generateWebauthnAuthenticationOptions', () => {
-  beforeEach(() => jest.clearAllMocks());
+  const config = testConfig();
 
-  it('passes config and input options to the library', async () => {
-    libMocks.generateAuthenticationOptions.mockResolvedValue({});
+  it('returns the original base64url challenge unchanged', async () => {
+    const challenge = randomBytes(32).toString('base64url');
 
-    await generateWebauthnAuthenticationOptions(
-      mockConfig({ userVerification: 'discouraged' }),
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge,
+      allowCredentials: [],
+    });
+
+    expect(options.challenge).toBe(challenge);
+  });
+
+  it('sets rpId and userVerification from config', async () => {
+    const options = await generateWebauthnAuthenticationOptions(
+      testConfig({ userVerification: 'discouraged' }),
       {
-        challenge: 'random-challenge-abc',
+        challenge: randomBytes(32).toString('base64url'),
         allowCredentials: [],
       }
     );
 
-    expect(libMocks.generateAuthenticationOptions).toHaveBeenCalledWith(
-      expect.objectContaining({
-        rpID: 'accounts.firefox.com',
-        challenge: 'random-challenge-abc',
-        userVerification: 'discouraged',
-      })
-    );
+    expect(options.rpId).toBe(TEST_RP_ID);
+    expect(options.userVerification).toBe('discouraged');
   });
 
-  it('passes undefined for allowCredentials when the array is empty (discoverable flow)', async () => {
-    libMocks.generateAuthenticationOptions.mockResolvedValue({});
-
-    await generateWebauthnAuthenticationOptions(mockConfig(), {
-      challenge: 'ch',
+  it('omits allowCredentials for discoverable flow (empty input)', async () => {
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge: randomBytes(32).toString('base64url'),
       allowCredentials: [],
     });
 
-    expect(libMocks.generateAuthenticationOptions).toHaveBeenCalledWith(
-      expect.objectContaining({ allowCredentials: undefined })
-    );
+    expect(options.allowCredentials).toBeUndefined();
   });
 
-  it('converts Buffer credential IDs to base64url ids', async () => {
-    libMocks.generateAuthenticationOptions.mockResolvedValue({});
+  it('converts Buffer credential IDs to base64url allow-list entries', async () => {
     const credId = Buffer.from('helloworld');
 
-    await generateWebauthnAuthenticationOptions(mockConfig(), {
-      challenge: 'ch',
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge: randomBytes(32).toString('base64url'),
       allowCredentials: [credId],
     });
 
-    expect(libMocks.generateAuthenticationOptions).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allowCredentials: [
-          expect.objectContaining({ id: credId.toString('base64url') }),
-        ],
-      })
-    );
-  });
-
-  it('returns the library result unchanged', async () => {
-    const fakeResult = { challenge: 'q1w2e3' };
-    libMocks.generateAuthenticationOptions.mockResolvedValue(fakeResult);
-
-    const result = await generateWebauthnAuthenticationOptions(mockConfig(), {
-      challenge: 'q1w2e3',
-      allowCredentials: [],
-    });
-
-    expect(result).toBe(fakeResult);
+    expect(options.allowCredentials).toEqual([
+      expect.objectContaining({ id: credId.toString('base64url') }),
+    ]);
   });
 });
 
 describe('verifyWebauthnAuthenticationResponse', () => {
-  beforeEach(() => jest.clearAllMocks());
+  const config = testConfig();
 
-  function makeInput() {
-    return {
-      response: mockAuthenticationResponse(),
-      challenge: 'auth-challenge',
-      credentialId: Buffer.from('aGVsbG93b3JsZA', 'base64url'),
-      publicKey: Buffer.from([0x04, 0xab, 0xcd, 0xef]),
-      signCount: 5,
-    };
-  }
+  it('succeeds with a valid assertion after registration', async () => {
+    const { cred, stored } = await registerCredential(config);
+    const challenge = randomBytes(32).toString('base64url');
 
-  const successLibResult = {
-    verified: true,
-    authenticationInfo: {
-      credentialID: 'aGVsbG93b3JsZA',
-      newCounter: 42,
-      credentialBackedUp: true,
-      credentialDeviceType: 'multiDevice',
-      userVerified: true,
-      rpID: 'accounts.firefox.com',
-      origin: 'https://accounts.firefox.com',
-    },
-  };
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge,
+      allowCredentials: [stored.credentialId],
+    });
 
-  it('returns { verified: true, data } when the library succeeds', async () => {
-    libMocks.verifyAuthenticationResponse.mockResolvedValue(successLibResult);
+    const assertion = VirtualAuthenticator.createAssertionResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: TEST_RP_ID,
+    });
 
-    const result = await verifyWebauthnAuthenticationResponse(
-      mockConfig(),
-      makeInput()
-    );
+    const result = await verifyWebauthnAuthenticationResponse(config, {
+      response: assertion,
+      challenge,
+      credentialId: stored.credentialId,
+      publicKey: stored.publicKey,
+      signCount: stored.signCount,
+    });
 
     expect(result.verified).toBe(true);
-    expect(result.data?.newSignCount).toBe(42);
-    expect(result.data?.backupState).toBe(true);
+    if (!result.verified) throw new Error('narrowing');
+    expect(result.data.newSignCount).toBe(1);
+    expect(result.data.backupState).toBe(false);
   });
 
-  it('returns { verified: false } with no data when library returns verified=false', async () => {
-    libMocks.verifyAuthenticationResponse.mockResolvedValue({
-      verified: false,
-      authenticationInfo: {
-        ...successLibResult.authenticationInfo,
-        newCounter: 0,
-        credentialBackedUp: false,
-      },
-    });
+  it('tracks incrementing sign counts across assertions', async () => {
+    const { cred, stored } = await registerCredential(config);
+    let currentSignCount = stored.signCount;
 
-    const result = await verifyWebauthnAuthenticationResponse(
-      mockConfig(),
-      makeInput()
-    );
+    for (const expectedCount of [1, 2, 3]) {
+      const challenge = randomBytes(32).toString('base64url');
+      const options = await generateWebauthnAuthenticationOptions(config, {
+        challenge,
+        allowCredentials: [stored.credentialId],
+      });
+      const assertion = VirtualAuthenticator.createAssertionResponse(cred, {
+        challenge: options.challenge,
+        origin: TEST_ORIGIN,
+        rpId: TEST_RP_ID,
+      });
+      const result = await verifyWebauthnAuthenticationResponse(config, {
+        response: assertion,
+        challenge,
+        credentialId: stored.credentialId,
+        publicKey: stored.publicKey,
+        signCount: currentSignCount,
+      });
 
-    expect(result.verified).toBe(false);
-    expect(result.data).toBeUndefined();
+      expect(result.verified).toBe(true);
+      expect(result.data?.newSignCount).toBe(expectedCount);
+      if (!result.data) throw Error('narrowing');
+      currentSignCount = result.data.newSignCount;
+    }
   });
 
-  it('reflects credentialBackedUp=false in data.backupState', async () => {
-    libMocks.verifyAuthenticationResponse.mockResolvedValue({
-      ...successLibResult,
-      authenticationInfo: {
-        ...successLibResult.authenticationInfo,
-        credentialBackedUp: false,
-      },
+  it('rejects a mismatched challenge', async () => {
+    const { cred, stored } = await registerCredential(config);
+    const realChallenge = randomBytes(32).toString('base64url');
+    const wrongChallenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge: realChallenge,
+      allowCredentials: [stored.credentialId],
     });
 
-    const result = await verifyWebauthnAuthenticationResponse(
-      mockConfig(),
-      makeInput()
-    );
-
-    expect(result.data?.backupState).toBe(false);
-  });
-
-  it('passes config and input options to the library', async () => {
-    libMocks.verifyAuthenticationResponse.mockResolvedValue(successLibResult);
-    const credPublicKey = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
-
-    await verifyWebauthnAuthenticationResponse(mockConfig(), {
-      response: mockAuthenticationResponse(),
-      challenge: 'specific-challenge-999',
-      credentialId: Buffer.from('dGVzdA', 'base64url'),
-      publicKey: credPublicKey,
-      signCount: 10,
+    const assertion = VirtualAuthenticator.createAssertionResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: TEST_RP_ID,
     });
 
-    expect(libMocks.verifyAuthenticationResponse).toHaveBeenCalledWith(
-      expect.objectContaining({
-        expectedChallenge: 'specific-challenge-999',
-        expectedOrigin: ['https://accounts.firefox.com'],
-        credential: expect.objectContaining({
-          id: Buffer.from('dGVzdA', 'base64url').toString('base64url'),
-          publicKey: credPublicKey,
-          counter: 10,
-        }),
+    await expect(
+      verifyWebauthnAuthenticationResponse(config, {
+        response: assertion,
+        challenge: wrongChallenge,
+        credentialId: stored.credentialId,
+        publicKey: stored.publicKey,
+        signCount: stored.signCount,
       })
-    );
+    ).rejects.toThrow();
+  });
+
+  it('rejects a wrong origin', async () => {
+    const { cred, stored } = await registerCredential(config);
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge,
+      allowCredentials: [stored.credentialId],
+    });
+
+    const assertion = VirtualAuthenticator.createAssertionResponse(cred, {
+      challenge: options.challenge,
+      origin: 'https://evil.example.com',
+      rpId: TEST_RP_ID,
+    });
+
+    await expect(
+      verifyWebauthnAuthenticationResponse(config, {
+        response: assertion,
+        challenge,
+        credentialId: stored.credentialId,
+        publicKey: stored.publicKey,
+        signCount: stored.signCount,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('rejects a wrong rpId', async () => {
+    const { cred, stored } = await registerCredential(config);
+    const challenge = randomBytes(32).toString('base64url');
+
+    const options = await generateWebauthnAuthenticationOptions(config, {
+      challenge,
+      allowCredentials: [stored.credentialId],
+    });
+
+    const assertion = VirtualAuthenticator.createAssertionResponse(cred, {
+      challenge: options.challenge,
+      origin: TEST_ORIGIN,
+      rpId: 'evil.example.com',
+    });
+
+    await expect(
+      verifyWebauthnAuthenticationResponse(config, {
+        response: assertion,
+        challenge,
+        credentialId: stored.credentialId,
+        publicKey: stored.publicKey,
+        signCount: stored.signCount,
+      })
+    ).rejects.toThrow();
   });
 });

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -8,6 +8,7 @@ import {
   generateAuthenticationOptions,
   verifyAuthenticationResponse,
 } from '@simplewebauthn/server';
+
 import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
@@ -44,8 +45,13 @@ export async function generateWebauthnRegistrationOptions(
     rpName: config.rpId,
     rpID: config.rpId,
     userName: input.email,
+    userDisplayName: input.email,
     userID: input.uid,
-    challenge: input.challenge,
+    // Challenge must be passed as a Buffer (Uint8Array) so that simplewebauthn
+    // base64url-encodes the raw bytes. Passing a string causes the library to
+    // UTF-8-encode the text first, producing a different base64url value than
+    // what was stored in Redis — breaking challenge lookup on finish.
+    challenge: Buffer.from(input.challenge, 'base64url'),
     authenticatorSelection: {
       residentKey: config.residentKey,
       userVerification: config.userVerification,
@@ -161,7 +167,8 @@ export async function generateWebauthnAuthenticationOptions(
   return generateAuthenticationOptions({
     rpID: config.rpId,
     userVerification: config.userVerification,
-    challenge: input.challenge,
+    // See comment in generateRegistrationOptions — same base64url roundtrip fix.
+    challenge: Buffer.from(input.challenge, 'base64url'),
     allowCredentials:
       input.allowCredentials.length > 0
         ? input.allowCredentials.map((id) => ({ id: id.toString('base64url') }))

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -172,7 +172,7 @@ describe('passkeys routes', () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         mockPasskeyService.generateRegistrationChallenge
-      ).toHaveBeenCalledWith(Buffer.from(UID), TEST_EMAIL);
+      ).toHaveBeenCalledWith(Buffer.from(UID, 'hex'), TEST_EMAIL);
     });
 
     it('enforces rate limiting via customs.checkAuthenticated', async () => {
@@ -249,7 +249,7 @@ describe('passkeys routes', () => {
       expect(
         mockPasskeyService.createPasskeyFromRegistrationResponse
       ).toHaveBeenCalledWith(
-        Buffer.from(UID),
+        Buffer.from(UID, 'hex'),
         payload.response,
         payload.challenge
       );
@@ -440,7 +440,7 @@ describe('passkeys routes', () => {
       );
 
       expect(mockPasskeyService.listPasskeysForUser).toHaveBeenCalledWith(
-        Buffer.from(UID)
+        Buffer.from(UID, 'hex')
       );
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
@@ -520,7 +520,7 @@ describe('passkeys routes', () => {
       );
 
       expect(mockPasskeyService.deletePasskey).toHaveBeenCalledWith(
-        Buffer.from(UID),
+        Buffer.from(UID, 'hex'),
         Buffer.from(CREDENTIAL_ID_B64, 'base64url')
       );
     });
@@ -704,7 +704,7 @@ describe('passkeys routes', () => {
       );
 
       expect(mockPasskeyService.renamePasskey).toHaveBeenCalledWith(
-        Buffer.from(UID),
+        Buffer.from(UID, 'hex'),
         Buffer.from(CREDENTIAL_ID_B64, 'base64url'),
         'Renamed Key'
       );

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -85,7 +85,7 @@ class PasskeyHandler {
     );
 
     const options = await this.service.generateRegistrationChallenge(
-      Buffer.from(uid),
+      Buffer.from(uid, 'hex'),
       account.email
     );
 
@@ -128,7 +128,7 @@ class PasskeyHandler {
 
     try {
       const passkey = await this.service.createPasskeyFromRegistrationResponse(
-        Buffer.from(uid),
+        Buffer.from(uid, 'hex'),
         response,
         challenge
       );
@@ -213,7 +213,9 @@ class PasskeyHandler {
       'passkeysList'
     );
 
-    const passkeys = await this.service.listPasskeysForUser(Buffer.from(uid));
+    const passkeys = await this.service.listPasskeysForUser(
+      Buffer.from(uid, 'hex')
+    );
 
     // omit publicKey and signCount
     return passkeys.map(
@@ -264,7 +266,7 @@ class PasskeyHandler {
 
     const credentialId = Buffer.from(credentialIdParam, 'base64url');
 
-    await this.service.deletePasskey(Buffer.from(uid), credentialId);
+    await this.service.deletePasskey(Buffer.from(uid, 'hex'), credentialId);
 
     await recordSecurityEvent('account.passkey.removed', {
       db: this.db,
@@ -317,7 +319,7 @@ class PasskeyHandler {
     const credentialId = Buffer.from(credentialIdParam, 'base64url');
 
     const passkey = await this.service.renamePasskey(
-      Buffer.from(uid),
+      Buffer.from(uid, 'hex'),
       credentialId,
       name
     );
@@ -495,9 +497,10 @@ export const passkeyRoutes = (
           }),
         },
       },
-      handler: function (request: AuthRequest) {
+      handler: async function (request: AuthRequest) {
         log.begin('passkey.registration.start', request);
-        return handler.registrationStart(request);
+        const result = await handler.registrationStart(request);
+        return result;
       },
     },
     {
@@ -531,9 +534,10 @@ export const passkeyRoutes = (
           }),
         },
       },
-      handler: function (request: AuthRequest) {
+      handler: async function (request: AuthRequest) {
         log.begin('passkey.registration.finish', request);
-        return handler.registrationFinish(request);
+        const result = await handler.registrationFinish(request);
+        return result;
       },
     },
     {

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -6,9 +6,11 @@ import { Container } from 'typedi';
 import Redis from 'ioredis';
 import { setupAccountDatabase } from '@fxa/shared/db/mysql/account';
 import {
+  PasskeyConfig,
   PasskeyService,
   PasskeyChallengeManager,
   PasskeyManager,
+  VirtualAuthenticator,
 } from '@fxa/accounts/passkey';
 import Config from '../../config';
 import {
@@ -20,6 +22,8 @@ const Client = require('../client')();
 let server: TestServerInstance;
 let redis: Redis | undefined;
 let db: Awaited<ReturnType<typeof setupAccountDatabase>> | undefined;
+let passkeyRpId: string;
+let passkeyOrigin: string;
 
 beforeAll(async () => {
   redis = new Redis({ host: 'localhost' });
@@ -32,18 +36,29 @@ beforeAll(async () => {
   };
   const config = Config.getProperties();
   db = await setupAccountDatabase(config.database.mysql.auth);
-  const passkeyManager = new PasskeyManager(db, config, mockStatsD, mockLog);
+
+  const passkeyConfig = new PasskeyConfig(config.passkeys as PasskeyConfig);
+  passkeyRpId = passkeyConfig.rpId;
+  passkeyOrigin = passkeyConfig.allowedOrigins[0];
+
+  const passkeyManager = new PasskeyManager(
+    db,
+    passkeyConfig,
+    mockStatsD as any,
+    mockLog as any
+  );
   const passkeyChallengeManager = new PasskeyChallengeManager(
     redis,
-    config,
-    mockLog,
-    mockStatsD
+    passkeyConfig,
+    mockLog as any,
+    mockStatsD as any
   );
   const passkeyService = new PasskeyService(
     passkeyManager,
     passkeyChallengeManager,
-    mockStatsD,
-    mockLog
+    passkeyConfig,
+    mockStatsD as any,
+    mockLog as any
   );
 
   // Register the PasskeyService instance before the server starts so that the
@@ -167,5 +182,38 @@ describe('#integration - remote passkey registration', () => {
     }).rejects.toMatchObject({
       code: 400,
     });
+  });
+
+  it('happy path: /passkey/registration/start then /passkey/registration/finish', async () => {
+    const accessToken = await getMfaAccessTokenForPasskey(passkeyClient);
+
+    const options = await passkeyClient.api.doRequestWithBearerToken(
+      'POST',
+      `${passkeyClient.api.baseURL}/passkey/registration/start`,
+      accessToken,
+      {}
+    );
+    expect(options.challenge).toBeDefined();
+    expect(options.rp).toBeDefined();
+
+    // Step 2: simulate authenticator
+    const cred = VirtualAuthenticator.createCredential();
+    const response = VirtualAuthenticator.createAttestationResponse(cred, {
+      challenge: options.challenge,
+      origin: passkeyOrigin,
+      rpId: passkeyRpId,
+    });
+
+    // Step 3: finish registration
+    const result = await passkeyClient.api.doRequestWithBearerToken(
+      'POST',
+      `${passkeyClient.api.baseURL}/passkey/registration/finish`,
+      accessToken,
+      { response, challenge: options.challenge }
+    );
+
+    expect(result.credentialId).toBeDefined();
+    expect(result.name).toBeDefined();
+    expect(result.createdAt).toEqual(expect.any(Number));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -13022,18 +13022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@peculiar/asn1-schema@npm:^2.3.13, @peculiar/asn1-schema@npm:^2.3.8":
-  version: 2.3.15
-  resolution: "@peculiar/asn1-schema@npm:2.3.15"
-  dependencies:
-    asn1js: "npm:^3.0.5"
-    pvtsutils: "npm:^1.3.6"
-    tslib: "npm:^2.8.1"
-  checksum: 10c0/0e73e292a17d00a8770825a9504ceaf0994481a39126317ca0ca5d3dc742087f2b71a4d086bb5613bf19ac57f001d42f594683797d43137702db3ee2b42736a0
-  languageName: node
-  linkType: hard
-
-"@peculiar/asn1-schema@npm:^2.6.0":
+"@peculiar/asn1-schema@npm:^2.3.13, @peculiar/asn1-schema@npm:^2.3.8, @peculiar/asn1-schema@npm:^2.6.0":
   version: 2.6.0
   resolution: "@peculiar/asn1-schema@npm:2.6.0"
   dependencies:


### PR DESCRIPTION
## Because

- simplewebauthn v13 treats string challenges as UTF-8 text and re-encodes them to base64url, producing a different value than what was stored in Redis. This caused challenge lookup to fail on registration/authentication finish.
- Calls to the sipmlewebauthn lib were being unnecessarily mocked, so we didn't catch this.
- We had a few spots where we were not buffer encoding correctly. Strings are hex strings, and UID are 16 bit length buffers.

## This pull request

- Passes challenge as Buffer.from(challenge, 'base64url') to generateRegistrationOptions and generateAuthenticationOptions so simplewebauthn base64url-encodes the raw bytes (roundtrip-safe).
- Adds webauthn-adapter.in.spec.ts with a virtual authenticator that exercises real simplewebauthn verifyRegistrationResponse (no mocks).
- Adds happy-path integration test for registration start → finish.
- Fixes uid buffer encodings

## Issue that this pull request solves

Closes: FXA-13343

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: Take a good look at the web authn tests now. These were updated by claude.
- Suggested review order: Webauthn then other parts
- Risky or complex parts: The virutal authenticator was all gen ai code.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
At first it appeared that challenges output by `libGenerateAuthenticationOptions` were always changing from the original challenge that is provided to the library call. I assumed that this was by design, however, after adding more tests that actually exercised the library call and doing some debugging it appears the core issue was just the encoding on the challenge. (Which is what Claude thought.) 

There was one red herring in previous tests worth noting. When using an arbitrary challenge like `test-challenge` in tests, failures would occur since it doesn't encode cleanly, e.g. `Buffer.from('test-challenge', 'base64url').toString('base64url'); -> 'test-challengQ'`. Using a actual challenge value like `const challenge = randomBytes(32).toString('base64url');` won't have this problem since the challenge is already base64 encoded.   
