### PR TITLE
bug(fix): Support webauthn implementations that return plain object

### DIFF
--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -46,7 +46,7 @@ export async function generateWebauthnRegistrationOptions(
     rpID: config.rpId,
     userName: input.email,
     userDisplayName: input.email,
-    userID: input.uid,
+    userID: new Uint8Array(input.uid),
     // Challenge must be passed as a Buffer (Uint8Array) so that simplewebauthn
     // base64url-encodes the raw bytes. Passing a string causes the library to
     // UTF-8-encode the text first, producing a different base64url value than
@@ -226,7 +226,7 @@ export async function verifyWebauthnAuthenticationResponse(
 ): Promise<AuthenticationVerificationResult> {
   const credential: WebAuthnCredential = {
     id: input.credentialId.toString('base64url'),
-    publicKey: input.publicKey,
+    publicKey: new Uint8Array(input.publicKey),
     counter: input.signCount,
   };
 

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.test.ts
@@ -110,8 +110,6 @@ describe('isWebAuthnLevel3Supported', () => {
   });
 });
 
-// ─── createCredential ─────────────────────────────────────────────────────────
-
 describe('createCredential', () => {
   let mockPKC: Record<string, jest.Mock>;
   let mockCreate: jest.Mock;
@@ -183,9 +181,34 @@ describe('createCredential', () => {
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
   });
-});
 
-// ─── getCredential ────────────────────────────────────────────────────────────
+  it('resolves via duck-typed toJSON() when credential is a plain object (e.g. 1Password)', async () => {
+    // 1Password returns a plain object that mimics PublicKeyCredential
+    // but is not an actual instance of the class.
+    const proxyCredential = {
+      id: mockCredentialJSON.id,
+      rawId: new ArrayBuffer(8),
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: {},
+      getClientExtensionResults: jest.fn().mockReturnValue({}),
+      toJSON: jest.fn().mockReturnValue(mockCredentialJSON),
+    };
+    mockCreate.mockResolvedValue(proxyCredential);
+
+    const result = await createCredential(mockCreationOptions);
+    expect(result).toEqual(mockCredentialJSON);
+    expect(proxyCredential.toJSON).toHaveBeenCalled();
+  });
+
+  it('throws when credential lacks toJSON()', async () => {
+    mockCreate.mockResolvedValue({ id: 'no-toJSON', type: 'public-key' });
+    await expect(createCredential(mockCreationOptions)).rejects.toMatchObject({
+      name: 'UnknownError',
+      message: expect.stringContaining('without toJSON()'),
+    });
+  });
+});
 
 describe('getCredential', () => {
   let mockPKC: Record<string, jest.Mock>;
@@ -257,5 +280,30 @@ describe('getCredential', () => {
     await expect(getCredential(mockRequestOptions)).rejects.toBeDefined();
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  });
+
+  it('resolves via duck-typed toJSON() when credential is a plain object (e.g. 1Password)', async () => {
+    const proxyCredential = {
+      id: mockCredentialJSON.id,
+      rawId: new ArrayBuffer(8),
+      type: 'public-key',
+      authenticatorAttachment: 'platform',
+      response: {},
+      getClientExtensionResults: jest.fn().mockReturnValue({}),
+      toJSON: jest.fn().mockReturnValue(mockCredentialJSON),
+    };
+    mockGet.mockResolvedValue(proxyCredential);
+
+    const result = await getCredential(mockRequestOptions);
+    expect(result).toEqual(mockCredentialJSON);
+    expect(proxyCredential.toJSON).toHaveBeenCalled();
+  });
+
+  it('throws when credential lacks toJSON()', async () => {
+    mockGet.mockResolvedValue({ id: 'no-toJSON', type: 'public-key' });
+    await expect(getCredential(mockRequestOptions)).rejects.toMatchObject({
+      name: 'UnknownError',
+      message: expect.stringContaining('without toJSON()'),
+    });
   });
 });

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.ts
@@ -174,6 +174,47 @@ export function isWebAuthnLevel3Supported(): boolean {
   );
 }
 
