### PR TITLE
fix(payments-cart): validate account customer prior to Stripe customer creation

### DIFF
--- a/libs/payments/cart/src/lib/checkout.error.ts
+++ b/libs/payments/cart/src/lib/checkout.error.ts
@@ -47,6 +47,13 @@ export class InvalidIntentStateError extends CheckoutError {
   }
 }
 
+export class AccountCustomerAlreadyExistsError extends CheckoutError {
+  constructor(uid: string) {
+    super('account customer already exists for uid', { uid });
+    this.name = 'AccountCustomerAlreadyExistsError';
+  }
+}
+
 export class SubmitNeedsInputFailedError extends CheckoutError {
   constructor(cartId: string) {
     super('payment failed while submitting user needs_input', { cartId });

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -65,6 +65,7 @@ import {
   ResultAccountCustomerFactory,
   MockStripeConfigProvider,
   AccountCustomerManager,
+  AccountCustomerNotFoundError,
   StripeConfirmationTokenFactory,
   StripeSetupIntentFactory,
 } from '@fxa/payments/stripe';
@@ -99,6 +100,7 @@ import {
   CartNoTaxAddressError,
   CartUidMismatchError,
 } from './cart.error';
+import { AccountCustomerAlreadyExistsError } from './checkout.error';
 import { CheckoutService } from './checkout.service';
 import { PrePayStepsResultFactory } from './checkout.factories';
 import { AccountManager } from '@fxa/shared/account/account';
@@ -503,6 +505,11 @@ describe('CheckoutService', () => {
         );
 
         jest
+          .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+          .mockRejectedValue(
+            new AccountCustomerNotFoundError(uid, new Error('not found'))
+          );
+        jest
           .spyOn(promotionCodeManager, 'assertValidPromotionCodeNameForPrice')
           .mockRejectedValue(
             new PromotionCodeNotFoundError(
@@ -528,9 +535,35 @@ describe('CheckoutService', () => {
           })
         );
 
+        jest
+          .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+          .mockRejectedValue(
+            new AccountCustomerNotFoundError(uid, new Error('not found'))
+          );
+
         await expect(
           checkoutService.prePaySteps(mockCart, mockCart.uid)
         ).rejects.toBeInstanceOf(CartTotalMismatchError);
+      });
+
+      it('throws account customer already exists error', async () => {
+        const mockCart = StripeResponseFactory(
+          ResultCartFactory({
+            uid: uid,
+            couponCode: faker.string.uuid(),
+            stripeCustomerId: null,
+            eligibilityStatus: CartEligibilityStatus.CREATE,
+            amount: mockInvoicePreview.subtotal,
+          })
+        );
+
+        jest
+          .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+          .mockResolvedValue(mockAccountCustomer);
+
+        await expect(
+          checkoutService.prePaySteps(mockCart, mockCart.uid)
+        ).rejects.toBeInstanceOf(AccountCustomerAlreadyExistsError);
       });
     });
   });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -41,6 +41,7 @@ import {
   StripePromotionCode,
   type StripePaymentIntent,
   type StripeSetupIntent,
+  AccountCustomerNotFoundError,
 } from '@fxa/payments/stripe';
 import { AccountManager } from '@fxa/shared/account/account';
 import { ProfileClient } from '@fxa/profile/client';
@@ -80,6 +81,7 @@ import {
   PayWithStripeNullCurrencyError,
   UpgradeSubscriptionNullCurrencyError,
   UnexpectedSubscriptionStatusForTrialError,
+  AccountCustomerAlreadyExistsError,
 } from './checkout.error';
 import { isPaymentIntentId } from './util/isPaymentIntentId';
 import { isPaymentIntent } from './util/isPaymentIntent';
@@ -175,6 +177,16 @@ export class CheckoutService {
     let stripeCustomerId = cart.stripeCustomerId;
     let customer: StripeCustomer;
     if (!stripeCustomerId) {
+      try {
+        await this.accountCustomerManager.getAccountCustomerByUid(uid);
+
+        throw new AccountCustomerAlreadyExistsError(uid);
+      } catch(error) {
+        if (!(error instanceof AccountCustomerNotFoundError)) {
+          throw error;
+        }
+      }
+
       customer = await this.customerManager.create({
         uid,
         email,
@@ -196,15 +208,12 @@ export class CheckoutService {
       });
     }
 
-    if (uid && !cart.stripeCustomerId) {
+    if (!cart.stripeCustomerId) {
       await this.accountCustomerManager.createAccountCustomer({
         uid,
         stripeCustomerId,
       });
-    }
 
-    // Cart only needs to be updated if we created a customer
-    if (!cart.uid || !cart.stripeCustomerId) {
       await this.cartManager.updateFreshCart(cart.id, cart.version, {
         uid,
         stripeCustomerId,


### PR DESCRIPTION
## Because

- We've seen that if a user has two tabs open with a cart and proceeds with both, they'll create a duplicate Stripe customer and receive the error "AccountCustomerNotCreatedError: AccountCustomer not created: Duplicate entry...".

## This pull request

- Narrows the race condition, but does not completely eliminate it. We should be fine as it stands now, given the window is very small and the impact is only that a duplicate Stripe customer will be created for the user, but the second cart will still fail anyway due to the unique PK for account customers if this timing were to ever happen.

## Issue that this pull request solves

Closes PAY-3541