### PR TITLE
fix(l10n): Fix l10n issues (linter, brand term)

### DIFF
--- a/packages/fxa-settings/src/pages/Pair/Index/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/Index/en.ftl
@@ -43,10 +43,10 @@ pair-signed-in-successfully = Signed in successfully!
 # Subheader for the download screen
 pair-download-subheader = Download { -brand-firefox } for mobile
 # Description for the download screen
-pair-download-description = To sync { -brand-firefox } on your phone or tablet, you first need to download { -brand-firefox } for mobile. Here's how:
+pair-download-description = To sync { -brand-firefox } on your phone or tablet, you first need to download { -brand-firefox } for mobile. Here’s how:
 # Step 1: scan QR code. $stepNumber is the step number (1)
 pair-download-step-scan-qr = <b>Step { $stepNumber }</b>: Download { -brand-firefox } by scanning this QR code with the camera on your mobile device:
 # Step 2: continue to sync. $stepNumber is the step number (2)
-pair-download-step-continue-sync = <b>Step { $stepNumber }</b>: Select "Continue to sync" to sync your { -brand-firefox } experience on your mobile device.
+pair-download-step-continue-sync = <b>Step { $stepNumber }</b>: Select “Continue to sync” to sync your { -brand-firefox } experience on your mobile device.
 # Button on the download screen that opens about:preferences for pairing
 pair-continue-to-sync-button = Continue to sync

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -186,7 +186,7 @@ const Pair = ({
           <FtlMsg id="pair-download-description">
             <p className="text-base mt-2">
               To sync Firefox on your phone or tablet, you first need to
-              download Firefox for mobile. Here's how:
+              download Firefox for mobile. Here’s how:
             </p>
           </FtlMsg>
           <ol>
@@ -214,7 +214,7 @@ const Pair = ({
                 elems={{ b: <b /> }}
               >
                 <p className="text-base mb-5">
-                  <b>Step 2</b>: Select "Continue to sync" to sync your Firefox
+                  <b>Step 2</b>: Select “Continue to sync” to sync your Firefox
                   experience on your mobile device.
                 </p>
               </FtlMsg>

--- a/packages/fxa-settings/src/pages/Pair/Unsupported/en.ftl
+++ b/packages/fxa-settings/src/pages/Pair/Unsupported/en.ftl
@@ -15,7 +15,7 @@ pair-unsupported-oops-mobile = Oops! It looks like you’re not using { -brand-f
 # v2: Heading for the mobile instructional message, shown on all mobile devices
 # (Firefox and non-Firefox) when the URL is NOT a system camera pair URL.
 # Aligned with legacy Backbone copy (see templates/partial/unsupported-pair.mustache).
-pair-unsupported-connecting-mobile-header-v2 = Connecting your mobile device with your Mozilla account
+pair-unsupported-connecting-mobile-header-v2 = Connecting your mobile device with your { -product-mozilla-account }
 
 # v2: Instructions shown below the mobile heading. `<b>` wraps the firefox.com/pair
 # URL so the domain does not wrap to a new line on narrow screens.


### PR DESCRIPTION
Because:
* New strings were added to #20126 after l10n review and l10n wasn't notified a number of strings with issues were introduced

This commit:
* Replaces straight apostrophe and quotes with curly quotes
* Replaces a hard coded "Mozilla account" with the appropriate brand term
