### PR TITLE
fix(admin): fix email bounce type display

### DIFF
--- a/packages/fxa-admin-server/src/rest/account/account.controller.ts
+++ b/packages/fxa-admin-server/src/rest/account/account.controller.ts
@@ -53,6 +53,7 @@ import {
   EventNames,
 } from '../../event-logging/event-logging.service';
 import { AccountEvent as AccountEventType } from '../model/account-events.model';
+import { BounceType, BounceSubType } from '../model/email-bounces.model';
 import { BasketService } from '../../newsletters/basket.service';
 import { FidoMdsService } from '../../backend/fido-mds.service';
 import { SubscriptionsService } from '../../subscriptions/subscriptions.service';
@@ -750,6 +751,7 @@ export class AccountController {
 
   // ─── Field resolver helpers (public so integration tests can call them) ───
 
+  @Features(AdminPanelFeature.AccountSearch)
   public async emailBounces(account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
     const emails = await this.db.emails
@@ -765,7 +767,14 @@ export class AccountController {
         'in',
         emails.map((x) => x.normalizedEmail)
       );
-    return result;
+    return result.map((bounce) => ({
+      ...bounce,
+      bounceType:
+        BounceType[bounce.bounceType] ?? BounceType[BounceType.unmapped],
+      bounceSubType:
+        BounceSubType[bounce.bounceSubType] ??
+        BounceSubType[BounceSubType.unmapped],
+    }));
   }
 
   @Features(AdminPanelFeature.AccountSearch)
@@ -869,6 +878,7 @@ export class AccountController {
     ];
   }
 
+  @Features(AdminPanelFeature.AccountSearch)
   public async linkedAccounts(account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
     return await this.db.linkedAccounts


### PR DESCRIPTION
## Because

- email bounce types are shown as enum integers instead of strings

## This pull request

- make the backend endpoint return transformed strings directly.

## Issue that this pull request solves

Closes: FXA-13417

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts: you'll need to add an email bounce to db manually because there's no way to simulate it yet.

## Screenshots (Optional)

<img width="1064" height="375" alt="image" src="https://github.com/user-attachments/assets/ac40d740-329c-49b8-98df-59209286378f" />

## Other information (Optional)

Any other information that is important to this pull request.
