### PR TITLE
chore(claude): add testing guidelines and fxa-test-* skills

### DIFF
--- a/.claude/skills/fxa-check-react/SKILL.md
+++ b/.claude/skills/fxa-check-react/SKILL.md
@@ -133,6 +133,37 @@ Focus on `.tsx`, `.ts`, `.jsx`, `.js` files. Read additional context from relate
 
 ---
 
+### 5. Testing Patterns (React/TSX)
+
+These are the React-specific test concerns to apply on top of the general FXA testing rules in `.claude/skills/fxa-testing-shared/GUIDELINES.md`. Apply both: the shared rules cover assertions, mocking, isolation, and async correctness; this section covers what's unique to component tests.
+
+**Querying by implementation detail**
+- Tests selecting by `className`, CSS selectors, `data-testid` (when a semantic query exists), refs, or component instances
+- Recommendation: prefer Testing Library queries that mirror how users find elements — `getByRole` (with `name` option), `getByLabelText`, `getByText`. `data-testid` is a last resort when no semantic query fits.
+
+**`fireEvent` instead of `userEvent`**
+- `fireEvent.click(...)`, `fireEvent.change(...)` for user interactions
+- Recommendation: use `userEvent` (`@testing-library/user-event`); it dispatches the full event sequence (focus → keydown → input → change → blur) that real interactions produce, surfacing bugs `fireEvent` misses
+
+**Asserting on component internals**
+- Reading `instance()`, `state()`, refs, or private hooks via Enzyme-style or test-only escape hatches
+- Recommendation: assert on rendered output (DOM, accessible names, ARIA states) — the user-visible contract, not the implementation
+
+**Missing or misused `act()`**
+- State updates in tests not wrapped in `act` produce console warnings and can cause flakiness
+- Most async Testing Library helpers (`findBy*`, `waitFor`) wrap `act` internally — reach for them before manually wrapping
+- Recommendation: prefer `findBy*` / `waitFor` for async UI changes; only manually `act(() => ...)` when no helper fits
+
+**Snapshot tests for non-trivial components**
+- Large `toMatchSnapshot()` outputs that get regenerated without scrutiny on every change
+- Recommendation: assert on specific user-observable properties (text content, ARIA attributes, presence of specific elements) instead of whole-tree snapshots; reserve snapshots for small, stable, hard-to-articulate output (e.g., serialized error messages)
+
+**Provider boilerplate duplicated per test**
+- Each test re-wrapping the component in the same chain of `MockedProvider` / `IntlProvider` / Router providers
+- Recommendation: extract a `renderWithProviders(ui, options)` helper in a test util; reuse across the suite
+
+---
+
 ## Output Format
 
 Lead with a **summary table** of all findings (severity, category, file:line, one-line description). Follow with detailed write-ups for High severity items. End with a **"Clean categories"** list for anything with no issues found.

--- a/.claude/skills/fxa-review-quick/SKILL.md
+++ b/.claude/skills/fxa-review-quick/SKILL.md
@@ -62,14 +62,26 @@ Evaluate the diff through these lenses, in order of priority:
 - Hapi route handlers that catch and re-throw instead of letting the error pipeline handle it
 
 **4. Tests**
+
+Apply the FXA testing rules in `.claude/skills/fxa-testing-shared/GUIDELINES.md` (read it before reviewing test changes). Common quick-review triggers:
+
 - New auth-server source files without co-located `*.spec.ts`; fxa-settings uses `*.test.tsx` convention
-- `jest.clearAllMocks()` in `beforeEach` — unnecessary, `clearMocks: true` is global
+- `jest.clearAllMocks()` in `beforeEach` — redundant only when the package's `jest.config.*` sets `clearMocks: true` (currently `fxa-auth-server` and `fxa-profile-server`); do not flag in other packages without checking their config
+- `mockClear`/`mockReset`/`jest.clearAllMocks`/`jest.resetAllMocks` called **inside** an `it()` body — band-aid for state leakage from prior tests or shared setup; fix the isolation instead
 - `proxyquire` in new test code — should use `jest.mock()`
 - New Mocha tests in `test/local/` or `test/remote/` — new tests must be Jest
-- Over-mocked tests that only test mock wiring
+- Over-mocked tests that only test mock wiring; mocking internal helpers in the same package instead of at system boundaries
+- Tautological mocks: mock returns `X`, assertion checks for `X`, no real logic in between
+- Untyped mocks where the real interface is available — typed mocks (`jest.Mocked<T>`) catch contract drift
+- Soft matchers used to make tests pass: `expect.anything()`, `expect.any(Object)`, broad `expect.objectContaining({})` with one trivial key
+- `forEach` / `for` loops driving multiple `expect` calls inside one `it()` body — use `it.each` so each case is independently reported
+- Manually bumped per-test timeouts (`it('...', async () => {...}, 30_000)`, `jest.setTimeout(...)` for a single file) — usually masks a real timer or unmocked I/O
 - Prefer `jest.useFakeTimers()` and `jest.setSystemTime()` over `setTimeout` or mocking `Date.now` directly
 - Flag patterns likely to cause open handle warnings (unclosed connections, uncleared timers)
 - Flag missing `act()` wrapping in React test state updates
+- Committed `it.only`, `describe.only`, `fit`, `fdescribe` — silently skips the rest of the suite, never acceptable. `it.skip`, `xit`, `xdescribe`, `it.todo` — flag only when there is no comment explaining the skip; a justified skip (ideally with a Jira/issue reference) is acceptable
+- For `*.test.tsx` in `fxa-settings`: also apply `.claude/skills/fxa-check-react/SKILL.md` Section 5 (querying by role, `userEvent` over `fireEvent`, no asserting on refs/instances)
+- Route/component tests with many fixtures-per-branch (>~3 tests differing only in input shape) — heavy branching at the route/component level signals the rule should be extracted and unit-tested directly; reserve route/component tests for wiring
 
 **5. Database Migrations**
 - Edits to existing published migration files — CRITICAL, never allowed

