### PR TITLE
fix(payments-cart): prevent updateFreshCart on a processing cart

### DIFF
--- a/libs/payments/cart/src/lib/cart.error.ts
+++ b/libs/payments/cart/src/lib/cart.error.ts
@@ -2,7 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { BaseError } from '@fxa/shared/error';
-import { FinishErrorCart, SetupCart, UpdateCart } from './cart.types';
+import {
+  FinishErrorCart,
+  SetupCart,
+  UpdateCart,
+  UpdateProcessingCart,
+} from './cart.types';
 import { CartEligibilityStatus, CartState } from '@fxa/shared/db/mysql/account';
 
 /**
@@ -90,6 +95,20 @@ export class UpdateFreshCartFailedError extends CartError {
       cause
     );
     this.name = 'UpdateFreshCartFailedError';
+  }
+}
+
+export class UpdateProcessingCartFailedError extends CartError {
+  constructor(cartId: string, items: UpdateProcessingCart, cause?: Error) {
+    super(
+      'Update processing cart failed',
+      {
+        cartId,
+        items,
+      },
+      cause
+    );
+    this.name = 'UpdateProcessingCartFailedError';
   }
 }
 

--- a/libs/payments/cart/src/lib/cart.factories.ts
+++ b/libs/payments/cart/src/lib/cart.factories.ts
@@ -19,6 +19,7 @@ import {
   TaxAmount,
   UpdateCart,
   UpdateCartInput,
+  UpdateProcessingCart,
   type BaseCartDTO,
   type FailCartDTO,
   type Invoice,
@@ -114,6 +115,12 @@ export const UpdateCartInputFactory = (
 export const UpdateCartFactory = (
   override?: Partial<UpdateCart>
 ): UpdateCart => ({
+  ...override,
+});
+
+export const UpdateProcessingCartFactory = (
+  override?: Partial<UpdateProcessingCart>
+): UpdateProcessingCart => ({
   ...override,
 });
 

--- a/libs/payments/cart/src/lib/cart.manager.in.spec.ts
+++ b/libs/payments/cart/src/lib/cart.manager.in.spec.ts
@@ -24,6 +24,7 @@ import {
   FinishErrorCartFactory,
   SetupCartFactory,
   UpdateCartFactory,
+  UpdateProcessingCartFactory,
 } from './cart.factories';
 import { CartManager } from './cart.manager';
 import { ResultCart } from './cart.types';
@@ -233,6 +234,21 @@ describe('CartManager', () => {
       }
     });
 
+    it('fails - rejects PROCESSING state', async () => {
+      await directUpdate(db, { state: CartState.PROCESSING }, testCart.id);
+      testCart = await cartManager.fetchCartById(testCart.id);
+      try {
+        await cartManager.updateFreshCart(
+          testCart.id,
+          testCart.version,
+          UpdateCartFactory()
+        );
+        fail('Error in updateFreshCart');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartInvalidStateForActionError);
+      }
+    });
+
     it('fails - cart could not be updated', async () => {
       await directUpdate(
         db,
@@ -246,6 +262,56 @@ describe('CartManager', () => {
           UpdateCartFactory()
         );
         fail('Error in updateFreshCart');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartVersionMismatchError);
+      }
+    });
+  });
+
+  describe('updateProcessingCart', () => {
+    it('succeeds', async () => {
+      const updateItems = UpdateProcessingCartFactory({
+        stripeSubscriptionId: 'sub_test123',
+      });
+      await directUpdate(db, { state: CartState.PROCESSING }, testCart.id);
+      testCart = await cartManager.fetchCartById(testCart.id);
+
+      await cartManager.updateProcessingCart(
+        testCart.id,
+        testCart.version,
+        updateItems
+      );
+      const cart = await cartManager.fetchCartById(testCart.id);
+
+      expect(cart).toEqual(expect.objectContaining(updateItems));
+    });
+
+    it('fails - rejects START state', async () => {
+      try {
+        await cartManager.updateProcessingCart(
+          testCart.id,
+          testCart.version,
+          UpdateProcessingCartFactory()
+        );
+        fail('Error in updateProcessingCart');
+      } catch (error) {
+        expect(error).toBeInstanceOf(CartInvalidStateForActionError);
+      }
+    });
+
+    it('fails - cart could not be updated', async () => {
+      await directUpdate(
+        db,
+        { state: CartState.PROCESSING, version: RANDOM_VERSION },
+        testCart.id
+      );
+      try {
+        await cartManager.updateProcessingCart(
+          testCart.id,
+          testCart.version,
+          UpdateProcessingCartFactory()
+        );
+        fail('Error in updateProcessingCart');
       } catch (error) {
         expect(error).toBeInstanceOf(CartVersionMismatchError);
       }

--- a/libs/payments/cart/src/lib/cart.manager.ts
+++ b/libs/payments/cart/src/lib/cart.manager.ts
@@ -21,6 +21,7 @@ import {
   SetNeedsInputCartFailedError,
   SetProcessingCartFailedError,
   UpdateFreshCartFailedError,
+  UpdateProcessingCartFailedError,
 } from './cart.error';
 import {
   createCart,
@@ -35,6 +36,7 @@ import type {
   ResultCart,
   SetupCart,
   UpdateCart,
+  UpdateProcessingCart,
 } from './cart.types';
 
 import type {
@@ -50,7 +52,8 @@ import {
 // For an action to be executed, the cart state needs to be in one of
 // valid states listed in the array of CartStates below
 const ACTIONS_VALID_STATE = {
-  updateFreshCart: [CartState.START, CartState.PROCESSING],
+  updateFreshCart: [CartState.START],
+  updateProcessingCart: [CartState.PROCESSING],
   finishCart: [CartState.PROCESSING, CartState.NEEDS_INPUT],
   finishErrorCart: [
     CartState.START,
@@ -232,6 +235,31 @@ export class CartManager {
     } catch (error) {
       const cause = error instanceof CartNotUpdatedError ? undefined : error;
       throw new UpdateFreshCartFailedError(cart.id, items, cause);
+    }
+  }
+
+  /**
+    * It is highly recommended to use updateFreshCart instead, adjusting your order of operations.
+    * Mutating a cart once it is already processing risks bugs that change the amount a customer may be charged.
+   */
+  @CaptureTimingWithStatsD()
+  public async updateProcessingCart(
+    cartId: string,
+    version: number,
+    items: UpdateProcessingCart
+  ) {
+    const cart = await this.fetchAndValidateCartVersion(cartId, version);
+
+    this.checkActionForValidCartState(cart, 'updateProcessingCart');
+
+    try {
+      await updateCart(this.db, Buffer.from(cartId, 'hex'), version, {
+        ...items,
+        uid: items.uid ? Buffer.from(items.uid, 'hex') : undefined,
+      });
+    } catch (error) {
+      const cause = error instanceof CartNotUpdatedError ? undefined : error;
+      throw new UpdateProcessingCartFailedError(cart.id, items, cause);
     }
   }
 

