### PR TITLE
fix(settings): respect Firefox-signed-in user on cached signin page

### DIFF
--- a/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
+++ b/packages/functional-tests/tests/oauth/syncSignIn.spec.ts
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { expect, test } from '../../lib/fixtures/standard';
+import {
+  smartWindowDesktopOAuthQueryParams,
+  syncDesktopOAuthQueryParams,
+} from '../../lib/query-params';
 
 test.describe('severity-1 #smoke', () => {
   test.describe('signin with OAuth after Sync', () => {
@@ -95,6 +99,85 @@ test.describe('severity-1 #smoke', () => {
 
       // OAuth sign-in should succeed even though the sync session was not verified
       expect(await relier.isLoggedIn()).toBe(true);
+    });
+
+    // After SyncOAuth signin and a localStorage wipe, OAuth-native flows
+    // should still suggest the browser user instead of the email-first form.
+    test('SmartWindow respects browser-signed-in user after SyncOAuth, localStorage cleared', async ({
+      target,
+      syncOAuthBrowserPages: {
+        page,
+        signin,
+        signinTokenCode,
+        connectAnotherDevice,
+      },
+      testAccountTracker,
+    }) => {
+      const syncCredentials = await testAccountTracker.signUpSync();
+
+      // Real SyncOAuth signin so Firefox stores the user via fxaccounts:login.
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(syncCredentials.email);
+      await signin.fillOutPasswordForm(syncCredentials.password);
+      await page.waitForURL(/signin_token_code/);
+      const code = await target.emailClient.getVerifyLoginCode(
+        syncCredentials.email
+      );
+      await signinTokenCode.fillOutCodeForm(code);
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+
+      await page.context().clearCookies();
+      await page.evaluate(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+      });
+
+      await signin.goto('/authorization', smartWindowDesktopOAuthQueryParams);
+      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(page.getByText(syncCredentials.email)).toBeVisible();
+      await expect(signin.emailFirstHeading).not.toBeVisible();
+    });
+
+    // Same scenario, taken end-to-end through token-code to /settings.
+    test('SmartWindow cached signin completes token verification', async ({
+      target,
+      syncOAuthBrowserPages: {
+        page,
+        signin,
+        signinTokenCode,
+        connectAnotherDevice,
+      },
+      testAccountTracker,
+    }) => {
+      const syncCredentials = await testAccountTracker.signUpSync();
+
+      await signin.goto('/authorization', syncDesktopOAuthQueryParams);
+      await signin.fillOutEmailFirstForm(syncCredentials.email);
+      await signin.fillOutPasswordForm(syncCredentials.password);
+      await page.waitForURL(/signin_token_code/);
+      let code = await target.emailClient.getVerifyLoginCode(
+        syncCredentials.email
+      );
+      await signinTokenCode.fillOutCodeForm(code);
+      await expect(connectAnotherDevice.fxaConnected).toBeVisible();
+
+      await page.context().clearCookies();
+      await page.evaluate(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+      });
+
+      await signin.goto('/authorization', smartWindowDesktopOAuthQueryParams);
+      await expect(signin.passwordFormHeading).toBeVisible();
+      await expect(page.getByText(syncCredentials.email)).toBeVisible();
+      await expect(signin.emailFirstHeading).not.toBeVisible();
+
+      await signin.fillOutPasswordForm(syncCredentials.password);
+      await page.waitForURL(/signin_token_code/);
+      code = await target.emailClient.getVerifyLoginCode(syncCredentials.email);
+      await signinTokenCode.fillOutCodeForm(code);
+
+      await page.waitForURL(/settings/);
     });
   });
 

--- a/packages/fxa-settings/src/pages/Index/container.test.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.test.tsx
@@ -24,6 +24,7 @@ import { IndexQueryParams } from '../../models/pages/index';
 import { GenericData, ModelValidationErrors } from '../../lib/model-data';
 import { mockUseFxAStatus } from '../../lib/hooks/useFxAStatus/mocks';
 import { firefox } from '../../lib/channels/firefox';
+import * as storageUtils from '../../lib/storage-utils';
 
 let mockLocationState = {};
 let mockNavigate = jest.fn();
@@ -58,8 +59,18 @@ jest.mock('../../lib/channels/firefox', () => ({
   ...jest.requireActual('../../lib/channels/firefox'),
   firefox: {
     fxaCanLinkAccount: jest.fn(),
+    requestSignedInUser: jest.fn().mockResolvedValue(undefined),
   },
 }));
