### PR TITLE
chore(content-server): replace esbuild with tsc/ts-node in packages/fxa-content-server

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -133,7 +133,6 @@
     "core-js": "^3.41.0",
     "css": "3.0.0",
     "esbuild": "^0.17.15",
-    "esbuild-register": "^3.5.0",
     "eslint": "^7.32.0",
     "firefox-profile": "4.7.0",
     "got": "11.8.5",

--- a/packages/fxa-content-server/pm2.config.js
+++ b/packages/fxa-content-server/pm2.config.js
@@ -11,7 +11,8 @@ const apps = [];
 
 apps.push({
   name: 'content',
-  script: 'node --inspect=9130 server/bin/fxa-content-server.js',
+  script:
+    'node --inspect=9130 -r ts-node/register/transpile-only -r tsconfig-paths/register server/bin/fxa-content-server.js',
   cwd: __dirname,
   watch: ['server/**/*.js', 'server/**/*.html', 'server/**/*.json'],
   env: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31789,7 +31789,6 @@ __metadata:
     css-loader: "npm:1.0.0"
     duration-js: "npm:4.0.0"
     esbuild: "npm:^0.17.15"
-    esbuild-register: "npm:^3.5.0"
     eslint: "npm:^7.32.0"
     expose-loader: "npm:5.0.0"
     express: "npm:^4.21.2"


### PR DESCRIPTION


## Because
- We want to test & develop with what we deploy.

## This pull request
- Replaces esbuild with tsc/ts-node in `packages/fxa-content-server`.
- One of 18 split PRs from #20390.



## Issue that this pull request solves

Closes: FXA-13587

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

## Other information (Optional)
Split of #20390 into per-folder PRs. Scope: `packages/fxa-content-server`.