### PR TITLE
fix(settings): add fallback text to webauthn error mapping and clarify field names

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -179,7 +179,9 @@ describe('PagePasskeyAdd', () => {
     mockHandleWebAuthnError.mockReturnValue({
       category: WebAuthnErrorCategory.UserAction,
       errorType: WebAuthnErrorType.NotAllowed,
-      userMessageKey: 'passkey-registration-error-not-allowed',
+      ftlId: 'passkey-registration-error-not-allowed',
+      fallbackText:
+        'Passkey setup failed or is unavailable. Try again or choose another method.',
       logToSentry: false,
     });
 
@@ -198,7 +200,8 @@ describe('PagePasskeyAdd', () => {
     mockHandleWebAuthnError.mockReturnValue({
       category: WebAuthnErrorCategory.UserAction,
       errorType: WebAuthnErrorType.Timeout,
-      userMessageKey: 'passkey-registration-error-timeout',
+      ftlId: 'passkey-registration-error-timeout',
+      fallbackText: 'Passkey setup was canceled. Try again.',
       logToSentry: false,
     });
 

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -101,13 +101,7 @@ export const PagePasskeyAdd = () => {
             Sentry.captureException
           );
           alertBar.error(
-            ftlMsgResolver.getMsg(
-              categorized.userMessageKey,
-              ftlMsgResolver.getMsg(
-                'page-passkey-add-error-system',
-                'System not available. Try again later.'
-              )
-            )
+            ftlMsgResolver.getMsg(categorized.ftlId, categorized.fallbackText)
           );
           navigateToSettings();
           return;

--- a/packages/fxa-settings/src/lib/passkeys/webauthn-errors.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn-errors.test.ts
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import fs from 'fs';
+import path from 'path';
 import {
   categorizeWebAuthnError,
+  ERROR_MAP,
   handleWebAuthnError,
   WebAuthnErrorCategory,
   WebAuthnErrorType,
@@ -30,8 +33,9 @@ describe('categorizeWebAuthnError — user-action errors (no Sentry)', () => {
         expect(result.category).toBe(WebAuthnErrorCategory.UserAction);
         expect(result.errorType).toBe(errorType);
         expect(result.logToSentry).toBe(false);
-        expect(result.userMessageKey).toContain(operation);
-        expect(result.userMessageKey).toMatch(/passkey-.+-error-.+/);
+        expect(result.ftlId).toContain(operation);
+        expect(result.ftlId).toMatch(/passkey-.+-error-.+/);
+        expect(result.fallbackText).toMatch(/passkey/i);
       }
     );
   });
@@ -42,9 +46,10 @@ describe('categorizeWebAuthnError — user-action errors (no Sentry)', () => {
       dom('NotAllowedError'),
       'authentication'
     );
-    expect(reg.userMessageKey).not.toBe(auth.userMessageKey);
-    expect(reg.userMessageKey).toContain('registration');
-    expect(auth.userMessageKey).toContain('authentication');
+    expect(reg.ftlId).not.toBe(auth.ftlId);
+    expect(reg.ftlId).toContain('registration');
+    expect(auth.ftlId).toContain('authentication');
+    expect(reg.fallbackText).not.toBe(auth.fallbackText);
   });
 });
 
@@ -64,6 +69,10 @@ describe('categorizeWebAuthnError — device/platform errors (no Sentry)', () =>
         expect(result.category).toBe(WebAuthnErrorCategory.DevicePlatform);
         expect(result.errorType).toBe(errorType);
         expect(result.logToSentry).toBe(false);
+        expect(result.fallbackText.length).toBeGreaterThan(0);
+        expect(result.fallbackText).toMatch(
+          /passkey|authenticator|secure site/i
+        );
       }
     );
   });
@@ -77,8 +86,8 @@ describe('categorizeWebAuthnError — device/platform errors (no Sentry)', () =>
       dom('InvalidStateError'),
       'authentication'
     );
-    expect(reg.userMessageKey).toContain('registration');
-    expect(auth.userMessageKey).toContain('authentication');
+    expect(reg.ftlId).toContain('registration');
+    expect(auth.ftlId).toContain('authentication');
   });
 });
 
