### PR TITLE
feat(payments-api): Update Stripe email when FxA account email updates

### DIFF
--- a/libs/payments/webhooks/src/lib/factories.ts
+++ b/libs/payments/webhooks/src/lib/factories.ts
@@ -13,6 +13,11 @@ import {
   type StripeEventStoreEntry,
   type StripeEventStoreEntryFirestoreRecord,
 } from './types';
+import {
+  FxaProfileChangeEvent,
+  FxaSecurityEventTokenPayload,
+} from './fxa-webhooks.types';
+import { FXA_PROFILE_EVENT_URI } from './fxa-webhooks.types';
 import { Timestamp } from '@google-cloud/firestore';
 import { faker } from '@faker-js/faker';
 
@@ -72,3 +77,38 @@ export const StripeEventStoreEntryFirestoreRecordFactory = (
     ...override,
   };
 };
+
+export const FxaProfileChangeEventFactory = (
+  override?: Partial<FxaProfileChangeEvent>
+): FxaProfileChangeEvent => ({
+  email: faker.internet.email(),
+  ...override,
+});
+
+export const FxaSecurityEventTokenPayloadFactory = (
+  events: Record<string, Record<string, any>>,
+  override?: Partial<FxaSecurityEventTokenPayload>
+): FxaSecurityEventTokenPayload => ({
+  iss: faker.internet.url(),
+  sub: faker.string.hexadecimal({
+    length: 32,
+    prefix: '',
+    casing: 'lower',
+  }),
+  aud: faker.string.hexadecimal({ length: 16 }),
+  iat: Math.floor(Date.now() / 1000),
+  jti: faker.string.alphanumeric({ length: 16 }),
+  events,
+  ...override,
+});
+
+export const FxaProfileChangeSecurityEventTokenPayloadFactory = (
+  eventOverride?: Partial<FxaProfileChangeEvent>,
+  payloadOverride?: Partial<FxaSecurityEventTokenPayload>
+): FxaSecurityEventTokenPayload =>
+  FxaSecurityEventTokenPayloadFactory(
+    {
+      [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory(eventOverride),
+    },
+    payloadOverride
+  );

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.controller.spec.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.controller.spec.ts
@@ -3,12 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Test } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
 import { MockPaymentsGleanServiceFactory } from '@fxa/payments/metrics';
+import {
+  AccountCustomerManager,
+  MockStripeConfigProvider,
+  StripeClient,
+} from '@fxa/payments/stripe';
+import { CustomerManager } from '@fxa/payments/customer';
+import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
+import { MockLoggerProvider } from '@fxa/shared/log';
+import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 import { FxaWebhooksController } from './fxa-webhooks.controller';
 import { FxaWebhookService } from './fxa-webhooks.service';
 import { MockFxaWebhookConfigProvider } from './fxa-webhooks.config';
