### PR TITLE
chore(payments-server): replace esbuild with tsc/ts-node in packages/fxa-payments-server

### DIFF
--- a/packages/fxa-payments-server/pm2.config.js
+++ b/packages/fxa-payments-server/pm2.config.js
@@ -11,7 +11,7 @@ const apps = [];
 apps.push({
   name: 'payments',
   cwd: __dirname,
-  script: 'node server/bin/fxa-payments-server.js',
+  script: 'node -r ts-node/register/transpile-only -r tsconfig-paths/register server/bin/fxa-payments-server.js',
   max_restarts: '1',
   min_uptime: '2m',
   env: {


### PR DESCRIPTION
Split of #20390 into per-folder PRs. Scope: `packages/fxa-payments-server`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `packages/fxa-payments-server`.
- One of 18 split PRs from #20390.