### PR TITLE
fix(payments): full relative paths for Next.js 15 redirects

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/error/page.tsx
@@ -58,9 +58,11 @@ export default async function CheckoutError({
   const acceptLanguage = (await headers()).get('accept-language');
 
   const sessionPromise = auth();
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/checkout/${resolvedParams.cartId}/error`;
   const cartPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.ERROR,
+    currentPathname,
     resolvedSearchParams
   );
   const l10n = getApp().getL10n(acceptLanguage, locale);

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/needs_input/page.tsx
@@ -54,9 +54,11 @@ export default async function NeedsInputPage({
   const l10n = getApp().getL10n(acceptLanguage, locale);
 
   const sessionPromise = auth();
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/checkout/${resolvedParams.cartId}/needs_input`;
   const cartPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.NEEDS_INPUT,
+    currentPathname,
     resolvedSearchParams
   );
   const [session, cart] = await Promise.all([sessionPromise, cartPromise]);

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/processing/page.tsx
@@ -48,9 +48,11 @@ export default async function ProcessingPage({
   const { locale } = resolvedParams;
   const acceptLanguage = (await headers()).get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, locale);
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/checkout/${resolvedParams.cartId}/processing`;
   await validateCartStateAndRedirectAction(
     resolvedParams.cartId,
     SupportedPages.PROCESSING,
+    currentPathname,
     resolvedSearchParams
   );
   return (

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -72,9 +72,11 @@ export default async function Checkout({
     acceptLanguage,
     locale
   );
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/checkout/${resolvedParams.cartId}/start`;
   const cartPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.START,
+    currentPathname,
     resolvedSearchParams
   );
   //TODO - Replace with cartPromise as part of FXA-8903

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/success/page.tsx
@@ -60,9 +60,11 @@ export default async function CheckoutSuccess({
     acceptLanguage,
     locale
   );
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/checkout/${resolvedParams.cartId}/success`;
   const cartDataPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.SUCCESS,
+    currentPathname,
     resolvedSearchParams
   );
   const sessionPromise = auth();

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/error/page.tsx
@@ -56,9 +56,11 @@ export default async function UpgradeError({
   const acceptLanguage = (await headers()).get('accept-language');
 
   const sessionPromise = auth();
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/upgrade/${resolvedParams.cartId}/error`;
   const cartPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.ERROR,
+    currentPathname,
     resolvedSearchParams
   );
   const l10n = getApp().getL10n(acceptLanguage, locale);

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/needs_input/page.tsx
@@ -52,9 +52,11 @@ export default async function NeedsInputPage({
   const { locale } = resolvedParams;
   const acceptLanguage = (await headers()).get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, locale);
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/upgrade/${resolvedParams.cartId}/needs_input`;
   const cartPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.NEEDS_INPUT,
+    currentPathname,
     resolvedSearchParams
   );
   const sessionPromise = auth();

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/processing/page.tsx
@@ -48,9 +48,11 @@ export default async function ProcessingPage({
   const { locale } = resolvedParams;
   const acceptLanguage = (await headers()).get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, locale);
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/upgrade/${resolvedParams.cartId}/processing`;
   await validateCartStateAndRedirectAction(
     resolvedParams.cartId,
     SupportedPages.PROCESSING,
+    currentPathname,
     resolvedSearchParams
   );
   return (

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(mainLayout)/success/page.tsx
@@ -64,9 +64,11 @@ export default async function UpgradeSuccess({
     acceptLanguage,
     locale
   );
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/upgrade/${resolvedParams.cartId}/success`;
   const cartDataPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.SUCCESS,
+    currentPathname,
     resolvedSearchParams
   );
   const sessionPromise = auth();

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/upgrade/[cartId]/(startLayout)/start/page.tsx
@@ -59,9 +59,11 @@ export default async function Upgrade({
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const session = await auth();
 
+  const currentPathname = `/${resolvedParams.locale}/${resolvedParams.offeringId}/${resolvedParams.interval}/upgrade/${resolvedParams.cartId}/start`;
   const cartDataPromise = getCartOrRedirectAction(
     resolvedParams.cartId,
     SupportedPages.START,
+    currentPathname,
     resolvedSearchParams
   );
   const cmsDataPromise = fetchCMSData(

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -9,6 +9,7 @@ import { getApp } from '../nestapp/app';
 import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
 import { URLSearchParams } from 'url';
+import { sanitizePathname } from '../utils/sanitizePathname';
 import {
   StartCartDTO,
   ProcessingCartDTO,
@@ -22,35 +23,42 @@ import {
  * Get Cart or Redirect if cart state does not match supported page
  * @@param cartId - Cart ID
  * @@param page - Page that action is being called from
+ * @@param currentPathname - Current pathname for constructing redirect URLs
  */
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.START,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ): Promise<StartCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.PROCESSING,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ): Promise<ProcessingCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.NEEDS_INPUT,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ): Promise<NeedsInputCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.ERROR,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ): Promise<FailCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages.SUCCESS,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ): Promise<SuccessCartDTO>;
 async function getCartOrRedirectAction(
   cartId: string,
   page: SupportedPages,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ): Promise<CartDTO> {
   const filteredParams = searchParams
@@ -63,7 +71,14 @@ async function getCartOrRedirectAction(
   });
 
   if (!validateCartState(cart.state, page)) {
-    redirect(getRedirect(cart.state) + params);
+    // Sanitize pathname to prevent open redirect vulnerabilities
+    const safePath = sanitizePathname(currentPathname);
+    
+    // Replace the last segment with the redirect path to maintain the full path structure
+    const pathSegments = safePath.split('/');
+    pathSegments[pathSegments.length - 1] = getRedirect(cart.state);
+    const redirectPath = pathSegments.join('/');
+    redirect(redirectPath + params);
   }
 
   return cart;

--- a/libs/payments/ui/src/lib/actions/handleStripeError.ts
+++ b/libs/payments/ui/src/lib/actions/handleStripeError.ts
@@ -10,14 +10,18 @@ import { redirect } from 'next/navigation';
 import { stripeErrorToErrorReasonId } from '@fxa/payments/cart';
 import { URLSearchParams } from 'url';
 import { flattenRouteParams } from '../utils/flatParam';
+import { sanitizePathname } from '../utils/sanitizePathname';
 
 export const handleStripeErrorAction = async (
   cartId: string,
   stripeError: StripeError,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>
 ) => {
   const errorReasonId = stripeErrorToErrorReasonId(stripeError);
-  const urlSearchParams = new URLSearchParams(searchParams ? flattenRouteParams(searchParams) : undefined);
+  const urlSearchParams = new URLSearchParams(
+    searchParams ? flattenRouteParams(searchParams) : undefined
+  );
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';
 
   await getApp().getActionsService().finalizeCartWithError({
@@ -25,5 +29,13 @@ export const handleStripeErrorAction = async (
     errorReasonId,
   });
 
-  redirect(`error${params}`);
+  // Sanitize pathname to prevent open redirect vulnerabilities
+  const safePath = sanitizePathname(currentPathname);
+  
+  // Replace the last segment with 'error' to maintain the full path structure
+  const pathSegments = safePath.split('/');
+  pathSegments[pathSegments.length - 1] = 'error';
+  const errorPath = pathSegments.join('/');
+
+  redirect(`${errorPath}${params}`);
 };

--- a/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/submitNeedsInputAndRedirect.ts
@@ -9,10 +9,12 @@ import { redirect } from 'next/navigation';
 import { URLSearchParams } from 'url';
 import { recordEmitterEventAction } from './recordEmitterEvent';
 import { flattenRouteParams } from '../utils/flatParam';
+import { sanitizePathname } from '../utils/sanitizePathname';
 
 export const submitNeedsInputAndRedirectAction = async (
   cartId: string,
   params: Record<string, string | string[] | undefined>,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>,
   isFreeTrial?: boolean
 ) => {
@@ -49,5 +51,13 @@ export const submitNeedsInputAndRedirectAction = async (
     redirectPath = 'error';
   }
 
-  redirect(`${redirectPath}${searchParamsString}`);
+  // Sanitize pathname to prevent open redirect vulnerabilities
+  const safePath = sanitizePathname(currentPathname);
+  
+  // Replace the last segment with the redirect path to maintain the full path structure
+  const pathSegments = safePath.split('/');
+  pathSegments[pathSegments.length - 1] = redirectPath;
+  const fullRedirectPath = pathSegments.join('/');
+
+  redirect(`${fullRedirectPath}${searchParamsString}`);
 };

--- a/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/validateCartStateAndRedirect.ts
@@ -10,15 +10,18 @@ import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
 import { URLSearchParams } from 'url';
 import { flattenRouteParams } from '../utils/flatParam';
+import { sanitizePathname } from '../utils/sanitizePathname';
 
 /**
  * Redirect if cart state does not match supported page
  * @@param cartId - Cart ID
  * @@param page - Page that action is being called from
+ * @@param currentPathname - Current pathname for constructing redirect URLs
  */
 async function validateCartStateAndRedirectAction(
   cartId: string,
   page: SupportedPages,
+  currentPathname: string,
   searchParams?: Record<string, string | string[] | undefined>,
   redirectNow = true
 ) {
@@ -29,7 +32,13 @@ async function validateCartStateAndRedirectAction(
   });
 
   if (!validateCartState(state, page)) {
-    const redirectToUrl = getRedirect(state) + params;
+    // Sanitize pathname to prevent open redirect vulnerabilities
+    const safePath = sanitizePathname(currentPathname);
+    
+    // Replace the last segment with the redirect path to maintain the full path structure
+    const pathSegments = safePath.split('/');
+    pathSegments[pathSegments.length - 1] = getRedirect(state);
+    const redirectToUrl = pathSegments.join('/') + params;
 
     if (redirectNow) {
       redirect(redirectToUrl);

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -21,6 +21,7 @@ import Image from 'next/image';
 import {
   ReadonlyURLSearchParams,
   useParams,
+  usePathname,
   useRouter,
   useSearchParams,
 } from 'next/navigation';
@@ -78,10 +79,10 @@ interface CheckoutFormProps {
     };
     paymentInfo?: {
       type:
-        | Stripe.PaymentMethod.Type
-        | 'google_iap'
-        | 'apple_iap'
-        | 'external_paypal';
+      | Stripe.PaymentMethod.Type
+      | 'google_iap'
+      | 'apple_iap'
+      | 'external_paypal';
       last4?: string;
       brand?: string;
       customerSessionClientSecret?: string;
@@ -111,6 +112,7 @@ export function CheckoutForm({
   const elements = useElements();
   const router = useRouter();
   const stripe = useStripe();
+  const pathname = usePathname();
   const rawParams = useParams();
   const params: Record<string, string | string[]> = {};
   for (const [key, value] of Object.entries(rawParams)) {
@@ -144,13 +146,13 @@ export function CheckoutForm({
     () =>
       isCancelInterstitialOffer
         ? {
-            offeringId: (params.offeringId as string) ?? undefined,
-            interval: (params.interval as Interval) ?? undefined,
-            utmSource: searchParams.get('utm_source') ?? undefined,
-            utmMedium: searchParams.get('utm_medium') ?? undefined,
-            utmCampaign: searchParams.get('utm_campaign') ?? undefined,
-            nimbusUserId: searchParams.get('nimbus_user_id') ?? undefined,
-          }
+          offeringId: (params.offeringId as string) ?? undefined,
+          interval: (params.interval as Interval) ?? undefined,
+          utmSource: searchParams.get('utm_source') ?? undefined,
+          utmMedium: searchParams.get('utm_medium') ?? undefined,
+          utmCampaign: searchParams.get('utm_campaign') ?? undefined,
+          nimbusUserId: searchParams.get('nimbus_user_id') ?? undefined,
+        }
         : null,
     [isCancelInterstitialOffer, params.interval, searchParams]
   );
@@ -280,12 +282,12 @@ export function CheckoutForm({
     const confirmationTokenParams: ConfirmationTokenCreateParams | undefined =
       !isSavedPaymentMethod
         ? {
-            payment_method_data: {
-              billing_details: {
-                email: sessionEmail || undefined,
-              },
+          payment_method_data: {
+            billing_details: {
+              email: sessionEmail || undefined,
             },
-          }
+          },
+        }
         : undefined;
 
     // Create the ConfirmationToken using the details collected by the Payment Element
@@ -304,6 +306,7 @@ export function CheckoutForm({
         await handleStripeErrorAction(
           cart.id,
           confirmationTokenError,
+          pathname,
           searchParamsRecord
         );
         setLoading(false);

--- a/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentInputHandler/index.tsx
@@ -13,7 +13,7 @@ import {
 import { useEffect } from 'react';
 import { useStripe } from '@stripe/react-stripe-js';
 import { SupportedPages } from '@fxa/payments/ui';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 export function PaymentInputHandler({
   cartId,
   isFreeTrial,
@@ -23,6 +23,7 @@ export function PaymentInputHandler({
 }) {
   const stripe = useStripe();
   const params = useParams();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
   const searchParamsRecord: Record<string, string> = {};
@@ -41,12 +42,13 @@ export function PaymentInputHandler({
             await stripe.handleNextAction({
               clientSecret: inputRequest.data.clientSecret,
             });
-            await submitNeedsInputAndRedirectAction(cartId, params, searchParamsRecord, isFreeTrial);
+            await submitNeedsInputAndRedirectAction(cartId, params, pathname, searchParamsRecord, isFreeTrial);
             break;
           case 'notRequired':
             const redirectResponse = await validateCartStateAndRedirectAction(
               cartId,
               SupportedPages.NEEDS_INPUT,
+              pathname,
               searchParamsRecord
             );
 

--- a/libs/payments/ui/src/lib/client/components/PaymentStateObserver/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentStateObserver/index.tsx
@@ -5,7 +5,7 @@
 'use client';
 
 import { SupportedPages } from '@fxa/payments/ui';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 import { validateCartStateAndRedirectAction } from '../../../actions/validateCartStateAndRedirect';
 import { recordEmitterEventAction } from '../../../actions';
@@ -21,6 +21,7 @@ export function PaymentStateObserver({
 }) {
   const searchParams = useSearchParams();
   const params = useParams();
+  const pathname = usePathname();
   const router = useRouter();
   const searchParamsRecord: Record<string, string> = {};
   for (const [key, value] of searchParams.entries()) {
@@ -36,6 +37,7 @@ export function PaymentStateObserver({
       const redirectResponse = await validateCartStateAndRedirectAction(
         cartId,
         SupportedPages.PROCESSING,
+        pathname,
         searchParamsRecord,
         false,
       );

--- a/libs/payments/ui/src/lib/utils/sanitizePathname.spec.ts
+++ b/libs/payments/ui/src/lib/utils/sanitizePathname.spec.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { sanitizePathname } from './sanitizePathname';
+
+describe('sanitizePathname', () => {
+  describe('valid pathnames', () => {
+    it('should accept valid relative pathnames', () => {
+      expect(sanitizePathname('/en/vpn/monthly/checkout/cart123/start')).toBe(
+        '/en/vpn/monthly/checkout/cart123/start'
+      );
+      expect(sanitizePathname('/en/vpn/monthly/checkout/cart123/error')).toBe(
+        '/en/vpn/monthly/checkout/cart123/error'
+      );
+      expect(sanitizePathname('/simple/path')).toBe('/simple/path');
+      expect(sanitizePathname('/')).toBe('/');
+    });
+
+    it('should normalize paths with query strings', () => {
+      expect(
+        sanitizePathname('/en/vpn/monthly/checkout/cart123/start?foo=bar')
+      ).toBe('/en/vpn/monthly/checkout/cart123/start');
+    });
+
+    it('should normalize paths with fragments', () => {
+      expect(
+        sanitizePathname('/en/vpn/monthly/checkout/cart123/start#section')
+      ).toBe('/en/vpn/monthly/checkout/cart123/start');
+    });
+
+    it('should normalize paths with ../ (path traversal)', () => {
+      // Path traversal is normalized by URL constructor
+      expect(sanitizePathname('/en/../vpn/monthly')).toBe('/vpn/monthly');
+      expect(sanitizePathname('/en/vpn/../../other')).toBe('/other');
+    });
+  });
+
+  describe('security - should reject malicious pathnames', () => {
+    it('should reject absolute URLs with http://', () => {
+      expect(() =>
+        sanitizePathname('http://evil.com/phishing')
+      ).toThrow('Absolute URLs are not allowed');
+    });
+
+    it('should reject absolute URLs with https://', () => {
+      expect(() =>
+        sanitizePathname('https://evil.com/phishing')
+      ).toThrow('Absolute URLs are not allowed');
+    });
+
+    it('should reject protocol-relative URLs', () => {
+      expect(() =>
+        sanitizePathname('//evil.com/phishing')
+      ).toThrow('Absolute URLs are not allowed');
+    });
+
+    it('should reject javascript: URLs', () => {
+      expect(() =>
+        sanitizePathname('javascript:alert(1)')
+      ).toThrow();
+    });
+
+    it('should reject data: URLs', () => {
+      expect(() =>
+        sanitizePathname('data:text/html,<script>alert(1)</script>')
+      ).toThrow();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should reject empty strings', () => {
+      expect(() => sanitizePathname('')).toThrow(
+        'Invalid pathname: must be a non-empty string'
+      );
+    });
+
+    it('should reject non-string inputs', () => {
+      expect(() => sanitizePathname(null as any)).toThrow(
+        'Invalid pathname: must be a non-empty string'
+      );
+      expect(() => sanitizePathname(undefined as any)).toThrow(
+        'Invalid pathname: must be a non-empty string'
+      );
+      expect(() => sanitizePathname(123 as any)).toThrow(
+        'Invalid pathname: must be a non-empty string'
+      );
+    });
+
+    it('should handle encoded characters', () => {
+      expect(sanitizePathname('/en/vpn%20test/monthly')).toBe(
+        '/en/vpn%20test/monthly'
+      );
+    });
+
+    it('should handle multiple slashes', () => {
+      expect(sanitizePathname('/en//vpn///monthly')).toBe('/en//vpn///monthly');
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/utils/sanitizePathname.ts
+++ b/libs/payments/ui/src/lib/utils/sanitizePathname.ts
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Sanitizes a pathname to prevent open redirect vulnerabilities.
+ * 
+ * This function ensures that the pathname:
+ * 1. Is a relative path (not an absolute URL)
+ * 2. Starts with a forward slash
+ * 3. Cannot navigate to external domains
+ * 
+ * @param pathname - The pathname to sanitize (may come from untrusted client input)
+ * @returns A safe, normalized pathname that always starts with '/'
+ * @throws Error if the pathname cannot be safely normalized
+ * 
+ * @example
+ * sanitizePathname('/en/vpn/monthly/checkout/cart123/start') // => '/en/vpn/monthly/checkout/cart123/start'
+ * sanitizePathname('https://evil.com/phishing') // => throws Error
+ * sanitizePathname('../../../etc/passwd') // => '/etc/passwd' (safe, but won't match any routes)
+ */
+export function sanitizePathname(pathname: string): string {
+  if (!pathname || typeof pathname !== 'string') {
+    throw new Error('Invalid pathname: must be a non-empty string');
+  }
+
+  // If it looks like an absolute URL, extract only the pathname
+  try {
+    if (pathname.includes('://') || pathname.startsWith('//')) {
+      // This could be an external URL - reject it
+      throw new Error('Absolute URLs are not allowed');
+    }
+  } catch (error) {
+    throw new Error(`Invalid pathname: ${error instanceof Error ? error.message : 'unknown error'}`);
+  }
+
+  // Normalize the pathname by parsing it as a URL
+  // Using a dummy base ensures we only get the pathname part
+  let normalizedPath: string;
+  try {
+    const url = new URL(pathname, 'http://localhost');
+    normalizedPath = url.pathname;
+  } catch (error) {
+    // If URL parsing fails, reject it
+    throw new Error('Invalid pathname format');
+  }
+
+  // Ensure the path starts with '/'
+  if (!normalizedPath.startsWith('/')) {
+    throw new Error('Pathname must start with /');
+  }
+
+  return normalizedPath;
+}


### PR DESCRIPTION
## Because

- Next.js 15 requires full relative paths for redirects
- Partial relative paths like redirect('error') cause TypeError

## This pull request

- Adds currentPathname param to redirect actions
- Updates components to pass pathname from usePathname()
- Maintains URL structure by replacing last segment
- Adds sanitizePathname() to block external URLs and XSS vectors

## Issue that this pull request solves

Closes: PAY-3653

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