+// ─── Credential extraction ──────────────────────────────────────────────────
+
+/** Type guard for objects that can serialize to credential JSON. */
+function hasToJSON(
+  value: unknown
+): value is { toJSON: () => PublicKeyCredentialJSON } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'toJSON' in value &&
+    typeof value.toJSON === 'function'
+  );
+}
+
+/**
+ * Extracts `PublicKeyCredentialJSON` from a browser credential result.
+ *
+ * Prefers duck-typing (`toJSON()`) over `instanceof PublicKeyCredential`
+ * because password managers (e.g. 1Password) may return a plain object
+ * that has all the right fields but is not a real `PublicKeyCredential`.
+ *
+ * No client-side shape validation of the `toJSON()` return value —
+ * `@simplewebauthn/server:verifyRegistrationResponse` performs strict
+ * WebAuthn spec validation server-side and rejects malformed data.
+ */
+function toCredentialJSON(
+  rawCredential: Credential | null,
+  operation: string
+): PublicKeyCredentialJSON {
+  if (!rawCredential) {
+    throw new DOMException(`${operation} returned null`, 'UnknownError');
+  }
+  if (hasToJSON(rawCredential)) {
+    return rawCredential.toJSON();
+  }
+  throw new DOMException(
+    `${operation} returned a credential without toJSON()`,
+    'UnknownError'
+  );
+}
+
 // ─── Wrapper functions ────────────────────────────────────────────────────────
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -217,27 +258,7 @@ export async function createCredential(
       signal: controller.signal,
     });
 
-    if (!rawCredential) {
-      throw new DOMException(
-        'navigator.credentials.create returned null',
-        'UnknownError'
-      );
-    }
-    if (rawCredential instanceof PublicKeyCredential) {
-      return rawCredential.toJSON();
-    }
-    const actualType =
-      (rawCredential as Credential).constructor?.name ?? typeof rawCredential;
-    const keyInfo = Object.entries(rawCredential as object)
-      .map(
-        ([k, v]) =>
-          `${k}: ${v instanceof ArrayBuffer ? 'ArrayBuffer' : typeof v}`
-      )
-      .join(', ');
-    throw new DOMException(
-      `navigator.credentials.create returned unexpected credential type: ${actualType} — fields: {${keyInfo}}`,
-      'UnknownError'
-    );
+    return toCredentialJSON(rawCredential, 'navigator.credentials.create');
   } catch (e) {
     if (timedOut) {
       throw new DOMException('WebAuthn operation timed out', 'TimeoutError');
@@ -287,27 +308,7 @@ export async function getCredential(
       signal: controller.signal,
     });
 
-    if (!rawCredential) {
-      throw new DOMException(
-        'navigator.credentials.get returned null',
-        'UnknownError'
-      );
-    }
-    if (rawCredential instanceof PublicKeyCredential) {
-      return rawCredential.toJSON();
-    }
-    const actualType =
-      (rawCredential as Credential).constructor?.name ?? typeof rawCredential;
-    const keyInfo = Object.entries(rawCredential as object)
-      .map(
-        ([k, v]) =>
-          `${k}: ${v instanceof ArrayBuffer ? 'ArrayBuffer' : typeof v}`
-      )
-      .join(', ');
-    throw new DOMException(
-      `navigator.credentials.get returned unexpected credential type: ${actualType} — fields: {${keyInfo}}`,
-      'UnknownError'
-    );
+    return toCredentialJSON(rawCredential, 'navigator.credentials.get');
   } catch (e) {
     if (timedOut) {
       throw new DOMException('WebAuthn operation timed out', 'TimeoutError');

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.ts
@@ -174,6 +174,40 @@ export function isWebAuthnLevel3Supported(): boolean {
   );
 }
 
+// ─── Credential extraction ──────────────────────────────────────────────────
+
+/** Minimal duck-type interface for objects that can serialize to credential JSON. */
+interface CredentialWithToJSON {
+  toJSON?: () => PublicKeyCredentialJSON;
+}
+
+/**
+ * Extracts `PublicKeyCredentialJSON` from a browser credential result.
+ *
+ * Prefers duck-typing (`toJSON()`) over `instanceof PublicKeyCredential`
+ * because password managers (e.g. 1Password) may return a plain object
+ * that has all the right fields but is not a real `PublicKeyCredential`.
+ *
+ * No client-side shape validation of the `toJSON()` return value —
+ * `@simplewebauthn/server:verifyRegistrationResponse` performs strict
+ * WebAuthn spec validation server-side and rejects malformed data.
+ */
+function toCredentialJSON(
+  rawCredential: Credential | null,
+  operation: string
+): PublicKeyCredentialJSON {
+  if (!rawCredential) {
+    throw new DOMException(`${operation} returned null`, 'UnknownError');
+  }
+  if (typeof (rawCredential as CredentialWithToJSON).toJSON === 'function') {
+    return (rawCredential as CredentialWithToJSON).toJSON!();
+  }
+  throw new DOMException(
+    `${operation} returned a credential without toJSON()`,
+    'UnknownError'
+  );
+}
+
 // ─── Wrapper functions ────────────────────────────────────────────────────────
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -217,27 +251,7 @@ export async function createCredential(
       signal: controller.signal,
     });
 
