### PR TITLE
fix(func-tests): clear inbox at start of destroyAccount

### DIFF
--- a/packages/functional-tests/lib/testAccountTracker.ts
+++ b/packages/functional-tests/lib/testAccountTracker.ts
@@ -385,6 +385,10 @@ export class TestAccountTracker {
    * Once we have a valid sessionToken, we disconnect 2FA then destroy the account.
    */
   private async destroyAccount(account: AccountDetails | Credentials) {
+    // Clear any stale OTP/verify emails left behind by the test's UI flow,
+    // so the codes we issue below aren't shadowed by older inbox entries.
+    await this.target.emailClient.clear(account.email);
+
     // Handle passwordless accounts - they need a password set before we can destroy them
     const isPasswordless =
       'isPasswordless' in account && account.isPasswordless;


### PR DESCRIPTION
## Because

- Cleanup picks up stale OTP/verify emails left by the test's UI flow and confirms with a code the server has already rotated, failing with errno 105 "Invalid confirmation code".

## This pull request

- Clears the restmail inbox at the top of destroyAccount.

## Issue that this pull request solves

Closes: FXA-13640

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Addresses CI failure: https://app.circleci.com/pipelines/github/mozilla/fxa/69393/workflows/27e9c5e2-7393-4cfc-a652-3d250d466736/jobs/668073/parallel-runs/3?filterBy=FAILED
