### PR TITLE
fix(storybook): fix broken PageSecondaryEmailAdd and PageChangePassword stories

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageChangePassword/index.stories.tsx
@@ -9,6 +9,8 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { MfaContext } from '../MfaGuard';
+import { AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
 
 export default {
   title: 'Pages/Settings/ChangePassword',
@@ -18,10 +20,12 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <SettingsLayout>
-      <MfaContext.Provider value="password">
-        <PageChangePassword />
-      </MfaContext.Provider>
-    </SettingsLayout>
+    <AppContext.Provider value={mockAppContext()}>
+      <SettingsLayout>
+        <MfaContext.Provider value="password">
+          <PageChangePassword />
+        </MfaContext.Provider>
+      </SettingsLayout>
+    </AppContext.Provider>
   </LocationProvider>
 );

--- a/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PageSecondaryEmailAdd/index.stories.tsx
@@ -9,6 +9,8 @@ import { Meta } from '@storybook/react';
 import { withLocalization } from 'fxa-react/lib/storybooks';
 import SettingsLayout from '../SettingsLayout';
 import { MfaContext } from '../MfaGuard';
+import { AppContext } from '../../../models';
+import { mockAppContext } from '../../../models/mocks';
 
 export default {
   title: 'Pages/Settings/SecondaryEmailAdd',
@@ -18,10 +20,12 @@ export default {
 
 export const Default = () => (
   <LocationProvider>
-    <SettingsLayout>
-      <MfaContext.Provider value="email">
-        <PageSecondaryEmailAdd />
-      </MfaContext.Provider>
-    </SettingsLayout>
+    <AppContext.Provider value={mockAppContext()}>
+      <SettingsLayout>
+        <MfaContext.Provider value="email">
+          <PageSecondaryEmailAdd />
+        </MfaContext.Provider>
+      </SettingsLayout>
+    </AppContext.Provider>
   </LocationProvider>
 );


### PR DESCRIPTION
## Because

- PageSecondaryEmailAdd and PageChangePassword stories were not loading because of a missing AppContext Provider

## This pull request

- Adds the missing provider

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
