### PR TITLE
fix(build): Set EJS download to --noproxy to fix auth-server startup problem

### DIFF
--- a/packages/fxa-auth-server/scripts/install-ejs.sh
+++ b/packages/fxa-auth-server/scripts/install-ejs.sh
@@ -14,4 +14,5 @@ ejs_version=3.1.10
 [ ! -d "./vendor" ] && mkdir vendor
 
 # Download it from github
-curl -L https://github.com/mde/ejs/releases/download/v$ejs_version/ejs.min.js -o ./vendor/ejs.js
+# Use --noproxy to avoid yarn/npm proxy env vars causing 504 gateway timeouts
+curl -fL --noproxy '*' https://github.com/mde/ejs/releases/download/v$ejs_version/ejs.min.js -o ./vendor/ejs.js


### PR DESCRIPTION
Not sure if anyone else is having this problem, but my stack would not start up today and I traced it down to auth-server not starting due to this script outputting this to `vendor/ejs.js`:

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>
```

Manually curling / running the command worked, but running `nx build` on auth-server or starting up the stack, would fail on this `vendor/ejs.js` having "no default export," because the file was the above.