### PR TITLE
fix(cors): add fxa-ci to CORS allowed headers

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -138,7 +138,7 @@ async function create(
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        additionalHeaders: ['sentry-trace', 'baggage'],
+        additionalHeaders: ['sentry-trace', 'baggage', 'fxa-ci'],
         // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
         // which is more forgiving of missing Origin header.
         origin: config.corsOrigin[0] === '*' ? 'ignore' : config.corsOrigin,

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -59,7 +59,7 @@ exports.create = async function createServer() {
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        additionalHeaders: ['sentry-trace', 'baggage'],
+        additionalHeaders: ['sentry-trace', 'baggage', 'fxa-ci'],
         // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
         // which is more forgiving of missing Origin header.
         origin: ['*'],


### PR DESCRIPTION
Relying parties that send the `fxa-ci` header to bypass Fastly CAPTCHA in CI trigger CORS preflight failures on cross-origin `fetch()` calls to `api-accounts`. The browser rejects the response because `fxa-ci` is not in `Access-Control-Allow-Headers`, which breaks the OAuth client info fetch and causes "Invalid OAuth parameter: scope" errors.

## Because
  - The `fxa-ci` header bypasses Fastly WAF rules (CAPTCHA, verify_challenge_token) for CI test runners
  - When relying parties send `fxa-ci` via Playwright's `extraHTTPHeaders`, the browser includes it on cross-origin fetch() calls to api-accounts
  - The custom header triggers a CORS preflight, and api-accounts doesn't include `fxa-ci` in `Access-Control-Allow-Headers`
  - The browser blocks the response, breaking the OAuth client info fetch and account creation

## This pull request

  - Adds `fxa-ci` to the CORS `additionalHeaders` list in the auth server and profile server
  - This allows the CORS preflight to pass so the header reaches the server and the WAF bypass works

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## Other information (Optional)

Both Relay and Monitor e2e tests are failing on stage because of this. Relay tried to work around it client-side but can't: stripping `fxa-ci` from api-accounts requests fixes the CORS preflight but then the `verify_challenge_token` WAF rule blocks account creation POSTs.