### PR TITLE
feat(passkeys): Support passkeys verification method for sessionTokens

### DIFF
--- a/libs/shared/account/account/src/lib/account.repository.ts
+++ b/libs/shared/account/account/src/lib/account.repository.ts
@@ -78,6 +78,7 @@ export enum VerificationMethods {
   totp2fa = 2,
   recoveryCode = 3,
   sms2fa = 4,
+  passkey = 5,
 }
 
 /**

--- a/packages/fxa-auth-server/lib/authMethods.js
+++ b/packages/fxa-auth-server/lib/authMethods.js
@@ -6,6 +6,21 @@
 
 const { AppError: error } = require('@fxa/accounts/errors');
 
+// This module serves two distinct purposes that should not be conflated:
+//
+// 1) RP reporting — availableAuthenticationMethods + maximumAssuranceLevel
+//    compute the amr/acr values returned to relying parties via the
+//    profile:amr scope. These reflect which mandatory second factors an
+//    account has configured, so RPs can decide whether to prompt for
+//    step-up authentication.
+//
+// 2) Session enforcement — accountRequiresAAL2 is used by the
+//    session auth strategies (verified-session-token, mfa) to decide
+//    whether to reject a session with insufficient AAL.
+//
+// The two paths intentionally use different functions. The semantics of
+// RP-facing AMR/AAL are not well-defined and warrant a rethink — FXA-13432.
+//
 // Maps our variety of verification methods down to a few short standard
 // "authentication method reference" strings that we're happy to expose to
 // reliers. We try to use the values defined in RFC8176 where possible:
@@ -20,6 +35,7 @@ const METHOD_TO_AMR = {
   'totp-2fa': 'otp',
   'recovery-code': 'otp',
   'sms-2fa': 'otp',
+  passkey: 'webauthn',
 };
 
 // Maps AMR values to the type of authenticator they represent, e.g.
@@ -29,12 +45,25 @@ const AMR_TO_TYPE = {
   pwd: 'know',
   email: 'know',
   otp: 'have',
+  // WebAuthn with user verification is intrinsically multi-factor ('know'/'are'
+  // + 'have'), so a passkey session should yield AAL2 on its own. Mapping only
+  // to 'have' here means the AAL2 result for passkey sessions currently depends
+  // on the 'pwd' entry always being present in the session AMR set — see the
+  // comment in session_token.js authenticationMethods. Fixing this requires
+  // maximumAssuranceLevel to support multi-type AMR entries — FXA-13432.
+  webauthn: 'have',
 };
 
 module.exports = {
   /**
-   * Returns the set of authentication methods available
-   * for the given account, as amr value strings.
+   * Returns the AMR values used to compute the authenticatorAssuranceLevel
+   * returned to relying parties via the profile:amr scope. In practice this
+   * reflects which *mandatory* second factors the account has enabled, not
+   * every method the account could theoretically use.
+   *
+   * Passkeys are intentionally excluded: they are optional and do not raise
+   * the required AAL for other sign-in paths. The semantics here are murky
+   * and need a proper rethink — see FXA-13432.
    */
   async availableAuthenticationMethods(db, account) {
     const amrValues = new Set();
@@ -71,18 +100,49 @@ module.exports = {
   },
 
   /**
-   * Given a set of AMR value strings, return the maximum authenticator assurance
-   * level that can be achieved using them.  We aim to follow the definition
-   * of levels 1, 2, and 3 from NIST SP 800-63B based on different categories
-   * of authenticator (e.g. "something you know" vs "something you have"),
-   * although we don't yet support any methods that would qualify the user
-   * for level 3.
+   * Given a set of AMR value strings, return the AAL implied by the
+   * distinct authenticator types present (NIST SP 800-63B levels 1–2;
+   * level 3 is not supported). Two distinct types (e.g. 'know' + 'have')
+   * yields AAL2; one type yields AAL1.
+   *
+   * This function has two call sites with different inputs and different
+   * semantics:
+   *
+   * - SessionToken.authenticatorAssuranceLevel passes the session's own AMR
+   *   set, producing the AAL of the current session. This value flows into
+   *   the fxa-aal JWT claim and is checked against RP acr_values requests.
+   *
+   * - The profile:amr response path passes the output of
+   *   availableAuthenticationMethods, which reflects mandatory second factors
+   *   only and intentionally excludes passkeys. An account with passkeys
+   *   registered but no TOTP will receive AAL1 here even though AAL2 is
+   *   achievable — see FXA-13432.
    */
   maximumAssuranceLevel(amrValues) {
     const types = new Set();
     amrValues.forEach((amr) => {
-      types.add(AMR_TO_TYPE[amr]);
+      const type = AMR_TO_TYPE[amr];
+      if (type) types.add(type);
     });
     return types.size;
+  },
+
+  /**
+   * Returns true if the account requires AAL2 on ALL sign-in paths.
+   *
+   * Only TOTP makes 2FA mandatory — if enabled, every session must reach AAL2.
+   * Passkeys are optional: registering one does not force AAL2 on password
+   * sign-ins.
+   */
+  async accountRequiresAAL2(db, account) {
+    let res;
+    try {
+      res = await db.totpToken(account.uid);
+    } catch (err) {
+      if (err.errno !== error.ERRNO.TOTP_TOKEN_NOT_FOUND) {
+        throw err;
+      }
+    }
+    return !!(res && res.verified && res.enabled);
   },
 };