@@ -123,7 +132,8 @@ describe('categorizeWebAuthnError — unexpected errors (Sentry enabled)', () =>
       expect(result.category).toBe(WebAuthnErrorCategory.Unexpected);
       expect(result.errorType).toBe(WebAuthnErrorType.Unknown);
       expect(result.logToSentry).toBe(true);
-      expect(result.userMessageKey).toContain(operation);
+      expect(result.ftlId).toContain(operation);
+      expect(result.fallbackText).toMatch(/try|went wrong/i);
     }
   );
 
@@ -133,9 +143,9 @@ describe('categorizeWebAuthnError — unexpected errors (Sentry enabled)', () =>
       dom('ConstraintError'),
       'authentication'
     );
-    expect(reg.userMessageKey).toContain('registration');
-    expect(reg.userMessageKey).toContain('constraint');
-    expect(auth.userMessageKey).toContain('unexpected');
+    expect(reg.ftlId).toContain('registration');
+    expect(reg.ftlId).toContain('constraint');
+    expect(auth.ftlId).toContain('unexpected');
   });
 });
 
@@ -161,6 +171,31 @@ describe('categorizeWebAuthnError — non-DOMException inputs default to unexpec
       expect(result.logToSentry).toBe(true);
     }
   );
+});
+
+describe('fallbackText matches FTL strings', () => {
+  const ftlPath = path.resolve(__dirname, 'en.ftl');
+  const ftlContent = fs.readFileSync(ftlPath, 'utf-8');
+
+  const ftlMessages = new Map<string, string>();
+  for (const line of ftlContent.split('\n')) {
+    const match = line.match(
+      /^(passkey-(?:registration|authentication)-error-\S+)\s*=\s*(.+)$/
+    );
+    if (match) {
+      ftlMessages.set(match[1], match[2].trim());
+    }
+  }
+
+  const entries = Object.entries(ERROR_MAP);
+
+  describe.each(OPERATIONS)('operation: %s', (operation) => {
+    test.each(entries)('%s fallbackText matches FTL', (_, entry) => {
+      const ftlValue = ftlMessages.get(entry.ftlId[operation]);
+      expect(ftlValue).toBeDefined();
+      expect(entry.fallbackText[operation]).toBe(ftlValue);
+    });
+  });
 });
 
 describe('handleWebAuthnError', () => {

--- a/packages/fxa-settings/src/lib/passkeys/webauthn-errors.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn-errors.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/** Which WebAuthn ceremony produced the error. Determines user-facing message. */
 export type WebAuthnOperation = 'registration' | 'authentication';
 
 /**
@@ -37,13 +36,10 @@ export enum WebAuthnErrorType {
 }
 
 export interface CategorizedWebAuthnError {
-  /** High-level grouping for Sentry routing and UI messaging strategy. */
   category: WebAuthnErrorCategory;
-  /** Specific error type, useful for metrics and fine-grained UI messaging. */
   errorType: WebAuthnErrorType;
-  /** FTL key for the user-facing error message. Operation-specific where messages differ. */
-  userMessageKey: string;
-  /** When true, the caller should report this error to Sentry. */
+  ftlId: string;
+  fallbackText: string;
   logToSentry: boolean;
 }
 
@@ -51,27 +47,48 @@ interface ErrorEntry {
   category: WebAuthnErrorCategory;
   errorType: WebAuthnErrorType;
   logToSentry: boolean;
-  /** Per-operation FTL keys. Separate keys allow distinct user-facing copy per context. */
-  messageKeys: Record<WebAuthnOperation, string>;
+  ftlId: Record<WebAuthnOperation, string>;
+  fallbackText: Record<WebAuthnOperation, string>;
 }
 
-const ERROR_MAP: Readonly<Record<string, ErrorEntry>> = {
+const UNEXPECTED_FALLBACK: Record<WebAuthnOperation, string> = {
+  registration: 'Passkey setup failed. Try again or choose another method.',
+  authentication:
+    'Something went wrong. Try again or choose another sign-in method.',
+};
+
+const UNEXPECTED_FTL_ID: Record<WebAuthnOperation, string> = {
+  registration: 'passkey-registration-error-unexpected',
+  authentication: 'passkey-authentication-error-unexpected',
+};
+
+export const ERROR_MAP: Record<string, ErrorEntry> = {
   NotAllowedError: {
     category: WebAuthnErrorCategory.UserAction,
     errorType: WebAuthnErrorType.NotAllowed,
     logToSentry: false,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-not-allowed',
       authentication: 'passkey-authentication-error-not-allowed',
+    },
+    fallbackText: {
+      registration:
+        'Passkey setup failed or is unavailable. Try again or choose another method.',
+      authentication:
+        'Sign-in with passkey failed or is unavailable. Try again or choose another method.',
     },
   },
   TimeoutError: {
     category: WebAuthnErrorCategory.UserAction,
     errorType: WebAuthnErrorType.Timeout,
     logToSentry: false,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-timeout',
       authentication: 'passkey-authentication-error-timeout',
+    },
+    fallbackText: {
+      registration: 'Passkey setup was canceled. Try again.',
+      authentication: 'Passkey request timed out. Please try again.',
     },
   },
 
@@ -79,108 +96,108 @@ const ERROR_MAP: Readonly<Record<string, ErrorEntry>> = {
     category: WebAuthnErrorCategory.DevicePlatform,
     errorType: WebAuthnErrorType.NotSupported,
     logToSentry: false,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-not-supported',
       authentication: 'passkey-authentication-error-not-supported',
+    },
+    fallbackText: {
+      registration: `Passkeys aren’t supported here. Try another method or device.`,
+      authentication: `Passkeys aren’t supported. Try another method or device.`,
     },
   },
   SecurityError: {
     category: WebAuthnErrorCategory.DevicePlatform,
     errorType: WebAuthnErrorType.Security,
     logToSentry: false,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-security',
       authentication: 'passkey-authentication-error-security',
     },
