### PR TITLE
polish(github): Make deployment more flexible

### DIFF
--- a/.claude/skills/fxa-dot-release/SKILL.md
+++ b/.claude/skills/fxa-dot-release/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: fxa-dot-release
+description: EXPERIMENTAL — Guides an engineer through the FXA release process for stage. Walks through tagging, building, deploying, and smoke-testing step by step. NOT for auto mode; performs irreversible actions and requires confirmation at each step.
+allowed-tools: Bash, Read, AskUserQuestion
+user-invocable: true
+context: fork
+---
+
+# FXA Release Walkthrough
+
+> ⚠️ **EXPERIMENTAL — DO NOT RUN THIS IN AUTO MODE.**
+>
+> This skill performs irreversible actions: pushing tags, kicking off deploys. It is a step-by-step guide for a human release owner. Pause at every step. Wait for explicit confirmation before running anything that mutates state. If anything looks wrong, **stop** and let the user decide.
+
+## Your role
+
+You are the release **guide**, not the release **owner**. Your job is to walk the user through the process and surface issues clearly. Do **not** troubleshoot failures, retry red builds, or skip steps to keep things moving. If a check fails, a pipeline goes red, or a version doesn't match — say so plainly and let the user choose what to do next.
+
+## Before you start
+
+If auto mode is active, decline politely and ask the user to disable it before proceeding.
+
+Verify the working directory is the FXA monorepo root (`package.json` should have `"name": "fxa"`).
+
+---
+
+## Step 1: Gather inputs
+
+Use **AskUserQuestion** twice:
+
+1. **What release tag is this?** (e.g. `v1.100.1` or `v1.100.0-rc1`)
+   Validate the response against `^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$`. If it doesn't match, re-ask. Store as `$tag`.
+
+---
+
+## Step 2: Validate setup
+
+Run both checks. If either fails, stop and tell the user how to fix it.
+
+### CIRCLECI_TOKEN in `.env`
+
+```bash
+test -f .env && grep -qE '^CIRCLECI_TOKEN=' .env
+```
+
+If missing: tell the user to get a personal API token at https://app.circleci.com/settings/user/tokens (project tokens won't work for v2 pipeline triggers) and add `CIRCLECI_TOKEN=<value>` to `.env` at the repo root.
+
+### `gh` CLI authenticated
+
+```bash
+gh auth status
+```
+
+If not authenticated: tell the user to run `gh auth login`.
+
+### Cherry-picks Have Been Validated
+
+Ask the user if they have run a quick test to make sure their cherry-picks are valid. They should run nx run-many -t test-unit before pushing the tag.
+
+---
+
+## Step 3: Tag and push the release
+
+Tell the user you'll run `yarn trigger:dot-release $tag` and ask for confirmation. The script will:
+
+- Fetch latest tags from origin
+- Verify the user is on the correct `train-<minor>` branch
+- Push the train branch to origin
+- Create an annotated tag at HEAD
+- Push the tag to origin
+
+The tag push triggers CircleCI's `test_and_deploy_tag` pipeline.
+
+After confirmation:
+
+```bash
+yarn trigger:dot-release $tag
+```
+
+Surface the script output verbatim. Then give the user this URL to find their pipeline:
+
+> https://app.circleci.com/pipelines/github/mozilla/fxa
+
+Tell them to filter or scroll to find the run for `$tag`.
+
+---
+
+## Step 4: Wait, or kick off the docker build now
+
+Use **AskUserQuestion**: wait for the CircleCI tag pipeline to finish, or kick off the docker build immediately?
+
+Options: `wait`, `kick-off-now`.
+
+### If `wait`
+
+Poll the CircleCI API every 30 seconds until the matching pipeline's workflow finishes. Find the pipeline first:
+
+```bash
+curl -s -H "Circle-Token: $(grep -E '^CIRCLECI_TOKEN=' .env | cut -d= -f2-)" \
+  "https://circleci.com/api/v2/project/github/mozilla/fxa/pipeline" | \
+  jq --arg tag "$tag" '.items[] | select(.vcs.tag == $tag) | {id, number, state}'
+```
+
+Then poll the workflow status:
+
+```bash
+curl -s -H "Circle-Token: $TOKEN" \
+  "https://circleci.com/api/v2/pipeline/<pipeline-id>/workflow" | \
+  jq '.items[] | {name, status}'
+```
+
+When all workflows finish: alert the user. If any are `failed`, **stop** and surface the failure. Do not proceed. If there are no failures, then run:
+
+```bash
+yarn trigger:docker-push $tag
+```
+Surface the script's output (it includes the GitHub Actions URL). Briefly mention that the docker build will push the image to GAR and Docker Hub.
+
+
+### If `kick-off-now`
+
+```bash
+yarn trigger:docker-push $tag
+```
+
+Surface the script's output (it includes the GitHub Actions URL). Briefly mention that the docker build will push the image to GAR and Docker Hub.
+
+---
+
+## Step 5: Wait for stage to deploy
+
+Once the docker image is pushed, stage will auto-deploy. Poll the version endpoint every 30 seconds:
+
+```bash
+curl -s https://accounts.stage.mozaws.net/__version__ | jq -r .version
+```
+
+Compare to `$tag` with the leading `v` stripped (e.g. `v1.100.5` → `1.100.5`). When the response matches, alert the user that stage has deployed.
+
+If the version doesn't match within ~20 minutes, surface that to the user — something may be wrong.
+
+---
+
+## Step 6: Stage smoke tests
+
+Tell the user the next step is to run the stage smoke tests:
+
+```bash
+dotenv -- yarn trigger:smoke-tests stage $tag
+```
+
+Ask for confirmation before running it. After running, surface the CircleCI pipeline URL the script prints. Tell the user to watch the smoke tests — do not proceed until they confirm the smokes have completed.
+
+
+## Done
+
+Briefly summarize what happened: tag, docker build, stage deploy, stage smokes. One short paragraph. The user knows what they did — don't lecture them.
+
+---
+
+## Reminders
+
+- **Never** run any of the yarn commands without explicit user confirmation immediately before.
+- **Never** retry a failed CircleCI workflow or rerun a failed deploy on your own. Surface the failure and stop.
+- **Never** edit files in this skill's flow. The only writes you make are the side effects of the yarn commands above.
+- This skill is a guide, not a fix-it tool. If something goes wrong, the user owns the next decision.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Docker
 
 on:
