### PR TITLE
fix(payments-api): stripe webhooks not recording glean

### DIFF
--- a/apps/payments/api/project.json
+++ b/apps/payments/api/project.json
@@ -55,7 +55,6 @@
       "continuous": true,
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",
-      "dependsOn": ["build"],
       "options": {
         "buildTarget": "payments-api:build",
         "runBuildTargetDependencies": false
@@ -70,7 +69,8 @@
       }
     },
     "start": {
-      "command": "pm2 start apps/payments/api/pm2.config.js && yarn check:url localhost:3037/__heartbeat__"
+      "command": "pm2 start apps/payments/api/pm2.config.js && yarn check:url localhost:3037/__heartbeat__",
+      "dependsOn": []
     },
     "stop": {
       "command": "pm2 stop apps/payments/api/pm2.config.js"

--- a/apps/payments/api/src/app/app.module.ts
+++ b/apps/payments/api/src/app/app.module.ts
@@ -34,9 +34,12 @@ import { CurrencyManager } from '@fxa/payments/currency';
 import { AccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { AccountManager } from '@fxa/shared/account/account';
 import { CartManager } from '@fxa/payments/cart';
-import { CmsContentValidationManager, ProductConfigurationManager, StrapiClient } from '@fxa/shared/cms';
 import {
-  MockPaymentsGleanFactory,
+  CmsContentValidationManager,
+  ProductConfigurationManager,
+  StrapiClient,
+} from '@fxa/shared/cms';
+import {
   PaymentsGleanManager,
   PaymentsGleanService,
 } from '@fxa/payments/metrics';
@@ -60,7 +63,12 @@ import { NimbusClient, NimbusClientConfig } from '@fxa/shared/experiments';
       }),
     }),
   ],
-  controllers: [AppController, CmsWebhooksController, FxaWebhooksController, StripeWebhooksController],
+  controllers: [
+    AppController,
+    CmsWebhooksController,
+    FxaWebhooksController,
+    StripeWebhooksController,
+  ],
   providers: [
     Logger,
     AccountDatabaseNestFactory,
@@ -96,7 +104,6 @@ import { NimbusClient, NimbusClientConfig } from '@fxa/shared/experiments';
     NimbusManagerConfig,
     NimbusClient,
     NimbusClientConfig,
-    MockPaymentsGleanFactory,
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
## Because

- The Stripe webhook handler is not recording glean events.

## This pull request

- Removes mock glean provider from payments-api app module.

## Issue that this pull request solves

Closes: #PAY-3321

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Accept stripe webhook events locally using the Stripe CLI
- Create a customer with a subscription
- Delete the subscription and ensure the webhook is received locally and that the glean event is recorded in stdout

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
