### PR TITLE
fix(pair): Fix /pair and /connect_another_device to check for signed in user

### DIFF
--- a/packages/functional-tests/lib/channels.ts
+++ b/packages/functional-tests/lib/channels.ts
@@ -2,13 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import type { FxAOAuthFlowBeginResponse } from 'fxa-settings/src/lib/channels/firefox';
+
 export enum FirefoxCommand {
   FxAStatus = 'fxaccounts:fxa_status',
   OAuthLogin = 'fxaccounts:oauth_login',
+  OAuthFlowBegin = 'fxaccounts:oauth_flow_begin',
   Logout = 'fxaccounts:logout',
   Login = 'fxaccounts:login',
   LinkAccount = 'fxaccounts:can_link_account',
   ChangePassword = 'fxaccounts:change_password',
+  PairPreferences = 'fxaccounts:pair_preferences',
 }
 
 export const FF_OAUTH_CLIENT_ID = '5882386c6d801776';
@@ -60,8 +64,21 @@ export type LinkAccountResponse = {
   };
 };
 
-export type FirefoxCommandResponse = LinkAccountResponse | FxAStatusResponse;
+// Reuses fxa-settings payload type to prevent drift.
+export type OAuthFlowBeginResponse = {
+  id: 'account_updates';
+  message: {
+    command: FirefoxCommand.OAuthFlowBegin;
+    data: FxAOAuthFlowBeginResponse;
+  };
+};
+
+export type FirefoxCommandResponse =
+  | LinkAccountResponse
+  | FxAStatusResponse
+  | OAuthFlowBeginResponse;
 export const FirefoxCommandsWithResponses = [
   FirefoxCommand.LinkAccount,
   FirefoxCommand.FxAStatus,
-];
+  FirefoxCommand.OAuthFlowBegin,
+] as const;

--- a/packages/functional-tests/tests/pairing/pairChoice.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairChoice.spec.ts
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { FirefoxCommand } from '../../lib/channels';
+import { test, expect } from '../../lib/fixtures/standard';
+
+test.describe('severity-2 #smoke', () => {
+  test.describe('Pair entry flow', () => {
+    test('direct /pair dispatches fxa_status and oauth_flow_begin and reveals the choice screen', async ({
+      target,
+      syncOAuthBrowserPages: { page, settings },
+    }) => {
+      await page.goto(`${target.contentServerUrl}/pair`);
+
+      // testid avoids the Localized/label text-content quirk that confuses
+      // getByLabel/getByRole here.
+      await expect(page.getByTestId('has-mobile')).toBeVisible();
+      await expect(page).toHaveURL(/\/pair(\?|$)/);
+
+      await settings.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      await settings.checkWebChannelMessage(FirefoxCommand.OAuthFlowBegin);
+    });
+
+    test('Continue on the choice screen dispatches pair_preferences', async ({
+      target,
+      syncOAuthBrowserPages: { page },
+    }) => {
+      await page.goto(`${target.contentServerUrl}/pair`);
+      // Click the label so React's onChange fires; the radio is hidden behind
+      // it, and check() on the input itself fails actionability.
+      await page.locator('label[for="has-mobile"]').click();
+      await expect(page.getByTestId('pair-continue-btn')).toBeEnabled();
+
+      // Capture WebChannelMessageToChrome dispatches in a page-side promise
+      // *before* clicking, so we observe pair_preferences even if Firefox's
+      // chrome handler tears the test tab down right after.
+      const dispatched = page.evaluate(
+        () =>
+          new Promise<string>((resolve) => {
+            window.addEventListener(
+              'WebChannelMessageToChrome',
+              (e: Event) => {
+                const detail = JSON.parse((e as CustomEvent).detail);
+                if (detail.message.command === 'fxaccounts:pair_preferences') {
+                  resolve(detail.message.command);
+                }
+              },
+              { once: false }
+            );
+          })
+      );
+
+      await page.getByTestId('pair-continue-btn').click();
+      expect(await dispatched).toBe('fxaccounts:pair_preferences');
+    });
+
+    test('direct /connect_another_device dispatches fxa_status and oauth_flow_begin', async ({
+      target,
+      syncOAuthBrowserPages: { page, settings },
+    }) => {
+      await page.goto(`${target.contentServerUrl}/connect_another_device`);
+
+      await settings.checkWebChannelMessage(FirefoxCommand.FxAStatus);
+      await settings.checkWebChannelMessage(FirefoxCommand.OAuthFlowBegin);
+    });
+  });
+});

--- a/packages/fxa-settings/src/lib/channels/firefox.ts
+++ b/packages/fxa-settings/src/lib/channels/firefox.ts
@@ -187,7 +187,35 @@ export type FxAOAuthFlowBeginResponse = {
   state: string;
   code_challenge?: string;
   code_challenge_method?: string;
+  // Forward to /authorization, otherwise the OAuth code is keyless and Sync never enables.
+  keys_jwk?: string;
 };
