### PR TITLE
fix(auth): scope credentials upgrade to exact /account/login path

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -388,6 +388,7 @@ export default class AuthClient {
     };
 
     // For specific endpoints + HTTPS, upgrade credentials to include cookies for WAF challenges
+    const pathname = path.split('?')[0];
     const includeCredentials = [
       '/account/login',
       '/account/create',
@@ -395,7 +396,7 @@ export default class AuthClient {
       '/account/passwordless/send_code',
       '/account/passwordless/confirm_code',
       '/account/passwordless/resend_code',
-    ].some((endpoint) => path.startsWith(endpoint));
+    ].includes(pathname);
 
     if (includeCredentials && new URL(this.uri).protocol === 'https:') {
       requestOptions.credentials = 'include';

--- a/packages/fxa-auth-client/test/client.ts
+++ b/packages/fxa-auth-client/test/client.ts
@@ -35,4 +35,55 @@ describe('lib/client', () => {
       assert.equal(e.message, 'extraHeaders missing!');
     }
   });
+
+  describe('credentials upgrade for WAF challenges', () => {
+    let httpsClient: AuthClient;
+    let originalFetch: typeof globalThis.fetch;
+    let lastInit: RequestInit | undefined;
+
+    before(() => {
+      httpsClient = new AuthClient('https://localhost:9000');
+    });
+
+    beforeEach(() => {
+      originalFetch = globalThis.fetch;
+      lastInit = undefined;
+      globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+        lastInit = init;
+        return new Response('{}', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('sets credentials=include on POST /account/login', async () => {
+      await httpsClient.signInWithAuthPW('user@example.com', '00'.repeat(32));
+      assert.equal(lastInit?.credentials, 'include');
+    });
+
+    it('sets credentials=include on POST /account/login?keys=true', async () => {
+      await httpsClient.signInWithAuthPW('user@example.com', '00'.repeat(32), {
+        keys: true,
+      });
+      assert.equal(lastInit?.credentials, 'include');
+    });
+
+    it('does not set credentials on /account/login/send_unblock_code', async () => {
+      await httpsClient.sendUnblockCode('user@example.com');
+      assert.notEqual(lastInit?.credentials, 'include');
+    });
+
+    it('does not set credentials on /account/login/reject_unblock_code', async () => {
+      await httpsClient.rejectUnblockCode(
+        '0123456789abcdef0123456789abcdef',
+        'ABCD1234'
+      );
+      assert.notEqual(lastInit?.credentials, 'include');
+    });
+  });
 });


### PR DESCRIPTION
## Because

- PR #20473 (a96dc89d) added /account/login to the auth-client's includeCredentials list, but the membership test used path.startsWith. This unintentionally matched /account/login/send_unblock_code and /account/login/reject_unblock_code, whose server-side routes do not set cors: { credentials: true }. Browsers blocked the credentialed cross-origin POST at preflight, dropping send_unblock_code traffic to ~0 in production after v1.335.4 / v1.335.5. Users who hit the customs unblock challenge could no longer receive the unblock email and were stuck at sign-in.

## This pull request

- Strips the query string and switches the includeCredentials check to an exact match against the configured leaf paths. Restores the original intent (cookies on /account/login for WAF challenges) and preserves /account/login?keys=true, while leaving the unblock and any future /account/login/* subroutes untouched.
- Adds regression tests stubbing globalThis.fetch to assert the credentials option for /account/login, /account/login?keys=true, /account/login/send_unblock_code, and /account/login/reject_unblock_code.

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
