### PR TITLE
feat(passwordless): switch OTP from 8 digits to 6 and harden rate limits

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
+++ b/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
@@ -6701,8 +6701,8 @@ exports[`FxA Email Renderer should render renderPasswordlessSigninOtp strapi: ma
               <tr>
                 <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-code">
-        Use this confirmation code:
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-code-v2">
+        Your verification code is
       </span></div>
     
                 </td>
@@ -7110,8 +7110,8 @@ exports[`FxA Email Renderer should render renderPasswordlessSigninOtp: matches f
               <tr>
                 <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-code">
-        Use this confirmation code:
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signin-otp-code-v2">
+        Your verification code is
       </span></div>
     
                 </td>
@@ -7515,8 +7515,8 @@ exports[`FxA Email Renderer should render renderPasswordlessSignupOtp strapi: ma
               <tr>
                 <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-code">
-        Use this confirmation code:
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-code-v2">
+        Your verification code is
       </span></div>
     
                 </td>
@@ -7924,8 +7924,8 @@ exports[`FxA Email Renderer should render renderPasswordlessSignupOtp: matches f
               <tr>
                 <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                   
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-code">
-        Use this confirmation code:
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="passwordless-signup-otp-code-v2">
+        Your verification code is
       </span></div>
     
                 </td>

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/en.ftl
@@ -5,5 +5,5 @@ passwordless-signin-otp-subject = Use { $code } to finish sign in
 passwordless-signin-otp-preview = Code expires in { $codeExpiryMinutes } minutes
 passwordless-signin-otp-title = Finish your sign in 
 passwordless-signin-otp-request = This email was used to sign in from:
-passwordless-signin-otp-code = Use this confirmation code:
+passwordless-signin-otp-code-v2 = Your verification code is
 passwordless-signin-otp-expiry-notice = It expires in { $codeExpiryMinutes } minutes.

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.mjml
@@ -22,8 +22,8 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
   <mj-column>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="passwordless-signin-otp-code">
-        Use this confirmation code:
+      <span data-l10n-id="passwordless-signin-otp-code-v2">
+        Your verification code is
       </span>
     </mj-text>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.stories.ts
@@ -13,7 +13,7 @@ export default {
 
 const data: TemplateData = {
   ...MOCK_USER_INFO,
-  code: '96318398',
+  code: '963183',
   codeExpiryMinutes: 10,
   supportUrl: 'https://support.mozilla.org',
   target: 'index',

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.txt
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.txt
@@ -4,7 +4,7 @@ passwordless-signin-otp-request = "This email was used to sign in from:"
 
 <%- include('/partials/userInfo/index.txt') %>
 
-passwordless-signin-otp-code = "Use this confirmation code:"
+passwordless-signin-otp-code-v2 = "Your verification code is"
 
 <%- code %>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/strapi.mjml
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/strapi.mjml
@@ -20,8 +20,8 @@
   <mj-column>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="passwordless-signin-otp-code">
-        Use this confirmation code:
+      <span data-l10n-id="passwordless-signin-otp-code-v2">
+        Your verification code is
       </span>
     </mj-text>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/strapi.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/strapi.stories.ts
@@ -13,7 +13,7 @@ export default {
 
 const data: TemplateData = {
   ...MOCK_USER_INFO,
-  code: '12345678',
+  code: '123456',
   codeExpiryMinutes: 10,
   supportUrl: 'https://support.mozilla.org',
   time: '11:45 AM',

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/strapi.txt
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/strapi.txt
@@ -4,7 +4,7 @@
 
 <%- include('/partials/userInfo/index.txt') %>
 
-passwordless-signin-otp-code = "Use this confirmation code:"
+passwordless-signin-otp-code-v2 = "Your verification code is"
 
 <%- code %>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/en.ftl
@@ -5,5 +5,5 @@ passwordless-signup-otp-subject = Use { $code } to finish sign up
 passwordless-signup-otp-preview = Code expires in { $codeExpiryMinutes } minutes
 passwordless-signup-otp-title = Finish your sign up
 passwordless-signup-otp-request = An account was created using this email address from:
-passwordless-signup-otp-code = Use this confirmation code:
+passwordless-signup-otp-code-v2 = Your verification code is
 passwordless-signup-otp-expiry-notice = It expires in { $codeExpiryMinutes } minutes.

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.mjml
@@ -22,8 +22,8 @@ can obtain one at http://mozilla.org/MPL/2.0/. %>
   <mj-column>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="passwordless-signup-otp-code">
-        Use this confirmation code:
+      <span data-l10n-id="passwordless-signup-otp-code-v2">
+        Your verification code is
       </span>
     </mj-text>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.stories.ts
@@ -13,7 +13,7 @@ export default {
 
 const data: TemplateData = {
   ...MOCK_USER_INFO,
-  code: '96318398',
+  code: '963183',
   codeExpiryMinutes: 10,
   supportUrl: 'https://support.mozilla.org',
   target: 'index',

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.txt
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.txt
@@ -4,7 +4,7 @@ passwordless-signup-otp-request = "An account was created using this email addre
 
 <%- include('/partials/userInfo/index.txt') %>
 
-passwordless-signup-otp-code = "Use this confirmation code:"
+passwordless-signup-otp-code-v2 = "Your verification code is"
 
 <%- code %>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/strapi.mjml
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/strapi.mjml
@@ -20,8 +20,8 @@
   <mj-column>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="passwordless-signup-otp-code">
-        Use this confirmation code:
+      <span data-l10n-id="passwordless-signup-otp-code-v2">
+        Your verification code is
       </span>
     </mj-text>
 

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/strapi.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/strapi.stories.ts
@@ -13,7 +13,7 @@ export default {
 
 const data: TemplateData = {
   ...MOCK_USER_INFO,
-  code: '12345678',
+  code: '123456',
   codeExpiryMinutes: 10,
   supportUrl: 'https://support.mozilla.org',
   time: '11:45 AM',

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/strapi.txt
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/strapi.txt
@@ -4,7 +4,7 @@
 
 <%- include('/partials/userInfo/index.txt') %>
 
-passwordless-signup-otp-code = "Use this confirmation code:"
+passwordless-signup-otp-code-v2 = "Your verification code is"
 
 <%- code %>
 

--- a/packages/functional-tests/pages/signinPasswordlessCode.ts
+++ b/packages/functional-tests/pages/signinPasswordlessCode.ts
@@ -16,7 +16,7 @@ export class SigninPasswordlessCodePage extends BaseTokenCodePage {
 
   get codeInput() {
     this.checkPath();
-    return this.page.getByLabel('Enter 8-digit code');
+    return this.page.getByLabel('Enter 6-digit code');
   }
 
   get submitButton() {

--- a/packages/functional-tests/tests/passwordless/passwordlessApi.spec.ts
+++ b/packages/functional-tests/tests/passwordless/passwordlessApi.spec.ts
@@ -229,13 +229,15 @@ test.describe('severity-2', () => {
           target.ciHeader
         );
 
-        // Consume the real code so we can test with a bogus one
-        await target.emailClient.getPasswordlessSignupCode(email);
+        // Get the real code, then derive an invalid one by mutating a digit
+        const realCode =
+          await target.emailClient.getPasswordlessSignupCode(email);
+        const invalidCode = `${(Number(realCode[0]) + 1) % 10}${realCode.slice(1)}`;
 
         try {
           await target.authClient.passwordlessConfirmCode(
             email,
-            '00000000',
+            invalidCode,
             {
               clientId: target.relierClientID,
               service: SUPPORTED_SERVICE,

--- a/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
+++ b/packages/functional-tests/tests/passwordless/signinPasswordless.spec.ts
@@ -660,8 +660,8 @@ test.describe('severity-1 #smoke', () => {
 
         await page.waitForURL(/signin_passwordless_code/);
 
-        // Enter an invalid 8-digit code
-        await signinPasswordlessCode.fillOutCodeForm('12345678');
+        // Enter an invalid 6-digit code
+        await signinPasswordlessCode.fillOutCodeForm('123456');
 
         // Should show error message (tooltip or error text)
         await expect(

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -2201,7 +2201,7 @@ const convictConf = convict({
     },
     digits: {
       doc: 'Number of digits in passwordless OTP code',
-      default: 8,
+      default: 6,
       format: 'nat',
       env: 'OTP_PASSWORDLESS_DIGITS',
     },

--- a/packages/fxa-auth-server/config/rate-limit-rules.txt
+++ b/packages/fxa-auth-server/config/rate-limit-rules.txt
@@ -193,8 +193,8 @@ passwordlessSendOtp                    : ip               : 100         : 24 hou
 
 # Passwordless OTP Verification Limits
 passwordlessVerifyOtp                  : ip_email         : 5           : 10 minutes      : 15 minutes   : block
-passwordlessVerifyOtp                  : email            : 10          : 10 minutes      : 30 minutes   : report
+passwordlessVerifyOtp                  : email            : 10          : 10 minutes      : 30 minutes   : block
 passwordlessVerifyOtp                  : ip               : 100         : 24 hours        : 15 minutes   : ban
 passwordlessVerifyOtpPerDay            : ip_email         : 10          : 24 hours        : 24 hours     : block
-passwordlessVerifyOtpPerDay            : email            : 20          : 24 hours        : 24 hours     : report
+passwordlessVerifyOtpPerDay            : email            : 20          : 24 hours        : 24 hours     : block
 passwordlessVerifyOtpPerDay            : ip               : 100         : 24 hours        : 15 minutes   : ban

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.test.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.test.tsx
@@ -76,15 +76,21 @@ describe('FormVerifyCode component', () => {
   describe('Submit button state management', () => {
     it('should disable submit button initially', () => {
       renderWithLocalizationProvider(<Subject />);
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
       expect(submitButton).toBeDisabled();
     });
 
     it('should enable submit button when valid code is entered', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
-      const input = screen.getByRole('textbox', { name: 'Enter your 4-digit code' });
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 4-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
 
       // Initially disabled
       expect(submitButton).toBeDisabled();
@@ -99,8 +105,12 @@ describe('FormVerifyCode component', () => {
     it('should disable submit button when invalid code is entered', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
-      const input = screen.getByRole('textbox', { name: 'Enter your 4-digit code' });
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 4-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
 
       // Type invalid code (less than 4 digits)
       await user.type(input, '123');
@@ -112,8 +122,12 @@ describe('FormVerifyCode component', () => {
     it('should disable submit button when code becomes invalid', async () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
-      const input = screen.getByRole('textbox', { name: 'Enter your 4-digit code' });
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 4-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
 
       // Type valid code first
       await user.type(input, '1234');
@@ -131,6 +145,7 @@ describe('FormVerifyCode component', () => {
         inputLabelText: 'Enter your 6-digit code',
         pattern: '[0-9]{6}',
         maxLength: 6,
+
         submitButtonFtlId: 'demo-submit-button-id',
         submitButtonText: 'Check that code',
       };
@@ -138,12 +153,18 @@ describe('FormVerifyCode component', () => {
       renderWithLocalizationProvider(
         <Subject
           formAttributes={customFormAttributes}
-          verifyCode={jest.fn().mockImplementation((code: string) => Promise.resolve())}
+          verifyCode={jest
+            .fn()
+            .mockImplementation((code: string) => Promise.resolve())}
         />
       );
 
-      const input = screen.getByRole('textbox', { name: 'Enter your 6-digit code' });
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 6-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
 
       // Initially disabled
       expect(submitButton).toBeDisabled();
@@ -163,8 +184,12 @@ describe('FormVerifyCode component', () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
 
-      const input = screen.getByRole('textbox', { name: 'Enter your 4-digit code' });
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 4-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
 
       // Type character by character
       await user.type(input, '1');
@@ -184,8 +209,12 @@ describe('FormVerifyCode component', () => {
       const user = userEvent.setup();
       renderWithLocalizationProvider(<Subject />);
 
-      const input = screen.getByRole('textbox', { name: 'Enter your 4-digit code' });
-      const submitButton = screen.getByRole('button', { name: 'Check that code' });
+      const input = screen.getByRole('textbox', {
+        name: 'Enter your 4-digit code',
+      });
+      const submitButton = screen.getByRole('button', {
+        name: 'Check that code',
+      });
 
       // Type valid code
       await user.type(input, '1234');
@@ -221,6 +250,7 @@ describe('FormVerifyCode component', () => {
         inputMode: InputModeEnum.text,
         pattern: '[a-zA-Z0-9]',
         maxLength: 10,
+
         submitButtonFtlId: 'demo-submit-button-id',
         submitButtonText: 'Check that code',
       };

--- a/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
+++ b/packages/fxa-settings/src/components/FormVerifyCode/index.tsx
@@ -31,6 +31,7 @@ export type FormAttributes = {
   inputMode?: InputModeEnum;
   pattern: string;
   maxLength: number;
+  autoComplete?: 'off' | 'one-time-code';
   submitButtonText: string;
   submitButtonFtlId: string;
 };
@@ -172,7 +173,7 @@ const FormVerifyCode = ({
         maxLength={formAttributes.maxLength}
         className="text-start"
         anchorPosition="start"
-        autoComplete="off"
+        autoComplete={formAttributes.autoComplete ?? 'off'}
         spellCheck={false}
         prefixDataTestId={viewName}
         tooltipPosition="bottom"

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/en.ftl
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/en.ftl
@@ -20,7 +20,7 @@ signin-passwordless-code-instruction = { $expirationMinutes ->
     *[other] Enter the code that was sent to <email>{ $email }</email> within { $expirationMinutes } minutes.
   }
 
-signin-passwordless-code-input-label = Enter 8-digit code
+signin-passwordless-code-input-label-v2 = Enter 6-digit code
 
 signin-passwordless-code-confirm-button = Confirm
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -93,9 +93,12 @@ jest.mock('../../../lib/hooks/useNavigateWithQuery', () => ({
 let mockHandleNavigation = jest.fn().mockResolvedValue({ error: undefined });
 
 jest.mock('../utils', () => ({
-  getSyncNavigate: jest.fn((search, options) => ({ to: '/connect_another_device' })),
+  getSyncNavigate: jest.fn((search, options) => ({
+    to: '/connect_another_device',
+  })),
   handleNavigation: (...args: any[]) => mockHandleNavigation(...args),
-  ensureCanLinkAcountOrRedirect: (...args: any[]) => mockEnsureCanLinkAcountOrRedirect(...args),
+  ensureCanLinkAcountOrRedirect: (...args: any[]) =>
+    mockEnsureCanLinkAcountOrRedirect(...args),
 }));
 
 jest.mock('../../../lib/hooks/useWebRedirect', () => ({
@@ -129,7 +132,8 @@ function render(
   } = {}
 ) {
   if (!props.integration) {
-    props.integration = createMockSigninWebIntegration() as SigninOAuthIntegration;
+    props.integration =
+      createMockSigninWebIntegration() as SigninOAuthIntegration;
   }
 
   renderWithLocalizationProvider(
@@ -140,7 +144,7 @@ function render(
 }
 
 function mockReactUtilsModule() {
-  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => { });
+  jest.spyOn(ReactUtils, 'hardNavigate').mockImplementation(() => {});
 }
 
 describe('SigninPasswordlessCode page', () => {
@@ -150,25 +154,33 @@ describe('SigninPasswordlessCode page', () => {
     mockNavigate = jest.fn();
     mockNavigateWithQuery = jest.fn().mockResolvedValue(undefined);
     mockEnsureCanLinkAcountOrRedirect = jest.fn().mockResolvedValue(true);
-    mockHandleNavigation = jest.fn().mockImplementation(async (navigationOptions) => {
-      // Simulate handleNavigation behavior for unverified sessions with TOTP
-      const { signinData } = navigationOptions;
-      if (signinData.verificationMethod === 'totp-2fa' && !signinData.sessionVerified) {
-        const mockNavigateModule = jest.requireMock('@reach/router');
-        mockNavigateModule.navigate(`/signin_totp_code${navigationOptions.queryParams || ''}`, {
-          state: {
-            email: navigationOptions.email,
-            uid: signinData.uid,
-            sessionToken: signinData.sessionToken,
-            emailVerified: signinData.emailVerified,
-            sessionVerified: signinData.sessionVerified,
-            verificationMethod: signinData.verificationMethod,
-            verificationReason: signinData.verificationReason,
-          },
-        });
-      }
-      return { error: undefined };
-    });
+    mockHandleNavigation = jest
+      .fn()
+      .mockImplementation(async (navigationOptions) => {
+        // Simulate handleNavigation behavior for unverified sessions with TOTP
+        const { signinData } = navigationOptions;
+        if (
+          signinData.verificationMethod === 'totp-2fa' &&
+          !signinData.sessionVerified
+        ) {
+          const mockNavigateModule = jest.requireMock('@reach/router');
+          mockNavigateModule.navigate(
+            `/signin_totp_code${navigationOptions.queryParams || ''}`,
+            {
+              state: {
+                email: navigationOptions.email,
+                uid: signinData.uid,
+                sessionToken: signinData.sessionToken,
+                emailVerified: signinData.emailVerified,
+                sessionVerified: signinData.sessionVerified,
+                verificationMethod: signinData.verificationMethod,
+                verificationReason: signinData.verificationReason,
+              },
+            }
+          );
+        }
+        return { error: undefined };
+      });
   });
 
   afterEach(() => {
@@ -185,12 +197,16 @@ describe('SigninPasswordlessCode page', () => {
       // Check for the instruction text including "Use a different account"
       screen.getByText(
         (_, element) =>
-          !!(element?.tagName === 'P' &&
-            element?.textContent?.includes(`Enter the code that was sent to ${MOCK_EMAIL}`) &&
-            element?.textContent?.includes('Use a different account'))
+          !!(
+            element?.tagName === 'P' &&
+            element?.textContent?.includes(
+              `Enter the code that was sent to ${MOCK_EMAIL}`
+            ) &&
+            element?.textContent?.includes('Use a different account')
+          )
       );
 
-      screen.getByLabelText('Enter 8-digit code');
+      screen.getByLabelText('Enter 6-digit code');
       screen.getByRole('button', { name: 'Confirm' });
       screen.getByText('Code expired?');
     });
@@ -204,9 +220,13 @@ describe('SigninPasswordlessCode page', () => {
       // Check for signup-specific instruction text including "Use a different account"
       screen.getByText(
         (_, element) =>
-          !!(element?.tagName === 'P' &&
-            element?.textContent?.includes(`Enter the code that was sent to ${MOCK_EMAIL}`) &&
-            element?.textContent?.includes('Use a different account'))
+          !!(
+            element?.tagName === 'P' &&
+            element?.textContent?.includes(
+              `Enter the code that was sent to ${MOCK_EMAIL}`
+            ) &&
+            element?.textContent?.includes('Use a different account')
+          )
       );
     });
 
@@ -226,16 +246,15 @@ describe('SigninPasswordlessCode page', () => {
     it('clicking navigates to root and removes email from query params', async () => {
       render({ isSignup: false });
 
-      const link = screen.getByRole('link', { name: 'Use a different account' });
+      const link = screen.getByRole('link', {
+        name: 'Use a different account',
+      });
       fireEvent.click(link);
 
       await waitFor(() => {
-        expect(mockNavigateWithQuery).toHaveBeenCalledWith(
-          '/?',
-          {
-            state: { prefillEmail: MOCK_EMAIL },
-          }
-        );
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith('/?', {
+          state: { prefillEmail: MOCK_EMAIL },
+        });
       });
     });
 
@@ -252,16 +271,15 @@ describe('SigninPasswordlessCode page', () => {
 
       render({ isSignup: false });
 
-      const link = screen.getByRole('link', { name: 'Use a different account' });
+      const link = screen.getByRole('link', {
+        name: 'Use a different account',
+      });
       fireEvent.click(link);
 
       await waitFor(() => {
-        expect(mockNavigateWithQuery).toHaveBeenCalledWith(
-          '/?other=param',
-          {
-            state: { prefillEmail: MOCK_EMAIL },
-          }
-        );
+        expect(mockNavigateWithQuery).toHaveBeenCalledWith('/?other=param', {
+          state: { prefillEmail: MOCK_EMAIL },
+        });
       });
 
       // Restore original
@@ -278,16 +296,21 @@ describe('SigninPasswordlessCode page', () => {
   describe('handleResendCode submission', () => {
     async function renderAndResend() {
       render();
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
       await waitFor(() => {
-        expect(mockAuthClient.passwordlessResendCode).toHaveBeenCalledWith(MOCK_EMAIL, {
-          clientId: undefined,
-          service: MozServices.Default,
-          metricsContext: {
+        expect(mockAuthClient.passwordlessResendCode).toHaveBeenCalledWith(
+          MOCK_EMAIL,
+          {
             clientId: undefined,
-          },
-        });
+            service: MozServices.Default,
+            metricsContext: {
+              clientId: undefined,
+            },
+          }
+        );
       });
     }
 
@@ -302,17 +325,23 @@ describe('SigninPasswordlessCode page', () => {
         .mockRejectedValue(AuthUiErrors.THROTTLED);
 
       render();
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
 
       await screen.findByText(/tried too many times/);
     });
 
     it('on other error, renders banner with expected default error message', async () => {
-      mockAuthClient.passwordlessResendCode = jest.fn().mockRejectedValue(new Error());
+      mockAuthClient.passwordlessResendCode = jest
+        .fn()
+        .mockRejectedValue(new Error());
 
       render();
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
 
       await screen.findByText(/Something went wrong/);
@@ -356,7 +385,7 @@ describe('SigninPasswordlessCode page', () => {
 
     async function submitCode(code = MOCK_PASSWORDLESS_CODE) {
       const user = userEvent.setup();
-      const input = screen.getByLabelText('Enter 8-digit code');
+      const input = screen.getByLabelText('Enter 6-digit code');
       await user.type(input, code);
       await submit();
     }
@@ -375,10 +404,10 @@ describe('SigninPasswordlessCode page', () => {
         expect(mockAuthClient.passwordlessConfirmCode).not.toHaveBeenCalled();
       });
 
-      it('if input length is less than 8', async () => {
+      it('if input length is less than 6', async () => {
         const user = userEvent.setup();
-        const input = screen.getByLabelText('Enter 8-digit code');
-        await user.type(input, '1234567');
+        const input = screen.getByLabelText('Enter 6-digit code');
+        await user.type(input, '12345');
 
         const button = screen.getByRole('button', { name: 'Confirm' });
         expect(button).toBeDisabled();
@@ -389,8 +418,8 @@ describe('SigninPasswordlessCode page', () => {
 
       it('if input is not numeric', async () => {
         const user = userEvent.setup();
-        const input = screen.getByLabelText('Enter 8-digit code');
-        await user.type(input, '1234567a');
+        const input = screen.getByLabelText('Enter 6-digit code');
+        await user.type(input, '12345a');
 
         const button = screen.getByRole('button', { name: 'Confirm' });
         expect(button).toBeDisabled();
@@ -401,8 +430,8 @@ describe('SigninPasswordlessCode page', () => {
 
       it('if input is scientific notation', async () => {
         const user = userEvent.setup();
-        const input = screen.getByLabelText('Enter 8-digit code');
-        await user.type(input, '1000e100');
+        const input = screen.getByLabelText('Enter 6-digit code');
+        await user.type(input, '100e10');
 
         const button = screen.getByRole('button', { name: 'Confirm' });
         expect(button).toBeDisabled();
@@ -539,7 +568,7 @@ describe('SigninPasswordlessCode page', () => {
       beforeEach(() => {
         hardNavigateSpy = jest
           .spyOn(ReactUtils, 'hardNavigate')
-          .mockImplementation(() => { });
+          .mockImplementation(() => {});
       });
 
       afterEach(() => {
@@ -557,13 +586,13 @@ describe('SigninPasswordlessCode page', () => {
         await submitCode();
 
         await waitFor(() => {
-          expect(mockEnsureCanLinkAcountOrRedirect).toHaveBeenCalledWith(expect.objectContaining(
-            {
+          expect(mockEnsureCanLinkAcountOrRedirect).toHaveBeenCalledWith(
+            expect.objectContaining({
               email: MOCK_EMAIL,
               uid: MOCK_UID,
               navigateWithQuery: mockNavigateWithQuery,
-            }
-          ))
+            })
+          );
         });
 
         await waitFor(() => {
@@ -660,16 +689,17 @@ describe('SigninPasswordlessCode page', () => {
         await submitCode();
 
         await waitFor(() => {
-          expect(hardNavigateSpy).toHaveBeenCalledWith(
-            'someUri',
-            { newAccountVerification: 'true' }
-          );
+          expect(hardNavigateSpy).toHaveBeenCalledWith('someUri', {
+            newAccountVerification: 'true',
+          });
         });
       });
 
       it('redirects to TOTP setup when integration wantsTwoStepAuthentication', async () => {
         const integration = createMockSigninOAuthIntegration();
-        integration.wantsTwoStepAuthentication = jest.fn().mockReturnValue(true);
+        integration.wantsTwoStepAuthentication = jest
+          .fn()
+          .mockReturnValue(true);
 
         render({ integration, isSignup: true });
         await submitCode();
@@ -695,9 +725,7 @@ describe('SigninPasswordlessCode page', () => {
         await submitCode();
 
         await waitFor(() => {
-          expect(hardNavigateSpy).toHaveBeenCalledWith(
-            'https://mozilla.org'
-          );
+          expect(hardNavigateSpy).toHaveBeenCalledWith('https://mozilla.org');
         });
       });
 
@@ -708,10 +736,9 @@ describe('SigninPasswordlessCode page', () => {
         await submitCode();
 
         await waitFor(() => {
-          expect(mockNavigateWithQuery).toHaveBeenCalledWith(
-            '/settings',
-            { replace: true }
-          );
+          expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings', {
+            replace: true,
+          });
         });
       });
     });
@@ -749,7 +776,9 @@ describe('SigninPasswordlessCode page', () => {
       await screen.findByText(/Unexpected error/);
 
       // Click resend code button
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
 
       await waitFor(() => {
@@ -782,7 +811,9 @@ describe('SigninPasswordlessCode page', () => {
       render({ sendError: mockError });
 
       // Click resend code button
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
 
       await waitFor(() => {
@@ -806,7 +837,7 @@ describe('SigninPasswordlessCode page', () => {
 
       // Submit a code
       const user = userEvent.setup();
-      const input = screen.getByLabelText('Enter 8-digit code');
+      const input = screen.getByLabelText('Enter 6-digit code');
       await user.type(input, MOCK_PASSWORDLESS_CODE);
       const button = screen.getByRole('button', { name: 'Confirm' });
       await user.click(button);
@@ -825,7 +856,7 @@ describe('SigninPasswordlessCode page', () => {
   describe('Glean metrics', () => {
     async function submitCode(code = MOCK_PASSWORDLESS_CODE) {
       const user = userEvent.setup();
-      const input = screen.getByLabelText('Enter 8-digit code');
+      const input = screen.getByLabelText('Enter 6-digit code');
       await user.type(input, code);
       const button = screen.getByRole('button', { name: 'Confirm' });
       await user.click(button);
@@ -851,7 +882,7 @@ describe('SigninPasswordlessCode page', () => {
     it('emits engage event on first keystroke', async () => {
       render({ isSignup: false });
       const user = userEvent.setup();
-      const input = screen.getByLabelText('Enter 8-digit code');
+      const input = screen.getByLabelText('Enter 6-digit code');
       await user.type(input, '1');
       expect(mockGleanPasswordlessLogin.engage).toHaveBeenCalledTimes(1);
 
@@ -866,7 +897,9 @@ describe('SigninPasswordlessCode page', () => {
 
       await waitFor(() => {
         expect(mockGleanPasswordlessLogin.submit).toHaveBeenCalledTimes(1);
-        expect(mockGleanPasswordlessLogin.submitSuccess).toHaveBeenCalledTimes(1);
+        expect(mockGleanPasswordlessLogin.submitSuccess).toHaveBeenCalledTimes(
+          1
+        );
       });
     });
 
@@ -904,7 +937,9 @@ describe('SigninPasswordlessCode page', () => {
 
     it('emits resendCode event on resend click', async () => {
       render({ isSignup: false });
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
 
       await waitFor(() => {
@@ -918,7 +953,9 @@ describe('SigninPasswordlessCode page', () => {
         .mockRejectedValue(AuthUiErrors.THROTTLED);
 
       render({ isSignup: false });
-      const resendButton = screen.getByRole('button', { name: 'Email new code.' });
+      const resendButton = screen.getByRole('button', {
+        name: 'Email new code.',
+      });
       fireEvent.click(resendButton);
 
       await waitFor(() => {

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -32,7 +32,11 @@ import {
   isSyncDesktopV3Integration,
   isWebIntegration,
 } from '../../../models';
-import { getSyncNavigate, handleNavigation, ensureCanLinkAcountOrRedirect } from '../utils';
+import {
+  getSyncNavigate,
+  handleNavigation,
+  ensureCanLinkAcountOrRedirect,
+} from '../utils';
 import firefox from '../../../lib/channels/firefox';
 import { useWebRedirect } from '../../../lib/hooks/useWebRedirect';
 import VerificationMethods from '../../../constants/verification-methods';
@@ -41,7 +45,7 @@ import GleanMetrics from '../../../lib/glean';
 
 export const viewName = 'signin-passwordless-code';
 
-const EIGHT_DIGIT_NUMBER_REGEX = /^\d{8}$/;
+const SIX_DIGIT_NUMBER_REGEX = /^\d{6}$/;
 const RESEND_CODE_COUNTDOWN = 30;
 
 const SigninPasswordlessCode = ({
@@ -103,7 +107,9 @@ const SigninPasswordlessCode = ({
   // Process sendError prop only once when it's first set
   useEffect(() => {
     if (sendError && !sendErrorProcessed.current) {
-      setLocalizedErrorBannerMessage(getLocalizedErrorMessage(ftlMsgResolver, sendError));
+      setLocalizedErrorBannerMessage(
+        getLocalizedErrorMessage(ftlMsgResolver, sendError)
+      );
       sendErrorProcessed.current = true;
     }
   }, [sendError, ftlMsgResolver]);
@@ -118,10 +124,11 @@ const SigninPasswordlessCode = ({
   );
 
   const formAttributes: FormAttributes = {
-    inputFtlId: 'signin-passwordless-code-input-label',
-    inputLabelText: 'Enter 8-digit code',
-    pattern: '[0-9]{8}',
-    maxLength: 8,
+    inputFtlId: 'signin-passwordless-code-input-label-v2',
+    inputLabelText: 'Enter 6-digit code',
+    pattern: '[0-9]{6}',
+    maxLength: 6,
+    autoComplete: 'one-time-code',
     submitButtonFtlId: 'signin-passwordless-code-confirm-button',
     submitButtonText: 'Confirm',
   };
@@ -190,7 +197,7 @@ const SigninPasswordlessCode = ({
 
   const onSubmit = async (code: string) => {
     clearErrorMessages();
-    if (!EIGHT_DIGIT_NUMBER_REGEX.test(code)) {
+    if (!SIX_DIGIT_NUMBER_REGEX.test(code)) {
       setCodeErrorMessage(localizedInvalidCode);
       return;
     }
@@ -254,7 +261,10 @@ const SigninPasswordlessCode = ({
       // For existing users signing into Sync (signin flow), show merge warning
       // before navigating to set password. For signup flows, the warning was
       // already shown on the email-first page.
-      if ((integration.isSync() || integration.isFirefoxNonSync()) && !isSignup) {
+      if (
+        (integration.isSync() || integration.isFirefoxNonSync()) &&
+        !isSignup
+      ) {
         const canLink = await ensureCanLinkAcountOrRedirect({
           email,
           uid: result.uid,
@@ -349,7 +359,8 @@ const SigninPasswordlessCode = ({
                 redirect,
                 state,
               });
-              const { error: navError } = await handleNavigation(navigationOptions);
+              const { error: navError } =
+                await handleNavigation(navigationOptions);
               if (navError) {
                 setLocalizedErrorBannerMessage(
                   getLocalizedErrorMessage(ftlMsgResolver, navError)

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
@@ -23,7 +23,7 @@ import { MozServices } from '../../../lib/types';
 import { GenericData } from '../../../lib/model-data';
 import { Constants } from '../../../lib/constants';
 
-export const MOCK_PASSWORDLESS_CODE = '12345678';
+export const MOCK_PASSWORDLESS_CODE = '123456';
 
 export function createMockWebIntegration(
   cmsInfo?: RelierCmsInfo


### PR DESCRIPTION
  ## Because

  - 8-digit codes are unnecessarily long for email-based OTP, adding friction to passwordless sign-in
  - The OTP input field lacked `autocomplete="one-time-code"`, preventing mobile browsers from offering autofill

  ## This pull request

  - Changes the default passwordless OTP length from 8 to 6 digits in `fxa-auth-server/config/index.ts`
  - Promotes `passwordlessVerifyOtp` and `passwordlessVerifyOtpPerDay` email-scoped rules from `report` to `block` in `rate-limit-rules.txt`
  - Updates `SigninPasswordlessCode` component: regex, `maxLength`, `pattern`, and FTL string ID (versioned to `-v2`)
  - Adds optional `autoComplete` prop to `FormVerifyCode` and sets it to `one-time-code` for passwordless flow
  - Updates email templates (signin + signup, index + strapi) to say "Your verification code is" instead of "Use this confirmation code"


  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13321
  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13200

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**
  1. Start local stack: `yarn start`
  2. Navigate to 123done → sign in with email
  3. Use `force_passwordless=true` query param or an existing passwordless account
  4. Verify the OTP input accepts 6 digits (not 8)
  5. Verify the email says "Your verification code is" followed by a 6-digit code