### PR TITLE
fix(auth): Do not send first invoice email for free trials

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -32,6 +32,7 @@ import {
   STRIPE_OBJECT_TYPE_TO_RESOURCE,
   StripeHelper,
   SUBSCRIPTION_UPDATE_TYPES,
+  SUBSCRIPTIONS_RESOURCE,
   VALID_RESOURCE_TYPES,
 } from '../../payments/stripe';
 import { AuthLogger, AuthRequest } from '../../types';
@@ -974,11 +975,34 @@ export class StripeWebhookHandler extends StripeHandler {
         email: account.primaryEmail,
       },
     ];
+    const subscription = invoice.subscription
+      ? await this.stripeHelper.expandResource(
+          invoice.subscription,
+          SUBSCRIPTIONS_RESOURCE
+        )
+      : null;
+
     switch (invoice.billing_reason) {
       case 'subscription_create':
-        await this.mailer.sendSubscriptionFirstInvoiceEmail(...mailParams);
+        // Do not send the first invoice email for free trial,
+        // as no payment has been charged yet.
+        if (subscription?.status !== 'trialing') {
+          await this.mailer.sendSubscriptionFirstInvoiceEmail(...mailParams);
+        }
 
         await this.mailer.sendDownloadSubscriptionEmail(...mailParams);
+        break;
+      case 'subscription_cycle':
+        if (
+          subscription?.trial_end &&
+          invoice.period_start === subscription.trial_end
+        ) {
+          await this.mailer.sendSubscriptionFirstInvoiceEmail(...mailParams);
+        } else {
+          await this.mailer.sendSubscriptionSubsequentInvoiceEmail(
+            ...mailParams
+          );
+        }
         break;
       case 'subscription_update':
         // We already send an email for subscription updates. https://mozilla-hub.atlassian.net/browse/PAY-2290

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhooks.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhooks.spec.ts
@@ -2350,6 +2350,9 @@ describe('StripeWebhookHandler', () => {
         StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.mockResolvedValue(
           mockInvoiceDetails
         );
+        StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+          { status: 'active' }
+        );
 
         const mockAccount: any = {
           emails: 'fakeemails',
@@ -2396,13 +2399,122 @@ describe('StripeWebhookHandler', () => {
       )
     );
 
+    it('does not send the first invoice email for a trialing subscription', async () => {
+      const invoice = eventInvoicePaid.data.object;
+      invoice.billing_reason = 'subscription_create';
+
+      const mockInvoiceDetails = { uid: '1234', test: 'fake' };
+      StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.mockResolvedValue(
+        mockInvoiceDetails
+      );
+      StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+        { status: 'trialing' }
+      );
+
+      const mockAccount: any = {
+        emails: 'fakeemails',
+        locale: 'fakelocale',
+        verifierSetAt: Date.now(),
+      };
+      StripeWebhookHandlerInstance.db.account = jest.fn(
+        async () => mockAccount
+      );
+
+      await StripeWebhookHandlerInstance.sendSubscriptionInvoiceEmail(invoice);
+
+      expect(
+        StripeWebhookHandlerInstance.mailer.sendSubscriptionFirstInvoiceEmail
+      ).not.toHaveBeenCalled();
+      expect(
+        StripeWebhookHandlerInstance.mailer.sendDownloadSubscriptionEmail
+      ).toHaveBeenCalledWith(mockAccount.emails, mockAccount, {
+        acceptLanguage: mockAccount.locale,
+        ...mockInvoiceDetails,
+        email: mockAccount.primaryEmail,
+      });
+    });
+
     it(
-      'sends the subsequent invoice email for billing reasons besides creation',
+      'sends the subsequent invoice email for subscription_cycle without trial',
       commonSendSubscriptionInvoiceEmailTest(
         'sendSubscriptionSubsequentInvoiceEmail',
         'subscription_cycle'
       )
     );
+
+    it('sends the first invoice email for subscription_cycle after a free trial', async () => {
+      const invoice = eventInvoicePaid.data.object;
+      invoice.billing_reason = 'subscription_cycle';
+      invoice.period_start = 1234567890;
+
+      const mockInvoiceDetails = { uid: '1234', test: 'fake' };
+      StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.mockResolvedValue(
+        mockInvoiceDetails
+      );
+      StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+        { status: 'active', trial_end: 1234567890 }
+      );
+
+      const mockAccount: any = {
+        emails: 'fakeemails',
+        locale: 'fakelocale',
+        verifierSetAt: Date.now(),
+      };
+      StripeWebhookHandlerInstance.db.account = jest.fn(
+        async () => mockAccount
+      );
+
+      await StripeWebhookHandlerInstance.sendSubscriptionInvoiceEmail(invoice);
+
+      expect(
+        StripeWebhookHandlerInstance.mailer.sendSubscriptionFirstInvoiceEmail
+      ).toHaveBeenCalledWith(mockAccount.emails, mockAccount, {
+        acceptLanguage: mockAccount.locale,
+        ...mockInvoiceDetails,
+        email: mockAccount.primaryEmail,
+      });
+      expect(
+        StripeWebhookHandlerInstance.mailer
+          .sendSubscriptionSubsequentInvoiceEmail
+      ).not.toHaveBeenCalled();
+    });
+
+    it('sends the subsequent invoice email for later renewals on a subscription that had a trial', async () => {
+      const invoice = eventInvoicePaid.data.object;
+      invoice.billing_reason = 'subscription_cycle';
+      invoice.period_start = 1237246290; // later than trial_end
+
+      const mockInvoiceDetails = { uid: '1234', test: 'fake' };
+      StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.mockResolvedValue(
+        mockInvoiceDetails
+      );
+      StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+        { status: 'active', trial_end: 1234567890 }
+      );
+
+      const mockAccount: any = {
+        emails: 'fakeemails',
+        locale: 'fakelocale',
+        verifierSetAt: Date.now(),
+      };
+      StripeWebhookHandlerInstance.db.account = jest.fn(
+        async () => mockAccount
+      );
+
+      await StripeWebhookHandlerInstance.sendSubscriptionInvoiceEmail(invoice);
+
+      expect(
+        StripeWebhookHandlerInstance.mailer.sendSubscriptionFirstInvoiceEmail
+      ).not.toHaveBeenCalled();
+      expect(
+        StripeWebhookHandlerInstance.mailer
+          .sendSubscriptionSubsequentInvoiceEmail
+      ).toHaveBeenCalledWith(mockAccount.emails, mockAccount, {
+        acceptLanguage: mockAccount.locale,
+        ...mockInvoiceDetails,
+        email: mockAccount.primaryEmail,
+      });
+    });
 
     it('does not send email for subscription_update billing reason', async () => {
       const invoice = eventInvoicePaid.data.object;
@@ -2411,6 +2523,9 @@ describe('StripeWebhookHandler', () => {
       const mockInvoiceDetails = { uid: '1234', test: 'fake' };
       StripeWebhookHandlerInstance.stripeHelper.extractInvoiceDetailsForEmail.mockResolvedValue(
         mockInvoiceDetails
+      );
+      StripeWebhookHandlerInstance.stripeHelper.expandResource.mockResolvedValue(
+        { status: 'active' }
       );
 
       const mockAccount = {


### PR DESCRIPTION
## Because

- the first invoice email should not be sent for free trials, as no payment was charged

## This pull request

- prevents first invoice email from being sent when free trial starts
- sends first invoice email after trial ends

## Issue that this pull request solves

Closes: PAY-3670

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.