+    fallbackText: {
+      registration: `Passkeys can’t be set up on this page. Use the secure site and try again.`,
+      authentication: `Passkeys can’t be used on this page. Check you’re on the correct secure site and try again.`,
+    },
   },
-  // Registration: credential already exists on this authenticator for this RP.
   InvalidStateError: {
     category: WebAuthnErrorCategory.DevicePlatform,
     errorType: WebAuthnErrorType.InvalidState,
     logToSentry: false,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-invalid-state',
       authentication: 'passkey-authentication-error-invalid-state',
     },
+    fallbackText: {
+      registration:
+        'This passkey is already registered. Use it to sign in or add a different passkey.',
+      authentication:
+        'Something went wrong with your passkey. Try again or use another sign-in method.',
+    },
   },
-  // Authenticator I/O failure (e.g., security key unplugged mid-ceremony).
   NotReadableError: {
     category: WebAuthnErrorCategory.DevicePlatform,
     errorType: WebAuthnErrorType.NotReadable,
     logToSentry: false,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-not-readable',
       authentication: 'passkey-authentication-error-not-readable',
     },
+    fallbackText: {
+      registration: `We couldn’t access the authenticator. Try again or choose another method.`,
+      authentication: `We couldn’t access the authenticator. Try again or use another sign-in method.`,
+    },
   },
 
-  // TypeError is not a DOMException — handled via instanceof in categorizeWebAuthnError.
   TypeError: {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Type,
     logToSentry: true,
-    messageKeys: {
-      registration: 'passkey-registration-error-unexpected',
-      authentication: 'passkey-authentication-error-unexpected',
-    },
+    ftlId: UNEXPECTED_FTL_ID,
+    fallbackText: UNEXPECTED_FALLBACK,
   },
-  // Malformed encoding in create()/get() options (invalid base64url, bad credential ID format).
   DataError: {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Data,
     logToSentry: true,
-    messageKeys: {
-      registration: 'passkey-registration-error-unexpected',
-      authentication: 'passkey-authentication-error-unexpected',
-    },
+    ftlId: UNEXPECTED_FTL_ID,
+    fallbackText: UNEXPECTED_FALLBACK,
   },
