### PR TITLE
fix(payments-next): Error: The customer's location isn't recognized. Set a valid customer address in order to automatically calculate tax.

### DIFF
--- a/libs/payments/management/src/lib/manage-payment-method.error.ts
+++ b/libs/payments/management/src/lib/manage-payment-method.error.ts
@@ -70,3 +70,14 @@ export class ManagePaymentMethodIntentInsufficientFundsError extends ManagePayme
     this.name = 'ManagePaymentMethodIntentInsufficientFundsError';
   }
 }
+
+export class ManagePaymentMethodTaxAddressRequiredError extends ManagePaymentMethodIntentFailedHandledError {
+  constructor(errorCode: string) {
+    super(
+      'ManagePaymentMethod could not resolve a tax address for the customer',
+      {},
+      errorCode
+    );
+    this.name = 'ManagePaymentMethodTaxAddressRequiredError';
+  }
+}

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -9,7 +9,13 @@ import { Test } from '@nestjs/testing';
 import {
   ChurnInterventionManager,
   MockChurnInterventionConfigProvider,
+  TaxService,
 } from '@fxa/payments/cart';
+import {
+  GeoDBManager,
+  GeoDBManagerConfig,
+  MockGeoDBNestFactory,
+} from '@fxa/shared/geodb';
 import {
   CurrencyManager,
   MockCurrencyConfigProvider,
@@ -85,6 +91,7 @@ import {
   ChurnInterventionByProductIdResultFactory,
 } from '@fxa/shared/cms';
 import { ChurnInterventionService } from './churn-intervention.service';
+import { ManagePaymentMethodTaxAddressRequiredError } from './manage-payment-method.error';
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
@@ -144,6 +151,7 @@ describe('SubscriptionManagementService', () => {
   let privateCustomerChanged: any;
   let paypalBillingAgreementManager: PaypalBillingAgreementManager;
   let paypalCustomerManager: PaypalCustomerManager;
+  let taxService: TaxService;
 
   const mockLogger = {
     error: jest.fn(),
@@ -198,6 +206,10 @@ describe('SubscriptionManagementService', () => {
         MockCurrencyConfigProvider,
         MockChurnInterventionConfigProvider,
         MockLocationConfigProvider,
+        TaxService,
+        GeoDBManager,
+        GeoDBManagerConfig,
+        MockGeoDBNestFactory,
         {
           provide: LOGGER_PROVIDER,
           useValue: mockLogger,
@@ -222,6 +234,7 @@ describe('SubscriptionManagementService', () => {
       PaypalBillingAgreementManager
     );
     paypalCustomerManager = moduleRef.get(PaypalCustomerManager);
+    taxService = moduleRef.get(TaxService);
 
     privateCustomerChanged = jest
       .spyOn(subscriptionManagementService as any, 'customerChanged')
@@ -1776,6 +1789,27 @@ describe('SubscriptionManagementService', () => {
   });
 
   describe('updateStripePaymentDetails', () => {
+    const mockIp = '127.0.0.1';
+    const customerWithShipping = () =>
+      StripeResponseFactory(
+        StripeCustomerFactory({
+          shipping: {
+            name: 'test',
+            address: StripeAddressFactory({
+              country: 'US',
+              postal_code: '10001',
+            }),
+            phone: null,
+          },
+        })
+      );
+
+    beforeEach(() => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(customerWithShipping());
+    });
+
     it('updates the stripe customer payment method details', async () => {
       const mockPaymentMethod = StripeResponseFactory(
         StripePaymentMethodFactory()
@@ -1816,7 +1850,8 @@ describe('SubscriptionManagementService', () => {
       const result =
         await subscriptionManagementService.updateStripePaymentDetails(
           mockAccountCustomer.uid,
-          '123'
+          '123',
+          mockIp
         );
 
       expect(result).toEqual({
@@ -1837,7 +1872,8 @@ describe('SubscriptionManagementService', () => {
       await expect(
         subscriptionManagementService.updateStripePaymentDetails(
           mockAccountCustomer.uid,
-          '123'
+          '123',
+          mockIp
         )
       ).rejects.toBeInstanceOf(UpdateAccountCustomerMissingStripeId);
     });
@@ -1877,7 +1913,8 @@ describe('SubscriptionManagementService', () => {
       await expect(
         subscriptionManagementService.updateStripePaymentDetails(
           mockAccountCustomer.uid,
-          '123'
+          '123',
+          mockIp
         )
       ).rejects.toBeInstanceOf(SetupIntentInvalidStatusError);
     });
@@ -1917,7 +1954,8 @@ describe('SubscriptionManagementService', () => {
       await expect(
         subscriptionManagementService.updateStripePaymentDetails(
           mockAccountCustomer.uid,
-          '123'
+          '123',
+          mockIp
         )
       ).rejects.toBeInstanceOf(SetupIntentMissingPaymentMethodError);
     });
@@ -1956,7 +1994,8 @@ describe('SubscriptionManagementService', () => {
       await expect(
         subscriptionManagementService.updateStripePaymentDetails(
           mockAccountCustomer.uid,
-          '123'
+          '123',
+          mockIp
         )
       ).rejects.toBeInstanceOf(SetupIntentMissingCustomerError);
     });
@@ -2008,7 +2047,8 @@ describe('SubscriptionManagementService', () => {
 
       await subscriptionManagementService.updateStripePaymentDetails(
         mockAccountCustomer.uid,
-        '123'
+        '123',
+        mockIp
       );
 
       expect(customerManager.update).toHaveBeenCalledWith(
@@ -2021,9 +2061,126 @@ describe('SubscriptionManagementService', () => {
         }
       );
     });
+
+    it('puts a geoip-resolved shipping address when the customer has none', async () => {
+      const mockPaymentMethod = StripeResponseFactory(
+        StripePaymentMethodFactory()
+      );
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+      const mockSetupIntent = StripeResponseFactory(
+        StripeSetupIntentFactory({
+          customer: mockCustomerWithoutShipping.id,
+          payment_method: mockPaymentMethod.id,
+          status: 'succeeded',
+        })
+      );
+      const resolvedTaxAddress = {
+        countryCode: 'US',
+        postalCode: '10001',
+      };
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(taxService, 'getTaxAddress')
+        .mockResolvedValue(resolvedTaxAddress);
+      jest
+        .spyOn(setupIntentManager, 'createAndConfirm')
+        .mockResolvedValue(mockSetupIntent);
+      jest
+        .spyOn(paymentMethodManager, 'retrieve')
+        .mockResolvedValue(mockPaymentMethod);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+
+      await subscriptionManagementService.updateStripePaymentDetails(
+        mockAccountCustomer.uid,
+        '123',
+        mockIp
+      );
+
+      expect(taxService.getTaxAddress).toHaveBeenCalledWith(
+        mockIp,
+        mockAccountCustomer.uid
+      );
+      expect(customerManager.update).toHaveBeenCalledWith(
+        mockCustomerWithoutShipping.id,
+        {
+          shipping: {
+            name: mockCustomerWithoutShipping.email || '',
+            address: {
+              country: resolvedTaxAddress.countryCode,
+              postal_code: resolvedTaxAddress.postalCode,
+            },
+          },
+        }
+      );
+    });
+
+    it('throws ManagePaymentMethodTaxAddressRequiredError when tax address is unresolvable', async () => {
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(taxService, 'getTaxAddress').mockResolvedValue(undefined);
+      const createAndConfirmSpy = jest.spyOn(
+        setupIntentManager,
+        'createAndConfirm'
+      );
+
+      await expect(
+        subscriptionManagementService.updateStripePaymentDetails(
+          mockAccountCustomer.uid,
+          '123',
+          mockIp
+        )
+      ).rejects.toBeInstanceOf(ManagePaymentMethodTaxAddressRequiredError);
+      expect(createAndConfirmSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('setDefaultStripePaymentDetails', () => {
+    const mockIp = '127.0.0.1';
+
+    const customerWithShipping = () =>
+      StripeResponseFactory(
+        StripeCustomerFactory({
+          shipping: {
+            name: 'test',
+            address: StripeAddressFactory({
+              country: 'US',
+              postal_code: '10001',
+            }),
+            phone: null,
+          },
+        })
+      );
+
+    beforeEach(() => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(customerWithShipping());
+    });
+
     it("updates the customer's payment details", async () => {
       const mockAccountCustomer = ResultAccountCustomerFactory();
       const mockCustomer = StripeResponseFactory(StripeCustomerFactory());
@@ -2038,7 +2195,8 @@ describe('SubscriptionManagementService', () => {
 
       await subscriptionManagementService.setDefaultStripePaymentDetails(
         mockCustomer.id,
-        mockPaymentMethod.id
+        mockPaymentMethod.id,
+        mockIp
       );
 
       expect(customerManager.update).toHaveBeenCalledWith(
@@ -2062,9 +2220,94 @@ describe('SubscriptionManagementService', () => {
       await expect(
         subscriptionManagementService.setDefaultStripePaymentDetails(
           mockAccountCustomer.uid,
-          'pm_12345'
+          'pm_12345',
+          mockIp
         )
       ).rejects.toBeInstanceOf(SetDefaultPaymentAccountCustomerMissingStripeId);
+    });
+
+    it('stamps a geoip-resolved shipping address when the customer has none', async () => {
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+      const resolvedTaxAddress = {
+        countryCode: 'US',
+        postalCode: '10001',
+      };
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(taxService, 'getTaxAddress')
+        .mockResolvedValue(resolvedTaxAddress);
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+
+      await subscriptionManagementService.setDefaultStripePaymentDetails(
+        mockAccountCustomer.uid,
+        'pm_12345',
+        mockIp
+      );
+
+      expect(taxService.getTaxAddress).toHaveBeenCalledWith(
+        mockIp,
+        mockAccountCustomer.uid
+      );
+      expect(customerManager.update).toHaveBeenNthCalledWith(
+        1,
+        mockCustomerWithoutShipping.id,
+        {
+          shipping: {
+            name: mockCustomerWithoutShipping.email || '',
+            address: {
+              country: resolvedTaxAddress.countryCode,
+              postal_code: resolvedTaxAddress.postalCode,
+            },
+          },
+        }
+      );
+      expect(customerManager.update).toHaveBeenNthCalledWith(
+        2,
+        mockCustomerWithoutShipping.id,
+        {
+          invoice_settings: { default_payment_method: 'pm_12345' },
+        }
+      );
+    });
+
+    it('throws ManagePaymentMethodTaxAddressRequiredError when tax address is unresolvable', async () => {
+      const mockCustomerWithoutShipping = StripeResponseFactory(
+        StripeCustomerFactory({ shipping: null })
+      );
+      const mockAccountCustomer = ResultAccountCustomerFactory({
+        stripeCustomerId: mockCustomerWithoutShipping.id,
+      });
+
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(mockCustomerWithoutShipping);
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest.spyOn(taxService, 'getTaxAddress').mockResolvedValue(undefined);
+      jest.spyOn(customerManager, 'update');
+
+      await expect(
+        subscriptionManagementService.setDefaultStripePaymentDetails(
+          mockAccountCustomer.uid,
+          'pm_12345',
+          mockIp
+        )
+      ).rejects.toBeInstanceOf(ManagePaymentMethodTaxAddressRequiredError);
+      expect(customerManager.update).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -67,7 +67,9 @@ import {
   ManagePaymentMethodIntentGetInTouchError,
   ManagePaymentMethodIntentTryAgainError,
   ManagePaymentMethodIntentInsufficientFundsError,
+  ManagePaymentMethodTaxAddressRequiredError,
 } from './manage-payment-method.error';
+import { TaxService } from '@fxa/payments/cart';
 import { NotifierService } from '@fxa/shared/notifier';
 import { ProfileClient } from '@fxa/profile/client';
 import {
@@ -105,10 +107,40 @@ export class SubscriptionManagementService {
     private productConfigurationManager: ProductConfigurationManager,
     private setupIntentManager: SetupIntentManager,
     private subscriptionManager: SubscriptionManager,
+    private taxService: TaxService,
     private paypalBillingAgreementManager: PaypalBillingAgreementManager,
     private paypalCustomerManager: PaypalCustomerManager,
     @Inject(Logger) private log: LoggerService
   ) {}
+
+  private async ensureCustomerTaxAddress(
+    stripeCustomerId: string,
+    uid: string,
+    ipAddress: string
+  ) {
+    const customer = await this.customerManager.retrieve(stripeCustomerId);
+    const hasValidShipping =
+      !!customer.shipping?.address?.country &&
+      !!customer.shipping?.address?.postal_code;
+    if (hasValidShipping) return;
+
+    const taxAddress = await this.taxService.getTaxAddress(ipAddress, uid);
+    if (!taxAddress) {
+      throw new ManagePaymentMethodTaxAddressRequiredError(
+        'tax_address_required'
+      );
+    }
+
+    await this.customerManager.update(stripeCustomerId, {
+      shipping: {
+        name: customer.email || '',
+        address: {
+          country: taxAddress.countryCode,
+          postal_code: taxAddress.postalCode,
+        },
+      },
+    });
+  }
 
   @SanitizeExceptions()
   async cancelSubscriptionAtPeriodEnd(uid: string, subscriptionId: string) {
@@ -1087,15 +1119,26 @@ export class SubscriptionManagementService {
       ManagePaymentMethodIntentGetInTouchError,
       ManagePaymentMethodIntentTryAgainError,
       ManagePaymentMethodIntentInsufficientFundsError,
+      ManagePaymentMethodTaxAddressRequiredError,
     ],
   })
-  async updateStripePaymentDetails(uid: string, confirmationTokenId: string) {
+  async updateStripePaymentDetails(
+    uid: string,
+    confirmationTokenId: string,
+    ipAddress: string
+  ) {
     const accountCustomer =
       await this.accountCustomerManager.getAccountCustomerByUid(uid);
 
     if (!accountCustomer.stripeCustomerId) {
       throw new UpdateAccountCustomerMissingStripeId(uid);
     }
+
+    await this.ensureCustomerTaxAddress(
+      accountCustomer.stripeCustomerId,
+      uid,
+      ipAddress
+    );
 
     let setupIntent;
     try {
@@ -1166,14 +1209,26 @@ export class SubscriptionManagementService {
     };
   }
 
-  @SanitizeExceptions()
-  async setDefaultStripePaymentDetails(uid: string, paymentMethodId: string) {
+  @SanitizeExceptions({
+    allowlist: [ManagePaymentMethodTaxAddressRequiredError],
+  })
+  async setDefaultStripePaymentDetails(
+    uid: string,
+    paymentMethodId: string,
+    ipAddress: string
+  ) {
     const accountCustomer =
       await this.accountCustomerManager.getAccountCustomerByUid(uid);
 
     if (!accountCustomer.stripeCustomerId) {
       throw new SetDefaultPaymentAccountCustomerMissingStripeId(uid);
     }
+
+    await this.ensureCustomerTaxAddress(
+      accountCustomer.stripeCustomerId,
+      uid,
+      ipAddress
+    );
 
     await this.customerManager.update(accountCustomer.stripeCustomerId, {
       invoice_settings: {

--- a/libs/payments/ui/src/lib/actions/setDefaultStripePaymentDetails.ts
+++ b/libs/payments/ui/src/lib/actions/setDefaultStripePaymentDetails.ts
@@ -5,15 +5,18 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import { getIpAddress } from '../utils/getIpAddress';
 
 export const setDefaultStripePaymentDetails = async (
   uid: string,
   paymentMethodId: string,
 ) => {
   const actionsService = getApp().getActionsService();
+  const ipAddress = await getIpAddress();
 
   return await actionsService.setDefaultStripePaymentDetails({
     uid,
     paymentMethodId,
+    ipAddress,
   });
 };

--- a/libs/payments/ui/src/lib/actions/updateStripePaymentDetails.ts
+++ b/libs/payments/ui/src/lib/actions/updateStripePaymentDetails.ts
@@ -5,15 +5,18 @@
 'use server';
 
 import { getApp } from '../nestapp/app';
+import { getIpAddress } from '../utils/getIpAddress';
 
 export const updateStripePaymentDetails = async (
   uid: string,
   confirmationTokenId: string
 ) => {
   const actionsService = getApp().getActionsService();
+  const ipAddress = await getIpAddress();
 
   return actionsService.updateStripePaymentDetails({
     uid,
     confirmationTokenId,
+    ipAddress,
   });
 };

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -25,6 +25,7 @@ import {
   ManagePaymentMethodIntentGetInTouchError,
   ManagePaymentMethodIntentTryAgainError,
   ManagePaymentMethodIntentInsufficientFundsError,
+  ManagePaymentMethodTaxAddressRequiredError,
 } from '@fxa/payments/management';
 import {
   CheckoutTokenManager,
@@ -1112,6 +1113,7 @@ export class NextJSActionsService {
       ManagePaymentMethodIntentGetInTouchError,
       ManagePaymentMethodIntentTryAgainError,
       ManagePaymentMethodIntentInsufficientFundsError,
+      ManagePaymentMethodTaxAddressRequiredError,
     ],
   })
   @NextIOValidator(
@@ -1122,12 +1124,14 @@ export class NextJSActionsService {
   async updateStripePaymentDetails(args: {
     uid: string;
     confirmationTokenId: string;
+    ipAddress: string;
   }) {
     try {
       const result =
         await this.subscriptionManagementService.updateStripePaymentDetails(
           args.uid,
-          args.confirmationTokenId
+          args.confirmationTokenId,
+          args.ipAddress
         );
       return {
         ok: true,
@@ -1143,16 +1147,20 @@ export class NextJSActionsService {
     }
   }
 
-  @SanitizeExceptions()
+  @SanitizeExceptions({
+    allowlist: [ManagePaymentMethodTaxAddressRequiredError],
+  })
   @NextIOValidator(SetDefaultStripePaymentDetailsActionArgs, undefined)
   @CaptureTimingWithStatsD()
   async setDefaultStripePaymentDetails(args: {
     uid: string;
     paymentMethodId: string;
+    ipAddress: string;
   }) {
     return await this.subscriptionManagementService.setDefaultStripePaymentDetails(
       args.uid,
-      args.paymentMethodId
+      args.paymentMethodId,
+      args.ipAddress
     );
   }
 

--- a/libs/payments/ui/src/lib/nestapp/validators/SetDefaultStripePaymentDetailsActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/SetDefaultStripePaymentDetailsActionArgs.ts
@@ -10,4 +10,7 @@ export class SetDefaultStripePaymentDetailsActionArgs {
 
   @IsString()
   paymentMethodId!: string;
+
+  @IsString()
+  ipAddress!: string;
 }

--- a/libs/payments/ui/src/lib/nestapp/validators/UpdateStripePaymentDetailsActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/UpdateStripePaymentDetailsActionArgs.ts
@@ -11,4 +11,7 @@ export class UpdateStripePaymentDetailsArgs
 
   @IsString()
   confirmationTokenId!: string;
+
+  @IsString()
+  ipAddress!: string;
 }

--- a/libs/payments/ui/src/lib/utils/en.ftl
+++ b/libs/payments/ui/src/lib/utils/en.ftl
@@ -61,6 +61,7 @@ manage-payment-method-intent-error-try-again = Hmm. There was a problem authoriz
 manage-payment-method-intent-error-get-in-touch = Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.
 manage-payment-method-intent-error-insufficient-funds = It looks like your card has insufficient funds. Try another card.
 manage-payment-method-intent-error-generic = An unexpected error has occurred while processing your payment, please try again.
+manage-payment-method-tax-address-required = We could not determine your billing location. Please verify your payment method information and try again.
 
 ## Next Charge
 

--- a/libs/payments/ui/src/lib/utils/getManagePaymentMethodErrorFtlInfo.ts
+++ b/libs/payments/ui/src/lib/utils/getManagePaymentMethodErrorFtlInfo.ts
@@ -34,6 +34,12 @@ export function getManagePaymentMethodErrorFtlInfo(errorCode?: string) {
           'It looks like your card has insufficient funds. Try another card.',
         messageFtl: 'manage-payment-method-intent-error-insufficient-funds',
       };
+    case 'tax_address_required':
+      return {
+        message:
+          'We could not determine your billing location. Please verify your payment method information and try again.',
+        messageFtl: 'manage-payment-method-tax-address-required',
+      };
     case 'intent_failed_generic':
     default:
       return {

--- a/packages/fxa-auth-server/lib/payments/initSubplat.ts
+++ b/packages/fxa-auth-server/lib/payments/initSubplat.ts
@@ -11,7 +11,8 @@ import {
   SetupIntentManager,
   SubscriptionManager,
 } from '@fxa/payments/customer';
-import { ChurnInterventionManager } from '@fxa/payments/cart';
+import { ChurnInterventionManager, TaxService } from '@fxa/payments/cart';
+import { GeoDBManager, setupGeoDB } from '@fxa/shared/geodb';
 import { AuthFirestore } from '@fxa/shared/db/firestore';
 import { ProductConfigurationManager, StrapiClient } from '@fxa/shared/cms';
 import {
@@ -164,6 +165,17 @@ export async function initSubplat({
   );
   const accountCustomerManager = new AccountCustomerManager(accountDatabase);
   const customerSessionManager = new CustomerSessionManager(stripeClient);
+  const geodbReader = await setupGeoDB(config.geodb.dbPath);
+  const geodbManager = new GeoDBManager(geodbReader, {
+    locationOverride: {},
+  });
+  const taxService = new TaxService(
+    accountCustomerManager,
+    customerManager,
+    geodbManager,
+    subscriptionManager,
+    currencyManager
+  );
   const notifierService = new NotifierService(
     notifierSnsConfig,
     logger,
@@ -221,6 +233,7 @@ export async function initSubplat({
     productConfigurationManager,
     setupIntentManager,
     subscriptionManager,
+    taxService,
     paypalBillingAgreementManager,
     paypalCustomerManager,
     logger


### PR DESCRIPTION
## Because

* Legacy customers without a tax location hit an error when updating or setting a default payment method.

## This pull request

* Uses TaxService.getTaxAddress to get a shipping address for the Stripe customer before updating the PM, and shows an informative error message if it fails to get an address.

## Issue that this pull request solves

Closes #[PAY-3662](https://mozilla-hub.atlassian.net/browse/PAY-3662)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)
Steps to reproduce original issue + cause error in Sentry:
1. Make an active subscription for a customer, use a card PM
2. In local Stripe CLI, run these commands:
(Replace `cus_UOb2Qmvzms9Z8n` with the relevant customer id)
    * `stripe customers update cus_UOb2Qmvzms9Z8n -d "shipping="`
    * `stripe customers retrieve cus_UOb2Qmvzms9Z8n --expand tax`
        (shipping should be null)
    * `stripe payment_methods create -d "type=card" -d "card[token]=tok_visa"`
        (this creates a no-address PM, take note of it. Mine was pm_1TPo1OBVqmGyQTMa1PtpFuXm, replace with yours in the relevant commands.)
    * Remove the original (real) PMs from customer in Stripe dashboard
    * `stripe payment_methods attach pm_1TPo1OBVqmGyQTMa1PtpFuXm -d "customer=cus_UOb2Qmvzms9Z8n"`
        (this attaches the no-address PM to the customer)
    * `stripe customers retrieve cus_UOb2Qmvzms9Z8n --expand tax` 
        (verify that all changes were applied)

3. Go to http://localhost:3035/en-US/subscriptions/payments/stripe, click on "Set as default payment method"
    Notice the button is clickable, even though if you expand the saved card PM, there's no location set.
    This triggered the error.

What my UI used to look like, before the changes in the PR:

https://github.com/user-attachments/assets/d05dde1e-a8e2-4593-8301-f5e82f3895c6

After applying the changes in the PR, doing the above then going through the flow should be as usual - no error thrown, PM updated.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3662]: https://mozilla-hub.atlassian.net/browse/PAY-3662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