### PR TITLE
fix(payments): Fix sign-out navigation showing blank

### DIFF
--- a/libs/payments/ui/src/lib/client/components/Header/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/Header/index.tsx
@@ -27,7 +27,6 @@ import { OFFERING_LINKS } from '../../../constants';
 import {
   ReadonlyURLSearchParams,
   useParams,
-  useRouter,
   useSearchParams,
 } from 'next/navigation';
 import { signOut } from 'next-auth/react';
@@ -68,7 +67,6 @@ type HeaderProps = {
 };
 
 export const Header = ({ auth, cart, redirectPath }: HeaderProps) => {
-  const router = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
 
@@ -389,9 +387,8 @@ export const Header = ({ auth, cart, redirectPath }: HeaderProps) => {
                     <div className="bg-gradient-to-r from-blue-500 via-pink-700 to-yellow-500 h-px" />
                     <div className="px-4 py-5">
                       <button
-                        onClick={async () => {
-                          const signOutRedirect = await signOut({ redirectTo: signOutRedirectPath, redirect: false })
-                          router.replace(signOutRedirect.url);
+                        onClick={() => {
+                          signOut({ redirectTo: signOutRedirectPath })
                         }}
                         className="pl-3 group"
                       >


### PR DESCRIPTION
Because:

- Sign-out was using client-side navigation via `router.replace()` after calling `signOut()` with `redirect: false`, which failed to properly re-render the new page in staging, showing users a blank screen

This commit:

- Lets next-auth handle the redirect automatically for proper page reload and session state cleanup

Closes: PAY-3639

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information (Optional)

I wasn't able to replicate the initial issue locally, but I was on stage. After researching the issue a bit and chatting with Claude, this seems to be the most likely problem and fix.
