### PR TITLE
chore(accounts): replace esbuild with tsc/ts-node in libs/accounts

### DIFF
--- a/libs/accounts/email-renderer/package.json
+++ b/libs/accounts/email-renderer/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/accounts/email-renderer",
-  "version": "0.0.1",
-  "dependencies": {},
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "types": "./index.d.ts",
-  "private": true
+  "version": "0.0.1"
 }

--- a/libs/accounts/email-renderer/project.json
+++ b/libs/accounts/email-renderer/project.json
@@ -19,7 +19,7 @@
       }
     },
     "build-ts": {
-      "executor": "@nx/esbuild:esbuild",
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "dependsOn": ["l10n-prime"],
       "options": {
@@ -31,11 +31,18 @@
           "libs/accounts/email-renderer/src/**/*.txt",
           "libs/accounts/email-renderer/src/**/*.mjml"
         ],
-        "format": ["cjs"]
+        "generatePackageJson": true
       }
     },
     "build-css": {
+      "cache": true,
       "executor": "nx:run-commands",
+      "inputs": [
+        "{projectRoot}/src/**/*.scss"
+      ],
+      "outputs": [
+        "{projectRoot}/src/css"
+      ],
       "options": {
         "commands": [
           "ts-node libs/accounts/email-renderer/src/sass-compile-files.ts"
@@ -125,6 +132,7 @@
       ]
     },
     "l10n-merge": {
+      "cache": true,
       "dependsOn": ["l10n-prime"],
       "executor": "nx:run-commands",
       "options": {

--- a/libs/accounts/email-sender/package.json
+++ b/libs/accounts/email-sender/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/accounts/email-sender",
-  "version": "0.0.1",
-  "dependencies": {},
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "types": "./index.d.ts",
-  "private": true
+  "version": "0.0.1"
 }

--- a/libs/accounts/email-sender/project.json
+++ b/libs/accounts/email-sender/project.json
@@ -6,14 +6,21 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/accounts/email-sender",
         "main": "libs/accounts/email-sender/src/index.ts",
         "tsConfig": "libs/accounts/email-sender/tsconfig.lib.json",
         "assets": ["libs/accounts/email-sender/*.md"],
-        "format": ["cjs"]
+        "generatePackageJson": true
       }
     },
     "test-unit": {

--- a/libs/accounts/errors/package.json
+++ b/libs/accounts/errors/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/accounts/errors",
-  "version": "0.0.1",
-  "dependencies": {},
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "types": "./index.d.ts",
-  "private": true
+  "version": "0.0.1"
 }

--- a/libs/accounts/errors/project.json
+++ b/libs/accounts/errors/project.json
@@ -6,14 +6,26 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "outputPath": "dist/libs/accounts/errors",
         "main": "libs/accounts/errors/src/index.ts",
+        "outputPath": "dist/libs/accounts/errors",
         "tsConfig": "libs/accounts/errors/tsconfig.lib.json",
-        "assets": ["libs/accounts/errors/*.md"],
-        "format": ["cjs"]
+        "assets": [
+          {
+            "glob": "libs/accounts/errors/*.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
       }
     },
     "test-unit": {

--- a/libs/accounts/errors/tsconfig.lib.json
+++ b/libs/accounts/errors/tsconfig.lib.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "../../..",
+    "module": "commonjs",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]

--- a/libs/accounts/oauth/package.json
+++ b/libs/accounts/oauth/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/accounts/oauth",
-  "version": "0.0.1",
-  "private": true,
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "types": "./index.d.ts",
-  "dependencies": {}
+  "version": "0.0.1"
 }

--- a/libs/accounts/oauth/project.json
+++ b/libs/accounts/oauth/project.json
@@ -6,14 +6,21 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/accounts/oauth",
         "main": "libs/accounts/oauth/src/index.ts",
         "tsConfig": "libs/accounts/oauth/tsconfig.lib.json",
         "assets": ["libs/accounts/oauth/*.md"],
