### PR TITLE
fix(payments-next): Add error handling to Free trial fetching

### DIFF
--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -2769,5 +2769,22 @@ describe('CheckoutService', () => {
 
       expect(result).toEqual(mockFreeTrial);
     });
+
+    it('returns null when an error is thrown', async () => {
+      const mockError = new Error('CMS fetch failed');
+      jest
+        .spyOn(nimbusManager, 'generateNimbusId')
+        .mockReturnValue('nimbus-id');
+      jest
+        .spyOn(nimbusManager, 'fetchExperiments')
+        .mockResolvedValue(mockNimbusResult);
+      jest
+        .spyOn(productConfigurationManager, 'getFreeTrial')
+        .mockRejectedValue(mockError);
+
+      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+
+      expect(result).toBeNull();
+    });
   });
 });

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -2802,5 +2802,21 @@ describe('CheckoutService', () => {
 
       expect(result).toEqual(mockFreeTrial);
     });
+
+    it('returns null when fetching free trial data throws', async () => {
+      jest
+        .spyOn(nimbusManager, 'generateNimbusId')
+        .mockReturnValue('nimbus-id');
+      jest
+        .spyOn(nimbusManager, 'fetchExperiments')
+        .mockResolvedValue(mockNimbusResult);
+      jest
+        .spyOn(productConfigurationManager, 'getFreeTrial')
+        .mockRejectedValue(new Error('CMS fetch failed'));
+
+      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+
+      expect(result).toBeNull();
+    });
   });
 });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -991,14 +991,30 @@ export class CheckoutService {
       return null;
     }
 
-    const [nimbusResult, freeTrialUtil] = await Promise.all([
+    const fetchResult = await Promise.all([
       this.nimbusManager.fetchExperiments({
         nimbusUserId: this.nimbusManager.generateNimbusId(uid),
         preview: false,
       }),
       this.productConfigurationManager.getFreeTrial(offeringConfigId),
-    ]);
+    ]).catch((error) => {
+      Sentry.captureException(error, {
+        extra: {
+          uid: uid,
+          offeringConfigId: offeringConfigId,
+          countryCode: countryCode,
+          interval: interval,
+          eligibilityStatus: eligibilityStatus,
+        },
+      });
+      return null;
+    });
 
+    if (!fetchResult) {
+      return null;
+    }
+
+    const [nimbusResult, freeTrialUtil] = fetchResult;
     if (
       !nimbusResult?.Features?.['free-trial-feature']?.enabled
     ) {

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -982,46 +982,59 @@ export class CheckoutService {
       return null;
     }
 
-    const [nimbusResult, freeTrialUtil] = await Promise.all([
-      this.nimbusManager.fetchExperiments({
-        nimbusUserId: this.nimbusManager.generateNimbusId(uid),
-        preview: false,
-      }),
-      this.productConfigurationManager.getFreeTrial(offeringConfigId),
-    ]);
+    try {
+      const [nimbusResult, freeTrialUtil] = await Promise.all([
+        this.nimbusManager.fetchExperiments({
+          nimbusUserId: this.nimbusManager.generateNimbusId(uid),
+          preview: false,
+        }),
+        this.productConfigurationManager.getFreeTrial(offeringConfigId),
+      ]);
 
-    if (
-      !nimbusResult?.Features?.['free-trial-feature']?.enabled
-    ) {
+      if (
+        !nimbusResult?.Features?.['free-trial-feature']?.enabled
+      ) {
+        return null;
+      }
+
+      const freeTrials = freeTrialUtil.getResult();
+      if (!freeTrials) {
+        return null;
+      }
+
+      const matchingTrial = freeTrials.find(
+        (trial) =>
+          trial.trialLengthDays > 0 &&
+          trial.countries.some((country) => country.slice(0, 2) === countryCode) &&
+          trial.intervals.includes(interval)
+      );
+
+      if (!matchingTrial) {
+        return null;
+      }
+
+      const isBlockedByCooldown = await this.freeTrialManager.isBlockedByCooldown(
+          uid,
+          matchingTrial.internalName,
+          matchingTrial.cooldownPeriodMonths
+        );
+
+      if (isBlockedByCooldown) {
+        return null;
+      }
+
+      return matchingTrial;
+    } catch (error) {
+      Sentry.captureException(error, {
+        extra: {
+          uid: uid,
+          offeringConfigId: offeringConfigId,
+          countryCode: countryCode,
+          interval: interval,
+          eligibilityStatus: eligibilityStatus,
+        },
+      });
       return null;
     }
-
-    const freeTrials = freeTrialUtil.getResult();
-    if (!freeTrials) {
-      return null;
-    }
-
-    const matchingTrial = freeTrials.find(
-      (trial) =>
-        trial.trialLengthDays > 0 &&
-        trial.countries.some((country) => country.slice(0, 2) === countryCode) &&
-        trial.intervals.includes(interval)
-    );
-
-    if (!matchingTrial) {
-      return null;
-    }
-
-    const isBlockedByCooldown = await this.freeTrialManager.isBlockedByCooldown(
-      uid,
-      matchingTrial.internalName,
-      matchingTrial.cooldownPeriodMonths
-    );
-
-    if (isBlockedByCooldown) {
-      return null;
-    }
-
-    return matchingTrial;
   }
 }


### PR DESCRIPTION
## Because

* Right now, if an error is thrown when fetching free trial info, the checkout page crashes.

## This pull request

* Wraps the fetch of free trial data in a try catch

## Issue that this pull request solves

Closes #[PAY-3634](https://mozilla-hub.atlassian.net/browse/PAY-3634)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3634]: https://mozilla-hub.atlassian.net/browse/PAY-3634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