### PR TITLE
chore(google): replace esbuild with tsc/ts-node in libs/google

### DIFF
--- a/libs/google/project.json
+++ b/libs/google/project.json
@@ -6,16 +6,20 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "main": "libs/google/src/index.ts",
         "outputPath": "dist/libs/google",
-        "outputFileName": "main.js",
         "tsConfig": "libs/google/tsconfig.lib.json",
-        "assets": ["libs/google/*.md"],
-        "declaration": true
+        "assets": ["libs/google/*.md"]
       }
     },
     "lint": {


### PR DESCRIPTION
**ON HOLD UNTIL esbuild-removal/shared lands**


Split of #20390 into per-folder PRs. Scope: `libs/google`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `libs/google`.
- One of 18 split PRs from #20390.