-  // Thrown by parseCreationOptionsFromJSON() / parseRequestOptionsFromJSON() for malformed options.
   EncodingError: {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Encoding,
     logToSentry: true,
-    messageKeys: {
-      registration: 'passkey-registration-error-unexpected',
-      authentication: 'passkey-authentication-error-unexpected',
-    },
+    ftlId: UNEXPECTED_FTL_ID,
+    fallbackText: UNEXPECTED_FALLBACK,
   },
-  // Registration has distinct copy: "not available with this device".
   ConstraintError: {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Constraint,
     logToSentry: true,
-    messageKeys: {
+    ftlId: {
       registration: 'passkey-registration-error-constraint',
       authentication: 'passkey-authentication-error-unexpected',
+    },
+    fallbackText: {
+      registration: `Passkey setup isn’t available with this device. Try another method or device.`,
+      authentication: UNEXPECTED_FALLBACK.authentication,
     },
   },
   OperationError: {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Operation,
     logToSentry: true,
-    messageKeys: {
-      registration: 'passkey-registration-error-unexpected',
-      authentication: 'passkey-authentication-error-unexpected',
-    },
+    ftlId: UNEXPECTED_FTL_ID,
+    fallbackText: UNEXPECTED_FALLBACK,
   },
-  // Thrown by our wrappers when the browser returns a null or unexpected credential type.
   UnknownError: {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Unknown,
     logToSentry: true,
-    messageKeys: {
-      registration: 'passkey-registration-error-unexpected',
-      authentication: 'passkey-authentication-error-unexpected',
-    },
+    ftlId: UNEXPECTED_FTL_ID,
+    fallbackText: UNEXPECTED_FALLBACK,
   },
 };
 
-/**
- * Translates a raw error thrown by createCredential() or getCredential() into
- * a semantic, UI-safe error category with an operation-specific FTL message key.
- *
- * Never throws; unrecognized errors default to the 'unexpected' category.
- */
+/** Never throws; unrecognized errors default to the 'unexpected' category. */
 export function categorizeWebAuthnError(
   error: unknown,
   operation: WebAuthnOperation
@@ -198,7 +215,8 @@ export function categorizeWebAuthnError(
       return {
         category: entry.category,
         errorType: entry.errorType,
-        userMessageKey: entry.messageKeys[operation],
+        ftlId: entry.ftlId[operation],
+        fallbackText: entry.fallbackText[operation],
         logToSentry: entry.logToSentry,
       };
     }
@@ -207,17 +225,13 @@ export function categorizeWebAuthnError(
   return {
     category: WebAuthnErrorCategory.Unexpected,
     errorType: WebAuthnErrorType.Unknown,
-    userMessageKey: `passkey-${operation}-error-unexpected`,
+    ftlId: UNEXPECTED_FTL_ID[operation],
+    fallbackText: UNEXPECTED_FALLBACK[operation],
     logToSentry: true,
   };
 }
 
-/**
- * Categorizes a WebAuthn error and fires captureException when logToSentry is
- * true. Intended as the single call site in each flow's error handler.
- *
- * @param captureException — pass Sentry.captureException or equivalent.
- */
+/** Categorizes and reports to Sentry when logToSentry is true. */
 export function handleWebAuthnError(
   error: unknown,
   operation: WebAuthnOperation,


### PR DESCRIPTION
## Because

- The error map only stored FTL keys, leaving callers without a single source of truth for fallbacks
- Field names (messageKeys, userMessageKey) were ambiguous

## This pull request

- Renames messageKeys → ftlId and userMessageKey → ftlId on ErrorEntry and CategorizedWebAuthnError
- Adds fallbackText field with English strings matching the FTL file exactly
- Extracts UNEXPECTED_FALLBACK and UNEXPECTED_FTL_ID constants to eliminate duplication
- Updates tests with fallbackText assertions across all error categories

## Issue that this pull request solves

Issue: FXA-12912

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
