### PR TITLE
task(passkeys): Prevent duplicate authenticator enrollment

### DIFF
--- a/libs/accounts/passkey/src/lib/passkey.service.spec.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.spec.ts
@@ -148,6 +148,7 @@ describe('PasskeyService', () => {
 
     beforeEach(() => {
       mockManager.checkPasskeyCount.mockResolvedValue(undefined);
+      mockManager.listPasskeysForUser.mockResolvedValue([]);
       mockChallengeManager.generateRegistrationChallenge.mockResolvedValue(
         MOCK_CHALLENGE
       );
@@ -191,6 +192,46 @@ describe('PasskeyService', () => {
           uid: MOCK_UID,
           email: MOCK_USER_NAME,
           challenge: MOCK_CHALLENGE,
+        })
+      );
+    });
+
+    it('passes empty excludeCredentials when user has no existing passkeys', async () => {
+      mockManager.listPasskeysForUser.mockResolvedValue([]);
+
+      await service.generateRegistrationChallenge(MOCK_UID, MOCK_USER_NAME);
+
+      expect(mockManager.listPasskeysForUser).toHaveBeenCalledWith(MOCK_UID);
+      expect(
+        webauthnAdapter.generateWebauthnRegistrationOptions
+      ).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({ excludeCredentials: [] })
+      );
+    });
+
+    it('forwards existing passkeys as excludeCredentials with id and transports', async () => {
+      const otherCredentialId = Buffer.alloc(32, 0xdd);
+      mockManager.listPasskeysForUser.mockResolvedValue([
+        { ...mockPasskey, transports: ['internal'] },
+        {
+          ...mockPasskey,
+          credentialId: otherCredentialId,
+          transports: ['usb', 'nfc'],
+        },
+      ]);
+
+      await service.generateRegistrationChallenge(MOCK_UID, MOCK_USER_NAME);
+
+      expect(
+        webauthnAdapter.generateWebauthnRegistrationOptions
+      ).toHaveBeenCalledWith(
+        mockConfig,
+        expect.objectContaining({
+          excludeCredentials: [
+            { id: MOCK_CREDENTIAL_ID, transports: ['internal'] },
+            { id: otherCredentialId, transports: ['usb', 'nfc'] },
+          ],
         })
       );
     });

--- a/libs/accounts/passkey/src/lib/passkey.service.ts
+++ b/libs/accounts/passkey/src/lib/passkey.service.ts
@@ -115,6 +115,8 @@ export class PasskeyService {
   ): Promise<PublicKeyCredentialCreationOptionsJSON> {
     await this.passkeyManager.checkPasskeyCount(uid);
 
+    const existingPasskeys = await this.passkeyManager.listPasskeysForUser(uid);
+
     const challenge =
       await this.challengeManager.generateRegistrationChallenge(uid);
 
@@ -122,6 +124,10 @@ export class PasskeyService {
       uid,
       email,
       challenge,
+      excludeCredentials: existingPasskeys.map((p) => ({
+        id: p.credentialId,
+        transports: p.transports as AuthenticatorTransportFuture[],
+      })),
     });
 
     return options;

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.spec.ts
@@ -117,6 +117,50 @@ describe('generateWebauthnRegistrationOptions', () => {
 
     expect(options.user.name).toBe('bob@example.com');
   });
