### PR TITLE
refactor(passkeys): confine Buffer conversion to the DB boundary

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.manager.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.in.spec.ts
@@ -14,7 +14,11 @@ import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { Test } from '@nestjs/testing';
 import { PasskeyManager } from './passkey.manager';
 import { PasskeyConfig, MAX_PASSKEY_NAME_LENGTH } from './passkey.config';
-import { findPasskeyByCredentialId, insertPasskey } from './passkey.repository';
+import {
+  bufferToAaguid,
+  findPasskeyByCredentialId,
+  insertPasskey,
+} from './passkey.repository';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { AppError } from '../../../errors/src';
 
@@ -83,10 +87,24 @@ describe('PasskeyManager (Integration)', () => {
     }
   });
 
-  async function createTestAccount(): Promise<Buffer> {
+  async function createTestAccount(): Promise<string> {
     const email = faker.internet.email();
-    const uidHex = await accountManager.createAccountStub(email, 1, 'en-US');
-    return Buffer.from(uidHex, 'hex');
+    return accountManager.createAccountStub(email, 1, 'en-US');
+  }
+
+  function uidBuffer(uid: string): Buffer {
+    return Buffer.from(uid, 'hex');
+  }
+
+  // PasskeyFactory produces the DB-row shape (credentialId/aaguid: Buffer);
+  // callers of registerPasskey / insertPasskey take NewPasskeyData
+  // (credentialId: base64url string, aaguid: hyphenated-UUID string).
+  function toNewPasskeyData(passkey: ReturnType<typeof PasskeyFactory>) {
+    return {
+      ...passkey,
+      credentialId: passkey.credentialId.toString('base64url'),
+      aaguid: bufferToAaguid(passkey.aaguid),
+    };
   }
 
   describe('registerPasskey', () => {
@@ -94,18 +112,23 @@ describe('PasskeyManager (Integration)', () => {
       const uid = await createTestAccount();
       // Pass lastUsedAt: null explicitly — PasskeyFactory may randomise it
       const passkey = PasskeyFactory({
-        uid,
+        uid: uidBuffer(uid),
         backupEligible: true,
         backupState: false,
         prfEnabled: false,
         lastUsedAt: null,
       });
 
-      await manager.registerPasskey(passkey);
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
-      expect(found?.uid).toEqual(uid);
-      expect(found?.credentialId).toEqual(passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
+      expect(found?.uid.toString('hex')).toEqual(uid);
+      expect(found?.credentialId).toEqual(
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.name).toBe(passkey.name);
       expect(found?.backupEligible).toBe(true);
       expect(found?.backupState).toBe(false);
@@ -117,11 +140,20 @@ describe('PasskeyManager (Integration)', () => {
       const uid = await createTestAccount();
 
       // Fill up to the limit (maxPasskeysPerUser = 2)
-      await manager.registerPasskey(PasskeyFactory({ uid }));
-      await manager.registerPasskey(PasskeyFactory({ uid }));
+      await manager.registerPasskey(
+        uid,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+      );
+      await manager.registerPasskey(
+        uid,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+      );
 
       await expect(
-        manager.registerPasskey(PasskeyFactory({ uid }))
+        manager.registerPasskey(
+          uid,
+          toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+        )
       ).rejects.toMatchObject(
         AppError.passkeyLimitReached(testConfig.maxPasskeysPerUser)
       );
@@ -129,13 +161,13 @@ describe('PasskeyManager (Integration)', () => {
 
     it('throws passkeyAlreadyRegistered AppError on duplicate credentialId', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
 
-      await manager.registerPasskey(passkey);
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       // Attempt to register the same credentialId again
       await expect(
-        manager.registerPasskey({ ...passkey })
+        manager.registerPasskey(uid, toNewPasskeyData(passkey))
       ).rejects.toMatchObject(AppError.passkeyAlreadyRegistered());
     });
   });
@@ -143,19 +175,26 @@ describe('PasskeyManager (Integration)', () => {
   describe('updatePasskeyAfterAuth', () => {
     it('updates signCount, backupState, and lastUsedAt', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, signCount: 0, backupState: false });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid),
+        signCount: 0,
+        backupState: false,
+      });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       const updated = await manager.updatePasskeyAfterAuth(
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         5,
         true
       );
 
       expect(updated).toBe(true);
 
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.signCount).toBe(5);
       expect(found?.backupState).toBe(true);
       expect(found?.lastUsedAt).toBeGreaterThan(0);
@@ -163,24 +202,30 @@ describe('PasskeyManager (Integration)', () => {
 
     it('sets backupState to false when passed false', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, backupState: true });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid),
+        backupState: true,
+      });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       await manager.updatePasskeyAfterAuth(
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         1,
         false
       );
 
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.backupState).toBe(false);
     });
 
     it('returns false when credentialId not found', async () => {
       const result = await manager.updatePasskeyAfterAuth(
-        Buffer.alloc(16, 0xff),
-        Buffer.alloc(32, 0xff),
+        Buffer.alloc(16, 0xff).toString('hex'),
+        Buffer.alloc(32, 0xff).toString('base64url'),
         1,
         false
       );
@@ -189,49 +234,59 @@ describe('PasskeyManager (Integration)', () => {
 
     it('returns false and does not update when signCount regresses', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, signCount: 10 });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid), signCount: 10 });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       // Attempt to set a lower signCount — should be rejected
       const result = await manager.updatePasskeyAfterAuth(
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         5,
         false
       );
 
       expect(result).toBe(false);
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.signCount).toBe(10);
     });
 
     it('returns false and does not update when new signCount equals stored non-zero signCount', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, signCount: 5 });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid), signCount: 5 });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       // Same non-zero signCount is a potential cloning signal — should be rejected
       const result = await manager.updatePasskeyAfterAuth(
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         5,
         false
       );
 
       expect(result).toBe(false);
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.signCount).toBe(5);
     });
 
     it('succeeds when both stored and new signCount are zero', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, signCount: 0, backupState: false });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid),
+        signCount: 0,
+        backupState: false,
+      });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       // Authenticators that never increment always return 0 — this is valid per WebAuthn spec
       const result = await manager.updatePasskeyAfterAuth(
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         0,
         false
       );
@@ -242,19 +297,22 @@ describe('PasskeyManager (Integration)', () => {
     it('returns false and does not update when uid does not match credential owner', async () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
-      const passkey = PasskeyFactory({ uid: uid1, signCount: 0 });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid1), signCount: 0 });
+      await manager.registerPasskey(uid1, toNewPasskeyData(passkey));
 
       // uid2 attempts to update uid1's credential — should be rejected
       const result = await manager.updatePasskeyAfterAuth(
         uid2,
-        passkey.credentialId,
+        passkey.credentialId.toString('base64url'),
         1,
         false
       );
 
       expect(result).toBe(false);
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.signCount).toBe(0);
     });
   });
@@ -265,12 +323,18 @@ describe('PasskeyManager (Integration)', () => {
       const now = Date.now();
 
       // Insert directly via repository to control createdAt precisely
-      const older = PasskeyFactory({ uid, createdAt: now - 5000 });
-      const middle = PasskeyFactory({ uid, createdAt: now - 2000 });
-      const newest = PasskeyFactory({ uid, createdAt: now });
-      await insertPasskey(db, older);
-      await insertPasskey(db, middle);
-      await insertPasskey(db, newest);
+      const older = PasskeyFactory({
+        uid: uidBuffer(uid),
+        createdAt: now - 5000,
+      });
+      const middle = PasskeyFactory({
+        uid: uidBuffer(uid),
+        createdAt: now - 2000,
+      });
+      const newest = PasskeyFactory({ uid: uidBuffer(uid), createdAt: now });
+      await insertPasskey(db, uid, toNewPasskeyData(older));
+      await insertPasskey(db, uid, toNewPasskeyData(middle));
+      await insertPasskey(db, uid, toNewPasskeyData(newest));
 
       const result = await manager.listPasskeysForUser(uid);
 
@@ -292,59 +356,71 @@ describe('PasskeyManager (Integration)', () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
 
-      await manager.registerPasskey(PasskeyFactory({ uid: uid1 }));
-      await manager.registerPasskey(PasskeyFactory({ uid: uid2 }));
+      await manager.registerPasskey(
+        uid1,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid1) }))
+      );
+      await manager.registerPasskey(
+        uid2,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid2) }))
+      );
 
       const result = await manager.listPasskeysForUser(uid1);
-      expect(result.every((p) => p.uid.equals(uid1))).toBe(true);
+      expect(result.every((p) => p.uid.toString('hex') === uid1)).toBe(true);
     });
   });
 
   describe('renamePasskey', () => {
     it('renames an existing passkey', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       const renamed = await manager.renamePasskey(
         uid,
-        passkey.credentialId,
+        passkey.credentialId.toString('base64url'),
         'New Name'
       );
 
       expect(renamed).toBe(true);
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.name).toBe('New Name');
     });
 
     it('does not rename a passkey belonging to a different user', async () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
-      const passkey = PasskeyFactory({ uid: uid1 });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid1) });
+      await manager.registerPasskey(uid1, toNewPasskeyData(passkey));
 
       // uid2 tries to rename uid1's passkey — should return false
       const renamed = await manager.renamePasskey(
         uid2,
-        passkey.credentialId,
+        passkey.credentialId.toString('base64url'),
         'Hijacked'
       );
       expect(renamed).toBe(false);
 
       // Name is unchanged
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found?.name).toBe(passkey.name);
     });
 
     it(`accepts a name at exactly ${MAX_PASSKEY_NAME_LENGTH} characters`, async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       const exactName = 'x'.repeat(MAX_PASSKEY_NAME_LENGTH);
       const renamed = await manager.renamePasskey(
         uid,
-        passkey.credentialId,
+        passkey.credentialId.toString('base64url'),
         exactName
       );
       expect(renamed).toBe(true);
@@ -354,7 +430,7 @@ describe('PasskeyManager (Integration)', () => {
       const uid = await createTestAccount();
       const result = await manager.renamePasskey(
         uid,
-        Buffer.alloc(32, 0xff),
+        Buffer.alloc(32, 0xff).toString('base64url'),
         'Ghost'
       );
       expect(result).toBe(false);
@@ -364,34 +440,49 @@ describe('PasskeyManager (Integration)', () => {
   describe('deletePasskey', () => {
     it('deletes an existing passkey and returns true', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
-      const deleted = await manager.deletePasskey(uid, passkey.credentialId);
+      const deleted = await manager.deletePasskey(
+        uid,
+        passkey.credentialId.toString('base64url')
+      );
 
       expect(deleted).toBe(true);
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found).toBeUndefined();
     });
 
     it('returns false when passkey is not found', async () => {
       const uid = await createTestAccount();
-      const result = await manager.deletePasskey(uid, Buffer.alloc(32, 0xff));
+      const result = await manager.deletePasskey(
+        uid,
+        Buffer.alloc(32, 0xff).toString('base64url')
+      );
       expect(result).toBe(false);
     });
 
     it('does not delete a passkey belonging to a different user', async () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
-      const passkey = PasskeyFactory({ uid: uid1 });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid1) });
+      await manager.registerPasskey(uid1, toNewPasskeyData(passkey));
 
       // uid2 tries to delete uid1's passkey — should return false
-      const deleted = await manager.deletePasskey(uid2, passkey.credentialId);
+      const deleted = await manager.deletePasskey(
+        uid2,
+        passkey.credentialId.toString('base64url')
+      );
       expect(deleted).toBe(false);
 
       // Passkey still exists
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found).toBeDefined();
     });
   });
@@ -405,20 +496,29 @@ describe('PasskeyManager (Integration)', () => {
     it('increments as passkeys are added', async () => {
       const uid = await createTestAccount();
 
-      await manager.registerPasskey(PasskeyFactory({ uid }));
+      await manager.registerPasskey(
+        uid,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+      );
       expect(await manager.countPasskeys(uid)).toBe(1);
 
-      await manager.registerPasskey(PasskeyFactory({ uid }));
+      await manager.registerPasskey(
+        uid,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+      );
       expect(await manager.countPasskeys(uid)).toBe(2);
     });
 
     it('decrements after deletion', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
-      await manager.registerPasskey(passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
+      await manager.registerPasskey(uid, toNewPasskeyData(passkey));
 
       expect(await manager.countPasskeys(uid)).toBe(1);
-      await manager.deletePasskey(uid, passkey.credentialId);
+      await manager.deletePasskey(
+        uid,
+        passkey.credentialId.toString('base64url')
+      );
       expect(await manager.countPasskeys(uid)).toBe(0);
     });
   });