--- a/.claude/skills/fxa-review/SKILL.md
+++ b/.claude/skills/fxa-review/SKILL.md
@@ -105,20 +105,28 @@ Output JSON array with fields: severity, category ("Logic/Bugs"), subcategory, f
 - model: opus
 - description: FXA test quality review
 
-Tell this agent it is a QA engineer who understands FXA's testing patterns and common flakiness causes. It should:
+Tell this agent it is a QA engineer who understands FXA's testing patterns and common flakiness causes. Tell it to read `.claude/skills/fxa-testing-shared/GUIDELINES.md` before reviewing — that file is the authoritative rule set; the bullets below are the FXA-specific triggers to apply on top of it.
 
 - Check new auth-server source files have co-located `*.spec.ts`; fxa-settings uses `*.test.tsx` convention
 - Flag new Mocha tests — all new tests must be Jest
 - Flag `proxyquire` in new code — should use `jest.mock()`
-- Check mock quality: tests that only assert output matches what the mock returns (tautological)
+- Check mock quality: tests that only assert output matches what the mock returns (tautological — mock returns `X`, assertion checks for `X`, no real logic in between)
 - Verify interaction assertions: `.toHaveBeenCalledWith()` on mocked dependencies, not just checking return values
-- Flag `jest.clearAllMocks()` in `beforeEach` — unnecessary, `clearMocks: true` is global
+- Flag `jest.clearAllMocks()` in `beforeEach` only when the package's `jest.config.*` sets `clearMocks: true` (currently `fxa-auth-server` and `fxa-profile-server`). In other packages it is required to reset mock state between tests — do not recommend removing it without verifying the project config.
+- Flag `mockClear`/`mockReset`/`jest.clearAllMocks`/`jest.resetAllMocks` calls **inside** an `it()` body — these are usually band-aids covering up state leaking from prior tests or shared setup; the fix is proper isolation, not inline clearing
 - Check for shared mutable state between tests, missing `await`, `setTimeout` in tests
 - Prefer `jest.useFakeTimers()` and `jest.setSystemTime()` over `setTimeout` or mocking `Date.now` directly
+- Flag manually bumped per-test timeouts (`it('...', async () => {...}, 30_000)`, `jest.setTimeout(30_000)` for a single file) — usually masks a real timer or unmocked I/O dependency
 - Flag patterns likely to cause open handle warnings (unclosed connections, uncleared timers)
 - Flag missing `act()` wrapping in React test state updates
-- Flag over-mocking: mocking internal functions in the same package instead of at system boundaries
+- Flag over-mocking: mocking internal functions in the same package instead of at system boundaries; mocking too aggressively obscures the behavior under test
+- Flag untyped mocks (`const mockFoo = { bar: jest.fn() }`) where the real interface could be used — typed mocks (`jest.Mocked<T>`) catch contract drift on the unit under test
+- Flag soft matchers used to make tests pass: `expect.anything()`, `expect.any(Object)`, broad `expect.objectContaining({})` with one trivial key. `expect.any(<Type>)` is fine for genuinely non-deterministic fields (timestamps, random IDs)
+- Flag `forEach` / `for` loops with `expect` calls inside a single `it()` body — use `it.each` so each case is named and independently reported
+- Flag committed `it.only`, `describe.only`, `fit`, `fdescribe` (silently skips the rest of the suite — CRITICAL/HIGH if it lands in CI). For `it.skip`, `xit`, `xdescribe`, `it.todo`: only flag when there is no adjacent comment explaining the skip — a justified skip with a Jira/issue reference is acceptable per the guidelines
 - Flag when there is a jira ticket number in a test name. We do not put tickets in test names.
+- For `*.test.tsx` files in `fxa-settings` and other React packages: also apply the React testing patterns in `.claude/skills/fxa-check-react/SKILL.md` Section 5 (queries by role, `userEvent` over `fireEvent`, no asserting on instances/refs, snapshot scope).
+- **Layer / shift-left:** flag route handler tests or React component tests that branch-cover business logic via repeated fixtures (more than ~3 tests differing only in input shape). The right fix is to extract the rule into a pure function/service and unit-test it directly; route/component tests should cover wiring (auth, request/response shape, error propagation, rendering), not internal business branching. See "Test layers and shift-left" in `.claude/skills/fxa-testing-shared/GUIDELINES.md`.
 
 Output JSON array with fields: severity, category ("Test Quality"), subcategory, file, line, issue, recommendation.
 

