### PR TITLE
chore(vendored): replace esbuild with tsc/ts-node in libs/vendored

### DIFF
--- a/libs/vendored/common-password-list/project.json
+++ b/libs/vendored/common-password-list/project.json
@@ -6,31 +6,26 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "main": "libs/vendored/common-password-list/src/index.ts",
         "outputPath": "dist/libs/vendored/common-password-list",
-        "outputFileName": "main.js",
         "tsConfig": "libs/vendored/common-password-list/tsconfig.lib.json",
-        "declaration": true,
         "assets": [
           {
             "glob": "libs/vendored/common-password-list/README.md",
             "input": ".",
             "output": "."
           }
-        ],
-        "platform": "node"
-      },
-      "configurations": {
-        "development": {
-          "minify": false
-        },
-        "production": {
-          "minify": true
-        }
+        ]
       }
     },
     "test-unit": {

--- a/libs/vendored/crypto-relier/project.json
+++ b/libs/vendored/crypto-relier/project.json
@@ -6,32 +6,26 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "main": "libs/vendored/crypto-relier/src/index.ts",
         "outputPath": "dist/libs/vendored/crypto-relier",
-        "outputFileName": "main.js",
         "tsConfig": "libs/vendored/crypto-relier/tsconfig.lib.json",
-        "declaration": true,
         "assets": [
           {
             "glob": "libs/vendored/crypto-relier/README.md",
             "input": ".",
             "output": "."
           }
-        ],
-        "platform": "node",
-        "format": ["cjs", "esm"]
-      },
-      "configurations": {
-        "development": {
-          "minify": false
-        },
-        "production": {
-          "minify": true
-        }
+        ]
       }
     },
     "test": {

--- a/libs/vendored/incremental-encoder/project.json
+++ b/libs/vendored/incremental-encoder/project.json
@@ -6,31 +6,26 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "main": "libs/vendored/incremental-encoder/src/index.ts",
         "outputPath": "dist/libs/vendored/incremental-encoder",
-        "outputFileName": "main.js",
         "tsConfig": "libs/vendored/incremental-encoder/tsconfig.lib.json",
-        "declaration": true,
         "assets": [
           {
             "glob": "libs/vendored/incremental-encoder/README.md",
             "input": ".",
             "output": "."
           }
-        ],
-        "platform": "node"
-      },
-      "configurations": {
-        "development": {
-          "minify": false
-        },
-        "production": {
-          "minify": true
-        }
+        ]
       }
     },
     "test-unit": {

--- a/libs/vendored/jwtool/project.json
+++ b/libs/vendored/jwtool/project.json
@@ -6,32 +6,26 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "main": "libs/vendored/jwtool/src/index.ts",
         "outputPath": "dist/libs/vendored/jwtool",
-        "outputFileName": "main.js",
         "tsConfig": "libs/vendored/jwtool/tsconfig.lib.json",
-        "declaration": true,
         "assets": [
           {
             "glob": "libs/vendored/jwtool/README.md",
             "input": ".",
             "output": "."
           }
-        ],
-        "platform": "node",
-        "format": ["cjs", "esm"]
-      },
-      "configurations": {
-        "development": {
-          "minify": false
-        },
-        "production": {
-          "minify": true
-        }
+        ]
       }
     },
     "test-unit": {

--- a/libs/vendored/typesafe-node-firestore/project.json
+++ b/libs/vendored/typesafe-node-firestore/project.json
@@ -6,31 +6,26 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
-      "defaultConfiguration": "production",
       "options": {
         "main": "libs/vendored/typesafe-node-firestore/src/index.ts",
         "outputPath": "dist/libs/vendored/typesafe-node-firestore",
-        "outputFileName": "main.js",
         "tsConfig": "libs/vendored/typesafe-node-firestore/tsconfig.lib.json",
-        "declaration": true,
         "assets": [
           {
             "glob": "libs/vendored/typesafe-node-firestore/README.md",
             "input": ".",
             "output": "."
           }
-        ],
-        "platform": "node"
-      },
-      "configurations": {
-        "development": {
-          "minify": false
-        },
-        "production": {
-          "minify": true
-        }
+        ]
       }
     },
     "test": {


### PR DESCRIPTION
Split of #20390 into per-folder PRs. Scope: `libs/vendored`.

## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `libs/vendored`.
- One of 18 split PRs from #20390.