--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -149,6 +149,17 @@ export type UpdateCart = {
   isFreeTrial?: boolean;
 };
 
+/*
+ * This is intentionally narrow: a cart in PROCESSING is otherwise immutable, and
+ * widening this type re-opens the possibility of bugs which change the amount a customer
+ * will be charged during the process of billing the customer.
+ * Please consider carefully before adding fields here.
+ */
+export type UpdateProcessingCart = Pick<
+  UpdateCart,
+  'uid' | 'stripeCustomerId' | 'stripeSubscriptionId' | 'stripeIntentId'
+>;
+
 export type UpdateCartInput = Pick<
   UpdateCart,
   'uid' | 'taxAddress' | 'couponCode'

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -336,7 +336,7 @@ describe('CheckoutService', () => {
       jest
         .spyOn(accountCustomerManager, 'createAccountCustomer')
         .mockResolvedValue(mockAccountCustomer);
-      jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+      jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
       jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
         subscriptionEligibilityResult: EligibilityStatus.CREATE,
       });
@@ -407,7 +407,7 @@ describe('CheckoutService', () => {
       });
 
       it('does not update the cart', () => {
-        expect(cartManager.updateFreshCart).not.toHaveBeenCalled();
+        expect(cartManager.updateProcessingCart).not.toHaveBeenCalled();
       });
 
       it('checks that customer does not have existing subscription to price', () => {
@@ -796,7 +796,7 @@ describe('CheckoutService', () => {
       jest
         .spyOn(subscriptionManager, 'create')
         .mockResolvedValue(mockSubscription);
-      jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+      jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
       jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
       jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
       jest
@@ -877,8 +877,8 @@ describe('CheckoutService', () => {
         expect(asyncLocalStorage.getStore).toHaveBeenCalled();
       });
 
-      it('calls updateFreshCart', async () => {
-        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+      it('calls updateProcessingCart', async () => {
+        expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
           mockCart.id,
           mockPrePayStepsResult.version,
           {
@@ -1034,8 +1034,8 @@ describe('CheckoutService', () => {
           );
         });
 
-        it('calls updateFreshCart', async () => {
-          expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+        it('calls updateProcessingCart', async () => {
+          expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
             mockCart.id,
             mockPrePayStepsResult.version,
             {
@@ -1064,7 +1064,7 @@ describe('CheckoutService', () => {
             )
           ).rejects.toThrow();
 
-          expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+          expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
             mockCart.id,
             mockPrePayStepsResult.version,
             {
@@ -1128,7 +1128,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
         jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
@@ -1266,7 +1266,7 @@ describe('CheckoutService', () => {
           jest
             .spyOn(subscriptionManager, 'create')
             .mockResolvedValue(mockTrialSubscription);
-          jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
           jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
           jest
             .spyOn(invoiceManager, 'retrieve')
@@ -1367,7 +1367,7 @@ describe('CheckoutService', () => {
           jest
             .spyOn(subscriptionManager, 'create')
             .mockResolvedValue(mockSubscription);
-          jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
           jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
           jest
             .spyOn(paymentIntentManager, 'confirm')
@@ -1497,7 +1497,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest
           .spyOn(invoiceManager, 'retrieve')
           .mockResolvedValue(mockTrialInvoice);
@@ -1574,7 +1574,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest
           .spyOn(invoiceManager, 'retrieve')
           .mockResolvedValue(mockTrialInvoice);
@@ -1637,7 +1637,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
           .spyOn(paymentIntentManager, 'confirm')
@@ -1679,7 +1679,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockNonTrialingSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest.spyOn(statsd, 'increment');
 
@@ -1733,7 +1733,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(checkoutService, 'upgradeSubscription')
           .mockResolvedValue(mockSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(invoiceManager, 'retrieve').mockResolvedValue(mockInvoice);
         jest
           .spyOn(paymentIntentManager, 'confirm')
@@ -1789,7 +1789,7 @@ describe('CheckoutService', () => {
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(cartManager, 'setNeedsInputCart').mockResolvedValue();
         jest
           .spyOn(invoiceManager, 'retrieve')
@@ -1887,7 +1887,7 @@ describe('CheckoutService', () => {
         jest.spyOn(subscriptionManager, 'cancel');
         jest.spyOn(paypalBillingAgreementManager, 'cancel').mockResolvedValue();
         jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
@@ -1993,8 +1993,8 @@ describe('CheckoutService', () => {
           },
         });
       });
-      it('calls cartManager.updateFreshCart', () => {
-        expect(cartManager.updateFreshCart).toHaveBeenCalledWith(
+      it('calls cartManager.updateProcessingCart', () => {
+        expect(cartManager.updateProcessingCart).toHaveBeenCalledWith(
           mockCart.id,
           mockPrePayStepsResult.version,
           { stripeSubscriptionId: mockSubscription.id }
@@ -2132,7 +2132,7 @@ describe('CheckoutService', () => {
             .spyOn(paypalBillingAgreementManager, 'cancel')
             .mockResolvedValue();
           jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
-          jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
             .mockResolvedValue(null);
@@ -2257,7 +2257,7 @@ describe('CheckoutService', () => {
           jest
             .spyOn(customerManager, 'update')
             .mockResolvedValue(mockCustomer);
-          jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
           jest.spyOn(asyncLocalStorage, 'getStore');
           jest
             .spyOn(freeTrialManager, 'recordFreeTrial')
@@ -2365,7 +2365,7 @@ describe('CheckoutService', () => {
           jest
             .spyOn(customerManager, 'update')
             .mockResolvedValue(mockCustomer);
-          jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+          jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
           jest.spyOn(asyncLocalStorage, 'getStore');
           jest
             .spyOn(freeTrialManager, 'recordFreeTrial')
@@ -2447,7 +2447,7 @@ describe('CheckoutService', () => {
           .spyOn(paypalCustomerManager, 'createPaypalCustomer')
           .mockResolvedValue(mockPaypalCustomer);
         jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
 
         await expect(
@@ -2508,7 +2508,7 @@ describe('CheckoutService', () => {
           .spyOn(paypalCustomerManager, 'createPaypalCustomer')
           .mockResolvedValue(mockPaypalCustomer);
         jest.spyOn(customerManager, 'update').mockResolvedValue(mockCustomer);
-        jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
+        jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest.spyOn(statsd, 'increment');
         jest

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -222,7 +222,7 @@ export class CheckoutService {
         stripeCustomerId,
       });
 
-      await this.cartManager.updateFreshCart(cart.id, cart.version, {
+      await this.cartManager.updateProcessingCart(cart.id, cart.version, {
         uid,
         stripeCustomerId,
       });
@@ -534,14 +534,14 @@ export class CheckoutService {
 
       if (!intent) {
         // At least update the cart with the subscription ID before throwing
-        await this.cartManager.updateFreshCart(cart.id, version, {
+        await this.cartManager.updateProcessingCart(cart.id, version, {
           stripeSubscriptionId: subscription.id,
         });
         throw error;
       }
     }
 
-    await this.cartManager.updateFreshCart(cart.id, version, {
+    await this.cartManager.updateProcessingCart(cart.id, version, {
       stripeSubscriptionId: subscription.id,
       stripeIntentId: intent.id,
     });
@@ -729,7 +729,7 @@ export class CheckoutService {
           [STRIPE_CUSTOMER_METADATA.PaypalAgreement]: billingAgreementId,
         },
       }),
-      this.cartManager.updateFreshCart(cart.id, version, {
+      this.cartManager.updateProcessingCart(cart.id, version, {
         stripeSubscriptionId: subscription.id,
       }),
     ]);


### PR DESCRIPTION
## Because

- We want to restrict mutations to the cart after it has been marked as processing

## This pull request

- Separates out updateFreshCart from updateProcessingCart

## Issue that this pull request solves

Closes FXA-3666