### PR TITLE
fix(pair): don't fail mobile pairing after post-OAuth webview reload

### DIFF
--- a/.claude/skills/fxa-review/SKILL.md
+++ b/.claude/skills/fxa-review/SKILL.md
@@ -118,6 +118,7 @@ Tell this agent it is a QA engineer who understands FXA's testing patterns and c
 - Flag patterns likely to cause open handle warnings (unclosed connections, uncleared timers)
 - Flag missing `act()` wrapping in React test state updates
 - Flag over-mocking: mocking internal functions in the same package instead of at system boundaries
+- Flag when there is a jira ticket number in a test name. We do not put tickets in test names.
 
 Output JSON array with fields: severity, category ("Test Quality"), subcategory, file, line, issue, recommendation.
 

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.test.ts
@@ -4,6 +4,7 @@
 
 import { GenericData } from '../../lib/model-data';
 import {
+  PAIR_COMPLETE_STORAGE_PREFIX,
   PairingSupplicantIntegration,
   SupplicantState,
 } from './pairing-supplicant-integration';
@@ -70,6 +71,7 @@ describe('PairingSupplicantIntegration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Object.keys(listeners).forEach((k) => delete listeners[k]);
+    sessionStorage.clear();
   });
 
   describe('openChannel', () => {
@@ -167,6 +169,26 @@ describe('PairingSupplicantIntegration', () => {
       expect(integration.state).toBe(SupplicantState.Failed);
       expect(integration.error?.message).toContain('without providing');
     });
+
+    it('sets sessionStorage completion marker on Complete', async () => {
+      const integration = createIntegration();
+      await integration.openChannel('wss://ch.example.com', 'chan-42', 'k');
+      emit('connected');
+      emit('remote:pair:auth:metadata', {
+        email: 'u@e.com',
+        remoteMetaData: { ua: '' },
+      });
+      emit('remote:pair:auth:authorize', {
+        code: VALID_OAUTH_CODE,
+        state: 'abc123',
+      });
+      await integration.supplicantApprove();
+
+      expect(integration.state).toBe(SupplicantState.Complete);
+      expect(
+        sessionStorage.getItem(PAIR_COMPLETE_STORAGE_PREFIX + 'chan-42')
+      ).toBe('1');
+    });
   });
 
   describe('error handling', () => {
@@ -206,11 +228,73 @@ describe('PairingSupplicantIntegration', () => {
       expect(onError).not.toHaveBeenCalled();
     });
 
-    it('channel error → Failed', async () => {
+    it('channel error after connect → Failed', async () => {
       const integration = createIntegration();
       await integration.openChannel('wss://ch.example.com', 'c', 'k');
+      emit('connected');
       emit('error', new Error('WebSocket failed'));
       expect(integration.state).toBe(SupplicantState.Failed);
+    });
+
+    it('channel close while still Connecting → Failed when no completion marker', async () => {
+      // Without the post-completion sessionStorage marker, a close during
+      // initial connect is a real failure and must surface — otherwise the
+      // user sits on the loading screen forever.
+      const integration = createIntegration();
+      const onError = jest.fn();
+      integration.onError = onError;
+
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+      // Do NOT emit 'connected'
+      emit('close');
+
+      expect(integration.state).toBe(SupplicantState.Failed);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('channel error while still Connecting → Failed when no completion marker', async () => {
+      const integration = createIntegration();
+      const onError = jest.fn();
+      integration.onError = onError;
+
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+      emit('error', new Error('WebSocket failed'));
+
+      expect(integration.state).toBe(SupplicantState.Failed);
+      expect(onError).toHaveBeenCalled();
+    });
+
+    it('channel close while still Connecting is ignored when completion marker is set', async () => {
+      // Matches legacy WaitForConnectionToChannelServer.socketClosed() no-op.
+      // Covers the Android Firefox post-OAuth reload case where the QR URL
+      // is re-entered after the channel has already been consumed.
+      sessionStorage.setItem(PAIR_COMPLETE_STORAGE_PREFIX + 'c', '1');
+      const integration = createIntegration();
+      const onError = jest.fn();
+      const onStateChange = jest.fn();
+      integration.onError = onError;
+      integration.onStateChange = onStateChange;
+
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+      // Do NOT emit 'connected' — simulate channel rejecting the reconnection
+      emit('close');
+
+      expect(integration.state).toBe(SupplicantState.Connecting);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onStateChange).not.toHaveBeenCalled();
+    });
+
+    it('channel error while still Connecting is ignored when completion marker is set', async () => {
+      sessionStorage.setItem(PAIR_COMPLETE_STORAGE_PREFIX + 'c', '1');
+      const integration = createIntegration();
+      const onError = jest.fn();
+      integration.onError = onError;
+
+      await integration.openChannel('wss://ch.example.com', 'c', 'k');
+      emit('error', new Error('WebSocket failed'));
+
+      expect(integration.state).toBe(SupplicantState.Connecting);
+      expect(onError).not.toHaveBeenCalled();
     });
 
     it('supplicantApprove send failure → Failed', async () => {

--- a/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
+++ b/packages/fxa-settings/src/models/integrations/pairing-supplicant-integration.ts
@@ -22,6 +22,36 @@ import config from '../../lib/config';
 const OAUTH_WEBCHANNEL_REDIRECT =
   'urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel';
 
+/** FXA-13616: marks a channel consumed so a post-OAuth webview reload can short-circuit. */
+export const PAIR_COMPLETE_STORAGE_PREFIX = 'fxa.pair.complete.';
+
+/** Read the channel-complete marker, tolerating an unavailable sessionStorage. */
+export function isChannelComplete(channelId: string): boolean {
+  try {
+    return (
+      sessionStorage.getItem(PAIR_COMPLETE_STORAGE_PREFIX + channelId) === '1'
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function clearChannelComplete(channelId: string): void {
+  try {
+    sessionStorage.removeItem(PAIR_COMPLETE_STORAGE_PREFIX + channelId);
+  } catch {
+    // sessionStorage may be unavailable (private mode, quota, SSR).
+  }
+}
+
+function setChannelComplete(channelId: string): void {
+  try {
+    sessionStorage.setItem(PAIR_COMPLETE_STORAGE_PREFIX + channelId, '1');
+  } catch {
+    // sessionStorage may be unavailable (private mode, quota, SSR).
+  }
+}
+
 /**
  * Supplicant state — mirrors the Backbone state machine but as a
  * simple enum that React components can switch on.
@@ -64,6 +94,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   private _error: Error | { errno: number; message: string } | null = null;
   private _email = '';
   private _deviceName = '';
+  private _channelId: string | null = null;
 
   public onStateChange: ((state: SupplicantState) => void) | null = null;
   public onError: ((error: unknown) => void) | null = null;
@@ -168,6 +199,7 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
       return; // already open
     }
 
+    this._channelId = channelId;
     this._channel = new PairingChannelClient();
 
     // Listen for channel events
@@ -285,8 +317,19 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
     }
   };
 
+  /** True when a close/error during connect is the FXA-13616 reload, not a real failure. */
+  private isPostCompletionReconnect(): boolean {
+    return (
+      this._state === SupplicantState.Connecting &&
+      this._channelId !== null &&
+      isChannelComplete(this._channelId)
+    );
+  }
+
   private handleClose = () => {
-    // Channel closed before reaching a terminal state — surface as an error.
+    if (this.isPostCompletionReconnect()) {
+      return;
+    }
     this.fail({
       errno: 1006,
       message: 'Connection to remote device closed, please try again',
@@ -294,6 +337,9 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
   };
 
   private handleChannelError = (event: Event) => {
+    if (this.isPostCompletionReconnect()) {
+      return;
+    }
     this.fail((event as CustomEvent).detail);
   };
 
@@ -311,6 +357,10 @@ export class PairingSupplicantIntegration extends OAuthWebIntegration {
         redirect: OAUTH_WEBCHANNEL_REDIRECT,
         action: 'pairing',
       });
+    }
+
+    if (this._channelId) {
+      setChannelComplete(this._channelId);
     }
 
     this.setState(SupplicantState.Complete);

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.test.tsx
@@ -18,11 +18,34 @@ jest.mock('../../../models/integrations/pairing-supplicant-integration', () => {
   const { MOCK_SUPPLICANT_STATE: SupplicantState } = jest.requireActual(
     '../__mocks__/pairing-test-helpers'
   );
+  const PAIR_COMPLETE_STORAGE_PREFIX = 'fxa.pair.complete.';
   return {
     SupplicantState,
+    PAIR_COMPLETE_STORAGE_PREFIX,
+    isChannelComplete: (channelId: string) => {
+      try {
+        return (
+          globalThis.sessionStorage.getItem(
+            PAIR_COMPLETE_STORAGE_PREFIX + channelId
+          ) === '1'
+        );
+      } catch {
+        return false;
+      }
+    },
+    clearChannelComplete: (channelId: string) => {
+      try {
+        globalThis.sessionStorage.removeItem(
+          PAIR_COMPLETE_STORAGE_PREFIX + channelId
+        );
+      } catch {
+        // ignore
+      }
+    },
     PairingSupplicantIntegration: class {
       validatePairingClient = jest.fn().mockReturnValue(true);
       openChannel = jest.fn().mockResolvedValue(undefined);
+      getClientId = jest.fn().mockReturnValue('test-client');
       onStateChange: ((state: string) => void) | null = null;
       onError: ((err: unknown) => void) | null = null;
       state = SupplicantState.Connecting;
@@ -88,11 +111,13 @@ describe('Pair/Supp page', () => {
       );
       mockIntegration = new PSI();
       mockNavigateWithQuery.mockClear();
+      sessionStorage.clear();
       window.location.hash = '#channel_id=test-chan&channel_key=dGVzdA';
     });
 
     afterEach(() => {
       window.location.hash = '';
+      sessionStorage.clear();
     });
 
     it('shows error when hash params are missing', () => {
@@ -132,6 +157,27 @@ describe('Pair/Supp page', () => {
         mockIntegration.onStateChange?.('waiting_for_authorizations');
       });
       expect(mockNavigateWithQuery).toHaveBeenCalledWith('/pair/supp/allow');
+    });
+
+    it('redirects to success when completion marker is set for this channel', () => {
+      sessionStorage.setItem('fxa.pair.complete.test-chan', '1');
+      renderWithLocalizationProvider(
+        <Supp integration={mockIntegration as unknown as Integration} />
+      );
+      expect(mockIntegration.openChannel).not.toHaveBeenCalled();
+      expect(mockNavigateWithQuery).toHaveBeenCalledWith(
+        '/oauth/success/test-client'
+      );
+      expect(sessionStorage.getItem('fxa.pair.complete.test-chan')).toBeNull();
+    });
+
+    it('ignores completion marker for a different channel', () => {
+      sessionStorage.setItem('fxa.pair.complete.other-chan', '1');
+      renderWithLocalizationProvider(
+        <Supp integration={mockIntegration as unknown as Integration} />
+      );
+      expect(mockIntegration.openChannel).toHaveBeenCalled();
+      expect(mockNavigateWithQuery).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Supp/index.tsx
@@ -12,15 +12,12 @@ import { useNavigateWithQuery } from '../../../lib/hooks/useNavigateWithQuery';
 import config from '../../../lib/config';
 import { Integration } from '../../../models';
 import {
+  clearChannelComplete,
+  isChannelComplete,
   PairingSupplicantIntegration,
   SupplicantState,
 } from '../../../models/integrations/pairing-supplicant-integration';
 
-// pair/supp is the gateway to the supplicant pairing flow.
-// It opens the WebSocket channel via the integration (which persists across
-// page transitions) and waits for connection + metadata before navigating
-// to pair/supp/allow.
-//
 // URL format: /pair/supp?client_id=...&scope=...#channel_id=...&channel_key=...
 
 export const viewName = 'pair.supp';
@@ -43,8 +40,7 @@ const Supp = ({
       return;
     }
 
-    // Supplicant receives channel_id and channel_key in the URL hash
-    // (never the query string) so they're not sent to the server.
+    // channel_id/key live in the URL hash so they're not sent to the server.
     const hashParams = new URLSearchParams(window.location.hash.substring(1));
     const channelId = hashParams.get('channel_id');
     const channelKey = hashParams.get('channel_key');
@@ -55,13 +51,24 @@ const Supp = ({
       return;
     }
 
-    // Validate client_id against pairing allowlist (matching Backbone behavior)
     if (!integration.validatePairingClient()) {
       setError('Invalid pairing client');
       return;
     }
 
-    // Subscribe to state changes — navigate when metadata is received
+    if (isChannelComplete(channelId)) {
+      const clientId = integration.getClientId();
+      if (clientId) {
+        // We can now remove the flag, since we are about to navigate to the success page
+        clearChannelComplete(channelId);
+        navigateWithQuery(`/oauth/success/${clientId}`);
+        return;
+      }
+      // Without a clientId, fall through rather than build /oauth/success/.
+      // Don't clear the marker so isPostCompletionReconnect() can still
+      // suppress the consumed-channel close/error from the WS reconnect.
+    }
+
     integration.onStateChange = (state: SupplicantState) => {
       if (state === SupplicantState.WaitingForAuthorizations) {
         navigateWithQuery('/pair/supp/allow');
@@ -74,8 +81,7 @@ const Supp = ({
       navigateWithQuery('/pair/failure');
     };
 
-    // Open channel — the integration manages the WebSocket connection
-    // and it persists across page transitions (component unmounts)
+    // The integration owns the WebSocket and persists across page transitions.
     integration
       .openChannel(channelServerUri, channelId, channelKey)
       .catch(() => {
@@ -83,8 +89,7 @@ const Supp = ({
       });
 
     return () => {
-      // Don't close the channel — it needs to persist for SuppAllow/WaitForAuth.
-      // Just unsubscribe our callbacks.
+      // Unsubscribe only — the channel must outlive this component for SuppAllow.
       integration.onStateChange = null;
       integration.onError = null;
     };


### PR DESCRIPTION
## Summary

- Fixes [FXA-13616](https://mozilla-hub.atlassian.net/browse/FXA-13616): Android mobile shows the pair-failure screen at the end of an otherwise-successful pairing (sync is actually on).
- Root cause: after the supplicant sends `fxaccounts:oauth_login`, Android Firefox reloads the webview to the original `/pair/supp?...#channel_id=...` URL. The React `Supp` page then calls `openChannel(...)` with the already-consumed `channel_id`; the channel server's close/error reaches `PairingSupplicantIntegration.handleClose` and is treated as a terminal failure → navigation to `/pair/failure`. Legacy Backbone (`supplicant-state-machine.js:47-50`, `144-146`) silently ignored close events in `WaitForConnectionToChannelServer` / `SendResultToRelier`; the React port lost that guard.
- Fix: (1) `handleClose` / `handleChannelError` now return early while state is still `Connecting` (legacy parity); (2) on reaching `Complete`, a `sessionStorage` marker `fxa.pair.complete.<channelId>` is written, and the `Supp` page short-circuits to `/oauth/success/<clientId>` when that marker is present — so the post-OAuth webview reload lands on the success screen instead of reconnecting.

## Test plan

- [x] `nx test-unit fxa-settings` — new + existing Pair tests pass (138/138 suites in `Pair/` + `pairing-*`).
- [ ] Manual QA on stage against Android Firefox following FXA-13616 repro steps:
  - [ ] Desktop: sign in to Sync → Connect Another Device → "I have a mobile device" → QR shown.
  - [ ] Mobile (Android Firefox): scan QR, approve on mobile, approve on desktop.
  - [ ] Expected: desktop shows success; mobile shows "Pairing was successful" (not `/pair/failure`) after the flash/refresh.
  - [ ] Sync still working on mobile (bookmark a page on desktop, verify it syncs).
- [ ] Regression check: genuine failures (channel server unreachable, user declines) still route to `/pair/failure` — covered by existing `Supp` / `SuppAllow` / `SuppWaitForAuth` tests, since the new guard only suppresses close while still in `Connecting`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FXA-13616]: https://mozilla-hub.atlassian.net/browse/FXA-13616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