--- a/packages/fxa-auth-server/lib/authMethods.spec.ts
+++ b/packages/fxa-auth-server/lib/authMethods.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import sinon from 'sinon';
 import { AppError as error } from '@fxa/accounts/errors';
 import * as authMethods from './authMethods';
 
@@ -10,70 +9,57 @@ const MOCK_ACCOUNT = {
   uid: 'abcdef123456',
 };
 
-function mockDB() {
-  return {
-    totpToken: sinon.stub(),
-    // Add other DB methods as needed
-  };
-}
-
 describe('availableAuthenticationMethods', () => {
-  let mockDbInstance: ReturnType<typeof mockDB>;
+  let db: { totpToken: jest.Mock };
 
   beforeEach(() => {
-    mockDbInstance = mockDB();
+    db = { totpToken: jest.fn() };
   });
 
   it('returns [`pwd`,`email`] for non-TOTP-enabled accounts', async () => {
-    mockDbInstance.totpToken = sinon.stub().rejects(error.totpTokenNotFound());
+    db.totpToken.mockRejectedValue(error.totpTokenNotFound());
     const amr = await authMethods.availableAuthenticationMethods(
-      mockDbInstance as any,
+      db as any,
       MOCK_ACCOUNT as any
     );
-    expect(mockDbInstance.totpToken.calledWithExactly(MOCK_ACCOUNT.uid)).toBe(true);
+    expect(db.totpToken).toHaveBeenCalledWith(MOCK_ACCOUNT.uid);
     expect(Array.from(amr).sort()).toEqual(['email', 'pwd']);
   });
 
   it('returns [`pwd`,`email`,`otp`] for TOTP-enabled accounts', async () => {
-    mockDbInstance.totpToken = sinon.stub().resolves({
+    db.totpToken.mockResolvedValue({
       verified: true,
       enabled: true,
       sharedSecret: 'secret!',
     });
     const amr = await authMethods.availableAuthenticationMethods(
-      mockDbInstance as any,
+      db as any,
       MOCK_ACCOUNT as any
     );
-    expect(mockDbInstance.totpToken.calledWithExactly(MOCK_ACCOUNT.uid)).toBe(true);
+    expect(db.totpToken).toHaveBeenCalledWith(MOCK_ACCOUNT.uid);
     expect(Array.from(amr).sort()).toEqual(['email', 'otp', 'pwd']);
   });
 
   it('returns [`pwd`,`email`] when TOTP token is not yet enabled', async () => {
-    mockDbInstance.totpToken = sinon.stub().resolves({
+    db.totpToken.mockResolvedValue({
       verified: true,
       enabled: false,
       sharedSecret: 'secret!',
     });
     const amr = await authMethods.availableAuthenticationMethods(
-      mockDbInstance as any,
+      db as any,
       MOCK_ACCOUNT as any
     );
-    expect(mockDbInstance.totpToken.calledWithExactly(MOCK_ACCOUNT.uid)).toBe(true);
+    expect(db.totpToken).toHaveBeenCalledWith(MOCK_ACCOUNT.uid);
     expect(Array.from(amr).sort()).toEqual(['email', 'pwd']);
   });
 
   it('rethrows unexpected DB errors', async () => {
-    mockDbInstance.totpToken = sinon.stub().rejects(error.serviceUnavailable());
-    try {
-      await authMethods.availableAuthenticationMethods(
-        mockDbInstance as any,
-        MOCK_ACCOUNT as any
-      );
-      throw new Error('error should have been re-thrown');
-    } catch (err: any) {
-      expect(mockDbInstance.totpToken.calledWithExactly(MOCK_ACCOUNT.uid)).toBe(true);
-      expect(err.errno).toBe(error.ERRNO.SERVER_BUSY);
-    }
+    db.totpToken.mockRejectedValue(error.serviceUnavailable());
+    await expect(
+      authMethods.availableAuthenticationMethods(db as any, MOCK_ACCOUNT as any)
+    ).rejects.toMatchObject({ errno: error.ERRNO.SERVER_BUSY });
+    expect(db.totpToken).toHaveBeenCalledWith(MOCK_ACCOUNT.uid);
   });
 });
 
@@ -96,6 +82,10 @@ describe('verificationMethodToAMR', () => {
 
   it('maps `recovery-code` to `otp`', () => {
     expect(authMethods.verificationMethodToAMR('recovery-code')).toBe('otp');
+  });
+
+  it('maps `passkey` to `webauthn`', () => {
+    expect(authMethods.verificationMethodToAMR('passkey')).toBe('webauthn');
   });
 
   it('throws when given an unknown verification method', () => {
@@ -129,5 +119,64 @@ describe('maximumAssuranceLevel', () => {
 
   it('returns 2 when both `pwd` and `otp` methods are used', () => {
     expect(authMethods.maximumAssuranceLevel(['pwd', 'otp'])).toBe(2);
+  });
+
+  it('returns 2 when both `pwd` and `webauthn` methods are used (passkey session)', () => {
+    expect(authMethods.maximumAssuranceLevel(['pwd', 'webauthn'])).toBe(2);
+  });
+});
+
+describe('accountRequiresAAL2', () => {
+  let db: { totpToken: jest.Mock };
+
+  beforeEach(() => {
+    db = { totpToken: jest.fn() };
+  });
+
+  it('returns false when account has no TOTP token', async () => {
+    db.totpToken.mockRejectedValue(error.totpTokenNotFound());
+    const result = await authMethods.accountRequiresAAL2(
+      db as any,
+      MOCK_ACCOUNT as any
+    );
+    expect(result).toBe(false);
+  });
+
+  // The current TOTP setup flow writes to the DB only at setup-complete via
+  // replaceTotpToken, always with both flags true — partial states cannot be
+  // produced by any current code path. These tests are defensive guards against
+  // legacy data or future regressions.
+  it('returns false when TOTP token exists but is not verified', async () => {
+    db.totpToken.mockResolvedValue({ verified: false, enabled: true });
+    const result = await authMethods.accountRequiresAAL2(
+      db as any,
+      MOCK_ACCOUNT as any
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns false when TOTP token exists but is not enabled', async () => {
+    db.totpToken.mockResolvedValue({ verified: true, enabled: false });
+    const result = await authMethods.accountRequiresAAL2(
+      db as any,
+      MOCK_ACCOUNT as any
+    );
+    expect(result).toBe(false);
+  });
+
+  it('returns true when TOTP token is both verified and enabled', async () => {
+    db.totpToken.mockResolvedValue({ verified: true, enabled: true });
+    const result = await authMethods.accountRequiresAAL2(
+      db as any,
+      MOCK_ACCOUNT as any
+    );
+    expect(result).toBe(true);
+  });
+
+  it('rethrows unexpected DB errors', async () => {
+    db.totpToken.mockRejectedValue(error.serviceUnavailable());
+    await expect(
+      authMethods.accountRequiresAAL2(db as any, MOCK_ACCOUNT as any)
+    ).rejects.toMatchObject({ errno: error.ERRNO.SERVER_BUSY });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1813,6 +1813,12 @@ export class AccountHandler {
       res.locale = account.locale;
     }
     if (scope.contains('profile:amr')) {
+      // authenticatorAssuranceLevel here is account-level: it tells the RP
+      // what AAL this account *requires* (based on mandatory second factors
+      // like TOTP), so the RP can decide whether to prompt for step-up.
+      // It is NOT the AAL of the current session. Passkeys are excluded from
+      // this computation — a passkey-only account reports AAL1 even though
+      // AAL2 is achievable. See FXA-13432.
       const amrValues = await authMethods.availableAuthenticationMethods(
         this.db,
         account

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.spec.ts
@@ -8,9 +8,6 @@ import jwt from 'jsonwebtoken';
 import { v4 as uuidv4 } from 'uuid';
 import { strategy } from './mfa';
 
-// Use CJS require so the returned object is mutable (ES import makes exports read-only)
-const authMethods = require('../../authMethods');
-
 function makeJwt(account: any, sessionToken: any, config: any) {
   const now = Math.floor(Date.now() / 1000);
   const claims = {
@@ -41,16 +38,8 @@ describe('lib/routes/auth-schemes/mfa', () => {
     jwtToken: string,
     getCredentialsFunc: any;
 
-  beforeAll(() => {
-    sinon.stub(authMethods, 'availableAuthenticationMethods');
-  });
-
   beforeEach(() => {
     sinon.reset();
-
-    authMethods.availableAuthenticationMethods = sinon.fake.resolves(
-      new Set(['pwd', 'email'])
-    );
 
     sessionToken = {
       uid: 'account-123',
@@ -103,7 +92,7 @@ describe('lib/routes/auth-schemes/mfa', () => {
     getCredentialsFunc = sinon.fake.resolves(sessionToken);
   });
 
-  afterAll(() => {
+  afterEach(() => {
     sinon.restore();
   });
 
@@ -259,9 +248,7 @@ describe('lib/routes/auth-schemes/mfa', () => {
   });
 
   it('fails when AAL mismatch', async () => {
-    authMethods.availableAuthenticationMethods = sinon.fake.resolves(
-      new Set(['pwd', 'email', 'otp'])
-    );
+    db.totpToken = sinon.fake.resolves({ verified: true, enabled: true });
     sessionToken.authenticatorAssuranceLevel = 1;
 
     const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
@@ -281,10 +268,24 @@ describe('lib/routes/auth-schemes/mfa', () => {
     }
   });
 
-  it('succeeds when account AAL is lower than session AAL', async () => {
-    authMethods.availableAuthenticationMethods = sinon.fake.resolves(
-      new Set(['pwd', 'email'])
-    );
+  it('succeeds when account does not require AAL2 (no TOTP) and session is AAL1', async () => {
+    db.totpToken = sinon.fake.resolves({ verified: false, enabled: false });
+    sessionToken.authenticatorAssuranceLevel = 1;
+
+    const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
+    await authStrategy.authenticate(request, h);
+
+    expect(
+      h.authenticated.calledOnceWithExactly({
+        credentials: sinon.match.same(sessionToken),
+      })
+    ).toBe(true);
+
+    expect(sessionToken.scope[0]).toBe('mfa:test');
+  });
+
+  it('succeeds when account requires AAL2 (TOTP enabled) and session is AAL2', async () => {
+    db.totpToken = sinon.fake.resolves({ verified: true, enabled: true });
     sessionToken.authenticatorAssuranceLevel = 2;
 
     const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
@@ -299,10 +300,8 @@ describe('lib/routes/auth-schemes/mfa', () => {
     expect(sessionToken.scope[0]).toBe('mfa:test');
   });
 
-  it('succeeds when account AAL is equal t session AAL', async () => {
-    authMethods.availableAuthenticationMethods = sinon.fake.resolves(
-      new Set(['pwd', 'email', 'otp'])
-    );
+  it('succeeds when session is AAL2 via passkey and account has no TOTP', async () => {
+    db.totpToken = sinon.fake.rejects(AppError.totpTokenNotFound());
     sessionToken.authenticatorAssuranceLevel = 2;
 
     const authStrategy = strategy(config, getCredentialsFunc, db, statsd)();
@@ -318,9 +317,7 @@ describe('lib/routes/auth-schemes/mfa', () => {
   });
 
   it('skips AAL check when configured', async () => {
-    authMethods.availableAuthenticationMethods = sinon.fake.resolves(
-      new Set(['pwd', 'email', 'otp'])
-    );
+    db.totpToken = sinon.fake.resolves({ verified: true, enabled: true });
     sessionToken.authenticatorAssuranceLevel = 1;
 
     config.authStrategies.verifiedSessionToken.skipAalCheckForRoutes = '/foo.*';

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/mfa.ts
@@ -178,15 +178,14 @@ export const strategy = (
         }
       }
 
-      // 3) account AAL and session AAL match
-      const accountAmr = await authMethods.availableAuthenticationMethods(
+      // 3) session AAL satisfies account requirements
+      const accountRequiresAal2 = await authMethods.accountRequiresAAL2(
         db,
         account
       );
-      const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
       const sessionAal = sessionToken.authenticatorAssuranceLevel;
 
-      if (sessionAal < accountAal) {
+      if (accountRequiresAal2 && sessionAal < 2) {
         if (skipAalCheckForRoutes?.test(req.route.path)) {
           statsd?.increment('verified_session_token.aal.skipped', [
             `path:${req.route.path}`,

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
@@ -12,7 +12,7 @@ const { parseAuthorizationHeader } = require('./hawk-fxa-token');
  * Authentication strategy that validates a Hawk session token and ensures:
  * 1) account email is verified
  * 2) session token is verified (no tokenVerificationId)
- * 3) account AAL and session AAL match
+ * 3) session AAL satisfies account requirements
  *
  * @param {Function} getCredentialsFunc - function to fetch a session token by id
  * @param {Object} db - database interface to fetch account and factors
@@ -99,15 +99,14 @@ function strategy(getCredentialsFunc, db, config, statsd) {
           }
         }
 
-        // 3) account AAL and session AAL match
-        const accountAmr = await authMethods.availableAuthenticationMethods(
+        // 3) session AAL satisfies account requirements
+        const accountRequiresAal2 = await authMethods.accountRequiresAAL2(
           db,
           account
         );
-        const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
         const sessionAal = token.authenticatorAssuranceLevel;
 
-        if (sessionAal < accountAal) {
+        if (accountRequiresAal2 && sessionAal < 2) {
           if (skipAalCheckForRoutes?.test(req.route.path)) {
             statsd?.increment('verified_session_token.aal.skipped', [
               `path:${req.route.path}`,

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.spec.ts
@@ -209,10 +209,25 @@ describe('lib/routes/auth-schemes/verified-session-token', () => {
     }
   });
 
-  it('passes when session AAL is greater than required AAL', async () => {
+  it('passes when account does not require AAL2 (no TOTP) and session is AAL1', async () => {
     db.totpToken = sinon.fake.resolves({
       verified: false,
       enabled: false,
+    });
+
+    const authStrategy = strategy(getCredentialsFunc, db, config, statsd)();
+    await authStrategy.authenticate(request, h);
+    expect(
+      h.authenticated.calledOnceWithExactly({
+        credentials: token,
+      })
+    ).toBe(true);
+  });
+
+  it('passes when account requires AAL2 (TOTP enabled) and session is AAL2', async () => {
+    db.totpToken = sinon.fake.resolves({
+      verified: true,
+      enabled: true,
     });
 
     token.authenticatorAssuranceLevel = 2;

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -7,7 +7,7 @@ import { PasskeyService } from '@fxa/accounts/passkey';
 import { AppError } from '@fxa/accounts/errors';
 import { recordSecurityEvent } from './utils/security-event';
 import { isPasskeyRegistrationEnabled } from '../passkey-utils';
-import { passkeyRoutes } from './passkeys';
+import { passkeyRoutes, PasskeyHandler } from './passkeys';
 import { FxaMailer } from '../senders/fxa-mailer';
 
 jest.mock('./utils/security-event', () => ({
@@ -106,8 +106,16 @@ describe('passkeys routes', () => {
     db = {
       account: jest.fn().mockResolvedValue({
         email: TEST_EMAIL,
+        emailCode: 'emailcode123',
+        emailVerified: true,
         verifierSetAt: 1234567890,
       }),
+      createSessionToken: jest
+        .fn()
+        .mockResolvedValue({ id: 'new-session-token-id' }),
+      verifyTokensWithMethod: jest.fn().mockResolvedValue(undefined),
+      deleteSessionToken: jest.fn().mockResolvedValue(undefined),
+      securityEvent: jest.fn().mockResolvedValue(undefined),
     };
 
     mockPasskeyService = {
@@ -786,6 +794,112 @@ describe('passkeys routes', () => {
         UID,
         TEST_EMAIL,
         'passkeysRename'
+      );
+    });
+  });
+
+  describe('PasskeyHandler.createPasskeySessionToken', () => {
+    const mockAccount = {
+      uid: UID,
+      email: TEST_EMAIL,
+      emailCode: 'emailcode123',
+      emailVerified: true,
+      verifierSetAt: 1234567890,
+    };
+
+    const mockRequest = {
+      app: {
+        ua: {
+          browser: 'Firefox',
+          browserVersion: '124.0',
+          os: 'macOS',
+          osVersion: '14.0',
+          deviceType: null,
+          formFactor: null,
+        },
+      },
+    };
+
+    let handler: PasskeyHandler;
+
+    beforeEach(() => {
+      handler = new PasskeyHandler(
+        mockPasskeyService,
+        db,
+        customs,
+        log,
+        mockFxaMailer,
+        statsd
+      );
+    });
+
+    it('creates a pre-verified session token with correct options', async () => {
+      await handler.createPasskeySessionToken(mockAccount, mockRequest as any);
+
+      expect(db.createSessionToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uid: UID,
+          email: TEST_EMAIL,
+          emailCode: 'emailcode123',
+          emailVerified: true,
+          verifierSetAt: 1234567890,
+          mustVerify: false,
+          tokenVerificationId: null,
+          uaBrowser: 'Firefox',
+          uaBrowserVersion: '124.0',
+          uaOS: 'macOS',
+          uaOSVersion: '14.0',
+        })
+      );
+    });
+
+    // TODO(FXA-13444): once the atomic stored procedure lands, this test
+    // should be updated to assert the single new DB call instead.
+    it('stamps the token with the passkey verification method', async () => {
+      await handler.createPasskeySessionToken(mockAccount, mockRequest as any);
+
+      expect(db.verifyTokensWithMethod).toHaveBeenCalledWith(
+        'new-session-token-id',
+        'passkey'
+      );
+    });
+
+    it('returns the created session token and emits success metric', async () => {
+      const result = await handler.createPasskeySessionToken(
+        mockAccount,
+        mockRequest as any
+      );
+
+      expect(result).toEqual({ id: 'new-session-token-id' });
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'passkeys.createSessionToken.success'
+      );
+    });
+
+    it('propagates errors from createSessionToken', async () => {
+      const dbError = new Error('DB unavailable');
+      db.createSessionToken.mockRejectedValue(dbError);
+
+      await expect(
+        handler.createPasskeySessionToken(mockAccount, mockRequest as any)
+      ).rejects.toThrow('DB unavailable');
+    });
+
+    // TODO(FXA-13444): remove this test once the atomic stored procedure lands.
+    it('deletes the token, emits failure metric, and rethrows if verifyTokensWithMethod fails', async () => {
+      const dbError = new Error('DB unavailable');
+      db.verifyTokensWithMethod.mockRejectedValue(dbError);
+
+      await expect(
+        handler.createPasskeySessionToken(mockAccount, mockRequest as any)
+      ).rejects.toThrow('DB unavailable');
+
+      expect(db.deleteSessionToken).toHaveBeenCalledWith({
+        id: 'new-session-token-id',
+        uid: UID,
+      });
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'passkeys.createSessionToken.failure'
       );
     });
   });

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -36,7 +36,35 @@ interface Customs {
 /** Subset of the database used by passkey routes. */
 interface DB {
   /** Fetches the account record for the given UID. */
-  account(uid: string): Promise<{ email: string; verifierSetAt: number }>;
+  account(uid: string): Promise<{
+    email: string;
+    emailCode: string;
+    emailVerified: boolean;
+    verifierSetAt: number;
+  }>;
+  /** Creates a new session token and persists it. */
+  createSessionToken(options: {
+    uid: string;
+    email: string;
+    emailCode: string;
+    emailVerified: boolean;
+    verifierSetAt: number;
+    mustVerify: boolean;
+    tokenVerificationId: string | null;
+    uaBrowser?: string;
+    uaBrowserVersion?: string;
+    uaOS?: string;
+    uaOSVersion?: string;
+    uaDeviceType?: string;
+    uaFormFactor?: string;
+  }): Promise<{ id: string }>;
+  /** Sets the verification method on a session token. */
+  verifyTokensWithMethod(
+    tokenId: string,
+    method: string | number
+  ): Promise<void>;
+  /** Deletes a session token. Used for cleanup on partial failure. */
+  deleteSessionToken(token: { id: string; uid: string }): Promise<void>;
   /** Records a security event in the audit log. */
   securityEvent: (arg: any) => Promise<void>;
 }
@@ -51,13 +79,14 @@ interface DB {
  * - Delegating business logic to {@link PasskeyService}
  * - Recording security audit events
  */
-class PasskeyHandler {
+export class PasskeyHandler {
   constructor(
     private readonly service: PasskeyService,
     private readonly db: DB,
     private readonly customs: Customs,
     private readonly log: any,
-    private readonly fxaMailer: FxaMailer
+    private readonly fxaMailer: FxaMailer,
+    private readonly statsd: any
     // TODO: FXA-12914 - Require glean be passed in.
   ) {}
 
@@ -337,6 +366,70 @@ class PasskeyHandler {
       prfEnabled: passkey.prfEnabled,
     };
   }
+
+  /**
+   * Creates a passkey-verified session token for the authenticated account.
+   *
+   * No `tokenVerificationId` is set — the passkey assertion is itself AAL2, so
+   * no follow-up email challenge is needed. After creation,
+   * `verifyTokensWithMethod` stamps `verificationMethod = 5` (passkey) on the
+   * row; the token's AMR becomes `{pwd, webauthn}` → AAL2.
+   *
+   * TODO(FXA-13444): this is a temporary two-step implementation. The create
+   * and stamp will be replaced by a single atomic stored procedure.
+   */
+  async createPasskeySessionToken(
+    account: {
+      uid: string;
+      email: string;
+      emailCode: string;
+      emailVerified: boolean;
+      verifierSetAt: number;
+    },
+    request: AuthRequest
+  ) {
+    const sessionToken = await this.db.createSessionToken({
+      uid: account.uid,
+      email: account.email,
+      emailCode: account.emailCode,
+      emailVerified: account.emailVerified,
+      verifierSetAt: account.verifierSetAt,
+      mustVerify: false,
+      tokenVerificationId: null,
+      uaBrowser: request.app.ua.browser,
+      uaBrowserVersion: request.app.ua.browserVersion,
+      uaOS: request.app.ua.os,
+      uaOSVersion: request.app.ua.osVersion,
+      uaDeviceType: request.app.ua.deviceType,
+      uaFormFactor: request.app.ua.formFactor,
+    });
+
+    try {
+      await this.db.verifyTokensWithMethod(sessionToken.id, 'passkey');
+    } catch (err) {
+      // If stamping the verification method fails, delete the token rather than
+      // leaving an orphan session at AAL1. If cleanup also fails, log and report
+      // it but always re-throw the original error.
+      // TODO(FXA-13444): remove this entire catch block once the atomic procedure lands.
+      try {
+        await this.db.deleteSessionToken({
+          id: sessionToken.id,
+          uid: account.uid,
+        });
+      } catch (cleanupErr) {
+        this.log.error('passkeys.createPasskeySessionToken.deleteOrphan', {
+          err: cleanupErr,
+          tokenId: sessionToken.id,
+        });
+        reportSentryError(cleanupErr, request);
+      }
+      this.statsd.increment('passkeys.createSessionToken.failure');
+      throw err;
+    }
+
+    this.statsd.increment('passkeys.createSessionToken.success');
+    return sessionToken;
+  }
 }
 
 /**
@@ -376,7 +469,14 @@ export const passkeyRoutes = (
     );
   }
   const fxaMailer = Container.get(FxaMailer);
-  const handler = new PasskeyHandler(service, db, customs, log, fxaMailer);
+  const handler = new PasskeyHandler(
+    service,
+    db,
+    customs,
+    log,
+    fxaMailer,
+    statsd
+  );
 
   return [
     {

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -200,13 +200,9 @@ module.exports = function (
             getClientServiceTags(request)
           );
         }
-        const accountAmr = await authMethods.availableAuthenticationMethods(
-          db,
-          account
-        );
-        const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
+        const requiresAal2 = await authMethods.accountRequiresAAL2(db, account);
         const sessionAal = sessionToken.authenticatorAssuranceLevel;
-        if (sessionAal < accountAal) {
+        if (requiresAal2 && sessionAal < 2) {
           statsd.increment(
             'session_reauth.all_not_met',
             getClientServiceTags(request)
@@ -339,11 +335,7 @@ module.exports = function (
         }
 
         // Check account assurance level
-        const accountAmr = await authMethods.availableAuthenticationMethods(
-          db,
-          account
-        );
-        const accountAal = authMethods.maximumAssuranceLevel(accountAmr);
+        const requiresAal2 = await authMethods.accountRequiresAAL2(db, account);
         const sessionAal = sessionToken.authenticatorAssuranceLevel;
 
         // Build response
@@ -356,7 +348,8 @@ module.exports = function (
         const sessionVerified = sessionToken.tokenVerified;
 
         // Account Assurance Level
-        const sessionVerificationMeetsMinimumAAL = sessionAal >= accountAal;
+        const sessionVerificationMeetsMinimumAAL =
+          !requiresAal2 || sessionAal >= 2;
 
         // Legacy verified flag. Keep for backwards compatibility.
         const verified = accountEmailVerified && sessionVerified;

--- a/packages/fxa-auth-server/lib/routes/session.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/session.spec.ts
@@ -196,6 +196,7 @@ describe('/session/status', () => {
         verified: false,
         tokenVerified: false,
         tokenVerificationId: 'token-123',
+        authenticatorAssuranceLevel: 1,
         uid: 'foo',
       },
     });
@@ -205,7 +206,7 @@ describe('/session/status', () => {
         state: 'unverified',
         details: {
           accountEmailVerified: false,
-          sessionVerificationMeetsMinimumAAL: false,
+          sessionVerificationMeetsMinimumAAL: true,
           sessionVerificationMethod: 'totp-2fa',
           sessionVerified: false,
           verified: false,
@@ -323,7 +324,7 @@ describe('/session/status', () => {
     });
   });
 
-  it('has unverified AAL 2', async () => {
+  it('session is AAL1 but account requires AAL2 (TOTP enabled)', async () => {
     db.account = jest.fn().mockResolvedValue({
       uid: 'account-123',
       primaryEmail: {
@@ -340,7 +341,7 @@ describe('/session/status', () => {
         uid: 'account-123',
         state: 'verified',
         tokenVerified: true,
-        verificationMethodValue: 'totp-2fa',
+        verificationMethodValue: 'email',
         authenticatorAssuranceLevel: 1,
       },
     });
@@ -351,7 +352,7 @@ describe('/session/status', () => {
       state: 'verified',
       details: {
         accountEmailVerified: true,
-        sessionVerificationMethod: 'totp-2fa',
+        sessionVerificationMethod: 'email',
         sessionVerified: true,
         verified: true,
         sessionVerificationMeetsMinimumAAL: false,
@@ -462,17 +463,8 @@ describe('/session/reauth', () => {
     mailer = mocks.mockMailer();
     mocks.mockFxaMailer();
     mocks.mockOAuthClientInfo();
-    signinUtils = require('./utils/signin')(
-      log,
-      config,
-      customs,
-      db,
-      mailer
-    );
-    SessionToken = require('../tokens/index')(
-      log,
-      config
-    ).SessionToken;
+    signinUtils = require('./utils/signin')(log, config, customs, db, mailer);
+    SessionToken = require('../tokens/index')(log, config).SessionToken;
     routes = makeRoutes({ log, config, customs, db, mailer, signinUtils });
     route = getRoute(routes, '/session/reauth');
     request = mocks.mockRequest({
@@ -869,15 +861,11 @@ describe('/session/duplicate', () => {
     route = getRoute(routes, '/session/duplicate');
 
     const Token = require(`../tokens/token`)(log);
-    const SessionToken = require(`../tokens/session_token`)(
-      log,
-      Token,
-      {
-        tokenLifetimes: {
-          sessionTokenWithoutDevice: 2419200000,
-        },
-      }
-    );
+    const SessionToken = require(`../tokens/session_token`)(log, Token, {
+      tokenLifetimes: {
+        sessionTokenWithoutDevice: 2419200000,
+      },
+    });
 
     const sessionToken = await SessionToken.create({
       uid: 'foo',
@@ -1323,7 +1311,13 @@ describe('/session/verify/send_push', () => {
 });
 
 describe('/session/verify/verify_push', () => {
-  let route: any, request: any, log: any, db: any, mailer: any, push: any, customs: any;
+  let route: any,
+    request: any,
+    log: any,
+    db: any,
+    mailer: any,
+    push: any,
+    customs: any;
 
   beforeEach(() => {
     db = mocks.mockDB({ ...signupCodeAccount, devices: MOCK_DEVICES });

--- a/packages/fxa-auth-server/lib/tokens/session_token.js
+++ b/packages/fxa-auth-server/lib/tokens/session_token.js
@@ -19,6 +19,7 @@ module.exports = (log, Token, config) => {
     [2, 'totp-2fa'],
     [3, 'recovery-code'],
     [4, 'sms-2fa'],
+    [5, 'passkey'],
   ]);
 
   class SessionToken extends Token {
@@ -100,7 +101,16 @@ module.exports = (log, Token, config) => {
 
     get authenticationMethods() {
       const amrValues = new Set();
-      // All sessionTokens require password authentication.
+      // 'pwd' is added to every session regardless of how the user authenticated.
+      // This pre-dates passwordless flows (linked accounts, email OTP, passkeys)
+      // and is factually wrong for all of them. For linked accounts and email OTP
+      // the error is inconsequential — {pwd, email} → {know, know} → AAL1 whether
+      // or not pwd is present. For passkey sessions the 'pwd' entry incidentally
+      // produces the correct AAL2 result, but only because AMR_TO_TYPE maps
+      // 'webauthn' to 'have' alone. A passkey with user verification is
+      // intrinsically multi-factor ('have' + 'know'/'are') and should yield AAL2
+      // without needing 'pwd'. Fixing both the mapping and this invariant is
+      // deferred (FXA-13432).
       amrValues.add('pwd');
       // Verified sessionTokens imply some additional authentication method(s).
       if (this.verificationMethodValue) {
@@ -113,6 +123,12 @@ module.exports = (log, Token, config) => {
       return amrValues;
     }
 
+    // The AAL of this specific session, derived from the methods used to
+    // establish it. This is distinct from the account-level AAL reported
+    // to RPs via profile:amr — that reflects mandatory second factors
+    // configured on the account; this reflects what actually happened
+    // during authentication. The fxa-aal JWT claim in OAuth assertions
+    // and the acr_values enforcement in grant.js both use this value.
     get authenticatorAssuranceLevel() {
       return authMethods.maximumAssuranceLevel(this.authenticationMethods);
     }

--- a/packages/fxa-auth-server/lib/tokens/session_token.spec.ts
+++ b/packages/fxa-auth-server/lib/tokens/session_token.spec.ts
@@ -75,9 +75,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
     expect(typeof token.lastAuthAt).toBe('function');
     expect(typeof token.setUserAgentInfo).toBe('function');
     expect(typeof token.copyTokenState).toBe('function');
-    expect(
-      Object.getOwnPropertyDescriptor(token, 'state')
-    ).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(token, 'state')).toBeUndefined();
     const descriptor = Object.getOwnPropertyDescriptor(
       Object.getPrototypeOf(token),
       'state'
@@ -89,7 +87,10 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
 
   it('re-creation from tokenData works', async () => {
     const token: SessionTokenLike = await SessionToken.create(TOKEN);
-    const token2: SessionTokenLike = await SessionToken.fromHex(token.data, token);
+    const token2: SessionTokenLike = await SessionToken.fromHex(
+      token.data,
+      token
+    );
     expect(token.data).toEqual(token2.data);
     expect(token.id).toEqual(token2.id);
     expect(token.authKey).toEqual(token2.authKey);
@@ -108,9 +109,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
     expect(token.verificationMethod).toBe(token2.verificationMethod);
     expect(token.verificationMethodValue).toBe('totp-2fa');
     expect(token.verifiedAt).toBe(token2.verifiedAt);
-    expect(token.authenticationMethods).toEqual(
-      token2.authenticationMethods
-    );
+    expect(token.authenticationMethods).toEqual(token2.authenticationMethods);
     expect(token.authenticatorAssuranceLevel).toEqual(
       token2.authenticatorAssuranceLevel
     );
@@ -170,7 +169,10 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
   it('sessionToken key derivations are test-vector compliant', async () => {
     const tokenData =
       'a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf';
-    const token: SessionTokenLike = await SessionToken.fromHex(tokenData, TOKEN);
+    const token: SessionTokenLike = await SessionToken.fromHex(
+      tokenData,
+      TOKEN
+    );
     expect(token.data.toString('hex')).toBe(tokenData);
     expect(token.id).toBe(
       'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab'
@@ -260,9 +262,7 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
         verificationMethod: null,
         verifiedAt: null,
       });
-      expect(Array.from(token.authenticationMethods).sort()).toEqual([
-        'pwd',
-      ]);
+      expect(Array.from(token.authenticationMethods).sort()).toEqual(['pwd']);
     });
 
     it('should be [`pwd`, `email`] for verified tokens', async () => {
@@ -299,6 +299,20 @@ describe('SessionToken, tokenLifetimes.sessionTokenWithoutDevice > 0', () => {
         'otp',
         'pwd',
       ]);
+    });
+
+    it('should be [`pwd`, `webauthn`] for tokens verified via passkey', async () => {
+      const token: SessionTokenLike = await SessionToken.create({
+        ...TOKEN,
+        tokenVerificationId: null,
+        verificationMethod: 5,
+      });
+      expect(Array.from(token.authenticationMethods).sort()).toEqual([
+        'pwd',
+        'webauthn',
+      ]);
+      // {pwd → know, webauthn → have} → two distinct types → AAL2
+      expect(token.authenticatorAssuranceLevel).toBe(2);
     });
   });
 });

--- a/packages/fxa-content-server/app/scripts/lib/verification-methods.ts
+++ b/packages/fxa-content-server/app/scripts/lib/verification-methods.ts
@@ -14,6 +14,7 @@ enum VerificationMethods {
   EMAIL_CAPTCHA = 'email-captcha',
   EMAIL_OTP = 'email-otp',
   TOTP_2FA = 'totp-2fa',
+  PASSKEY = 'passkey',
 }
 
 export default VerificationMethods;

--- a/packages/fxa-settings/src/constants/authentication-methods.ts
+++ b/packages/fxa-settings/src/constants/authentication-methods.ts
@@ -8,6 +8,7 @@ enum AuthenticationMethods {
   EMAIL = 'email',
   // TOTP / 2FA token
   OTP = 'otp',
+  WEBAUTHN = 'webauthn',
 }
 
 export default AuthenticationMethods;

--- a/packages/fxa-settings/src/constants/verification-methods.ts
+++ b/packages/fxa-settings/src/constants/verification-methods.ts
@@ -10,6 +10,7 @@ enum VerificationMethods {
   EMAIL_CAPTCHA = 'email-captcha',
   EMAIL_OTP = 'email-otp',
   TOTP_2FA = 'totp-2fa',
+  PASSKEY = 'passkey',
 }
 
 export default VerificationMethods;

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -22,6 +22,7 @@ const VERIFICATION_METHOD = {
   'totp-2fa': 2,
   'recovery-code': 3,
   'sms-2fa': 4,
+  passkey: 5,
 } as const;
 
 export type VerificationMethod = keyof typeof VERIFICATION_METHOD;


### PR DESCRIPTION
## Because

* Passkey authentication needs a verified session token with verificationMethod = 5 and AAL2. Adding passkey also required fixing AAL enforcement, which could have blocked password sign-in for passkey-holding accounts (passkeys are optional; only TOTP mandates 2FA).

## This pull request

* Registers passkey as verification method across auth-server, fxa-shared, and account repository
* Maps passkey -> webauth AMR in authMethods
* Adds maximumAssuranceLevelRequired() and replaces the old AAL enforcement pattern in the session auth strategies
* Adds createPasskeySessionToken utility to PasskeyHandler (needed for FXA-13095)
* Adds PASSKEY/WEBAUTHN enum values to fxa-settings and fxa-content-server
* Extends unit tests across affected files

## Issue that this pull request solves

Closes: FXA-13097

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts: This work uncovered some issues with current AMR handling. I recommend reading the notes in `FXA-13432` for additional context.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
