### PR TITLE
fix(auth): remove prefixing on saved ip for security events

### DIFF
--- a/packages/fxa-shared/db/models/auth/security-event.ts
+++ b/packages/fxa-shared/db/models/auth/security-event.ts
@@ -91,11 +91,6 @@ export function sanitizeIp(addr: string) {
     addr = addr.split(',')[0].trim();
   }
 
-  // Pefix with :: for v6 formatting
-  if (ip.isV4Format(addr)) {
-    addr = '::' + addr;
-  }
-
   return addr.trim();
 }
 
@@ -103,7 +98,27 @@ function ipHmac(key: Buffer, uid: Buffer, addr: string) {
   addr = sanitizeIp(addr);
   const hmac = crypto.createHmac('sha256', key);
   hmac.update(uid);
-  hmac.update(ip.toBuffer(sanitizeIp(addr)));
+  hmac.update(ip.toBuffer(addr));
+
+  return hmac.digest();
+}
+/**
+ * This is used during lookups only to match records written before we
+ * stopped prefixing ipv4 addresses; FXA-13433.
+ *
+ * After some amount of time, we will have more recent login records with the new HMAC than
+ * the old, and we can remove this legacy HMAC function and the associated tests.
+ *
+ * Cleanup ticket: https://mozilla-hub.atlassian.net/browse/FXA-13667
+ */
+function ipHmacLegacy(key: Buffer, uid: Buffer, addr: string) {
+  addr = sanitizeIp(addr);
+  if (ip.isV4Format(addr)) {
+    addr = '::' + addr;
+  }
+  const hmac = crypto.createHmac('sha256', key);
+  hmac.update(uid);
+  hmac.update(ip.toBuffer(addr));
 
   return hmac.digest();
 }
@@ -185,7 +200,8 @@ export class SecurityEvent extends BaseAuthModel {
 
   static async findByUidAndIP(uid: string, ipAddr: string, ipHmacKey: string) {
     const id = uuidTransformer.to(uid);
-    const ipAddrHmac = ipHmac(Buffer.from(ipHmacKey), id, ipAddr);
+    const key = Buffer.from(ipHmacKey);
+    const hmacs = [ipHmac(key, id, ipAddr), ipHmacLegacy(key, id, ipAddr)];
     return SecurityEvent.query()
       .select(
         'securityEventNames.name as name',
@@ -200,7 +216,7 @@ export class SecurityEvent extends BaseAuthModel {
         'securityEventNames.id'
       )
       .where('securityEvents.uid', id)
-      .andWhere('securityEvents.ipAddrHmac', ipAddrHmac)
+      .whereIn('securityEvents.ipAddrHmac', hmacs)
       .orderBy('securityEvents.createdAt', 'DESC')
       .limit(20);
   }
@@ -211,7 +227,8 @@ export class SecurityEvent extends BaseAuthModel {
     ipHmacKey: string
   ) {
     const id = uuidTransformer.to(uid);
-    const ipAddrHmac = ipHmac(Buffer.from(ipHmacKey), id, ipAddr);
+    const key = Buffer.from(ipHmacKey);
+    const hmacs = [ipHmac(key, id, ipAddr), ipHmacLegacy(key, id, ipAddr)];
     return SecurityEvent.query()
       .select(
         'securityEventNames.name as name',
@@ -228,7 +245,7 @@ export class SecurityEvent extends BaseAuthModel {
       .where('securityEvents.uid', id)
       .where('securityEvents.verified', 1)
       .where('securityEvents.nameId', EVENT_NAMES['account.login'])
-      .andWhere('securityEvents.ipAddrHmac', ipAddrHmac)
+      .whereIn('securityEvents.ipAddrHmac', hmacs)
       .orderBy('securityEvents.createdAt', 'DESC')
       .limit(20);
   }

--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -672,25 +672,20 @@ describe('security-event', async () => {
   describe('sanitizes ip address', () => {
     it('handles multiple ips', () => {
       const ip = sanitizeIp(' 127.0.0.1, 127.0.0.2');
-      assert.equal(ip, '::127.0.0.1');
+      assert.equal(ip, '127.0.0.1');
     });
     it('handles ip v4', () => {
       const ip = sanitizeIp('127.0.0.1');
-      assert(ip, '::127.0.0.1');
+      assert.equal(ip, '127.0.0.1');
     });
 
-    it('handles ip v4 with spaces', () => {
-      const ip = sanitizeIp('127.0.0.1  ');
-      assert.equal(ip, '::127.0.0.1');
+    it('trims whitespace', () => {
+      const ip = sanitizeIp(' 127.0.0.1  ');
+      assert.equal(ip, '127.0.0.1');
     });
 
     it('handles multiple ip v6', () => {
       const ip = sanitizeIp('2001:db8::1111, 2001:db8::2222');
-      assert.equal(ip, '2001:db8::1111');
-    });
-
-    it('handles multiple ip v6 with spaces', () => {
-      const ip = sanitizeIp(' 2001:db8::1111 ');
       assert.equal(ip, '2001:db8::1111');
     });
   });


### PR DESCRIPTION
Because:
 - We were prefixing ipv4 addresses with "::" and we shouldn't

This Commit:
 - Removes the prefixing from the writes moving forward
 - Adds a `whereIn` clause to the lookup so we can lookup with and without the prefix to maintain backwards compatibility with the ip bypass

Closes: FXA-13433

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
