### PR TITLE
fix(auth): Use fxaMailer for verifyShortCode email

### DIFF
--- a/libs/accounts/email-renderer/src/partials/cmsEmail/index.ts
+++ b/libs/accounts/email-renderer/src/partials/cmsEmail/index.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export type TemplateData = {
+  cmsRpClientId?: string;
+  cmsRpFromName?: string;
+  entrypoint?: string;
+  subject?: string;
+  headline?: string;
+  description?: string;
+  target?: 'index' | 'strapi';
+};

--- a/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
+++ b/libs/accounts/email-renderer/src/renderer/__snapshots__/fxa-email-renderer.spec.ts.snap
@@ -21539,6 +21539,399 @@ exports[`FxA Email Renderer should render renderVerifySecondaryCode: matches ful
   </body></html>"
 `;
 
+exports[`FxA Email Renderer should render renderVerifyShortCode with CMS: matches full email snapshot 1`] = `
+"<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
+    <title>Strapi subject</title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      #outlook a { padding:0; }
+      body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+      table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+      img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+      p { display:block;margin:13px 0; }
+    </style>
+    <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+    <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+    
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+    
+    
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+    <style media="screen and (min-width:480px)">
+      .moz-text-html .mj-column-per-100 { width:100% !important; max-width: 100%; }
+    </style>
+    
+    
+  
+    
+    <style type="text/css">
+
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile { width: 100% !important; }
+      td.mj-full-width-mobile { width: auto !important; }
+    }
+  
+    </style>
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+  </head>
+  <body style="word-spacing:normal;">
+    
+    
+      <div aria-label="Strapi subject" aria-roledescription="email" style="" role="article" lang="und" dir="auto">
+        
+      
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="body-outlook" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div class="body" style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="center" class="mozilla-logo" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+        <tbody>
+          <tr>
+            <td style="width:100px;" data-l10n-id="fxa-header-mozilla-logo"><img alt="Mozilla logo" src="http://localhost:3030/logo.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="100" height="auto" data-l10n-name="mozilla-logo"></td>
+          </tr>
+        </tbody>
+      </table>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-header" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span>Strapi test headline</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span>Strapi test description</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body-grey" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="device-all" data-l10n-args="{&quot;uaBrowser&quot;:&quot;Firefox&quot;,&quot;uaOS&quot;:&quot;Windows&quot;,&quot;uaOSVersion&quot;:&quot;100&quot;}">Firefox on Windows 100</span>
+      
+    
+  
+
+        <br>
+      
+      
+        
+
+
+  
+    
+      <span data-l10n-id="location-all" data-l10n-args="{&quot;city&quot;:&quot;San Francisco&quot;,&quot;stateCode&quot;:&quot;CA&quot;,&quot;country&quot;:&quot;US&quot;}">San Francisco, CA, US (estimated)</span>
+    
+  
+
+        <br>
+      
+      
+        Jan 1, 2024
+        <br></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-body" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="verifyShortCode-prompt-3">Use this confirmation code:</span></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="code-large" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">345678</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-body-no-margin" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="verifyShortCode-expiry-notice">It expires in 5 minutes.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer-automatedEmail" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><span data-l10n-id="automated-email-no-action">This is an automated email. If you received it by mistake, you don’t need to do anything. For more info, visit <a class="link-blue" href="http://localhost:3030/support" data-l10n-name="supportLink">Mozilla Support</a>.</span></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    
+      
+      <div style="margin:0px auto;max-width:600px;">
+        
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+            
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+        
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
+          
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Mozilla. 149 New Montgomery St, 4th Floor, San Francisco, CA 94105</div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-privacy-url-2" href="http://localhost:3030/privacy">Mozilla Accounts Privacy Notice</a></div>
+    
+                </td>
+              </tr>
+            
+              <tr>
+                <td align="left" class="text-footer" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                  
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a class="link-blue" data-l10n-id="moz-accounts-terms-url" href="https://www.mozilla.org/about/legal/terms/services/">Mozilla Accounts Terms of Service</a></div>
+    
+                </td>
+              </tr>
+            
+        </tbody>
+      </table>
+    
+      </div>
+    
+          <!--[if mso | IE]></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
+      </div>
+    
+      
+      <!--[if mso | IE]></td></tr></table><![endif]-->
+    
+    
+      </div>
+    
+  
+
+  </body></html>"
+`;
+
 exports[`FxA Email Renderer should render renderVerifyShortCode: matches full email snapshot 1`] = `
 "<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
     <title>Use 345678 to confirm your account</title>

--- a/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
+++ b/libs/accounts/email-renderer/src/renderer/fxa-email-renderer.spec.ts
@@ -809,4 +809,23 @@ describe('FxA Email Renderer', () => {
     expect(email).toBeDefined();
     expect(email.html).toMatchSnapshot('matches full email snapshot');
   });
+
+  it('should render renderVerifyShortCode with CMS', async () => {
+    const email = await renderer.renderVerifyShortCode({
+      date: 'Jan 1, 2024',
+      device: mockDevice,
+      location: mockLocation,
+      code: '345678',
+      ...defaultLayoutTemplateValues,
+      // these are the cmsEmail partial values, should show in the resulting
+      // snapshot if properly passed through. Other values on the partial (cmsRpClientId) aren't
+      // used for rendering, only for sending
+      subject: 'Strapi subject',
+      headline: 'Strapi test headline',
+      description: 'Strapi test description',
+      target: 'strapi',
+    });
+    expect(email).toBeDefined();
+    expect(email.html).toMatchSnapshot('matches full email snapshot');
+  });
 });

--- a/libs/accounts/email-renderer/src/templates/newDeviceLogin/index.ts
+++ b/libs/accounts/email-renderer/src/templates/newDeviceLogin/index.ts
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as CmsEmailTemplateData } from '../../partials/cmsEmail';
 import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
 
 export type TemplateData = AutomatedEmailNoActionTemplateData &
+  CmsEmailTemplateData &
   UserInfoTemplateData & {
     date: string;
     time: string;
@@ -14,12 +16,6 @@ export type TemplateData = AutomatedEmailNoActionTemplateData &
     link: string;
     mozillaSupportUrl: string;
     showBannerWarning: boolean;
-    cmsRpClientId?: string;
-    cmsRpFromName?: string;
-    entrypoint?: string;
-    subject?: string;
-    headline?: string;
-    description?: string;
   };
 
 export const template = 'newDeviceLogin';

--- a/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSigninOtp/index.ts
@@ -3,22 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as CmsEmailTemplateData } from '../../partials/cmsEmail';
 import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
 
 export type TemplateData = AutomatedEmailNoActionTemplateData &
+  CmsEmailTemplateData &
   UserInfoTemplateData & {
     code: string;
     codeExpiryMinutes: number;
     time: string;
     date: string;
-
-    cmsRpClientId?: string;
-    cmsRpFromName?: string;
-    entrypoint?: string;
-    subject?: string;
-    headline?: string;
-    description?: string;
-    target: 'index' | 'strapi';
   };
 
 export const template = 'passwordlessSigninOtp';
@@ -34,4 +28,3 @@ export const includes = {
     message: 'Code expires in <%- codeExpiryMinutes %> minutes',
   },
 };
-

--- a/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.ts
+++ b/libs/accounts/email-renderer/src/templates/passwordlessSignupOtp/index.ts
@@ -3,22 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as CmsEmailTemplateData } from '../../partials/cmsEmail';
 import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
 
 export type TemplateData = AutomatedEmailNoActionTemplateData &
+  CmsEmailTemplateData &
   UserInfoTemplateData & {
     code: string;
     codeExpiryMinutes: number;
     time: string;
     date: string;
-
-    cmsRpClientId?: string;
-    cmsRpFromName?: string;
-    entrypoint?: string;
-    subject?: string;
-    headline?: string;
-    description?: string;
-    target: 'index' | 'strapi';
   };
 
 export const template = 'passwordlessSignupOtp';

--- a/libs/accounts/email-renderer/src/templates/verifyLoginCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyLoginCode/index.ts
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TemplateData as AutomatedEmailChangePasswordTemplateData } from '../../partials/automatedEmailChangePassword';
+import { TemplateData as CmsEmailTemplateData } from '../../partials/cmsEmail';
 import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
 
 export type TemplateData = AutomatedEmailChangePasswordTemplateData &
+  CmsEmailTemplateData &
   UserInfoTemplateData & {
     code: string;
     passwordChangeLink: string;
@@ -22,13 +24,6 @@ export type TemplateData = AutomatedEmailChangePasswordTemplateData &
       city: string;
     };
     date: string;
-
-    cmsRpClientId?: string;
-    cmsRpFromName?: string;
-    entrypoint?: string;
-    subject?: string;
-    headline?: string;
-    description?: string;
   };
 
 export const template = 'verifyLoginCode';

--- a/libs/accounts/email-renderer/src/templates/verifyShortCode/index.ts
+++ b/libs/accounts/email-renderer/src/templates/verifyShortCode/index.ts
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { TemplateData as AutomatedEmailNoActionTemplateData } from '../../partials/automatedEmailNoAction';
+import { TemplateData as CmsEmailTemplateData } from '../../partials/cmsEmail';
 import { TemplateData as UserInfoTemplateData } from '../../partials/userInfo';
 
 export type TemplateData = AutomatedEmailNoActionTemplateData &
+  CmsEmailTemplateData &
   UserInfoTemplateData & {
     code: string;
     device: {
@@ -19,12 +21,6 @@ export type TemplateData = AutomatedEmailNoActionTemplateData &
       city: string;
     };
     date: string;
-    cmsRpClientId?: string;
-    cmsRpFromName?: string;
-    entrypoint?: string;
-    subject?: string;
-    headline?: string;
-    description?: string;
     time?: string;
   };
 

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -1188,12 +1188,15 @@ describe('/account/create', () => {
   describe('should accept `verficationMethod`', () => {
     describe('email-otp', () => {
       it('should send sign-up code from `email-otp` method', async () => {
-        const { config, emailCode, mockMailer, mockRequest, route } = setup();
+        const { config, emailCode, mockFxaMailer, mockRequest, route } =
+          setup();
 
         mockRequest.payload.verificationMethod = 'email-otp';
 
         await runTest(route, mockRequest, (res: any) => {
-          expect(mockMailer.sendVerifyShortCodeEmail).toHaveBeenCalledTimes(1);
+          expect(mockFxaMailer.sendVerifyShortCodeEmail).toHaveBeenCalledTimes(
+            1
+          );
 
           const authenticator = new otplib.authenticator.Authenticator();
           authenticator.options = Object.assign(
@@ -1203,13 +1206,13 @@ describe('/account/create', () => {
             { secret: emailCode }
           );
           const expectedCode = authenticator.generate();
-          const args = mockMailer.sendVerifyShortCodeEmail.mock.calls[0];
-          expect(args[2].code).toBe(expectedCode);
-          expect(args[2].acceptLanguage).toBe(mockRequest.app.acceptLanguage);
-
-          expect(args[2].location).toBe(mockRequest.app.geo.location);
-
-          expect(args[2].timeZone).toBe(mockRequest.app.geo.timeZone);
+          const args = mockFxaMailer.sendVerifyShortCodeEmail.mock.calls[0];
+          expect(args[0].code).toBe(expectedCode);
+          expect(args[0].location).toEqual({
+            stateCode: mockRequest.app.geo.location.stateCode,
+            country: mockRequest.app.geo.location.country,
+            city: mockRequest.app.geo.location.city,
+          });
 
           expect(res.verificationMethod).toBe(
             mockRequest.payload.verificationMethod
@@ -1289,17 +1292,16 @@ describe('/account/create', () => {
         verificationMethod: 'email-otp',
       },
     });
-    const { mockMailer, mockRequest, route } = setup({}, mockRequestOpts);
+    const { mockFxaMailer, mockRequest, route } = setup({}, mockRequestOpts);
 
     const now = Date.now();
     jest.useFakeTimers();
     jest.setSystemTime(now);
 
     return runTest(route, mockRequest, () => {
-      expect(mockMailer.sendVerifyShortCodeEmail).toHaveBeenCalledTimes(1);
-      const args = mockMailer.sendVerifyShortCodeEmail.mock.calls[0];
-      const emailMessage = args[2];
-      expect(emailMessage.target).toBe('strapi');
+      expect(mockFxaMailer.sendVerifyShortCodeEmail).toHaveBeenCalledTimes(1);
+      const args = mockFxaMailer.sendVerifyShortCodeEmail.mock.calls[0];
+      const emailMessage = args[0];
       expect(emailMessage.cmsRpClientId).toBe('00f00f');
       expect(emailMessage.cmsRpFromName).toBe('Testo Inc.');
       expect(emailMessage.entrypoint).toBe('testo');
@@ -2041,6 +2043,7 @@ describe('/account/set_password', () => {
       }
     );
     const mockMailer = mocks.mockMailer();
+    const mockFxaMailer = mocks.mockFxaMailer();
     const mockPush = mocks.mockPush();
     const verificationReminders = mocks.mockVerificationReminders();
     const subscriptionAccountReminders = mocks.mockVerificationReminders();
@@ -2087,6 +2090,7 @@ describe('/account/set_password', () => {
       mockDB,
       mockLog,
       mockMailer,
+      mockFxaMailer,
       mockMetricsContext,
       mockRequest,
       route,
@@ -2101,7 +2105,7 @@ describe('/account/set_password', () => {
       route,
       mockRequest,
       mockDB,
-      mockMailer,
+      mockFxaMailer,
       subscriptionAccountReminders,
       uid,
     } = setup({
@@ -2112,7 +2116,7 @@ describe('/account/set_password', () => {
     });
     return runTest(route, mockRequest, (response: any) => {
       expect(mockDB.resetAccount).toHaveBeenCalledTimes(1);
-      expect(mockMailer.sendVerifyShortCodeEmail).toHaveBeenCalledTimes(1);
+      expect(mockFxaMailer.sendVerifyShortCodeEmail).toHaveBeenCalledTimes(1);
       expect(subscriptionAccountReminders.create).toHaveBeenCalledTimes(1);
       expect(response.sessionToken).toBeTruthy();
       expect(response.uid).toBe(uid);

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -391,11 +391,23 @@ export class AccountHandler {
           );
 
           if (!rpCmsConfig || !rpCmsConfig.VerifyShortCodeEmail) {
-            await this.mailer.sendVerifyShortCodeEmail(
-              [],
-              account,
-              emailContext
-            );
+            if (this.fxaMailer.canSend('verifyShortCode')) {
+              await this.fxaMailer.sendVerifyShortCodeEmail({
+                ...FxaMailerFormat.account(account),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.sync(form.service || query.service || false),
+                code,
+              });
+            } else {
+              await this.mailer.sendVerifyShortCodeEmail(
+                [],
+                account,
+                emailContext
+              );
+            }
           } else {
             const metricsContext = await request.app.metricsContext;
             const rpEmailContext = {
@@ -409,12 +421,28 @@ export class AccountHandler {
               logoWidth: rpCmsConfig?.shared?.emailLogoWidth,
               ...rpCmsConfig.VerifyShortCodeEmail,
             };
-
-            await this.mailer.sendVerifyShortCodeEmail(
-              [],
-              account,
-              rpEmailContext
-            );
+            if (this.fxaMailer.canSend('verifyShortCode')) {
+              await this.fxaMailer.sendVerifyShortCodeEmail({
+                ...FxaMailerFormat.account(account),
+                ...(await FxaMailerFormat.metricsContext(request)),
+                ...FxaMailerFormat.localTime(request),
+                ...FxaMailerFormat.location(request),
+                ...FxaMailerFormat.device(request),
+                ...FxaMailerFormat.sync(form.service || query.service || false),
+                ...FxaMailerFormat.cmsLogo(rpCmsConfig.shared),
+                ...FxaMailerFormat.cmsEmailSubject(
+                  rpCmsConfig.VerifyShortCodeEmail
+                ),
+                ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
+                code,
+              });
+            } else {
+              await this.mailer.sendVerifyShortCodeEmail(
+                [],
+                account,
+                rpEmailContext
+              );
+            }
           }
           break;
         }
@@ -1476,6 +1504,7 @@ export class AccountHandler {
                   ...FxaMailerFormat.cmsRpInfo(rpCmsConfig),
                   clientName: clientInfo.name,
                   showBannerWarning: false,
+                  target: 'strapi',
                 });
               } else {
                 const rpEmailContext = {

--- a/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
+++ b/packages/fxa-auth-server/lib/senders/fxa-mailer.ts
@@ -495,10 +495,7 @@ export class FxaMailer extends FxaEmailRenderer {
       { 'X-Link': links.passwordChangeLink },
       opts
     );
-    const rendered = await this.renderNewDeviceLogin({
-      ...opts,
-      ...links,
-    });
+    const rendered = await this.renderNewDeviceLogin({ ...opts, ...links });
 
     return this.sendEmail(opts, headers, rendered);
   }


### PR DESCRIPTION
## Because:

 - We were not using the new fxaMailer for verifyShortCode emails
 - Email templates were having to re-define cms properties each time

## This Commit:

 - Updates to use the fxaMailer for verifyShortCode emails
 - Adds a shared CmsEmailTemplateData to make properties similar between
   cms emails, including a target value for subject localization
 - Updates appropriate tests

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
