### PR TITLE
feat(payment-next): Pass experimentationPreview param through to Nimbus

### DIFF
--- a/apps/payments/next/app/[locale]/error.tsx
+++ b/apps/payments/next/app/[locale]/error.tsx
@@ -32,7 +32,8 @@ export default function Error({
   const [loading, setLoading] = useState(false);
   const { locale, offeringId, interval, cartId } = useParams<ErrorParams>();
   const hasProductData = locale && offeringId && interval;
-  const queryParams = useSearchParams().toString();
+  const searchParams = useSearchParams();
+  const queryParams = searchParams.toString();
 
   const SUPPORT_URL = process.env.SUPPORT_URL ?? 'https://support.mozilla.org';
 
@@ -40,7 +41,10 @@ export default function Error({
   async function redirectWithCart() {
     setLoading(true);
     try {
-      const cart = await getCartAction(cartId);
+      const cart = await getCartAction(
+        cartId,
+        Object.fromEntries(searchParams.entries())
+      );
       if (cart.state === 'start') {
         const newCart = await restartCartAction(cartId);
         setLoading(false);

--- a/libs/payments/cart/src/index.ts
+++ b/libs/payments/cart/src/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 export * from './lib/cart.types';
+export * from './lib/searchParams.schema';
 export * from './lib/cart.factories';
 export * from './lib/cart.manager';
 export * from './lib/cart.service';

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -2491,6 +2491,7 @@ describe('CartService', () => {
         countryCode: mockCart.taxAddress?.countryCode,
         interval: mockCart.interval,
         eligibilityStatus: EligibilityStatus.CREATE,
+        searchParams: undefined,
       });
     });
 

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -107,6 +107,7 @@ import {
 } from './cart.utils';
 import { SubmitNeedsInputFailedError } from './checkout.error';
 import { CheckoutService } from './checkout.service';
+import type { PaymentsSearchParams } from './searchParams.schema';
 import { resolveErrorInstance } from './util/resolveErrorInstance';
 import { isPaymentIntentId } from './util/isPaymentIntentId';
 import { isPaymentIntent } from './util/isPaymentIntent';
@@ -881,7 +882,10 @@ export class CartService {
    * Fetch a cart from the database by ID
    */
   @SanitizeExceptions()
-  async getCart(cartId: string): Promise<CartDTO> {
+  async getCart(
+    cartId: string,
+    searchParams?: PaymentsSearchParams
+  ): Promise<CartDTO> {
     const cart = (await this.cartManager.fetchCartById(
       cartId
     )) as ResultCart & { taxAddress: TaxAddress; currency: string };
@@ -938,6 +942,7 @@ export class CartService {
           countryCode: cart.taxAddress.countryCode || '',
           interval: cart.interval as SubplatInterval,
           eligibilityStatus: eligibility.subscriptionEligibilityResult,
+          searchParams,
         }
       );
     }

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -98,6 +98,7 @@ import {
 } from '@fxa/payments/metrics';
 import { isCancelInterstitialOffer } from './util/isCancelInterstitialOffer';
 import { FreeTrialManager } from './free-trial.manager';
+import type { PaymentsSearchParams } from './searchParams.schema';
 
 const FREE_TRIAL_PREPAID_CARD_BLOCKED_HOURS = 24;
 
@@ -999,9 +1000,16 @@ export class CheckoutService {
     countryCode: string;
     interval: SubplatInterval;
     eligibilityStatus: EligibilityStatus;
+    searchParams?: PaymentsSearchParams;
   }): Promise<FreeTrial | null> {
-    const { uid, offeringConfigId, countryCode, interval, eligibilityStatus } =
-      args;
+    const {
+      uid,
+      offeringConfigId,
+      countryCode,
+      interval,
+      eligibilityStatus,
+      searchParams,
+    } = args;
 
     if (eligibilityStatus !== EligibilityStatus.CREATE) {
       return null;
@@ -1010,7 +1018,7 @@ export class CheckoutService {
     const fetchResult = await Promise.all([
       this.nimbusManager.fetchExperiments({
         nimbusUserId: this.nimbusManager.generateNimbusId(uid),
-        preview: false,
+        preview: searchParams?.experimentationPreview === 'true',
       }),
       this.productConfigurationManager.getFreeTrial(offeringConfigId),
     ]).catch((error) => {

--- a/libs/payments/cart/src/lib/searchParams.schema.ts
+++ b/libs/payments/cart/src/lib/searchParams.schema.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { z } from 'zod';
+
+// Known query params that payments code reads off of the incoming URL.
+// `.passthrough()` keeps unknown keys on the parsed object — searchParams
+// are user-controlled and we never want to drop or reject unexpected values.
+export const paymentsSearchParamsSchema = z
+  .object({
+    experimentationPreview: z.string().optional(),
+  })
+  .passthrough();
+
+export type PaymentsSearchParams = z.infer<typeof paymentsSearchParamsSchema>;

--- a/libs/payments/ui/src/lib/actions/getCart.ts
+++ b/libs/payments/ui/src/lib/actions/getCart.ts
@@ -5,10 +5,15 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import { parseSearchParams } from '../utils/searchParams';
 
-export const getCartAction = async (cartId: string) => {
+export const getCartAction = async (
+  cartId: string,
+  searchParams?: Record<string, string | string[] | undefined>
+) => {
   const cart = await getApp().getActionsService().getCart({
     cartId,
+    searchParams: parseSearchParams(searchParams),
   });
 
   return cart;

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -10,6 +10,7 @@ import { getRedirect, validateCartState } from '../utils/get-cart';
 import { SupportedPages } from '../utils/types';
 import { URLSearchParams } from 'url';
 import { sanitizePathname } from '../utils/sanitizePathname';
+import { parseSearchParams } from '../utils/searchParams';
 import {
   StartCartDTO,
   ProcessingCartDTO,
@@ -68,6 +69,7 @@ async function getCartOrRedirectAction(
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';
   const cart = await getApp().getActionsService().getCart({
     cartId,
+    searchParams: parseSearchParams(searchParams),
   });
 
   if (!validateCartState(cart.state, page)) {

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -8,6 +8,7 @@ import { GoogleManager } from '@fxa/google';
 import {
   CartInvalidStateForActionError,
   CartService,
+  type PaymentsSearchParams,
   SubscriptionAttributionParams,
   SuccessCartDTO,
   TaxChangeAllowedStatus,
@@ -207,8 +208,11 @@ export class NextJSActionsService {
   @NextIOValidator(GetCartActionArgs, GetCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async getCart(args: { cartId: string }) {
-    return this.cartService.getCart(args.cartId);
+  async getCart(args: {
+    cartId: string;
+    searchParams?: PaymentsSearchParams;
+  }) {
+    return this.cartService.getCart(args.cartId, args.searchParams);
   }
 
   @SanitizeExceptions()
@@ -249,8 +253,11 @@ export class NextJSActionsService {
   @NextIOValidator(GetCartActionArgs, GetSuccessCartActionResult)
   @WithTypeCachableAsyncLocalStorage()
   @CaptureTimingWithStatsD()
-  async getSuccessCart(args: { cartId: string }): Promise<SuccessCartDTO> {
-    const cart = await this.cartService.getCart(args.cartId);
+  async getSuccessCart(args: {
+    cartId: string;
+    searchParams?: PaymentsSearchParams;
+  }): Promise<SuccessCartDTO> {
+    const cart = await this.cartService.getCart(args.cartId, args.searchParams);
 
     if (cart.state !== CartState.SUCCESS) {
       throw new Error('Cart is not in success state');

--- a/libs/payments/ui/src/lib/nestapp/validators/GetCartActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetCartActionArgs.ts
@@ -2,9 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { IsString } from 'class-validator';
+import type { PaymentsSearchParams } from '@fxa/payments/cart';
+import { IsObject, IsOptional, IsString } from 'class-validator';
 
 export class GetCartActionArgs {
   @IsString()
   cartId!: string;
+
+  @IsObject()
+  @IsOptional()
+  searchParams?: PaymentsSearchParams;
 }

--- a/libs/payments/ui/src/lib/utils/searchParams.ts
+++ b/libs/payments/ui/src/lib/utils/searchParams.ts
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  paymentsSearchParamsSchema,
+  type PaymentsSearchParams,
+} from '@fxa/payments/cart';
+import { flattenRouteParams } from './flatParam';
+
+/**
+ * Flattens raw Next.js searchParams (which may contain arrays or undefineds)
+ * and runs them through the payments searchParams schema.
+ *
+ * The schema is `.passthrough()`-based and all fields are optional, so this
+ * never throws — it returns a typed view of the known keys while preserving
+ * any unknown keys on the returned object. Callers can trust the declared
+ * shape for autocompletion; unknown keys remain readable via index access.
+ */
+export const parseSearchParams = (
+  input: Record<string, string | string[] | undefined> | undefined
+): PaymentsSearchParams | undefined => {
+  if (!input) return undefined;
+  const flat = flattenRouteParams(input);
+  const result = paymentsSearchParamsSchema.safeParse(flat);
+  return result.success ? result.data : flat;
+};


### PR DESCRIPTION
Because:

* The Checkout Service was hardcoding "false" when fetching Nimbus experiments

This commit:

* Passes through the query param through to the nimbusManager.fetchExperiments calls, like is done in the Glean Service

Closes #PAY-3668

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