-        "format": ["cjs"]
+        "generatePackageJson": true
       }
     },
     "test": {

--- a/libs/accounts/passkey/package.json
+++ b/libs/accounts/passkey/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/accounts/passkey",
-  "version": "0.0.1",
-  "private": true,
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "types": "./index.d.ts",
-  "dependencies": {}
+  "version": "0.0.1"
 }

--- a/libs/accounts/passkey/project.json
+++ b/libs/accounts/passkey/project.json
@@ -6,15 +6,20 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/accounts/passkey",
         "main": "libs/accounts/passkey/src/index.ts",
         "tsConfig": "libs/accounts/passkey/tsconfig.lib.json",
-        "assets": ["libs/accounts/passkey/*.md"],
-        "format": ["cjs"],
-        "declaration": true
+        "assets": ["libs/accounts/passkey/*.md"]
       }
     },
     "test-unit": {

--- a/libs/accounts/passkey/tsconfig.lib.json
+++ b/libs/accounts/passkey/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "../../..",
     "outDir": "../../../dist/out-tsc",
     "declaration": true,
     "types": ["node"]

--- a/libs/accounts/rate-limit/package.json
+++ b/libs/accounts/rate-limit/package.json
@@ -1,9 +1,4 @@
 {
   "name": "@fxa/accounts/rate-limit",
-  "version": "0.0.1",
-  "dependencies": {},
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "types": "./index.d.ts",
-  "private": true
+  "version": "0.0.1"
 }

--- a/libs/accounts/rate-limit/project.json
+++ b/libs/accounts/rate-limit/project.json
@@ -6,14 +6,21 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/accounts/rate-limit",
         "main": "libs/accounts/rate-limit/src/index.ts",
         "tsConfig": "libs/accounts/rate-limit/tsconfig.lib.json",
         "assets": ["libs/accounts/rate-limit/*.md"],
-        "format": ["cjs"]
+        "generatePackageJson": true
       }
     },
     "test-unit": {

--- a/libs/accounts/recovery-phone/package.json
+++ b/libs/accounts/recovery-phone/package.json
@@ -1,8 +1,4 @@
 {
   "name": "@fxa/accounts/recovery-phone",
-  "version": "0.0.1",
-  "dependencies": {},
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "private": true
+  "version": "0.0.1"
 }

--- a/libs/accounts/recovery-phone/project.json
+++ b/libs/accounts/recovery-phone/project.json
@@ -6,14 +6,21 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/accounts/recovery-phone",
         "main": "libs/accounts/recovery-phone/src/index.ts",
         "tsConfig": "libs/accounts/recovery-phone/tsconfig.lib.json",
         "assets": ["libs/accounts/recovery-phone/*.md"],
-        "format": ["cjs"]
+        "generatePackageJson": true
       }
     },
     "test-unit": {

--- a/libs/accounts/two-factor/project.json
+++ b/libs/accounts/two-factor/project.json
@@ -6,24 +6,21 @@
   "tags": ["scope:shared:lib"],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "outputPath": "dist/libs/accounts/two-factor",
         "tsConfig": "libs/accounts/two-factor/tsconfig.lib.json",
         "packageJson": "libs/accounts/two-factor/package.json",
         "main": "libs/accounts/two-factor/src/index.ts",
-        "assets": ["libs/accounts/two-factor/*.md"],
-        "platform": "node"
-      },
-      "configurations": {
-        "development": {
-          "minify": false
-        },
-        "production": {
-          "minify": true
-        }
+        "assets": ["libs/accounts/two-factor/*.md"]
       }
     },
     "test-unit": {


### PR DESCRIPTION
**ON HOLD UNTIL esbuild-removal/shared LANDS**


Split of #20390 into per-folder PRs. Scope: `libs/accounts`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `libs/accounts`.
- One of 18 split PRs from #20390.

## Issue that this pull request solves

Closes: 

- FXA-13524
- FXA-13525
- FXA-13526
- FXA-13527
- FXA-13528
- FXA-13529
- FXA-13530
- FXA-13531
 
## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [X] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

There's a lot of cron jobs in FxA. I'm thinking we just need to keep an eye on these during next deployment to make sure something didn't get overlooked here.
