### PR TITLE
fix(settings): Add entrypoint param to subscriptions link

### DIFF
--- a/packages/fxa-settings/src/components/Settings/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/Nav/index.tsx
@@ -50,7 +50,7 @@ export const Nav = ({
     )}`;
   const subscriptionLink = config.featureFlags
     ?.paymentsNextSubscriptionManagement
-    ? `${config.servers.paymentsNext.url}/subscriptions/landing`
+    ? `${config.servers.paymentsNext.url}/subscriptions/landing?entrypoint=internal_nav`
     : '/subscriptions';
 
   useEffect(() => {


### PR DESCRIPTION
## This pull request

- Adds 'internal_nav' value as entrypoint value to subscriptions

## Issue that this pull request solves

Closes: PAY-3679

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.