@@ -426,8 +526,14 @@ describe('PasskeyManager (Integration)', () => {
   describe('deleteAllPasskeysForUser', () => {
     it('removes all passkeys for the user and returns the count deleted', async () => {
       const uid = await createTestAccount();
-      await manager.registerPasskey(PasskeyFactory({ uid }));
-      await manager.registerPasskey(PasskeyFactory({ uid }));
+      await manager.registerPasskey(
+        uid,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+      );
+      await manager.registerPasskey(
+        uid,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid) }))
+      );
 
       const deleted = await manager.deleteAllPasskeysForUser(uid);
 
@@ -444,8 +550,14 @@ describe('PasskeyManager (Integration)', () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
 
-      await manager.registerPasskey(PasskeyFactory({ uid: uid1 }));
-      await manager.registerPasskey(PasskeyFactory({ uid: uid2 }));
+      await manager.registerPasskey(
+        uid1,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid1) }))
+      );
+      await manager.registerPasskey(
+        uid2,
+        toNewPasskeyData(PasskeyFactory({ uid: uidBuffer(uid2) }))
+      );
 
       await manager.deleteAllPasskeysForUser(uid1);
 

--- a/libs/accounts/passkey/src/lib/passkey.manager.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.spec.ts
@@ -13,6 +13,7 @@ import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { PasskeyManager } from './passkey.manager';
 import { PasskeyConfig, MAX_PASSKEY_NAME_LENGTH } from './passkey.config';
 import * as PasskeyRepository from './passkey.repository';
+import { bufferToAaguid } from './passkey.repository';
 import { AppError } from '../../../errors/src';
 
 // Mock the repository module, keeping isMysqlDupEntry as the real implementation
