### PR TITLE
chore(123done): replace esbuild with tsc/ts-node in packages/123done

### DIFF
--- a/packages/123done/pm2.config.js
+++ b/packages/123done/pm2.config.js
@@ -10,7 +10,8 @@ module.exports = {
   apps: [
     {
       name: '123done',
-      script: 'node server.js',
+      script:
+        'node -r ts-node/register/transpile-only -r tsconfig-paths/register server.js',
       cwd: __dirname,
       max_restarts: '1',
       env: {
@@ -26,7 +27,8 @@ module.exports = {
     },
     {
       name: '321done',
-      script: 'node server.js',
+      script:
+        'node -r ts-node/register/transpile-only -r tsconfig-paths/register server.js',
       cwd: __dirname,
       max_restarts: '1',
       env: {

--- a/packages/123done/tsconfig.json
+++ b/packages/123done/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["*.js"]
+}


### PR DESCRIPTION
Split of #20390 into per-folder PRs. Scope: `packages/123done`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `packages/123done`.
- One of 18 split PRs from #20390.

## Issue that this pull request solves

Closes: FXA-13661

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

## Other information (Optional)