### PR TITLE
fix(payments-next): Add free trial reactivation email variant

### DIFF
--- a/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.ts
+++ b/libs/accounts/email-renderer/src/renderer/subplat-email-renderer.ts
@@ -237,7 +237,9 @@ export class SubplatEmailRender extends EmailRenderer {
       template: SubscriptionReactivation.template,
       version: SubscriptionReactivation.version,
       layout: SubscriptionReactivation.layout,
-      includes: SubscriptionReactivation.includes,
+      includes: SubscriptionReactivation.getIncludes(
+        templateValues.isFreeTrialReactivation
+      ),
       ...templateValues,
       ...layoutTemplateValues,
     });

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/en.ftl
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/en.ftl
@@ -1,9 +1,15 @@
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionReactivation-subject = { $productName } subscription reactivated
+subscriptionReactivation-subject-2 = Your { $productName } subscription has been reactivated
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionReactivation-freeTrial-subject = Your { $productName } trial has been reactivated
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionReactivation-title = Thank you for reactivating your { $productName } subscription!
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionReactivation-freeTrial-title = Thank you for reactivating your { $productName } trial!
 # Variables:
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 2016/01/20

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.mjml
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.mjml
@@ -7,7 +7,11 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
+      <% if (isFreeTrialReactivation) { %>
+        <span data-l10n-id="subscriptionReactivation-freeTrial-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> trial!</span>
+      <% } else { %>
+        <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
+      <% } %>
     </mj-text>
 
     <mj-text css-class="text-body">

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.stories.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.stories.ts
@@ -4,7 +4,7 @@
 
 import { Meta } from '@storybook/html';
 import { subplatStoryWithProps } from '../../storybook-email';
-import { includes, TemplateData } from './index';
+import { getIncludes, TemplateData } from './index';
 
 export default {
   title: 'SubPlat Emails/Templates/subscriptionReactivation',
@@ -16,13 +16,28 @@ const data = {
   nextInvoiceDateOnly: '11/13/2021',
   icon: 'https://placekitten.com/512/512',
   subscriptionSupportUrl: 'http://localhost:3030/support',
+  isFreeTrialReactivation: false,
 };
 
 const createStory = subplatStoryWithProps<TemplateData>(
   'subscriptionReactivation',
   'Sent when a user reactivates their subscription.',
   data,
-  includes
+  getIncludes(data.isFreeTrialReactivation)
 );
 
 export const SubscriptionReactivation = createStory();
+
+const freeTrialData = {
+  ...data,
+  isFreeTrialReactivation: true,
+};
+
+const createFreeTrialStory = subplatStoryWithProps<TemplateData>(
+  'subscriptionReactivation',
+  'Sent when a user reactivates their subscription while still in a free trial.',
+  freeTrialData,
+  getIncludes(freeTrialData.isFreeTrialReactivation)
+);
+
+export const SubscriptionReactivationFreeTrial = createFreeTrialStory();

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.ts
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.ts
@@ -12,14 +12,23 @@ export type TemplateData = IconTemplateData &
     nextInvoiceDateOnly: string;
     icon: string;
     subscriptionSupportUrl: string;
+    isFreeTrialReactivation: boolean;
   };
 
 export const template = 'subscriptionReactivation';
-export const version = 2;
+export const version = 3;
 export const layout = 'subscription';
-export const includes = {
-  subject: {
-    id: 'subscriptionReactivation-subject-2',
-    message: 'Your <%- productName %> subscription has been reactivated',
-  },
-};
+
+export function getIncludes(isFreeTrialReactivation: boolean) {
+  return {
+    subject: isFreeTrialReactivation
+      ? {
+          id: 'subscriptionReactivation-freeTrial-subject',
+          message: 'Your <%- productName %> trial has been reactivated',
+        }
+      : {
+          id: 'subscriptionReactivation-subject-2',
+          message: 'Your <%- productName %> subscription has been reactivated',
+        },
+  };
+}

--- a/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.txt
+++ b/libs/accounts/email-renderer/src/templates/subscriptionReactivation/index.txt
@@ -1,4 +1,8 @@
+<% if (isFreeTrialReactivation) { %>
+subscriptionReactivation-freeTrial-title = "Thank you for reactivating your <%- productName %> trial!"
+<% } else { %>
 subscriptionReactivation-title = "Thank you for reactivating your <%- productName %> subscription!"
+<% } %>
 
 subscriptionReactivation-content = "Your billing cycle and payment will remain the same. Your next charge will be <%- invoiceTotal %> on <%- nextInvoiceDateOnly %>. Your subscription will automatically renew each billing period unless you choose to cancel."
 