@@ -73,23 +74,34 @@ describe('PasskeyManager', () => {
   });
 
   describe('registerPasskey', () => {
+    // PasskeyFactory produces the DB-row shape (credentialId: Buffer); the
+    // manager takes NewPasskeyData (credentialId: base64url string).
+    const newPasskeyData = (passkey: ReturnType<typeof PasskeyFactory>) => ({
+      ...passkey,
+      credentialId: passkey.credentialId.toString('base64url'),
+      aaguid: bufferToAaguid(passkey.aaguid),
+    });
+
     it('checks the limit and inserts the passkey', async () => {
       const passkey = PasskeyFactory();
+      const uid = passkey.uid.toString('hex');
+      const data = newPasskeyData(passkey);
 
       (PasskeyRepository.countPasskeysByUid as jest.Mock).mockResolvedValue(1);
       (PasskeyRepository.insertPasskey as jest.Mock).mockResolvedValue(
         undefined
       );
 
-      await manager.registerPasskey(passkey);
+      await manager.registerPasskey(uid, data);
 
       expect(PasskeyRepository.countPasskeysByUid).toHaveBeenCalledWith(
         mockDb,
-        passkey.uid
+        uid
       );
       expect(PasskeyRepository.insertPasskey).toHaveBeenCalledWith(
         mockDb,
-        passkey
+        uid,
+        data
       );
     });
 
@@ -98,8 +110,12 @@ describe('PasskeyManager', () => {
         MOCK_MAX_PASSKEYS_PER_USER
       );
 
+      const passkey = PasskeyFactory();
       await expect(
-        manager.registerPasskey(PasskeyFactory())
+        manager.registerPasskey(
+          passkey.uid.toString('hex'),
+          newPasskeyData(passkey)
+        )
       ).rejects.toMatchObject(
         AppError.passkeyLimitReached(MOCK_MAX_PASSKEYS_PER_USER)
       );
@@ -115,8 +131,12 @@ describe('PasskeyManager', () => {
         dupError
       );
 
+      const passkey = PasskeyFactory();
       await expect(
-        manager.registerPasskey(PasskeyFactory())
+        manager.registerPasskey(
+          passkey.uid.toString('hex'),
+          newPasskeyData(passkey)
+        )
       ).rejects.toMatchObject(AppError.passkeyAlreadyRegistered());
     });
 
@@ -127,20 +147,24 @@ describe('PasskeyManager', () => {
         unknownError
       );
 
-      await expect(manager.registerPasskey(PasskeyFactory())).rejects.toThrow(
-        'connection timeout'
-      );
+      const passkey = PasskeyFactory();
+      await expect(
+        manager.registerPasskey(
+          passkey.uid.toString('hex'),
+          newPasskeyData(passkey)
+        )
+      ).rejects.toThrow('connection timeout');
     });
   });
 
   describe('updatePasskeyAfterAuth', () => {
-    it('converts backupState=false to numeric 0', async () => {
+    it('passes backupState=false through to the repository', async () => {
       (
         PasskeyRepository.updatePasskeyCounterAndLastUsed as jest.Mock
       ).mockResolvedValue(true);
 
-      const uid = Buffer.alloc(16, 1);
-      const credId = Buffer.alloc(32, 2);
+      const uid = Buffer.alloc(16, 1).toString('hex');
+      const credId = Buffer.alloc(32, 2).toString('base64url');
       const result = await manager.updatePasskeyAfterAuth(
         uid,
         credId,
@@ -150,18 +174,18 @@ describe('PasskeyManager', () => {
 
       expect(
         PasskeyRepository.updatePasskeyCounterAndLastUsed
-      ).toHaveBeenCalledWith(mockDb, uid, credId, 0, 0);
+      ).toHaveBeenCalledWith(mockDb, uid, credId, 0, false);
       expect(result).toBe(true);
     });
 
-    it('converts backupState=true to numeric 1', async () => {
+    it('passes backupState=true through to the repository', async () => {
       (
         PasskeyRepository.updatePasskeyCounterAndLastUsed as jest.Mock
       ).mockResolvedValue(true);
 
       const result = await manager.updatePasskeyAfterAuth(
-        Buffer.alloc(16),
-        Buffer.alloc(32),
+        Buffer.alloc(16).toString('hex'),
+        Buffer.alloc(32).toString('base64url'),
         1,
         true
       );
@@ -170,10 +194,10 @@ describe('PasskeyManager', () => {
         PasskeyRepository.updatePasskeyCounterAndLastUsed
       ).toHaveBeenCalledWith(
         mockDb,
-        expect.any(Buffer),
-        expect.any(Buffer),
+        expect.any(String),
+        expect.any(String),
         1,
-        1
+        true
       );
       expect(result).toBe(true);
     });
@@ -185,7 +209,7 @@ describe('PasskeyManager', () => {
         MOCK_MAX_PASSKEYS_PER_USER - 1
       );
       await expect(
-        manager.checkPasskeyCount(Buffer.alloc(16, 1))
+        manager.checkPasskeyCount(Buffer.alloc(16, 1).toString('hex'))
       ).resolves.toBeUndefined();
     });
 
@@ -199,7 +223,7 @@ describe('PasskeyManager', () => {
           count
         );
         await expect(
-          manager.checkPasskeyCount(Buffer.alloc(16, 1))
+          manager.checkPasskeyCount(Buffer.alloc(16, 1).toString('hex'))
         ).rejects.toMatchObject({
           errno: 226,
           message: 'Maximum number of passkeys reached',
@@ -212,8 +236,8 @@ describe('PasskeyManager', () => {
   describe('renamePasskey', () => {
     it(`returns false without calling repository when name exceeds ${MAX_PASSKEY_NAME_LENGTH} characters`, async () => {
       const result = await manager.renamePasskey(
-        Buffer.alloc(16, 1),
-        Buffer.alloc(32, 2),
+        Buffer.alloc(16, 1).toString('hex'),
+        Buffer.alloc(32, 2).toString('base64url'),
         'x'.repeat(MAX_PASSKEY_NAME_LENGTH + 1)
       );
 

--- a/libs/accounts/passkey/src/lib/passkey.manager.ts
+++ b/libs/accounts/passkey/src/lib/passkey.manager.ts
@@ -6,7 +6,6 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import {
   AccountDatabase,
   AccountDbProvider,
-  Passkey,
 } from '@fxa/shared/db/mysql/account';
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { StatsD, StatsDService } from '@fxa/shared/metrics/statsd';
@@ -18,6 +17,8 @@ import {
   findPasskeysByUid,
   insertPasskey,
   isMysqlDupEntry,
+  NewPasskeyData,
+  PasskeyRecord,
   updatePasskeyCounterAndLastUsed,
   updatePasskeyName,
 } from './passkey.repository';
@@ -53,24 +54,23 @@ export class PasskeyManager {
    * caught from the database unique constraint and converted to
    * AppError.passkeyAlreadyRegistered().
    *
+   * @param uid - Owning user's ID as a hex string
+   * @param data - Passkey fields to persist (uid passed separately)
    * @throws {AppError} (passkeyLimitReached) if the user has reached the maximum passkey count
    * @throws {AppError} (passkeyAlreadyRegistered) if credentialId is already registered
    */
-  async registerPasskey(passkey: Passkey): Promise<void> {
-    const uidHex = passkey.uid.toString('hex');
-
-    await this.checkPasskeyCount(passkey.uid);
+  async registerPasskey(uid: string, data: NewPasskeyData): Promise<void> {
+    await this.checkPasskeyCount(uid);
 
     try {
-      await insertPasskey(this.db, passkey);
+      await insertPasskey(this.db, uid, data);
       this.metrics.increment('registerPasskey.success');
     } catch (err: unknown) {
       if (isMysqlDupEntry(err)) {
-        const credentialIdHex = passkey.credentialId.toString('hex');
         this.metrics.increment('registerPasskey.fail', { reason: 'duplicate' });
         this.log.error(
           'PasskeyManager.registerPasskey: duplicate credentialId',
-          { uid: uidHex, credentialId: credentialIdHex }
+          { uid, credentialId: data.credentialId }
         );
         throw AppError.passkeyAlreadyRegistered();
       }
@@ -90,15 +90,15 @@ export class PasskeyManager {
    * A false return indicates the credential was not found or a concurrent write
    * conflict — not a detected cloning attempt.
    *
-   * @param uid - User ID (16-byte Buffer)
-   * @param credentialId - WebAuthn credential ID
+   * @param uid - User ID as a hex string
+   * @param credentialId - WebAuthn credential ID as a base64url string
    * @param signCount - Verified new signature counter value from authenticator data
    * @param backupState - Current backup-state flag (BS) from authenticator data
    * @returns true if updated, false if not found or concurrent write conflict
    */
   async updatePasskeyAfterAuth(
-    uid: Buffer,
-    credentialId: Buffer,
+    uid: string,
+    credentialId: string,
     signCount: number,
     backupState: boolean
   ): Promise<boolean> {
@@ -107,7 +107,7 @@ export class PasskeyManager {
       uid,
       credentialId,
       signCount,
-      backupState ? 1 : 0
+      backupState
     );
   }
 
@@ -122,22 +122,22 @@ export class PasskeyManager {
    * passkey's uid matches the authenticated session uid before acting on
    * the result. Do not use the returned uid as proof of identity.
    *
-   * @param credentialId - WebAuthn credential ID (Buffer)
+   * @param credentialId - WebAuthn credential ID as a base64url string
    * @returns Passkey if found, undefined otherwise
    */
   async findPasskeyByCredentialId(
-    credentialId: Buffer
-  ): Promise<Passkey | undefined> {
+    credentialId: string
+  ): Promise<PasskeyRecord | undefined> {
     return repositoryFindPasskeyByCredentialId(this.db, credentialId);
   }
 
   /**
    * List all passkeys for a user, ordered by creation date newest-first.
    *
-   * @param uid - User ID (16-byte Buffer)
+   * @param uid - User ID as a hex string
    * @returns Array of passkeys ordered by createdAt descending
    */
-  async listPasskeysForUser(uid: Buffer): Promise<Passkey[]> {
+  async listPasskeysForUser(uid: string): Promise<PasskeyRecord[]> {
     return findPasskeysByUid(this.db, uid);
   }
 
@@ -150,8 +150,8 @@ export class PasskeyManager {
    * @returns true if the passkey was found and renamed, false if not found, wrong user, or name exceeds MAX_PASSKEY_NAME_LENGTH characters
    */
   async renamePasskey(
-    uid: Buffer,
-    credentialId: Buffer,
+    uid: string,
+    credentialId: string,
     newName: string
   ): Promise<boolean> {
     if (newName.length > MAX_PASSKEY_NAME_LENGTH) {
@@ -174,7 +174,7 @@ export class PasskeyManager {
    *
    * @returns true if the passkey was found and deleted, false otherwise
    */
-  async deletePasskey(uid: Buffer, credentialId: Buffer): Promise<boolean> {
+  async deletePasskey(uid: string, credentialId: string): Promise<boolean> {
     return repositoryDeletePasskey(this.db, uid, credentialId);
   }
 
@@ -183,10 +183,10 @@ export class PasskeyManager {
    *
    * Used during account deletion to remove all passkey credentials.
    *
-   * @param uid - User ID (16-byte Buffer)
+   * @param uid - User ID as a hex string
    * @returns Number of passkeys deleted
    */
-  async deleteAllPasskeysForUser(uid: Buffer): Promise<number> {
+  async deleteAllPasskeysForUser(uid: string): Promise<number> {
     return repositoryDeleteAllPasskeysForUser(this.db, uid);
   }
 
@@ -195,16 +195,15 @@ export class PasskeyManager {
    *
    * @returns Current passkey count for the user
    */
-  async countPasskeys(uid: Buffer): Promise<number> {
+  async countPasskeys(uid: string): Promise<number> {
     return countPasskeysByUid(this.db, uid);
   }
 
   /**
    * Checks if the user has exceeded the passkey limit and throws if so.
-   * @param uid - User ID (16-byte Buffer)
+   * @param uid - User ID as a hex string
    */
-  async checkPasskeyCount(uid: Buffer): Promise<void> {
-    const uidHex = uid.toString('hex');
+  async checkPasskeyCount(uid: string): Promise<void> {
     const count = await this.countPasskeys(uid);
 
     if (count >= this.maxPasskeysPerUser) {
@@ -212,7 +211,7 @@ export class PasskeyManager {
         reason: 'limit_reached',
       });
       this.log.error('PasskeyManager.passkeyLimitReached', {
-        uid: uidHex,
+        uid,
         limit: this.maxPasskeysPerUser,
       });
       throw AppError.passkeyLimitReached(this.maxPasskeysPerUser);

--- a/libs/accounts/passkey/src/lib/passkey.repository.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.repository.in.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@fxa/shared/db/mysql/account';
 import { AccountManager } from '@fxa/shared/account/account';
 import * as PasskeyRepository from './passkey.repository';
+import { bufferToAaguid } from './passkey.repository';
 
 describe('PasskeyRepository (Integration)', () => {
   let db: AccountDatabase;
@@ -29,10 +30,24 @@ describe('PasskeyRepository (Integration)', () => {
   });
 
   // Helper to create an account for testing
-  async function createTestAccount() {
+  async function createTestAccount(): Promise<string> {
     const email = faker.internet.email();
-    const uidHex = await accountManager.createAccountStub(email, 1, 'en-US');
-    return Buffer.from(uidHex, 'hex');
+    return accountManager.createAccountStub(email, 1, 'en-US');
+  }
+
+  function uidBuffer(uid: string): Buffer {
+    return Buffer.from(uid, 'hex');
+  }
+
+  // PasskeyFactory produces the DB-row shape (credentialId/aaguid: Buffer);
+  // insertPasskey takes NewPasskeyData (credentialId: base64url string,
+  // aaguid: hyphenated-UUID string).
+  function toNewPasskeyData(passkey: ReturnType<typeof PasskeyFactory>) {
+    return {
+      ...passkey,
+      credentialId: passkey.credentialId.toString('base64url'),
+      aaguid: bufferToAaguid(passkey.aaguid),
+    };
   }
 
   afterAll(async () => {
@@ -44,42 +59,42 @@ describe('PasskeyRepository (Integration)', () => {
   describe('insert and find operations', () => {
     it('should insert and retrieve a passkey', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
 
-      await PasskeyRepository.insertPasskey(db, passkey);
+      await PasskeyRepository.insertPasskey(db, uid, toNewPasskeyData(passkey));
 
       const found = await PasskeyRepository.findPasskeyByCredentialId(
         db,
-        passkey.credentialId
+        passkey.credentialId.toString('base64url')
       );
 
       expect(found).toBeDefined();
-      expect(found?.uid).toEqual(passkey.uid);
+      expect(found?.uid.toString('hex')).toEqual(passkey.uid.toString('hex'));
       expect(found?.name).toBe(passkey.name);
       expect(found?.transports).toBeDefined(); // JSON field
-      expect(found?.aaguid).toEqual(passkey.aaguid); // NOT NULL
+      expect(found?.aaguid).toEqual(bufferToAaguid(passkey.aaguid)); // NOT NULL
     });
   });
 
   describe('update operations', () => {
     it('should update counter and lastUsedAt after authentication', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid });
-      await PasskeyRepository.insertPasskey(db, passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid) });
+      await PasskeyRepository.insertPasskey(db, uid, toNewPasskeyData(passkey));
 
       const success = await PasskeyRepository.updatePasskeyCounterAndLastUsed(
         db,
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         5,
-        1
+        true
       );
 
       expect(success).toBe(true);
 
       const updated = await PasskeyRepository.findPasskeyByCredentialId(
         db,
-        passkey.credentialId
+        passkey.credentialId.toString('base64url')
       );
       expect(updated?.signCount).toBe(5);
       expect(updated?.backupState).toBe(true);
@@ -88,38 +103,38 @@ describe('PasskeyRepository (Integration)', () => {
 
     it('should reject update when new signCount equals stored non-zero signCount', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, signCount: 5 });
-      await PasskeyRepository.insertPasskey(db, passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid), signCount: 5 });
+      await PasskeyRepository.insertPasskey(db, uid, toNewPasskeyData(passkey));
 
       // Same non-zero signCount is a potential cloning signal — should be rejected
       const success = await PasskeyRepository.updatePasskeyCounterAndLastUsed(
         db,
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         5,
-        0
+        false
       );
 
       expect(success).toBe(false);
       const found = await PasskeyRepository.findPasskeyByCredentialId(
         db,
-        passkey.credentialId
+        passkey.credentialId.toString('base64url')
       );
       expect(found?.signCount).toBe(5);
     });
 
     it('should allow update when both stored and new signCount are zero', async () => {
       const uid = await createTestAccount();
-      const passkey = PasskeyFactory({ uid, signCount: 0 });
-      await PasskeyRepository.insertPasskey(db, passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid), signCount: 0 });
+      await PasskeyRepository.insertPasskey(db, uid, toNewPasskeyData(passkey));
 
       // Authenticators that never increment always return 0 — valid per WebAuthn spec
       const success = await PasskeyRepository.updatePasskeyCounterAndLastUsed(
         db,
-        passkey.uid,
-        passkey.credentialId,
+        passkey.uid.toString('hex'),
+        passkey.credentialId.toString('base64url'),
         0,
-        0
+        false
       );
 
       expect(success).toBe(true);
@@ -128,22 +143,22 @@ describe('PasskeyRepository (Integration)', () => {
     it('should not update when uid does not match credential owner', async () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
-      const passkey = PasskeyFactory({ uid: uid1, signCount: 0 });
-      await PasskeyRepository.insertPasskey(db, passkey);
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid1), signCount: 0 });
+      await PasskeyRepository.insertPasskey(db, uid1, toNewPasskeyData(passkey));
 
       // Wrong uid — WHERE clause should prevent the update
       const success = await PasskeyRepository.updatePasskeyCounterAndLastUsed(
         db,
         uid2,
-        passkey.credentialId,
+        passkey.credentialId.toString('base64url'),
         1,
-        0
+        false
       );
 
       expect(success).toBe(false);
       const found = await PasskeyRepository.findPasskeyByCredentialId(
         db,
-        passkey.credentialId
+        passkey.credentialId.toString('base64url')
       );
       expect(found?.signCount).toBe(0);
     });

--- a/libs/accounts/passkey/src/lib/passkey.repository.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.repository.spec.ts
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  aaguidToBuffer,
+  base64urlToBuffer,
+  bufferToAaguid,
+} from './passkey.repository';
+
+describe('aaguidToBuffer', () => {
+  it('converts a standard AAGUID UUID string to a 16-byte Buffer', () => {
+    const result = aaguidToBuffer('adce0002-35bc-c60a-648b-0b25f1f05503');
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBe(16);
+    expect(result[0]).toBe(0xad);
+    expect(result[1]).toBe(0xce);
+    expect(result[2]).toBe(0x00);
+    expect(result[3]).toBe(0x02);
+  });
+
+  it('converts the all-zeros AAGUID to a 16-byte zero Buffer', () => {
+    const result = aaguidToBuffer('00000000-0000-0000-0000-000000000000');
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(result.length).toBe(16);
+    expect(result.equals(Buffer.alloc(16, 0))).toBe(true);
+  });
+
+  it('strips hyphens correctly regardless of position', () => {
+    const uuid = 'f1d0f1d0-f1d0-f1d0-f1d0-f1d0f1d0f1d0';
+    const result = aaguidToBuffer(uuid);
+
+    expect(result.length).toBe(16);
+    for (let i = 0; i < 16; i++) {
+      expect(result[i]).toBe(i % 2 === 0 ? 0xf1 : 0xd0);
+    }
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['missing hyphens', 'adce000235bcc60a648b0b25f1f05503'],
+    ['too short', 'adce0002-35bc-c60a-648b-0b25f1f0550'],
+    ['too long', 'adce0002-35bc-c60a-648b-0b25f1f055033'],
+    ['non-hex characters', 'zzce0002-35bc-c60a-648b-0b25f1f05503'],
+    ['wrong separators', 'adce0002_35bc_c60a_648b_0b25f1f05503'],
+  ])('throws on malformed input (%s)', (_label, input) => {
+    expect(() => aaguidToBuffer(input)).toThrow('Invalid aaguid format');
+  });
+});
+
+describe('bufferToAaguid', () => {
+  it('converts a 16-byte Buffer back to a hyphenated UUID string', () => {
+    const buf = Buffer.from('adce000235bcc60a648b0b25f1f05503', 'hex');
+    expect(bufferToAaguid(buf)).toBe('adce0002-35bc-c60a-648b-0b25f1f05503');
+  });
+
+  it('round-trips the all-zeros aaguid', () => {
+    expect(bufferToAaguid(Buffer.alloc(16, 0))).toBe(
+      '00000000-0000-0000-0000-000000000000'
+    );
+  });
+
+  it('round-trips via aaguidToBuffer', () => {
+    const uuid = 'f1d0f1d0-f1d0-f1d0-f1d0-f1d0f1d0f1d0';
+    expect(bufferToAaguid(aaguidToBuffer(uuid))).toBe(uuid);
+  });
+});
+
+describe('base64urlToBuffer', () => {
+  it('decodes a valid base64url string to a Buffer', () => {
+    const buf = base64urlToBuffer('aGVsbG8td29ybGQ');
+    expect(buf).toBeInstanceOf(Buffer);
+    expect(buf.toString('utf8')).toBe('hello-world');
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['contains +', 'aGVsbG8+d29ybGQ'],
+    ['contains /', 'aGVsbG8/d29ybGQ'],
+    ['contains =', 'aGVsbG8td29ybGQ='],
+    ['non-alphabet character', 'aGVsbG8*d29ybGQ'],
+  ])('throws on malformed input (%s)', (_label, input) => {
+    expect(() => base64urlToBuffer(input)).toThrow('Invalid base64url data');
+  });
+});

--- a/libs/accounts/passkey/src/lib/passkey.repository.ts
+++ b/libs/accounts/passkey/src/lib/passkey.repository.ts
@@ -25,11 +25,93 @@
  * - For SELECT: Kysely returns booleans (false or true)
  */
 
+import { uuidTransformer } from '@fxa/shared/db/mysql/core';
 import type {
   AccountDatabase,
   Passkey,
   NewPasskey,
 } from '@fxa/shared/db/mysql/account';
+
+const BASE64URL_RE = /^[A-Za-z0-9_-]+$/;
+const AAGUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Convert a base64url-encoded credential ID to a Buffer, validating format.
+ *
+ * Mirrors `uuidTransformer.to` for hex uids: catches malformed input at the
+ * DB boundary instead of silently coercing it to garbage bytes. Throws on
+ * any character outside the base64url alphabet.
+ */
+export function base64urlToBuffer(value: string): Buffer {
+  if (!BASE64URL_RE.test(value)) {
+    throw new Error('Invalid base64url data');
+  }
+  return Buffer.from(value, 'base64url');
+}
+
+/**
+ * Convert a hyphenated-UUID aaguid string to a 16-byte Buffer for DB storage.
+ *
+ * Validates the hyphenated-UUID format and throws on malformed input, so we
+ * fail loudly at the conversion boundary instead of silently writing short
+ * or garbage bytes to the BINARY(16) column.
+ *
+ * @param aaguid - Hyphenated-UUID aaguid string from SimpleWebAuthn
+ */
+export function aaguidToBuffer(aaguid: string): Buffer {
+  if (!AAGUID_RE.test(aaguid)) {
+    throw new Error('Invalid aaguid format');
+  }
+  return Buffer.from(aaguid.replace(/-/g, ''), 'hex');
+}
+
+/**
+ * Convert a 16-byte aaguid Buffer (as stored in the DB) back to its
+ * conventional hyphenated-UUID string form.
+ *
+ * @param buf - 16-byte Buffer
+ */
+export function bufferToAaguid(buf: Buffer): string {
+  const hex = buf.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Fields needed to persist a new passkey, minus the owning user's uid.
+ *
+ * The uid is passed as a separate hex-string argument; `credentialId` is a
+ * base64url string; `aaguid` is a hyphenated-UUID string. The service and
+ * manager stay free of DB-layer `Buffer` conversions — the repository
+ * converts at the DB boundary.
+ */
+export type NewPasskeyData = Omit<
+  Passkey,
+  'uid' | 'credentialId' | 'aaguid'
+> & {
+  /** WebAuthn credential ID as a base64url string. */
+  credentialId: string;
+  /** Authenticator aaguid as a hyphenated-UUID string. */
+  aaguid: string;
+};
+
+/**
+ * Passkey row as seen by the rest of the app. Mirrors the DB-row shape but
+ * exposes `credentialId` as a base64url string and `aaguid` as a
+ * hyphenated-UUID string, so callers never touch the raw bytes.
+ */
+export type PasskeyRecord = Omit<Passkey, 'aaguid' | 'credentialId'> & {
+  aaguid: string;
+  credentialId: string;
+};
+
+function toPasskeyRecord(row: Passkey): PasskeyRecord {
+  return {
+    ...row,
+    aaguid: bufferToAaguid(row.aaguid),
+    credentialId: row.credentialId.toString('base64url'),
+  };
+}
 
 /**
  * Type guard for MySQL duplicate-entry errors (ER_DUP_ENTRY).
@@ -50,56 +132,63 @@ export function isMysqlDupEntry(err: unknown): err is { code: 'ER_DUP_ENTRY' } {
  * Find all passkeys for a given user, ordered by creation date newest-first.
  *
  * @param db - Database instance
- * @param uid - User ID (16-byte Buffer)
+ * @param uid - User ID as a hex string
  * @returns Array of passkeys ordered by createdAt descending
  */
 export async function findPasskeysByUid(
   db: AccountDatabase,
-  uid: Buffer
-): Promise<Passkey[]> {
-  return await db
+  uid: string
+): Promise<PasskeyRecord[]> {
+  const rows = await db
     .selectFrom('passkeys')
     .selectAll()
-    .where('uid', '=', uid)
+    .where('uid', '=', uuidTransformer.to(uid))
     .orderBy('createdAt', 'desc')
     .orderBy('credentialId', 'asc')
     .execute();
+  return rows.map(toPasskeyRecord);
 }
 
 /**
  * Find a passkey by its credential ID.
  *
  * @param db - Database instance
- * @param credentialId - WebAuthn credential ID (Buffer)
+ * @param credentialId - WebAuthn credential ID as a base64url string
  * @returns Passkey if found, undefined otherwise
  */
 export async function findPasskeyByCredentialId(
   db: AccountDatabase,
-  credentialId: Buffer
-): Promise<Passkey | undefined> {
-  return await db
+  credentialId: string
+): Promise<PasskeyRecord | undefined> {
+  const row = await db
     .selectFrom('passkeys')
     .selectAll()
-    .where('credentialId', '=', credentialId)
+    .where('credentialId', '=', base64urlToBuffer(credentialId))
     .executeTakeFirst();
+  return row && toPasskeyRecord(row);
 }
 
 /**
  * Insert a new passkey record.
  *
  * @param db - Database instance
- * @param passkey - Passkey data to insert
+ * @param uid - Owning user's ID as a hex string
+ * @param data - Passkey fields to persist (uid passed separately)
  */
 export async function insertPasskey(
   db: AccountDatabase,
-  passkey: Passkey
+  uid: string,
+  data: NewPasskeyData
 ): Promise<void> {
   const newPasskey: NewPasskey = {
-    ...passkey,
-    transports: JSON.stringify(passkey.transports),
-    backupEligible: passkey.backupEligible ? 1 : 0,
-    backupState: passkey.backupState ? 1 : 0,
-    prfEnabled: passkey.prfEnabled ? 1 : 0,
+    ...data,
+    uid: uuidTransformer.to(uid),
+    credentialId: base64urlToBuffer(data.credentialId),
+    aaguid: aaguidToBuffer(data.aaguid),
+    transports: JSON.stringify(data.transports),
+    backupEligible: data.backupEligible ? 1 : 0,
+    backupState: data.backupState ? 1 : 0,
+    prfEnabled: data.prfEnabled ? 1 : 0,
   };
   await db.insertInto('passkeys').values(newPasskey).execute();
 }
@@ -122,28 +211,28 @@ export async function insertPasskey(
  * verifyAuthenticationResponse() before this function is called.
  *
  * @param db - Database instance
- * @param uid - User ID (16-byte Buffer)
- * @param credentialId - WebAuthn credential ID (Buffer)
+ * @param uid - User ID as a hex string
+ * @param credentialId - WebAuthn credential ID as a base64url string
  * @param signCount - Verified new signature count from authenticator data
- * @param backupState - Current backup state flag (0 or 1) from authenticator data
+ * @param backupState - Current backup state flag from authenticator data
  * @returns true if updated, false if credential not found or concurrent write conflict
  */
 export async function updatePasskeyCounterAndLastUsed(
   db: AccountDatabase,
-  uid: Buffer,
-  credentialId: Buffer,
+  uid: string,
+  credentialId: string,
   signCount: number,
-  backupState: number
+  backupState: boolean
 ): Promise<boolean> {
   const result = await db
     .updateTable('passkeys')
     .set({
       lastUsedAt: Date.now(),
       signCount: signCount,
-      backupState: backupState,
+      backupState: backupState ? 1 : 0,
     })
-    .where('uid', '=', uid)
-    .where('credentialId', '=', credentialId)
+    .where('uid', '=', uuidTransformer.to(uid))
+    .where('credentialId', '=', base64urlToBuffer(credentialId))
     .where((eb) =>
       // Per WebAuthn spec: authenticators that never increment always return 0
       // (both stored and new must be 0). For all other authenticators, the new
@@ -164,22 +253,22 @@ export async function updatePasskeyCounterAndLastUsed(
  * another user's passkey with a known credential ID.
  *
  * @param db - Database instance
- * @param uid - User ID (16-byte Buffer)
- * @param credentialId - WebAuthn credential ID (Buffer)
+ * @param uid - User ID as a hex string
+ * @param credentialId - WebAuthn credential ID as a base64url string
  * @param name - New friendly name for the passkey
  * @returns Number of rows updated (1 if successful, 0 if not found or wrong user)
  */
 export async function updatePasskeyName(
   db: AccountDatabase,
-  uid: Buffer,
-  credentialId: Buffer,
+  uid: string,
+  credentialId: string,
   name: string
 ): Promise<number> {
   const result = await db
     .updateTable('passkeys')
     .set({ name })
-    .where('uid', '=', uid)
-    .where('credentialId', '=', credentialId)
+    .where('uid', '=', uuidTransformer.to(uid))
+    .where('credentialId', '=', base64urlToBuffer(credentialId))
     .executeTakeFirst();
 
   return Number(result.numUpdatedRows);
@@ -189,19 +278,19 @@ export async function updatePasskeyName(
  * Delete a specific passkey for a user.
  *
  * @param db - Database instance
- * @param uid - User ID (16-byte Buffer)
- * @param credentialId - WebAuthn credential ID (Buffer)
+ * @param uid - User ID as a hex string
+ * @param credentialId - WebAuthn credential ID as a base64url string
  * @returns true if a passkey was deleted, false otherwise
  */
 export async function deletePasskey(
   db: AccountDatabase,
-  uid: Buffer,
-  credentialId: Buffer
+  uid: string,
+  credentialId: string
 ): Promise<boolean> {
   const result = await db
     .deleteFrom('passkeys')
-    .where('uid', '=', uid)
-    .where('credentialId', '=', credentialId)
+    .where('uid', '=', uuidTransformer.to(uid))
+    .where('credentialId', '=', base64urlToBuffer(credentialId))
     .executeTakeFirst();
 
   return result.numDeletedRows === BigInt(1);
@@ -211,16 +300,16 @@ export async function deletePasskey(
  * Delete all passkeys for a user.
  *
  * @param db - Database instance
- * @param uid - User ID (16-byte Buffer)
+ * @param uid - User ID as a hex string
  * @returns Number of passkeys deleted
  */
 export async function deleteAllPasskeysForUser(
   db: AccountDatabase,
-  uid: Buffer
+  uid: string
 ): Promise<number> {
   const result = await db
     .deleteFrom('passkeys')
-    .where('uid', '=', uid)
+    .where('uid', '=', uuidTransformer.to(uid))
     .executeTakeFirst();
 
   return Number(result.numDeletedRows);
@@ -230,17 +319,17 @@ export async function deleteAllPasskeysForUser(
  * Count the number of passkeys for a user.
  *
  * @param db - Database instance
- * @param uid - User ID (16-byte Buffer)
+ * @param uid - User ID as a hex string
  * @returns Number of passkeys for the user
  */
 export async function countPasskeysByUid(
   db: AccountDatabase,
-  uid: Buffer
+  uid: string
 ): Promise<number> {
   const result = await db
     .selectFrom('passkeys')
     .select(db.fn.count('credentialId').as('count'))
-    .where('uid', '=', uid)
+    .where('uid', '=', uuidTransformer.to(uid))
     .executeTakeFirst();
 
   return Number(result?.count ?? 0);

--- a/libs/accounts/passkey/src/lib/passkey.security.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.security.in.spec.ts
@@ -27,7 +27,11 @@ import { PasskeyChallengeManager } from './passkey.challenge.manager';
 import { PasskeyConfig } from './passkey.config';
 import { AppError } from '@fxa/accounts/errors';
 import { PASSKEY_CHALLENGE_REDIS } from './passkey.provider';
-import { findPasskeyByCredentialId, insertPasskey } from './passkey.repository';
+import {
+  bufferToAaguid,
+  findPasskeyByCredentialId,
+  insertPasskey,
+} from './passkey.repository';
 
 const mockLogger = {
   log: jest.fn(),
@@ -83,27 +87,42 @@ describe('Passkey Security Tests', () => {
       }
     });
 
-    async function createTestAccount(): Promise<Buffer> {
+    async function createTestAccount(): Promise<string> {
       const email = faker.internet.email();
-      const uidHex = await accountManager.createAccountStub(email, 1, 'en-US');
-      return Buffer.from(uidHex, 'hex');
+      return accountManager.createAccountStub(email, 1, 'en-US');
+    }
+
+    function uidBuffer(uid: string): Buffer {
+      return Buffer.from(uid, 'hex');
+    }
+
+    // PasskeyFactory produces the DB-row shape (credentialId/aaguid: Buffer);
+    // callers of registerPasskey / insertPasskey take NewPasskeyData
+    // (credentialId: base64url string, aaguid: hyphenated-UUID string).
+    function toNewPasskeyData(passkey: ReturnType<typeof PasskeyFactory>) {
+      return {
+        ...passkey,
+        credentialId: passkey.credentialId.toString('base64url'),
+        aaguid: bufferToAaguid(passkey.aaguid),
+      };
     }
 
     // WebAuthn §4: https://www.w3.org/TR/webauthn-3/#credential-id
     it('credentialId uniqueness is globally scoped across users', async () => {
       const uid1 = await createTestAccount();
       const uid2 = await createTestAccount();
-      const passkey = PasskeyFactory({ uid: uid1 });
+      const passkey = PasskeyFactory({ uid: uidBuffer(uid1) });
+      const data = toNewPasskeyData(passkey);
 
-      await manager.registerPasskey(passkey);
+      await manager.registerPasskey(uid1, data);
 
       // Same user, same credentialId — also rejected
-      await expect(manager.registerPasskey(passkey)).rejects.toMatchObject(
+      await expect(manager.registerPasskey(uid1, data)).rejects.toMatchObject(
         AppError.passkeyAlreadyRegistered()
       );
       // Different user, same credentialId — UNIQUE INDEX is global, not per-user
       await expect(
-        manager.registerPasskey({ ...passkey, uid: uid2 })
+        manager.registerPasskey(uid2, { ...data })
       ).rejects.toMatchObject(AppError.passkeyAlreadyRegistered());
     });
 
@@ -112,11 +131,17 @@ describe('Passkey Security Tests', () => {
     it('publicKey survives DB round-trip as binary Buffer, not a base64 string', async () => {
       const uid = await createTestAccount();
       const knownKey = Buffer.from('deadbeefcafebabe'.repeat(8), 'hex');
-      const passkey = PasskeyFactory({ uid, publicKey: knownKey });
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid),
+        publicKey: knownKey,
+      });
 
-      await insertPasskey(db, passkey);
+      await insertPasskey(db, uid, toNewPasskeyData(passkey));
 
-      const found = await findPasskeyByCredentialId(db, passkey.credentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        passkey.credentialId.toString('base64url')
+      );
       expect(found).toBeDefined();
       expect(Buffer.isBuffer(found?.publicKey)).toBe(true);
       expect(found?.publicKey).toEqual(knownKey);
@@ -132,13 +157,21 @@ describe('Passkey Security Tests', () => {
       const binaryCredentialId = Buffer.from(
         Array.from({ length: 32 }, (_, i) => 0x80 + i)
       );
-      const passkey = PasskeyFactory({ uid, credentialId: binaryCredentialId });
+      const passkey = PasskeyFactory({
+        uid: uidBuffer(uid),
+        credentialId: binaryCredentialId,
+      });
 
-      await insertPasskey(db, passkey);
+      await insertPasskey(db, uid, toNewPasskeyData(passkey));
 
-      const found = await findPasskeyByCredentialId(db, binaryCredentialId);
+      const found = await findPasskeyByCredentialId(
+        db,
+        binaryCredentialId.toString('base64url')
+      );
       expect(found).toBeDefined();
-      expect(found?.credentialId).toEqual(binaryCredentialId);
+      expect(found?.credentialId).toEqual(
+        binaryCredentialId.toString('base64url')
+      );
     });
   });
 

--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -33,15 +33,19 @@ const mockVerifyWebauthnRegistrationResponse =
 describe('PasskeyService', () => {
   let service: PasskeyService;
 
-  const MOCK_UID = Buffer.alloc(16, 0xaa);
+  const MOCK_UID_BUFFER = Buffer.alloc(16, 0xaa);
+  const MOCK_UID = MOCK_UID_BUFFER.toString('hex');
   const MOCK_USER_NAME = 'user@example.com';
   const MOCK_CHALLENGE = 'mock-challenge-base64url';
-  const MOCK_CREDENTIAL_ID = Buffer.alloc(32, 0xbb);
+  const MOCK_CREDENTIAL_ID_BUFFER = Buffer.alloc(32, 0xbb);
+  const MOCK_CREDENTIAL_ID = MOCK_CREDENTIAL_ID_BUFFER.toString('base64url');
   const MOCK_PUBLIC_KEY = Buffer.alloc(64, 0xcc);
-  const MOCK_AAGUID_ZEROS = Buffer.alloc(16, 0x00);
+  const MOCK_AAGUID_ZEROS = '00000000-0000-0000-0000-000000000000';
 
+  // PasskeyRecord shape: uid is Buffer (DB-row); credentialId is base64url
+  // string; aaguid is hyphenated-UUID string.
   const mockPasskey = {
-    uid: MOCK_UID,
+    uid: MOCK_UID_BUFFER,
     credentialId: MOCK_CREDENTIAL_ID,
     publicKey: MOCK_PUBLIC_KEY,
     signCount: 5,
@@ -52,12 +56,12 @@ describe('PasskeyService', () => {
     createdAt: Date.now(),
     lastUsedAt: null,
     transports: [],
-    aaguid: Buffer.alloc(16),
+    aaguid: MOCK_AAGUID_ZEROS,
   };
 
   const mockResponse: AuthenticationResponseJSON = {
-    id: MOCK_CREDENTIAL_ID.toString('base64url'),
-    rawId: MOCK_CREDENTIAL_ID.toString('base64url'),
+    id: MOCK_CREDENTIAL_ID,
+    rawId: MOCK_CREDENTIAL_ID,
     response: {
       authenticatorData: 'mock-auth-data',
       clientDataJSON: 'mock-client-data-json',
@@ -177,7 +181,7 @@ describe('PasskeyService', () => {
 
       expect(
         mockChallengeManager.generateRegistrationChallenge
-      ).toHaveBeenCalledWith(MOCK_UID.toString('hex'));
+      ).toHaveBeenCalledWith(MOCK_UID);
 
       expect(
         webauthnAdapter.generateWebauthnRegistrationOptions
@@ -210,7 +214,7 @@ describe('PasskeyService', () => {
       mockChallengeManager.consumeRegistrationChallenge.mockResolvedValue({
         challenge: MOCK_CHALLENGE,
         type: 'registration',
-        uid: MOCK_UID.toString('hex'),
+        uid: MOCK_UID,
         createdAt: Date.now() - 1000,
         expiresAt: Date.now() + 299000,
       });
@@ -280,10 +284,10 @@ describe('PasskeyService', () => {
       );
       expect(
         mockChallengeManager.consumeRegistrationChallenge
-      ).toHaveBeenCalledWith(MOCK_CHALLENGE, MOCK_UID.toString('hex'));
+      ).toHaveBeenCalledWith(MOCK_CHALLENGE, MOCK_UID);
     });
 
-    it('calls passkeyManager.registerPasskey with correct Passkey shape', async () => {
+    it('calls passkeyManager.registerPasskey with the uid and passkey data', async () => {
       await service.createPasskeyFromRegistrationResponse(
         MOCK_UID,
         mockResponse,
@@ -291,8 +295,8 @@ describe('PasskeyService', () => {
       );
 
       expect(mockManager.registerPasskey).toHaveBeenCalledWith(
+        MOCK_UID,
         expect.objectContaining({
-          uid: MOCK_UID,
           createdAt: expect.any(Number),
           lastUsedAt: null,
           ...mockVerifiedData,
@@ -300,7 +304,7 @@ describe('PasskeyService', () => {
       );
     });
 
-    it('returns a Passkey object with correct shape', async () => {
+    it('returns the persisted passkey data', async () => {
       const result = await service.createPasskeyFromRegistrationResponse(
         MOCK_UID,
         mockResponse,
@@ -308,7 +312,6 @@ describe('PasskeyService', () => {
       );
       expect(result).toEqual(
         expect.objectContaining({
-          uid: MOCK_UID,
           name: expect.any(String),
           credentialId: MOCK_CREDENTIAL_ID,
           publicKey: MOCK_PUBLIC_KEY,
@@ -335,7 +338,7 @@ describe('PasskeyService', () => {
       );
       expect(mockLogger.log).toHaveBeenCalledWith(
         'passkey.registered',
-        expect.objectContaining({ uid: MOCK_UID.toString('hex') })
+        expect.objectContaining({ uid: MOCK_UID })
       );
     });
 
@@ -370,7 +373,7 @@ describe('PasskeyService', () => {
     describe('passkey name generation (via createPasskeyFromRegistrationResponse)', () => {
       async function getRegisteredPasskeyName(
         transports: string[],
-        aaguid: Buffer = MOCK_AAGUID_ZEROS
+        aaguid: string = MOCK_AAGUID_ZEROS
       ): Promise<string> {
         mockVerifyWebauthnRegistrationResponse.mockResolvedValue({
           verified: true,
@@ -381,8 +384,8 @@ describe('PasskeyService', () => {
           mockResponse,
           MOCK_CHALLENGE
         );
-        const call = mockManager.registerPasskey.mock.calls[0][0];
-        return call.name;
+        const [, data] = mockManager.registerPasskey.mock.calls[0];
+        return data.name;
       }
 
       it('returns "Platform Passkey" for transport ["internal"]', async () => {
@@ -578,7 +581,7 @@ describe('PasskeyService', () => {
       ).toHaveBeenCalledWith(mockConfig, {
         response: mockResponse,
         challenge: MOCK_CHALLENGE,
-        credentialId: mockPasskey.credentialId,
+        credentialId: MOCK_CREDENTIAL_ID,
         publicKey: mockPasskey.publicKey,
         signCount: mockPasskey.signCount,
       });
@@ -605,7 +608,7 @@ describe('PasskeyService', () => {
       await service.verifyAuthenticationResponse(mockResponse, MOCK_CHALLENGE);
       expect(mockLogger.log).toHaveBeenCalledWith(
         'passkey.authenticated',
-        expect.objectContaining({ uid: MOCK_UID.toString('hex') })
+        expect.objectContaining({ uid: MOCK_UID })
       );
     });
 
@@ -657,7 +660,7 @@ describe('PasskeyService', () => {
     });
 
     it('throws a passkeyAuthenticationFailed AppError when expectedUid does not match the passkey owner', async () => {
-      const wrongUid = Buffer.from('0000000000000000', 'hex');
+      const wrongUid = '00'.repeat(16);
 
       await expect(
         service.verifyAuthenticationResponse(
@@ -688,8 +691,8 @@ describe('PasskeyService', () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(
         'passkey.signCount.rollback',
         expect.objectContaining({
-          uid: MOCK_UID.toString('hex'),
-          credentialId: MOCK_CREDENTIAL_ID.toString('hex'),
+          uid: MOCK_UID,
+          credentialId: MOCK_CREDENTIAL_ID,
           oldCount: mockPasskey.signCount,
         })
       );
@@ -726,8 +729,8 @@ describe('PasskeyService', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(
         'passkey.updateAfterAuth.failed',
         expect.objectContaining({
-          uid: MOCK_UID.toString('hex'),
-          credentialId: MOCK_CREDENTIAL_ID.toString('hex'),
+          uid: MOCK_UID,
+          credentialId: MOCK_CREDENTIAL_ID,
           newSignCount: 6,
         })
       );
@@ -739,8 +742,13 @@ describe('PasskeyService', () => {
   });
 
   describe('listPasskeysForUser', () => {
+    // PasskeyRecord shape: uid is Buffer (DB-row), credentialId is base64url string.
     const mockPasskeys = [
-      { uid: MOCK_UID, credentialId: MOCK_CREDENTIAL_ID, name: 'Passkey' },
+      {
+        uid: MOCK_UID_BUFFER,
+        credentialId: MOCK_CREDENTIAL_ID,
+        name: 'Passkey',
+      },
     ];
 
     it('returns passkeys from manager', async () => {
@@ -785,7 +793,7 @@ describe('PasskeyService', () => {
       );
       expect(mockLogger.log).toHaveBeenCalledWith(
         'passkey.renamed',
-        expect.objectContaining({ uid: MOCK_UID.toString('hex') })
+        expect.objectContaining({ uid: MOCK_UID })
       );
     });
 
@@ -927,7 +935,7 @@ describe('PasskeyService', () => {
       );
       expect(mockLogger.log).toHaveBeenCalledWith(
         'passkey.deleted',
-        expect.objectContaining({ uid: MOCK_UID.toString('hex') })
+        expect.objectContaining({ uid: MOCK_UID })
       );
     });
 

--- a/libs/accounts/passkey/src/lib/passkey.service.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.ts
@@ -10,7 +10,6 @@ import type {
 import { LOGGER_PROVIDER } from '@fxa/shared/log';
 import { StatsD, StatsDService } from '@fxa/shared/metrics/statsd';
 import * as Sentry from '@sentry/nestjs';
-import type { Passkey } from '@fxa/shared/db/mysql/account';
 import type {
   AuthenticatorTransportFuture,
   PublicKeyCredentialCreationOptionsJSON,
@@ -18,6 +17,7 @@ import type {
 } from '@simplewebauthn/server';
 import { PasskeyConfig } from './passkey.config';
 import { PasskeyManager } from './passkey.manager';
+import { NewPasskeyData, PasskeyRecord } from './passkey.repository';
 import { PasskeyChallengeManager } from './passkey.challenge.manager';
 import {
   generateWebauthnRegistrationOptions,
@@ -30,7 +30,8 @@ import {
 import { AppError } from '@fxa/accounts/errors';
 
 export interface AuthenticationResult {
-  uid: Buffer;
+  /** Authenticated user ID as a hex string. */
+  uid: string;
 }
 
 /**
@@ -104,20 +105,18 @@ export class PasskeyService {
    * Validates the user has not exceeded the passkey limit, then generates
    * a challenge and returns WebAuthn PublicKeyCredentialCreationOptions.
    *
-   * @param uid - User ID (16-byte Buffer)
+   * @param uid - User ID as a hex string
    * @param email - User's display name (e.g. email) for WebAuthn options
    * @returns WebAuthn registration options to pass to the browser
    */
   async generateRegistrationChallenge(
-    uid: Buffer,
+    uid: string,
     email: string
   ): Promise<PublicKeyCredentialCreationOptionsJSON> {
-    const uidHex = uid.toString('hex');
-
     await this.passkeyManager.checkPasskeyCount(uid);
 
     const challenge =
-      await this.challengeManager.generateRegistrationChallenge(uidHex);
+      await this.challengeManager.generateRegistrationChallenge(uid);
 
     const options = await generateWebauthnRegistrationOptions(this.config, {
       uid,
@@ -134,7 +133,7 @@ export class PasskeyService {
    * Validates the challenge, verifies the attestation, generates a passkey name,
    * and stores the credential in the database.
    *
-   * @param uid - User ID (16-byte Buffer)
+   * @param uid - User ID as a hex string
    * @param response - Raw registration response from the browser
    * @param challenge - Challenge that was issued for this registration
    * @returns The newly created passkey record as stored in the database.
@@ -144,17 +143,12 @@ export class PasskeyService {
    *   fails or the verified flag is false.
    */
   async createPasskeyFromRegistrationResponse(
-    uid: Buffer,
+    uid: string,
     response: RegistrationResponseJSON,
     challenge: string
-  ): Promise<Passkey> {
-    const uidHex = uid.toString('hex');
-
+  ): Promise<NewPasskeyData> {
     const storedChallenge =
-      await this.challengeManager.consumeRegistrationChallenge(
-        challenge,
-        uidHex
-      );
+      await this.challengeManager.consumeRegistrationChallenge(challenge, uid);
 
     if (!storedChallenge) {
       this.metrics.increment('passkey.registration.failed', {
@@ -192,29 +186,28 @@ export class PasskeyService {
 
     const name = this.generatePasskeyName(aaguid, transports, existingPasskeys);
 
-    const passkey: Passkey = {
-      uid,
+    const passkeyData: NewPasskeyData = {
       name,
       createdAt: Date.now(),
       lastUsedAt: null,
       ...result.data,
     };
 
-    await this.passkeyManager.registerPasskey(passkey);
+    await this.passkeyManager.registerPasskey(uid, passkeyData);
 
     this.metrics.increment('passkey.registration.success');
-    this.log?.log('passkey.registered', { uid: uidHex });
+    this.log?.log('passkey.registered', { uid });
 
-    return passkey;
+    return passkeyData;
   }
 
   /**
    * Returns all passkeys for a user, ordered by createdAt descending.
    *
-   * @param uid - User ID (16-byte Buffer)
+   * @param uid - User ID as a hex string
    * @returns Array of passkeys belonging to the user
    */
-  async listPasskeysForUser(uid: Buffer): Promise<Passkey[]> {
+  async listPasskeysForUser(uid: string): Promise<PasskeyRecord[]> {
     const passkeys = await this.passkeyManager.listPasskeysForUser(uid);
     this.metrics.increment('passkey.list.success');
     return passkeys;
@@ -224,17 +217,17 @@ export class PasskeyService {
    * Updates the friendly name for a passkey, ensuring the passkey belongs to the user.
    * The name is trimmed before validation and storage.
    *
-   * @param uid - User ID (16-byte Buffer)
-   * @param credentialId - Credential ID of the passkey to rename
+   * @param uid - User ID as a hex string
+   * @param credentialId - Credential ID (base64url) of the passkey to rename
    * @param newName - New display name for the passkey
    * @throws {AppError} (passkeyInvalidName) - when name is empty, whitespace-only, or exceeds 255 chars
    * @throws {AppError} (passkeyNotFound) - when passkey does not exist or does not belong to the user
    */
   async renamePasskey(
-    uid: Buffer,
-    credentialId: Buffer,
+    uid: string,
+    credentialId: string,
     newName: string
-  ): Promise<Passkey> {
+  ): Promise<PasskeyRecord> {
     const trimmed = newName.trim();
     if (
       !trimmed ||
@@ -274,7 +267,7 @@ export class PasskeyService {
     }
 
     this.metrics.increment('passkey.rename.success');
-    this.log?.log('passkey.renamed', { uid: uid.toString('hex') });
+    this.log?.log('passkey.renamed', { uid });
 
     return passkey;
   }
@@ -282,12 +275,12 @@ export class PasskeyService {
   /**
    * Deletes a passkey, ensuring the passkey belongs to the user.
    *
-   * @param uid - User ID (16-byte Buffer)
-   * @param credentialId - Credential ID of the passkey to delete
+   * @param uid - User ID as a hex string
+   * @param credentialId - Credential ID (base64url) of the passkey to delete
    * @throws {AppError} (passkeyNotFound) - when passkey does not exist or does not belong to the user
    * @throws {AppError} (passkeyDeleteFailed) - when a database error occurs during deletion
    */
-  async deletePasskey(uid: Buffer, credentialId: Buffer): Promise<void> {
+  async deletePasskey(uid: string, credentialId: string): Promise<void> {
     let deleted = false;
     try {
       deleted = await this.passkeyManager.deletePasskey(uid, credentialId);
@@ -306,7 +299,7 @@ export class PasskeyService {
     }
 
     this.metrics.increment('passkey.delete.success');
-    this.log?.log('passkey.deleted', { uid: uid.toString('hex') });
+    this.log?.log('passkey.deleted', { uid });
   }
 
   /**
@@ -317,9 +310,9 @@ export class PasskeyService {
    * (e.g., "Passkey", "Passkey 2", "Passkey 3").
    */
   private generatePasskeyName(
-    aaguid: Buffer,
+    aaguid: string,
     transports: AuthenticatorTransportFuture[],
-    existingPasskeys: Passkey[]
+    existingPasskeys: PasskeyRecord[]
   ): string {
     const baseName = this.getBasePasskeyName(aaguid, transports);
     return this.deduplicatePasskeyName(baseName, existingPasskeys);
@@ -334,10 +327,10 @@ export class PasskeyService {
    * 3. Generic fallback: "Passkey"
    */
   private getBasePasskeyName(
-    aaguid: Buffer,
+    aaguid: string,
     transports: AuthenticatorTransportFuture[]
   ): string {
-    const allZeros = aaguid.every((b) => b === 0);
+    const allZeros = aaguid === '00000000-0000-0000-0000-000000000000';
 
     if (!allZeros) {
       // TODO: FIDO MDS lookup — return device name if found
@@ -361,7 +354,7 @@ export class PasskeyService {
 
   private deduplicatePasskeyName(
     baseName: string,
-    existingPasskeys: Passkey[]
+    existingPasskeys: PasskeyRecord[]
   ): string {
     const existingNames = existingPasskeys.map((p) => p.name).filter(Boolean);
 
@@ -391,12 +384,12 @@ export class PasskeyService {
    * @returns WebAuthn authentication options
    */
   async generateAuthenticationChallenge(
-    uid?: Buffer
+    uid?: string
   ): Promise<PublicKeyCredentialRequestOptionsJSON> {
     const challenge =
       await this.challengeManager.generateAuthenticationChallenge();
 
-    let allowCredentials: Buffer[] = [];
+    let allowCredentials: string[] = [];
     if (uid) {
       const passkeys = await this.passkeyManager.listPasskeysForUser(uid);
       allowCredentials = passkeys.map((p) => p.credentialId);
@@ -424,9 +417,9 @@ export class PasskeyService {
   async verifyAuthenticationResponse(
     response: AuthenticationResponseJSON,
     challenge: string,
-    expectedUid?: Buffer
+    expectedUid?: string
   ): Promise<AuthenticationResult> {
-    const credentialId = Buffer.from(response.id, 'base64url');
+    const credentialId = response.id;
 
     const passkey =
       await this.passkeyManager.findPasskeyByCredentialId(credentialId);
@@ -437,7 +430,8 @@ export class PasskeyService {
       throw AppError.passkeyNotFound();
     }
 
-    if (expectedUid && !passkey.uid.equals(expectedUid)) {
+    const uid = passkey.uid.toString('hex');
+    if (expectedUid && uid !== expectedUid) {
       this.metrics.increment('passkey.authentication.failed', {
         reason: 'uidMismatch',
       });
@@ -450,9 +444,7 @@ export class PasskeyService {
       this.metrics.increment('passkey.authentication.failed', {
         reason: 'challengeNotFound',
       });
-      this.log?.warn('passkey.challengeNotFound', {
-        credentialId: credentialId.toString('hex'),
-      });
+      this.log?.warn('passkey.challengeNotFound', { credentialId });
       throw AppError.passkeyChallengeNotFound();
     }
 
@@ -461,7 +453,7 @@ export class PasskeyService {
       result = await verifyWebauthnAuthenticationResponse(this.config, {
         response,
         challenge: storedChallenge.challenge,
-        credentialId: passkey.credentialId,
+        credentialId,
         publicKey: passkey.publicKey,
         signCount: passkey.signCount,
       });
@@ -469,8 +461,8 @@ export class PasskeyService {
       // simplewebauthn throws when signCount decrements
       if (err instanceof Error && /^Response counter value/.test(err.message)) {
         this.log?.warn('passkey.signCount.rollback', {
-          uid: passkey.uid.toString('hex'),
-          credentialId: credentialId.toString('hex'),
+          uid,
+          credentialId,
           oldCount: passkey.signCount,
           error: err.message,
         });
@@ -492,15 +484,15 @@ export class PasskeyService {
     const { newSignCount, backupState } = result.data;
 
     const updated = await this.passkeyManager.updatePasskeyAfterAuth(
-      passkey.uid,
-      passkey.credentialId,
+      uid,
+      credentialId,
       newSignCount,
       backupState
     );
     if (!updated) {
       this.log?.error('passkey.updateAfterAuth.failed', {
-        uid: passkey.uid.toString('hex'),
-        credentialId: credentialId.toString('hex'),
+        uid,
+        credentialId,
         newSignCount,
       });
       this.metrics.increment('passkey.authentication.failed', {
@@ -510,10 +502,8 @@ export class PasskeyService {
     }
 
     this.metrics.increment('passkey.authentication.success');
-    this.log?.log('passkey.authenticated', {
-      uid: passkey.uid.toString('hex'),
-    });
+    this.log?.log('passkey.authenticated', { uid });
 
-    return { uid: passkey.uid };
+    return { uid };
   }
 }

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.in.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.in.spec.ts
@@ -40,7 +40,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
       const challenge = randomBytes(32).toString('base64url');
 
       const options = await generateWebauthnRegistrationOptions(config, {
-        uid: Buffer.alloc(16, 0xaa),
+        uid: Buffer.alloc(16, 0xaa).toString('hex'),
         email: 'test@example.com',
         challenge,
       });
@@ -53,7 +53,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
       const challenge = randomBytes(32).toString('base64url');
 
       const options = await generateWebauthnRegistrationOptions(config, {
-        uid: Buffer.alloc(16, 0xaa),
+        uid: Buffer.alloc(16, 0xaa).toString('hex'),
         email: 'test@example.com',
         challenge,
       });
@@ -71,11 +71,13 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
 
       expect(result.verified).toBe(true);
       if (!result.verified) throw new Error('narrowing');
-      expect(result.data.credentialId).toBeInstanceOf(Buffer);
+      expect(typeof result.data.credentialId).toBe('string');
       expect(result.data.publicKey).toBeInstanceOf(Buffer);
       expect(result.data.signCount).toBe(0);
-      expect(result.data.aaguid).toBeInstanceOf(Buffer);
-      expect(result.data.aaguid.length).toBe(16);
+      expect(typeof result.data.aaguid).toBe('string');
+      expect(result.data.aaguid).toBe(
+        '00000000-0000-0000-0000-000000000000'
+      );
     });
 
     it('verifyWebauthnRegistrationResponse rejects a mismatched challenge', async () => {
@@ -84,7 +86,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
       const wrongChallenge = randomBytes(32).toString('base64url');
 
       const options = await generateWebauthnRegistrationOptions(config, {
-        uid: Buffer.alloc(16, 0xaa),
+        uid: Buffer.alloc(16, 0xaa).toString('hex'),
         email: 'test@example.com',
         challenge: realChallenge,
       });
@@ -109,7 +111,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
       const challenge = randomBytes(32).toString('base64url');
 
       const options = await generateWebauthnRegistrationOptions(config, {
-        uid: Buffer.alloc(16, 0xaa),
+        uid: Buffer.alloc(16, 0xaa).toString('hex'),
         email: 'test@example.com',
         challenge,
       });
@@ -130,7 +132,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
       const challenge = randomBytes(32).toString('base64url');
 
       const options = await generateWebauthnRegistrationOptions(config, {
-        uid: Buffer.alloc(16, 0xaa),
+        uid: Buffer.alloc(16, 0xaa).toString('hex'),
         email: 'test@example.com',
         challenge,
       });
@@ -153,7 +155,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
       const challenge = randomBytes(32).toString('base64url');
 
       const options = await generateWebauthnRegistrationOptions(config, {
-        uid: Buffer.alloc(16, 0xaa),
+        uid: Buffer.alloc(16, 0xaa).toString('hex'),
         email: 'test@example.com',
         challenge,
       });
@@ -171,7 +173,7 @@ describe('webauthn-adapter (real @simplewebauthn/server)', () => {
 
       expect(result.verified).toBe(true);
       if (!result.verified) throw new Error('narrowing');
-      expect(result.data.credentialId.equals(cred.id)).toBe(true);
+      expect(result.data.credentialId).toBe(cred.id.toString('base64url'));
       expect(result.data.transports).toEqual(['internal']);
       expect(typeof result.data.backupEligible).toBe('boolean');
       expect(typeof result.data.backupState).toBe('boolean');

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -8,7 +8,6 @@ import {
   verifyWebauthnRegistrationResponse,
   generateWebauthnAuthenticationOptions,
   verifyWebauthnAuthenticationResponse,
-  uuidToBuffer,
 } from './webauthn-adapter';
 import { PasskeyConfig } from './passkey.config';
 import { VirtualAuthenticator } from './virtual-authenticator';
@@ -39,7 +38,7 @@ async function registerCredential(config: PasskeyConfig) {
   const challenge = randomBytes(32).toString('base64url');
 
   const options = await generateWebauthnRegistrationOptions(config, {
-    uid: Buffer.alloc(16, 0xaa),
+    uid: Buffer.alloc(16, 0xaa).toString('hex'),
     email: 'test@example.com',
     challenge,
   });
@@ -59,43 +58,12 @@ async function registerCredential(config: PasskeyConfig) {
   return { cred, stored: result.data };
 }
 
-describe('uuidToBuffer', () => {
-  it('converts a standard AAGUID UUID string to a 16-byte Buffer', () => {
-    const result = uuidToBuffer('adce0002-35bc-c60a-648b-0b25f1f05503');
-
-    expect(result).toBeInstanceOf(Buffer);
-    expect(result.length).toBe(16);
-    expect(result[0]).toBe(0xad);
-    expect(result[1]).toBe(0xce);
-    expect(result[2]).toBe(0x00);
-    expect(result[3]).toBe(0x02);
-  });
-
-  it('converts the all-zeros AAGUID to a 16-byte zero Buffer', () => {
-    const result = uuidToBuffer('00000000-0000-0000-0000-000000000000');
-
-    expect(result).toBeInstanceOf(Buffer);
-    expect(result.length).toBe(16);
-    expect(result.equals(Buffer.alloc(16, 0))).toBe(true);
-  });
-
-  it('strips hyphens correctly regardless of position', () => {
-    const uuid = 'f1d0f1d0-f1d0-f1d0-f1d0-f1d0f1d0f1d0';
-    const result = uuidToBuffer(uuid);
-
-    expect(result.length).toBe(16);
-    for (let i = 0; i < 16; i++) {
-      expect(result[i]).toBe(i % 2 === 0 ? 0xf1 : 0xd0);
-    }
-  });
-});
-
 describe('generateWebauthnRegistrationOptions', () => {
   it('returns the original base64url challenge unchanged', async () => {
     const challenge = randomBytes(32).toString('base64url');
 
     const options = await generateWebauthnRegistrationOptions(testConfig(), {
-      uid: Buffer.alloc(16, 0xaa),
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
       email: 'test@example.com',
       challenge,
     });
@@ -107,7 +75,7 @@ describe('generateWebauthnRegistrationOptions', () => {
     const options = await generateWebauthnRegistrationOptions(
       testConfig({ rpId: 'example.com' }),
       {
-        uid: Buffer.alloc(16),
+        uid: Buffer.alloc(16).toString('hex'),
         email: 'alice@example.com',
         challenge: randomBytes(32).toString('base64url'),
       }
@@ -125,7 +93,7 @@ describe('generateWebauthnRegistrationOptions', () => {
         authenticatorAttachment: 'platform',
       }),
       {
-        uid: Buffer.alloc(16),
+        uid: Buffer.alloc(16).toString('hex'),
         email: 'alice@example.com',
         challenge: randomBytes(32).toString('base64url'),
       }
@@ -142,7 +110,7 @@ describe('generateWebauthnRegistrationOptions', () => {
 
   it('sets user name from email', async () => {
     const options = await generateWebauthnRegistrationOptions(testConfig(), {
-      uid: Buffer.alloc(16, 0xbb),
+      uid: Buffer.alloc(16, 0xbb).toString('hex'),
       email: 'bob@example.com',
       challenge: randomBytes(32).toString('base64url'),
     });
@@ -159,7 +127,7 @@ describe('verifyWebauthnRegistrationResponse', () => {
     const challenge = randomBytes(32).toString('base64url');
 
     const options = await generateWebauthnRegistrationOptions(config, {
-      uid: Buffer.alloc(16, 0xaa),
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
       email: 'test@example.com',
       challenge,
     });
@@ -178,14 +146,13 @@ describe('verifyWebauthnRegistrationResponse', () => {
     expect(result.verified).toBe(true);
     if (!result.verified) throw new Error('narrowing');
 
-    expect(result.data.credentialId).toBeInstanceOf(Buffer);
-    expect(result.data.credentialId.equals(cred.id)).toBe(true);
+    expect(typeof result.data.credentialId).toBe('string');
+    expect(result.data.credentialId).toBe(cred.id.toString('base64url'));
     expect(result.data.publicKey).toBeInstanceOf(Buffer);
     expect(result.data.signCount).toBe(0);
     expect(result.data.transports).toEqual(['internal']);
-    expect(result.data.aaguid).toBeInstanceOf(Buffer);
-    expect(result.data.aaguid.length).toBe(16);
-    expect(result.data.aaguid.equals(Buffer.alloc(16, 0))).toBe(true);
+    expect(typeof result.data.aaguid).toBe('string');
+    expect(result.data.aaguid).toBe('00000000-0000-0000-0000-000000000000');
     expect(result.data.backupEligible).toBe(false);
     expect(result.data.backupState).toBe(false);
     expect(result.data.prfEnabled).toBe(false);
@@ -197,7 +164,7 @@ describe('verifyWebauthnRegistrationResponse', () => {
     const wrongChallenge = randomBytes(32).toString('base64url');
 
     const options = await generateWebauthnRegistrationOptions(config, {
-      uid: Buffer.alloc(16, 0xaa),
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
       email: 'test@example.com',
       challenge: realChallenge,
     });
@@ -221,7 +188,7 @@ describe('verifyWebauthnRegistrationResponse', () => {
     const challenge = randomBytes(32).toString('base64url');
 
     const options = await generateWebauthnRegistrationOptions(config, {
-      uid: Buffer.alloc(16, 0xaa),
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
       email: 'test@example.com',
       challenge,
     });
@@ -245,7 +212,7 @@ describe('verifyWebauthnRegistrationResponse', () => {
     const challenge = randomBytes(32).toString('base64url');
 
     const options = await generateWebauthnRegistrationOptions(config, {
-      uid: Buffer.alloc(16, 0xaa),
+      uid: Buffer.alloc(16, 0xaa).toString('hex'),
       email: 'test@example.com',
       challenge,
     });
@@ -301,8 +268,8 @@ describe('generateWebauthnAuthenticationOptions', () => {
     expect(options.allowCredentials).toBeUndefined();
   });
 
-  it('converts Buffer credential IDs to base64url allow-list entries', async () => {
-    const credId = Buffer.from('helloworld');
+  it('passes base64url credential IDs through to allow-list entries', async () => {
+    const credId = Buffer.from('helloworld').toString('base64url');
 
     const options = await generateWebauthnAuthenticationOptions(config, {
       challenge: randomBytes(32).toString('base64url'),
@@ -310,7 +277,7 @@ describe('generateWebauthnAuthenticationOptions', () => {
     });
 
     expect(options.allowCredentials).toEqual([
-      expect.objectContaining({ id: credId.toString('base64url') }),
+      expect.objectContaining({ id: credId }),
     ]);
   });
 });

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -18,11 +18,13 @@ import type {
   AuthenticatorTransportFuture,
 } from '@simplewebauthn/server';
 
+import { uuidTransformer } from '@fxa/shared/db/mysql/core';
+
 import { PasskeyConfig } from './passkey.config';
 
 export interface RegistrationOptionsInput {
-  /** User's uid as a Buffer, used as the WebAuthn userID. */
-  uid: Buffer;
+  /** User's uid as a hex string, used as the WebAuthn userID. */
+  uid: string;
   /** User's email address, used as the WebAuthn userName. */
   email: string;
   /** Challenge from ChallengeManager. */
@@ -46,7 +48,7 @@ export async function generateWebauthnRegistrationOptions(
     rpID: config.rpId,
     userName: input.email,
     userDisplayName: input.email,
-    userID: input.uid,
+    userID: uuidTransformer.to(input.uid),
     // Challenge must be passed as a Buffer (Uint8Array) so that simplewebauthn
     // base64url-encodes the raw bytes. Passing a string causes the library to
     // UTF-8-encode the text first, producing a different base64url value than
@@ -68,11 +70,13 @@ export interface VerifyRegistrationInput {
 }
 
 export interface VerifiedRegistrationData {
-  credentialId: Buffer;
+  /** Credential ID as a base64url string, forwarded unchanged from SimpleWebAuthn. */
+  credentialId: string;
   publicKey: Buffer;
   signCount: number;
   transports: AuthenticatorTransportFuture[];
-  aaguid: Buffer;
+  /** aaguid as a hyphenated-UUID string, forwarded unchanged from SimpleWebAuthn. */
+  aaguid: string;
   backupEligible: boolean;
   backupState: boolean;
   prfEnabled: boolean;
@@ -127,11 +131,11 @@ export async function verifyWebauthnRegistrationResponse(
   return {
     verified: true,
     data: {
-      credentialId: Buffer.from(credential.id, 'base64url'),
+      credentialId: credential.id,
       publicKey: Buffer.from(credential.publicKey),
       signCount: credential.counter,
       transports: credential.transports ?? [],
-      aaguid: uuidToBuffer(aaguid),
+      aaguid,
       backupEligible: credentialDeviceType === 'multiDevice',
       backupState: credentialBackedUp,
       prfEnabled: extractPrfEnabled(authenticatorExtensionResults),
@@ -147,11 +151,11 @@ export interface AuthenticationOptionsInput {
   /** Challenge from ChallengeManager. */
   challenge: string;
   /**
-   * Credential IDs to restrict authentication to.
+   * Credential IDs (base64url) to restrict authentication to.
    * Pass the user's stored credential IDs for known-user flows.
    * Pass an empty array for usernameless/discoverable flows.
    */
-  allowCredentials: Buffer[];
+  allowCredentials: string[];
 }
 
 /**
@@ -171,7 +175,7 @@ export async function generateWebauthnAuthenticationOptions(
     challenge: Buffer.from(input.challenge, 'base64url'),
     allowCredentials:
       input.allowCredentials.length > 0
-        ? input.allowCredentials.map((id) => ({ id: id.toString('base64url') }))
+        ? input.allowCredentials.map((id) => ({ id }))
         : undefined,
   });
 }
@@ -181,7 +185,8 @@ export interface VerifyAuthenticationInput {
   response: AuthenticationResponseJSON;
   /** Challenge that was issued for this authentication. */
   challenge: string;
-  credentialId: Buffer;
+  /** Credential ID as a base64url string. */
+  credentialId: string;
   publicKey: Buffer;
   signCount: number;
 }
@@ -225,7 +230,7 @@ export async function verifyWebauthnAuthenticationResponse(
   input: VerifyAuthenticationInput
 ): Promise<AuthenticationVerificationResult> {
   const credential: WebAuthnCredential = {
-    id: input.credentialId.toString('base64url'),
+    id: input.credentialId,
     publicKey: input.publicKey,
     counter: input.signCount,
   };
@@ -251,14 +256,3 @@ export async function verifyWebauthnAuthenticationResponse(
   };
 }
 
-/**
- * Convert a UUID string to a 16-byte Buffer.
- *
- * SimpleWebAuthn returns `aaguid` as a lower-case hyphenated UUID string.
- * This strips the hyphens and parses the result to a Buffer.
- *
- * @param uuid - Lower-case hyphenated UUID string
- */
-export function uuidToBuffer(uuid: string): Buffer {
-  return Buffer.from(uuid.replace(/-/g, ''), 'hex');
-}

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -4784,12 +4784,12 @@ describe('/account', () => {
     const { PasskeyService } = require('@fxa/accounts/passkey');
 
     const mockPasskey = {
-      credentialId: Buffer.from('cred-id'),
+      credentialId: 'mock-cred-id',
       name: 'My Passkey',
       createdAt: 1000000,
       lastUsedAt: 2000000,
       transports: ['internal'],
-      aaguid: Buffer.from('aaguid12345678ab'),
+      aaguid: 'adce0002-35bc-c60a-648b-0b25f1f05503',
       backupEligible: true,
       backupState: false,
       prfEnabled: true,
@@ -4818,17 +4818,15 @@ describe('/account', () => {
       const route = buildPasskeysRoute(mockService);
       const result: any = await runTest(route, request);
 
-      expect(mockService.listPasskeysForUser).toHaveBeenCalledWith(
-        Buffer.from(uid, 'hex')
-      );
+      expect(mockService.listPasskeysForUser).toHaveBeenCalledWith(uid);
       expect(result.passkeys).toHaveLength(1);
       expect(result.passkeys[0]).toEqual({
-        credentialId: mockPasskey.credentialId.toString('base64url'),
+        credentialId: mockPasskey.credentialId,
         name: mockPasskey.name,
         createdAt: mockPasskey.createdAt,
         lastUsedAt: mockPasskey.lastUsedAt,
         transports: mockPasskey.transports,
-        aaguid: mockPasskey.aaguid.toString('base64url'),
+        aaguid: mockPasskey.aaguid,
         backupEligible: mockPasskey.backupEligible,
         backupState: mockPasskey.backupState,
         prfEnabled: mockPasskey.prfEnabled,

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -72,8 +72,7 @@ import { FxaMailerFormat } from '../senders/fxa-mailer-format';
 import { OAuthClientInfoServiceName } from '../senders/oauth_client_info';
 import { BackupCodeManager } from '@fxa/accounts/two-factor';
 import { RecoveryPhoneService } from '@fxa/accounts/recovery-phone';
-import { PasskeyService } from '@fxa/accounts/passkey';
-import type { Passkey } from '@fxa/shared/db/mysql/account';
+import { PasskeyService, PasskeyRecord } from '@fxa/accounts/passkey';
 import { BOUNCE_TYPE_HARD } from '@fxa/accounts/email-sender';
 import { getClientServiceTags } from '../metrics/client-tags';
 
@@ -2457,9 +2456,7 @@ export class AccountHandler {
       this.db.devices(uid),
       listAuthorizedClients(uid),
       this.config.passkeys?.enabled
-        ? Container.get(PasskeyService).listPasskeysForUser(
-            Buffer.from(uid, 'hex')
-          )
+        ? Container.get(PasskeyService).listPasskeysForUser(uid)
         : Promise.resolve([]),
     ]);
 
@@ -2560,7 +2557,7 @@ export class AccountHandler {
 
     const passkeys =
       passkeysResult.status === 'fulfilled'
-        ? (passkeysResult.value as Passkey[]).map(
+        ? (passkeysResult.value as PasskeyRecord[]).map(
             ({
               credentialId,
               name,
@@ -2572,12 +2569,12 @@ export class AccountHandler {
               backupState,
               prfEnabled,
             }) => ({
-              credentialId: credentialId.toString('base64url'),
+              credentialId,
               name,
               createdAt,
               lastUsedAt,
               transports,
-              aaguid: aaguid.toString('base64url'),
+              aaguid,
               backupEligible,
               backupState,
               prfEnabled,

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -63,15 +63,19 @@ describe('passkeys routes', () => {
     attestation: 'none',
   };
 
+  const MOCK_AAGUID = 'adce0002-35bc-c60a-648b-0b25f1f05503';
+  const MOCK_CREDENTIAL_ID = 'mock-credential-id-xyz';
+
+  // PasskeyRecord shape: credentialId and aaguid are strings.
   const mockPasskeyRecord = {
-    credentialId: Buffer.from('credential-id-xyz'),
+    credentialId: MOCK_CREDENTIAL_ID,
     name: 'My Passkey',
     createdAt: Date.now(),
     lastUsedAt: null,
     transports: ['internal'],
     publicKey: Buffer.from('public-key'),
     signCount: 42,
-    aaguid: Buffer.from('aaguid12345678ab'),
+    aaguid: MOCK_AAGUID,
     backupEligible: true,
     backupState: false,
     prfEnabled: true,
@@ -184,7 +188,7 @@ describe('passkeys routes', () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         mockPasskeyService.generateRegistrationChallenge
-      ).toHaveBeenCalledWith(Buffer.from(UID, 'hex'), TEST_EMAIL);
+      ).toHaveBeenCalledWith(UID, TEST_EMAIL);
     });
 
     it('enforces rate limiting via customs.checkAuthenticated', async () => {
@@ -244,12 +248,12 @@ describe('passkeys routes', () => {
       });
 
       expect(result).toEqual({
-        credentialId: mockPasskeyRecord.credentialId.toString('base64url'),
+        credentialId: mockPasskeyRecord.credentialId,
         name: mockPasskeyRecord.name,
         createdAt: mockPasskeyRecord.createdAt,
         lastUsedAt: mockPasskeyRecord.lastUsedAt,
         transports: mockPasskeyRecord.transports,
-        aaguid: mockPasskeyRecord.aaguid.toString('base64url'),
+        aaguid: mockPasskeyRecord.aaguid,
         backupEligible: mockPasskeyRecord.backupEligible,
         backupState: mockPasskeyRecord.backupState,
         prfEnabled: mockPasskeyRecord.prfEnabled,
@@ -260,11 +264,7 @@ describe('passkeys routes', () => {
       ).toHaveBeenCalledTimes(1);
       expect(
         mockPasskeyService.createPasskeyFromRegistrationResponse
-      ).toHaveBeenCalledWith(
-        Buffer.from(UID, 'hex'),
-        payload.response,
-        payload.challenge
-      );
+      ).toHaveBeenCalledWith(UID, payload.response, payload.challenge);
     });
 
     it('records a success security event on successful registration', async () => {
@@ -468,7 +468,7 @@ describe('passkeys routes', () => {
 
       expect(result).toEqual(
         expect.objectContaining({
-          credentialId: mockPasskeyRecord.credentialId.toString('base64url'),
+          credentialId: mockPasskeyRecord.credentialId,
         })
       );
       expect(log.error).toHaveBeenCalledWith(
@@ -494,17 +494,15 @@ describe('passkeys routes', () => {
         'GET'
       );
 
-      expect(mockPasskeyService.listPasskeysForUser).toHaveBeenCalledWith(
-        Buffer.from(UID, 'hex')
-      );
+      expect(mockPasskeyService.listPasskeysForUser).toHaveBeenCalledWith(UID);
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual({
-        credentialId: mockPasskeyRecord.credentialId.toString('base64url'),
+        credentialId: mockPasskeyRecord.credentialId,
         name: mockPasskeyRecord.name,
         createdAt: mockPasskeyRecord.createdAt,
         lastUsedAt: mockPasskeyRecord.lastUsedAt,
         transports: mockPasskeyRecord.transports,
-        aaguid: mockPasskeyRecord.aaguid.toString('base64url'),
+        aaguid: mockPasskeyRecord.aaguid,
         backupEligible: mockPasskeyRecord.backupEligible,
         backupState: mockPasskeyRecord.backupState,
         prfEnabled: mockPasskeyRecord.prfEnabled,
@@ -575,8 +573,8 @@ describe('passkeys routes', () => {
       );
 
       expect(mockPasskeyService.deletePasskey).toHaveBeenCalledWith(
-        Buffer.from(UID, 'hex'),
-        Buffer.from(CREDENTIAL_ID_B64, 'base64url')
+        UID,
+        CREDENTIAL_ID_B64
       );
     });
 
@@ -810,8 +808,8 @@ describe('passkeys routes', () => {
       );
 
       expect(mockPasskeyService.renamePasskey).toHaveBeenCalledWith(
-        Buffer.from(UID, 'hex'),
-        Buffer.from(CREDENTIAL_ID_B64, 'base64url'),
+        UID,
+        CREDENTIAL_ID_B64,
         'Renamed Key'
       );
     });
@@ -834,12 +832,12 @@ describe('passkeys routes', () => {
       );
 
       expect(result).toEqual({
-        credentialId: mockPasskeyRecord.credentialId.toString('base64url'),
+        credentialId: mockPasskeyRecord.credentialId,
         name: mockPasskeyRecord.name,
         createdAt: mockPasskeyRecord.createdAt,
         lastUsedAt: mockPasskeyRecord.lastUsedAt,
         transports: mockPasskeyRecord.transports,
-        aaguid: mockPasskeyRecord.aaguid.toString('base64url'),
+        aaguid: mockPasskeyRecord.aaguid,
         backupEligible: mockPasskeyRecord.backupEligible,
         backupState: mockPasskeyRecord.backupState,
         prfEnabled: mockPasskeyRecord.prfEnabled,

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -105,7 +105,7 @@ export class PasskeyHandler {
     );
 
     const options = await this.service.generateRegistrationChallenge(
-      Buffer.from(uid, 'hex'),
+      uid,
       account.email
     );
 
@@ -145,7 +145,7 @@ export class PasskeyHandler {
 
     try {
       const passkey = await this.service.createPasskeyFromRegistrationResponse(
-        Buffer.from(uid, 'hex'),
+        uid,
         response,
         challenge
       );
@@ -187,12 +187,12 @@ export class PasskeyHandler {
       } = passkey;
 
       return {
-        credentialId: credentialId.toString('base64url'),
+        credentialId,
         name,
         createdAt,
         lastUsedAt,
         transports,
-        aaguid: aaguid.toString('base64url'),
+        aaguid,
         backupEligible,
         backupState,
         prfEnabled,
@@ -226,9 +226,7 @@ export class PasskeyHandler {
       'passkeysList'
     );
 
-    const passkeys = await this.service.listPasskeysForUser(
-      Buffer.from(uid, 'hex')
-    );
+    const passkeys = await this.service.listPasskeysForUser(uid);
 
     // omit publicKey and signCount
     return passkeys.map(
@@ -243,12 +241,12 @@ export class PasskeyHandler {
         backupState,
         prfEnabled,
       }) => ({
-        credentialId: credentialId.toString('base64url'),
+        credentialId,
         name,
         createdAt,
         lastUsedAt,
         transports,
-        aaguid: aaguid.toString('base64url'),
+        aaguid,
         backupEligible,
         backupState,
         prfEnabled,
@@ -265,7 +263,7 @@ export class PasskeyHandler {
    */
   async deletePasskey(request: AuthRequest) {
     const { uid } = request.auth.credentials as { uid: string };
-    const { credentialId: credentialIdParam } = request.params as {
+    const { credentialId } = request.params as {
       credentialId: string;
     };
 
@@ -277,9 +275,7 @@ export class PasskeyHandler {
       'passkeyDelete'
     );
 
-    const credentialId = Buffer.from(credentialIdParam, 'base64url');
-
-    await this.service.deletePasskey(Buffer.from(uid, 'hex'), credentialId);
+    await this.service.deletePasskey(uid, credentialId);
 
     await recordSecurityEvent('account.passkey.removed', {
       db: this.db,
@@ -315,7 +311,7 @@ export class PasskeyHandler {
    */
   async renamePasskey(request: AuthRequest) {
     const { uid } = request.auth.credentials as { uid: string };
-    const { credentialId: credentialIdParam } = request.params as {
+    const { credentialId } = request.params as {
       credentialId: string;
     };
     const { name } = request.payload as { name: string };
@@ -328,23 +324,17 @@ export class PasskeyHandler {
       'passkeysRename'
     );
 
-    const credentialId = Buffer.from(credentialIdParam, 'base64url');
-
-    const passkey = await this.service.renamePasskey(
-      Buffer.from(uid, 'hex'),
-      credentialId,
-      name
-    );
+    const passkey = await this.service.renamePasskey(uid, credentialId, name);
 
     await this.glean.passkey.renameSuccess(request);
 
     return {
-      credentialId: passkey.credentialId.toString('base64url'),
+      credentialId: passkey.credentialId,
       name: passkey.name,
       createdAt: passkey.createdAt,
       lastUsedAt: passkey.lastUsedAt,
       transports: passkey.transports,
-      aaguid: passkey.aaguid.toString('base64url'),
+      aaguid: passkey.aaguid,
       backupEligible: passkey.backupEligible,
       backupState: passkey.backupState,
       prfEnabled: passkey.prfEnabled,


### PR DESCRIPTION
## Because

- Passkey identifiers (uid, credentialId, aaguid) were being converted to Buffer mid-flight across routes and services, leaking DB representation   upward and silently coercing malformed input.
- aaguid was also emitted to clients as base64url of raw bytes, disagreeing with SimpleWebAuthn and the WebAuthn spec's hyphenated-UUID convention.

## This pull request

- Services and routes carry strings; Buffer conversion happens only inside passkey.repository.ts via validating helpers (uuidTransformer.to, base64urlToBuffer, aaguidToBuffer) that throw on malformed input.
- Repository reads return a PasskeyRecord domain type with UUID-string aaguid; HTTP responses now emit hyphenated UUIDs.
- Specs updated across the passkey lib and auth-server routes.

## Issue that this pull request solves

Closes: FXA-13600

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

N/A (backend-only refactor).

## Other information (Optional)
