### PR TITLE
task(auth): Record email sent event

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -373,7 +373,8 @@ async function run(config) {
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings()
+    new NodeRendererBindings(),
+    accountEventsManager
   );
   Container.set(FxaMailer, fxaMailer);
 

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer-sanity-check.ts
@@ -10,6 +10,7 @@ import {
   NodeRendererBindings,
 } from '@fxa/accounts/email-renderer';
 import { ConfigType } from '../../config';
+import { AccountEventsManager } from '../account-events';
 
 /**
  * This is jsut a strong typed driver that allows us to validate the params we pass into FxaMailer
@@ -22,7 +23,8 @@ const fxaMailer = new FxaMailer(
   {} as unknown as EmailSender,
   {} as unknown as EmailLinkBuilder,
   {} as unknown as ConfigType['smtp'],
-  {} as unknown as NodeRendererBindings
+  {} as unknown as NodeRendererBindings,
+  {} as unknown as AccountEventsManager
 );
 
 // Setup fake / mocked objects

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.spec.ts
@@ -8,11 +8,24 @@ import {
   EmailLinkBuilder,
   NodeRendererBindings,
 } from '@fxa/accounts/email-renderer';
+import { AccountEventsManager } from '../account-events';
 
 describe('lib/senders/fxa-mailer', () => {
   let fxaMailer: FxaMailer;
   let mockEmailSender: jest.Mocked<Pick<EmailSender, 'send' | 'buildHeaders'>>;
-  let mockLinkBuilder: jest.Mocked<Pick<EmailLinkBuilder, 'buildPrivacyLink' | 'buildSupportLink' | 'buildPasswordChangeLink' | 'buildAccountSettingsLink' | 'buildMozillaSupportUrl'>>;
+  let mockLinkBuilder: jest.Mocked<
+    Pick<
+      EmailLinkBuilder,
+      | 'buildPrivacyLink'
+      | 'buildSupportLink'
+      | 'buildPasswordChangeLink'
+      | 'buildAccountSettingsLink'
+      | 'buildMozillaSupportUrl'
+    >
+  >;
+  let mockAccountEventsManager: jest.Mocked<
+    Pick<AccountEventsManager, 'recordEmailEvent'>
+  >;
   let mockBindings: NodeRendererBindings;
   let mockConfig: any;
 
@@ -30,9 +43,19 @@ describe('lib/senders/fxa-mailer', () => {
     mockLinkBuilder = {
       buildPrivacyLink: jest.fn().mockReturnValue('https://privacy.link'),
       buildSupportLink: jest.fn().mockReturnValue('https://support.link'),
-      buildPasswordChangeLink: jest.fn().mockReturnValue('https://password.link'),
-      buildAccountSettingsLink: jest.fn().mockReturnValue('https://settings.link'),
-      buildMozillaSupportUrl: jest.fn().mockReturnValue('https://mozilla.support'),
+      buildPasswordChangeLink: jest
+        .fn()
+        .mockReturnValue('https://password.link'),
+      buildAccountSettingsLink: jest
+        .fn()
+        .mockReturnValue('https://settings.link'),
+      buildMozillaSupportUrl: jest
+        .fn()
+        .mockReturnValue('https://mozilla.support'),
+    };
+
+    mockAccountEventsManager = {
+      recordEmailEvent: jest.fn().mockResolvedValue(undefined),
     };
 
     mockBindings = {} as any;
@@ -46,7 +69,8 @@ describe('lib/senders/fxa-mailer', () => {
       mockEmailSender as any,
       mockLinkBuilder as any,
       mockConfig,
-      mockBindings
+      mockBindings,
+      mockAccountEventsManager as any
     );
   });
 
@@ -131,7 +155,8 @@ describe('lib/senders/fxa-mailer', () => {
           mockEmailSender as any,
           mockLinkBuilder as any,
           mockConfig,
-          mockBindings
+          mockBindings,
+          mockAccountEventsManager as any
         );
 
         jest.spyOn(fxaMailer as any, 'renderNewDeviceLogin').mockResolvedValue({
@@ -164,7 +189,8 @@ describe('lib/senders/fxa-mailer', () => {
         mockEmailSender as any,
         mockLinkBuilder as any,
         mockConfig,
-        mockBindings
+        mockBindings,
+        mockAccountEventsManager as any
       );
       expect(fxaMailer.canSend('newDeviceLogin')).toBe(false);
     });
@@ -175,10 +201,77 @@ describe('lib/senders/fxa-mailer', () => {
         mockEmailSender as any,
         mockLinkBuilder as any,
         mockConfig,
-        mockBindings
+        mockBindings,
+        mockAccountEventsManager as any
       );
       expect(fxaMailer.canSend('verifyLogin')).toBe(false);
       expect(fxaMailer.canSend('newDeviceLogin')).toBe(true);
+    });
+  });
+
+  describe('recordEmailEvent', () => {
+    const baseOpts = {
+      to: 'user@example.com',
+      uid: 'test-uid',
+      metricsEnabled: true,
+      acceptLanguage: 'en',
+      timeZone: 'America/New_York',
+      clientName: 'Test Client',
+      device: 'Firefox on Mac',
+      time: '10:00 AM',
+      date: 'January 1, 2026',
+      location: { city: 'San Francisco', stateCode: 'CA', country: 'USA' },
+      showBannerWarning: false,
+      flowId: 'test-flow-id',
+      deviceId: 'test-device-id',
+    };
+
+    function stubRender() {
+      jest.spyOn(fxaMailer as any, 'renderNewDeviceLogin').mockResolvedValue({
+        subject: 'New sign-in to Test Client',
+        html: '<html>test</html>',
+        text: 'test',
+        preview: 'test preview',
+        template: 'newDeviceLogin',
+      });
+    }
+
+    it('records an emailSent event after a successful send', async () => {
+      stubRender();
+      await fxaMailer.sendNewDeviceLoginEmail(baseOpts);
+
+      expect(mockAccountEventsManager.recordEmailEvent).toHaveBeenCalledTimes(
+        1
+      );
+      const [uid, message, name] =
+        mockAccountEventsManager.recordEmailEvent.mock.calls[0];
+      expect(uid).toBe('test-uid');
+      expect(name).toBe('emailSent');
+      expect(message).toMatchObject({
+        template: 'newDeviceLogin',
+        name: 'newDeviceLogin',
+        eventType: 'emailEvent',
+        flowId: 'test-flow-id',
+        deviceId: 'test-device-id',
+      });
+    });
+
+    it('does not record an event when uid is missing', async () => {
+      stubRender();
+      const { uid: _uid, ...optsWithoutUid } = baseOpts;
+      await fxaMailer.sendNewDeviceLoginEmail(optsWithoutUid as any);
+
+      expect(mockAccountEventsManager.recordEmailEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not record an event when send throws', async () => {
+      stubRender();
+      mockEmailSender.send.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(fxaMailer.sendNewDeviceLoginEmail(baseOpts)).rejects.toThrow(
+        'boom'
+      );
+      expect(mockAccountEventsManager.recordEmailEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -62,6 +62,7 @@ import {
 import { EmailSender } from '@fxa/accounts/email-sender';
 import { FxaEmailRenderer } from '@fxa/accounts/email-renderer';
 import { ConfigType } from '../../config';
+import { AccountEventsManager } from '../account-events';
 
 const SERVER = 'fxa-auth-server';
 
@@ -118,7 +119,8 @@ export class FxaMailer extends FxaEmailRenderer {
     private emailSender: EmailSender,
     private linkBuilder: EmailLinkBuilder,
     private mailerConfig: ConfigType['smtp'],
-    bindings: NodeRendererBindings
+    bindings: NodeRendererBindings,
+    private accountEventsManager?: AccountEventsManager
   ) {
     super(bindings);
   }
@@ -1820,7 +1822,14 @@ export class FxaMailer extends FxaEmailRenderer {
   }
 
   private async sendEmail(
-    opts: { to: string; cc?: string[]; cmsRpFromName?: string },
+    opts: {
+      to: string;
+      cc?: string[];
+      cmsRpFromName?: string;
+      uid?: string;
+      deviceId?: string;
+      flowId?: string;
+    },
     headers: Record<string, string>,
     rendered: RenderedTemplate,
     throwErrorOnSendFailure = true
@@ -1838,7 +1847,7 @@ export class FxaMailer extends FxaEmailRenderer {
       ? `${cmsRpFromName} <${senderEmail}>`
       : this.mailerConfig.sender;
 
-    return this.emailSender.send(
+    const result = await this.emailSender.send(
       {
         to,
         cc,
@@ -1848,5 +1857,24 @@ export class FxaMailer extends FxaEmailRenderer {
       },
       throwErrorOnSendFailure
     );
+
+    if (opts.uid) {
+      this.accountEventsManager?.recordEmailEvent(
+        opts.uid,
+        {
+          createdAt: Date.now(),
+          template: rendered.template,
+          deviceId: opts.deviceId,
+          flowId: opts.flowId,
+          service:
+            headers['X-Service-Id'] || headers['x-service-id'] || undefined,
+          name: rendered.template,
+          eventType: 'emailEvent',
+        },
+        'emailSent'
+      );
+    }
+
+    return result;
   }
 }

--- a/packages/fxa-auth-server/scripts/recorded-future/check-and-reset.ts
+++ b/packages/fxa-auth-server/scripts/recorded-future/check-and-reset.ts
@@ -321,7 +321,8 @@ async function resetAccounts(
     emailSender,
     linkBuilder,
     config.smtp,
-    new NodeRendererBindings()
+    new NodeRendererBindings(),
+    accountEventManager
   );
 
   for (const acct of accountsToReset) {


### PR DESCRIPTION
## Because

- We want to record email sends in firestore

## This pull request

- Records email sends in firestore

## Issue that this pull request solves

Closes: [FXA-13626](https://mozilla-hub.atlassian.net/browse/FXA-13626)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

This is a regression in the fxa-mailer. The old mailer recorded these. 


[FXA-13626]: https://mozilla-hub.atlassian.net/browse/FXA-13626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