### PR TITLE
fix(libs/payments): Update payment could not process copy and add Cancel subscription button

### DIFF
--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -291,6 +291,63 @@ describe('SubscriptionManagementService', () => {
     });
   });
 
+  describe('cancelSubscriptionImmediately', () => {
+    const mockStripeCustomer = StripeCustomerFactory();
+    const mockAccountCustomer = ResultAccountCustomerFactory({
+      stripeCustomerId: mockStripeCustomer.id,
+    });
+    const mockSubscription = StripeResponseFactory(
+      StripeSubscriptionFactory({
+        customer: mockStripeCustomer.id,
+      })
+    );
+
+    beforeEach(() => {
+      jest
+        .spyOn(accountCustomerManager, 'getAccountCustomerByUid')
+        .mockResolvedValue(mockAccountCustomer);
+      jest
+        .spyOn(subscriptionManager, 'retrieve')
+        .mockResolvedValue(mockSubscription);
+      jest
+        .spyOn(subscriptionManager, 'cancel')
+        .mockResolvedValue(mockSubscription);
+    });
+
+    it('successfully cancels the subscription immediately', async () => {
+      await subscriptionManagementService.cancelSubscriptionImmediately(
+        mockAccountCustomer.uid,
+        mockSubscription.id
+      );
+
+      expect(subscriptionManager.cancel).toHaveBeenCalledWith(
+        mockSubscription.id
+      );
+      expect(privateCustomerChanged).toHaveBeenCalledWith(
+        mockAccountCustomer.uid
+      );
+    });
+
+    it('fails with error on mismatching customer id between subscription and account', async () => {
+      jest.spyOn(subscriptionManager, 'retrieve').mockResolvedValueOnce(
+        StripeResponseFactory(
+          StripeSubscriptionFactory({
+            customer: 'differentCustomerId',
+          })
+        )
+      );
+
+      await expect(
+        subscriptionManagementService.cancelSubscriptionImmediately(
+          mockAccountCustomer.uid,
+          mockSubscription.id
+        )
+      ).rejects.toBeInstanceOf(CancelSubscriptionCustomerMismatch);
+      expect(subscriptionManager.cancel).not.toHaveBeenCalled();
+      expect(privateCustomerChanged).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getPageContent', () => {
     const mockProductNameByPriceIdsResultUtil = {
       purchaseForPriceId: jest.fn(),

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -139,6 +139,27 @@ export class SubscriptionManagementService {
     await this.customerChanged(uid);
   }
 
+  @SanitizeExceptions()
+  async cancelSubscriptionImmediately(uid: string, subscriptionId: string) {
+    const accountCustomer =
+      await this.accountCustomerManager.getAccountCustomerByUid(uid);
+    const subscription =
+      await this.subscriptionManager.retrieve(subscriptionId);
+
+    if (subscription.customer !== accountCustomer.stripeCustomerId) {
+      throw new CancelSubscriptionCustomerMismatch(
+        uid,
+        accountCustomer.uid,
+        subscription.customer,
+        subscriptionId
+      );
+    }
+
+    await this.subscriptionManager.cancel(subscriptionId);
+
+    await this.customerChanged(uid);
+  }
+
   /**
    * Reload the customer data to reflect a change.
    * NOTE: This is currently duplicated in checkout.service.ts

--- a/libs/payments/ui/src/lib/actions/cancelSubscriptionImmediately.ts
+++ b/libs/payments/ui/src/lib/actions/cancelSubscriptionImmediately.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { getApp } from '../nestapp/app';
+
+export const cancelSubscriptionImmediatelyAction = async (
+  uid: string,
+  subscriptionId: string
+) => {
+  const result = await getApp()
+    .getActionsService()
+    .cancelSubscriptionImmediately({
+      uid,
+      subscriptionId,
+    });
+
+  revalidatePath('/[locale]/subscriptions/manage', 'page');
+
+  return result;
+};

--- a/libs/payments/ui/src/lib/actions/index.ts
+++ b/libs/payments/ui/src/lib/actions/index.ts
@@ -4,6 +4,7 @@
 
 export { applyCouponAction } from './applyCoupon';
 export { cancelSubscriptionAtPeriodEndAction } from './cancelSubscriptionAtPeriodEnd';
+export { cancelSubscriptionImmediatelyAction } from './cancelSubscriptionImmediately';
 export { checkoutCartWithPaypal } from './checkoutCartWithPaypal';
 export { checkoutCartWithStripe } from './checkoutCartWithStripe';
 export { determineCurrencyAction } from './determineCurrency';

--- a/libs/payments/ui/src/lib/client/components/FreeTrialContent/en.ftl
+++ b/libs/payments/ui/src/lib/client/components/FreeTrialContent/en.ftl
@@ -34,6 +34,8 @@ free-trial-content-button-resume-trial = Resume trial
 free-trial-content-button-resume-trial-aria = Resume trial for { $productName }
 free-trial-content-button-cancel-trial = Cancel trial
 free-trial-content-button-cancel-trial-aria = Cancel trial for { $productName }
+free-trial-content-button-cancel-subscription = Cancel subscription
+free-trial-content-button-cancel-subscription-aria = Cancel subscription for { $productName }
 
 ## $billedOnDate (Date) - The date of the last bill (e.g., July 20, 2025)
 ## $invoiceTotal (Number) - The invoice total amount excluding tax. It will be formatted as currency.
@@ -49,6 +51,6 @@ free-trial-content-link-view-invoice = View invoice
 # $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 free-trial-content-link-view-invoice-aria = View invoice for { $productName }
 # $date (Date) - The date the free trial ended (e.g., January 16, 2026)
-free-trial-content-payment-failed = Your free trial ended on <bold>{ $date }</bold>. We were unable to process your payment to start your subscription. Please update your payment method to activate your subscription and restore access to your services.
-free-trial-content-payment-failed-no-date = We were unable to process your payment to start your subscription. Please update your payment method to activate your subscription and restore access to your services.
+free-trial-content-trial-ended = Your free trial ended on <bold>{ $date }</bold>.
+free-trial-content-could-not-process-payment = We couldn’t process your payment. Update your payment method to restore access. Processing can take up to 24 hours and may vary by bank or payment method.
 free-trial-content-button-update-payment = Update payment method

--- a/libs/payments/ui/src/lib/client/components/FreeTrialContent/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/FreeTrialContent/index.tsx
@@ -10,7 +10,8 @@ import { Localized, useLocalization } from '@fluent/react';
 
 import {
   cancelSubscriptionAtPeriodEndAction,
-  resubscribeSubscriptionAction
+  cancelSubscriptionImmediatelyAction,
+  resubscribeSubscriptionAction,
 } from '@fxa/payments/ui/actions';
 import alertIcon from '@fxa/shared/assets/images/alert-yellow.svg';
 import infoIcon from '@fxa/shared/assets/images/infoBlack.svg';
@@ -97,7 +98,7 @@ export const FreeTrialContent = ({
     hasTax?: boolean,
     amount?: string,
     tax?: string,
-    date?: string,
+    date?: string
   ): { ftlId: string; fallbackText: string } => {
     if (hasTax) {
       switch (interval) {
@@ -174,10 +175,22 @@ export const FreeTrialContent = ({
     setLoading(true);
     setShowActionError(false);
 
-    const result = await cancelSubscriptionAtPeriodEndAction(
-      userId,
-      trial.id
-    );
+    const result = await cancelSubscriptionAtPeriodEndAction(userId, trial.id);
+    if (result.ok) {
+      setIsCancelled(true);
+    } else {
+      setShowActionError(true);
+    }
+    setLoading(false);
+  }
+
+  async function cancelSubscription() {
+    if (loading) return;
+
+    setLoading(true);
+    setShowActionError(false);
+
+    const result = await cancelSubscriptionImmediatelyAction(userId, trial.id);
     if (result.ok) {
       setIsCancelled(true);
     } else {
@@ -192,10 +205,7 @@ export const FreeTrialContent = ({
     setLoading(true);
     setShowActionError(false);
 
-    const result = await resubscribeSubscriptionAction(
-      userId,
-      trial.id
-    );
+    const result = await resubscribeSubscriptionAction(userId, trial.id);
     if (result.ok) {
       setIsCancelled(false);
     } else {
@@ -277,27 +287,31 @@ export const FreeTrialContent = ({
                 aria-hidden="true"
               />
               {trialEndDateFallback ? (
-                <Localized
-                  id="free-trial-content-payment-failed"
-                  vars={{ date: trialEndDateFallback }}
-                  elems={{ bold: <span className="font-bold" /> }}
-                >
-                  <p className="text-sm text-black">
-                    Your free trial ended on{' '}
-                    <span className="font-bold">{trialEndDateFallback}</span>.
-                    We were unable to process your payment to start your
-                    subscription. Please update your payment method to
-                    activate your subscription and restore access to your
-                    services.
-                  </p>
-                </Localized>
+                <p>
+                  <Localized
+                    id="free-trial-content-trial-ended"
+                    vars={{ date: trialEndDateFallback }}
+                    elems={{ bold: <span className="font-bold" /> }}
+                  >
+                    <span className="text-sm text-black">
+                      Your free trial ended on{' '}
+                      <span className="font-bold">{trialEndDateFallback}</span>.
+                    </span>
+                  </Localized>{' '}
+                  <Localized id="free-trial-content-could-not-process-payment">
+                    <span className="text-sm text-black">
+                      We couldn’t process your payment. Update your payment
+                      method to restore access. Processing can take up to 24
+                      hours and may vary by bank or payment method.
+                    </span>
+                  </Localized>
+                </p>
               ) : (
-                <Localized id="free-trial-content-payment-failed-no-date">
+                <Localized id="free-trial-content-could-not-process-payment">
                   <p className="text-sm text-black">
-                    We were unable to process your payment to start your
-                    subscription. Please update your payment method to
-                    activate your subscription and restore access to your
-                    services.
+                    We couldn’t process your payment. Update your payment method
+                    to restore access. Processing can take up to 24 hours and
+                    may vary by bank or payment method.
                   </p>
                 </Localized>
               )}
@@ -305,8 +319,8 @@ export const FreeTrialContent = ({
           </div>
         )}
 
-        {updatePaymentUrl && (
-          <div className="flex justify-end items-start gap-2 self-stretch">
+        <div className="flex flex-col tablet:flex-row tablet:justify-end items-start gap-2">
+          {updatePaymentUrl && (
             <div className="ms-auto w-full tablet:w-auto">
               <LinkExternal
                 href={updatePaymentUrl}
@@ -317,8 +331,32 @@ export const FreeTrialContent = ({
                 </Localized>
               </LinkExternal>
             </div>
-          </div>
-        )}
+          )}
+
+          <button
+            onClick={cancelSubscription}
+            disabled={loading}
+            className="relative border border-grey-200 box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-grey-10 hover:bg-grey-50 w-full tablet:w-auto"
+            aria-label={l10n.getString(
+              'free-trial-content-button-cancel-subscription-aria',
+              { productName },
+              `Cancel subscription for ${productName}`
+            )}
+          >
+            {loading && (
+              <Image
+                src={spinner}
+                alt=""
+                className="absolute animate-spin h-5 w-5"
+              />
+            )}
+            <span className={loading ? 'text-transparent' : ''}>
+              <Localized id="free-trial-content-button-cancel-subscription">
+                Cancel subscription
+              </Localized>
+            </span>
+          </button>
+        </div>
       </>
     );
   } else {
@@ -352,126 +390,129 @@ export const FreeTrialContent = ({
     }
     return (
       <>
-      {isClient && (
-        <div className="bg-grey-10 leading-6 p-4 rounded-lg">
-          {isCancelled ? (
-            <div className="flex items-center gap-1">
-              <Image
-                src={alertIcon}
-                alt=""
-                width={20}
-                height={20}
-                aria-hidden="true"
-              />
-              {trialEndDateFallback ? (
-                <Localized
-                  id="free-trial-content-trial-expires"
-                  vars={{ date: trialEndDateFallback }}
-                >
-                  <p className="text-sm text-yellow-800">
-                    Your free trial expires on {trialEndDateFallback}.
-                  </p>
-                </Localized>
-              ) : (
-                <Localized id="free-trial-content-trial-cancelled">
-                  <p className="text-sm text-yellow-800">
-                    Your free trial has been cancelled.
-                  </p>
-                </Localized>
-              )}
-            </div>
-          ) : (
-            <div className="flex items-center gap-1">
-              <Image
-                src={infoIcon}
-                alt=""
-                width={20}
-                height={20}
-                aria-hidden="true"
-              />
-              {chargeInfoContent ? (
-                chargeInfoContent
-              ) : trialEndDateFallback ? (
-                <Localized
-                  id="free-trial-content-trial-ends"
-                  vars={{ date: trialEndDateFallback }}
-                >
-                  <p className="text-sm">Your free trial ends on {trialEndDateFallback}. Update your payment method to keep access after your free trial.</p>
-                </Localized>
-              ) : (
-                <Localized id="free-trial-content-trial-active">
-                  <p className="text-sm">Your free trial is active.</p>
-                </Localized>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-
-      {showActionError && (
-        <Localized id="free-trial-content-action-error">
-          <p
-            className="mt-1 text-alert-red font-normal text-start"
-            role="alert"
-          >
-            An unexpected error occurred. Please try again.
-          </p>
-        </Localized>
-      )}
-
-      <div className="mt-3 tablet:mt-0 flex w-full flex-col tablet:flex-row tablet:justify-end gap-3">
-        <div className="ms-auto w-full tablet:w-auto">
-          {isCancelled ? (
-            <button
-              onClick={resumeTrial}
-              disabled={loading}
-              className="relative border box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-blue-500 hover:bg-blue-700 text-white w-full tablet:w-auto"
-              aria-label={l10n.getString(
-                'free-trial-content-button-resume-trial-aria',
-                { productName },
-                `Resume trial for ${productName}`
-              )}
-            >
-              {loading && (
+        {isClient && (
+          <div className="bg-grey-10 leading-6 p-4 rounded-lg">
+            {isCancelled ? (
+              <div className="flex items-center gap-1">
                 <Image
-                  src={spinner}
+                  src={alertIcon}
                   alt=""
-                  className="absolute animate-spin h-5 w-5"
+                  width={20}
+                  height={20}
+                  aria-hidden="true"
                 />
-              )}
-              <span className={loading ? 'text-transparent' : ''}>
-                <Localized id="free-trial-content-button-resume-trial">
-                  Resume trial
-                </Localized>
-              </span>
-            </button>
-          ) : (
-            <button
-              onClick={cancelTrial}
-              disabled={loading}
-              className="relative border border-grey-200 box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-grey-10 hover:bg-grey-50 w-full tablet:w-auto"
-              aria-label={l10n.getString(
-                'free-trial-content-button-cancel-trial-aria',
-                { productName },
-                `Cancel trial for ${productName}`
-              )}
-            >
-              {loading && (
+                {trialEndDateFallback ? (
+                  <Localized
+                    id="free-trial-content-trial-expires"
+                    vars={{ date: trialEndDateFallback }}
+                  >
+                    <p className="text-sm text-yellow-800">
+                      Your free trial expires on {trialEndDateFallback}.
+                    </p>
+                  </Localized>
+                ) : (
+                  <Localized id="free-trial-content-trial-cancelled">
+                    <p className="text-sm text-yellow-800">
+                      Your free trial has been cancelled.
+                    </p>
+                  </Localized>
+                )}
+              </div>
+            ) : (
+              <div className="flex items-center gap-1">
                 <Image
-                  src={spinner}
+                  src={infoIcon}
                   alt=""
-                  className="absolute animate-spin h-5 w-5"
+                  width={20}
+                  height={20}
+                  aria-hidden="true"
                 />
-              )}
-              <span className={loading ? 'text-transparent' : ''}>
-                <Localized id="free-trial-content-button-cancel-trial">
-                  Cancel trial
-                </Localized>
-              </span>
-            </button>
-          )}
+                {chargeInfoContent ? (
+                  chargeInfoContent
+                ) : trialEndDateFallback ? (
+                  <Localized
+                    id="free-trial-content-trial-ends"
+                    vars={{ date: trialEndDateFallback }}
+                  >
+                    <p className="text-sm">
+                      Your free trial ends on {trialEndDateFallback}. Update
+                      your payment method to keep access after your free trial.
+                    </p>
+                  </Localized>
+                ) : (
+                  <Localized id="free-trial-content-trial-active">
+                    <p className="text-sm">Your free trial is active.</p>
+                  </Localized>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {showActionError && (
+          <Localized id="free-trial-content-action-error">
+            <p
+              className="mt-1 text-alert-red font-normal text-start"
+              role="alert"
+            >
+              An unexpected error occurred. Please try again.
+            </p>
+          </Localized>
+        )}
+
+        <div className="mt-3 tablet:mt-0 flex w-full flex-col tablet:flex-row tablet:justify-end gap-3">
+          <div className="ms-auto w-full tablet:w-auto">
+            {isCancelled ? (
+              <button
+                onClick={resumeTrial}
+                disabled={loading}
+                className="relative border box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-blue-500 hover:bg-blue-700 text-white w-full tablet:w-auto"
+                aria-label={l10n.getString(
+                  'free-trial-content-button-resume-trial-aria',
+                  { productName },
+                  `Resume trial for ${productName}`
+                )}
+              >
+                {loading && (
+                  <Image
+                    src={spinner}
+                    alt=""
+                    className="absolute animate-spin h-5 w-5"
+                  />
+                )}
+                <span className={loading ? 'text-transparent' : ''}>
+                  <Localized id="free-trial-content-button-resume-trial">
+                    Resume trial
+                  </Localized>
+                </span>
+              </button>
+            ) : (
+              <button
+                onClick={cancelTrial}
+                disabled={loading}
+                className="relative border border-grey-200 box-border flex font-bold font-header h-10 items-center justify-center rounded-md py-2 px-5 bg-grey-10 hover:bg-grey-50 w-full tablet:w-auto"
+                aria-label={l10n.getString(
+                  'free-trial-content-button-cancel-trial-aria',
+                  { productName },
+                  `Cancel trial for ${productName}`
+                )}
+              >
+                {loading && (
+                  <Image
+                    src={spinner}
+                    alt=""
+                    className="absolute animate-spin h-5 w-5"
+                  />
+                )}
+                <span className={loading ? 'text-transparent' : ''}>
+                  <Localized id="free-trial-content-button-cancel-trial">
+                    Cancel trial
+                  </Localized>
+                </span>
+              </button>
+            )}
+          </div>
         </div>
-      </div>
       </>
     );
   }

--- a/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
+++ b/libs/payments/ui/src/lib/nestapp/nextjs-actions.service.ts
@@ -124,6 +124,8 @@ import { UpdateStripePaymentDetailsResult } from './validators/UpdateStripePayme
 import { SetDefaultStripePaymentDetailsActionArgs } from './validators/SetDefaultStripePaymentDetailsActionArgs';
 import { CancelSubscriptionAtPeriodEndActionArgs } from './validators/CancelSubscriptionAtPeriodEndActionArgs';
 import { CancelSubscriptionAtPeriodEndActionResult } from './validators/CancelSubscriptionAtPeriodEndActionResult';
+import { CancelSubscriptionImmediatelyActionArgs } from './validators/CancelSubscriptionImmediatelyActionArgs';
+import { CancelSubscriptionImmediatelyActionResult } from './validators/CancelSubscriptionImmediatelyActionResult';
 import { RedeemChurnCouponActionResult } from './validators/RedeemChurnCouponActionResult';
 import { ResubscribeSubscriptionActionArgs } from './validators/ResubscribeSubscriptionActionArgs';
 import { ResubscribeSubscriptionActionResult } from './validators/ResubscribeSubscriptionActionResult';
@@ -180,6 +182,33 @@ export class NextJSActionsService {
   }) {
     try {
       await this.subscriptionManagementService.cancelSubscriptionAtPeriodEnd(
+        args.uid,
+        args.subscriptionId
+      );
+
+      return {
+        ok: true,
+      };
+    } catch (error) {
+      return {
+        ok: false,
+      };
+    }
+  }
+
+  @SanitizeExceptions()
+  @NextIOValidator(
+    CancelSubscriptionImmediatelyActionArgs,
+    CancelSubscriptionImmediatelyActionResult
+  )
+  @WithTypeCachableAsyncLocalStorage()
+  @CaptureTimingWithStatsD()
+  async cancelSubscriptionImmediately(args: {
+    uid: string;
+    subscriptionId: string;
+  }) {
+    try {
+      await this.subscriptionManagementService.cancelSubscriptionImmediately(
         args.uid,
         args.subscriptionId
       );

--- a/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionImmediatelyActionArgs.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionImmediatelyActionArgs.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsString } from 'class-validator';
+
+export class CancelSubscriptionImmediatelyActionArgs {
+  @IsString()
+  uid!: string;
+
+  @IsString()
+  subscriptionId!: string;
+}

--- a/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionImmediatelyActionResult.ts
+++ b/libs/payments/ui/src/lib/nestapp/validators/CancelSubscriptionImmediatelyActionResult.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { IsBoolean } from 'class-validator';
+
+export class CancelSubscriptionImmediatelyActionResult {
+  @IsBoolean()
+  ok!: boolean;
+}


### PR DESCRIPTION
## Because

- the customer expects service to be restored upon updating payment method, but retry may take longer


## This pull request

- updates copy to set customer expectations
- adds button to cancel subscription


## Issue that this pull request solves

Closes: PAY-3669

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots
When payment method could not be processed -
Mobile
<img width="398" height="854" alt="Screenshot 2026-05-01 at 11 18 14 AM" src="https://github.com/user-attachments/assets/77b735f7-ab51-4231-b3b2-1b1184a6a5ab" />

Tablet+
<img width="1226" height="1003" alt="Screenshot 2026-05-01 at 11 18 27 AM" src="https://github.com/user-attachments/assets/448a52ba-a6e3-45ac-bf85-95817aa1bec6" />