--- a/packages/fxa-auth-server/lib/payments/stripe.spec.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.spec.ts
@@ -7237,6 +7237,7 @@ describe('StripeHelper', () => {
         cardType: card.brand,
         lastFour: card.last4,
         nextInvoiceDate: new Date(mockInvoice.lines.data[0].period.end * 1000),
+        isFreeTrialReactivation: false,
       };
 
       const { lastFour, cardType } = defaultExpected;
@@ -7277,6 +7278,24 @@ describe('StripeHelper', () => {
           [{ subscription: event.data.object.id }],
         ]);
         expect(result).toEqual(defaultExpected);
+      });
+
+      it('sets isFreeTrialReactivation to true when subscription status is trialing', async () => {
+        const event = deepCopy(eventCustomerSubscriptionUpdated);
+        event.data.object.status = 'trialing';
+        jest
+          .spyOn(stripeHelper, 'fetchCustomer')
+          .mockResolvedValue(reactivationMockCustomer);
+        const result =
+          await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
+        expect(result).toEqual({
+          ...defaultExpected,
+          isFreeTrialReactivation: true,
+        });
       });
 
       it('does not throw an exception when payment method is missing', async () => {

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -3380,6 +3380,7 @@ export class StripeHelper extends StripeHelperBase {
       nextInvoiceDate: nextInvoiceDate
         ? new Date(nextInvoiceDate * 1000)
         : null,
+      isFreeTrialReactivation: subscription.status === 'trialing',
       planConfig,
     };
   }

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -3092,6 +3092,7 @@ module.exports = function (log, config, bounces, statsd) {
       lastFour,
       nextInvoiceDate,
       payment_provider,
+      isFreeTrialReactivation = false,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -3142,6 +3143,7 @@ module.exports = function (log, config, bounces, statsd) {
         cardName: cardTypeToText(cardType),
         lastFour,
         nextInvoiceDate,
+        isFreeTrialReactivation,
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_versions.json
@@ -1,6 +1,6 @@
 {
   "freeTrialEndingReminder": 2,
-  "subscriptionReactivation": 2,
+  "subscriptionReactivation": 3,
   "subscriptionRenewalReminder": 4,
   "subscriptionEndingReminder": 2,
   "subscriptionUpgrade": 7,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/en.ftl
@@ -1,9 +1,15 @@
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionReactivation-subject = { $productName } subscription reactivated
+subscriptionReactivation-subject-2 = Your { $productName } subscription has been reactivated
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionReactivation-freeTrial-subject = Your { $productName } trial has been reactivated
 # Variables:
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 subscriptionReactivation-title = Thank you for reactivating your { $productName } subscription!
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionReactivation-freeTrial-title = Thank you for reactivating your { $productName } trial!
 # Variables:
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 2016/01/20

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.json
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.json
@@ -1,6 +1,0 @@
-{
-  "subject": {
-    "id": "subscriptionReactivation-subject",
-    "message": "<%- productName %> subscription reactivated"
-  }
-}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/includes.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { GlobalTemplateValues } from '../../../renderer';
+
+export const getIncludes = (
+  isFreeTrialReactivation: boolean
+): GlobalTemplateValues => ({
+  subject: isFreeTrialReactivation
+    ? {
+        id: 'subscriptionReactivation-freeTrial-subject',
+        message: 'Your <%- productName %> trial has been reactivated',
+      }
+    : {
+        id: 'subscriptionReactivation-subject-2',
+        message: 'Your <%- productName %> subscription has been reactivated',
+      },
+});
+
+export default getIncludes;

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
@@ -7,7 +7,11 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
+      <% if (isFreeTrialReactivation) { %>
+        <span data-l10n-id="subscriptionReactivation-freeTrial-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> trial!</span>
+      <% } else { %>
+        <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
+      <% } %>
     </mj-text>
 
     <mj-text css-class="text-body">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.stories.ts
@@ -22,3 +22,18 @@ const createStory = subplatStoryWithProps(
 );
 
 export const SubscriptionReactivation = createStory();
+
+const createFreeTrialStory = subplatStoryWithProps(
+  'subscriptionReactivation',
+  'Sent when a user reactivates their subscription while still in a free trial.',
+  {
+    productName: '123Done Pro',
+    invoiceTotal: '$20',
+    nextInvoiceDateOnly: '11/13/2021',
+    icon: 'https://placekitten.com/512/512',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+    isFreeTrialReactivation: true,
+  }
+);
+
+export const SubscriptionReactivationFreeTrial = createFreeTrialStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.txt
@@ -1,4 +1,8 @@
+<% if (isFreeTrialReactivation) { %>
+subscriptionReactivation-freeTrial-title = "Thank you for reactivating your <%- productName %> trial!"
+<% } else { %>
 subscriptionReactivation-title = "Thank you for reactivating your <%- productName %> subscription!"
+<% } %>
 
 subscriptionReactivation-content = "Your billing cycle and payment will remain the same. Your next charge will be <%- invoiceTotal %> on <%- nextInvoiceDateOnly %>. Your subscription will automatically renew each billing period unless you choose to cancel."
 

--- a/packages/fxa-auth-server/lib/senders/renderer/index.ts
+++ b/packages/fxa-auth-server/lib/senders/renderer/index.ts
@@ -178,6 +178,11 @@ class Renderer extends Localizer {
           },
         };
       }
+      if (context.template === 'subscriptionReactivation') {
+        return (
+          await require(`../emails/templates/${context.template}/includes`)
+        ).getIncludes(context.isFreeTrialReactivation);
+      }
       return require(`../emails/templates/${context.template}/includes.json`);
     } catch (e) {
       throw e;


### PR DESCRIPTION
Because:

* Upon reactivating a free trial after cancelling it, the user receives an email. This email contains language centered around full subscriptions

This commit:

* Updates the emails to include a conditional, changing the banner to reference renewing the users trial when a free trial is being renewed

Closes #PAY-3656

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)
(free trial variant)
<img width="967" height="1104" alt="Screenshot 2026-04-21 at 1 48 02 PM" src="https://github.com/user-attachments/assets/32492635-8510-45b2-964d-5c0cb77bb89b" />

(subscription variant, current/unchanged)
<img width="975" height="999" alt="Screenshot 2026-04-21 at 1 47 56 PM" src="https://github.com/user-attachments/assets/68236ec3-baf5-4409-a01b-32d860e8d9ce" />

