### PR TITLE
chore(ci): bump Unit Test (PR) to xlarge to complete FXA-13473 mitigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -925,6 +925,7 @@ workflows:
             - fail-fast
       - unit-test:
           name: Unit Test (PR)
+          resource_class: xlarge
           nx_run: affected --base=main --head=$CIRCLE_SHA1
           workflow: test_pull_request
           requires:


### PR DESCRIPTION
## Summary

- Adds `resource_class: xlarge` to the `Unit Test (PR)` workflow entry in `.circleci/config.yml` (line 927), matching the `Unit Test` (tagged deploy, line 1115) and `Unit Test (nightly)` (line 1244) variants.
- Completes the interim mitigation tracked in [FXA-13473](https://mozilla-hub.atlassian.net/browse/FXA-13473); the xlarge bump landed for tagged-deploy and nightly but was not applied to the PR variant, so PR runs still hit the SIGKILL OOM.
- Does not fix the root cause (the `jest.resetModules()` pattern in `packages/fxa-auth-server/lib/metrics/context.spec.ts`). FXA-13473 remains the tracking ticket for the proper refactor.

## Why now

The flake has hit multiple PRs this week. Example: PR #20452 — today, unrelated @apollo/server removal, failed with:

```
FAIL lib/metrics/context.spec.ts
● Test suite failed to run
A jest worker process (pid=3055) was terminated by another process: signal=SIGKILL, exitCode=null.
Test Suites: 1 failed, 149 passed, 150 total
Tests:       3334 passed, 3334 total
```

Classic OOM-killer fingerprint (kernel SIGKILL, zero test failures). Isolated measurement of `context.spec.ts` with `--coverage` shows ~616 MB RSS per worker; with `nx --parallel=2` × `maxWorkers: 4` that can easily spike past the `large` container's 8 GB ceiling.

## Test plan

- [ ] Open PR → Unit Test (PR) job on CircleCI shows `xlarge` executor in its build log
- [ ] Re-verify on a couple of subsequent PRs that the SIGKILL flake does not recur
- [ ] Track FXA-13473 for the real fix (spec refactor to stop reloading the require graph per test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FXA-13473]: https://mozilla-hub.atlassian.net/browse/FXA-13473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