-import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 
 describe('FxaWebhooksController', () => {
   let controller: FxaWebhooksController;
@@ -17,12 +24,17 @@ describe('FxaWebhooksController', () => {
   beforeEach(async () => {
     const module = await Test.createTestingModule({
       providers: [
-        { provide: Logger, useValue: { error: jest.fn(), log: jest.fn() } },
         FxaWebhooksController,
         FxaWebhookService,
         MockFxaWebhookConfigProvider,
         MockStatsDProvider,
+        MockLoggerProvider,
         MockPaymentsGleanServiceFactory,
+        AccountCustomerManager,
+        MockAccountDatabaseNestFactory,
+        CustomerManager,
+        StripeClient,
+        MockStripeConfigProvider,
       ],
     }).compile();
 

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.service.spec.ts
@@ -4,13 +4,40 @@
 
 import { Test } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
+import type { LoggerService } from '@nestjs/common';
 import * as Sentry from '@sentry/nestjs';
 import { JWTool, PrivateJWK } from '@fxa/vendored/jwtool';
-import { StatsDService } from '@fxa/shared/metrics/statsd';
+import {
+  MockStatsDProvider,
+  StatsDService,
+} from '@fxa/shared/metrics/statsd';
+import { MockLoggerProvider } from '@fxa/shared/log';
+import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import type { StatsD } from 'hot-shots';
-import { PaymentsGleanService } from '@fxa/payments/metrics';
+import {
+  MockPaymentsGleanServiceFactory,
+  PaymentsGleanService,
+} from '@fxa/payments/metrics';
+import {
+  AccountCustomerManager,
+  AccountCustomerNotFoundError,
+  MockStripeConfigProvider,
+  ResultAccountCustomerFactory,
+  StripeClient,
+  StripeCustomerFactory,
+  StripeResponseFactory,
+} from '@fxa/payments/stripe';
+import { CustomerManager, CustomerDeletedError } from '@fxa/payments/customer';
 import { FxaWebhookService } from './fxa-webhooks.service';
-import { FxaWebhookConfig } from './fxa-webhooks.config';
+import {
+  MockFxaWebhookConfig,
+  MockFxaWebhookConfigProvider,
+} from './fxa-webhooks.config';
+import {
+  FxaProfileChangeEventFactory,
+  FxaProfileChangeSecurityEventTokenPayloadFactory,
+  FxaSecurityEventTokenPayloadFactory,
+} from './factories';
 import {
   FxaWebhookAuthError,
   FxaWebhookJwksError,
@@ -23,6 +50,7 @@ import {
   FXA_PASSWORD_EVENT_URI,
   FXA_PROFILE_EVENT_URI,
   FXA_SUBSCRIPTION_STATE_EVENT_URI,
+  FxaSecurityEventTokenPayload,
 } from './fxa-webhooks.types';
 
 jest.mock('@sentry/nestjs', () => {
@@ -88,27 +116,24 @@ const TEST_PUBLIC_KEY = {
   n: TEST_KEY.n,
 };
 
-const TEST_ISSUER = 'https://accounts.firefox.com/';
-const TEST_AUDIENCE = 'abc1234';
 const TEST_UID = 'uid1234';
-const TEST_JWKS_URI = 'https://accounts.firefox.com/jwks';
 
 const privateKey = JWTool.JWK.fromObject(TEST_KEY, {
-  iss: TEST_ISSUER,
+  iss: MockFxaWebhookConfig.fxaWebhookIssuer,
 }) as PrivateJWK;
 
-function signToken(
+async function signToken(
   events: Record<string, any>,
-  overrides: Record<string, any> = {}
+  overrides: Partial<FxaSecurityEventTokenPayload> = {}
 ): Promise<string> {
-  return privateKey.sign({
-    aud: TEST_AUDIENCE,
+  const payload = FxaSecurityEventTokenPayloadFactory(events, {
     sub: TEST_UID,
-    iat: Date.now() / 1000,
+    iss: MockFxaWebhookConfig.fxaWebhookIssuer,
+    aud: MockFxaWebhookConfig.fxaWebhookAudience,
     jti: 'test-jti',
-    events,
     ...overrides,
   });
+  return privateKey.sign(payload);
 }
 
 function mockFetchForJwks() {
@@ -122,45 +147,56 @@ function mockFetchForJwks() {
 
 describe('FxaWebhookService', () => {
   let service: FxaWebhookService;
-  let statsd: { increment: jest.Mock; timing: jest.Mock };
-  let logger: { error: jest.Mock; log: jest.Mock };
-  let paymentsGleanService: { handleUserDelete: jest.Mock };
+  let statsd: StatsD;
+  let logger: LoggerService;
+  let paymentsGleanService: PaymentsGleanService;
+  let accountCustomerManager: AccountCustomerManager;
+  let customerManager: CustomerManager;
   let originalFetch: typeof global.fetch;
 
   beforeEach(async () => {
     originalFetch = global.fetch;
     global.fetch = mockFetchForJwks();
 
-    logger = { error: jest.fn(), log: jest.fn() };
-    statsd = { increment: jest.fn(), timing: jest.fn() };
-    paymentsGleanService = { handleUserDelete: jest.fn() };
-
     const module = await Test.createTestingModule({
       providers: [
-        { provide: Logger, useValue: logger },
         FxaWebhookService,
-        {
-          provide: FxaWebhookConfig,
-          useValue: {
-            fxaWebhookIssuer: TEST_ISSUER,
-            fxaWebhookAudience: TEST_AUDIENCE,
-            fxaWebhookJwksUri: TEST_JWKS_URI,
-          } satisfies FxaWebhookConfig,
-        },
-        { provide: StatsDService, useValue: statsd as unknown as StatsD },
-        {
-          provide: PaymentsGleanService,
-          useValue: paymentsGleanService,
-        },
+        MockFxaWebhookConfigProvider,
+        MockStatsDProvider,
+        MockLoggerProvider,
+        MockPaymentsGleanServiceFactory,
+        AccountCustomerManager,
+        MockAccountDatabaseNestFactory,
+        CustomerManager,
+        StripeClient,
+        MockStripeConfigProvider,
       ],
     }).compile();
 
     service = module.get(FxaWebhookService);
+    statsd = module.get(StatsDService);
+    logger = module.get<LoggerService>(Logger);
+    paymentsGleanService = module.get(PaymentsGleanService);
+    accountCustomerManager = module.get(AccountCustomerManager);
+    customerManager = module.get(CustomerManager);
+
+    jest.spyOn(statsd, 'increment');
+    jest.spyOn(logger, 'log');
+    jest.spyOn(logger, 'error');
+    jest.spyOn(paymentsGleanService, 'handleUserDelete');
+
+    // Default behaviour: no AccountCustomer for the test uid. Tests that need
+    // a customer override this with mockResolvedValue.
+    jest
+      .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+      .mockRejectedValue(
+        new AccountCustomerNotFoundError(TEST_UID, new Error('not found'))
+      );
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
   describe('handleWebhookEvent', () => {
@@ -182,10 +218,9 @@ describe('FxaWebhookService', () => {
 
     it('handles profile-change event', async () => {
       const token = await signToken({
-        [FXA_PROFILE_EVENT_URI]: {
-          email: 'test@mozilla.com',
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
           locale: 'en-US',
-        },
+        }),
       });
 
       await service.handleWebhookEvent(`Bearer ${token}`);
@@ -273,7 +308,7 @@ describe('FxaWebhookService', () => {
     it('handles multiple events in a single SET', async () => {
       const token = await signToken({
         [FXA_PASSWORD_EVENT_URI]: { changeTime: Date.now() },
-        [FXA_PROFILE_EVENT_URI]: { email: 'test@mozilla.com' },
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory(),
       });
 
       await service.handleWebhookEvent(`Bearer ${token}`);
@@ -330,16 +365,23 @@ describe('FxaWebhookService', () => {
 
     it('rejects wrong issuer', async () => {
       // Spread to avoid mutating the shared TEST_KEY (addExtras mutates in-place)
-      const wrongIssuerKey = JWTool.JWK.fromObject({ ...TEST_KEY }, {
-        iss: 'https://wrong-issuer.example.com/',
-      }) as PrivateJWK;
-      const token = await wrongIssuerKey.sign({
-        aud: TEST_AUDIENCE,
-        sub: TEST_UID,
-        iat: Date.now() / 1000,
-        jti: 'test-jti',
-        events: { [FXA_DELETE_EVENT_URI]: {} },
-      });
+      const wrongIssuerKey = JWTool.JWK.fromObject(
+        { ...TEST_KEY },
+        {
+          iss: 'https://wrong-issuer.example.com/',
+        }
+      ) as PrivateJWK;
+      const token = await wrongIssuerKey.sign(
+        FxaSecurityEventTokenPayloadFactory(
+          { [FXA_DELETE_EVENT_URI]: {} },
+          {
+            sub: TEST_UID,
+            aud: MockFxaWebhookConfig.fxaWebhookAudience,
+            iss: MockFxaWebhookConfig.fxaWebhookIssuer,
+            jti: 'test-jti',
+          }
+        )
+      );
 
       await expect(
         service.handleWebhookEvent(`Bearer ${token}`)
@@ -386,7 +428,7 @@ describe('FxaWebhookService', () => {
 
     it('rejects SET payload with missing events field', async () => {
       const token = await privateKey.sign({
-        aud: TEST_AUDIENCE,
+        aud: MockFxaWebhookConfig.fxaWebhookAudience,
         sub: TEST_UID,
         iat: Date.now() / 1000,
         jti: 'test-jti',
@@ -462,6 +504,222 @@ describe('FxaWebhookService', () => {
       await expect(
         service.handleWebhookEvent(`Bearer ${token}`)
       ).rejects.toThrow(FxaWebhookValidationError);
+    });
+  });
+
+  describe('handleProfileChange email sync', () => {
+    const NEW_EMAIL = 'new@mozilla.com';
+    const OLD_EMAIL = 'old@mozilla.com';
+    const STRIPE_CUSTOMER_ID = 'cus_abc123';
+
+    beforeEach(() => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(
+          ResultAccountCustomerFactory({
+            stripeCustomerId: STRIPE_CUSTOMER_ID,
+          })
+        );
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeCustomerFactory({
+              id: STRIPE_CUSTOMER_ID,
+              email: OLD_EMAIL,
+            })
+          )
+        );
+      jest
+        .spyOn(customerManager, 'update')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeCustomerFactory({
+              id: STRIPE_CUSTOMER_ID,
+              email: NEW_EMAIL,
+            })
+          )
+        );
+    });
+
+    it('does nothing when event has no email', async () => {
+      const payload = FxaProfileChangeSecurityEventTokenPayloadFactory(
+        { email: undefined, locale: 'en-US' },
+        {
+          sub: TEST_UID,
+          iss: MockFxaWebhookConfig.fxaWebhookIssuer,
+          aud: MockFxaWebhookConfig.fxaWebhookAudience,
+          jti: 'test-jti',
+        }
+      );
+      const token = await privateKey.sign(payload);
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(
+        accountCustomerManager.getAccountCustomerByUid
+      ).not.toHaveBeenCalled();
+      expect(customerManager.retrieve).not.toHaveBeenCalled();
+      expect(customerManager.update).not.toHaveBeenCalled();
+    });
+
+    it('records no_customer outcome when AccountCustomer is not found', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockRejectedValue(
+          new AccountCustomerNotFoundError(TEST_UID, new Error('not found'))
+        );
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'fxa.webhook.profile_change.email_sync',
+        { outcome: 'no_customer' }
+      );
+      expect(customerManager.retrieve).not.toHaveBeenCalled();
+      expect(customerManager.update).not.toHaveBeenCalled();
+    });
+
+    it('records no_stripe_customer_id outcome when stripeCustomerId is null', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(
+          ResultAccountCustomerFactory({ stripeCustomerId: null })
+        );
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'fxa.webhook.profile_change.email_sync',
+        { outcome: 'no_stripe_customer_id' }
+      );
+      expect(customerManager.retrieve).not.toHaveBeenCalled();
+      expect(customerManager.update).not.toHaveBeenCalled();
+    });
+
+    it('records customer_deleted outcome when Stripe customer is deleted', async () => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockRejectedValue(new CustomerDeletedError(STRIPE_CUSTOMER_ID));
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'fxa.webhook.profile_change.email_sync',
+        { outcome: 'customer_deleted' }
+      );
+      expect(customerManager.update).not.toHaveBeenCalled();
+    });
+
+    it('records no_change outcome when Stripe customer email already matches', async () => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockResolvedValue(
+          StripeResponseFactory(
+            StripeCustomerFactory({
+              id: STRIPE_CUSTOMER_ID,
+              email: NEW_EMAIL,
+            })
+          )
+        );
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'fxa.webhook.profile_change.email_sync',
+        { outcome: 'no_change' }
+      );
+      expect(customerManager.update).not.toHaveBeenCalled();
+    });
+
+    it('updates Stripe customer email and records updated outcome when emails differ', async () => {
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await service.handleWebhookEvent(`Bearer ${token}`);
+
+      expect(customerManager.update).toHaveBeenCalledWith(STRIPE_CUSTOMER_ID, {
+        email: NEW_EMAIL,
+      });
+      expect(statsd.increment).toHaveBeenCalledWith(
+        'fxa.webhook.profile_change.email_sync',
+        { outcome: 'updated' }
+      );
+    });
+
+    it('propagates non-NotFound errors from AccountCustomerManager', async () => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockRejectedValue(new Error('database unreachable'));
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await expect(
+        service.handleWebhookEvent(`Bearer ${token}`)
+      ).rejects.toThrow('database unreachable');
+    });
+
+    it('propagates non-Deleted errors from CustomerManager.retrieve', async () => {
+      jest
+        .spyOn(customerManager, 'retrieve')
+        .mockRejectedValue(new Error('stripe down'));
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await expect(
+        service.handleWebhookEvent(`Bearer ${token}`)
+      ).rejects.toThrow('stripe down');
+    });
+
+    it('propagates errors from CustomerManager.update', async () => {
+      jest
+        .spyOn(customerManager, 'update')
+        .mockRejectedValue(new Error('stripe rate limited'));
+
+      const token = await signToken({
+        [FXA_PROFILE_EVENT_URI]: FxaProfileChangeEventFactory({
+          email: NEW_EMAIL,
+        }),
+      });
+
+      await expect(
+        service.handleWebhookEvent(`Bearer ${token}`)
+      ).rejects.toThrow('stripe rate limited');
     });
   });
 

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.service.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.service.ts
@@ -16,6 +16,11 @@ import {
 } from '@fxa/shared/db/type-cacheable';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
 import { PaymentsGleanService } from '@fxa/payments/metrics';
+import {
+  AccountCustomerManager,
+  AccountCustomerNotFoundError,
+} from '@fxa/payments/stripe';
+import { CustomerManager, CustomerDeletedError } from '@fxa/payments/customer';
 import { FxaWebhookConfig } from './fxa-webhooks.config';
 import {
   FxaWebhookAuthError,
@@ -62,7 +67,9 @@ export class FxaWebhookService {
     private fxaWebhookConfig: FxaWebhookConfig,
     @Inject(StatsDService) private statsd: StatsD,
     @Inject(Logger) private log: LoggerService,
-    private paymentsGleanService: PaymentsGleanService
+    private paymentsGleanService: PaymentsGleanService,
+    private accountCustomerManager: AccountCustomerManager,
+    private customerManager: CustomerManager
   ) {
     this.memoryCacheAdapter = new MemoryAdapter();
     this.fallbackCacheAdapter = new MemoryAdapter();
@@ -276,6 +283,60 @@ export class FxaWebhookService {
     this.log.log('handleProfileChange', { sub, event });
     this.statsd.increment('fxa.webhook.event', {
       eventType: 'profile-change',
+    });
+
+    if (!event.email) {
+      return;
+    }
+
+    let accountCustomer;
+    try {
+      accountCustomer =
+        await this.accountCustomerManager.getAccountCustomerByUid(sub);
+    } catch (error) {
+      if (error instanceof AccountCustomerNotFoundError) {
+        this.statsd.increment('fxa.webhook.profile_change.email_sync', {
+          outcome: 'no_customer',
+        });
+        return;
+      }
+      throw error;
+    }
+
+    if (!accountCustomer.stripeCustomerId) {
+      this.statsd.increment('fxa.webhook.profile_change.email_sync', {
+        outcome: 'no_stripe_customer_id',
+      });
+      return;
+    }
+
+    let customer;
+    try {
+      customer = await this.customerManager.retrieve(
+        accountCustomer.stripeCustomerId
+      );
+    } catch (error) {
+      if (error instanceof CustomerDeletedError) {
+        this.statsd.increment('fxa.webhook.profile_change.email_sync', {
+          outcome: 'customer_deleted',
+        });
+        return;
+      }
+      throw error;
+    }
+
+    if (customer.email === event.email) {
+      this.statsd.increment('fxa.webhook.profile_change.email_sync', {
+        outcome: 'no_change',
+      });
+      return;
+    }
+
+    await this.customerManager.update(accountCustomer.stripeCustomerId, {
+      email: event.email,
+    });
+    this.statsd.increment('fxa.webhook.profile_change.email_sync', {
+      outcome: 'updated',
     });
   }
 

--- a/packages/fxa-auth-server/scripts/sync-stripe-customer-emails.ts
+++ b/packages/fxa-auth-server/scripts/sync-stripe-customer-emails.ts
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+
+import { setupProcessingTaskObjects } from '../lib/payments/processing-tasks-setup';
+import { StripeCustomerEmailSyncer } from './sync-stripe-customer-emails/sync-stripe-customer-emails';
+
+const pckg = require('../package.json');
+
+const parseRateLimit = (rateLimit: string | number) =>
+  parseInt(rateLimit.toString(), 10);
+
+const parseLimit = (limit: string | number) => {
+  const n = parseInt(limit.toString(), 10);
+  return Number.isFinite(n) ? n : Infinity;
+};
+
+async function init() {
+  program
+    .version(pckg.version)
+    .option(
+      '--no-dry-run',
+      'Apply Stripe customer email updates. By default the script runs in dry-run mode and reports without writing.'
+    )
+    .option(
+      '-l, --limit [number]',
+      'Maximum number of Stripe customers to process before stopping.',
+      parseLimit,
+      Infinity
+    )
+    .option(
+      '--starting-after [stripe_id]',
+      'Stripe customer ID to resume listing after.'
+    )
+    .option(
+      '-r, --rate-limit [number]',
+      'Maximum Stripe write operations per second.',
+      parseRateLimit,
+      70
+    )
+    .option(
+      '-o, --output-file [string]',
+      'CSV output file path.',
+      'sync-stripe-customer-emails-output.csv'
+    )
+    .parse(process.argv);
+
+  const { stripeHelper, database, log } = await setupProcessingTaskObjects(
+    'sync-stripe-customer-emails'
+  );
+
+  const syncer = new StripeCustomerEmailSyncer(
+    stripeHelper,
+    database,
+    log,
+    {
+      dryRun: !!program.dryRun,
+      limit: program.limit,
+      startingAfter: program.startingAfter,
+      rateLimit: program.rateLimit,
+      outputFile: program.outputFile,
+    }
+  );
+
+  await syncer.run();
+
+  return 0;
+}
+
+if (require.main === module) {
+  let exitStatus = 1;
+  init()
+    .then((result) => {
+      exitStatus = result;
+    })
+    .catch((err) => {
+      console.error(err);
+    })
+    .finally(() => {
+      process.exit(exitStatus);
+    });
+}

--- a/packages/fxa-auth-server/scripts/sync-stripe-customer-emails/sync-stripe-customer-emails.spec.ts
+++ b/packages/fxa-auth-server/scripts/sync-stripe-customer-emails/sync-stripe-customer-emails.spec.ts
@@ -1,0 +1,356 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import fs from 'fs';
+import Stripe from 'stripe';
+
+import { StripeHelper } from '../../lib/payments/stripe';
+import { StripeCustomerEmailSyncer, SyncOptions } from './sync-stripe-customer-emails';
+
+const VALID_UID = 'a'.repeat(32);
+const STRIPE_CUSTOMER_ID = 'cus_abc123';
+const FXA_EMAIL = 'fxa@mozilla.com';
+const STRIPE_EMAIL = 'stripe@mozilla.com';
+
+function makeCustomer(overrides: Partial<Stripe.Customer> = {}): Stripe.Customer {
+  return {
+    id: STRIPE_CUSTOMER_ID,
+    email: STRIPE_EMAIL,
+    description: VALID_UID,
+    metadata: { userid: VALID_UID },
+    ...overrides,
+  } as Stripe.Customer;
+}
+
+function setupStripeListMock(customers: Stripe.Customer[]) {
+  return {
+    customers: {
+      list: jest.fn().mockReturnValue({
+        async *[Symbol.asyncIterator]() {
+          for (const c of customers) yield c;
+        },
+      }),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+function setupSyncer(
+  stripeMock: any,
+  databaseMock: any,
+  optionsOverrides: Partial<SyncOptions> = {}
+) {
+  const stripeHelper = { stripe: stripeMock } as unknown as StripeHelper;
+  const log = { info: jest.fn() };
+  const options: SyncOptions = {
+    dryRun: true,
+    limit: Infinity,
+    rateLimit: 70,
+    outputFile: '/tmp/sync-stripe-customer-emails-test-output.csv',
+    ...optionsOverrides,
+  };
+  return {
+    syncer: new StripeCustomerEmailSyncer(
+      stripeHelper,
+      databaseMock,
+      log,
+      options
+    ),
+    log,
+  };
+}
+
+describe('StripeCustomerEmailSyncer', () => {
+  let writeMock: jest.Mock;
+  let endMock: jest.Mock;
+  let createWriteStreamSpy: jest.SpyInstance;
+  let writtenRows: string[];
+
+  beforeEach(() => {
+    writtenRows = [];
+    writeMock = jest.fn((line: string) => {
+      writtenRows.push(line);
+      return true;
+    });
+    endMock = jest.fn((cb?: () => void) => {
+      if (cb) cb();
+    });
+    createWriteStreamSpy = jest
+      .spyOn(fs, 'createWriteStream')
+      .mockReturnValue({
+        write: writeMock,
+        end: endMock,
+        on: jest.fn(),
+      } as unknown as fs.WriteStream);
+  });
+
+  afterEach(() => {
+    createWriteStreamSpy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('records skip-no-uid for customers with neither metadata.userid nor description', async () => {
+    const customer = makeCustomer({ metadata: {}, description: null });
+    const stripe = setupStripeListMock([customer]);
+    const database = { account: jest.fn() };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(database.account).not.toHaveBeenCalled();
+    expect(writtenRows.some((row) => row.includes('skip-no-uid'))).toBe(true);
+  });
+
+  it('falls back to customer.description when metadata.userid is missing', async () => {
+    const customer = makeCustomer({
+      metadata: {},
+      description: VALID_UID,
+      email: FXA_EMAIL,
+    });
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(database.account).toHaveBeenCalledWith(VALID_UID);
+    expect(writtenRows.some((row) => row.includes(',ok,'))).toBe(true);
+  });
+
+  it('records skip-invalid-uid when uid does not match expected format', async () => {
+    const customer = makeCustomer({
+      metadata: { userid: 'not-a-hex-uid' },
+      description: 'not-a-hex-uid',
+    });
+    const stripe = setupStripeListMock([customer]);
+    const database = { account: jest.fn() };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(database.account).not.toHaveBeenCalled();
+    expect(writtenRows.some((row) => row.includes('skip-invalid-uid'))).toBe(
+      true
+    );
+  });
+
+  it('records skip-account-not-found when db.account throws Unknown account', async () => {
+    const customer = makeCustomer();
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest.fn().mockRejectedValue(new Error('Unknown account')),
+    };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(stripe.customers.update).not.toHaveBeenCalled();
+    expect(
+      writtenRows.some((row) => row.includes('skip-account-not-found'))
+    ).toBe(true);
+  });
+
+  it('records error when db.account throws an unexpected error', async () => {
+    const customer = makeCustomer();
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest.fn().mockRejectedValue(new Error('database unreachable')),
+    };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(stripe.customers.update).not.toHaveBeenCalled();
+    expect(
+      writtenRows.some(
+        (row) => row.includes(',error,') && row.includes('database unreachable')
+      )
+    ).toBe(true);
+  });
+
+  it('records error when account has no primaryEmail', async () => {
+    const customer = makeCustomer();
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest.fn().mockResolvedValue({ primaryEmail: undefined }),
+    };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(stripe.customers.update).not.toHaveBeenCalled();
+    expect(
+      writtenRows.some(
+        (row) => row.includes(',error,') && row.includes('no primaryEmail')
+      )
+    ).toBe(true);
+  });
+
+  it('records ok when emails already match', async () => {
+    const customer = makeCustomer({ email: FXA_EMAIL });
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const { syncer } = setupSyncer(stripe, database);
+
+    await syncer.run();
+
+    expect(stripe.customers.update).not.toHaveBeenCalled();
+    expect(writtenRows.some((row) => row.includes(',ok,'))).toBe(true);
+  });
+
+  it('records would-update in dry-run when emails differ', async () => {
+    const customer = makeCustomer({ email: STRIPE_EMAIL });
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const { syncer } = setupSyncer(stripe, database, { dryRun: true });
+
+    await syncer.run();
+
+    expect(stripe.customers.update).not.toHaveBeenCalled();
+    expect(writtenRows.some((row) => row.includes('would-update'))).toBe(true);
+  });
+
+  it('updates Stripe customer and records updated when not in dry-run and emails differ', async () => {
+    const customer = makeCustomer({ email: STRIPE_EMAIL });
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const { syncer } = setupSyncer(stripe, database, { dryRun: false });
+
+    await syncer.run();
+
+    expect(stripe.customers.update).toHaveBeenCalledWith(STRIPE_CUSTOMER_ID, {
+      email: FXA_EMAIL,
+    });
+    expect(writtenRows.some((row) => row.includes(',updated,'))).toBe(true);
+  });
+
+  it('records error when Stripe update throws and continues processing', async () => {
+    const customer1 = makeCustomer({ id: 'cus_one', email: STRIPE_EMAIL });
+    const customer2 = makeCustomer({ id: 'cus_two', email: STRIPE_EMAIL });
+    const stripe = setupStripeListMock([customer1, customer2]);
+    stripe.customers.update
+      .mockRejectedValueOnce(new Error('stripe rate limited'))
+      .mockResolvedValueOnce({});
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const { syncer } = setupSyncer(stripe, database, { dryRun: false });
+
+    await syncer.run();
+
+    expect(stripe.customers.update).toHaveBeenCalledTimes(2);
+    expect(
+      writtenRows.some(
+        (row) =>
+          row.includes('cus_one') &&
+          row.includes(',error,') &&
+          row.includes('stripe rate limited')
+      )
+    ).toBe(true);
+    expect(
+      writtenRows.some(
+        (row) => row.includes('cus_two') && row.includes(',updated,')
+      )
+    ).toBe(true);
+  });
+
+  it('writes a CSV header row', async () => {
+    const stripe = setupStripeListMock([]);
+    const { syncer } = setupSyncer(stripe, { account: jest.fn() });
+
+    await syncer.run();
+
+    expect(writtenRows[0]).toBe(
+      'stripe_customer_id,uid,stripe_email,fxa_primary_email,action,error\n'
+    );
+  });
+
+  it('respects the limit option and stops processing when reached', async () => {
+    const customers = [
+      makeCustomer({ id: 'cus_1' }),
+      makeCustomer({ id: 'cus_2' }),
+      makeCustomer({ id: 'cus_3' }),
+    ];
+    const stripe = setupStripeListMock(customers);
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const { syncer } = setupSyncer(stripe, database, { limit: 2 });
+
+    await syncer.run();
+
+    // 1 header row + 2 data rows = 3 lines
+    expect(writtenRows.length).toBe(3);
+  });
+
+  it('rejects when the output stream emits an error', async () => {
+    let capturedErrorListener: ((err: Error) => void) | undefined;
+    createWriteStreamSpy.mockReturnValue({
+      write: writeMock,
+      end: endMock,
+      on: jest.fn((event: string, listener: any) => {
+        if (event === 'error') capturedErrorListener = listener;
+      }),
+    } as unknown as fs.WriteStream);
+
+    const customer = makeCustomer();
+    const stripe = setupStripeListMock([customer]);
+    const database = {
+      account: jest
+        .fn()
+        .mockResolvedValue({ primaryEmail: { email: FXA_EMAIL } }),
+    };
+    const log = { info: jest.fn(), error: jest.fn() };
+    const stripeHelper = { stripe } as any;
+    const syncer = new StripeCustomerEmailSyncer(stripeHelper, database, log, {
+      dryRun: true,
+      limit: Infinity,
+      rateLimit: 70,
+      outputFile: '/tmp/sync-stripe-customer-emails-test-output.csv',
+    });
+
+    capturedErrorListener?.(new Error('disk full'));
+
+    await expect(syncer.run()).rejects.toThrow('disk full');
+    expect(log.error).toHaveBeenCalledWith(
+      'sync-stripe-customer-emails.stream-error',
+      expect.objectContaining({ error: 'disk full' })
+    );
+  });
+
+  it('passes starting_after to Stripe list when provided', async () => {
+    const stripe = setupStripeListMock([]);
+    const { syncer } = setupSyncer(
+      stripe,
+      { account: jest.fn() },
+      { startingAfter: 'cus_resume_token' }
+    );
+
+    await syncer.run();
+
+    expect(stripe.customers.list).toHaveBeenCalledWith({
+      starting_after: 'cus_resume_token',
+    });
+  });
+});

--- a/packages/fxa-auth-server/scripts/sync-stripe-customer-emails/sync-stripe-customer-emails.ts
+++ b/packages/fxa-auth-server/scripts/sync-stripe-customer-emails/sync-stripe-customer-emails.ts
@@ -1,0 +1,278 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import fs from 'fs';
+import Stripe from 'stripe';
+import PQueue from 'p-queue';
+
+import { StripeHelper } from '../../lib/payments/stripe';
+
+const UID_REGEX = /^[0-9a-f]{32}$/;
+const PROGRESS_LOG_INTERVAL = 500;
+
+export type SyncAction =
+  | 'ok'
+  | 'would-update'
+  | 'updated'
+  | 'skip-no-uid'
+  | 'skip-invalid-uid'
+  | 'skip-account-not-found'
+  | 'error';
+
+export interface SyncOptions {
+  dryRun: boolean;
+  limit: number;
+  startingAfter?: string;
+  rateLimit: number;
+  outputFile: string;
+}
+
+interface ResultRow {
+  stripeCustomerId: string;
+  uid: string;
+  stripeEmail: string;
+  fxaPrimaryEmail: string;
+  action: SyncAction;
+  error: string;
+}
+
+function isAccountNotFoundError(err: any): boolean {
+  return err?.message === 'Unknown account';
+}
+
+function csvEscape(value: string): string {
+  if (
+    value.includes(',') ||
+    value.includes('"') ||
+    value.includes('\n') ||
+    value.includes('\r')
+  ) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export class StripeCustomerEmailSyncer {
+  private stripe: Stripe;
+  private stripeQueue: PQueue;
+  private outputStream: fs.WriteStream;
+  private streamError: Error | null = null;
+
+  constructor(
+    private stripeHelper: StripeHelper,
+    private database: any,
+    private log: any,
+    private options: SyncOptions
+  ) {
+    this.stripe = stripeHelper.stripe;
+    this.stripeQueue = new PQueue({
+      intervalCap: options.rateLimit,
+      interval: 1000,
+    });
+    this.outputStream = fs.createWriteStream(options.outputFile);
+    this.outputStream.on('error', (err: Error) => {
+      this.log.error('sync-stripe-customer-emails.stream-error', {
+        error: err.message,
+        outputFile: options.outputFile,
+      });
+      this.streamError = err;
+    });
+    this.outputStream.write(
+      'stripe_customer_id,uid,stripe_email,fxa_primary_email,action,error\n'
+    );
+  }
+
+  async run(): Promise<void> {
+    const counts: Record<SyncAction, number> = {
+      ok: 0,
+      'would-update': 0,
+      updated: 0,
+      'skip-no-uid': 0,
+      'skip-invalid-uid': 0,
+      'skip-account-not-found': 0,
+      error: 0,
+    };
+    let processed = 0;
+
+    const listParams: Stripe.CustomerListParams = {};
+    if (this.options.startingAfter) {
+      listParams.starting_after = this.options.startingAfter;
+    }
+
+    try {
+      for await (const customer of this.stripe.customers.list(listParams)) {
+        if (this.streamError) {
+          throw this.streamError;
+        }
+
+        if (processed >= this.options.limit) {
+          this.log.info('sync-stripe-customer-emails.limit-reached', {
+            stripeCustomerId: customer.id,
+            processed,
+          });
+          break;
+        }
+
+        let row: ResultRow;
+        try {
+          row = await this.processCustomer(customer);
+        } catch (err: any) {
+          row = {
+            stripeCustomerId: customer.id,
+            uid: '',
+            stripeEmail: customer.email ?? '',
+            fxaPrimaryEmail: '',
+            action: 'error',
+            error: err?.message ?? String(err),
+          };
+        }
+
+        this.writeRow(row);
+        counts[row.action]++;
+        processed++;
+
+        if (processed % PROGRESS_LOG_INTERVAL === 0) {
+          this.log.info('sync-stripe-customer-emails.progress', {
+            processed,
+            ...counts,
+            dryRun: this.options.dryRun,
+          });
+        }
+      }
+    } finally {
+      await new Promise<void>((resolve) => this.outputStream.end(resolve));
+      this.log.info('sync-stripe-customer-emails.complete', {
+        processed,
+        ...counts,
+        dryRun: this.options.dryRun,
+      });
+    }
+  }
+
+  private async processCustomer(
+    customer: Stripe.Customer
+  ): Promise<ResultRow> {
+    const stripeEmail = customer.email ?? '';
+    const uidCandidate =
+      (customer.metadata && customer.metadata.userid) ||
+      customer.description ||
+      '';
+
+    if (!uidCandidate) {
+      return {
+        stripeCustomerId: customer.id,
+        uid: '',
+        stripeEmail,
+        fxaPrimaryEmail: '',
+        action: 'skip-no-uid',
+        error: 'no uid in metadata.userid or description',
+      };
+    }
+
+    if (!UID_REGEX.test(uidCandidate)) {
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail: '',
+        action: 'skip-invalid-uid',
+        error: `uid does not match expected format: ${uidCandidate}`,
+      };
+    }
+
+    let account: any;
+    try {
+      account = await this.database.account(uidCandidate);
+    } catch (err: any) {
+      if (isAccountNotFoundError(err)) {
+        return {
+          stripeCustomerId: customer.id,
+          uid: uidCandidate,
+          stripeEmail,
+          fxaPrimaryEmail: '',
+          action: 'skip-account-not-found',
+          error: '',
+        };
+      }
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail: '',
+        action: 'error',
+        error: err?.message ?? String(err),
+      };
+    }
+
+    const fxaPrimaryEmail = account?.primaryEmail?.email ?? '';
+
+    if (!fxaPrimaryEmail) {
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail: '',
+        action: 'error',
+        error: 'fxa account has no primaryEmail',
+      };
+    }
+
+    if (stripeEmail === fxaPrimaryEmail) {
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail,
+        action: 'ok',
+        error: '',
+      };
+    }
+
+    if (this.options.dryRun) {
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail,
+        action: 'would-update',
+        error: '',
+      };
+    }
+
+    try {
+      await this.stripeQueue.add(() =>
+        this.stripe.customers.update(customer.id, { email: fxaPrimaryEmail })
+      );
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail,
+        action: 'updated',
+        error: '',
+      };
+    } catch (err: any) {
+      return {
+        stripeCustomerId: customer.id,
+        uid: uidCandidate,
+        stripeEmail,
+        fxaPrimaryEmail,
+        action: 'error',
+        error: err?.message ?? String(err),
+      };
+    }
+  }
+
+  private writeRow(row: ResultRow): void {
+    this.outputStream.write(
+      [
+        csvEscape(row.stripeCustomerId),
+        csvEscape(row.uid),
+        csvEscape(row.stripeEmail),
+        csvEscape(row.fxaPrimaryEmail),
+        csvEscape(row.action),
+        csvEscape(row.error),
+      ].join(',') + '\n'
+    );
+  }
+}


### PR DESCRIPTION
Because:

* In SubPlat 3.0 we lost the ability to update a Stripe Customer's email when the FxA account was updated. This has caused confusion and misalignment for customer support, stripe automated emails, and more

In this commit:

* Adds in a script (sync-stripe-customer-emails.ts) to backport mismatched emails
* Wires up logic into the handleProfileChange payments-api webhook handler, to conditionally find and update the Stripe Customer's email when appropriate
* Adds tests, and refactors test cases that had fallen out of sync with our NestJS DI framework pattern

Closes #PAY-3576

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