--- a/.claude/skills/fxa-test-draft/SKILL.md
+++ b/.claude/skills/fxa-test-draft/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: fxa-test-draft
+description: Drafts Jest tests for changed code. Defaults to staged/unstaged changes or the most recent commit. Output is a starting point for review, not final.
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: [file-path | commit-ref | git-range]
+user-invocable: true
+context: fork
+---
+
+# FXA Draft Tests
+
+Draft Jest tests for changed code following FXA conventions and the project testing guidelines. Output is a **draft** — review before committing.
+
+Read the shared testing guidelines before proceeding:
+`.claude/skills/fxa-testing-shared/GUIDELINES.md`
+
+If any of the changed files are React/TSX (`fxa-settings` and similar), also read Section 5 ("Testing Patterns (React/TSX)") of `.claude/skills/fxa-check-react/SKILL.md` and apply those rules to drafted component tests.
+
+---
+
+## Step 1: Identify Scope
+
+If `$ARGUMENTS` is provided, use it as the target (file path, commit ref, or git range). Otherwise determine scope automatically:
+
+1. **Unstaged + staged changes first:**
+```bash
+git diff HEAD       # unstaged
+git diff --cached   # staged
+```
+If either produces output, that is your scope.
+
+2. **Fallback — most recent commit** (if working tree is clean):
+```bash
+git diff HEAD~1..HEAD
+```
+
+Read the full diff before proceeding.
+
+---
+
+## Step 2: Identify Source Files to Test
+
+From the diff, extract files that:
+- Contain new or modified logic (functions, branches, classes, route handlers)
+- Are **not** already test files (`*.spec.ts`, `*.test.ts`, `*.test.tsx`)
+- Are **not** generated, config, or migration files
+
+For each source file, check whether a co-located test file already exists and what it already covers. Most times, tests will be co-located but can be in a dedicated `test[s]/` directory.
+
+---
+
+## Step 3: Explore Existing Test Patterns
+
+For each source file, read nearby test files and shared mocks to understand the conventions in that package. Substitute `<pkg>` with the package directory (e.g. `fxa-auth-server`, `fxa-settings`) and `<src-dir>` with the directory of the source file under test.
+
+```bash
+# 1. Find existing tests near the source file (auth-server uses *.spec.ts in lib/,
+#    fxa-settings uses co-located *.test.tsx next to components)
+find packages/<pkg>/<src-dir> -maxdepth 2 \( -name '*.spec.ts' -o -name '*.test.ts' -o -name '*.test.tsx' \) | head -20
+
+# 2. Find shared mocks at the package root (e.g. packages/fxa-auth-server/test/mocks.js
+#    exposes mockDB, mockLog, mockMailer, mockPush, etc.)
+find packages/<pkg>/test -maxdepth 3 \( -iname 'mocks*' -o -iname 'mock-*' \) 2>/dev/null
+
+# 3. Read a representative existing test in the package to mirror its jest.mock layout,
+#    setup/teardown structure, and any custom matchers
+grep -rn 'jest.mock(' packages/<pkg> --include='*.spec.ts' --include='*.test.ts' --include='*.test.tsx' | head -10
+
+# 4. For React tests in fxa-settings: see how providers are wrapped (Intl, Router, etc.)
+grep -rn 'renderWithProviders\|MockedProvider\|IntlProvider' packages/fxa-settings/src --include='*.test.tsx' | head -5
+```
+
+Determine:
+- Framework in use — must be Jest. Flag if Mocha is present (legacy; no new Mocha tests).
+- Co-location convention: `*.spec.ts` (auth-server `lib/`) or `*.test.tsx` (fxa-settings)
+- Available shared mocks: `mockDB`, `mockLog`, `mockMailer`, `mockPush`, etc. from `test/mocks.js`
+- How `jest.mock()` is structured in this package
+
+---
+
+## Step 4: Analyze What Needs Tests
+
+For each changed function or module, identify:
+- **Happy paths** — the expected successful flows
+- **Error cases** — thrown errors, rejected promises, validation failures
+- **Edge cases** — nulls, empty arrays, boundary values, missing auth
+- **Branches** — every `if`/`else`, `switch`, ternary, optional chaining path
+
+**Call out** any code that is difficult to test due to:
+- Missing dependency injection (direct `new Foo()` instantiation inside logic)
+- Functions doing too many things (test surface too large)
+- Side effects embedded in otherwise pure logic
+- Missing error boundaries
+- **Business rules embedded in route handlers or React components** that should live in pure functions / hooks / services for unit testing (see "Test layers and shift-left" in GUIDELINES.md)
+
+Do not skip coverage for hard-to-test code — flag it explicitly and suggest a refactor where applicable.
+
+**Pick the right layer before drafting.** Before writing route-handler or component tests, ask: is the branching here business logic, or wiring? If the changeset has nuanced internal rules (validation, calculation, decision logic) sitting inside a route handler or component, propose extracting the rule first and unit-testing the extracted unit. Reserve route/component tests for wiring (auth, request/response shape, error propagation, rendering). Heavy per-branch fixtures at the route/component level are the signal you're testing at the wrong layer.
+
+---
+
+## Step 5: Present the Test Plan
+
+Before writing any code, output a test plan table for the engineer to review:
+
+| File | Function / Handler | Type | Proposed test name |
+|------|--------------------|------|--------------------|
+| `lib/account.ts` | `getAccount` | happy path | returns account when found |
+| `lib/account.ts` | `getAccount` | error | throws NotFound when account does not exist |
+| `lib/account.ts` | `getAccount` | edge case | returns null when db returns empty result |
+
+Include a row for every case identified in Step 4. Mark any cases flagged as difficult to test with a `⚠️` and a brief inline note.
+
+**Pause here.** Ask the engineer if the coverage looks right, if any cases should be added or removed, or if the scope should be adjusted. Do not proceed to drafting until confirmed.
+
+---
+
+## Step 6: Draft the Tests
+
+Write Jest tests for each identified case following the shared guidelines.
+
+Place tests in the co-located test file (`*.spec.ts` or `*.test.tsx`). If the file doesn't exist, create it with the MPL-2.0 license header at the top.
+
+**Leave things better than you found them.** When adding tests to an existing file, write new tests to the guidelines standard — don't copy existing patterns that violate them. If existing tests have clear issues, note them in the output and suggest the engineer run `/fxa-test-repair`. Don't rewrite existing tests wholesale unless that's explicitly in scope.
+
+After drafting, consider running `/fxa-test-independence` to verify the new tests pass both as a suite and in isolation.
+
+---
+
+## Step 7: Output
+
+For each source file, produce:
+
+1. **Test file path** — where the tests should live
+2. **Coverage summary** — happy paths, error cases, and branches covered
+3. **Drafted tests** — complete, runnable Jest test blocks
+4. **Callouts** — any code that is difficult to test, with a brief explanation and suggested refactor if applicable
+
+If a test file already exists, show only the new blocks to add, not the full file.
+
+Remind the user: these are drafts. Review mock return values, error types, and edge case assumptions before committing.