+
+// Builds the oauth_webchannel_v1 Sync sign-in URL search params from the
+// fxa_oauth_flow_begin response. Callers may set additional params on the
+// returned URLSearchParams (e.g. entrypoint, email, utm_*).
+export function buildSyncOAuthSearch(
+  oauthParams: FxAOAuthFlowBeginResponse
+): URLSearchParams {
+  const search = new URLSearchParams({
+    context: 'oauth_webchannel_v1',
+    service: 'sync',
+    client_id: oauthParams.client_id,
+    state: oauthParams.state,
+    scope: oauthParams.scope,
+    access_type: oauthParams.access_type ?? 'offline',
+    response_type: oauthParams.response_type ?? 'code',
+  });
+  if (oauthParams.action) search.set('action', oauthParams.action);
+  if (oauthParams.code_challenge) {
+    search.set('code_challenge', oauthParams.code_challenge);
+  }
+  if (oauthParams.code_challenge_method) {
+    search.set('code_challenge_method', oauthParams.code_challenge_method);
+  }
+  if (oauthParams.keys_jwk) search.set('keys_jwk', oauthParams.keys_jwk);
+  return search;
+}
 
 // timeout tuned for device latency
 // max timeout of 100-200 ms would be optimal for an ultra-snappy UX, but could cause false negatives on mobile

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.stories.tsx
@@ -35,7 +35,6 @@ export const CanSignInNoSuccessMessage = () => (
       email={MOCK_ACCOUNT.primaryEmail.email}
       entrypoint={ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT}
       device={Devices.FIREFOX_DESKTOP}
-      forceView
       showSuccessMessage={false}
       isSignIn={false}
       isSignUp={false}
@@ -58,7 +57,6 @@ export const WithSignupSuccessMessage = () => (
       showSuccessMessage
       isSignedIn={false}
       canSignIn
-      forceView
       {...MOCK_DEFAULTS}
     />
   </AppLayout>
@@ -72,7 +70,6 @@ export const WithSignInSuccessMessage = () => (
       showSuccessMessage
       isSignedIn={false}
       canSignIn
-      forceView
       {...MOCK_DEFAULTS}
     />
   </AppLayout>

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.test.tsx
@@ -127,7 +127,7 @@ describe('ConnectAnotherDevice', () => {
     expect(
       screen.getByText('Sign in to this Firefox to complete set-up')
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
   });
 
   it('renders device-specific messaging for Android', () => {

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/index.tsx
@@ -2,27 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useEffect } from 'react';
-import {
-  RouteComponentProps,
-  Link,
-  navigate,
-  useLocation,
-} from '@reach/router';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { RouteComponentProps, Link, useLocation } from '@reach/router';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { ENTRYPOINTS, REACT_ENTRYPOINT } from '../../constants';
 import { HeartsVerifiedImage } from '../../components/images';
-import { FtlMsg } from 'fxa-react/lib/utils';
+import { FtlMsg, hardNavigate } from 'fxa-react/lib/utils';
 import Banner from '../../components/Banner';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { useFtlMsgResolver } from '../../models';
 import { Constants } from '../../lib/constants';
 import { getBasicAccountData } from '../../lib/account-storage';
+import firefox, { buildSyncOAuthSearch } from '../../lib/channels/firefox';
 import GleanMetrics from '../../lib/glean';
 import AppLayout from '../../components/AppLayout';
 
 export type ConnectAnotherDeviceProps = {
   email?: string;
-  forceView?: boolean;
   entrypoint?: ENTRYPOINTS;
   isSignedIn?: boolean;
   showSuccessMessage?: boolean;
@@ -89,13 +85,6 @@ function isSyncAuthSupported(): boolean {
   return (isDesktop && version >= 40) || (isAndroid && version >= 43);
 }
 
-// Check if the current UA is a mobile browser.
-function isMobile(): boolean {
-  const ua = navigator.userAgent;
-  return /Android|iPhone|iPad|iPod|FxiOS/i.test(ua);
-}
-
-// Entrypoints eligible for pairing redirect (module-level to avoid recreation per render).
 const PAIRING_ENTRYPOINTS = new Set([
   ENTRYPOINTS.FIREFOX_PREFERENCES_ENTRYPOINT,
   ENTRYPOINTS.FIREFOX_SYNCED_TABS_ENTRYPOINT,
@@ -107,7 +96,6 @@ const PAIRING_ENTRYPOINTS = new Set([
 export const viewName = 'connect-another-device';
 const ConnectAnotherDevice = ({
   email: emailProp,
-  forceView: forceViewProp,
   entrypoint: entrypointProp,
   isSignedIn: isSignedInProp,
   showSuccessMessage: showSuccessMessageProp,
@@ -120,17 +108,17 @@ const ConnectAnotherDevice = ({
 
   const ftlMsgResolver = useFtlMsgResolver();
   const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
+  const searchParams = useMemo(
+    () => new URLSearchParams(location.search),
+    [location.search]
+  );
   const locationState = (location.state || {}) as Record<string, unknown>;
 
-  // Derive values from hooks/params when props aren't provided
   const accountData = getBasicAccountData();
-
   const email = emailProp ?? accountData?.email ?? '';
   const isSignedIn = isSignedInProp ?? !!accountData?.sessionToken;
   const entrypoint =
     entrypointProp ?? getValidEntrypoint(searchParams.get('entrypoint'));
-  const forceView = forceViewProp ?? locationState.forceView === true;
   const showSuccessMessage =
     showSuccessMessageProp ??
     !!(
@@ -138,23 +126,34 @@ const ConnectAnotherDevice = ({
     );
   const isSignUp = isSignUpProp ?? locationState.type === 'sign_up';
   const isSignIn = isSignInProp ?? locationState.type === 'sign_in';
-  const canSignIn = canSignInProp ?? (!isSignedIn && isSyncAuthSupported());
+  // Set when the WebChannel sign-in attempt fails so the button stops
+  // rendering instead of leaving the user with a silent no-op click.
+  const [oauthFlowUnavailable, setOauthFlowUnavailable] = useState(false);
+  const canSignIn =
+    canSignInProp ??
+    (!isSignedIn && isSyncAuthSupported() && !oauthFlowUnavailable);
   const device = deviceProp ?? detectDevice();
 
-  // Construct the sign-in URL matching Backbone's _getEscapedSignInUrl + SyncAuthMixin.
-  const getEscapedSignInUrl = () => {
-    const params = new URLSearchParams({
-      context: Constants.FX_DESKTOP_V3_CONTEXT,
-      entrypoint: 'fxa:connect_another_device',
-      service: Constants.SYNC_SERVICE,
-      action: 'email',
-    });
-    if (email) {
-      params.set('email', email);
-    }
-    // Forward UTM params from the current URL (matches Backbone relier UTM forwarding).
-    // The utm_source is hard-coded to 'email' to reflect that users reach CAD from
-    // a verification email (see content-server #6258).
+  // Callers that pass rendering props (tests, post-verify flows) skip the
+  // bootstrap and render directly.
+  const propsDriveRender =
+    isSignedInProp !== undefined ||
+    showSuccessMessageProp !== undefined ||
+    canSignInProp !== undefined;
+  const [bootstrapping, setBootstrapping] = useState(!propsDriveRender);
+
+  // Ask Firefox for fresh Sync OAuth params and hard-navigate to / so the
+  // App re-instantiates with an oauth_webchannel_v1 Sync integration.
+  const startSyncOAuthFlow = useCallback(async (): Promise<boolean> => {
+    const oauthParams = await firefox
+      .fxaOAuthFlowBegin(['profile', Constants.OAUTH_OLDSYNC_SCOPE])
+      .catch(() => null);
+    if (!oauthParams) return false;
+    const params = buildSyncOAuthSearch(oauthParams);
+    // Underscore form: the CMS endpoint validator rejects ':' in entrypoint.
+    params.set('entrypoint', 'fxa_connect_another_device');
+    if (email) params.set('email', email);
+    // Users reach CAD from a verification email (content-server #6258).
     params.set('utm_source', Constants.UTM_SOURCE_EMAIL);
     for (const key of [
       'utm_campaign',
@@ -163,59 +162,86 @@ const ConnectAnotherDevice = ({
       'utm_term',
     ]) {
       const val = searchParams.get(key);
-      if (val) {
-        params.set(key, val);
-      }
+      if (val) params.set(key, val);
     }
-    return `/?${params}`;
-  };
+    hardNavigate(`/?${params}`);
+    return true;
+  }, [email, searchParams]);
 
-  const isEligibleForPairing = () => {
+  const handleSignIn = useCallback(async () => {
+    const ok = await startSyncOAuthFlow();
+    if (!ok) setOauthFlowUnavailable(true);
+  }, [startSyncOAuthFlow]);
+
+  // Sync context + Firefox-chrome entrypoint required, else every direct
+  // visit would bounce to /pair.
+  const isEligibleForPairing = useCallback(() => {
     const context = searchParams.get('context') || '';
     const validContext =
       context === Constants.FX_DESKTOP_V3_CONTEXT ||
       context === Constants.OAUTH_WEBCHANNEL_CONTEXT;
-    if (!isSignedIn || !validContext) {
-      return false;
-    }
-    if (entrypoint === ENTRYPOINTS.FIREFOX_TOOLBAR_ENTRYPOINT) {
-      return true;
-    }
+    if (!validContext) return false;
+    if (entrypoint === ENTRYPOINTS.FIREFOX_TOOLBAR_ENTRYPOINT) return true;
     return (
       searchParams.get('action') !== 'email' &&
       PAIRING_ENTRYPOINTS.has(entrypoint)
     );
-  };
+  }, [entrypoint, searchParams]);
 
   useEffect(() => {
-    // Matches Backbone's beforeRender sequence.
-    if (forceView) {
+    if (propsDriveRender) {
       GleanMetrics.cad.view();
       return;
     }
 
-    if (isEligibleForPairing()) {
-      navigate('/pair');
+    // RPs that pass redirect_to + redirect_immediately=true expect /settings
+    // to validate the redirect URL and bounce the user back.
+    if (
+      searchParams.get('redirect_immediately') === 'true' &&
+      searchParams.get('redirect_to')
+    ) {
+      hardNavigate('/settings');
       return;
     }
 
-    // Some RPs specify redirect_to + redirect_immediately=true.
-    // Route through /settings which validates the redirect URL.
-    if (searchParams.get('redirect_immediately') === 'true') {
-      navigate('/settings');
-      return;
-    }
+    let cancelled = false;
+    (async () => {
+      const signedInUser = await firefox
+        .requestSignedInUser(
+          Constants.OAUTH_CONTEXT,
+          true,
+          Constants.SYNC_SERVICE
+        )
+        .catch(() => undefined);
+      if (cancelled) return;
+      const browserSignedIn = !!(
+        signedInUser?.sessionToken && signedInUser.verified
+      );
+      if (browserSignedIn && isEligibleForPairing()) {
+        hardNavigate('/pair');
+        return;
+      }
+      if (browserSignedIn) {
+        setBootstrapping(false);
+        GleanMetrics.cad.view();
+        return;
+      }
+      const redirected = await startSyncOAuthFlow();
+      if (cancelled || redirected) return;
+      // WebChannel didn't reply; reveal the page so the user isn't stuck.
+      setBootstrapping(false);
+      GleanMetrics.cad.view();
+    })();
 
-    // Signed-in desktop users should go directly to /pair.
-    if (isSignedIn && !isMobile()) {
-      navigate('/pair');
-      return;
-    }
-
-    // Log view metric only when the user actually stays on this page.
-    GleanMetrics.cad.view();
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [forceView]);
+  }, []);
+
+  if (bootstrapping) {
+    return <LoadingSpinner fullScreen />;
+  }
 
   return (
     <AppLayout>
@@ -263,9 +289,13 @@ const ConnectAnotherDevice = ({
             </FtlMsg>
             <div className="flex">
               <FtlMsg id="connect-another-device-signin-link">
-                <Link className="cta-primary cta-xl" to={getEscapedSignInUrl()}>
+                <button
+                  type="button"
+                  className="cta-primary cta-xl"
+                  onClick={handleSignIn}
+                >
                   Sign in
-                </Link>
+                </button>
               </FtlMsg>
             </div>
           </>

--- a/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
+++ b/packages/fxa-settings/src/pages/ConnectAnotherDevice/mocks.tsx
@@ -14,7 +14,6 @@ export const MOCK_DEFAULTS = {
 
 export const MOCK_BASIC_PROPS = {
   ...MOCK_DEFAULTS,
-  forceView: true,
   showSuccessMessage: true,
   isSignedIn: true,
   canSignIn: false,
@@ -23,7 +22,6 @@ export const MOCK_BASIC_PROPS = {
 export const MOCK_DEVICE_BASIC_PROPS = {
   email: MOCK_ACCOUNT.primaryEmail.email,
   entrypoint: ENTRYPOINTS.FIREFOX_FX_VIEW_ENTRYPOINT,
-  forceView: true,
   showSuccessMessage: true,
   isSignIn: false,
   isSignUp: true,

--- a/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.test.tsx
@@ -9,6 +9,7 @@ import { usePageViewEvent } from '../../../lib/metrics';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
 import firefox from '../../../lib/channels/firefox';
+import * as ReactUtils from 'fxa-react/lib/utils';
 import { MOCK_ERROR } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
 import Pair, { viewName } from '.';
@@ -18,6 +19,7 @@ jest.mock('../../../lib/metrics', () => ({
 }));
 
 let mockLocationState: unknown = null;
+const mockNavigate = jest.fn();
 jest.mock('@reach/router', () => ({
   ...jest.requireActual('@reach/router'),
   useLocation: () => ({
@@ -25,13 +27,23 @@ jest.mock('@reach/router', () => ({
     search: '',
     state: mockLocationState,
   }),
+  useNavigate: () => mockNavigate,
 }));
 
 jest.mock('../../../lib/channels/firefox', () => ({
   __esModule: true,
   default: {
     send: jest.fn(),
+    requestSignedInUser: jest.fn().mockResolvedValue({
+      uid: 'sync-uid',
+      email: 'sync@example.com',
+      sessionToken: 'token',
+      verified: true,
+    }),
+    fxaOAuthFlowBegin: jest.fn().mockResolvedValue(null),
   },
+  buildSyncOAuthSearch: jest.requireActual('../../../lib/channels/firefox')
+    .buildSyncOAuthSearch,
   FirefoxCommand: {
     PairPreferences: 'fxaccounts:pair_preferences',
   },
@@ -53,14 +65,39 @@ jest.mock('../../../lib/glean', () => ({
 }));
 
 describe('Pair', () => {
+  // jsdom's default UA lacks "Firefox", which would trip the mount-effect UA check and redirect to /pair/unsupported.
+  const realUserAgent = navigator.userAgent;
+  beforeAll(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) ' +
+        'Gecko/20100101 Firefox/124.0',
+      configurable: true,
+    });
+  });
+  afterAll(() => {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: realUserAgent,
+      configurable: true,
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
     mockLocationState = null;
   });
 
+  // Render Pair and wait for the bootstrap spinner to clear before asserting.
+  async function renderPair(
+    props: React.ComponentProps<typeof Pair> = {}
+  ): Promise<void> {
+    renderWithRouter(<Pair {...props} />);
+    await screen.findByLabelText(/I already have Firefox for mobile/);
+  }
+
   describe('choice screen', () => {
-    it('renders the choice screen by default', () => {
-      renderWithRouter(<Pair />);
+    it('renders the choice screen by default', async () => {
+      await renderPair();
       expect(
         screen.getByText('Sync your Firefox experience')
       ).toBeInTheDocument();
@@ -82,13 +119,13 @@ describe('Pair', () => {
       ).toBeInTheDocument();
     });
 
-    it('fires choiceView Glean event on render', () => {
-      renderWithRouter(<Pair />);
+    it('fires choiceView Glean event on render', async () => {
+      await renderPair();
       expect(GleanMetrics.cadFireFox.choiceView).toHaveBeenCalled();
     });
 
-    it('enables Continue button after selecting a radio', () => {
-      renderWithRouter(<Pair />);
+    it('enables Continue button after selecting a radio', async () => {
+      await renderPair();
       fireEvent.click(
         screen.getByLabelText(/I already have Firefox for mobile/)
       );
@@ -97,8 +134,8 @@ describe('Pair', () => {
       ).not.toBeDisabled();
     });
 
-    it('fires choiceEngage with "has mobile" reason', () => {
-      renderWithRouter(<Pair />);
+    it('fires choiceEngage with "has mobile" reason', async () => {
+      await renderPair();
       fireEvent.click(
         screen.getByLabelText(/I already have Firefox for mobile/)
       );
@@ -107,16 +144,16 @@ describe('Pair', () => {
       });
     });
 
-    it('fires choiceEngage with "does not have mobile" reason', () => {
-      renderWithRouter(<Pair />);
+    it('fires choiceEngage with "does not have mobile" reason', async () => {
+      await renderPair();
       fireEvent.click(screen.getByLabelText(/I don’t have Firefox for mobile/));
       expect(GleanMetrics.cadFireFox.choiceEngage).toHaveBeenCalledWith({
         event: { reason: 'does not have mobile' },
       });
     });
 
-    it('sends pair_preferences when "has mobile" is selected and Continue is clicked', () => {
-      renderWithRouter(<Pair />);
+    it('sends pair_preferences when "has mobile" is selected and Continue is clicked', async () => {
+      await renderPair();
       fireEvent.click(
         screen.getByLabelText(/I already have Firefox for mobile/)
       );
@@ -130,8 +167,8 @@ describe('Pair', () => {
       );
     });
 
-    it('transitions to download screen when "needs mobile" is selected and Continue is clicked', () => {
-      renderWithRouter(<Pair />);
+    it('transitions to download screen when "needs mobile" is selected and Continue is clicked', async () => {
+      await renderPair();
       fireEvent.click(screen.getByLabelText(/I don’t have Firefox for mobile/));
       fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
       expect(GleanMetrics.cadFireFox.choiceSubmit).toHaveBeenCalledWith({
@@ -145,22 +182,22 @@ describe('Pair', () => {
       ).toBeInTheDocument();
     });
 
-    it('fires choiceNotnowSubmit when "Not now" is clicked on choice screen', () => {
-      renderWithRouter(<Pair />);
+    it('fires choiceNotnowSubmit when "Not now" is clicked on choice screen', async () => {
+      await renderPair();
       fireEvent.click(screen.getByText('Not now'));
       expect(GleanMetrics.cadFireFox.choiceNotnowSubmit).toHaveBeenCalled();
     });
   });
 
   describe('download screen', () => {
-    function renderAndNavigateToDownload() {
-      renderWithRouter(<Pair />);
+    async function renderAndNavigateToDownload(): Promise<void> {
+      await renderPair();
       fireEvent.click(screen.getByLabelText(/I don’t have Firefox for mobile/));
       fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
     }
 
-    it('renders download screen with QR code and instructions', () => {
-      renderAndNavigateToDownload();
+    it('renders download screen with QR code and instructions', async () => {
+      await renderAndNavigateToDownload();
       expect(
         screen.getByText('Download Firefox for mobile')
       ).toBeInTheDocument();
@@ -173,13 +210,13 @@ describe('Pair', () => {
       ).toBeInTheDocument();
     });
 
-    it('fires view Glean event when download screen renders', () => {
-      renderAndNavigateToDownload();
+    it('fires view Glean event when download screen renders', async () => {
+      await renderAndNavigateToDownload();
       expect(GleanMetrics.cadFireFox.view).toHaveBeenCalled();
     });
 
-    it('sends pair_preferences on "Continue to sync"', () => {
-      renderAndNavigateToDownload();
+    it('sends pair_preferences on "Continue to sync"', async () => {
+      await renderAndNavigateToDownload();
       fireEvent.click(screen.getByRole('button', { name: 'Continue to sync' }));
       expect(GleanMetrics.cadFireFox.syncDeviceSubmit).toHaveBeenCalled();
       expect(firefox.send).toHaveBeenCalledWith(
@@ -188,14 +225,14 @@ describe('Pair', () => {
       );
     });
 
-    it('fires notnowSubmit when "Not now" is clicked on download screen', () => {
-      renderAndNavigateToDownload();
+    it('fires notnowSubmit when "Not now" is clicked on download screen', async () => {
+      await renderAndNavigateToDownload();
       fireEvent.click(screen.getByText('Not now'));
       expect(GleanMetrics.cadFireFox.notnowSubmit).toHaveBeenCalled();
     });
 
     it('navigates back to choice screen on back button', async () => {
-      renderAndNavigateToDownload();
+      await renderAndNavigateToDownload();
       const backButton = screen.getByTitle('Back');
       fireEvent.click(backButton);
       await waitFor(() => {
@@ -207,51 +244,156 @@ describe('Pair', () => {
   });
 
   describe('general', () => {
-    it('renders any arising errors on choice screen', () => {
-      renderWithRouter(<Pair error={MOCK_ERROR} />);
+    it('renders any arising errors on choice screen', async () => {
+      await renderPair({ error: MOCK_ERROR });
       expect(screen.getByText(MOCK_ERROR)).toBeInTheDocument();
     });
 
-    it('emits expected page view metric on render', () => {
-      renderWithRouter(<Pair />);
+    it('emits expected page view metric on render', async () => {
+      await renderPair();
       expect(usePageViewEvent).toHaveBeenCalledWith(viewName, REACT_ENTRYPOINT);
     });
   });
 
+  describe('sync bootstrap on mount', () => {
+    const requestSignedInUserMock = jest.mocked(firefox.requestSignedInUser);
+    const fxaOAuthFlowBeginMock = jest.mocked(firefox.fxaOAuthFlowBegin);
+
+    it('renders the choice screen when Firefox has a verified Sync user', async () => {
+      await renderPair();
+      expect(requestSignedInUserMock).toHaveBeenCalledWith(
+        'oauth',
+        true,
+        'sync'
+      );
+      expect(fxaOAuthFlowBeginMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['no SignedInUser', undefined],
+      [
+        'SignedInUser missing sessionToken',
+        {
+          uid: 'sync-uid',
+          email: 'sync@example.com',
+          sessionToken: undefined,
+          verified: true,
+        },
+      ],
+      [
+        'SignedInUser is unverified',
+        {
+          uid: 'sync-uid',
+          email: 'sync@example.com',
+          sessionToken: 'token',
+          verified: false,
+        },
+      ],
+    ])(
+      'starts an OAuth flow when fxa_status returns %s',
+      async (_, response) => {
+        requestSignedInUserMock.mockResolvedValueOnce(response);
+        renderWithRouter(<Pair />);
+        await waitFor(() =>
+          expect(fxaOAuthFlowBeginMock).toHaveBeenCalledWith([
+            'profile',
+            'https://identity.mozilla.com/apps/oldsync',
+          ])
+        );
+      }
+    );
+
+    it('hard-navigates to / with the OAuth params Firefox returned', async () => {
+      const hardNavigateSpy = jest
+        .spyOn(ReactUtils, 'hardNavigate')
+        .mockImplementation(() => {});
+      try {
+        requestSignedInUserMock.mockResolvedValueOnce(undefined);
+        fxaOAuthFlowBeginMock.mockResolvedValueOnce({
+          action: 'signin',
+          response_type: 'code',
+          access_type: 'offline',
+          scope: 'profile https://identity.mozilla.com/apps/oldsync',
+          client_id: 'cid-abc',
+          state: 'state-xyz',
+          code_challenge: 'cc',
+          code_challenge_method: 'S256',
+        });
+        renderWithRouter(<Pair />);
+        await waitFor(() => expect(hardNavigateSpy).toHaveBeenCalled());
+        const [target] = hardNavigateSpy.mock.calls[0];
+        const url = new URL(target, 'http://localhost');
+        expect(url.pathname).toBe('/');
+        expect(Object.fromEntries(url.searchParams)).toEqual({
+          context: 'oauth_webchannel_v1',
+          service: 'sync',
+          client_id: 'cid-abc',
+          state: 'state-xyz',
+          scope: 'profile https://identity.mozilla.com/apps/oldsync',
+          access_type: 'offline',
+          response_type: 'code',
+          action: 'signin',
+          code_challenge: 'cc',
+          code_challenge_method: 'S256',
+        });
+      } finally {
+        hardNavigateSpy.mockRestore();
+      }
+    });
+
+    it('reveals the choice screen when WebChannel never replies', async () => {
+      requestSignedInUserMock.mockResolvedValueOnce(undefined);
+      fxaOAuthFlowBeginMock.mockResolvedValueOnce(null);
+      await renderPair();
+      expect(
+        screen.getByLabelText(/I already have Firefox for mobile/)
+      ).toBeInTheDocument();
+    });
+
+    it('reveals the choice screen when fxa_status throws and OAuth never replies', async () => {
+      requestSignedInUserMock.mockRejectedValueOnce(new Error('boom'));
+      fxaOAuthFlowBeginMock.mockResolvedValueOnce(null);
+      await renderPair();
+      expect(
+        screen.getByLabelText(/I already have Firefox for mobile/)
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('success banner from location state', () => {
-    it('renders the signed-in banner for origin=signin', () => {
+    it('renders the signed-in banner for origin=signin', async () => {
       mockLocationState = { origin: 'signin' };
-      renderWithRouter(<Pair />);
+      await renderPair();
       expect(screen.getByText('Signed in successfully!')).toBeInTheDocument();
     });
 
-    it('renders the signup banner for origin=signup', () => {
+    it('renders the signup banner for origin=signup', async () => {
       mockLocationState = { origin: 'signup' };
-      renderWithRouter(<Pair />);
+      await renderPair();
       expect(
         screen.getByText('Account created. You’re now syncing.')
       ).toBeInTheDocument();
     });
 
-    it('renders the password-created banner for origin=post-verify-set-password', () => {
+    it('renders the password-created banner for origin=post-verify-set-password', async () => {
       mockLocationState = { origin: 'post-verify-set-password' };
-      renderWithRouter(<Pair />);
+      await renderPair();
       expect(
         screen.getByText('Password created. You’re now syncing.')
       ).toBeInTheDocument();
     });
 
-    it('does not render a banner when origin is absent', () => {
+    it('does not render a banner when origin is absent', async () => {
       mockLocationState = null;
-      renderWithRouter(<Pair />);
+      await renderPair();
       expect(
         screen.queryByText('Signed in successfully!')
       ).not.toBeInTheDocument();
     });
 
-    it('does not render the banner on the download screen', () => {
+    it('does not render the banner on the download screen', async () => {
       mockLocationState = { origin: 'signin' };
-      renderWithRouter(<Pair />);
+      await renderPair();
       fireEvent.click(screen.getByLabelText(/I don’t have Firefox for mobile/));
       fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
       expect(
@@ -265,8 +407,8 @@ describe('Pair', () => {
       data: { entrypoint: 'send-tab-toolbar-icon' },
     } as unknown as import('../../../models').Integration;
 
-    it('renders the send-tab heading without the grey "Connect another device" text', () => {
-      renderWithRouter(<Pair integration={sendTabIntegration} />);
+    it('renders the send-tab heading without the grey "Connect another device" text', async () => {
+      await renderPair({ integration: sendTabIntegration });
       expect(
         screen.getByRole('heading', {
           level: 1,
@@ -281,8 +423,8 @@ describe('Pair', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('omits the "View your saved passwords…" description', () => {
-      renderWithRouter(<Pair integration={sendTabIntegration} />);
+    it('omits the "View your saved passwords…" description', async () => {
+      await renderPair({ integration: sendTabIntegration });
       expect(
         screen.queryByText(/View your saved passwords/)
       ).not.toBeInTheDocument();
@@ -290,8 +432,8 @@ describe('Pair', () => {
   });
 
   describe('CMS theming', () => {
-    it('renders the choice screen Continue button with CMS button color', () => {
-      renderWithRouter(<Pair cmsInfo={MOCK_CMS_INFO} />);
+    it('renders the choice screen Continue button with CMS button color', async () => {
+      await renderPair({ cmsInfo: MOCK_CMS_INFO });
       const continueBtn = screen.getByRole('button', { name: 'Continue' });
       expect(continueBtn).toHaveClass('cta-primary-cms');
       // CmsButtonWithFallback sets --cta-bg as an inline CSS variable.
@@ -300,8 +442,8 @@ describe('Pair', () => {
       );
     });
 
-    it('renders the download screen Continue to sync button with CMS button color', () => {
-      renderWithRouter(<Pair cmsInfo={MOCK_CMS_INFO} />);
+    it('renders the download screen Continue to sync button with CMS button color', async () => {
+      await renderPair({ cmsInfo: MOCK_CMS_INFO });
       // Navigate from choice → download by selecting "needs mobile" + Continue
       fireEvent.click(screen.getByLabelText(/I don’t have Firefox for mobile/));
       fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
@@ -314,14 +456,14 @@ describe('Pair', () => {
       );
     });
 
-    it('renders the CMS header logo from cmsInfo.shared.headerLogoUrl', () => {
-      renderWithRouter(<Pair cmsInfo={MOCK_CMS_INFO} />);
+    it('renders the CMS header logo from cmsInfo.shared.headerLogoUrl', async () => {
+      await renderPair({ cmsInfo: MOCK_CMS_INFO });
       const logo = screen.getByAltText(MOCK_CMS_INFO.shared.headerLogoAltText);
       expect(logo).toHaveAttribute('src', MOCK_CMS_INFO.shared.headerLogoUrl);
     });
 
-    it('falls back to the default Continue button when no cmsInfo is provided', () => {
-      renderWithRouter(<Pair />);
+    it('falls back to the default Continue button when no cmsInfo is provided', async () => {
+      await renderPair();
       const continueBtn = screen.getByRole('button', { name: 'Continue' });
       expect(continueBtn).toHaveClass('cta-primary');
       expect(continueBtn).not.toHaveClass('cta-primary-cms');

--- a/packages/fxa-settings/src/pages/Pair/Index/index.tsx
+++ b/packages/fxa-settings/src/pages/Pair/Index/index.tsx
@@ -11,14 +11,18 @@ import { useFtlMsgResolver } from '../../../models';
 import { useCmsInfoState } from '../../../models/hooks';
 import { RelierCmsInfo } from '../../../models/integrations';
 import AppLayout from '../../../components/AppLayout';
+import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import CmsButtonWithFallback from '../../../components/CmsButtonWithFallback';
 import { REACT_ENTRYPOINT } from '../../../constants';
 import GleanMetrics from '../../../lib/glean';
 import Banner from '../../../components/Banner';
 import ButtonBack from '../../../components/ButtonBack';
-import { getBasicAccountData } from '../../../lib/account-storage';
 import { Constants } from '../../../lib/constants';
-import firefox, { FirefoxCommand } from '../../../lib/channels/firefox';
+import firefox, {
+  buildSyncOAuthSearch,
+  FirefoxCommand,
+} from '../../../lib/channels/firefox';
+import { hardNavigate } from 'fxa-react/lib/utils';
 import qrCodeFirefoxMobile from '../../../components/images/qr_code_firefox_mobile.svg';
 import mobileFirefoxIcon from './mobile-ff.svg';
 import mobileDownloadIcon from './mobile-download.svg';
@@ -83,6 +87,8 @@ const Pair = ({
 
   const [currentView, setCurrentView] = useState<PairView>('choice');
   const [selectedRadio, setSelectedRadio] = useState<MobileChoice | null>(null);
+  // Hide the choice screen until the WebChannel decision resolves.
+  const [bootstrapping, setBootstrapping] = useState(true);
 
   const choiceHeaderRef = useRef<HTMLHeadingElement>(null);
   const downloadHeaderRef = useRef<HTMLHeadingElement>(null);
@@ -95,9 +101,6 @@ const Pair = ({
   }, [currentView]);
 
   useEffect(() => {
-    // Matches Backbone's beforeRender sequence — runs once on mount.
-    // getBasicAccountData() is called inside the effect to avoid creating
-    // a new object reference on every render (which would re-trigger this effect).
     const ua = navigator.userAgent;
     const isFirefoxDesktop =
       /Firefox/i.test(ua) && !/FxiOS/i.test(ua) && !/Android/i.test(ua);
@@ -106,37 +109,51 @@ const Pair = ({
       navigateWithQuery('/pair/unsupported');
       return;
     }
-    const accountData = getBasicAccountData();
-    if (!accountData) {
-      navigateWithQuery('/connect_another_device', {
-        state: { forceView: true },
-      });
-      return;
-    }
-    if (!accountData.verified || !accountData.sessionToken) {
-      const params = new URLSearchParams({
-        context: Constants.FX_DESKTOP_V3_CONTEXT,
-        entrypoint: 'fxa:pair',
-        service: Constants.SYNC_SERVICE,
-      });
-      navigateWithQuery(`/signin?${params}`);
-      return;
-    }
+
+    let cancelled = false;
+    (async () => {
+      const signedInUser = await firefox
+        .requestSignedInUser(
+          Constants.OAUTH_CONTEXT,
+          true,
+          Constants.SYNC_SERVICE
+        )
+        .catch(() => undefined);
+      if (cancelled) return;
+      if (signedInUser?.sessionToken && signedInUser.verified) {
+        setBootstrapping(false);
+        return;
+      }
+      const oauthParams = await firefox
+        .fxaOAuthFlowBegin(['profile', Constants.OAUTH_OLDSYNC_SCOPE])
+        .catch(() => null);
+      if (cancelled) return;
+      if (oauthParams) {
+        hardNavigate(`/?${buildSyncOAuthSearch(oauthParams)}`);
+        return;
+      }
+      // WebChannel didn't reply; reveal the page so the user isn't stuck.
+      setBootstrapping(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Fire Glean view events for the choice flow
+  // Fire Glean view events only after the bootstrap reveals the page;
+  // otherwise users redirected during bootstrap would skew the metric.
   useEffect(() => {
+    if (bootstrapping) return;
     if (currentView === 'choice') {
       GleanMetrics.cadFireFox.choiceView();
       return;
     }
     GleanMetrics.cadFireFox.view();
-  }, [currentView]);
+  }, [bootstrapping, currentView]);
 
-  // Show success banner only on the choice screen (matches Backbone). Drive
-  // the banner variant from reach-router location state set by getSyncNavigate
-  // — the Backbone-era query params are only read by Backbone /pair now.
+  // Banner variant is driven by reach-router state from getSyncNavigate.
   const { origin: pairOrigin } = (location.state ?? {}) as Pick<
     SigninLocationState,
     'origin'
@@ -146,8 +163,7 @@ const Pair = ({
 
   const isSendTab = isSendTabEntrypoint(integration?.data.entrypoint);
 
-  // Send the pair_preferences WebChannel command to Firefox.
-  // This tells Firefox to open about:preferences#sync and start the pairing flow.
+  // Tells Firefox to open about:preferences#sync and start pairing.
   const openPairPreferences = useCallback(() => {
     firefox.send(FirefoxCommand.PairPreferences, {});
   }, []);
@@ -185,6 +201,10 @@ const Pair = ({
     GleanMetrics.cadFireFox.syncDeviceSubmit();
     openPairPreferences();
   }, [openPairPreferences]);
+
+  if (bootstrapping) {
+    return <LoadingSpinner fullScreen />;
+  }
 
   if (currentView === 'download') {
     return (


### PR DESCRIPTION
  ## Because

  - /pair and /connect_another_device produced inconsistent behavior depending on browser sign-in state.
  - After the OAuth redirect, Sync was not actually enabling because `keys_jwk` from `fxa_oauth_flow_begin` was not being forwarded, so the OAuth code came back without scoped Sync keys.

  ## This pull request

  - Rewrites the `/pair` bootstrap in `Pair/Index/index.tsx`: ask Firefox via WebChannel for a Sync user; render the choice screen if signed in, else request fresh OAuth params and `hardNavigate('/?...sync params...')`.
  - Mirrors the same bootstrap in `ConnectAnotherDevice/index.tsx` for direct visits, with `hardNavigate('/pair')` when signed in.
  - Adds shared `buildSyncOAuthSearch` helper and `FxAOAuthFlowBeginResponse` type in `lib/channels/firefox.ts`; forwards `keys_jwk` so Sync actually enables after `oauth_login`.
  - Switches the CAD entrypoint to `fxa_connect_another_device` (underscore form) so the CMS validator accepts it.

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13617
  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13440

  ## Checklist

  _Put an `x` in the boxes that apply_

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test (Firefox Desktop, fresh profile, not signed into Sync):**
  1. Visit `/pair` → should redirect to `/?...sync OAuth params...` and load the email-first page (no Index crash).
  2. Sign in; should land on `/pair` showing the choice screen.
  3. Open Firefox preferences and verify Sync is enabled and signed in as the test account.
  4. From the choice screen, select "I already have Firefox for mobile" → Continue → Firefox opens `about:preferences#sync`.

  Direct visits to `/connect_another_device`:
  - Signed-in browser → redirects to `/pair`.
  - Signed-out browser → starts the same OAuth flow as `/pair`.