### PR TITLE
fix(storybook): fix page delete account storybook

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageDeleteAccount/index.stories.tsx
@@ -8,6 +8,8 @@ import { LocationProvider } from '@reach/router';
 import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
+import { Account, AppContext } from '../../../models';
+import { mockAppContext, MOCK_ACCOUNT } from '../../../models/mocks';
 
 export default {
   title: 'Pages/Settings/DeleteAccount',
@@ -15,10 +17,31 @@ export default {
   decorators: [withLocalization],
 } as Meta;
 
-export const Default = () => (
-  <LocationProvider>
-    <SettingsLayout>
-      <PageDeleteAccount />
-    </SettingsLayout>
-  </LocationProvider>
-);
+const accountWithPassword = {
+  ...MOCK_ACCOUNT,
+  hasPassword: true,
+  destroy: () => Promise.resolve(),
+} as unknown as Account;
+
+const accountWithoutPassword = {
+  ...MOCK_ACCOUNT,
+  hasPassword: false,
+  destroy: () => Promise.resolve(),
+} as unknown as Account;
+
+const storyWithContext = (account: Account) => {
+  const story = () => (
+    <LocationProvider>
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <SettingsLayout>
+          <PageDeleteAccount />
+        </SettingsLayout>
+      </AppContext.Provider>
+    </LocationProvider>
+  );
+  return story;
+};
+
+export const Default = storyWithContext(accountWithPassword);
+
+export const WithoutPassword = storyWithContext(accountWithoutPassword);


### PR DESCRIPTION
## Because

- Page Delete account storybook was broken (missing App Context Provider)

## This pull request

- wraps PageDeleteAccount in AppContext.Provider with mockAppContext(), which supplies the missing authClient
- expands story variants to include both `default` and `passwordless` accounts

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="288" height="94" alt="image" src="https://github.com/user-attachments/assets/bb3db880-d48f-44a1-8a95-4d55be057f2f" />

<img width="704" height="724" alt="image" src="https://github.com/user-attachments/assets/15835f55-15ca-4127-b3c1-058465555a89" />

<img width="655" height="696" alt="image" src="https://github.com/user-attachments/assets/897bbf68-e51c-46ee-a786-fd7014aa20b0" />


## Other information (Optional)

Any other information that is important to this pull request.
