### PR TITLE
chore(payments-next): replace esbuild with tsc/ts-node in apps/payments/next

### DIFF
--- a/apps/payments/next/project.json
+++ b/apps/payments/next/project.json
@@ -52,25 +52,52 @@
       "command": "pm2 delete apps/payments/next/pm2.config.js"
     },
     "l10n-merge": {
+      "cache": true,
       "command": "yarn grunt --gruntfile='apps/payments/next/Gruntfile.js' merge-ftl",
-      "dependsOn": ["l10n-prime"]
+      "dependsOn": ["l10n-prime"],
+      "inputs": ["{projectRoot}/gruntfile.js", "{projectRoot}/app/**/en.ftl"],
+      "outputs": [
+        "{projectRoot}/public/locales/en/payments-next.ftl"
+      ]
     },
     "l10n-prime": {
       "command": "./_scripts/l10n/prime.sh apps/payments/next"
     },
     "l10n-bundle": {
+      "cache": true,
       "dependsOn": ["l10n-merge"],
-      "command": "./_scripts/l10n/bundle.sh apps/payments/next branding,react,payments-next"
+      "command": "./_scripts/l10n/bundle.sh apps/payments/next branding,react,payments-next",
+      "inputs": [
+        "{projectRoot}/public/locales/**/branding.ftl",
+        "{projectRoot}/public/locales/**/react.ftl",
+        "{projectRoot}/public/locales/**/payments.ftl",
+        "{projectRoot}/public/locales/**/payments-next.ftl",
+        "{projectRoot}/public/locales/**/react.ftl"
+      ],
+      "outputs": [
+        "{projectRoot}/public/locales/**/main.ftl"
+      ]
     },
     "watchers": {
       "command": "yarn grunt --gruntfile='apps/payments/next/Gruntfile.js' watchers"
     },
     "glean-generate": {
+      "cache": true,
       "dependsOn": ["glean-lint"],
-      "command": "yarn glean translate libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml -f typescript_server -o libs/payments/metrics/src/lib/glean/__generated__"
+      "command": "yarn glean translate libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml -f typescript_server -o libs/payments/metrics/src/lib/glean/__generated__",
+      "inputs": [
+        "{workspaceRoot}/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml"
+      ],
+      "outputs": [
+        "{workspaceRoot}/libs/payments/metrics/src/lib/glean/__generated__"
+      ]
     },
     "glean-lint": {
-      "command": "yarn glean glinter libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml"
+      "cache": true,
+      "command": "yarn glean glinter libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml",
+      "inputs": [
+        "{workspaceRoot}/libs/shared/metrics/glean/src/registry/subplat-backend-metrics.yaml"
+      ]
     }
   },
   "tags": ["app", "payments", "type:sp3"]


### PR DESCRIPTION
Split of #20390 into per-folder PRs. Scope: `apps/payments/next`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `apps/payments/next`.
- One of 18 split PRs from #20390.

## Issue that this pull request solves

Closes: FXA-13523

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [X] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There's a lot of cron jobs in FxA. I'm thinking we just need to keep an eye on these during next deployment to make sure something didn't get overlooked here.
