### PR TITLE
fix(settings): surface OAuth client-info fetch failures as discrete errors

### DIFF
--- a/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.test.ts
@@ -217,6 +217,80 @@ describe('lib/integrations/integration-factory', () => {
         expect(integration.wantsKeys()).toBeFalsy();
         expect(integration.isTrusted()).toBeTruthy();
       });
+
+      it('does not flag clientInfoLoadFailed when clientInfo is provided', () => {
+        expect(integration.clientInfoLoadFailed).toBe(false);
+      });
+    });
+
+    describe('when /v1/oauth/client/:id fetch failed', () => {
+      beforeEach(() => {
+        sandbox.restore();
+        sandbox.stub(flags, 'isOAuth').returns(true);
+        sandbox.stub(flags, 'isDevicePairingAsAuthority').returns(false);
+        sandbox.stub(flags, 'isDevicePairingAsSupplicant').returns(false);
+        sandbox.stub(flags, 'isServiceSync').returns(false);
+        sandbox.stub(flags, 'isV3DesktopContext').returns(false);
+        sandbox.stub(flags, 'isOAuthWebChannelContext').returns(false);
+
+        urlQueryData.set('scope', 'profile');
+        urlQueryData.set('client_id', '720bc80adfa6988d');
+        urlQueryData.set('redirect_uri', 'https://redirect.to');
+
+        const factory = new IntegrationFactory({
+          window,
+          data: urlQueryData,
+          channelData: urlHashData,
+          storageData,
+          flags,
+          clientInfo: undefined,
+          clientInfoLoadFailed: true,
+          productInfo,
+        });
+        integration = factory.getIntegration() as OAuthIntegration;
+      });
+
+      it('flags clientInfoLoadFailed so downstream code surfaces the error', () => {
+        expect(integration.clientInfoLoadFailed).toBe(true);
+      });
+    });
+
+    describe('when clientInfo is missing but the fetch did not fail', () => {
+      // Some flows populate `data.clientId` from non-URL-query sources
+      // (e.g. the `/oauth/success/:clientId` pathname via
+      // `initOAuthIntegration`). In those flows `useClientInfoState` never
+      // ran a fetch, so the factory should not flag clientInfoLoadFailed
+      // even though `clientInfo` is undefined and `data.clientId` is set.
+      beforeEach(() => {
+        sandbox.restore();
+        sandbox.stub(flags, 'isOAuth').returns(true);
+        sandbox.stub(flags, 'isDevicePairingAsAuthority').returns(false);
+        sandbox.stub(flags, 'isDevicePairingAsSupplicant').returns(false);
+        sandbox.stub(flags, 'isServiceSync').returns(false);
+        sandbox.stub(flags, 'isV3DesktopContext').returns(false);
+        sandbox.stub(flags, 'isOAuthWebChannelContext').returns(false);
+        sandbox.stub(flags, 'isOAuthSuccessFlow').returns({
+          status: true,
+          clientId: '720bc80adfa6988d',
+        });
+
+        const factory = new IntegrationFactory({
+          window,
+          data: urlQueryData,
+          channelData: urlHashData,
+          storageData,
+          flags,
+          clientInfo: undefined,
+          clientInfoLoadFailed: false,
+          productInfo,
+        });
+        integration = factory.getIntegration() as OAuthIntegration;
+      });
+
+      it('does not flag clientInfoLoadFailed', () => {
+        expect(integration.data.clientId).toEqual('720bc80adfa6988d');
+        expect(integration.clientInfoLoadFailed).toBe(false);
+      });
     });
 
     // TODO: Port remaining tests from content-server