--- a/.claude/skills/fxa-test-independence/SKILL.md
+++ b/.claude/skills/fxa-test-independence/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: fxa-test-independence
+description: Validates that Jest tests in a given file pass both as a full suite and individually in isolation, catching hidden order dependencies and shared mutable state.
+allowed-tools: Bash, Read, Grep
+argument-hint: <test-file-path>
+user-invocable: true
+context: fork
+---
+
+# FXA Test Independence
+
+Validate that tests pass both when run together and when run individually. A test that passes in the full suite but fails in isolation has a hidden dependency on execution order or shared state — that is a bug in the test, not the code.
+
+---
+
+## Step 1: Identify the Target File
+
+If `$ARGUMENTS` is provided, use it as the test file path.
+
+Otherwise, check for recently changed test files:
+```bash
+git diff HEAD --name-only | grep -E '\.(spec|test)\.(ts|tsx)$'
+git diff --cached --name-only | grep -E '\.(spec|test)\.(ts|tsx)$'
+```
+
+If multiple files are found, ask the engineer which to validate. If no file is found, ask for one explicitly.
+
+---
+
+## Step 2: Extract Test Names
+
+Read the target file and extract every `it(...)` / `test(...)` name. Build the full list before running anything.
+
+---
+
+## Step 3: Present the Plan and Confirm
+
+Show the engineer the list of tests to be validated and the commands that will be run. Do not proceed without confirmation.
+
+```
+File: packages/fxa-auth-server/lib/account.spec.ts
+Tests found: 12
+
+Will run:
+  1. Full suite (all 12 tests together)
+  2. Each test individually (12 isolated runs)
+  Total runs: 13
+```
+
+---
+
+## Step 4: Run the Full Suite
+
+Derive the package root from the test file path (e.g. `packages/fxa-auth-server/lib/foo.spec.ts` → `packages/fxa-auth-server`). Always `cd` into the package before invoking Jest so the local `jest.config.*` is picked up. **Do NOT use `nx test-unit` — it runs the entire package suite regardless of the file argument.**
+
+Show the exact command, then run it:
+```bash
+cd <package-root> && npx jest <relative-path-to-spec> --no-coverage
+```
+
+Example: for `packages/fxa-auth-server/lib/metricsCache.spec.ts`:
+```bash
+cd packages/fxa-auth-server && npx jest lib/metricsCache.spec.ts --no-coverage
+```
+
+Record: pass/fail and any output for failing tests.
+
+---
+
+## Step 5: Run Each Test in Isolation
+
+For each test name extracted in Step 2, run it individually from the same package root:
+```bash
+cd <package-root> && npx jest <relative-path-to-spec> --testNamePattern="<exact test name>" --no-coverage
+```
+
+Record the result for each.
+
+---
+
+## Step 6: Report Results
+
+Output a results table:
+
+| # | Test name | Full suite | Isolated | Status |
+|---|-----------|-----------|----------|--------|
+| 1 | returns account when found | ✅ | ✅ | OK |
+| 2 | throws NotFound when missing | ✅ | ❌ | **ORDER DEPENDENCY** |
+
+**Status codes:**
+- `OK` — passes in both contexts
+- `ORDER DEPENDENCY` — passes in suite, fails in isolation; likely depends on state set by a prior test
+- `BROKEN` — fails in both; implementation or mock issue
+- `FALSE POSITIVE` — passes in isolation, fails in suite; likely pollutes shared state for other tests
+
+For any non-OK result, include the failure output and a diagnosis:
+
+**Likely causes by status:**
+- `ORDER DEPENDENCY`: missing `beforeEach` reset, shared module-level variable mutated by a prior test, or singleton not re-initialised between tests
+- `FALSE POSITIVE`: test mutates a shared mock or global without cleaning up in `afterEach`
+- `BROKEN`: wrong mock return value, missing `await`, or the implementation under test has changed
+
+Suggest a concrete fix for each failure. Do not fix automatically — present the diagnosis and let the engineer decide.

--- a/.claude/skills/fxa-test-repair/SKILL.md
+++ b/.claude/skills/fxa-test-repair/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: fxa-test-repair
+description: Reviews a test file for violations of FXA testing guidelines, then suggests concrete repairs. Does not auto-apply changes — output is a repair plan for engineer review.
+allowed-tools: Bash, Read, Grep, Glob
+argument-hint: <test-file-path>
+user-invocable: true
+context: fork
+---
+
+# FXA Test Repair
+
+Review a test file for violations of the FXA testing guidelines and produce a prioritized repair plan with before/after code suggestions. This skill does not modify files — all repairs are presented for engineer review for correctness and scope before implementation.
+
+If scope of changes is large, suggest a reasonable subset of repairs to implement in a single pass to avoid overwhelming diffs and code review. Always prioritize correctness and test value over style — if a repair improves readability but risks changing test behavior, flag it as Medium severity and note the risk.
+
+Read the shared testing guidelines before proceeding:
+`.claude/skills/fxa-testing-shared/GUIDELINES.md`
+
+If the target file is a React component test (`*.test.tsx`), also read Section 5 ("Testing Patterns (React/TSX)") of `.claude/skills/fxa-check-react/SKILL.md` and audit against those rules in addition to the shared rules.
+
+---
+
+## Step 1: Identify the Target File
+
+If `$ARGUMENTS` is provided, use it as the test file path.
+
+Otherwise check for recently changed test files:
+```bash
+git diff HEAD --name-only | grep -E '\.(spec|test)\.(ts|tsx)$'
+git diff --cached --name-only | grep -E '\.(spec|test)\.(ts|tsx)$'
+```
+
+If multiple files are found, ask the engineer which to repair. If none, ask explicitly.
+
+---
+
+## Step 2: Read the File
+
+Read the full test file. Note:
+- Total number of tests
+- Testing framework (Jest vs Mocha — flag Mocha, no new tests should be added)
+- How mocks are structured (module-level, `beforeEach`, inline)
+- Whether shared state variables exist at module or `describe` scope
+
+---
+
+## Step 3: Audit for Violations
+
+Work through every rule in the shared guidelines. For each violation found, record: location, the rule it breaks, and a before/after repair snippet. If a rule has no violations, note it as clean — do not skip rules.
+
+---
+
+## Step 4: Present the Repair Plan
+
+Output a prioritized findings table:
+
+| # | Severity | Rule violated | Location | Description |
+|---|----------|---------------|----------|-------------|
+| 1 | High | Independent & order-agnostic | `account.spec.ts:14` | `account` mutated across tests without `beforeEach` reset |
+| 2 | Medium | Assert explicitly | `account.spec.ts:42` | `toBeTruthy()` used where exact value is known |
+| 3 | Low | Independent & order-agnostic | `account.spec.ts:8` | `jest.clearAllMocks()` in `beforeEach` redundant — this package's `jest.config.*` already sets `clearMocks: true` (only flag when verified against the project config) |
+
+**Severity:**
+- **High** — likely causes false positives, order-dependent failures, or masks real regressions (shared mutable state, missing `await`, over-mocking)
+- **Medium** — reduces test value or maintainability (vague assertions, non-deterministic values, implementation-detail testing)
+- **Low** — noise or convention violations that don't affect correctness (redundant calls, vague names, minor patterns)
+
+Follow the table with a detailed write-up for each High finding, including a before/after code snippet showing the repair.
+
+For Medium and Low findings, a one-line description and the repair snippet is sufficient.
+
+---
+
+## Step 5: Suggest Scope
+
+After presenting findings, suggest a reasonable repair scope based on the volume of issues:
+
+- **Few issues (1–5):** Suggest fixing all in one pass.
+- **Moderate (6–15):** Suggest prioritizing High findings first; Medium/Low in a follow-up.
+- **Many (16+):** Suggest tackling by rule category across the file rather than line-by-line, and note that `/fxa-test-independence` should be run after repairs to validate nothing regressed.
+
+Remind the engineer: repairs are suggestions. Review each one — especially mock restructuring, which can change test behavior, not just style.

