### PR TITLE
chore(profile): replace esbuild with tsc/ts-node in libs/profile

### DIFF
--- a/libs/profile/client/package.json
+++ b/libs/profile/client/package.json
@@ -1,8 +1,4 @@
 {
   "name": "@fxa/profile/client",
-  "version": "0.0.1",
-  "dependencies": {},
-  "type": "commonjs",
-  "main": "./index.cjs",
-  "private": true
+  "version": "0.0.1"
 }

--- a/libs/profile/client/project.json
+++ b/libs/profile/client/project.json
@@ -6,14 +6,21 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
         "outputPath": "dist/libs/profile/client",
         "main": "libs/profile/client/src/index.ts",
         "tsConfig": "libs/profile/client/tsconfig.lib.json",
         "assets": ["libs/profile/client/*.md"],
-        "declaration": true
+        "generatePackageJson": true
       }
     },
     "test-unit": {


### PR DESCRIPTION
Split of #20390 into per-folder PRs. Scope: `libs/profile`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `libs/profile`.
- One of 18 split PRs from #20390.