### PR TITLE
fix(emails): Update oauth_client_info service/name check

### DIFF
--- a/packages/fxa-auth-server/lib/senders/oauth_client_info.js
+++ b/packages/fxa-auth-server/lib/senders/oauth_client_info.js
@@ -6,6 +6,9 @@
 
 const { Keyv } = require('keyv');
 const client = require('../oauth/client');
+const { OAuthNativeServices } = require('@fxa/accounts/oauth');
+
+const NATIVE_SERVICES = new Set(Object.values(OAuthNativeServices));
 
 module.exports = (log, config) => {
   const OAUTH_CLIENT_INFO_CACHE_TTL = config.oauth.clientInfoCacheTTL;
@@ -43,7 +46,7 @@ module.exports = (log, config) => {
     }
 
     // Set the client name to 'Firefox' if the service is browser-based
-    if (service === 'sync' || service === 'relay') {
+    if (NATIVE_SERVICES.has(service)) {
       log.trace('fetch.firefoxClient');
       return FIREFOX_CLIENT;
     }

--- a/packages/fxa-auth-server/lib/senders/oauth_client_info.spec.ts
+++ b/packages/fxa-auth-server/lib/senders/oauth_client_info.spec.ts
@@ -12,7 +12,7 @@ jest.mock('../oauth/client', () => ({
       case '0000000000000000':
         throw new Error();
       default:
-        return { name: 'Firefox' };
+        return { name: 'NotFirefox' };
     }
   },
 }));
@@ -57,6 +57,16 @@ describe('lib/senders/oauth_client_info:', () => {
 
     it('returns Firefox if service=relay', async () => {
       const res = await fetch('relay');
+      expect(res.name).toBe('Firefox');
+    });
+
+    it('returns Firefox if service=smartwindow', async () => {
+      const res = await fetch('smartwindow');
+      expect(res.name).toBe('Firefox');
+    });
+
+    it('returns Firefox if service=vpn', async () => {
+      const res = await fetch('vpn');
       expect(res.name).toBe('Firefox');
     });
 


### PR DESCRIPTION
Because:
* In the verifyLoginCode email, Smart Window and VPN say '...  Mozilla?' (the default) in the subject line/body copy, and we want to be consistent with Sync and Relay and focus on '... Firefox?' wording

This commit:
* Changes the hardcoded check against sync/relay to include the OAuthNativeServices enum to return 'Firefox' as the name

closes FXA-13080

---

This is easiest to check in Maildev by running `yarn pm2 stop inbox` and `sudo maildev -s 9999` then checking port 1080 to compare.

Please see the ticket for a comment with a chart of the state of things before this change. This affects the email code email (you may need to use a `@mozilla` email locally and set `SIGNIN_CONFIRMATION_SKIP_FOR_NEW_ACCOUNTS` to `false`) and the new device email.

I messaged Ipsita and Ross for how we want to make these consistent and they prefer the "Firefox" wording.