### PR TITLE
feat(payments-next): Show free trial on checkout when user is not signed in

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -57,6 +57,12 @@ export default async function CheckoutLayout({
   const purchaseDetails =
     cms.defaultPurchase.purchaseDetails.localizations.at(0) ||
     cms.defaultPurchase.purchaseDetails;
+  const showFreeTrialOffer =
+    !!cart.freeTrialOffer &&
+    (!session?.user || !!cart.freeTrialUserEligible);
+  const freeTrialOffer = showFreeTrialOffer
+    ? cart.freeTrialOffer
+    : null;
   return (
     <MetricsWrapper cart={cart}>
       <Header
@@ -82,7 +88,7 @@ export default async function CheckoutLayout({
           <div className="mb-6 tablet:mt-6 tablet:min-w-[18rem] tablet:max-w-xs tablet:col-start-2 tablet:row-start-1 tablet:row-span-3">
             <PurchaseDetails
               invoice={
-                cart.trialEndDate || cart.freeTrialEligibility
+                cart.trialEndDate || freeTrialOffer
                   ? cart.upcomingInvoicePreview
                   : (cart.latestInvoicePreview ?? cart.upcomingInvoicePreview)
               }
@@ -115,7 +121,7 @@ export default async function CheckoutLayout({
                 cart.state === CartState.PROCESSING ||
                 cart.state === CartState.SUCCESS
               }
-              freeTrialEligibility={cart.freeTrialEligibility}
+              freeTrialOffer={freeTrialOffer}
               firstChargeAmount={cart.upcomingInvoicePreview.totalAmount}
               interval={cart.interval}
               cartState={cart.state}

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/start/page.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import Image from 'next/image';
 import clsx from 'clsx';
 import {
@@ -10,6 +10,7 @@ import {
   buildRedirectUrl,
   ButtonVariant,
   PaymentSection,
+  SAW_TRIAL_OFFER_COOKIE_PREFIX,
   SignInForm,
 } from '@fxa/payments/ui';
 import {
@@ -63,8 +64,11 @@ export default async function Checkout({
   const { locale } = resolvedParams;
 
   const headersList = await headers();
+  const cookieStore = await cookies();
   const acceptLanguage = headersList.get('accept-language');
   const nonce = headersList.get('x-nonce') || undefined;
+  const sawTrialOfferCookieName = `${SAW_TRIAL_OFFER_COOKIE_PREFIX}${resolvedParams.offeringId}`;
+  const sawTrialOffer = !!cookieStore.get(sawTrialOfferCookieName);
   const sessionPromise = auth();
   const l10n = getApp().getL10n(acceptLanguage, locale);
   const cmsDataPromise = fetchCMSData(
@@ -295,6 +299,7 @@ export default async function Checkout({
               paypalClientId={config.paypal.clientId}
               sessionUid={session?.user?.id}
               sessionEmail={session?.user?.email ?? undefined}
+              sawTrialOffer={sawTrialOffer}
             />
           )}
       </section>

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -675,7 +675,7 @@ describe('CartService', () => {
       });
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
-        .mockResolvedValue(null);
+        .mockResolvedValue({ offer: null, userEligible: false });
     });
 
     it('calls createCart with expected parameters', async () => {
@@ -1396,7 +1396,7 @@ describe('CartService', () => {
           .mockResolvedValue(mockPreviewInvoice);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
       });
 
       it('calls cartManager.updateFreshCart with no currency change', async () => {
@@ -1517,7 +1517,7 @@ describe('CartService', () => {
         jest.spyOn(cartManager, 'updateFreshCart').mockResolvedValue();
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
       });
 
       it('success if coupon is valid for new customer', async () => {
@@ -1746,6 +1746,9 @@ describe('CartService', () => {
         .mockResolvedValue(mockLatestInvoicePreview);
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
+        .mockResolvedValue({ offer: null, userEligible: false });
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
         .mockResolvedValue(null);
     });
 
@@ -1779,7 +1782,8 @@ describe('CartService', () => {
         },
         metricsOptedOut: false,
         hasActiveSubscriptions: true,
-        freeTrialEligibility: null,
+        freeTrialOffer: null,
+        freeTrialUserEligible: false,
       });
 
       expect(cartManager.fetchCartById).toHaveBeenCalledWith(mockCart.id);
@@ -1842,7 +1846,8 @@ describe('CartService', () => {
           customerSessionClientSecret: mockCustomerSession.client_secret,
         },
         hasActiveSubscriptions: true,
-        freeTrialEligibility: null,
+        freeTrialOffer: null,
+        freeTrialUserEligible: false,
       });
       expect(
         'latestInvoicePreview' in result && result.latestInvoicePreview
@@ -1911,7 +1916,8 @@ describe('CartService', () => {
           customerSessionClientSecret: mockCustomerSession.client_secret,
         },
         hasActiveSubscriptions: true,
-        freeTrialEligibility: null,
+        freeTrialOffer: null,
+        freeTrialUserEligible: false,
       });
       expect(
         'latestInvoicePreview' in result && result.latestInvoicePreview
@@ -1962,7 +1968,8 @@ describe('CartService', () => {
         upcomingInvoicePreview: mockInvoicePreview,
         metricsOptedOut: false,
         hasActiveSubscriptions: false,
-        freeTrialEligibility: null,
+        freeTrialOffer: null,
+        freeTrialUserEligible: false,
       });
 
       expect(cartManager.fetchCartById).toHaveBeenCalledWith(mockCart.id);
@@ -2035,7 +2042,8 @@ describe('CartService', () => {
           unitAmount: mockFromPrice.unit_amount,
         },
         hasActiveSubscriptions: true,
-        freeTrialEligibility: null,
+        freeTrialOffer: null,
+        freeTrialUserEligible: false,
         isUpgradeFromTrial: false,
       });
 
@@ -2481,10 +2489,11 @@ describe('CartService', () => {
         .mockResolvedValue(mockInvoicePreview);
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
-        .mockResolvedValue(mockFreeTrial);
+        .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
 
       const result = await cartService.getCart(mockCart.id);
-      expect(result.freeTrialEligibility).toEqual(mockFreeTrial);
+      expect(result.freeTrialOffer).toEqual(mockFreeTrial);
+      expect(result.freeTrialUserEligible).toBe(true);
       expect(checkoutService.getFreeTrialEligibility).toHaveBeenCalledWith({
         uid: mockCart.uid,
         offeringConfigId: mockCart.offeringConfigId,
@@ -2495,7 +2504,7 @@ describe('CartService', () => {
       });
     });
 
-    it('does not call getFreeTrialEligibility when cart was not promised a trial', async () => {
+    it('returns offer with userEligible false for signed-in cart when user is not eligible', async () => {
       const mockFreeTrial = FreeTrialFactory({ trialLengthDays: 7 });
       const mockCart = ResultCartFactory({
         uid: faker.string.uuid(),
@@ -2515,16 +2524,58 @@ describe('CartService', () => {
         .mockResolvedValue(mockInvoicePreview);
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
-        .mockResolvedValue(mockFreeTrial);
+        .mockResolvedValue({ offer: mockFreeTrial, userEligible: false });
 
       const result = await cartService.getCart(mockCart.id);
-      expect(result.freeTrialEligibility).toBeNull();
+      expect(result.freeTrialOffer).toEqual(mockFreeTrial);
+      expect(result.freeTrialUserEligible).toBe(false);
+    });
+
+    it('uses getProductFreeTrialOffer for anonymous cart in START state', async () => {
+      const mockFreeTrial = FreeTrialFactory({ trialLengthDays: 7 });
+      const mockCart = ResultCartFactory({
+        uid: undefined,
+        state: CartState.START,
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        eligibilityStatus: CartEligibilityStatus.CREATE,
+      });
+      const mockInvoicePreview = InvoicePreviewFactory();
+      const mockSearchParams = { experimentationPreview: 'true' };
+      const mockExperimentationId = 'guest-experiment-123';
+
+      jest.spyOn(cartManager, 'fetchCartById').mockResolvedValue(mockCart);
+      jest.spyOn(eligibilityService, 'checkEligibility').mockResolvedValue({
+        subscriptionEligibilityResult: EligibilityStatus.CREATE,
+      });
+      jest
+        .spyOn(invoiceManager, 'previewUpcoming')
+        .mockResolvedValue(mockInvoicePreview);
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(mockFreeTrial);
+
+      const result = await cartService.getCart(
+        mockCart.id,
+        mockSearchParams,
+        mockExperimentationId
+      );
+      expect(result.freeTrialOffer).toEqual(mockFreeTrial);
+      expect(result.freeTrialUserEligible).toBe(false);
+      expect(checkoutService.getProductFreeTrialOffer).toHaveBeenCalledWith({
+        offeringConfigId: mockCart.offeringConfigId,
+        countryCode: mockCart.taxAddress?.countryCode,
+        interval: mockCart.interval,
+        experimentationId: mockExperimentationId,
+        searchParams: mockSearchParams,
+      });
       expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
     });
 
-    it('sets freeTrialEligibility to null when cart has no uid', async () => {
+    it('returns null offer for anonymous cart when product has no trial', async () => {
       const mockCart = ResultCartFactory({
         uid: undefined,
+        state: CartState.START,
         stripeCustomerId: null,
         stripeSubscriptionId: null,
         eligibilityStatus: CartEligibilityStatus.CREATE,
@@ -2538,13 +2589,17 @@ describe('CartService', () => {
       jest
         .spyOn(invoiceManager, 'previewUpcoming')
         .mockResolvedValue(mockInvoicePreview);
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(null);
 
       const result = await cartService.getCart(mockCart.id);
-      expect(result.freeTrialEligibility).toBeNull();
+      expect(result.freeTrialOffer).toBeNull();
+      expect(result.freeTrialUserEligible).toBe(false);
       expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
     });
 
-    it('does not call getFreeTrialEligibility when cart is not START and subscription has no trial_end', async () => {
+    it('does not call getFreeTrialEligibility when cart is not START', async () => {
       const mockCart = ResultCartFactory({
         uid: faker.string.uuid(),
         state: CartState.SUCCESS,
@@ -2566,9 +2621,10 @@ describe('CartService', () => {
       jest.spyOn(paymentMethodManager, 'retrieve').mockResolvedValue(mockPM);
 
       const result = await cartService.getCart(mockCart.id);
-      expect(result.freeTrialEligibility).toBeNull();
-
+      expect(result.freeTrialOffer).toBeNull();
+      expect(result.freeTrialUserEligible).toBe(false);
       expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
+      expect(checkoutService.getProductFreeTrialOffer).not.toHaveBeenCalled();
     });
 
     it('does not fetch trial config when cart is PROCESSING', async () => {
@@ -2589,8 +2645,10 @@ describe('CartService', () => {
         .mockResolvedValue(mockInvoicePreview);
 
       const result = await cartService.getCart(mockCart.id);
-      expect(result.freeTrialEligibility).toBeNull();
+      expect(result.freeTrialOffer).toBeNull();
+      expect(result.freeTrialUserEligible).toBe(false);
       expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
+      expect(checkoutService.getProductFreeTrialOffer).not.toHaveBeenCalled();
     });
 
     it('populates trialStartDate and trialEndDate from subscription when trial_end exists', async () => {
@@ -2616,7 +2674,8 @@ describe('CartService', () => {
       const result = await cartService.getCart(mockCart.id);
       expect(result.trialStartDate).toBe(mockTrialSubscription.trial_start);
       expect(result.trialEndDate).toBe(mockTrialSubscription.trial_end);
-      expect(result.freeTrialEligibility).toBeNull();
+      expect(result.freeTrialOffer).toBeNull();
+      expect(result.freeTrialUserEligible).toBe(false);
       expect(checkoutService.getFreeTrialEligibility).not.toHaveBeenCalled();
     });
   });

--- a/libs/payments/cart/src/lib/cart.service.ts
+++ b/libs/payments/cart/src/lib/cart.service.ts
@@ -445,7 +445,7 @@ export class CartService {
       }
     }
 
-    const freeTrial = args.uid
+    const freeTrialResult = args.uid
       ? await this.checkoutService.getFreeTrialEligibility({
           uid: args.uid,
           offeringConfigId: args.offeringConfigId,
@@ -453,7 +453,7 @@ export class CartService {
           interval: args.interval,
           eligibilityStatus: eligibility.subscriptionEligibilityResult,
         })
-      : null;
+      : { offer: null, userEligible: false };
 
     const createCartParams: SetupCart = {
       interval: args.interval,
@@ -466,7 +466,7 @@ export class CartService {
       currency,
       eligibilityStatus: cartEligibilityStatus,
       couponCode,
-      isFreeTrial: !!freeTrial,
+      isFreeTrial: !!freeTrialResult.offer && !!freeTrialResult.userEligible,
     };
 
     if (eligibility.subscriptionEligibilityResult === EligibilityStatus.SAME) {
@@ -843,7 +843,7 @@ export class CartService {
           effectiveUid &&
           oldCart.eligibilityStatus === CartEligibilityStatus.CREATE
         ) {
-          const freeTrial =
+          const freeTrialResult =
             await this.checkoutService.getFreeTrialEligibility({
               uid: effectiveUid,
               offeringConfigId: oldCart.offeringConfigId,
@@ -854,7 +854,7 @@ export class CartService {
               interval: oldCart.interval as SubplatInterval,
               eligibilityStatus: EligibilityStatus.CREATE,
             });
-          cartDetails.isFreeTrial = !!freeTrial;
+          cartDetails.isFreeTrial = !!freeTrialResult.offer && !!freeTrialResult.userEligible;
         } else {
           cartDetails.isFreeTrial = false;
         }
@@ -884,7 +884,8 @@ export class CartService {
   @SanitizeExceptions()
   async getCart(
     cartId: string,
-    searchParams?: PaymentsSearchParams
+    searchParams?: PaymentsSearchParams,
+    experimentationId?: string
   ): Promise<CartDTO> {
     const cart = (await this.cartManager.fetchCartById(
       cartId
@@ -933,18 +934,30 @@ export class CartService {
     const trialStartDate = trialSubscription?.trial_start ?? undefined;
     const trialEndDate = trialSubscription?.trial_end ?? undefined;
 
-    let freeTrialEligibility: FreeTrial | null = null;
-    if (cart.uid && cart.state === CartState.START && cart.isFreeTrial) {
-      freeTrialEligibility = await this.checkoutService.getFreeTrialEligibility(
-        {
-          uid: cart.uid,
+    let freeTrialOffer: FreeTrial | null = null;
+    let freeTrialUserEligible = false;
+    if (cart.state === CartState.START) {
+      if (cart.uid) {
+        const freeTrialResult =
+          await this.checkoutService.getFreeTrialEligibility({
+            uid: cart.uid,
+            offeringConfigId: cart.offeringConfigId,
+            countryCode: cart.taxAddress.countryCode || '',
+            interval: cart.interval as SubplatInterval,
+            eligibilityStatus: eligibility.subscriptionEligibilityResult,
+            searchParams,
+          });
+        freeTrialOffer = freeTrialResult.offer;
+        freeTrialUserEligible = freeTrialResult.userEligible;
+      } else {
+        freeTrialOffer = await this.checkoutService.getProductFreeTrialOffer({
           offeringConfigId: cart.offeringConfigId,
           countryCode: cart.taxAddress.countryCode || '',
           interval: cart.interval as SubplatInterval,
-          eligibilityStatus: eligibility.subscriptionEligibilityResult,
+          experimentationId,
           searchParams,
-        }
-      );
+        });
+      }
     }
 
     const { unitAmountForCurrency: offeringPrice } =
@@ -1084,7 +1097,8 @@ export class CartService {
         latestInvoicePreview,
         paymentInfo,
         hasActiveSubscriptions: !!subscriptions?.length,
-        freeTrialEligibility,
+        freeTrialOffer,
+        freeTrialUserEligible,
         trialStartDate,
         trialEndDate,
         isUpgradeFromTrial,
@@ -1139,7 +1153,8 @@ export class CartService {
           : undefined,
       fromPrice: 'fromPrice' in eligibility ? fromPrice : undefined,
       hasActiveSubscriptions: !!subscriptions?.length,
-      freeTrialEligibility,
+      freeTrialOffer,
+      freeTrialUserEligible,
       trialStartDate,
       trialEndDate,
       isUpgradeFromTrial,

--- a/libs/payments/cart/src/lib/cart.types.ts
+++ b/libs/payments/cart/src/lib/cart.types.ts
@@ -80,7 +80,8 @@ export type BaseCartDTO = Omit<ResultCart, 'state'> & {
   fromPrice?: FromPrice;
   taxAddress: TaxAddress;
   currency: string;
-  freeTrialEligibility?: FreeTrial | null;
+  freeTrialOffer?: FreeTrial | null;
+  freeTrialUserEligible?: boolean;
   trialStartDate?: number;
   trialEndDate?: number;
   isUpgradeFromTrial?: boolean;

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -360,7 +360,7 @@ describe('CheckoutService', () => {
         .mockResolvedValue([mockAccount]);
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
-        .mockResolvedValue(null);
+        .mockResolvedValue({ offer: null, userEligible: false });
     });
 
     describe('success - with stripeCustomerId attached to cart', () => {
@@ -505,6 +505,13 @@ describe('CheckoutService', () => {
       });
 
       it('throws cart free trial mismatch error when cart promised a trial but user is no longer eligible', async () => {
+        const mockFreeTrial: FreeTrial = {
+          internalName: 'test-free-trial',
+          intervals: ['monthly'],
+          trialLengthDays: 14,
+          countries: ['US'],
+          cooldownPeriodMonths: 6,
+        };
         const mockCart = StripeResponseFactory(
           ResultCartFactory({
             uid: uid,
@@ -518,7 +525,28 @@ describe('CheckoutService', () => {
 
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: false });
+
+        await expect(
+          checkoutService.prePaySteps(mockCart, mockCart.uid)
+        ).rejects.toBeInstanceOf(CartFreeTrialMismatchError);
+      });
+
+      it('throws cart free trial mismatch error when cart promised a trial but offer no longer exists', async () => {
+        const mockCart = StripeResponseFactory(
+          ResultCartFactory({
+            uid: uid,
+            couponCode: faker.string.uuid(),
+            stripeCustomerId: mockCustomer.id,
+            eligibilityStatus: CartEligibilityStatus.CREATE,
+            amount: mockInvoicePreview.subtotal,
+            isFreeTrial: true,
+          })
+        );
+
+        jest
+          .spyOn(checkoutService, 'getFreeTrialEligibility')
+          .mockResolvedValue({ offer: null, userEligible: false });
 
         await expect(
           checkoutService.prePaySteps(mockCart, mockCart.uid)
@@ -546,7 +574,7 @@ describe('CheckoutService', () => {
 
         const getFreeTrialEligibilitySpy = jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
 
         const result = await checkoutService.prePaySteps(
           mockCart,
@@ -811,7 +839,7 @@ describe('CheckoutService', () => {
         .mockResolvedValue(mockPaymentMethod);
       jest
         .spyOn(checkoutService, 'getFreeTrialEligibility')
-        .mockResolvedValue(null);
+        .mockResolvedValue({ offer: null, userEligible: false });
     });
 
     describe('succeeded', () => {
@@ -1139,7 +1167,7 @@ describe('CheckoutService', () => {
         jest.spyOn(checkoutService, 'postPaySteps').mockResolvedValue();
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
 
         await checkoutService.payWithStripe(
           mockCart,
@@ -1262,7 +1290,7 @@ describe('CheckoutService', () => {
             .mockResolvedValue(mockPricingForCurrency);
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
-            .mockResolvedValue(mockFreeTrial);
+            .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
           jest
             .spyOn(subscriptionManager, 'create')
             .mockResolvedValue(mockTrialSubscription);
@@ -1363,7 +1391,7 @@ describe('CheckoutService', () => {
             .mockResolvedValue(mockPricingForCurrency);
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
-            .mockResolvedValue(null);
+            .mockResolvedValue({ offer: null, userEligible: false });
           jest
             .spyOn(subscriptionManager, 'create')
             .mockResolvedValue(mockSubscription);
@@ -1439,7 +1467,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
         jest
           .spyOn(confirmationTokenManager, 'retrieve')
           .mockResolvedValue(mockPrepaidConfirmationToken);
@@ -1493,7 +1521,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
@@ -1567,7 +1595,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
         jest
           .spyOn(confirmationTokenManager, 'retrieve')
           .mockResolvedValue(mockCreditConfirmationToken);
@@ -1632,7 +1660,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
         jest.spyOn(confirmationTokenManager, 'retrieve');
         jest
           .spyOn(subscriptionManager, 'create')
@@ -1675,7 +1703,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockNonTrialingSubscription);
@@ -1729,7 +1757,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
         jest
           .spyOn(checkoutService, 'upgradeSubscription')
           .mockResolvedValue(mockSubscription);
@@ -1785,7 +1813,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
         jest
           .spyOn(subscriptionManager, 'create')
           .mockResolvedValue(mockTrialSubscription);
@@ -1891,7 +1919,7 @@ describe('CheckoutService', () => {
         jest.spyOn(asyncLocalStorage, 'getStore');
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
       });
 
       beforeEach(async () => {
@@ -2135,7 +2163,7 @@ describe('CheckoutService', () => {
           jest.spyOn(cartManager, 'updateProcessingCart').mockResolvedValue();
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
-            .mockResolvedValue(null);
+            .mockResolvedValue({ offer: null, userEligible: false });
 
           await expect(
             checkoutService.payWithPaypal(
@@ -2243,7 +2271,7 @@ describe('CheckoutService', () => {
             .mockResolvedValue(mockPricingForCurrency);
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
-            .mockResolvedValue(mockFreeTrial);
+            .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
           jest.spyOn(statsd, 'increment');
           jest
             .spyOn(subscriptionManager, 'create')
@@ -2351,7 +2379,7 @@ describe('CheckoutService', () => {
             .mockResolvedValue(mockPricingForCurrency);
           jest
             .spyOn(checkoutService, 'getFreeTrialEligibility')
-            .mockResolvedValue(null);
+            .mockResolvedValue({ offer: null, userEligible: false });
           jest.spyOn(statsd, 'increment');
           jest
             .spyOn(subscriptionManager, 'create')
@@ -2435,7 +2463,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(mockFreeTrial);
+          .mockResolvedValue({ offer: mockFreeTrial, userEligible: true });
         jest.spyOn(statsd, 'increment');
         jest
           .spyOn(subscriptionManager, 'create')
@@ -2497,7 +2525,7 @@ describe('CheckoutService', () => {
           .mockResolvedValue(mockPricingForCurrency);
         jest
           .spyOn(checkoutService, 'getFreeTrialEligibility')
-          .mockResolvedValue(null);
+          .mockResolvedValue({ offer: null, userEligible: false });
         jest
           .spyOn(checkoutService, 'upgradeSubscription')
           .mockResolvedValue(mockSubscription);
@@ -2863,8 +2891,7 @@ describe('CheckoutService', () => {
     });
   });
 
-  describe('getFreeTrialEligibility', () => {
-    const mockUid = faker.string.uuid();
+  describe('getProductFreeTrialOffer', () => {
     const mockOfferingConfigId = faker.string.alphanumeric(10);
     const mockCountryCode = 'US';
     const mockInterval = 'monthly' as SubplatInterval;
@@ -2891,21 +2918,10 @@ describe('CheckoutService', () => {
     };
 
     const baseArgs = {
-      uid: mockUid,
       offeringConfigId: mockOfferingConfigId,
       countryCode: mockCountryCode,
       interval: mockInterval,
-      eligibilityStatus: EligibilityStatus.CREATE,
     };
-
-    it('returns null when eligibilityStatus is UPGRADE', async () => {
-      const result = await checkoutService.getFreeTrialEligibility({
-        ...baseArgs,
-        eligibilityStatus: EligibilityStatus.UPGRADE,
-      });
-
-      expect(result).toBeNull();
-    });
 
     it('returns null when Nimbus returns null', async () => {
       jest
@@ -2918,7 +2934,7 @@ describe('CheckoutService', () => {
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(mockFreeTrialUtil as any);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toBeNull();
     });
@@ -2938,7 +2954,7 @@ describe('CheckoutService', () => {
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(mockFreeTrialUtil as any);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toBeNull();
     });
@@ -2955,7 +2971,7 @@ describe('CheckoutService', () => {
         freeTrial: { freeTrials: [] },
       } as any);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toBeNull();
     });
@@ -2971,7 +2987,7 @@ describe('CheckoutService', () => {
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(mockFreeTrialUtil as any);
 
-      const result = await checkoutService.getFreeTrialEligibility({
+      const result = await checkoutService.getProductFreeTrialOffer({
         ...baseArgs,
         countryCode: 'DE',
       });
@@ -2990,7 +3006,7 @@ describe('CheckoutService', () => {
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(mockFreeTrialUtil as any);
 
-      const result = await checkoutService.getFreeTrialEligibility({
+      const result = await checkoutService.getProductFreeTrialOffer({
         ...baseArgs,
         interval: 'yearly' as SubplatInterval,
       });
@@ -3012,26 +3028,7 @@ describe('CheckoutService', () => {
         freeTrial: { freeTrials: [{ ...mockFreeTrial, trialLengthDays: 0 }] },
       } as any);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
-
-      expect(result).toBeNull();
-    });
-
-    it('returns null when blocked by cooldown', async () => {
-      jest
-        .spyOn(nimbusManager, 'fetchExperiments')
-        .mockResolvedValue(mockNimbusResult);
-      jest
-        .spyOn(nimbusManager, 'generateNimbusId')
-        .mockReturnValue('nimbus-id');
-      jest
-        .spyOn(productConfigurationManager, 'getFreeTrial')
-        .mockResolvedValue(mockFreeTrialUtil as any);
-      jest
-        .spyOn(freeTrialManager, 'isBlockedByCooldown')
-        .mockResolvedValue(true);
-
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toBeNull();
     });
@@ -3046,11 +3043,8 @@ describe('CheckoutService', () => {
       jest
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(mockFreeTrialUtil as any);
-      jest
-        .spyOn(freeTrialManager, 'isBlockedByCooldown')
-        .mockResolvedValue(false);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toEqual(mockFreeTrial);
     });
@@ -3067,32 +3061,9 @@ describe('CheckoutService', () => {
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(mockFreeTrialUtil as any);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toBeNull();
-    });
-
-    it('verifies arguments passed to isBlockedByCooldown', async () => {
-      jest
-        .spyOn(nimbusManager, 'fetchExperiments')
-        .mockResolvedValue(mockNimbusResult);
-      jest
-        .spyOn(nimbusManager, 'generateNimbusId')
-        .mockReturnValue('nimbus-id');
-      jest
-        .spyOn(productConfigurationManager, 'getFreeTrial')
-        .mockResolvedValue(mockFreeTrialUtil as any);
-      jest
-        .spyOn(freeTrialManager, 'isBlockedByCooldown')
-        .mockResolvedValue(false);
-
-      await checkoutService.getFreeTrialEligibility(baseArgs);
-
-      expect(freeTrialManager.isBlockedByCooldown).toHaveBeenCalledWith(
-        mockUid,
-        mockFreeTrial.internalName,
-        mockFreeTrial.cooldownPeriodMonths
-      );
     });
 
     it('returns first matching trial when multiple exist', async () => {
@@ -3117,11 +3088,8 @@ describe('CheckoutService', () => {
       jest
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockResolvedValue(multiTrialUtil as any);
-      jest
-        .spyOn(freeTrialManager, 'isBlockedByCooldown')
-        .mockResolvedValue(false);
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toEqual(mockFreeTrial);
     });
@@ -3137,9 +3105,136 @@ describe('CheckoutService', () => {
         .spyOn(productConfigurationManager, 'getFreeTrial')
         .mockRejectedValue(new Error('CMS fetch failed'));
 
-      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+      const result = await checkoutService.getProductFreeTrialOffer(baseArgs);
 
       expect(result).toBeNull();
+    });
+
+    it('passes uid to generateNimbusId when provided', async () => {
+      const generateSpy = jest
+        .spyOn(nimbusManager, 'generateNimbusId')
+        .mockReturnValue('nimbus-id');
+      jest
+        .spyOn(nimbusManager, 'fetchExperiments')
+        .mockResolvedValue(mockNimbusResult);
+      jest
+        .spyOn(productConfigurationManager, 'getFreeTrial')
+        .mockResolvedValue(mockFreeTrialUtil as any);
+
+      await checkoutService.getProductFreeTrialOffer({
+        ...baseArgs,
+        uid: 'test-uid',
+        experimentationId: 'test-experiment-id',
+      });
+
+      expect(generateSpy).toHaveBeenCalledWith(
+        'test-uid',
+        'test-experiment-id'
+      );
+    });
+
+    it('passes only experimentationId for anonymous users', async () => {
+      const generateSpy = jest
+        .spyOn(nimbusManager, 'generateNimbusId')
+        .mockReturnValue('nimbus-id');
+      jest
+        .spyOn(nimbusManager, 'fetchExperiments')
+        .mockResolvedValue(mockNimbusResult);
+      jest
+        .spyOn(productConfigurationManager, 'getFreeTrial')
+        .mockResolvedValue(mockFreeTrialUtil as any);
+
+      await checkoutService.getProductFreeTrialOffer({
+        ...baseArgs,
+        experimentationId: 'guest-abc-123',
+      });
+
+      expect(generateSpy).toHaveBeenCalledWith(undefined, 'guest-abc-123');
+    });
+  });
+
+  describe('getFreeTrialEligibility', () => {
+    const mockUid = faker.string.uuid();
+    const mockOfferingConfigId = faker.string.alphanumeric(10);
+    const mockCountryCode = 'US';
+    const mockInterval = 'monthly' as SubplatInterval;
+
+    const mockFreeTrial: FreeTrial = {
+      internalName: 'test-free-trial',
+      intervals: ['monthly'],
+      trialLengthDays: 30,
+      countries: ['US - United States', 'CA - Canada'],
+      cooldownPeriodMonths: 6,
+    };
+
+    const baseArgs = {
+      uid: mockUid,
+      offeringConfigId: mockOfferingConfigId,
+      countryCode: mockCountryCode,
+      interval: mockInterval,
+      eligibilityStatus: EligibilityStatus.CREATE,
+    };
+
+    it('returns {offer: null, userEligible: false} when eligibilityStatus is UPGRADE', async () => {
+      const result = await checkoutService.getFreeTrialEligibility({
+        ...baseArgs,
+        eligibilityStatus: EligibilityStatus.UPGRADE,
+      });
+
+      expect(result).toEqual({ offer: null, userEligible: false });
+    });
+
+    it('returns {offer: null, userEligible: false} when product has no offer', async () => {
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(null);
+
+      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+
+      expect(result).toEqual({ offer: null, userEligible: false });
+    });
+
+    it('returns {offer, userEligible: false} when blocked by cooldown', async () => {
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(mockFreeTrial);
+      jest
+        .spyOn(freeTrialManager, 'isBlockedByCooldown')
+        .mockResolvedValue(true);
+
+      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+
+      expect(result).toEqual({ offer: mockFreeTrial, userEligible: false });
+    });
+
+    it('returns {offer, userEligible: true} when product offers and user not blocked', async () => {
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(mockFreeTrial);
+      jest
+        .spyOn(freeTrialManager, 'isBlockedByCooldown')
+        .mockResolvedValue(false);
+
+      const result = await checkoutService.getFreeTrialEligibility(baseArgs);
+
+      expect(result).toEqual({ offer: mockFreeTrial, userEligible: true });
+    });
+
+    it('verifies arguments passed to isBlockedByCooldown', async () => {
+      jest
+        .spyOn(checkoutService, 'getProductFreeTrialOffer')
+        .mockResolvedValue(mockFreeTrial);
+      jest
+        .spyOn(freeTrialManager, 'isBlockedByCooldown')
+        .mockResolvedValue(false);
+
+      await checkoutService.getFreeTrialEligibility(baseArgs);
+
+      expect(freeTrialManager.isBlockedByCooldown).toHaveBeenCalledWith(
+        mockUid,
+        mockFreeTrial.internalName,
+        mockFreeTrial.cooldownPeriodMonths
+      );
     });
   });
 });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -251,16 +251,17 @@ export class CheckoutService {
 
     let freeTrial: FreeTrial | null = null;
     if (cart.isFreeTrial) {
-      freeTrial = await this.getFreeTrialEligibility({
+      const freeTrialResult = await this.getFreeTrialEligibility({
         uid,
         offeringConfigId: cart.offeringConfigId,
         countryCode: taxAddress.countryCode,
         interval: cart.interval as SubplatInterval,
         eligibilityStatus: eligibility.subscriptionEligibilityResult,
       });
-      if (!freeTrial) {
+      if (!freeTrialResult.userEligible || !freeTrialResult.offer) {
         throw new CartFreeTrialMismatchError(cart.id, true, false);
       }
+      freeTrial = freeTrialResult.offer;
     }
 
     // re-validate total amount against upcoming invoice
@@ -994,12 +995,12 @@ export class CheckoutService {
     }
   }
 
-  async getFreeTrialEligibility(args: {
-    uid: string;
+  async getProductFreeTrialOffer(args: {
     offeringConfigId: string;
     countryCode: string;
     interval: SubplatInterval;
-    eligibilityStatus: EligibilityStatus;
+    uid?: string;
+    experimentationId?: string;
     searchParams?: PaymentsSearchParams;
   }): Promise<FreeTrial | null> {
     const {
@@ -1007,17 +1008,13 @@ export class CheckoutService {
       offeringConfigId,
       countryCode,
       interval,
-      eligibilityStatus,
+      experimentationId,
       searchParams,
     } = args;
 
-    if (eligibilityStatus !== EligibilityStatus.CREATE) {
-      return null;
-    }
-
     const fetchResult = await Promise.all([
       this.nimbusManager.fetchExperiments({
-        nimbusUserId: this.nimbusManager.generateNimbusId(uid),
+        nimbusUserId: this.nimbusManager.generateNimbusId(uid, experimentationId),
         preview: searchParams?.experimentationPreview === 'true',
       }),
       this.productConfigurationManager.getFreeTrial(offeringConfigId),
@@ -1028,7 +1025,6 @@ export class CheckoutService {
           offeringConfigId: offeringConfigId,
           countryCode: countryCode,
           interval: interval,
-          eligibilityStatus: eligibilityStatus,
         },
       });
       return null;
@@ -1056,21 +1052,43 @@ export class CheckoutService {
         trial.countries.some((country) => country.slice(0, 2) === countryCode) &&
         trial.intervals.includes(interval)
     );
+    return matchingTrial ?? null;
+  }
 
-    if (!matchingTrial) {
-      return null;
+  async getFreeTrialEligibility(args: {
+    uid: string;
+    offeringConfigId: string;
+    countryCode: string;
+    interval: SubplatInterval;
+    eligibilityStatus: EligibilityStatus;
+    experimentationId?: string;
+    searchParams?: PaymentsSearchParams;
+  }): Promise<{ offer: FreeTrial | null; userEligible: boolean }> {
+    if (args.eligibilityStatus !== EligibilityStatus.CREATE) {
+      return { offer: null, userEligible: false };
+    }
+
+    const offer = await this.getProductFreeTrialOffer({
+      offeringConfigId: args.offeringConfigId,
+      countryCode: args.countryCode,
+      interval: args.interval,
+      uid: args.uid,
+      experimentationId: args.experimentationId,
+      searchParams: args.searchParams
+    });
+    if (!offer) {
+      return { offer: null, userEligible: false };
     }
 
     const isBlockedByCooldown = await this.freeTrialManager.isBlockedByCooldown(
-      uid,
-      matchingTrial.internalName,
-      matchingTrial.cooldownPeriodMonths
+      args.uid,
+      offer.internalName,
+      offer.cooldownPeriodMonths
     );
 
-    if (isBlockedByCooldown) {
-      return null;
-    }
-
-    return matchingTrial;
+    return {
+      offer,
+      userEligible: !isBlockedByCooldown
+    };
   }
 }

--- a/libs/payments/ui/src/lib/actions/getCart.ts
+++ b/libs/payments/ui/src/lib/actions/getCart.ts
@@ -4,6 +4,7 @@
 
 'use server';
 
+import { headers } from 'next/headers';
 import { getApp } from '../nestapp/app';
 import { parseSearchParams } from '../utils/searchParams';
 
@@ -11,9 +12,11 @@ export const getCartAction = async (
   cartId: string,
   searchParams?: Record<string, string | string[] | undefined>
 ) => {
+  const experimentationId = (await headers()).get('x-experimentation-id') || undefined;
   const cart = await getApp().getActionsService().getCart({
     cartId,
     searchParams: parseSearchParams(searchParams),
+    experimentationId,
   });
 
   return cart;

--- a/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
+++ b/libs/payments/ui/src/lib/actions/getCartOrRedirect.ts
@@ -4,6 +4,7 @@
 
 'use server';
 
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getApp } from '../nestapp/app';
 import { getRedirect, validateCartState } from '../utils/get-cart';
@@ -67,15 +68,17 @@ async function getCartOrRedirectAction(
     : undefined;
   const urlSearchParams = new URLSearchParams(filteredParams);
   const params = searchParams ? `?${urlSearchParams.toString()}` : '';
+  const experimentationId = (await headers()).get('x-experimentation-id') || undefined;
   const cart = await getApp().getActionsService().getCart({
     cartId,
     searchParams: parseSearchParams(searchParams),
+    experimentationId,
   });
 
   if (!validateCartState(cart.state, page)) {
     // Sanitize pathname to prevent open redirect vulnerabilities
     const safePath = sanitizePathname(currentPathname);
-    
+
     // Replace the last segment with the redirect path to maintain the full path structure
     const pathSegments = safePath.split('/');
     pathSegments[pathSegments.length - 1] = getRedirect(cart.state);

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/en.ftl
@@ -3,3 +3,5 @@
 next-new-user-submit = Subscribe Now
 
 next-pay-with-heading-paypal = Pay with { -brand-paypal }
+
+free-trial-ineligible-notice = Your account is not eligible for a free trial. You may continue with a paid subscription.

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -94,6 +94,7 @@ interface CheckoutFormProps {
   sessionEmail?: string;
   isFreeTrial?: boolean;
   trialLengthDays?: number;
+  showTrialIneligibleNotice?: boolean;
   metricsEnabled?: boolean;
   isCancelInterstitialOffer?: boolean;
 }
@@ -106,6 +107,7 @@ export function CheckoutForm({
   sessionEmail,
   isFreeTrial,
   trialLengthDays,
+  showTrialIneligibleNotice,
   metricsEnabled,
   isCancelInterstitialOffer,
 }: CheckoutFormProps) {
@@ -356,6 +358,26 @@ export function CheckoutForm({
         engageGlean();
       }}
     >
+      {showTrialIneligibleNotice && (
+        <>
+          <div
+            className="border-b border-grey-200 my-6"
+            role="separator"
+            aria-hidden="true"
+          ></div>
+          <Localized id="free-trial-ineligible-notice">
+            <p className="leading-5 text-sm">
+              Your account is not eligible for a free trial. You may continue
+              with a paid subscription.
+            </p>
+          </Localized>
+          <div
+            className="border-b border-grey-200 my-6"
+            role="separator"
+            aria-hidden="true"
+          ></div>
+        </>
+      )}
       <CheckoutCheckbox
         isRequired={showConsentError}
         disabled={!cart.uid}

--- a/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
@@ -4,13 +4,17 @@
 
 'use client';
 
+import { useEffect } from 'react';
 import Stripe from 'stripe';
 import { CheckoutForm } from '../CheckoutForm';
 import { StripeWrapper } from '../StripeWrapper';
+import { SAW_TRIAL_OFFER_COOKIE_PREFIX } from '../../../constants';
 import {
   PayPalScriptProvider,
   ReactPayPalScriptOptions,
 } from '@paypal/react-paypal-js';
+
+const SAW_TRIAL_OFFER_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 
 const paypalInitialOptions: ReactPayPalScriptOptions = {
   clientId: '',
@@ -33,6 +37,7 @@ interface PaymentFormProps {
     id: string;
     version: number;
     uid?: string | null;
+    offeringConfigId: string;
     errorReasonId: string | null;
     couponCode: string | null;
     currency: string;
@@ -52,15 +57,17 @@ interface PaymentFormProps {
       walletType?: string;
     };
     hasActiveSubscriptions: boolean;
-    freeTrialEligibility?: {
+    freeTrialOffer?: {
       trialLengthDays: number;
     } | null;
+    freeTrialUserEligible?: boolean;
   };
   locale: string;
   nonce?: string;
   paypalClientId: string;
   sessionUid?: string;
   sessionEmail?: string;
+  sawTrialOffer?: boolean;
   metricsEnabled?: boolean;
   isCancelInterstitialOffer?: boolean;
 }
@@ -74,11 +81,24 @@ export function PaymentSection({
   paypalClientId,
   sessionUid,
   sessionEmail,
+  sawTrialOffer,
   metricsEnabled,
   isCancelInterstitialOffer,
 }: PaymentFormProps) {
-  const isFreeTrial = !!cart.freeTrialEligibility;
-  const trialLengthDays = cart.freeTrialEligibility?.trialLengthDays;
+  const isFreeTrial =
+    !!cart.freeTrialOffer && (!sessionUid || !!cart.freeTrialUserEligible);
+  const trialLengthDays = cart.freeTrialOffer?.trialLengthDays;
+  const showTrialIneligibleNotice =
+    !!cart.freeTrialOffer &&
+    !!sessionUid &&
+    !cart.freeTrialUserEligible &&
+    !!sawTrialOffer;
+
+  useEffect(() => {
+    if (isFreeTrial) {
+      document.cookie = `${SAW_TRIAL_OFFER_COOKIE_PREFIX}${cart.offeringConfigId}=1; path=/; max-age=${SAW_TRIAL_OFFER_COOKIE_MAX_AGE}; samesite=lax`;
+    }
+  }, [isFreeTrial, cart.offeringConfigId]);
 
   return (
     <PayPalScriptProvider
@@ -102,6 +122,7 @@ export function PaymentSection({
           sessionEmail={sessionEmail}
           isFreeTrial={isFreeTrial}
           trialLengthDays={trialLengthDays}
+          showTrialIneligibleNotice={showTrialIneligibleNotice}
           metricsEnabled={metricsEnabled}
           isCancelInterstitialOffer={isCancelInterstitialOffer}
         />

--- a/libs/payments/ui/src/lib/client/components/PurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PurchaseDetails/index.tsx
@@ -29,7 +29,7 @@ type PurchaseDetailsProps = {
   totalPrice: React.ReactNode;
   locale: string;
   showPrices: boolean;
-  freeTrialEligibility?: {
+  freeTrialOffer?: {
     trialLengthDays: number;
   } | null;
   firstChargeAmount?: number;
@@ -48,7 +48,7 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
     totalPrice,
     locale,
     showPrices,
-    freeTrialEligibility,
+    freeTrialOffer,
     firstChargeAmount,
     interval,
     cartState,
@@ -61,8 +61,8 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
   // may return different data as Stripe state changes
   const [stableInvoice, setStableInvoice] = useState(invoice);
   const [stableTotalPrice, setStableTotalPrice] = useState(totalPrice);
-  const [stableFreeTrialEligibility, setStableFreeTrialEligibility] =
-    useState(freeTrialEligibility);
+  const [stableFreeTrialOffer, setStableFreeTrialOffer] =
+    useState(freeTrialOffer);
   const [stableTrialStartDate, setStableTrialStartDate] =
     useState(trialStartDate);
   const [stableTrialEndDate, setStableTrialEndDate] = useState(trialEndDate);
@@ -70,7 +70,7 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
     if (cartState === 'start' || cartState === 'success') {
       setStableInvoice(invoice);
       setStableTotalPrice(totalPrice);
-      setStableFreeTrialEligibility(freeTrialEligibility);
+      setStableFreeTrialOffer(freeTrialOffer);
       setStableTrialStartDate(trialStartDate);
       setStableTrialEndDate(trialEndDate);
     }
@@ -78,7 +78,7 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
     cartState,
     invoice,
     totalPrice,
-    freeTrialEligibility,
+    freeTrialOffer,
     trialStartDate,
     trialEndDate,
   ]);
@@ -102,12 +102,12 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
   );
   const freeTrial =
     !!stableTrialEndDate ||
-    (!!stableFreeTrialEligibility &&
-      stableFreeTrialEligibility.trialLengthDays > 0);
+    (!!stableFreeTrialOffer &&
+      stableFreeTrialOffer.trialLengthDays > 0);
   const trialDayLength =
     stableTrialStartDate && stableTrialEndDate
       ? Math.round((stableTrialEndDate - stableTrialStartDate) / 86400)
-      : stableFreeTrialEligibility?.trialLengthDays;
+      : stableFreeTrialOffer?.trialLengthDays;
   const formattedTrialEndDate = freeTrial
     ? getLocalizedDateString(
         stableTrialEndDate ??

--- a/libs/payments/ui/src/lib/constants.ts
+++ b/libs/payments/ui/src/lib/constants.ts
@@ -19,3 +19,5 @@ export const OFFERING_LINKS = {
   relay: 'https://relay.firefox.com/',
   vpn: 'https://vpn.mozilla.org/',
 };
+
+export const SAW_TRIAL_OFFER_COOKIE_PREFIX = 'saw_trial_offer_';

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -241,8 +241,13 @@ export class NextJSActionsService {
   async getCart(args: {
     cartId: string;
     searchParams?: PaymentsSearchParams;
+    experimentationId?: string;
   }) {
-    return this.cartService.getCart(args.cartId, args.searchParams);
+    return this.cartService.getCart(
+      args.cartId,
+      args.searchParams,
+      args.experimentationId
+    );
   }
 
   @SanitizeExceptions()

--- a/libs/payments/ui/src/lib/nestapp/validators/GetCartActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/GetCartActionArgs.ts
@@ -12,4 +12,8 @@ export class GetCartActionArgs {
   @IsObject()
   @IsOptional()
   searchParams?: PaymentsSearchParams;
+
+  @IsString()
+  @IsOptional()
+  experimentationId?: string;
 }


### PR DESCRIPTION
## Because

* The current experience on the checkout page is to only show the user the free trial data once they are signed in. We want to allow the user to see the free trial before they sign in. As part of this, we will need to explain to the user why they are being shown a non-trial subscription if their account is ineligible.

## This pull request

* Separates free trial checks into offer-level check and user eligibility so that logged out customers can see the free trial offer.
* Uses cookie to set whether or not customer saw a free trial offer for a specific offering.
* Displays appropriate information after user logs in:
  * if offer exists and user is eligible, shows free trial info
  * if offer exists and user is ineligible, shows message explaining that their account is not eligible for the free trial following upgrade page's UI approach
  * if offer DNE, proceeds to standard checkout experience.

## Issue that this pull request solves

Closes #[PAY-3665](https://mozilla-hub.atlassian.net/browse/PAY-3665)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code. 

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="2748" height="1762" alt="image" src="https://github.com/user-attachments/assets/27639af0-d8b5-46cf-b783-aa36be2e7212" />

What an eligible user would see (before refresh), vs an ineligible (hardcoded them to not be eligible). An ineligible user will only see the warning message for an offering's checkout only if they saw a free trial option for that offering (for ex., in the video, they saw a free trial option for vpn but not 123donepro).

https://github.com/user-attachments/assets/3004d994-ee7e-4396-8bf1-74eef2f09ca8


## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3665]: https://mozilla-hub.atlassian.net/browse/PAY-3665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