### PR TITLE
fix(settings): fix double hash/fragment in navigateWithQuery

### DIFF
--- a/packages/fxa-settings/src/lib/utilities.test.ts
+++ b/packages/fxa-settings/src/lib/utilities.test.ts
@@ -306,6 +306,31 @@ describe('navigateWithQueryHelper', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/signin?email=test@example.com');
   });
 
+  it('does not append the current hash when destination already has a hash', async () => {
+    mockLocation.search = '?';
+    mockLocation.hash = '#section';
+    await navigateWithQueryHelper(
+      mockLocation,
+      mockNavigate,
+      '/settings#two-step-authentication'
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/settings#two-step-authentication'
+    );
+  });
+
+  it('inserts preserved query params before the destination hash', async () => {
+    mockLocation.search = '?email=test@example.com';
+    await navigateWithQueryHelper(
+      mockLocation,
+      mockNavigate,
+      '/settings#two-step-authentication'
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/settings?email=test@example.com#two-step-authentication'
+    );
+  });
+
   it('does not add query params when path already contains them', async () => {
     mockLocation.search = '?email=old@example.com';
     await navigateWithQueryHelper(

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -204,15 +204,20 @@ export function navigateWithQueryHelper(
   options?: NavigateOptions<{}>,
   includeHash: boolean = true
 ): Promise<void> {
-  let path = to;
+  const [destinationPath, destinationHash = ''] = to.split('#');
+  let path = destinationPath;
 
-  if (to.includes('?')) {
-    path = to;
-  } else if (location.search && location.search !== '?') {
-    path = `${to}${location.search}`;
+  if (
+    !destinationPath.includes('?') &&
+    location.search &&
+    location.search !== '?'
+  ) {
+    path = `${path}${location.search}`;
   }
 
-  if (includeHash && location.hash) {
+  if (to.includes('#')) {
+    path = `${path}#${destinationHash}`;
+  } else if (includeHash && location.hash) {
     path = `${path}${location.hash}`;
   }
 


### PR DESCRIPTION
## Because

- navigateWithQuery adds current location's fragment (#) on top of destination's fragment

## This pull request

- makes it prioritize destination's fragment.

## Issue that this pull request solves

Closes: FXA-12290

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Looks like the original bug can't be reproduced anymore, but I still want to harden navigateWithQuery a bit anyway
