### PR TITLE
fix(auth): free trial duplicate reminder emails

### DIFF
--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -119,7 +119,8 @@ export class SubscriptionReminders {
         days: endingReminderOptions.freeTrialReminderDays,
       });
     }
-    this.freeTrialEndingReminderEnabled = endingReminderOptions.freeTrialEndRemindersEnabled;
+    this.freeTrialEndingReminderEnabled =
+      endingReminderOptions.freeTrialEndRemindersEnabled;
     this.paymentsNextUrl = endingReminderOptions.paymentsNextUrl;
     this.stripeHelper = stripeHelper;
     this.subscriptionManager = subscriptionManager;
@@ -313,7 +314,7 @@ export class SubscriptionReminders {
     if (
       await this.alreadySentEmail(
         uid,
-        Math.floor(subscription.current_period_end * 1000),
+        Math.floor(subscription.current_period_start * 1000),
         emailParams,
         'freeTrialEndingReminder'
       )


### PR DESCRIPTION
## Because

- Free trial reminder emails are sending duplicate emails.

## This pull request

- Update call of alreadySentEmail, by free trial logic, to pass in required current_period_start instead of current_period_end.

## Issue that this pull request solves

Closes: #PAY-3652

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Subscribe to a free trial
- Run the reminder script with the following parameters. Note the reminder length might need to change depending on trial reminder.
```
CONFIG_FILES='config/secrets.json' NODE_ENV=dev FIRESTORE_EMULATOR_HOST=localhost:9090 yarn workspace fxa-auth-server subscription-reminders -t true --free-trial-ending-reminder-length=13
```

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
