### PR TITLE
fix(auth-server): correct typo 'seperately' to 'separately' in tests

### DIFF
--- a/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/oauth_api.in.spec.ts
@@ -3319,7 +3319,7 @@ describe('#integration - /v1', function () {
         expect(clients2[0].client_id).toBe(client2Id.toString('hex'));
       });
 
-      it('should seperately list different refresh tokens from the same client', async () => {
+      it('should separately list different refresh tokens from the same client', async () => {
         await makeAccessToken(client1, user1, ['profile']);
         await makeAccessToken(client1, user1, ['other', 'scope']);
         await makeRefreshToken(client2, user1, ['profile']);


### PR DESCRIPTION
This PR fixes a minor typo in OAuth test descriptions. Refiled as a targeted PR as requested in #19940.