### PR TITLE
fix(payments-ui): Fix inconsistent free trial breakdown on success page

### DIFF
--- a/libs/payments/ui/src/lib/client/components/PurchaseDetails/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PurchaseDetails/index.tsx
@@ -67,11 +67,7 @@ export function PurchaseDetails(props: PurchaseDetailsProps) {
     useState(trialStartDate);
   const [stableTrialEndDate, setStableTrialEndDate] = useState(trialEndDate);
   useEffect(() => {
-    const isFreeTrial =
-      !!stableTrialEndDate ||
-      (!!stableFreeTrialEligibility &&
-        stableFreeTrialEligibility.trialLengthDays > 0);
-    if (cartState === 'start' || (cartState === 'success' && !isFreeTrial)) {
+    if (cartState === 'start' || cartState === 'success') {
       setStableInvoice(invoice);
       setStableTotalPrice(totalPrice);
       setStableFreeTrialEligibility(freeTrialEligibility);


### PR DESCRIPTION
## Because

- The invoice breakdown displayed on Success page for Free trials was inconsistent as there was a race condition
  - The component could remount, losing the cache, and render what the server provides for Success

## This pull request

- Updates useEffect, as it should allow updates on success regardless of free trial status

## Issue that this pull request solves

Closes: PAY-3680

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.