### PR TITLE
test(functional-tests): Add E2E tests for passkey management flows

### DIFF
--- a/packages/functional-tests/pages/settings/components/unitRow.ts
+++ b/packages/functional-tests/pages/settings/components/unitRow.ts
@@ -109,6 +109,14 @@ export class PasskeyRow extends UnitRow {
   get confirmDeleteButton() {
     return this.page.getByTestId('confirm-delete-passkey-button');
   }
+
+  // Cancel button inside the delete-confirmation modal. Scoped to the
+  // dialog so it does not collide with other Cancel buttons on the page.
+  get cancelDeleteButton() {
+    return this.page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Cancel' });
+  }
 }
 
 export class TotpRow extends UnitRow {

--- a/packages/functional-tests/pages/settings/index.ts
+++ b/packages/functional-tests/pages/settings/index.ts
@@ -131,6 +131,21 @@ export class SettingsPage extends SettingsLayout {
   }
 
   /**
+   * Drives the passkey-deletion flow: clicks the delete icon, satisfies the
+   * MFA guard if it is presented (the JWT cache may already cover the
+   * `passkey` scope from a prior add/delete in the same session), and
+   * confirms the deletion modal. Callers are responsible for asserting the
+   * resulting state (alert bar, row status, etc.) in their test steps.
+   */
+  async deletePasskey(email: string) {
+    await this.passkey.deleteButton.click();
+    await this.confirmMfaGuardIfVisible(email);
+
+    await expect(this.passkey.deleteModalHeading).toBeVisible();
+    await this.passkey.confirmDeleteButton.click();
+  }
+
+  /**
    * Indicates that the MFA guard's modal dialog is currently displayed.
    * @returns true if the MFA modal is open
    */

--- a/packages/functional-tests/pages/settings/passkey.ts
+++ b/packages/functional-tests/pages/settings/passkey.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { expect } from '@playwright/test';
 import { PasskeyPage } from '../passkey';
+import type { SettingsPage } from './index';
 
 /**
  * Page object for the `/settings/passkeys/add` page, which auto-starts a
@@ -22,5 +24,30 @@ export class SettingsPasskeyAddPage extends PasskeyPage {
 
   get cancelButton() {
     return this.page.getByTestId('passkey-add-cancel');
+  }
+
+  /**
+   * Happy-path passkey registration. Assumes the user is signed in and the
+   * settings page is loaded. Installs the WebAuthn polyfill (idempotent),
+   * clicks Create on the passkey row, satisfies the MFA guard with the email
+   * OTP, and waits for the success alert. Returns the credentialId of the
+   * freshly minted passkey so callers can target it later (e.g. to sign in
+   * with it or to assert it was deleted).
+   */
+  async registerNewPasskey(settings: SettingsPage, email: string) {
+    await this.initPasskeys(this.page);
+
+    await this.passkeyAuth.success(async () => {
+      await settings.passkey.createButton.click();
+      await settings.confirmMfaGuardIfVisible(email);
+    });
+
+    await expect(settings.settingsHeading).toBeVisible();
+    await expect(settings.alertBar).toHaveText('Passkey created');
+    await expect(settings.passkey.status).toHaveText('Enabled');
+    await expect(settings.passkey.subRow).toBeVisible();
+
+    const credentials = this.passkeyAuth.getCredentials();
+    return credentials[credentials.length - 1].credentialId;
   }
 }

--- a/packages/functional-tests/tests/settings/passkey.spec.ts
+++ b/packages/functional-tests/tests/settings/passkey.spec.ts
@@ -138,6 +138,80 @@ test.describe('severity-1 #smoke', () => {
       await expect(page.getByText('Your browser or device')).toBeVisible();
     });
   });
+
+  test.describe('passkey management', () => {
+    test.beforeEach(async ({ pages: { configPage } }) => {
+      const config = await configPage.getConfig();
+      test.skip(
+        !config.featureFlags?.passkeysEnabled ||
+          !config.featureFlags?.passkeyRegistrationEnabled,
+        'Passkey feature flags are not enabled'
+      );
+    });
+
+    test('deletes a registered passkey', async ({
+      target,
+      pages: { page, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      const { email } = await signInAccount(
+        target,
+        page,
+        settings,
+        signin,
+        testAccountTracker
+      );
+
+      await settings.goto();
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.passkey.status).toHaveText('Not set');
+
+      const credentialId = await settingsPasskeyAdd.registerNewPasskey(
+        settings,
+        email
+      );
+      expect(credentialId).toBeTruthy();
+
+      // The MFA JWT minted during registration covers the `passkey` scope,
+      // so deletion in the same session should bypass the MFA modal and go
+      // straight to the confirm-deletion dialog.
+      await settings.deletePasskey(email);
+
+      await expect(settings.alertBar).toHaveText('Passkey deleted');
+      await expect(settings.passkey.status).toHaveText('Not set');
+      await expect(settings.passkey.subRow).toHaveCount(0);
+    });
+
+    test('cancels passkey deletion via Cancel button', async ({
+      target,
+      pages: { page, settings, settingsPasskeyAdd, signin },
+      testAccountTracker,
+    }) => {
+      const { email } = await signInAccount(
+        target,
+        page,
+        settings,
+        signin,
+        testAccountTracker
+      );
+
+      await settings.goto();
+      await expect(settings.settingsHeading).toBeVisible();
+      await expect(settings.passkey.status).toHaveText('Not set');
+
+      await settingsPasskeyAdd.registerNewPasskey(settings, email);
+
+      await settings.passkey.deleteButton.click();
+      await settings.confirmMfaGuardIfVisible(email);
+      await expect(settings.passkey.deleteModalHeading).toBeVisible();
+
+      await settings.passkey.cancelDeleteButton.click();
+
+      await expect(settings.passkey.deleteModalHeading).toBeHidden();
+      await expect(settings.passkey.status).toHaveText('Enabled');
+      await expect(settings.passkey.subRow).toBeVisible();
+    });
+  });
 });
 
 async function signInAccount(


### PR DESCRIPTION
## Because

- FXA-13075 requires E2E coverage for the passkey delete flow.
- A reusable deletion helper is needed for follow-up tests (e.g. delete-then-attempt-signin with the deleted passkey).

## This pull request

- Adds `SettingsPage.deletePasskey(email)`, a reusable helper that drives the deletion flow (delete click, MFA guard if presented, confirm modal). Callers own the post-state assertions.
- Adds `SettingsPasskeyAddPage.registerNewPasskey(settings, email)`, a reusable happy-path registration helper that returns the new credentialId so callers can target it later.
- Adds `PasskeyRow.cancelDeleteButton`, scoped to the dialog to avoid collisions with other Cancel buttons on the page.
- Adds a `passkey management` describe block under the existing severity-1 #smoke group with two tests:
  - deletes a registered passkey (asserts alert, status reset, sub-row removal)
  - cancels passkey deletion via Cancel button (asserts modal closes and the passkey remains Enabled)

## Issue that this pull request solves

Closes: FXA-13075

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