--- a/packages/fxa-settings/src/lib/integrations/integration-factory.ts
+++ b/packages/fxa-settings/src/lib/integrations/integration-factory.ts
@@ -68,6 +68,7 @@ export class IntegrationFactory {
   protected readonly channelData: ModelDataStore;
   protected readonly storageData: ModelDataStore;
   protected readonly clientInfo?: RelierClientInfo;
+  protected readonly clientInfoLoadFailed: boolean;
   protected readonly cmsInfo?: RelierCmsInfo;
   protected readonly legalTerms?: RelierLegalTerms;
   protected readonly productInfo?: RelierSubscriptionInfo;
@@ -78,6 +79,7 @@ export class IntegrationFactory {
     window: ReachRouterWindow;
     productInfo?: RelierSubscriptionInfo;
     clientInfo?: RelierClientInfo;
+    clientInfoLoadFailed?: boolean;
     cmsInfo?: RelierCmsInfo;
     legalTerms?: RelierLegalTerms;
     data?: ModelDataStore;
@@ -96,6 +98,7 @@ export class IntegrationFactory {
         new StorageData(window)
       );
     this.clientInfo = opts.clientInfo;
+    this.clientInfoLoadFailed = opts.clientInfoLoadFailed ?? false;
     this.productInfo = opts.productInfo;
     this.cmsInfo = opts.cmsInfo;
     this.legalTerms = opts.legalTerms;
@@ -304,6 +307,13 @@ export class IntegrationFactory {
      * acts as a clientId, and we currently consider this an OAuth flow (in Backbone as well)
      * that does not want to redirect. In this case, createClientInfo with 'service'.
      */
+
+    // Without this flag, a failed `/v1/oauth/client/:id` fetch leaves every
+    // `clientInfo` field undefined, which reads as `trusted=false` and silently
+    // strips every requested scope. `useClientInfoState` is the source of truth
+    // — we don't infer from `integration.data.clientId` because some flows
+    // (e.g. `/oauth/success/:clientId`) populate it without a fetch.
+    integration.clientInfoLoadFailed = this.clientInfoLoadFailed;
 
     const redirectUris = this.clientInfo?.redirectUri?.split(',');
     const clientRedirectUri = getClientRedirect(

--- a/packages/fxa-settings/src/models/hooks.test.ts
+++ b/packages/fxa-settings/src/models/hooks.test.ts
@@ -7,7 +7,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { ReactNode, createElement } from 'react';
 import * as Sentry from '@sentry/browser';
 
-import { useCmsInfoState } from './hooks';
+import { useClientInfoState, useCmsInfoState } from './hooks';
 import { AppContext } from './contexts/AppContext';
 
 // Mock all external dependencies before importing the hook
@@ -528,5 +528,113 @@ describe('useCmsInfoState', () => {
     expect(result.current.data?.cmsInfo).toEqual({
       customization: 'english-selected-test',
     });
+  });
+});
+
+describe('useClientInfoState', () => {
+  let mockUrlQueryData: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const { UrlQueryData } = require('../lib/model-data');
+    mockUrlQueryData = { get: jest.fn() };
+    UrlQueryData.mockImplementation(() => mockUrlQueryData);
+
+    const { isHexadecimal, length } = require('class-validator');
+    isHexadecimal.mockReturnValue(true);
+    length.mockReturnValue(true);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        id: '1234567890abcdef',
+        name: 'Test RP',
+        redirect_uri: 'https://example.test/redirect',
+        image_uri: '',
+        trusted: true,
+      }),
+    });
+  });
+
+  it('populates clientInfo from the fetch response', async () => {
+    mockUrlQueryData.get.mockImplementation((key: string) =>
+      key === 'client_id' ? '1234567890abcdef' : null
+    );
+
+    const { result } = renderHook(() => useClientInfoState(), {
+      wrapper: MockAppProvider,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data?.clientInfo).toEqual({
+      clientId: '1234567890abcdef',
+      imageUri: null,
+      redirectUri: 'https://example.test/redirect',
+      serviceName: 'Test RP',
+      trusted: true,
+    });
+    expect(result.current.error).toBeUndefined();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('captures fetch errors to Sentry with a dedicated area tag', async () => {
+    mockUrlQueryData.get.mockImplementation((key: string) =>
+      key === 'client_id' ? '1234567890abcdef' : null
+    );
+
+    const fetchError = new Error('Network error');
+    mockFetch.mockRejectedValue(fetchError);
+
+    const { result } = renderHook(() => useClientInfoState(), {
+      wrapper: MockAppProvider,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toEqual(fetchError);
+    expect(result.current.data).toBeUndefined();
+    expect(Sentry.captureException).toHaveBeenCalledWith(fetchError, {
+      tags: { area: 'useClientInfoState.fetch' },
+      extra: { clientId: '1234567890abcdef' },
+    });
+  });
+
+  it('captures non-OK HTTP responses to Sentry', async () => {
+    mockUrlQueryData.get.mockImplementation((key: string) =>
+      key === 'client_id' ? '1234567890abcdef' : null
+    );
+
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+    const { result } = renderHook(() => useClientInfoState(), {
+      wrapper: MockAppProvider,
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toMatch(/403/);
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/403/) }),
+      { tags: { area: 'useClientInfoState.fetch' }, extra: { clientId: '1234567890abcdef' } }
+    );
+  });
+
+  it('does not fetch when client_id is missing', async () => {
+    mockUrlQueryData.get.mockReturnValue(null);
+    const { isHexadecimal, length } = require('class-validator');
+    isHexadecimal.mockReturnValue(false);
+    length.mockReturnValue(false);
+
+    const { result } = renderHook(() => useClientInfoState(), {
+      wrapper: MockAppProvider,
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeUndefined();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/packages/fxa-settings/src/models/hooks.ts
+++ b/packages/fxa-settings/src/models/hooks.ts
@@ -120,6 +120,11 @@ export function useIntegration() {
       flags,
       window: windowWrapper,
       clientInfo: clientInfoState.data?.clientInfo,
+      // useClientInfoState is the source of truth for whether the
+      // /v1/oauth/client/:id fetch was attempted and failed; the factory
+      // can't infer this from URL state alone because subsequent init
+      // steps may populate `data.clientId` from non-query sources.
+      clientInfoLoadFailed: !!clientInfoState.error,
       cmsInfo: cmsInfoState.data?.cmsInfo,
       legalTerms,
       productInfo: productInfoState.data?.productInfo,
@@ -320,11 +325,18 @@ export function useClientInfoState() {
           });
         }
       } catch (error) {
+        const err =
+          error instanceof Error ? error : new Error('Unknown error');
+        // Surface fetch failures as their own Sentry issue so the real cause
+        // (network, WAF challenge, 5xx, unknown client_id) is observable
+        // separately from the downstream scope-validation paths it used to
+        // be misattributed to — see FXA-13618.
+        Sentry.captureException(err, {
+          tags: { area: 'useClientInfoState.fetch' },
+          extra: { clientId },
+        });
         if (mounted) {
-          setState({
-            loading: false,
-            error: error instanceof Error ? error : new Error('Unknown error'),
-          });
+          setState({ loading: false, error: err });
         }
       }
     };

--- a/packages/fxa-settings/src/models/integrations/integration.ts
+++ b/packages/fxa-settings/src/models/integrations/integration.ts
@@ -51,6 +51,12 @@ export class GenericIntegration<
   subscriptionInfo: RelierSubscriptionInfo | undefined;
   cmsInfo: RelierCmsInfo | undefined;
   legalTerms: RelierLegalTerms | undefined;
+  // Set by IntegrationFactory.initClientInfo when the /v1/oauth/client/:id
+  // fetch in `useClientInfoState` failed (network, WAF challenge, 5xx,
+  // unknown client_id). Downstream code uses this to surface a discrete
+  // error instead of falling through to scope-validation paths with a
+  // half-populated clientInfo.
+  clientInfoLoadFailed: boolean = false;
 
   constructor(
     type: IntegrationType,

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.test.ts
@@ -251,6 +251,37 @@ describe('models/integrations/oauth-relier', function () {
       });
     });
 
+    describe('clientInfo fetch failed', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('throws SERVICE_UNAVAILABLE and does not capture a scope-error to Sentry', () => {
+        const integration = new OAuthWebIntegration(
+          new GenericData({ scope: 'profile' }),
+          new GenericData({}),
+          {
+            scopedKeysEnabled: true,
+            scopedKeysValidation: {},
+            isPromptNoneEnabled: true,
+            isPromptNoneEnabledClientIds: [],
+          }
+        );
+        integration.clientInfoLoadFailed = true;
+
+        let caught: OAuthError | undefined;
+        try {
+          integration.getPermissions();
+        } catch (err) {
+          caught = err as OAuthError;
+        }
+
+        expect(caught).toBeInstanceOf(OAuthError);
+        expect(caught?.errno).toBe(OAUTH_ERRORS.SERVICE_UNAVAILABLE.errno);
+        expect(Sentry.captureException).not.toHaveBeenCalled();
+      });
+    });
+
     describe('trusted reliers that do not ask for consent', () => {
       function getIntegration(scope: string) {
         const integration = getIntegrationWithScope(scope);

--- a/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/oauth-web-integration.ts
@@ -189,6 +189,17 @@ export class OAuthWebIntegration extends GenericIntegration<
   }
 
   getPermissions() {
+    // If the /v1/oauth/client/:id fetch failed during factory initialisation,
+    // `isTrusted()` returns false and scope sanitisation would strip every
+    // scope a real RP typically asks for, throwing an errno-109 that looks
+    // like an RP misconfiguration. Surface the real cause (service
+    // unavailable) so the App-level catch renders OAuthDataError without a
+    // misleading Sentry capture here — the fetch failure is already logged
+    // from useClientInfoState.
+    if (this.clientInfoLoadFailed) {
+      throw new OAuthError(OAUTH_ERRORS.SERVICE_UNAVAILABLE.errno);
+    }
+
     // Ported from content server, search for _normalizeScopesAndPermissions
     let permissions = Array.from(scopeStrToArray(this.data.scope || ''));
 


### PR DESCRIPTION
## Because

* A failed `/v1/oauth/client/:id` fetch silently builds a ghost OAuth integration: scope sanitization strips every scope and the flow throws errno 109, masking the real cause across Sentry events ([FXA-CONTENT-1HYP](https://mozilla.sentry.io/issues/6966503332/?environment=prod&project=6231069&referrer=issue-list&statsPeriod=7d) for example)
* Regression from [FXA-12995](https://mozilla-hub.atlassian.net/browse/FXA-12995): the REST replacement for Apollo's useQuery dropped the error signal that useIntegration relied on.

## This pull request

* Adds `clientInfoLoadFailed` on `GenericIntegration`, set when `client_id` was present but `clientInfo` is undefined.
* Short-circuits `OAuthWebIntegration.getPermissions` to throw `SERVICE_UNAVAILABLE` (errno 998) when the flag is set; existing OAuthDataError handling keeps user-facing behaviour unchanged.
* Captures the fetch error from useClientInfoState under area: 'useClientInfoState.fetch'.
* Adds unit coverage for the flag, the early-return, and the Sentry capture.

## Issue that this pull request solves

Closes: FXA-13618

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Suggested review order:
  1. \`packages/fxa-settings/src/models/integrations/integration.ts\` — the new \`clientInfoLoadFailed\` field.
  2. \`packages/fxa-settings/src/lib/integrations/integration-factory.ts\` — where the flag gets set.
  3. \`packages/fxa-settings/src/models/integrations/oauth-web-integration.ts\` — the early return in \`getPermissions\`.
  4. \`packages/fxa-settings/src/models/hooks.ts\` — Sentry capture in \`useClientInfoState\`.
  5. The three \`*.test.ts\` files covering each of the above.
- Key thing to confirm: the \`SERVICE_UNAVAILABLE\` throw is caught at \`components/App/index.tsx:522-537\` and renders \`OAuthDataError\`, matching the UX path the existing scope-error throw was already taking.
- Risky parts: none expected. The flag defaults to \`false\`, so any integration path that doesn't go through the factory (tests, non-OAuth flows) is untouched. The ghost-integration synthesis in \`initClientInfo\` is preserved as-is for backward compatibility; the flag is additive.

## Screenshots (Optional)

N/A — no UI change. The user-visible behaviour when the client-info fetch fails continues to be \`OAuthDataError\`, just with an honest errno (998 "System unavailable, try again soon") instead of a misleading errno 109.

## Other information (Optional)

Supersedes FXA-13172, FXA-13171, FXA-12759 (all linked from the Jira ticket — those should close once Sentry events stop accruing on post-deploy). Related to FXA-13088 which was previously cancelled but is the same ghost-integration pattern reaching a different validator.

Separate follow-ups (not in this PR):
- If the 67k+ prod events remain after this PR lands, the new \`useClientInfoState.fetch\` Sentry tag gives us a clean target to investigate further.

[FXA-12995]: https://mozilla-hub.atlassian.net/browse/FXA-12995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