--- a/.claude/skills/fxa-testing-shared/GUIDELINES.md
+++ b/.claude/skills/fxa-testing-shared/GUIDELINES.md
@@ -1,0 +1,404 @@
+# FXA Testing Guidelines
+
+Shared reference for `fxa-test-draft`, `fxa-test-repair`, `fxa-test-independence`, and the FXA review skills (`fxa-review`, `fxa-review-quick`). This document is the single source of truth for FXA test rules; the bullets in `CLAUDE.md` Section 8 mirror the rule set and ordering here. If the two diverge, treat this file as authoritative and update `CLAUDE.md`.
+
+For React/TSX tests in `fxa-settings`, also apply the React-specific testing patterns in `.claude/skills/fxa-check-react/SKILL.md` (querying by role, `userEvent` over `fireEvent`, avoiding refs/instances in assertions). The rules below apply to all FXA tests; the React skill covers the additional concerns specific to component tests.
+
+## Test layers and shift-left
+
+FXA has three test layers, each costlier than the last:
+
+- **Unit** (`*.spec.ts` / `*.test.ts` / `*.test.tsx`, `nx test-unit`) — pure functions, services, hooks, components in isolation. Milliseconds per test, no real I/O. The default place to test business rules.
+- **Integration** (`nx test-integration`) — wiring across units, often hitting real infrastructure (MySQL, Redis). Reserve for verifying the integration itself, not for branching business logic.
+- **Functional / E2E** (Playwright in `packages/functional-tests`) — user-facing flows end-to-end. Slowest and most brittle; reserve for critical happy paths and regressions.
+
+**Shift left.** When code has nuanced business rules — validation, calculation, normalization, decision logic — extract it into a pure function or service and test it directly. Route handlers and React components should be thin shells; their tests cover wiring (auth, request/response shape, error propagation), not every branch of the underlying rule. Each branch tested at the route/component level multiplies the cost (Hapi harness, mocked DB/Redis, React provider tree); the same branch as a unit test runs in milliseconds with no harness.
+
+```ts
+// Rule extracted into a pure function; cheap and exhaustive to unit-test
+export function calculateDiscount(plan: Plan, account: Account): number {
+  if (account.delinquentSince) return 0;
+  return plan.tier === 'enterprise' ? 0.2 : 0.1;
+}
+
+it.each([
+  { tier: 'free', expected: 0.1 },
+  { tier: 'enterprise', expected: 0.2 },
+])('returns a $expected discount for the $tier tier', ({ tier, expected }) => {...});
+it('returns 0 when the account is delinquent', () => {...});
+
+// Route handler is a thin shell; route tests cover wiring only
+async function getDiscountHandler(request) {
+  const account = await db.getAccount(request.auth.credentials.uid);
+  return { discount: calculateDiscount(account.plan, account) };
+}
+
+it('returns 401 without a session token', () => {...});
+it('returns the discount in the response body', () => {...});
+```
+
+**Anti-patterns.**
+- Hapi route tests covering every business-logic branch via per-fixture `server.inject()` calls — extract the rule and unit-test it.
+- Component tests building provider trees to verify validation or formatters that could be pure-function / hook unit tests.
+- Playwright tests asserting on copy or branch outcomes outside a critical user flow.
+
+**Signal to extract.** When a single route or component has more than ~3 tests differing only in input shape, the underlying logic should likely be extracted and unit-tested directly.
+
+---
+
+## Rules
+
+Each rule includes the intent, a violation example, and the correct pattern.
+
+---
+
+### 1. Name tests for what they assert
+
+Test names should make the assertion self-evident. Don't assert behavior outside the scope of the name. Don't bury multiple cases inside one `it()` body — each named test should describe exactly one observable behavior.
+
+```ts
+// Violation — vague name, over-reaching assertions
+it('works', () => {
+  const result = createSession(user);
+  expect(result.uid).toBe(user.uid);
+  expect(result.createdAt).toBeDefined();
+  expect(db.createSession).toHaveBeenCalled();
+});
+
+// Correct — each test owns exactly one assertion surface
+it('returns a session with the user uid', () => {
+  const result = createSession(user);
+  expect(result.uid).toBe(user.uid);
+});
+
+it('persists the session to the database', () => {
+  createSession(user);
+  expect(db.createSession).toHaveBeenCalledWith(
+    expect.objectContaining({ uid: user.uid })
+  );
+});
+
+// Violation — `forEach` inside one `it` hides which case fails; the first failure
+// kills the loop, leaving later cases untested even after the bug is fixed
+it('returns the right discount per tier', () => {
+  [
+    { tier: 'free', expected: 0.0 },
+    { tier: 'pro', expected: 0.1 },
+    { tier: 'enterprise', expected: 0.2 },
+  ].forEach(({ tier, expected }) => {
+    expect(getDiscount({ tier })).toBe(expected);
+  });
+});
+
+// Correct — `it.each` produces one named test per case; each is independently reportable
+it.each([
+  { tier: 'free', expected: 0.0 },
+  { tier: 'pro', expected: 0.1 },
+  { tier: 'enterprise', expected: 0.2 },
+])('returns a $expected discount for the $tier tier', ({ tier, expected }) => {
+  expect(getDiscount({ tier })).toBe(expected);
+});
+```
+
+---
+
+### 2. Cover all paths
+
+All happy paths and error cases require tests. Call out when testing is difficult due to code complexity or anti-patterns rather than skipping coverage.
+
+**Don't only `mockResolvedValue`.** A common pattern is to stub every external dependency with success-only mocks and never exercise the rejection paths. Every dependency that can fail in production needs at least one `mockRejectedValue` test for the consumer's error-handling behavior — otherwise the catch/error-mapping/recovery code is silently uncovered.
+
+```ts
+// Happy path
+it('returns the account when found', async () => {
+  db.getAccountByEmail.mockResolvedValue(MOCK_ACCOUNT);
+  const result = await getAccount('user@example.com');
+  expect(result).toEqual(MOCK_ACCOUNT);
+});
+
+// Error case — null result
+it('throws NotFound when the account does not exist', async () => {
+  db.getAccountByEmail.mockResolvedValue(null);
+  await expect(getAccount('missing@example.com')).rejects.toThrow(
+    AppError.unknownAccount()
+  );
+});
+
+// Error case — dependency rejection (often missed)
+it('wraps a DB connection failure in AppError.backendServiceFailure', async () => {
+  db.getAccountByEmail.mockRejectedValue(new Error('ECONNREFUSED'));
+  await expect(getAccount('user@example.com')).rejects.toThrow(
+    AppError.backendServiceFailure() // Leverage the actual AppError thrown instead of recreating the error object
+  );
+});
+```
+
+---
+
+### 3. Tests are first-class
+
+A reader should be able to infer the intent and expected behavior from tests alone, without reading the implementation.
+
+```ts
+// Violation — requires reading the implementation to understand
+it('handles the flag', async () => {
+  const result = await processAccount(MOCK_ACCOUNT, true);
+  expect(result.status).toBe(2);
+});
+
+// Correct — intent is self-evident
+it('marks the account as verified when verifyEmail is true', async () => {
+  const result = await processAccount(MOCK_ACCOUNT, { verifyEmail: true });
+  expect(result.status).toBe(ACCOUNT_STATUS.VERIFIED);
+});
+```
+
+---
+
+### 4. Trust, but verify
+
+Use tests to verify changes. When tests and implementation disagree, investigate — never assume one is automatically correct over the other. "Fixing" a test by changing the assertion to match a buggy implementation hides regressions.
+
+```ts
+// Implementation:
+function getDiscount(plan: Plan): number {
+  return plan.tier === 'enterprise' ? 0.2 : 0.1;
+}
+
+// Violation — assertion was edited to match the implementation without
+// confirming which side was wrong
+it('applies a 20% discount for enterprise plans', () => {
+  expect(getDiscount({ tier: 'enterprise' })).toBe(0.1); // silently masks the bug
+});
+
+// Correct — assertion expresses the intended behavior; if it fails, the
+// engineer investigates the implementation rather than mutating the test
+it('applies a 20% discount for enterprise plans', () => {
+  expect(getDiscount({ tier: 'enterprise' })).toBe(0.2);
+});
+```
+
+---
+
+### 5. Mock at system boundaries, not internals
+
+Mock external dependencies (DB, Redis, email, external APIs). Use real implementations for internal helpers within the same package. Over-mocking produces tests that only verify mock wiring and obscures the behavior the test should be exercising — when in doubt, mock less.
+
+**Tautological mocks are not tests.** A test that mocks a function to return `X` and then asserts the result is `X`, with no real logic between the mock and the assertion, just verifies the mock plumbing — not the unit under test. If everything in the call path is mocked, there is no behavior left to exercise.
+
+```ts
+// Violation — mocking an internal helper in the same package
+jest.mock('./validation', () => ({
+  validateEmail: jest.fn().mockReturnValue(true),
+}));
+
+// Correct — mocking at the DB boundary
+const mockDB = { getAccountByEmail: jest.fn() };
+jest.mock('../db', () => mockDB);
+
+// Violation — tautological; the only logic exercised is mock plumbing
+discountService.getDiscount.mockResolvedValue(0.2);
+const result = await discountService.getDiscount('enterprise');
+expect(result).toBe(0.2);
+
+// Correct — the mock supplies an input; the unit under test still does real work
+db.getPlan.mockResolvedValue({ tier: 'enterprise', baseRate: 100 });
+const result = await calculateMonthlyRate('user-123');
+expect(result).toBe(80); // baseRate - (baseRate * enterpriseDiscount)
+```
+
+---
+
+### 6. Use real types in mocks
+
+Type mocks against the real interface they replace. `any` is acceptable when the real type is too cumbersome to satisfy, but typed mocks couple the test to the unit under test — when the underlying interface changes, the test fails with a clear type error instead of silently passing on a stale shape.
+
+```ts
+// Violation — untyped, will not break when AccountsDb changes shape
+const mockDb = {
+  getAccountByEmail: jest.fn(),
+};
+
+// Correct — coupled to the real interface, breaks on contract drift
+import type { AccountsDb } from '../db';
+const mockDb: jest.Mocked<Pick<AccountsDb, 'getAccountByEmail'>> = {
+  getAccountByEmail: jest.fn(),
+};
+```
+
+---
+
+### 7. Tests must be independent and order-agnostic
+
+No shared mutable state between tests. Each test owns its setup; use `beforeEach` for resets.
+
+`jest.clearAllMocks()` in `beforeEach` is redundant **only** when the package's Jest config sets `clearMocks: true`. At time of writing, only `fxa-auth-server` and `fxa-profile-server` set this; the root Jest preset does not. Before flagging it as redundant, check the relevant package's `jest.config.*` — removing it from a package without that setting will silently leak mock state between tests.
+
+**Mid-test mock resets are a smell.** Calling `mockClear()`, `mockReset()`, `jest.clearAllMocks()`, or `jest.resetAllMocks()` inside an `it()` body is almost always a band-aid hiding state leakage from a prior test or from shared setup — fix the leak (scope the mock per-test, move it into `beforeEach`, stop sharing module-level mocks across describes) instead of clearing inline. The narrow legitimate case is asserting "no further calls happened after this point" in a multi-phase test; in that case, leave a comment explaining why.
+
+```ts
+// Violation — shared mutable state, order-dependent
+let account: Account;
+beforeAll(() => { account = createAccount(); });
+it('can update email', () => { account.email = 'new@example.com'; });
+it('has the original email', () => {
+  expect(account.email).toBe('original@example.com'); // fails if prior test ran first
+});
+
+// Correct — each test resets to a known state
+let account: Account;
+beforeEach(() => { account = { ...MOCK_ACCOUNT }; });
+
+// Violation — band-aid mid-test reset hides state leaking in from another test
+it('sends one email per signup', () => {
+  jest.clearAllMocks(); // ⚠ why is this needed here? root cause is elsewhere
+  signup(MOCK_ACCOUNT);
+  expect(mailer.send).toHaveBeenCalledTimes(1);
+});
+
+// Correct — mock state is reset uniformly via beforeEach (or clearMocks: true)
+beforeEach(() => { jest.clearAllMocks(); });
+it('sends one email per signup', () => {
+  signup(MOCK_ACCOUNT);
+  expect(mailer.send).toHaveBeenCalledTimes(1);
+});
+```
+
+---
+
+### 8. Assert explicitly
+
+Prefer exact values and shapes over loose matchers. Vague assertions hide regressions.
+
+**Soft matchers are a smell.** `expect.anything()`, `expect.any(Object)`, and broad `expect.objectContaining({})` with one trivial key are usually a way to make a flaky or evolving test pass without committing to a contract. They don't catch regressions in the un-asserted fields. Use specific values; reach for `expect.any(<Type>)` only on fields that are genuinely non-deterministic (timestamps, randomly generated IDs) and use `objectContaining` only when you intentionally want to ignore unrelated fields — name the assertion accordingly.
+
+```ts
+// Violation — passes for almost any object shape, hides regressions
+expect(result).toBeTruthy();
+expect(error).toBeDefined();
+expect(result).toEqual(expect.objectContaining({ uid: expect.anything() }));
+expect(mailer.send).toHaveBeenCalledWith(expect.any(Object));
+
+// Correct — exact shape; `expect.any(...)` only on truly non-deterministic fields
+expect(result).toEqual({
+  uid: MOCK_UID,
+  email: 'user@example.com',
+  createdAt: expect.any(Number),
+});
+expect(error).toBeInstanceOf(AppError);
+expect(error.errno).toBe(102);
+expect(mailer.send).toHaveBeenCalledWith({
+  to: 'user@example.com',
+  subject: 'Verify your email',
+  templateValues: { code: MOCK_VERIFICATION_CODE },
+});
+```
+
+---
+
+### 9. Test behavior, not implementation
+
+Test through public interfaces. Avoid asserting on private state or calling private methods.
+
+```ts
+// Violation — couples test to internal structure
+expect((authService as any)._tokenCache.size).toBe(1);
+
+// Correct — tests observable behavior through the public API
+const token = await authService.createToken(user);
+await expect(authService.validateToken(token)).resolves.toEqual(
+  expect.objectContaining({ uid: user.uid })
+);
+```
+
+---
+
+### 10. Test async code correctly
+
+Always `await` async operations. Use `jest.useFakeTimers()` + `jest.setSystemTime()` over real timers or `setTimeout` hacks. Un-awaited assertions pass vacuously.
+
+**Manually bumped timeouts are a bug indicator.** `it('...', async () => {...}, 30_000)` or `jest.setTimeout(30_000)` for a single file usually means the test is using a real timer, hitting an unmocked I/O dependency, or polling for state. Fix the underlying issue — fake the timer, mock the dependency, or rewrite the wait — instead of bumping the timeout. Long-running integration tests that genuinely need a higher ceiling should be in an integration suite, not unit tests.
+
+```ts
+const MOCK_NOW = 1_700_000_000_000;
+
+// Violation — missing await, passes vacuously
+it('rejects on invalid input', () => {
+  expect(validateToken('')).rejects.toThrow();
+});
+
+// Violation — real timer, slow and flaky
+it('expires after 1 hour', (done) => {
+  setTimeout(() => { expect(token.isExpired()).toBe(true); done(); }, 3_600_000);
+});
+
+// Correct
+it('rejects on invalid input', async () => {
+  await expect(validateToken('')).rejects.toThrow(AppError.invalidToken());
+});
+
+it('expires after 1 hour', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date(MOCK_NOW + 3_600_000));
+  expect(token.isExpired()).toBe(true);
+  jest.useRealTimers();
+});
+```
+
+---
+
+### 11. Prefer deterministic test values
+
+Use hardcoded or factory-generated constants for UIDs, tokens, timestamps, and identifiers. Avoid `Math.random()`, `uuid()`, `Date.now()` in test setup — reserve randomness for tests that explicitly exercise randomness-dependent behavior.
+
+```ts
+// Violation
+const uid = uuid();
+const token = crypto.randomBytes(32).toString('hex');
+const createdAt = Date.now();
+
+// Correct
+const MOCK_UID = 'f9416ce3703e4916a4cd6b1e665a3f1a';
+const MOCK_SESSION_TOKEN = 'a'.repeat(64);
+const MOCK_CREATED_AT = 1_700_000_000_000;
+```
+
+---
+
+### 12. Leave things better than you found them
+
+When adding tests to an existing file, write new tests to these standards. Don't blindly copy existing patterns that violate these rules. Note violations in existing tests and suggest `/fxa-test-repair` — but don't rewrite them wholesale unless that's explicitly in scope.
+
+---
+
+### 13. No focused tests in commits; skipped tests need a reason
+
+**Focused tests must never be committed.** `it.only`, `describe.only`, `fit`, and `fdescribe` cause Jest to silently skip everything else in the file or suite, shrinking the safety net to a single test. A passing CI run on one focused test gives false confidence. These are debugging tools — strip them before commit.
+
+**Skipped tests are acceptable when justified.** `it.skip`, `xit`, `xdescribe`, and `it.todo` are fine in committed code *only* when accompanied by a comment explaining **why** the test is skipped. Prefer a follow-up reference (Jira ticket, GitHub issue) so the skip is trackable; at minimum, a short rationale that lets a future reader decide whether the skip is still warranted. An unjustified `.skip` rots into permanent dead weight — if there's no plan to re-enable it and no reason worth recording, delete the test instead.
+
+```ts
+// Violation — focused tests, never commit
+it.only('returns the user', () => {...});
+fit('throws on missing email', () => {...});
+
+// Violation — disabled with no explanation; will never be re-enabled
+it.skip('throws on missing email', () => {...});
+xit('throws on missing email', () => {...});
+
+// Violation — placeholder with no reason or owner
+it.todo('throws on missing email');
+
+// Correct — skip is justified and trackable
+// Skipped pending FXA-12345: rate-limiter mock collides with the global timer reset.
+it.skip('throttles after 3 attempts', () => {...});
+
+// Also correct — short rationale for an unfixable-here skip
+// Disabled in CI: depends on a real Stripe sandbox the runner cannot reach.
+// Run locally with STRIPE_SANDBOX=1.
+it.skip('processes a live Stripe webhook', () => {...});
+
+// Correct — placeholder paired with a tracking reference
+// FXA-13700: implement once the new email-template renderer lands.
+it.todo('renders the verification email in French');
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,26 @@ Suggest these proactively when the task matches — do not wait to be asked.
 | `/fxa-simplify`                 | Cleaning up recently written code                                                           |
 | `/fxa-check-githistory`         | Checking for regressions or conflicts with past fixes                                       |
 | `/fxa-pr-open`                  | Opening a new pull request from a feature branch                                            |
+| `/fxa-test-draft`               | Drafting Jest tests for staged/unstaged changes or recent commits                           |
+| `/fxa-test-independence`        | Validating tests pass both as a full suite and individually in isolation                    |
+| `/fxa-test-repair`              | Auditing a test file for guideline violations and producing a prioritized repair plan       |
+
+## 8) Testing Guidelines
+
+> Examples and rationale: `.claude/skills/fxa-testing-shared/GUIDELINES.md`
+
+**Test layers and shift-left.** Three layers from cheapest to costliest: unit (`nx test-unit`), integration (`nx test-integration`), functional/E2E (Playwright in `packages/functional-tests`). Test business logic at its source as a unit — route handlers and React components are thin shells, not branch-coverage harnesses. When a route/component has more than ~3 tests differing only in input shape, that's the signal to extract the rule into a pure function and unit-test it directly; reserve route/component tests for wiring (auth, response shape, error propagation).
+
+- **Name tests for what they assert.** One observable behavior per `it()`; use `it.each` for table cases, never `forEach` inside one test.
+- **Cover all paths.** Happy paths _and_ rejection paths (`mockRejectedValue`); flag hard-to-test code rather than skipping coverage.
+- **Tests are first-class.** Intent and expected behavior should be inferable from tests alone.
+- **Trust, but verify.** When tests and implementation disagree, investigate — don't blindly fix one to match the other.
+- **Mock at system boundaries.** No mocking same-package helpers, no tautological mocks (mock returns `X` → assert `X`). When in doubt, mock less.
+- **Type your mocks.** Prefer `jest.Mocked<T>`; `any` is an escape hatch that loses contract-drift detection.
+- **Tests must be independent.** No shared mutable state; reset in `beforeEach`. `jest.clearAllMocks()` in `beforeEach` is redundant _only_ if the package's `jest.config.*` sets `clearMocks: true` (currently `fxa-auth-server`, `fxa-profile-server`). Mid-`it()` `mockClear`/`mockReset` is a band-aid for leakage — fix the leak.
+- **Assert explicitly.** Exact values and shapes; avoid `toBeTruthy()`, `expect.anything()`, broad `objectContaining({})`. `expect.any(<Type>)` only for genuinely non-deterministic fields.
+- **Test behavior, not implementation.** Public interfaces only — no asserting on private state.
+- **Test async correctly.** Always `await`; use `jest.useFakeTimers()` + `jest.setSystemTime()`. Bumped per-test timeouts usually mask real-timer or unmocked-I/O bugs.
+- **Deterministic test values.** Hardcoded constants for UIDs/tokens/timestamps; no `Math.random()`/`uuid()`/`Date.now()` in setup.
+- **Leave things better.** New tests follow these rules; suggest `/fxa-test-repair` for legacy violations rather than copying them.
+- **No focused tests in commits; skipped tests need a reason.** Never commit `it.only`/`describe.only`/`fit`/`fdescribe`. `it.skip`/`xit`/`xdescribe`/`it.todo` are OK only with a comment explaining why (ideally a Jira/issue reference); otherwise delete the test.


### PR DESCRIPTION
## Because: 
- There were no general testing guidelines for Claude to reference when writing or reviewing tests, and no dedicated skill for test authoring, repair, or independence validation.

## This commit:
- Adds Section 8 (Testing Guidelines) to CLAUDE.md with 10 behavioral rules
- Adds fxa-test-draft skill for writing tests against a changeset
- Adds fxa-test-repair skill for auditing and repairing existing test files
- Adds fxa-test-independence skill for validating test isolation
- Adds fxa-testing-shared/GUIDELINES.md as a single source of truth for rules and examples shared across the test skills

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