-    if (!rawCredential) {
-      throw new DOMException(
-        'navigator.credentials.create returned null',
-        'UnknownError'
-      );
-    }
-    if (rawCredential instanceof PublicKeyCredential) {
-      return rawCredential.toJSON();
-    }
-    const actualType =
-      (rawCredential as Credential).constructor?.name ?? typeof rawCredential;
-    const keyInfo = Object.entries(rawCredential as object)
-      .map(
-        ([k, v]) =>
-          `${k}: ${v instanceof ArrayBuffer ? 'ArrayBuffer' : typeof v}`
-      )
-      .join(', ');
-    throw new DOMException(
-      `navigator.credentials.create returned unexpected credential type: ${actualType} — fields: {${keyInfo}}`,
-      'UnknownError'
-    );
+    return toCredentialJSON(rawCredential, 'navigator.credentials.create');
   } catch (e) {
     if (timedOut) {
       throw new DOMException('WebAuthn operation timed out', 'TimeoutError');
@@ -287,27 +301,7 @@ export async function getCredential(
       signal: controller.signal,
     });
 
-    if (!rawCredential) {
-      throw new DOMException(
-        'navigator.credentials.get returned null',
-        'UnknownError'
-      );
-    }
-    if (rawCredential instanceof PublicKeyCredential) {
-      return rawCredential.toJSON();
-    }
-    const actualType =
-      (rawCredential as Credential).constructor?.name ?? typeof rawCredential;
-    const keyInfo = Object.entries(rawCredential as object)
-      .map(
-        ([k, v]) =>
-          `${k}: ${v instanceof ArrayBuffer ? 'ArrayBuffer' : typeof v}`
-      )
-      .join(', ');
-    throw new DOMException(
-      `navigator.credentials.get returned unexpected credential type: ${actualType} — fields: {${keyInfo}}`,
-      'UnknownError'
-    );
+    return toCredentialJSON(rawCredential, 'navigator.credentials.get');
   } catch (e) {
     if (timedOut) {
       throw new DOMException('WebAuthn operation timed out', 'TimeoutError');


### PR DESCRIPTION
## Because

- While testing https://github.com/mozilla/fxa/pull/20385, noticed 1Password on macOS returns a plain object that mimics `PublicKeyCredential` but is not an `instanceof` match, which broke the WebAuthn browser path.

## This pull request

-  duck-type WebAuthn credential to support 1Password proxy objects

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This PR previously contained other types mismatches - these changes were moved to their own PR
