### PR TITLE
fix(fxa-settings): Preserve URL hash in query-fix.js for pairing flow

### DIFF
--- a/packages/fxa-settings/public/query-fix.js
+++ b/packages/fxa-settings/public/query-fix.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* This script re-encodes the current URL’s query parameters to ensure that any special
+/* This script re-encodes the current URL's query parameters to ensure that any special
  * characters (such as '+') are properly encoded. This re-encoding is necessary due to
  * backwards compatibility requirements for clients (e.g., the VPN client) that send
  * unencoded query components, which can cause issues with parameter validation in the app.
@@ -31,11 +31,15 @@
       })
       .join('&');
   if (newSearch !== search) {
-    // IMPORTANT: preserve `window.location.hash`. The pairing supplicant
-    // flow encodes `channel_id` and `channel_key` in the URL fragment
-    // (e.g. `/pair/supp?client_id=...#channel_id=...&channel_key=...`),
-    // and stripping the hash here would break the supplicant before the
-    // React app has a chance to read it.
-    window.history.replaceState({}, '', newSearch + window.location.hash);
+    // IMPORTANT: preserve the URL hash fragment. The pairing supplicant
+    // flow encodes channel_id and channel_key in the fragment. On iOS
+    // WKWebView, window.location.hash may be empty when inline scripts
+    // run early, so fall back to parsing the hash from the full href.
+    const hash =
+      window.location.hash ||
+      (window.location.href.includes('#')
+        ? window.location.href.substring(window.location.href.indexOf('#'))
+        : '');
+    window.history.replaceState({}, '', newSearch + hash);
   }
 })();


### PR DESCRIPTION
  ## Because

  - Mobile browsers (Firefox iOS via WKWebView, Firefox Android via GeckoView) do not populate `window.location.hash` when inline scripts run early in the page lifecycle
  - `query-fix.js` calls `history.replaceState` to re-encode `+` as `%2B` in query params, but the original code passed no hash at all (`replaceState({}, '', newSearch)`), stripping the URL fragment
  - This drops `#channel_id` and `#channel_key` from the pairing supplicant URL, causing "Invalid pairing configuration" on mobile
                                                                                                                                                                                                                                                               
  ## This pull request
                                                                                                                                                                                                                                                               
  - Adds hash preservation to `replaceState` in `query-fix.js`, falling back to parsing the fragment from `window.location.href` when `window.location.hash` is empty                                                                                          
                                                                                                                                                                                                                                                               
  ## Checklist                               
                                                                                                                                                                                                                                                               
  _Put an `x` in the boxes that apply_              
                                         
  - [x] My commit is GPG signed.                    
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.                                                                                                                                                                                                        
   
  ## Other information                                                                                                                                                                                                                                         

I verified fix against stage by injecting the patched logic into the iOS WKWebView via user script and running the E2E pairing test.