### PR TITLE
test(auth-server): drop per-test resetModules to fix Jest worker OOM

### DIFF
--- a/packages/fxa-auth-server/lib/geodb.spec.ts
+++ b/packages/fxa-auth-server/lib/geodb.spec.ts
@@ -2,7 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const knownIpLocation = require('../test/known-ip-location');
+// `./geodb` captures the config object by reference at module load, so
+// per-test variation must mutate properties, not reassign the variable.
+const geodbConfig: { enabled: boolean; locationOverride: any } = {
+  enabled: true,
+  locationOverride: {},
+};
+
+jest.mock('../config', () => ({
+  default: {
+    get: function (item: string) {
+      if (item === 'geodb') {
+        return geodbConfig;
+      }
+      return undefined;
+    },
+  },
+}));
+
+import knownIpLocation from '../test/known-ip-location';
+import geodbFactory from './geodb';
 
 function mockLog() {
   return {
@@ -16,26 +35,12 @@ function mockLog() {
 
 describe('geodb', () => {
   beforeEach(() => {
-    jest.resetModules();
+    geodbConfig.enabled = true;
+    geodbConfig.locationOverride = {};
   });
 
   it('returns location data when enabled', () => {
-    jest.doMock('../config', () => ({
-      default: {
-        get: function (item: string) {
-          if (item === 'geodb') {
-            return {
-              enabled: true,
-              locationOverride: {},
-            };
-          }
-          return undefined;
-        },
-      },
-    }));
-
-    const thisMockLog = mockLog();
-    const getGeoData = require('./geodb')(thisMockLog);
+    const getGeoData = geodbFactory(mockLog());
     const geoData = getGeoData(knownIpLocation.ip);
 
     expect(knownIpLocation.location.city.has(geoData.location.city)).toBe(true);
@@ -49,21 +54,9 @@ describe('geodb', () => {
   });
 
   it('returns empty object data when disabled', () => {
-    jest.doMock('../config', () => ({
-      default: {
-        get: function (item: string) {
-          if (item === 'geodb') {
-            return {
-              enabled: false,
-            };
-          }
-          return undefined;
-        },
-      },
-    }));
+    geodbConfig.enabled = false;
 
-    const thisMockLog = mockLog();
-    const getGeoData = require('./geodb')(thisMockLog);
+    const getGeoData = geodbFactory(mockLog());
     const geoData = getGeoData('8.8.8.8');
 
     expect(geoData).toEqual({});

--- a/packages/fxa-auth-server/lib/log.spec.ts
+++ b/packages/fxa-auth-server/lib/log.spec.ts
@@ -2,6 +2,64 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const logger = {
+  debug: jest.fn(),
+  error: jest.fn(),
+  critical: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+};
+
+const mockMozlogInstance = jest.fn();
+const mockMozlog = jest.fn();
+
+const sentryScope = { setContext: jest.fn() };
+const mockSentry = {
+  withScope: jest.fn(),
+  getActiveSpan: jest.fn(),
+};
+
+const mockReportSentryMessage = jest.fn();
+const mockValidate = jest.fn();
+const mockNotifierSend = jest.fn();
+const mockNotifierFactory = jest.fn();
+const mockAmplitudeConfig: { schemaValidation: boolean } = {
+  schemaValidation: true,
+};
+
+jest.mock('mozlog', () => mockMozlog);
+jest.mock('@sentry/node', () => mockSentry);
+jest.mock('../config', () => ({
+  config: {
+    get(name: string) {
+      switch (name) {
+        case 'log':
+          return { fmt: 'mozlog' };
+        case 'amplitude':
+          return mockAmplitudeConfig;
+        case 'domain':
+          return 'example.com';
+        case 'oauth.clientIds':
+          return { clientid: 'human readable name' };
+        default:
+          throw new Error(`unexpected config get: ${name}`);
+      }
+    },
+  },
+}));
+jest.mock('./notifier', () => mockNotifierFactory);
+jest.mock('./sentry', () => ({
+  reportSentryMessage: mockReportSentryMessage,
+}));
+jest.mock('./oauth/validators', () => ({
+  HEX_STRING: /^(?:[0-9a-f]{2})+$/,
+}));
+jest.mock('fxa-shared', () => ({
+  metrics: { amplitude: { validate: mockValidate } },
+}));
+
+import logModule from './log';
+
 const validEvent = {
   op: 'amplitudeEvent',
   event_type: 'fxa_activity - access_token_checked',
@@ -25,85 +83,43 @@ const validEvent = {
   },
 };
 
+// `./log` keeps a module-level `_registered` map of logger names to dedup
+// double-init; hand out a unique name per test to avoid spurious warnings.
+let nextTestId = 0;
+const nextLoggerName = () => `test-${++nextTestId}`;
+
 describe('log', () => {
-  let logger: Record<string, jest.Mock>;
-  let mockMozlog: jest.Mock;
-  let mockMozlogInstance: jest.Mock;
-  let mockSentry: Record<string, jest.Mock>;
-  let mockReportSentryMessage: jest.Mock;
-  let mockValidate: jest.Mock;
-  let mockNotifierSend: jest.Mock;
-  let mockAmplitudeConfig: { schemaValidation: boolean };
-  let sentryScope: { setContext: jest.Mock };
   let log: any;
+  let loggerName: string;
 
   beforeEach(() => {
-    jest.resetModules();
+    logger.debug.mockReset();
+    logger.error.mockReset();
+    logger.critical.mockReset();
+    logger.warn.mockReset();
+    logger.info.mockReset();
 
-    logger = {
-      debug: jest.fn(),
-      error: jest.fn(),
-      critical: jest.fn(),
-      warn: jest.fn(),
-      info: jest.fn(),
-    };
+    mockMozlogInstance.mockReset().mockReturnValue(logger);
+    mockMozlog.mockReset().mockReturnValue(mockMozlogInstance);
 
-    mockMozlogInstance = jest.fn().mockReturnValue(logger);
-    mockMozlog = jest.fn().mockReturnValue(mockMozlogInstance);
+    sentryScope.setContext.mockReset();
+    mockSentry.withScope
+      .mockReset()
+      .mockImplementation((cb: (scope: Record<string, jest.Mock>) => void) => {
+        cb(sentryScope);
+      });
+    mockSentry.getActiveSpan.mockReset().mockReturnValue(undefined);
 
-    sentryScope = { setContext: jest.fn() };
-    mockSentry = {
-      withScope: jest
-        .fn()
-        .mockImplementation(
-          (cb: (scope: Record<string, jest.Mock>) => void) => {
-            cb(sentryScope);
-          }
-        ),
-      getActiveSpan: jest.fn().mockReturnValue(undefined),
-    };
+    mockReportSentryMessage.mockReset().mockReturnValue({});
+    mockValidate.mockReset();
+    mockNotifierSend.mockReset();
+    mockNotifierFactory.mockReset().mockReturnValue({ send: mockNotifierSend });
+    mockAmplitudeConfig.schemaValidation = true;
 
-    mockReportSentryMessage = jest.fn().mockReturnValue({});
-    mockValidate = jest.fn();
-    mockNotifierSend = jest.fn();
-    mockAmplitudeConfig = { schemaValidation: true };
-
-    jest.doMock('mozlog', () => mockMozlog);
-    jest.doMock('@sentry/node', () => mockSentry);
-    jest.doMock('../config', () => ({
-      config: {
-        get(name: string) {
-          switch (name) {
-            case 'log':
-              return { fmt: 'mozlog' };
-            case 'amplitude':
-              return mockAmplitudeConfig;
-            case 'domain':
-              return 'example.com';
-            case 'oauth.clientIds':
-              return { clientid: 'human readable name' };
-            default:
-              throw new Error(`unexpected config get: ${name}`);
-          }
-        },
-      },
-    }));
-    jest.doMock('./notifier', () =>
-      jest.fn().mockReturnValue({ send: mockNotifierSend })
-    );
-    jest.doMock('./sentry', () => ({
-      reportSentryMessage: mockReportSentryMessage,
-    }));
-    jest.doMock('./oauth/validators', () => ({
-      HEX_STRING: /^(?:[0-9a-f]{2})+$/,
-    }));
-    jest.doMock('fxa-shared', () => ({
-      metrics: { amplitude: { validate: mockValidate } },
-    }));
-
-    log = require('./log')({
+    loggerName = nextLoggerName();
+    log = logModule({
       level: 'debug',
-      name: 'test',
+      name: loggerName,
       stdout: { on: jest.fn() },
     });
   });
@@ -118,7 +134,7 @@ describe('log', () => {
     const args = mockMozlog.mock.calls[0];
     expect(args).toHaveLength(1);
     expect(Object.keys(args[0])).toHaveLength(4);
-    expect(args[0].app).toBe('test');
+    expect(args[0].app).toBe(loggerName);
     expect(args[0].level).toBe('debug');
     expect(args[0].stream).toBe(process.stderr);
 
@@ -152,10 +168,10 @@ describe('log', () => {
   });
 
   it('warns and fixes duplicate logger names', () => {
-    const logModule = require('./log');
+    const dupName = `${loggerName}-duplicates`;
     const opts = {
       level: 'debug',
-      name: 'test-duplicates',
+      name: dupName,
       stdout: { on: jest.fn() },
     };
 
@@ -164,34 +180,34 @@ describe('log', () => {
     logModule(opts);
 
     // Edge case: user passes in already incremented name
-    logModule({ ...opts, name: 'test-duplicates-1' });
+    logModule({ ...opts, name: `${dupName}-1` });
 
-    // Initial 'test' call + 4 calls above = 5
+    // Initial beforeEach call + 4 calls above = 5
     expect(mockMozlog).toHaveBeenCalledTimes(5);
     expect(mockMozlog).toHaveBeenCalledWith(
-      expect.objectContaining({ app: 'test' })
+      expect.objectContaining({ app: loggerName })
     );
     expect(mockMozlog).toHaveBeenCalledWith(
-      expect.objectContaining({ app: opts.name })
+      expect.objectContaining({ app: dupName })
     );
     expect(mockMozlog).toHaveBeenCalledWith(
-      expect.objectContaining({ app: opts.name + '-1' })
+      expect.objectContaining({ app: `${dupName}-1` })
     );
     expect(mockMozlog).toHaveBeenCalledWith(
-      expect.objectContaining({ app: opts.name + '-2' })
+      expect.objectContaining({ app: `${dupName}-2` })
     );
     expect(mockMozlog).toHaveBeenCalledWith(
-      expect.objectContaining({ app: opts.name + '-1-1' })
+      expect.objectContaining({ app: `${dupName}-1-1` })
     );
 
     expect(logger.warn).toHaveBeenCalledWith('init', {
-      msg: `Logger with name of ${opts.name} already registered. Adjusting name to ${opts.name}-1 to prevent double log scenario.`,
+      msg: `Logger with name of ${dupName} already registered. Adjusting name to ${dupName}-1 to prevent double log scenario.`,
     });
     expect(logger.warn).toHaveBeenCalledWith('init', {
-      msg: `Logger with name of ${opts.name} already registered. Adjusting name to ${opts.name}-2 to prevent double log scenario.`,
+      msg: `Logger with name of ${dupName} already registered. Adjusting name to ${dupName}-2 to prevent double log scenario.`,
     });
     expect(logger.warn).toHaveBeenCalledWith('init', {
-      msg: `Logger with name of ${opts.name}-1 already registered. Adjusting name to ${opts.name}-1-1 to prevent double log scenario.`,
+      msg: `Logger with name of ${dupName}-1 already registered. Adjusting name to ${dupName}-1-1 to prevent double log scenario.`,
     });
   });
 
@@ -600,9 +616,9 @@ describe('log', () => {
   describe('traceId', () => {
     it("doesn't set if tracing is not enabled", () => {
       // Re-create log without nodeTracer
-      log = require('./log')({
+      log = logModule({
         level: 'debug',
-        name: 'test',
+        name: nextLoggerName(),
         stdout: { on: jest.fn() },
       });
 
@@ -616,9 +632,9 @@ describe('log', () => {
     });
 
     it('should set trace id', () => {
-      log = require('./log')({
+      log = logModule({
         level: 'debug',
-        name: 'test',
+        name: nextLoggerName(),
         stdout: { on: jest.fn() },
         nodeTracer: {
           getTraceId: jest.fn().mockReturnValue('fake trace id'),

--- a/packages/fxa-auth-server/lib/metrics/context.spec.ts
+++ b/packages/fxa-auth-server/lib/metrics/context.spec.ts
@@ -3,6 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import crypto from 'crypto';
+import { MetricsRedis } from '../metricsCache';
+import mocks from '../../test/mocks';
+import contextFactory from './context';
+
+const cache = {
+  add: jest.fn(),
+  del: jest.fn(),
+  get: jest.fn(),
+};
+
+jest.mock('../metricsCache', () => ({
+  MetricsRedis: jest.fn().mockImplementation(() => cache),
+}));
 
 function hashToken(token: { uid: string; id: string }) {
   const hash = crypto.createHash('sha256');
@@ -13,28 +26,23 @@ function hashToken(token: { uid: string; id: string }) {
 
 describe('metricsContext', () => {
   let results: Record<string, any>;
-  let cache: Record<string, jest.Mock>;
-  let cacheFactory: jest.Mock;
   let log: any;
   let config: any;
   let metricsContext: any;
 
   beforeEach(() => {
-    jest.resetModules();
-
     results = {
       del: Promise.resolve(),
       get: Promise.resolve(),
       set: Promise.resolve(),
       exists: Promise.resolve(),
     };
-    cache = {
-      add: jest.fn().mockImplementation(() => results.add),
-      del: jest.fn().mockImplementation(() => results.del),
-      get: jest.fn().mockImplementation(() => results.get),
-    };
-    cacheFactory = jest.fn().mockReturnValue(cache);
-    log = require('../../test/mocks').mockLog();
+    cache.add.mockReset().mockImplementation(() => results.add);
+    cache.del.mockReset().mockImplementation(() => results.del);
+    cache.get.mockReset().mockImplementation(() => results.get);
+    (MetricsRedis as jest.Mock).mockClear();
+
+    log = mocks.mockLog();
     config = {
       redis: {
         metrics: {
@@ -45,12 +53,7 @@ describe('metricsContext', () => {
       },
     };
 
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: cacheFactory,
-    }));
-
-    const contextModule = require('./context');
-    metricsContext = contextModule(log, config);
+    metricsContext = contextFactory(log, config);
   });
 
   afterEach(() => {
@@ -58,12 +61,9 @@ describe('metricsContext', () => {
   });
 
   it('metricsContext interface is correct', () => {
-    // Re-require un-mocked module for static exports check
-    const metricsContextModule = jest.requireActual('./context');
-
-    expect(typeof metricsContextModule).toBe('function');
-    expect(typeof metricsContextModule.schema).toBe('object');
-    expect(metricsContextModule.schema).not.toBeNull();
+    expect(typeof contextFactory).toBe('function');
+    expect(typeof contextFactory.schema).toBe('object');
+    expect(contextFactory.schema).not.toBeNull();
 
     expect(typeof metricsContext).toBe('object');
     expect(metricsContext).not.toBeNull();
@@ -92,8 +92,8 @@ describe('metricsContext', () => {
   });
 
   it('instantiated cache correctly', () => {
-    expect(cacheFactory).toHaveBeenCalledTimes(1);
-    expect(cacheFactory).toHaveBeenCalledWith(config);
+    expect(MetricsRedis).toHaveBeenCalledTimes(1);
+    expect(MetricsRedis).toHaveBeenCalledWith(config);
   });
 
   it('metricsContext.stash', async () => {
@@ -669,363 +669,260 @@ describe('metricsContext', () => {
     expect(cache.del).toHaveBeenCalledTimes(1);
   });
 
-  it('metricsContext.validate with valid data', () => {
-    const flowBeginTime = 1451566800000;
-    const flowId =
-      '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f';
-    jest.spyOn(Date, 'now').mockReturnValue(flowBeginTime + 59999);
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'S3CR37',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-      payload: {
-        metricsContext: {
-          flowId,
-          flowBeginTime,
+  describe('metricsContext.validate', () => {
+    // Each `validate` test wants its own (log, config) but the same module
+    // graph; just call the already-loaded factory with a fresh config
+    // instead of re-requiring `./context`.
+    function makeValidateContext(flowIdKey = 'test') {
+      const mockLog = mocks.mockLog();
+      const mockConfig = {
+        redis: { metrics: {} },
+        metrics: {
+          flow_id_expiry: 60000,
+          flow_id_key: flowIdKey,
         },
-      },
-    };
+      };
+      return contextFactory(mockLog, mockConfig);
+    }
 
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const result = localContext.validate.call(mockRequest);
-
-    expect(result).toBe(true);
-    expect(mockRequest.payload.metricsContext.flowId).toBe(
-      '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f'
-    );
-  });
-
-  it('metricsContext.validate with missing payload', () => {
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'test',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-    };
-
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
-
-    expect(valid).toBe(false);
-  });
-
-  it('metricsContext.validate with missing data bundle', () => {
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'test',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-      payload: {
-        email: 'test@example.com',
-        // note that 'metricsContext' key is absent
-      },
-    };
-
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
-
-    expect(valid).toBe(false);
-  });
-
-  it('metricsContext.validate with missing flowId', () => {
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'test',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-      payload: {
-        metricsContext: {
-          flowBeginTime: Date.now() - 1,
-        } as any,
-      },
-    };
-
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
-
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowBeginTime).toBeFalsy();
-  });
-
-  it('metricsContext.validate with missing flowBeginTime', () => {
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'test',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-      payload: {
-        metricsContext: {
-          flowId:
-            'f1031df1031df1031df1031df1031df1031df1031df1031df1031df1031df103',
-        } as any,
-      },
-    };
-
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
-
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
-  });
-
-  it('metricsContext.validate with flowBeginTime that is too old', () => {
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'test',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-      payload: {
-        metricsContext: {
-          flowId:
-            'f1031df1031df1031df1031df1031df1031df1031df1031df1031df1031df103',
-          flowBeginTime: Date.now() - mockConfig.metrics.flow_id_expiry - 1,
+    it('with valid data', () => {
+      const flowBeginTime = 1451566800000;
+      const flowId =
+        '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f';
+      jest.spyOn(Date, 'now').mockReturnValue(flowBeginTime + 59999);
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
         },
-      },
-    };
-
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
-
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
-  });
-
-  it('metricsContext.validate with an invalid flow signature', () => {
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'test',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'test-agent',
-      },
-      payload: {
-        metricsContext: {
-          flowId:
-            'f1031df1031df1031df1031df1031df1031df1031df1031df1031df1031df103',
-          flowBeginTime: Date.now() - 1,
+        payload: {
+          metricsContext: {
+            flowId,
+            flowBeginTime,
+          },
         },
-      },
-    };
+      };
 
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
+      const localContext = makeValidateContext('S3CR37');
+      const result = localContext.validate.call(mockRequest);
 
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
-  });
+      expect(result).toBe(true);
+      expect(mockRequest.payload.metricsContext.flowId).toBe(
+        '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f'
+      );
+    });
 
-  it('metricsContext.validate with flow signature from different key', () => {
-    const expectedTime = 1451566800000;
-    const expectedSalt = '4d6f7a696c6c6146697265666f782121';
-    const expectedHmac = '2a204a6d26b009b26b3116f643d84c6f';
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'ThisIsTheWrongKey',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'Firefox',
-      },
-      payload: {
-        metricsContext: {
-          flowId: expectedSalt + expectedHmac,
-          flowBeginTime: expectedTime,
+    it('with missing payload', () => {
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
         },
-      },
-    };
-    jest.spyOn(Date, 'now').mockReturnValue(expectedTime + 20000);
+      };
 
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
+      const localContext = makeValidateContext();
+      const valid = localContext.validate.call(mockRequest);
 
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
-  });
+      expect(valid).toBe(false);
+    });
 
-  it('metricsContext.validate with flow signature from different timestamp', () => {
-    const expectedTime = 1451566800000;
-    const expectedSalt = '4d6f7a696c6c6146697265666f782121';
-    const expectedHmac = '2a204a6d26b009b26b3116f643d84c6f';
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'S3CR37',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'Firefox',
-      },
-      payload: {
-        metricsContext: {
-          flowId: expectedSalt + expectedHmac,
-          flowBeginTime: expectedTime - 1,
+    it('with missing data bundle', () => {
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
         },
-      },
-    };
-    jest.spyOn(Date, 'now').mockReturnValue(expectedTime + 20000);
-
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
-
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
-  });
-
-  it('metricsContext.validate with flow signature including user agent', () => {
-    const expectedTime = 1451566800000;
-    // This is the correct signature for the *old* recipe, where we used
-    // to include the user agent string in the hash. The test is expected
-    // to fail because we don't support that recipe any more.
-    const expectedSalt = '4d6f7a696c6c6146697265666f782121';
-    const expectedHmac = 'c89d56556d22039fbbf54d34e0baf206';
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'S3CR37',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'Firefox',
-      },
-      payload: {
-        metricsContext: {
-          flowId: expectedSalt + expectedHmac,
-          flowBeginTime: expectedTime,
+        payload: {
+          email: 'test@example.com',
+          // note that 'metricsContext' key is absent
         },
-      },
-    };
-    jest.spyOn(Date, 'now').mockReturnValue(expectedTime + 20000);
+      };
 
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const valid = localContext.validate.call(mockRequest);
+      const localContext = makeValidateContext();
+      const valid = localContext.validate.call(mockRequest);
 
-    expect(valid).toBe(false);
-    expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
-  });
+      expect(valid).toBe(false);
+    });
 
-  it('metricsContext.validate with flow signature compared without user agent', () => {
-    const flowBeginTime = 1451566800000;
-    const flowId =
-      '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f';
-    jest.spyOn(Date, 'now').mockReturnValue(flowBeginTime + 59999);
-    const mockLog = require('../../test/mocks').mockLog();
-    const mockConfig = {
-      redis: { metrics: {} },
-      metrics: {
-        flow_id_expiry: 60000,
-        flow_id_key: 'S3CR37',
-      },
-    };
-    const mockRequest = {
-      headers: {
-        'user-agent': 'some other user agent',
-      },
-      payload: {
-        metricsContext: {
-          flowId,
-          flowBeginTime,
+    it('with missing flowId', () => {
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
         },
-      },
-    };
+        payload: {
+          metricsContext: {
+            flowBeginTime: Date.now() - 1,
+          } as any,
+        },
+      };
 
-    jest.doMock('../metricsCache', () => ({
-      MetricsRedis: jest.fn().mockReturnValue(cache),
-    }));
-    const localContext = require('./context')(mockLog, mockConfig);
-    const result = localContext.validate.call(mockRequest);
+      const localContext = makeValidateContext();
+      const valid = localContext.validate.call(mockRequest);
 
-    expect(result).toBe(true);
-    expect(mockRequest.payload.metricsContext.flowId).toBe(
-      '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f'
-    );
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowBeginTime).toBeFalsy();
+    });
+
+    it('with missing flowBeginTime', () => {
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
+        },
+        payload: {
+          metricsContext: {
+            flowId:
+              'f1031df1031df1031df1031df1031df1031df1031df1031df1031df1031df103',
+          } as any,
+        },
+      };
+
+      const localContext = makeValidateContext();
+      const valid = localContext.validate.call(mockRequest);
+
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
+    });
+
+    it('with flowBeginTime that is too old', () => {
+      const flowIdExpiry = 60000;
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
+        },
+        payload: {
+          metricsContext: {
+            flowId:
+              'f1031df1031df1031df1031df1031df1031df1031df1031df1031df1031df103',
+            flowBeginTime: Date.now() - flowIdExpiry - 1,
+          },
+        },
+      };
+
+      const localContext = makeValidateContext();
+      const valid = localContext.validate.call(mockRequest);
+
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
+    });
+
+    it('with an invalid flow signature', () => {
+      const mockRequest = {
+        headers: {
+          'user-agent': 'test-agent',
+        },
+        payload: {
+          metricsContext: {
+            flowId:
+              'f1031df1031df1031df1031df1031df1031df1031df1031df1031df1031df103',
+            flowBeginTime: Date.now() - 1,
+          },
+        },
+      };
+
+      const localContext = makeValidateContext();
+      const valid = localContext.validate.call(mockRequest);
+
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
+    });
+
+    it('with flow signature from different key', () => {
+      const expectedTime = 1451566800000;
+      const expectedSalt = '4d6f7a696c6c6146697265666f782121';
+      const expectedHmac = '2a204a6d26b009b26b3116f643d84c6f';
+      const mockRequest = {
+        headers: {
+          'user-agent': 'Firefox',
+        },
+        payload: {
+          metricsContext: {
+            flowId: expectedSalt + expectedHmac,
+            flowBeginTime: expectedTime,
+          },
+        },
+      };
+      jest.spyOn(Date, 'now').mockReturnValue(expectedTime + 20000);
+
+      const localContext = makeValidateContext('ThisIsTheWrongKey');
+      const valid = localContext.validate.call(mockRequest);
+
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
+    });
+
+    it('with flow signature from different timestamp', () => {
+      const expectedTime = 1451566800000;
+      const expectedSalt = '4d6f7a696c6c6146697265666f782121';
+      const expectedHmac = '2a204a6d26b009b26b3116f643d84c6f';
+      const mockRequest = {
+        headers: {
+          'user-agent': 'Firefox',
+        },
+        payload: {
+          metricsContext: {
+            flowId: expectedSalt + expectedHmac,
+            flowBeginTime: expectedTime - 1,
+          },
+        },
+      };
+      jest.spyOn(Date, 'now').mockReturnValue(expectedTime + 20000);
+
+      const localContext = makeValidateContext('S3CR37');
+      const valid = localContext.validate.call(mockRequest);
+
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
+    });
+
+    it('with flow signature including user agent', () => {
+      const expectedTime = 1451566800000;
+      // This is the correct signature for the *old* recipe, where we used
+      // to include the user agent string in the hash. The test is expected
+      // to fail because we don't support that recipe any more.
+      const expectedSalt = '4d6f7a696c6c6146697265666f782121';
+      const expectedHmac = 'c89d56556d22039fbbf54d34e0baf206';
+      const mockRequest = {
+        headers: {
+          'user-agent': 'Firefox',
+        },
+        payload: {
+          metricsContext: {
+            flowId: expectedSalt + expectedHmac,
+            flowBeginTime: expectedTime,
+          },
+        },
+      };
+      jest.spyOn(Date, 'now').mockReturnValue(expectedTime + 20000);
+
+      const localContext = makeValidateContext('S3CR37');
+      const valid = localContext.validate.call(mockRequest);
+
+      expect(valid).toBe(false);
+      expect(mockRequest.payload.metricsContext.flowId).toBeFalsy();
+    });
+
+    it('with flow signature compared without user agent', () => {
+      const flowBeginTime = 1451566800000;
+      const flowId =
+        '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f';
+      jest.spyOn(Date, 'now').mockReturnValue(flowBeginTime + 59999);
+      const mockRequest = {
+        headers: {
+          'user-agent': 'some other user agent',
+        },
+        payload: {
+          metricsContext: {
+            flowId,
+            flowBeginTime,
+          },
+        },
+      };
+
+      const localContext = makeValidateContext('S3CR37');
+      const result = localContext.validate.call(mockRequest);
+
+      expect(result).toBe(true);
+      expect(mockRequest.payload.metricsContext.flowId).toBe(
+        '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f'
+      );
+    });
   });
 
   it('setFlowCompleteSignal', () => {

--- a/packages/fxa-auth-server/lib/monitoring.spec.ts
+++ b/packages/fxa-auth-server/lib/monitoring.spec.ts
@@ -2,58 +2,62 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const mockInitMonitoring = jest.fn();
+const mockIgnoreErrors = jest.fn();
+const mockLogger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+  trace: jest.fn(),
+};
+const mockLog = jest.fn().mockReturnValue(mockLogger);
+const mockHapiIntegration = jest.fn().mockReturnValue({ name: 'Hapi' });
+const mockLinkedErrorsIntegration = jest
+  .fn()
+  .mockReturnValue({ name: 'LinkedErrors' });
+
+jest.mock('fxa-shared/monitoring', () => ({
+  initMonitoring: mockInitMonitoring,
+}));
+jest.mock('../config', () => ({
+  config: {
+    getProperties: jest.fn().mockReturnValue({
+      log: { level: 'debug' },
+      sentry: { dsn: 'https://test@sentry.io/123' },
+    }),
+  },
+}));
+jest.mock('./log', () => mockLog);
+jest.mock('../package.json', () => ({ version: '1.234.0' }), {
+  virtual: true,
+});
+jest.mock('@fxa/accounts/errors', () => ({
+  ignoreErrors: mockIgnoreErrors,
+}));
+jest.mock('@sentry/node', () => ({
+  hapiIntegration: mockHapiIntegration,
+  linkedErrorsIntegration: mockLinkedErrorsIntegration,
+}));
+
+// Importing the module triggers the top-level initMonitoring() call once.
+import './monitoring';
+
+// Snapshot one-shot call args before `clearMocks: true` wipes them
+// between tests; the module-load side-effect can't be replayed.
+const initMonitoringCallCount = mockInitMonitoring.mock.calls.length;
+const initMonitoringArg = mockInitMonitoring.mock.calls[0]?.[0];
+const hapiIntegrationCallCount = mockHapiIntegration.mock.calls.length;
+const linkedErrorsIntegrationCalls = mockLinkedErrorsIntegration.mock.calls.map(
+  (c) => c[0]
+);
+const logCalls = mockLog.mock.calls.map((c) => [...c]);
+const filterSentryEvent: (event: any, hint?: any) => any =
+  initMonitoringArg.config.eventFilters[0];
 
 describe('monitoring', () => {
-  let mockInitMonitoring: jest.Mock;
-  let mockIgnoreErrors: jest.Mock;
-  let mockLog: jest.Mock;
-  let mockLogger: Record<string, jest.Mock>;
-  let mockHapiIntegration: jest.Mock;
-  let mockLinkedErrorsIntegration: jest.Mock;
-
   beforeEach(() => {
-    jest.resetModules();
-
-    mockInitMonitoring = jest.fn();
-    mockIgnoreErrors = jest.fn();
-    mockLogger = {
-      info: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
-      debug: jest.fn(),
-      trace: jest.fn(),
-    };
-    mockLog = jest.fn().mockReturnValue(mockLogger);
-    mockHapiIntegration = jest.fn().mockReturnValue({ name: 'Hapi' });
-    mockLinkedErrorsIntegration = jest
-      .fn()
-      .mockReturnValue({ name: 'LinkedErrors' });
-
-    jest.doMock('fxa-shared/monitoring', () => ({
-      initMonitoring: mockInitMonitoring,
-    }));
-    jest.doMock('../config', () => ({
-      config: {
-        getProperties: jest.fn().mockReturnValue({
-          log: { level: 'debug' },
-          sentry: { dsn: 'https://test@sentry.io/123' },
-        }),
-      },
-    }));
-    jest.doMock('./log', () => mockLog);
-    jest.doMock('../package.json', () => ({ version: '1.234.0' }), {
-      virtual: true,
-    });
-    jest.doMock('@fxa/accounts/errors', () => ({
-      ignoreErrors: mockIgnoreErrors,
-    }));
-    jest.doMock('@sentry/node', () => ({
-      hapiIntegration: mockHapiIntegration,
-      linkedErrorsIntegration: mockLinkedErrorsIntegration,
-    }));
-
-    // Requiring the module triggers the top-level initMonitoring() call.
-    require('./monitoring');
+    mockIgnoreErrors.mockReset();
   });
 
   afterEach(() => {
@@ -61,43 +65,33 @@ describe('monitoring', () => {
   });
 
   it('calls initMonitoring on module load', () => {
-    expect(mockInitMonitoring).toHaveBeenCalledTimes(1);
+    expect(initMonitoringCallCount).toBe(1);
 
-    const callArg = mockInitMonitoring.mock.calls[0][0];
-
-    // Logger is the return value of require('./log')(level, name)
-    expect(callArg.logger).toBe(mockLogger);
-    expect(mockLog).toHaveBeenCalledWith('debug', 'configure-sentry');
+    // Logger is the return value of the mocked log(level, name)
+    expect(initMonitoringArg.logger).toBe(mockLogger);
+    expect(logCalls).toContainEqual(['debug', 'configure-sentry']);
 
     // Config includes spread properties, release, eventFilters, integrations
-    expect(callArg.config).toEqual(
+    expect(initMonitoringArg.config).toEqual(
       expect.objectContaining({
         log: { level: 'debug' },
         sentry: { dsn: 'https://test@sentry.io/123' },
         release: '1.234.0',
       })
     );
-    expect(callArg.config.eventFilters).toHaveLength(1);
-    expect(typeof callArg.config.eventFilters[0]).toBe('function');
-    expect(callArg.config.integrations).toHaveLength(2);
+    expect(initMonitoringArg.config.eventFilters).toHaveLength(1);
+    expect(typeof initMonitoringArg.config.eventFilters[0]).toBe('function');
+    expect(initMonitoringArg.config.integrations).toHaveLength(2);
   });
 
   it('passes Sentry integrations with correct configuration', () => {
-    expect(mockHapiIntegration).toHaveBeenCalledTimes(1);
-    expect(mockLinkedErrorsIntegration).toHaveBeenCalledWith({
+    expect(hapiIntegrationCallCount).toBe(1);
+    expect(linkedErrorsIntegrationCalls).toContainEqual({
       key: 'jse_cause',
     });
   });
 
   describe('filterSentryEvent', () => {
-    let filterSentryEvent: (event: any, hint?: any) => any;
-
-    beforeEach(() => {
-      // Extract the filterSentryEvent function from the initMonitoring call
-      const callArg = mockInitMonitoring.mock.calls[0][0];
-      filterSentryEvent = callArg.config.eventFilters[0];
-    });
-
     it('returns null when ignoreErrors returns true', () => {
       mockIgnoreErrors.mockReturnValue(true);
 

--- a/packages/fxa-auth-server/lib/oauth/grant.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/grant.spec.ts
@@ -2,7 +2,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { config } = require('../../config');
+// `grant.js` captures `JWT_ACCESS_TOKENS_ENABLED` and the allow-list at
+// module load, so the config is fixed once here. validateRequestedGrant
+// tests don't depend on those values; generateTokens tests do.
+jest.mock('../../config', () => {
+  const realConfig = jest.requireActual('../../config').config;
+  return {
+    config: {
+      get(key: string) {
+        switch (key) {
+          case 'oauthServer.jwtAccessTokens.enabled':
+            return true;
+          case 'oauthServer.jwtAccessTokens.enabledClientIds':
+            return ['9876543210'];
+          default:
+            return realConfig.get(key);
+        }
+      },
+    },
+  };
+});
+
+jest.mock('./db', () => ({
+  getScope: jest.fn(),
+  generateAccessToken: jest.fn(),
+  generateIdToken: jest.fn(),
+  generateRefreshToken: jest.fn(),
+}));
+
+jest.mock('./jwt_access_token', () => ({
+  create: jest.fn(),
+}));
+
+// Fake signer producing a base64-decodable token; avoids needing a real
+// signing key for the OpenID ID-token tests.
+jest.mock('./jwt', () => ({
+  sign(claims: any) {
+    const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
+      'base64'
+    );
+    const payload = Buffer.from(JSON.stringify(claims)).toString('base64');
+    const signature = 'fakesig';
+    return `${header}.${payload}.${signature}`;
+  },
+}));
+
+import fxaShared from 'fxa-shared';
+import { Container } from 'typedi';
+
+const ScopeSet = (fxaShared as any).oauth.scopes;
+import * as grantModule from './grant';
+import * as mockDBModule from './db';
+import * as mockJWTAccessTokenModule from './jwt_access_token';
+import { CapabilityService } from '../../lib/payments/capability';
+
+const { validateRequestedGrant, generateTokens, setStripeHelper } = grantModule;
+const mockDB = mockDBModule as unknown as Record<string, jest.Mock>;
+const mockJWTAccessToken = mockJWTAccessTokenModule as unknown as {
+  create: jest.Mock;
+};
 
 function decodeJWT(b64: string) {
   const jwt = b64.split('.');
@@ -32,16 +90,8 @@ const CLIENT = {
 };
 
 describe('validateRequestedGrant', () => {
-  let mockDB: any, validateRequestedGrant: any, FreshScopeSet: any;
-
   beforeEach(() => {
-    mockDB = {};
-    jest.resetModules();
-    jest.doMock('./db', () => mockDB);
-    validateRequestedGrant = require('./grant').validateRequestedGrant;
-    // Get ScopeSet from the same module registry as the freshly-required grant
-    // module, so that instanceof checks inside grant.js work correctly.
-    FreshScopeSet = require('fxa-shared').oauth.scopes;
+    mockDB.getScope.mockReset();
   });
 
   it('should allow unchecked AAL if not requested in acr_values', async () => {
@@ -90,13 +140,9 @@ describe('validateRequestedGrant', () => {
   });
 
   it('should check key-bearing scopes in the database, and reject if not allowed for that client', async () => {
-    mockDB.getScope = jest.fn().mockImplementation(async () => {
-      return { hasScopedKeys: true };
-    });
+    mockDB.getScope.mockImplementation(async () => ({ hasScopedKeys: true }));
     const requestedGrant = {
-      scope: FreshScopeSet.fromArray([
-        'https://identity.mozilla.com/apps/oldsync',
-      ]),
+      scope: ScopeSet.fromArray(['https://identity.mozilla.com/apps/oldsync']),
     };
     await expect(
       validateRequestedGrant(CLAIMS, CLIENT, requestedGrant)
@@ -119,13 +165,9 @@ describe('validateRequestedGrant', () => {
   });
 
   it('should reject key-bearing scopes requested with claims from an unverified session', async () => {
-    mockDB.getScope = jest.fn().mockImplementation(async () => {
-      return { hasScopedKeys: true };
-    });
+    mockDB.getScope.mockImplementation(async () => ({ hasScopedKeys: true }));
     const requestedGrant = {
-      scope: FreshScopeSet.fromArray([
-        'https://identity.mozilla.com/apps/oldsync',
-      ]),
+      scope: ScopeSet.fromArray(['https://identity.mozilla.com/apps/oldsync']),
     };
     await expect(
       validateRequestedGrant(
@@ -139,37 +181,12 @@ describe('validateRequestedGrant', () => {
 
 describe('generateTokens', () => {
   let mockAccessToken: any;
-  let mockDB: any;
-  let mockJWTAccessToken: any;
   let mockCapabilityService: any;
-
-  let generateTokens: any;
   let requestedGrant: any;
   let scope: any;
-  let FreshScopeSet: any;
 
   beforeEach(() => {
-    jest.resetModules();
-    jest.doMock('../../config', () => ({
-      config: {
-        get(key: string) {
-          switch (key) {
-            case 'oauthServer.jwtAccessTokens.enabled':
-              return true;
-            case 'oauthServer.jwtAccessTokens.enabledClientIds':
-              return ['9876543210'];
-            default:
-              return config.get(key);
-          }
-        },
-      },
-    }));
-
-    // Get ScopeSet from the same module registry as the freshly-required grant
-    // module, so that instanceof checks inside grant.js work correctly.
-    FreshScopeSet = require('fxa-shared').oauth.scopes;
-
-    scope = FreshScopeSet.fromArray([
+    scope = ScopeSet.fromArray([
       'profile:uid',
       'profile:email',
       'profile:subscriptions',
@@ -189,51 +206,24 @@ describe('generateTokens', () => {
       userId: Buffer.from('ABCDEF123456', 'hex'),
     };
 
-    mockDB = {
-      generateAccessToken: jest.fn(async () => mockAccessToken),
-      generateIdToken: jest.fn(async () => ({ token: 'id_token' })),
-      generateRefreshToken: jest.fn(async () => ({
-        token: 'refresh_token',
-      })),
-    };
-    mockCapabilityService = {};
+    mockDB.generateAccessToken
+      .mockReset()
+      .mockImplementation(async () => mockAccessToken);
+    mockDB.generateIdToken
+      .mockReset()
+      .mockImplementation(async () => ({ token: 'id_token' }));
+    mockDB.generateRefreshToken
+      .mockReset()
+      .mockImplementation(async () => ({ token: 'refresh_token' }));
 
-    mockJWTAccessToken = {
-      create: jest.fn(async () => {
-        return {
-          ...mockAccessToken,
-          jwt_token: 'signed jwt access token',
-        };
-      }),
-    };
-
-    jest.doMock('./db', () => mockDB);
-    jest.doMock('./jwt_access_token', () => mockJWTAccessToken);
-    // Mock the jwt module to avoid needing a real signing key for ID token tests.
-    // The sign function produces a fake JWT whose payload can be decoded by decodeJWT.
-    jest.doMock('./jwt', () => ({
-      sign(claims: any) {
-        const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
-          'base64'
-        );
-        const payload = Buffer.from(JSON.stringify(claims)).toString('base64');
-        const signature = 'fakesig';
-        return `${header}.${payload}.${signature}`;
-      },
+    mockJWTAccessToken.create.mockReset().mockImplementation(async () => ({
+      ...mockAccessToken,
+      jwt_token: 'signed jwt access token',
     }));
 
-    const grantModule = require('./grant');
-    // After jest.resetModules(), we must get Container and CapabilityService
-    // from the same module registry used by the freshly-required grant module,
-    // otherwise Container.set() would target a stale Container instance.
-    const freshContainer = require('typedi').default;
-    const {
-      CapabilityService: FreshCapabilityService,
-    } = require('../../lib/payments/capability');
-    freshContainer.set(FreshCapabilityService, mockCapabilityService);
-    grantModule.setStripeHelper(undefined);
-
-    generateTokens = grantModule.generateTokens;
+    mockCapabilityService = {};
+    Container.set(CapabilityService, mockCapabilityService);
+    setStripeHelper(undefined);
   });
 
   it('should return required params in result, normal access token by default', async () => {
@@ -310,7 +300,7 @@ describe('generateTokens', () => {
   });
 
   it('should generate an OpenID ID token if requested', async () => {
-    requestedGrant.scope = FreshScopeSet.fromArray(['openid']);
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
     const result = await generateTokens(requestedGrant);
     expect(result.id_token).toBeTruthy();
 
@@ -319,7 +309,7 @@ describe('generateTokens', () => {
   });
 
   it('should propagate `resource` and `clientId` in the `aud` claim', async () => {
-    requestedGrant.scope = FreshScopeSet.fromArray(['openid']);
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
     requestedGrant.resource = 'https://resource.server1.com';
     const result = await generateTokens(requestedGrant);
     expect(result.id_token).toBeTruthy();
@@ -331,7 +321,7 @@ describe('generateTokens', () => {
   });
 
   it('should propagate auth_time in claims', async () => {
-    requestedGrant.scope = FreshScopeSet.fromArray(['openid']);
+    requestedGrant.scope = ScopeSet.fromArray(['openid']);
     requestedGrant.authAt = Date.now();
     const result = await generateTokens(requestedGrant);
     expect(result.id_token).toBeTruthy();

--- a/packages/fxa-auth-server/lib/oauth/jwt.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/jwt.spec.ts
@@ -2,16 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const jsonwebtoken = require('jsonwebtoken');
+// Wrap `publicPEM` in a jest fn delegating to the real implementation by
+// default; one test below overrides it via `mockImplementationOnce`.
+jest.mock('./keys', () => {
+  const real = jest.requireActual('./keys');
+  return {
+    ...real,
+    publicPEM: jest.fn((kid: string) => real.publicPEM(kid)),
+  };
+});
+
+import jsonwebtoken from 'jsonwebtoken';
+import * as JWT from './jwt';
+import * as keys from './keys';
 
 describe('lib/jwt', () => {
-  let JWT: any;
-
-  beforeEach(() => {
-    jest.resetModules();
-    JWT = require('./jwt');
-  });
-
   describe('sign', () => {
     it('signs the claims, passes on options', async () => {
       const jwt = await JWT.sign(
@@ -39,29 +44,15 @@ describe('lib/jwt', () => {
       });
 
       it('fails if kid is invalid', async () => {
-        const realKeys = require('./keys');
-        const { SIGNING_PEM, SIGNING_KID, SIGNING_ALG } = realKeys;
+        keys.publicPEM.mockImplementationOnce(() => {
+          throw new Error('PEM not found');
+        });
 
-        jest.resetModules();
-        jest.doMock('./keys', () => ({
-          SIGNING_PEM,
-          SIGNING_KID,
-          SIGNING_ALG,
-          publicPEM() {
-            throw new Error('PEM not found');
-          },
-        }));
-        const MockedJWT = require('./jwt');
+        const jwt = await JWT.sign({ foo: 'bar' });
 
-        const jwt = await MockedJWT.sign({ foo: 'bar' });
-
-        try {
-          await expect(MockedJWT.verify(jwt)).rejects.toThrow(
-            'error in secret or public key callback: Invalid kid'
-          );
-        } finally {
-          jest.dontMock('./keys');
-        }
+        await expect(JWT.verify(jwt)).rejects.toThrow(
+          'error in secret or public key callback: Invalid kid'
+        );
       });
 
       it('fails if signature does not match', async () => {
@@ -106,10 +97,7 @@ describe('lib/jwt', () => {
       });
 
       it('fails if header `typ` is not expected', async () => {
-        const jwt = await JWT.sign(
-          { foo: 'bar' },
-          { header: { typ: 'JWT' } }
-        );
+        const jwt = await JWT.sign({ foo: 'bar' }, { header: { typ: 'JWT' } });
         await expect(JWT.verify(jwt, { typ: 'custom JWT' })).rejects.toThrow(
           'error in secret or public key callback: Invalid typ'
         );

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.spec.ts
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.spec.ts
@@ -2,22 +2,26 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const ScopeSet = require('fxa-shared').oauth.scopes;
-const { OAUTH_SCOPE_OLD_SYNC } = require('fxa-shared/oauth/constants');
-const TOKEN_SERVER_URL =
-  require('../../config').default.get('syncTokenserverUrl');
+jest.mock('./jwt', () => ({
+  sign: jest.fn(),
+  verify: jest.fn(),
+}));
+
+import fxaShared from 'fxa-shared';
+import { OAUTH_SCOPE_OLD_SYNC } from 'fxa-shared/oauth/constants';
+
+const ScopeSet = (fxaShared as any).oauth.scopes;
+import config from '../../config';
+import * as JWT from './jwt';
+import * as JWTAccessToken from './jwt_access_token';
+
+const mockSign = JWT.sign as jest.Mock;
+const mockVerify = JWT.verify as jest.Mock;
+const TOKEN_SERVER_URL = config.get('syncTokenserverUrl');
 
 describe('lib/jwt_access_token', () => {
-  let JWTAccessToken: any;
-
-  beforeEach(() => {
-    jest.resetModules();
-    JWTAccessToken = require('./jwt_access_token');
-  });
-
   describe('create', () => {
     let mockAccessToken: any;
-    let mockJWT: any;
     let requestedGrant: any;
     let scope: any;
 
@@ -37,15 +41,7 @@ describe('lib/jwt_access_token', () => {
         userId: Buffer.from('feedcafe', 'hex'),
       };
 
-      mockJWT = {
-        sign: jest.fn(async () => {
-          return 'signed jwt access token';
-        }),
-      };
-
-      jest.resetModules();
-      jest.doMock('./jwt', () => mockJWT);
-      JWTAccessToken = require('./jwt_access_token');
+      mockSign.mockResolvedValue('signed jwt access token');
     });
 
     it('should return JWT format access token with the expected fields', async () => {
@@ -60,9 +56,9 @@ describe('lib/jwt_access_token', () => {
       const afterSec = Math.floor(Date.now() / 1000);
 
       expect(result.jwt_token).toBe('signed jwt access token');
-      expect(mockJWT.sign).toHaveBeenCalledTimes(1);
+      expect(mockSign).toHaveBeenCalledTimes(1);
 
-      const signedClaims = mockJWT.sign.mock.calls[0][0];
+      const signedClaims = mockSign.mock.calls[0][0];
       expect(Object.keys(signedClaims)).toHaveLength(7);
       expect(signedClaims.aud).toBe('deadbeef');
       expect(signedClaims.client_id).toBe('deadbeef');
@@ -77,7 +73,7 @@ describe('lib/jwt_access_token', () => {
     it('should propagate `resource` and `clientId` in the `aud` claim', async () => {
       requestedGrant.resource = 'https://resource.server1.com';
       await JWTAccessToken.create(mockAccessToken, requestedGrant);
-      const signedClaims = mockJWT.sign.mock.calls[0][0];
+      const signedClaims = mockSign.mock.calls[0][0];
       expect(signedClaims.aud).toEqual([
         'deadbeef',
         'https://resource.server1.com',
@@ -87,7 +83,7 @@ describe('lib/jwt_access_token', () => {
     it('should propagate `fxa-subscriptions`', async () => {
       requestedGrant['fxa-subscriptions'] = ['subscription1', 'subscription2'];
       await JWTAccessToken.create(mockAccessToken, requestedGrant);
-      const signedClaims = mockJWT.sign.mock.calls[0][0];
+      const signedClaims = mockSign.mock.calls[0][0];
       expect(Object.keys(signedClaims)).toHaveLength(8);
 
       expect(signedClaims['fxa-subscriptions']).toBe(
@@ -98,7 +94,7 @@ describe('lib/jwt_access_token', () => {
     it('should propagate `fxa-generation`', async () => {
       requestedGrant.generation = 12345;
       await JWTAccessToken.create(mockAccessToken, requestedGrant);
-      const signedClaims = mockJWT.sign.mock.calls[0][0];
+      const signedClaims = mockSign.mock.calls[0][0];
 
       expect(signedClaims['fxa-generation']).toBe(requestedGrant.generation);
     });
@@ -106,7 +102,7 @@ describe('lib/jwt_access_token', () => {
     it('should propagate `fxa-profileChangedAt`', async () => {
       requestedGrant.profileChangedAt = 12345;
       await JWTAccessToken.create(mockAccessToken, requestedGrant);
-      const signedClaims = mockJWT.sign.mock.calls[0][0];
+      const signedClaims = mockSign.mock.calls[0][0];
 
       expect(signedClaims['fxa-profileChangedAt']).toBe(
         requestedGrant.profileChangedAt
@@ -116,7 +112,7 @@ describe('lib/jwt_access_token', () => {
     it('defaults oldsync scope to tokenserver audience', async () => {
       requestedGrant.scope = ScopeSet.fromString(OAUTH_SCOPE_OLD_SYNC);
       await JWTAccessToken.create(mockAccessToken, requestedGrant);
-      const signedClaims = mockJWT.sign.mock.calls[0][0];
+      const signedClaims = mockSign.mock.calls[0][0];
 
       expect(signedClaims.aud).toBe(TOKEN_SERVER_URL);
     });
@@ -124,22 +120,17 @@ describe('lib/jwt_access_token', () => {
 
   // Shared mock setup for tokenId and verify tests since the test
   // environment has no signing keys configured.
+  const TOKEN_PREFIX = 'mock-jwt:';
   function setupMockJWT() {
-    const TOKEN_PREFIX = 'mock-jwt:';
-
-    jest.resetModules();
-    jest.doMock('./jwt', () => ({
-      sign(claims: any) {
-        return TOKEN_PREFIX + JSON.stringify(claims);
-      },
-      async verify(token: string) {
-        if (!token.startsWith(TOKEN_PREFIX)) {
-          throw new Error('Invalid token');
-        }
-        return JSON.parse(token.slice(TOKEN_PREFIX.length));
-      },
-    }));
-    JWTAccessToken = require('./jwt_access_token');
+    mockSign.mockImplementation(
+      (claims: any) => TOKEN_PREFIX + JSON.stringify(claims)
+    );
+    mockVerify.mockImplementation(async (token: string) => {
+      if (!token.startsWith(TOKEN_PREFIX)) {
+        throw new Error('Invalid token');
+      }
+      return JSON.parse(token.slice(TOKEN_PREFIX.length));
+    });
   }
 
   describe('tokenId', () => {

--- a/packages/fxa-auth-server/lib/push.spec.ts
+++ b/packages/fxa-auth-server/lib/push.spec.ts
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const Ajv = require('ajv');
-const ajv = new Ajv();
-const fs = require('fs');
-const path = require('path');
+import Ajv from 'ajv';
+import fs from 'fs';
+import path from 'path';
+import mocks from '../test/mocks';
 
-const mocks = require('../test/mocks');
+const ajv = new Ajv();
 const mockUid = 'deadbeef';
 
 const TTL = '42';
@@ -77,20 +77,24 @@ const WINDOWS_DESKTOP_PUSH_DEFAULTS = {
   pushEndpointExpired: false,
 } as const;
 
+jest.mock('web-push', () => ({
+  sendNotification: jest.fn(),
+}));
+
+import webPush from 'web-push';
+import pushFactory from './push';
+
+const mockSendNotification = webPush.sendNotification as jest.Mock;
+
 describe('push', () => {
   let mockDb: ReturnType<typeof mocks.mockDB>,
     mockLog: ReturnType<typeof mocks.mockLog>,
     mockConfig: Record<string, unknown>,
     mockStatsD: { increment: jest.Mock },
-    mockDevices: MockDevice[],
-    mockSendNotification: jest.Mock;
+    mockDevices: MockDevice[];
 
   function loadMockedPushModule() {
-    jest.resetModules();
-    jest.doMock('web-push', () => ({
-      sendNotification: mockSendNotification,
-    }));
-    return require('./push')(mockLog, mockDb, mockConfig, mockStatsD);
+    return pushFactory(mockLog, mockDb, mockConfig, mockStatsD);
   }
 
   beforeEach(() => {
@@ -135,7 +139,7 @@ describe('push', () => {
     mockStatsD = {
       increment: jest.fn(),
     };
-    mockSendNotification = jest.fn(async () => {});
+    mockSendNotification.mockReset().mockImplementation(async () => {});
   });
 
   it('sendPush does not reject on empty device array', async () => {
@@ -281,7 +285,7 @@ describe('push', () => {
 
   it('sendPush logs metrics about failed sends', async () => {
     let shouldFail = false;
-    mockSendNotification = jest.fn(async () => {
+    mockSendNotification.mockImplementation(async () => {
       try {
         if (shouldFail) {
           throw new Error('intermittent failure');
@@ -551,7 +555,7 @@ describe('push', () => {
   });
 
   it('push reports errors when web-push fails', async () => {
-    mockSendNotification = jest.fn(async () => {
+    mockSendNotification.mockImplementation(async () => {
       throw new Error('Failed with a nasty error');
     });
     const push = loadMockedPushModule();
@@ -588,7 +592,7 @@ describe('push', () => {
   });
 
   it('push resets device push data when push server responds with a 400 level error', async () => {
-    mockSendNotification = jest.fn(async () => {
+    mockSendNotification.mockImplementation(async () => {
       const err: Error & { statusCode?: number } = new Error('Failed');
       err.statusCode = 410;
       throw err;
@@ -618,7 +622,7 @@ describe('push', () => {
   });
 
   it('push resets device push data when a failure is caused by bad encryption keys', async () => {
-    mockSendNotification = jest.fn(async () => {
+    mockSendNotification.mockImplementation(async () => {
       throw new Error('Failed');
     });
     const push = loadMockedPushModule();
@@ -647,7 +651,7 @@ describe('push', () => {
   });
 
   it('push does not reset device push data after an unexpected failure', async () => {
-    mockSendNotification = jest.fn(async () => {
+    mockSendNotification.mockImplementation(async () => {
       throw new Error('Failed unexpectedly');
     });
     const push = loadMockedPushModule();
@@ -706,7 +710,7 @@ describe('push', () => {
   });
 
   it('notifyCommandReceived re-throws errors', async () => {
-    mockSendNotification = jest.fn(async () => {
+    mockSendNotification.mockImplementation(async () => {
       throw new Error('Failed with a nasty error');
     });
     const push = loadMockedPushModule();

--- a/packages/fxa-auth-server/lib/serverJWT.spec.ts
+++ b/packages/fxa-auth-server/lib/serverJWT.spec.ts
@@ -2,19 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const mockSign = jest.fn();
+const mockVerify = jest.fn();
+
+jest.mock('jsonwebtoken', () => ({
+  sign: mockSign,
+  verify: mockVerify,
+}));
+
+import * as serverJWT from './serverJWT';
+
 const noop = () => {};
 
-function loadWithMock(overrides: any) {
-  const mock = { sign: noop, verify: noop, ...overrides };
-  jest.resetModules();
-  jest.doMock('jsonwebtoken', () => mock);
-  return require('./serverJWT');
-}
-
 describe('lib/serverJWT', () => {
+  beforeEach(() => {
+    mockSign.mockReset().mockImplementation(noop);
+    mockVerify.mockReset().mockImplementation(noop);
+  });
+
   describe('signJWT', () => {
     it('signs the JWT', async () => {
-      const signSpy = jest.fn(function (
+      mockSign.mockImplementation(function (
         _claims: any,
         _key: any,
         _opts: any,
@@ -23,13 +31,11 @@ describe('lib/serverJWT', () => {
         callback(null, 'j.w.t');
       });
 
-      const serverJWT = loadWithMock({ sign: signSpy });
-
       const jwt = await serverJWT.signJWT({ foo: 'bar' }, 'biz', 'buz', 'zoom');
       expect(jwt).toBe('j.w.t');
 
-      expect(signSpy).toHaveBeenCalledTimes(1);
-      expect(signSpy).toHaveBeenNthCalledWith(
+      expect(mockSign).toHaveBeenCalledTimes(1);
+      expect(mockSign).toHaveBeenNthCalledWith(
         1,
         { foo: 'bar' },
         'zoom',
@@ -47,7 +53,7 @@ describe('lib/serverJWT', () => {
   describe('verifyJWT', () => {
     describe('signed with the current key', () => {
       it('returns the claims', async () => {
-        const verifySpy = jest.fn(function (
+        mockVerify.mockImplementation(function (
           _jwt: any,
           _key: any,
           _opts: any,
@@ -56,8 +62,6 @@ describe('lib/serverJWT', () => {
           callback(null, { sub: 'foo' });
         });
 
-        const serverJWT = loadWithMock({ verify: verifySpy });
-
         const claims = await serverJWT.verifyJWT('j.w.t', 'foo', 'bar', [
           'current',
           'old',
@@ -65,8 +69,8 @@ describe('lib/serverJWT', () => {
 
         expect(claims).toEqual({ sub: 'foo' });
 
-        expect(verifySpy).toHaveBeenCalledTimes(1);
-        expect(verifySpy).toHaveBeenNthCalledWith(
+        expect(mockVerify).toHaveBeenCalledTimes(1);
+        expect(mockVerify).toHaveBeenNthCalledWith(
           1,
           'j.w.t',
           'current',
@@ -82,7 +86,7 @@ describe('lib/serverJWT', () => {
 
     describe('signed with an old key', () => {
       it('returns the claims', async () => {
-        const verifySpy = jest.fn(function (
+        mockVerify.mockImplementation(function (
           _jwt: any,
           key: any,
           _opts: any,
@@ -95,8 +99,6 @@ describe('lib/serverJWT', () => {
           }
         });
 
-        const serverJWT = loadWithMock({ verify: verifySpy });
-
         const claims = await serverJWT.verifyJWT('j.w.t', 'foo', 'bar', [
           'current',
           'old',
@@ -104,9 +106,9 @@ describe('lib/serverJWT', () => {
 
         expect(claims).toEqual({ sub: 'foo' });
 
-        expect(verifySpy).toHaveBeenCalledTimes(2);
+        expect(mockVerify).toHaveBeenCalledTimes(2);
 
-        expect(verifySpy).toHaveBeenNthCalledWith(
+        expect(mockVerify).toHaveBeenNthCalledWith(
           1,
           'j.w.t',
           'current',
@@ -118,7 +120,7 @@ describe('lib/serverJWT', () => {
           expect.any(Function)
         );
 
-        expect(verifySpy).toHaveBeenNthCalledWith(
+        expect(mockVerify).toHaveBeenNthCalledWith(
           2,
           'j.w.t',
           'old',
@@ -134,7 +136,7 @@ describe('lib/serverJWT', () => {
 
     describe('no key found', () => {
       it('throws an `Invalid jwt` error', async () => {
-        const verifySpy = jest.fn(function (
+        mockVerify.mockImplementation(function (
           _jwt: any,
           _key: any,
           _opts: any,
@@ -142,8 +144,6 @@ describe('lib/serverJWT', () => {
         ) {
           callback(new Error('invalid signature'));
         });
-
-        const serverJWT = loadWithMock({ verify: verifySpy });
 
         await expect(
           serverJWT.verifyJWT('j.w.t', 'foo', 'bar', ['current', 'old'])
@@ -153,7 +153,7 @@ describe('lib/serverJWT', () => {
 
     describe('invalid JWT', () => {
       it('re-throw the verification error', async () => {
-        const verifySpy = jest.fn(function (
+        mockVerify.mockImplementation(function (
           _jwt: any,
           _key: any,
           _opts: any,
@@ -161,8 +161,6 @@ describe('lib/serverJWT', () => {
         ) {
           callback(new Error('invalid sub'));
         });
-
-        const serverJWT = loadWithMock({ verify: verifySpy });
 
         await expect(
           serverJWT.verifyJWT('j.w.t', 'foo', 'bar', ['current', 'old'])


### PR DESCRIPTION
  ## Because

  - `lib/metrics/context.spec.ts` was SIGKILL'ing a Jest worker
  - Root cause is per-test `jest.resetModules()` + `jest.doMock(...)` + `require('./context')` in a shared `beforeEach`. That reloaded the `./context → validators → fxa-shared → joi` graph ~94 times per file. Eight sibling specs followed the same anti-pattern.

  ## This pull request

  - Refactors `lib/metrics/context.spec.ts` to mock `../metricsCache` once at file scope, load `./context` once, and recreate `metricsContext` via the factory per-test. **33.5 s → 2.6 s.**
  - Applies the same pattern to eight sibling specs: `lib/log.spec.ts` (28 tests), `lib/monitoring.spec.ts` (8), `lib/geodb.spec.ts` (2), `lib/oauth/jwt.spec.ts` (11), `lib/oauth/jwt_access_token.spec.ts` (11), `lib/oauth/grant.spec.ts` (13), `lib/push.spec.ts` (28), `lib/serverJWT.spec.ts` (5).

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13473

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**

  ```bash
  cd packages/fxa-auth-server
  yarn jest lib/metrics/context.spec.ts lib/log.spec.ts lib/monitoring.spec.ts \
            lib/geodb.spec.ts lib/oauth/jwt.spec.ts lib/oauth/jwt_access_token.spec.ts \
            lib/oauth/grant.spec.ts lib/push.spec.ts lib/serverJWT.spec.ts
  # 9 suites, 145 tests, ~5s
  yarn jest  # full suite: 150 suites, 3379 tests, ~55s

  Verified clean across 5 consecutive full-suite runs. No production code changed; refactor is test-only.