### PR TITLE
fix(settings): detect 400 errors in email domain validation

### DIFF
--- a/packages/fxa-settings/src/lib/email-domain-validator-resolve-domain.ts
+++ b/packages/fxa-settings/src/lib/email-domain-validator-resolve-domain.ts
@@ -6,6 +6,16 @@
 
 const EMAIL_VALIDATION_ENDPOINT = '/validate-email-domain';
 
+export class DomainValidationError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'DomainValidationError';
+    this.status = status;
+  }
+}
+
 export async function resolveDomain(domain: string) {
   const response = await fetch(
     `${EMAIL_VALIDATION_ENDPOINT}?domain=${domain}`,
@@ -17,7 +27,10 @@ export async function resolveDomain(domain: string) {
     }
   );
   if (!response.ok) {
-    throw new Error(`Failed to check domain ${domain}: ${response.statusText}`);
+    throw new DomainValidationError(
+      `Failed to check domain ${domain}: ${response.status} ${response.statusText}`,
+      response.status
+    );
   }
   return response.json();
 }

--- a/packages/fxa-settings/src/lib/email-domain-validator.test.ts
+++ b/packages/fxa-settings/src/lib/email-domain-validator.test.ts
@@ -5,9 +5,13 @@
 import { checkEmailDomain } from './email-domain-validator';
 import { AuthUiErrors } from './auth-errors/auth-errors';
 import topEmailDomains from 'fxa-shared/email/topEmailDomains';
-import { resolveDomain } from './email-domain-validator-resolve-domain';
+import {
+  resolveDomain,
+  DomainValidationError,
+} from './email-domain-validator-resolve-domain';
 
 jest.mock('./email-domain-validator-resolve-domain', () => ({
+  ...jest.requireActual('./email-domain-validator-resolve-domain'),
   resolveDomain: jest.fn(),
 }));
 
@@ -61,6 +65,24 @@ describe('checkEmailDomain', () => {
     );
     await expect(
       checkEmailDomain('user@server-down.com')
+    ).resolves.toBeUndefined();
+  });
+
+  it('should throw INVALID_EMAIL_DOMAIN on 400 Bad Request error', async () => {
+    (resolveDomain as jest.Mock).mockRejectedValueOnce(
+      new DomainValidationError('Failed to check domain: 400 Bad Request', 400)
+    );
+    await expect(checkEmailDomain('user@bad-domain.com')).rejects.toBe(
+      AuthUiErrors.INVALID_EMAIL_DOMAIN
+    );
+  });
+
+  it('should allow submission on non-400 HTTP errors', async () => {
+    (resolveDomain as jest.Mock).mockRejectedValueOnce(
+      new DomainValidationError('Failed to check domain: 500 Internal Server Error', 500)
+    );
+    await expect(
+      checkEmailDomain('user@server-error.com')
     ).resolves.toBeUndefined();
   });
 

--- a/packages/fxa-settings/src/lib/email-domain-validator.ts
+++ b/packages/fxa-settings/src/lib/email-domain-validator.ts
@@ -4,7 +4,10 @@
 
 import { AuthUiErrors } from './auth-errors/auth-errors';
 import topEmailDomains from 'fxa-shared/email/topEmailDomains';
-import { resolveDomain } from './email-domain-validator-resolve-domain';
+import {
+  resolveDomain,
+  DomainValidationError,
+} from './email-domain-validator-resolve-domain';
 
 let previousDomain: string | undefined;
 let previousDomainResult: string | undefined;
@@ -61,7 +64,8 @@ export const checkEmailDomain = async (email: string) => {
       return;
     }
   } catch (error) {
-    if (error.message?.includes('Bad Request')) {
+    // Check for 400 Bad Request errors (invalid domain format/malformed request)
+    if (error instanceof DomainValidationError && error.status === 400) {
       throw AuthUiErrors.INVALID_EMAIL_DOMAIN;
     }
     // Don't error and allow submission in case of server failure


### PR DESCRIPTION
## Because

- HTTP/2 and HTTP/3 responses have empty statusText, causing the error.message check for "Bad Request" to fail
- When the check failed, the code silently allowed form submission instead of showing an error
- Users with invalid email domains were incorrectly navigated to the next page in Stage and Production

## This pull request

- Creates a custom DomainValidationError class that includes the HTTP status code
- Updates error detection to check error.status === 400 instead of relying on statusText

## Issue that this pull request solves

Closes: #FXA-13636

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
