### PR TITLE
fix(payments-next): Don't show location error when redirect is successful

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
@@ -4,7 +4,7 @@
 
 import { headers } from 'next/headers';
 import Image from 'next/image';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 
 import { LocationStatus } from '@fxa/payments/eligibility';
 import {
@@ -193,7 +193,10 @@ export default async function Location({
                 )
               );
 
-              redirect(redirectUrl.href);
+              return {
+                ok: true,
+                data: { redirectToUrl: redirectUrl.href },
+              };
             }}
           />
           <p id="form-information" className="pt-5 text-center">

--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.tsx
@@ -9,7 +9,7 @@ import * as Form from '@radix-ui/react-form';
 import classNames from 'classnames';
 import countries from 'i18n-iso-countries';
 import Image from 'next/image';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 import { BaseButton, ButtonVariant, SubmitButton } from '@fxa/payments/ui';
@@ -643,6 +643,7 @@ export function IsolatedSelectTaxLocation({
   currentCurrency?: string;
 }) {
   const queryParams = useSearchParams();
+  const router = useRouter();
 
   const countryCode = queryParams?.get('countryCode') ?? '';
   const postalCode = queryParams?.get('postalCode') ?? '';
@@ -656,7 +657,11 @@ export function IsolatedSelectTaxLocation({
       saveAction={async (countryCode: string, postalCode: string) => {
         setUpdatedCountryCode(countryCode);
         setUpdatedPostalCode(postalCode);
-        return await saveAction(countryCode, postalCode);
+        const result = await saveAction(countryCode, postalCode);
+        if (result?.ok && result.data?.redirectToUrl) {
+          router.push(result.data.redirectToUrl);
+        }
+        return result;
       }}
       cmsCountryCodes={cmsCountryCodes}
       locale={locale}


### PR DESCRIPTION
## Because

* From [NextJS redirect docs](https://nextjs.org/docs/app/guides/redirecting#redirect-function), "redirect throws an error so it should be called outside the try block when using try/catch statements." We have a try/catch which calls saveAction that has a redirect() inside it, therefore our catch catches the error and sets an error to locationNotUpdated, which is why we're seeing the red error before redirect() is finalized and we are redirected.

## This pull request

* Instead of redirecting from the server action, returns status and relevant data, then does router.push() from the client component.

## Issue that this pull request solves

Closes #[PAY-3674](https://mozilla-hub.atlassian.net/browse/PAY-3674)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)


https://github.com/user-attachments/assets/8fb5c160-4349-4b70-bdad-c324fa2fc52b



## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3674]: https://mozilla-hub.atlassian.net/browse/PAY-3674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