### PR TITLE
feat(auth): enable CORS credentials on /account/login

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -389,6 +389,7 @@ export default class AuthClient {
 
     // For specific endpoints + HTTPS, upgrade credentials to include cookies for WAF challenges
     const includeCredentials = [
+      '/account/login',
       '/account/create',
       '/password/forgot/send_otp',
       '/account/passwordless/send_code',

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -2867,6 +2867,11 @@ export const accountRoutes = (
       },
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_LOGIN_POST,
+        ...(enableCredentials && {
+          cors: {
+            credentials: true,
+          },
+        }),
         validate: {
           query: isA.object({
             keys: isA.boolean().optional().description(DESCRIPTION.keys),


### PR DESCRIPTION
## Because

- `/account/login` is being added to the WAF dynamic challenge verify rule, and the challenge cookie must travel with the request

## This pull request

- Enables credentials for `/account/login` CORS config in auth-server
- Adds `/account/login` to the `includeCredentials` path list in auth-client

## Issue that this pull request solves

Closes: FXA-13496

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.