-  check_run:
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       git_tag:
@@ -17,45 +14,18 @@ jobs:
     permissions: {}
     outputs:
       TAG: ${{ steps.determine.outputs.tag }}
-    if: |
-      github.event_name == 'workflow_dispatch'
-      || (
-        github.event_name == 'check_run'
-        && github.event.check_run.conclusion == 'success'
-        && github.event.check_run.app.client_id == 'Iv1.44befee49e3e76a4'
-        && github.event.check_run.name == 'test_and_deploy_tag'
-      )
     env:
-      CIRCLECI_EXTERNAL_ID: ${{ github.event.check_run.external_id }}
       GIT_TAG: ${{ inputs.git_tag }}
     steps:
       - id: determine
         run: |
-          tag=""
-
-          # Use the provided git tag
-          if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" && "${GIT_TAG:-}" != "" ]]; then
-            tag="${GIT_TAG}"
-          elif [[ "${GITHUB_EVENT_NAME:-}" == "check_run" ]]; then
-            CIRCLECI_WORKFLOW_ID=$(echo "${CIRCLECI_EXTERNAL_ID}" | jq -r '."workflow-id"')
-            CIRCLECI_WORKFLOW_DATA=$(curl "https://circleci.com/api/v2/workflow/${CIRCLECI_WORKFLOW_ID}")
-            CIRCLECI_PIPELINE_ID=$(echo "${CIRCLECI_WORKFLOW_DATA}" | jq -r '.pipeline_id')
-            CIRCLECI_PIPELINE_DATA=$(curl "https://circleci.com/api/v2/pipeline/${CIRCLECI_PIPELINE_ID}")
-            TAG=$(echo "${CIRCLECI_PIPELINE_DATA}" | jq -r '.vcs.tag')
-            if [[ "${TAG}" != "" ]]; then
-              tag="${TAG}"
-            fi
-          fi
-
-          if [[ "${tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
-            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-            echo "Trigger docker build & push on ${GITHUB_EVENT_NAME} and found tag ${tag}" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          else
-            echo "Cannot determine valid tag"
-            echo "Trigger docker build & push on ${GITHUB_EVENT_NAME} and cannot determine tag" >> "$GITHUB_STEP_SUMMARY"
+          if [[ ! "${GIT_TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+            echo "Invalid tag: ${GIT_TAG}"
+            echo "Invalid tag format: ${GIT_TAG}" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+          echo "tag=${GIT_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Building docker image for tag ${GIT_TAG}" >> "$GITHUB_STEP_SUMMARY"
 
   docker:
     name: Docker build and push to GAR
@@ -89,7 +59,7 @@ jobs:
           git describe --tags --exact-match | grep -Fx "$GIT_TAG"
           git show -s --format='%H %D' HEAD
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           cache: yarn
 
@@ -140,7 +110,7 @@ jobs:
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - id: build-and-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
           file: _dev/docker/mono/Dockerfile

--- a/_scripts/trigger-docker-push.sh
+++ b/_scripts/trigger-docker-push.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+#
+# Trigger the GitHub Actions docker.yml workflow to build and push the
+# fxa-mono image at a given git tag.
+#
+# Usage:
+#   ./_scripts/trigger-docker-push.sh <tag>
+#
+# Examples:
+#   ./_scripts/trigger-docker-push.sh v1.2.3
+#   ./_scripts/trigger-docker-push.sh v1.2.3-rc4
+#
+# Requires the `gh` CLI authenticated (run `gh auth status` to check).
+
+set -euo pipefail
+
+tag="${1:-}"
+
+if [[ -z "${tag}" ]]; then
+  echo "Usage: ${0} <tag>" >&2
+  exit 1
+fi
+
+if [[ ! "${tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+  echo "ERROR: '${tag}' does not match the expected format (vMAJOR.MINOR.PATCH[-rcN])." >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: the 'gh' CLI is not installed (https://cli.github.com)." >&2
+  exit 1
+fi
+
+repo="mozilla/fxa"
+
+if ! gh api "repos/${repo}/git/refs/tags/${tag}" --silent >/dev/null 2>&1; then
+  echo "ERROR: tag '${tag}' does not exist on github.com/${repo}." >&2
+  exit 1
+fi
+
+gh workflow run docker.yml --repo "${repo}" -f "git_tag=${tag}"
+
+echo "Triggered docker build for tag ${tag}"
+echo "https://github.com/${repo}/actions/workflows/docker.yml"

--- a/_scripts/trigger-dot-release.sh
+++ b/_scripts/trigger-dot-release.sh
@@ -1,0 +1,73 @@
+#! /bin/bash
+#
+# Tag a patch release on the current train branch and push it to origin.
+# Pushing the tag is what kicks off the docker.yml build via
+# `yarn trigger:docker-push <tag>`.
+#
+# Usage:
+#   ./_scripts/trigger-dot-release.sh <tag>
+#
+# Examples:
+#   ./_scripts/trigger-dot-release.sh v1.100.5
+#   ./_scripts/trigger-dot-release.sh v1.100.0-rc1
+#
+# Pre-flight checklist (run yourself before invoking):
+#   - Patch has been merged into the train branch locally
+#   - You've run the server and tests to verify the patch behaves correctly
+
+set -euo pipefail
+
+tag="${1:-}"
+
+if [[ -z "${tag}" ]]; then
+  echo "Usage: ${0} <tag>" >&2
+  exit 1
+fi
+
+if [[ ! "${tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc[0-9]+)?$ ]]; then
+  echo "ERROR: '${tag}' does not match the expected format (vMAJOR.MINOR.PATCH[-rcN])." >&2
+  exit 1
+fi
+
+minor="${BASH_REMATCH[2]}"
+branch="train-${minor}"
+remote="origin"
+
+echo "Fetching latest tags from ${remote}..."
+git fetch "${remote}" --tags
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${current_branch}" != "${branch}" ]]; then
+  echo "ERROR: current branch is '${current_branch}', expected '${branch}'." >&2
+  echo "Switch to ${branch} before tagging: git checkout ${branch}" >&2
+  exit 1
+fi
+
+if git rev-parse "${tag}" >/dev/null 2>&1; then
+  echo "ERROR: tag '${tag}' already exists locally." >&2
+  exit 1
+fi
+
+if git ls-remote --tags --exit-code "${remote}" "refs/tags/${tag}" >/dev/null 2>&1; then
+  echo "ERROR: tag '${tag}' already exists on ${remote}." >&2
+  exit 1
+fi
+
+echo "About to:"
+echo "  1. push ${branch} to ${remote}"
+echo "  2. create tag ${tag} at HEAD ($(git rev-parse --short HEAD))"
+echo "  3. push tag ${tag} to ${remote}"
+echo
+read -p "Proceed? (y/N): " confirm
+if [[ ! "${confirm}" =~ ^[yY]([eE][sS])?$ ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+git push "${remote}" "${branch}"
+git tag -a "${tag}" -m "Train release ${tag}"
+git push "${remote}" "${tag}"
+
+echo
+echo "Tagged ${tag}. Kick off the docker build with:"
+echo "  yarn trigger:docker-push ${tag}"

--- a/_scripts/trigger-smoke-tests.sh
+++ b/_scripts/trigger-smoke-tests.sh
@@ -1,0 +1,71 @@
+#! /bin/bash
+#
+# Trigger CircleCI smoke tests for stage or production.
+#
+# Usage:
+#   CIRCLECI_TOKEN=<token> ./_scripts/trigger-smoke-tests.sh <stage|production> <branch>
+#
+# Requires a CIRCLECI_TOKEN! Get a personal API token at https://app.circleci.com/settings/user/tokens.
+# Project tokens do not work for v2 pipeline triggers.
+#
+# The branch argument is required - specify the train or tag that you intend to deploy. main may
+# have a different test state than your train branch.
+
+set -euo pipefail
+
+env="${1:-}"
+branch="${2:-}"
+
+case "${env}" in
+  stage|production) ;;
+  *)
+    echo "Usage: ${0} <stage|production> <branch>" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${branch}" ]]; then
+  echo "ERROR: branch argument is required." >&2
+  echo "Usage: ${0} <stage|production> <branch>" >&2
+  exit 1
+fi
+
+if [[ -z "${CIRCLECI_TOKEN:-}" ]]; then
+  echo "ERROR: CIRCLECI_TOKEN env var is not set." >&2
+  echo "Get a personal token at https://app.circleci.com/settings/user/tokens" >&2
+  exit 1
+fi
+
+parameter_name="enable_${env}_smoke_tests"
+project_slug="github/mozilla/fxa"
+
+payload=$(jq -n \
+  --arg branch "${branch}" \
+  --arg param "${parameter_name}" \
+  '{
+    branch: $branch,
+    parameters: {
+      enable_test_pull_request: false,
+      enable_test_and_deploy_tag: false,
+      enable_deploy_packages: false,
+      enable_deploy_ci_images: false,
+      enable_nightly: false
+    } | .[$param] = true
+  }')
+
+response=$(curl -sS -X POST \
+  -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "${payload}" \
+  "https://circleci.com/api/v2/project/${project_slug}/pipeline")
+
+pipeline_number=$(echo "${response}" | jq -r '.number // empty')
+
+if [[ -z "${pipeline_number}" ]]; then
+  echo "ERROR: Failed to trigger pipeline. Response:" >&2
+  echo "${response}" >&2
+  exit 1
+fi
+
+echo "Triggered ${env} smoke tests (branch: ${branch})"
+echo "https://app.circleci.com/pipelines/${project_slug}/${pipeline_number}"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "check:mysql": "_scripts/check-mysql.sh",
     "check:url": "_scripts/check-url.sh",
     "prepare": "husky",
-    "check:frozen": "ts-node _scripts/check-frozen.ts"
+    "check:frozen": "ts-node _scripts/check-frozen.ts",
+    "trigger:docker-push": "_scripts/trigger-docker-push.sh",
+    "trigger:smoke-tests": "_scripts/trigger-smoke-tests.sh",
+    "trigger:dot-release": "_scripts/trigger-dot-release.sh"
   },
   "homepage": "https://github.com/mozilla/fxa",
   "bugs": {


### PR DESCRIPTION
## Because

- We want to make our deployment more flexible and more explicit.

## This pull request

- Stop triggering deployment on CircleCI completion. It's now up to the engineer.
- Create a yarn command that makes tagging a release easy and less error prone
- Create a yarn command that makes triggering a docker push easy and less error prone
- Create a yarn command that makes running smoke tests on release easy and less error prone.

## Issue that this pull request solves

Closes: FXA-13637

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