+
+jest.mock('../../lib/storage-utils', () => {
+  const actual = jest.requireActual('../../lib/storage-utils');
+  return {
+    ...actual,
+    persistAccount: jest.fn(),
+    setCurrentAccount: jest.fn(),
+  };
+});
 
 jest.mock('../../lib/email-domain-validator', () => ({
   checkEmailDomain: jest.fn(),
@@ -603,6 +614,172 @@ describe('IndexContainer', () => {
           true
         );
       });
+    });
+  });
+
+  describe('WebChannel browser-user fallback', () => {
+    let isProbablyFirefoxSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      isProbablyFirefoxSpy = jest
+        .spyOn(ModelsModule, 'isProbablyFirefox')
+        .mockReturnValue(true);
+      (firefox.requestSignedInUser as jest.Mock).mockReset();
+      (storageUtils.persistAccount as jest.Mock).mockReset();
+      (storageUtils.setCurrentAccount as jest.Mock).mockReset();
+    });
+
+    afterEach(() => {
+      isProbablyFirefoxSpy.mockRestore();
+    });
+
+    it('persists browser user (without sessionToken) when verified is false', async () => {
+      jest.spyOn(cache, 'currentAccount').mockReturnValue(undefined);
+      jest.spyOn(cache, 'lastStoredAccount').mockReturnValue(undefined);
+      (firefox.requestSignedInUser as jest.Mock).mockResolvedValue({
+        uid: 'browseruid123',
+        email: 'browser@example.com',
+        sessionToken: 'untrusted-token',
+        verified: false,
+      });
+
+      renderWithLocalizationProvider(
+        <LocationProvider>
+          <IndexContainer
+            {...{
+              integration,
+              serviceName: MozServices.Default,
+              useFxAStatusResult: mockUseFxAStatusResult,
+            }}
+          />
+        </LocationProvider>
+      );
+
+      await waitFor(() => {
+        expect(firefox.requestSignedInUser).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(storageUtils.persistAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            uid: 'browseruid123',
+            email: 'browser@example.com',
+          })
+        );
+      });
+      const persisted = (storageUtils.persistAccount as jest.Mock).mock
+        .calls[0][0];
+      expect(persisted.sessionToken).toBeUndefined();
+      expect(storageUtils.setCurrentAccount).toHaveBeenCalledWith(
+        'browseruid123'
+      );
+    });
+
+    it('persists browser sessionToken when verified is true', async () => {
+      jest.spyOn(cache, 'currentAccount').mockReturnValue(undefined);
+      jest.spyOn(cache, 'lastStoredAccount').mockReturnValue(undefined);
+      (firefox.requestSignedInUser as jest.Mock).mockResolvedValue({
+        uid: 'browseruid123',
+        email: 'browser@example.com',
+        sessionToken: 'trusted-token',
+        verified: true,
+      });
+
+      renderWithLocalizationProvider(
+        <LocationProvider>
+          <IndexContainer
+            {...{
+              integration,
+              serviceName: MozServices.Default,
+              useFxAStatusResult: mockUseFxAStatusResult,
+            }}
+          />
+        </LocationProvider>
+      );
+
+      await waitFor(() => {
+        expect(storageUtils.persistAccount).toHaveBeenCalledWith(
+          expect.objectContaining({
+            uid: 'browseruid123',
+            email: 'browser@example.com',
+            sessionToken: 'trusted-token',
+          })
+        );
+      });
+    });
+
+    it('does not query the browser when localStorage already has an account', async () => {
+      jest.spyOn(cache, 'currentAccount').mockReturnValue({
+        uid: 'cacheduid',
+        email: 'cached@example.com',
+        lastLogin: Date.now(),
+      });
+      jest.spyOn(cache, 'lastStoredAccount').mockReturnValue(undefined);
+
+      renderWithLocalizationProvider(
+        <LocationProvider>
+          <IndexContainer
+            {...{
+              integration,
+              serviceName: MozServices.Default,
+              useFxAStatusResult: mockUseFxAStatusResult,
+            }}
+          />
+        </LocationProvider>
+      );
+
+      // Cached account triggers auto-submit; navigation proves we skipped the WebChannel call.
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalled();
+      });
+      expect(firefox.requestSignedInUser).not.toHaveBeenCalled();
+      expect(storageUtils.persistAccount).not.toHaveBeenCalled();
+    });
+
+    it('does not query the browser when not running in Firefox', async () => {
+      isProbablyFirefoxSpy.mockReturnValue(false);
+      jest.spyOn(cache, 'currentAccount').mockReturnValue(undefined);
+      jest.spyOn(cache, 'lastStoredAccount').mockReturnValue(undefined);
+
+      renderWithLocalizationProvider(
+        <LocationProvider>
+          <IndexContainer
+            {...{
+              integration,
+              serviceName: MozServices.Default,
+              useFxAStatusResult: mockUseFxAStatusResult,
+            }}
+          />
+        </LocationProvider>
+      );
+
+      await waitFor(() => {
+        expect(IndexModule.default).toHaveBeenCalled();
+      });
+      expect(firefox.requestSignedInUser).not.toHaveBeenCalled();
+    });
+
+    it('does not persist when the browser returns no signed-in user', async () => {
+      jest.spyOn(cache, 'currentAccount').mockReturnValue(undefined);
+      jest.spyOn(cache, 'lastStoredAccount').mockReturnValue(undefined);
+      (firefox.requestSignedInUser as jest.Mock).mockResolvedValue(undefined);
+
+      renderWithLocalizationProvider(
+        <LocationProvider>
+          <IndexContainer
+            {...{
+              integration,
+              serviceName: MozServices.Default,
+              useFxAStatusResult: mockUseFxAStatusResult,
+            }}
+          />
+        </LocationProvider>
+      );
+
+      await waitFor(() => {
+        expect(firefox.requestSignedInUser).toHaveBeenCalled();
+      });
+      expect(storageUtils.persistAccount).not.toHaveBeenCalled();
+      expect(storageUtils.setCurrentAccount).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/fxa-settings/src/pages/Index/container.tsx
+++ b/packages/fxa-settings/src/pages/Index/container.tsx
@@ -22,6 +22,7 @@ import { AuthError } from '../../lib/oauth';
 
 import {
   isOAuthNativeIntegration,
+  isProbablyFirefox,
   useAuthClient,
   useConfig,
   useFtlMsgResolver,
@@ -29,6 +30,7 @@ import {
 import { isOAuthWebIntegration } from '../../models/integrations/oauth-web-integration';
 import { isUnsupportedContext } from '../../models/integrations/utils';
 import { IndexQueryParams } from '../../models/pages/index';
+import { persistAccount, setCurrentAccount } from '../../lib/storage-utils';
 
 import Index from '.';
 import { getLocalizedEmailValidationErrorMessage } from './errorMessageMapper';
@@ -99,6 +101,44 @@ const IndexContainer = ({
 
   const { prefillEmail, deleteAccountSuccess, hasBounced } =
     location.state || {};
+
+  // sessionToken is dropped unless verified===true; the browser's flag can be
+  // stale (no follow-up fxaLogin after SyncOAuth token-code), so we re-prompt.
+  const [browserUserChecked, setBrowserUserChecked] = useState(false);
+  useEffect(() => {
+    if (browserUserChecked) {
+      return;
+    }
+    if (currentAccount() || lastStoredAccount() || !isProbablyFirefox()) {
+      setBrowserUserChecked(true);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const userFromBrowser = await firefox.requestSignedInUser(
+        integration.data?.context || '',
+        false,
+        integration.data?.service || ''
+      );
+      if (cancelled) {
+        return;
+      }
+      if (userFromBrowser?.uid && userFromBrowser.email) {
+        const { uid, email, sessionToken, verified } = userFromBrowser;
+        persistAccount({
+          uid,
+          email,
+          lastLogin: Date.now(),
+          ...(verified === true ? { sessionToken } : {}),
+        });
+        setCurrentAccount(uid);
+      }
+      setBrowserUserChecked(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [browserUserChecked, integration]);
 
   // Only used for suggestedEmail; handleSuccessNavigation reads fresh from
   // localStorage to avoid stale closures when checking session state.
@@ -338,6 +378,11 @@ const IndexContainer = ({
       return;
     }
 
+    // Wait for the WebChannel check; otherwise the email-first form flashes briefly.
+    if (!browserUserChecked) {
+      return;
+    }
+
     if (isUnsupportedContext(integration.data.context)) {
       hardNavigate('/update_firefox', {}, true);
     } else if (shouldTrySuggestedEmail && !attemptedEmailAutoSubmit.current) {
@@ -363,6 +408,7 @@ const IndexContainer = ({
   }, [
     ftlMsgResolver,
     attemptedEmailAutoSubmit,
+    browserUserChecked,
     navigateWithQuery,
     processEmailSubmission,
     suggestedEmail,


### PR DESCRIPTION
  ## Because

  - When localStorage is cleared (e.g. "Clear cookies and site data on close" or "Forget about this site") but Firefox already has a signed-in user via WebChannel, the Index/cached signin page asked for the email instead of recognising the user.
  - For OAuth-native flows like SmartWindow and VPN, the browser's `signedInUser.verified` flag stays `false` even after a successful SyncOAuth signin, because `SigninTokenCode` deliberately does not send a follow-up `fxaLogin` with `verified=true` after token-code completion (`pages/Signin/SigninTokenCode/index.tsx:180`). The existing `App` session-init only trusts `verified === true`, so it fell through to empty localStorage.

  ## This pull request

  - Adds a WebChannel browser-user fallback in `pages/Index/container.tsx`: when localStorage is empty and we are in Firefox, calls `firefox.requestSignedInUser` and persists `{ uid, email }` so the cached signin page suggests the right account.
  - Omits `sessionToken` when the browser reports `verified=false` so we never trust a stale token; the user is routed to the password form, which is the safe path.
  - Holds the `isLoading` state until the WebChannel check completes so the email-first form does not briefly flash before the suggested email appears.

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13494

  ## Checklist

  _Put an `x` in the boxes that apply_

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test (manual):**
  1. In Firefox, sign into Sync via SyncOAuth and complete the email token verification.
  2. Open `about:preferences#privacy` and use "Clear data" / "Forget about this site" for `accounts.firefox.com` (or set "Delete cookies and site data when Firefox is closed" and restart).
  3. Trigger a SmartWindow or VPN signin flow.                                                                                                                                                                                                                                                                                                                                                                                                                               
  4. Expect the password page with your email already shown — not the email-first form.                                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                             