+
+  it('omits excludeCredentials when input is not provided', async () => {
+    const options = await generateWebauthnRegistrationOptions(testConfig(), {
+      uid: Buffer.alloc(16, 0xbb).toString('hex'),
+      email: 'bob@example.com',
+      challenge: randomBytes(32).toString('base64url'),
+    });
+
+    expect(options.excludeCredentials).toEqual([]);
+  });
+
+  it('forwards excludeCredentials as base64url with type and transports', async () => {
+    const credId = Buffer.from('existing-credential').toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(testConfig(), {
+      uid: Buffer.alloc(16, 0xbb).toString('hex'),
+      email: 'bob@example.com',
+      challenge: randomBytes(32).toString('base64url'),
+      excludeCredentials: [{ id: credId, transports: ['internal', 'hybrid'] }],
+    });
+
+    expect(options.excludeCredentials).toEqual([
+      {
+        id: credId,
+        type: 'public-key',
+        transports: ['internal', 'hybrid'],
+      },
+    ]);
+  });
+
+  it('forwards excludeCredentials without transports when not provided', async () => {
+    const credId = Buffer.from('existing-credential').toString('base64url');
+
+    const options = await generateWebauthnRegistrationOptions(testConfig(), {
+      uid: Buffer.alloc(16, 0xbb).toString('hex'),
+      email: 'bob@example.com',
+      challenge: randomBytes(32).toString('base64url'),
+      excludeCredentials: [{ id: credId }],
+    });
+
+    expect(options.excludeCredentials).toEqual([
+      { id: credId, type: 'public-key' },
+    ]);
+  });
 });
 
 describe('verifyWebauthnRegistrationResponse', () => {

--- a/libs/accounts/passkey/src/lib/webauthn-adapter.ts
+++ b/libs/accounts/passkey/src/lib/webauthn-adapter.ts
@@ -22,6 +22,18 @@ import { uuidTransformer } from '@fxa/shared/db/mysql/core';
 
 import { PasskeyConfig } from './passkey.config';
 
+/**
+ * A credential to exclude from a registration ceremony. When forwarded to the
+ * authenticator, the browser surfaces a native "already registered" prompt
+ * instead of completing the ceremony.
+ */
+export interface ExcludeCredential {
+  /** Existing credential ID as a string. */
+  id: string;
+  /** Stored transports for the credential. Optional — improves UX hints. */
+  transports?: AuthenticatorTransportFuture[];
+}
+
 export interface RegistrationOptionsInput {
   /** User's uid as a hex string, used as the WebAuthn userID. */
   uid: string;
@@ -29,6 +41,12 @@ export interface RegistrationOptionsInput {
   email: string;
   /** Challenge from ChallengeManager. */
   challenge: string;
+  /**
+   * Credentials already registered for this user. Forwarded to the authenticator
+   * so duplicate enrolments are short-circuited at the browser level rather than
+   * failing server-side on the unique constraint.
+   */
+  excludeCredentials?: ExcludeCredential[];
 }
 
 /**
@@ -59,6 +77,7 @@ export async function generateWebauthnRegistrationOptions(
       userVerification: config.userVerification,
       authenticatorAttachment: config.authenticatorAttachment,
     },
+    excludeCredentials: input.excludeCredentials,
   });
 }
 
@@ -255,4 +274,3 @@ export async function verifyWebauthnAuthenticationResponse(
     },
   };
 }
-

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -212,9 +212,43 @@ describe('PagePasskeyAdd', () => {
     ).toHaveBeenCalledWith({
       event: { reason: 'not_allowed' },
     });
+    expect(mockHandleWebAuthnError).toHaveBeenCalledWith(
+      cancelError,
+      'registration',
+      expect.any(Function),
+      { hadExcludeCredentials: false }
+    );
     expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
       replace: true,
     });
+  });
+
+  it('forwards hadExcludeCredentials=true when the server-sent options listed existing passkeys', async () => {
+    mockBeginPasskeyRegistration.mockResolvedValue({
+      ...mockCreationOptions,
+      excludeCredentials: [
+        { id: 'Y3JlZDE', type: 'public-key', transports: ['internal'] },
+      ],
+    });
+    const cancelError = new DOMException('not allowed', 'NotAllowedError');
+    mockCreateCredential.mockRejectedValue(cancelError);
+    mockHandleWebAuthnError.mockReturnValue({
+      category: WebAuthnErrorCategory.UserAction,
+      errorType: WebAuthnErrorType.NotAllowed,
+      userMessageKey: 'passkey-registration-error-not-allowed-existing',
+      logToSentry: false,
+    });
+
+    renderPage();
+    await waitFor(() => {
+      expect(mockAlertError).toHaveBeenCalled();
+    });
+    expect(mockHandleWebAuthnError).toHaveBeenCalledWith(
+      cancelError,
+      'registration',
+      expect.any(Function),
+      { hadExcludeCredentials: true }
+    );
   });
 
   it('handles timeout error', async () => {

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -65,11 +65,18 @@ export const PagePasskeyAdd = () => {
 
     const runCeremony = async () => {
       GleanMetrics.accountPref.passkeyCreateView();
+
+      // Tracks whether the server sent an excludeCredentials list (i.e., the
+      // account already has passkeys). Used to bias NotAllowedError toward the
+      // "duplicate authenticator" interpretation on Firefox, which collapses
+      // that case and user-cancel into the same DOMException.
+      let hadExcludeCredentials = false;
       try {
         // Step 1: Get registration options from server
         const jwt = account.getCachedJwtByScope('passkey');
         const creationOptions = await authClient.beginPasskeyRegistration(jwt);
         const challenge = creationOptions.challenge;
+        hadExcludeCredentials = !!creationOptions.excludeCredentials?.length;
 
         if (!isMounted.current) return;
 
@@ -105,7 +112,8 @@ export const PagePasskeyAdd = () => {
           const categorized = handleWebAuthnError(
             error,
             'registration',
-            Sentry.captureException
+            Sentry.captureException,
+            { hadExcludeCredentials }
           );
           const reasonMap: Record<string, string> = {
             [WebAuthnErrorType.NotAllowed]: 'not_allowed',

--- a/packages/fxa-settings/src/lib/passkeys/en.ftl
+++ b/packages/fxa-settings/src/lib/passkeys/en.ftl
@@ -6,6 +6,11 @@
 # User cancelled or dismissed the browser prompt, or the authenticator could not satisfy the options
 passkey-registration-error-not-allowed = Passkey setup failed or is unavailable. Try again or choose another method.
 
+# Shown on NotAllowedError when the account already has passkeys (excludeCredentials was sent).
+# Firefox collapses user-cancel and duplicate-authenticator into the same error, but duplicate is
+# the far more likely cause when the user has existing passkeys, so we state it plainly.
+passkey-registration-error-not-allowed-existing = Passkey setup isn’t available with this device. Either the device has already been registered or the setup process was cancelled.
+
 # The ceremony timed out before the user responded
 passkey-registration-error-timeout = Passkey setup was canceled. Try again.
 
@@ -31,6 +36,9 @@ passkey-registration-error-unexpected = Passkey setup failed. Try again or choos
 
 # User cancelled or dismissed the browser prompt, or no passkey is available / verification failed
 passkey-authentication-error-not-allowed = Sign-in with passkey failed or is unavailable. Try again or choose another method.
+
+# User already registered a device
+passkey-authentication-error-not-allowed-existing = Passkey setup isn’t available with this device. Please try again or choose another method.
 
 # The ceremony timed out before the user responded
 passkey-authentication-error-timeout = Passkey request timed out. Please try again.

--- a/packages/fxa-settings/src/lib/passkeys/webauthn-errors.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn-errors.test.ts
@@ -231,4 +231,17 @@ describe('handleWebAuthnError', () => {
     handleWebAuthnError(error, 'registration', captureException);
     expect(captureException).toHaveBeenCalledWith(error);
   });
+
+  it('forwards ceremony context to categorization (duplicate-authenticator message)', () => {
+    const captureException = jest.fn();
+    const result = handleWebAuthnError(
+      dom('NotAllowedError'),
+      'registration',
+      captureException,
+      { hadExcludeCredentials: true }
+    );
+    expect(result.ftlId).toBe(
+      'passkey-registration-error-not-allowed-existing'
+    );
+  });
 });

--- a/packages/fxa-settings/src/lib/passkeys/webauthn-errors.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn-errors.ts
@@ -62,6 +62,22 @@ const UNEXPECTED_FTL_ID: Record<WebAuthnOperation, string> = {
   authentication: 'passkey-authentication-error-unexpected',
 };
 
+const AUTHENTICATOR_ALREADY_REGISTERED_FTL_ID: Record<
+  WebAuthnOperation,
+  string
+> = {
+  registration: 'passkey-registration-error-not-allowed-existing',
+  authentication: 'passkey-authentication-error-not-allowed-existing',
+};
+
+const AUTHENTICATOR_ALREADY_REGISTERED_FALLBACK: Record<
+  WebAuthnOperation,
+  string
+> = {
+  registration: `Passkey setup isn’t available with this device. Either the device has already been registered or the setup process was cancelled.`,
+  authentication: `Passkey setup isn’t available with this device. Please try again or choose another method.`,
+};
+
 export const ERROR_MAP: Record<string, ErrorEntry> = {
   NotAllowedError: {
     category: WebAuthnErrorCategory.UserAction,
@@ -195,19 +211,57 @@ export const ERROR_MAP: Record<string, ErrorEntry> = {
     ftlId: UNEXPECTED_FTL_ID,
     fallbackText: UNEXPECTED_FALLBACK,
   },
+  AuthenticatorAlreadyRegistered: {
+    category: WebAuthnErrorCategory.UserAction,
+    errorType: WebAuthnErrorType.NotSupported,
+    logToSentry: true,
+    ftlId: AUTHENTICATOR_ALREADY_REGISTERED_FTL_ID,
+    fallbackText: AUTHENTICATOR_ALREADY_REGISTERED_FALLBACK,
+  },
 };
+
+/**
+ * Extra ceremony context that refines error categorization. Currently used to
+ * disambiguate NotAllowedError during registration: Firefox collapses user-cancel
+ * and excludeCredentials-duplicate into the same DOMException, so we lean on
+ * context to choose a more helpful user-facing message.
+ */
+export interface WebAuthnErrorContext {
+  /**
+   * True when the registration options included a non-empty excludeCredentials
+   * list (i.e., the user already has passkeys registered for this account).
+   */
+  hadExcludeCredentials?: boolean;
+}
 
 /** Never throws; unrecognized errors default to the 'unexpected' category. */
 export function categorizeWebAuthnError(
   error: unknown,
-  operation: WebAuthnOperation
+  operation: WebAuthnOperation,
+  context?: { hadExcludeCredentials: boolean }
 ): CategorizedWebAuthnError {
-  const name =
-    error instanceof TypeError
-      ? 'TypeError'
-      : error instanceof DOMException
-        ? error.name
-        : null;
+  const name = (() => {
+    if (error instanceof TypeError) {
+      return 'TypeError';
+    }
+
+    // There is a special error message when authentication is not allowed due to the authenticator already being
+    // registered.
+    if (
+      error instanceof DOMException &&
+      error.name === 'NotAllowedError' &&
+      context?.hadExcludeCredentials === true
+    ) {
+      return 'AuthenticatorAlreadyRegistered';
+    }
+
+    // Otherise, just return the name of the name dom exception for look up.
+    if (error instanceof DOMException) {
+      return error.name;
+    }
+
+    return null;
+  })();
 
   if (name !== null) {
     const entry = ERROR_MAP[name];
@@ -235,9 +289,10 @@ export function categorizeWebAuthnError(
 export function handleWebAuthnError(
   error: unknown,
   operation: WebAuthnOperation,
-  captureException: (error: unknown) => void
+  captureException: (error: unknown) => void,
+  context?: { hadExcludeCredentials: boolean }
 ): CategorizedWebAuthnError {
-  const categorized = categorizeWebAuthnError(error, operation);
+  const categorized = categorizeWebAuthnError(error, operation, context);
   if (categorized.logToSentry) {
     captureException(error);
   }


### PR DESCRIPTION
## Because

- We want to prevent an authenticator from being registered more than once.

## This pull request

- Prevents an authenticator from being registered more than once.

## Issue that this pull request solves

Closes: FXA-13491

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

One tricky thing here is the the 'NotAllowed' dom error can occur because of a duplicate authenticator or because a user cancelled midway through the passkey setup. I can't find a good way to distinguish between these error states, so the error message has been adjusted to indicate either is possible.
