### PR TITLE
feat(auth): add passkey authentication endpoints (FXA-13095)

### DIFF
--- a/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
+++ b/packages/fxa-auth-server/docs/swagger/passkeys-api.ts
@@ -60,9 +60,61 @@ const PASSKEY_REGISTRATION_FINISH_POST = {
   ],
 };
 
+/**
+ * Swagger/OpenAPI documentation for `POST /passkey/authentication/start`.
+ *
+ * Initiates the WebAuthn authentication (assertion) ceremony.
+ */
+const PASSKEY_AUTHENTICATION_START_POST = {
+  ...TAGS_PASSKEYS,
+  description: '/passkey/authentication/start',
+  notes: [
+    dedent`
+      🔓 Unauthenticated
+
+      Initiates the WebAuthn authentication ceremony. Returns
+      \`PublicKeyCredentialRequestOptionsJSON\` to pass to
+      \`navigator.credentials.get\`. \`allowCredentials\` is always empty
+      \`allowCredentials\` is omitted when the allow-list is empty (discoverable flow).
+
+      **Request body:** none
+    `,
+  ],
+};
+
+/**
+ * Swagger/OpenAPI documentation for `POST /passkey/authentication/finish`.
+ *
+ * Completes the WebAuthn authentication ceremony and creates an AAL2 session.
+ */
+const PASSKEY_AUTHENTICATION_FINISH_POST = {
+  ...TAGS_PASSKEYS,
+  description: '/passkey/authentication/finish',
+  notes: [
+    dedent`
+      🔓 Unauthenticated
+
+      Completes the WebAuthn authentication ceremony. On success, returns an
+      AAL2 session token.
+
+      **Request body:**
+      - \`response\` (object, required) — AuthenticationResponseJSON from the browser
+      - \`challenge\` (string, required) — challenge from the start endpoint
+      - \`service\` (string, optional) — OAuth service identifier (e.g. \`"sync"\`)
+
+      **Response:** \`uid\`, \`sessionToken\`, \`verified\`, \`requiresPasswordForSync\`,
+      \`hasPassword\`
+
+      **Security event:** \`account.passkey.authentication_success\` recorded on success.
+    `,
+  ],
+};
+
 const PASSKEYS_API_DOCS = {
   PASSKEY_REGISTRATION_START_POST,
   PASSKEY_REGISTRATION_FINISH_POST,
+  PASSKEY_AUTHENTICATION_START_POST,
+  PASSKEY_AUTHENTICATION_FINISH_POST,
   PASSKEYS_GET: {
     ...TAGS_PASSKEYS,
     description: '/passkeys',

--- a/packages/fxa-auth-server/lib/passkey-utils.ts
+++ b/packages/fxa-auth-server/lib/passkey-utils.ts
@@ -35,7 +35,6 @@ export function isPasskeyRegistrationEnabled(config: ConfigType): boolean {
  * Checks if passkey authentication (sign in with passkey) is enabled.
  * Requires both the master `passkeys.enabled` flag and `passkeys.authenticationEnabled`.
  * @throws AppError.featureNotEnabled if either flag is disabled
- * TODO FXA-13069: wire into passkey authentication routes once they are added to passkeys.ts
  */
 export function isPasskeyAuthenticationEnabled(config: ConfigType): boolean {
   if (!config.passkeys.enabled || !config.passkeys.authenticationEnabled) {

--- a/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.spec.ts
@@ -6,7 +6,10 @@ import { Container } from 'typedi';
 import { PasskeyService } from '@fxa/accounts/passkey';
 import { AppError } from '@fxa/accounts/errors';
 import { recordSecurityEvent } from './utils/security-event';
-import { isPasskeyRegistrationEnabled } from '../passkey-utils';
+import {
+  isPasskeyRegistrationEnabled,
+  isPasskeyAuthenticationEnabled,
+} from '../passkey-utils';
 import { passkeyRoutes, PasskeyHandler } from './passkeys';
 import { FxaMailer } from '../senders/fxa-mailer';
 
@@ -51,7 +54,15 @@ describe('passkeys routes', () => {
     passkeys: {
       enabled: true,
       registrationEnabled: true,
+      authenticationEnabled: true,
     },
+  };
+
+  const mockAuthenticationOptions = {
+    challenge: 'auth-challenge-xyz',
+    timeout: 60000,
+    userVerification: 'required',
+    rpId: 'accounts.firefox.com',
   };
 
   const mockRegistrationOptions = {
@@ -102,6 +113,7 @@ describe('passkeys routes', () => {
     };
     customs = {
       checkAuthenticated: jest.fn(),
+      checkIpOnly: jest.fn(),
     };
     statsd = {
       increment: jest.fn(),
@@ -139,6 +151,10 @@ describe('passkeys routes', () => {
       listPasskeysForUser: jest.fn().mockResolvedValue([mockPasskeyRecord]),
       deletePasskey: jest.fn().mockResolvedValue(undefined),
       renamePasskey: jest.fn().mockResolvedValue(mockPasskeyRecord),
+      generateAuthenticationChallenge: jest
+        .fn()
+        .mockResolvedValue(mockAuthenticationOptions),
+      verifyAuthenticationResponse: jest.fn().mockResolvedValue({ uid: UID }),
     };
 
     mockFxaMailer = {
@@ -154,6 +170,7 @@ describe('passkeys routes', () => {
   afterEach(() => {
     config.passkeys.enabled = true;
     config.passkeys.registrationEnabled = true;
+    config.passkeys.authenticationEnabled = true;
     Container.reset();
   });
 
@@ -164,6 +181,19 @@ describe('passkeys routes', () => {
           passkeys: {
             enabled: true,
             registrationEnabled: false,
+          },
+        })
+      ).toThrow('Feature not enabled');
+    });
+  });
+
+  describe('isPasskeyAuthenticationEnabled', () => {
+    it('throws featureNotEnabled when authenticationEnabled is false', () => {
+      expect(() =>
+        isPasskeyAuthenticationEnabled({
+          passkeys: {
+            enabled: true,
+            authenticationEnabled: false,
           },
         })
       ).toThrow('Feature not enabled');
@@ -947,6 +977,207 @@ describe('passkeys routes', () => {
     });
   });
 
+  describe('POST /passkey/authentication/start', () => {
+    it('calls PasskeyService.generateAuthenticationChallenge with no uid and returns options', async () => {
+      const result = await runTest('/passkey/authentication/start', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+      });
+
+      expect(result).toBe(mockAuthenticationOptions);
+      expect(
+        mockPasskeyService.generateAuthenticationChallenge
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        mockPasskeyService.generateAuthenticationChallenge
+      ).toHaveBeenCalledWith();
+    });
+
+    it('enforces rate limiting via customs.checkIpOnly', async () => {
+      await runTest('/passkey/authentication/start', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+      });
+
+      expect(customs.checkIpOnly).toHaveBeenCalledWith(
+        expect.anything(),
+        'passkeyAuthStart'
+      );
+    });
+
+    it('throws when customs rate limit blocks the request', async () => {
+      customs.checkIpOnly = jest
+        .fn()
+        .mockRejectedValue(AppError.tooManyRequests(60));
+
+      await expect(() =>
+        runTest('/passkey/authentication/start', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+        })
+      ).rejects.toThrow('Client has sent too many requests');
+    });
+  });
+
+  describe('POST /passkey/authentication/finish', () => {
+    const payload = {
+      response: {
+        id: 'credential-id',
+        type: 'public-key',
+        response: { authenticatorData: 'abc' },
+      },
+      challenge: 'auth-challenge-xyz',
+    };
+
+    it('verifies the response and returns session token with metadata', async () => {
+      const result = await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      expect(
+        mockPasskeyService.verifyAuthenticationResponse
+      ).toHaveBeenCalledWith(payload.response, payload.challenge);
+      expect(db.createPasskeyVerifiedSessionToken).toHaveBeenCalledWith(
+        expect.objectContaining({ uid: UID })
+      );
+      expect(result).toEqual({
+        uid: UID,
+        sessionToken: 'new-session-token-id',
+        verified: true,
+        requiresPasswordForSync: false,
+        hasPassword: true,
+      });
+    });
+
+    it('sets requiresPasswordForSync true when service is sync', async () => {
+      const result = await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload: { ...payload, service: 'sync' },
+      });
+
+      expect(result.requiresPasswordForSync).toBe(true);
+    });
+
+    it('sets hasPassword false for passwordless accounts', async () => {
+      db.account.mockResolvedValueOnce({
+        email: TEST_EMAIL,
+        emailCode: 'emailcode123',
+        emailVerified: true,
+        verifierSetAt: 0,
+      });
+
+      const result = await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      expect(result.hasPassword).toBe(false);
+    });
+
+    it('records account.passkey.authentication_success security event', async () => {
+      await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.authentication_success',
+        expect.anything()
+      );
+    });
+
+    it('enforces rate limiting via customs.checkIpOnly', async () => {
+      await runTest('/passkey/authentication/finish', {
+        auth: { credentials: {} },
+        app: { ua: {} },
+        payload,
+      });
+
+      expect(customs.checkIpOnly).toHaveBeenCalledWith(
+        expect.anything(),
+        'passkeyAuthFinish'
+      );
+    });
+
+    it('records authentication_failure and rethrows when verifyAuthenticationResponse fails', async () => {
+      mockPasskeyService.verifyAuthenticationResponse = jest
+        .fn()
+        .mockRejectedValue(AppError.passkeyAuthenticationFailed());
+
+      await expect(() =>
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toThrow();
+
+      expect(recordSecurityEvent).toHaveBeenCalledWith(
+        'account.passkey.authentication_failure',
+        expect.anything()
+      );
+    });
+
+    it('does not record authentication_success when verification fails', async () => {
+      mockPasskeyService.verifyAuthenticationResponse = jest
+        .fn()
+        .mockRejectedValue(AppError.passkeyAuthenticationFailed());
+
+      await expect(() =>
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toThrow();
+
+      expect(recordSecurityEvent).not.toHaveBeenCalledWith(
+        'account.passkey.authentication_success',
+        expect.anything()
+      );
+    });
+
+    it('throws when customs rate limit blocks the request', async () => {
+      customs.checkIpOnly = jest
+        .fn()
+        .mockRejectedValue(AppError.tooManyRequests(60));
+
+      await expect(() =>
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toThrow('Client has sent too many requests');
+    });
+
+    it('propagates db.account failure after successful verification', async () => {
+      db.account.mockRejectedValueOnce(new Error('DB error'));
+
+      await expect(() =>
+        runTest('/passkey/authentication/finish', {
+          auth: { credentials: {} },
+          app: { ua: {} },
+          payload,
+        })
+      ).rejects.toThrow('DB error');
+
+      expect(recordSecurityEvent).not.toHaveBeenCalledWith(
+        'account.passkey.authentication_success',
+        expect.anything()
+      );
+      expect(recordSecurityEvent).not.toHaveBeenCalledWith(
+        'account.passkey.authentication_failure',
+        expect.anything()
+      );
+    });
+  });
+
   describe('PasskeyHandler.createPasskeySessionToken', () => {
     const mockAccount = {
       uid: UID,
@@ -978,7 +1209,8 @@ describe('passkeys routes', () => {
         customs,
         log,
         mockFxaMailer,
-        statsd
+        statsd,
+        glean
       );
     });
 

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -11,10 +11,15 @@ import { ConfigType } from '../../config';
 import {
   isPasskeyFeatureEnabled,
   isPasskeyRegistrationEnabled,
+  isPasskeyAuthenticationEnabled,
 } from '../passkey-utils';
 import { GleanMetricsType } from '../metrics/glean';
 import PASSKEYS_API_DOCS from '../../docs/swagger/passkeys-api';
-import { RegistrationResponseJSON } from '@simplewebauthn/server';
+import validators from './validators';
+import {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
 import { FxaMailer } from '../senders/fxa-mailer';
 import { FxaMailerFormat } from '../senders/fxa-mailer-format';
 import { reportSentryError } from '../sentry';
@@ -31,6 +36,11 @@ interface Customs {
     email: string,
     action: string
   ) => Promise<void>;
+  /**
+   * Enforces rate-limiting by IP address only (no uid/email required).
+   * Used for unauthenticated endpoints where the caller is not yet identified.
+   */
+  checkIpOnly: (req: AuthRequest, action: string) => Promise<void>;
 }
 
 /** Subset of the database used by passkey routes. */
@@ -342,6 +352,91 @@ export class PasskeyHandler {
   }
 
   /**
+   * Handles `POST /passkey/authentication/start`.
+   *
+   * Initiates the WebAuthn authentication (assertion) ceremony by generating
+   * a challenge and returning `PublicKeyCredentialRequestOptions` for the
+   * browser. No email or uid is accepted in the request body — discoverable
+   * credentials only.
+   *
+   * @param request - Unauthenticated Hapi request.
+   * @returns WebAuthn authentication options to pass to `navigator.credentials.get`.
+   */
+  async authenticationStart(request: AuthRequest) {
+    await this.customs.checkIpOnly(request, 'passkeyAuthStart');
+
+    const options = await this.service.generateAuthenticationChallenge();
+
+    // TODO: FXA-12914 — Glean event name needs to be defined in the Glean schema
+    // await this.glean.passkey.authenticationStarted(request);
+
+    return options;
+  }
+
+  /**
+   * Handles `POST /passkey/authentication/finish`.
+   *
+   * Completes the WebAuthn authentication ceremony by verifying the assertion
+   * response, creating an AAL2 session token, and returning the session along
+   * with flags the UI needs to drive the post-login flow.
+   *
+   * @param request - Unauthenticated Hapi request containing `response`,
+   *   `challenge`, and optional `service` in the payload.
+   * @returns Session token, uid, and metadata including `requiresPasswordForSync`
+   *   and `hasPassword`.
+   */
+  async authenticationFinish(request: AuthRequest) {
+    await this.customs.checkIpOnly(request, 'passkeyAuthFinish');
+
+    const { response, challenge, service } = request.payload as {
+      response: AuthenticationResponseJSON;
+      challenge: string;
+      service?: string;
+    };
+
+    let uid: string;
+    try {
+      ({ uid } = await this.service.verifyAuthenticationResponse(
+        response,
+        challenge
+      ));
+    } catch (err) {
+      await recordSecurityEvent('account.passkey.authentication_failure', {
+        db: this.db,
+        request,
+      });
+      throw err;
+    }
+
+    const account = await this.db.account(uid);
+
+    const sessionToken = await this.createPasskeySessionToken(
+      { ...account, uid },
+      request
+    );
+
+    await recordSecurityEvent('account.passkey.authentication_success', {
+      db: this.db,
+      request,
+      account: { uid },
+    });
+
+    // TODO: FXA-12914 — Glean event name needs to be defined in the Glean schema
+    // await this.glean.passkey.authenticationSuccess(request);
+
+    const requiresPasswordForSync = service === 'sync';
+    const hasPassword = account.verifierSetAt > 0;
+
+    return {
+      uid,
+      sessionToken: sessionToken.id,
+      verified: true,
+      requiresPasswordForSync,
+      hasPassword,
+    };
+  }
+
+  /**
    * Creates a passkey-verified session token for the authenticated account.
    *
    * No `tokenVerificationId` is set — the passkey assertion is itself AAL2, so
@@ -396,18 +491,20 @@ export class PasskeyHandler {
  */
 export const passkeyRoutes = (
   customs: Customs,
-  db: any,
+  db: DB,
   config: ConfigType,
   statsd: any,
   glean: GleanMetricsType,
   log: any
 ) => {
   // Passkey route flag hierarchy:
-  //   passkeys.enabled (master switch) — gates management routes (list/delete/rename)
-  //   + registrationEnabled            — gates registration routes
-  //   + authenticationEnabled          — gates auth routes (TODO FXA-13095)
+  //   passkeys.enabled (master switch)  — gates management routes (list/delete/rename)
+  //   + registrationEnabled             — gates registration routes
+  //   + authenticationEnabled           — gates authentication routes
   const passkeysEnabledCheck = () => isPasskeyFeatureEnabled(config);
   const registrationEnabledCheck = () => isPasskeyRegistrationEnabled(config);
+  const authenticationEnabledCheck = () =>
+    isPasskeyAuthenticationEnabled(config);
 
   const service = Container.get(PasskeyService);
   if (!service) {
@@ -640,6 +737,77 @@ export const passkeyRoutes = (
       handler: function (request: AuthRequest) {
         log.begin('passkey.delete', request);
         return handler.deletePasskey(request);
+      },
+    },
+    {
+      method: 'POST',
+      path: '/passkey/authentication/start',
+      options: {
+        ...PASSKEYS_API_DOCS.PASSKEY_AUTHENTICATION_START_POST,
+        pre: [{ method: authenticationEnabledCheck }],
+        auth: false,
+        response: {
+          schema: isA.object({
+            challenge: isA.string().required(),
+            allowCredentials: isA.array().items(isA.object()).optional(),
+            timeout: isA.number().optional(),
+            userVerification: isA
+              .string()
+              .valid('discouraged', 'preferred', 'required')
+              .optional(),
+            rpId: isA.string().optional(),
+            hints: isA
+              .array()
+              .items(
+                isA.string().valid('hybrid', 'security-key', 'client-device')
+              )
+              .optional(),
+            extensions: isA.object().optional(),
+          }),
+        },
+      },
+      handler: async function (request: AuthRequest) {
+        log.begin('passkey.authentication.start', request);
+        return handler.authenticationStart(request);
+      },
+    },
+    {
+      method: 'POST',
+      path: '/passkey/authentication/finish',
+      options: {
+        ...PASSKEYS_API_DOCS.PASSKEY_AUTHENTICATION_FINISH_POST,
+        pre: [{ method: authenticationEnabledCheck }],
+        auth: false,
+        validate: {
+          payload: isA.object({
+            response: isA
+              .object({
+                id: isA.string().required(),
+                type: isA.string().valid('public-key').required(),
+              })
+              .unknown(true)
+              .required(),
+            challenge: isA
+              .string()
+              .max(64)
+              .regex(/^[A-Za-z0-9_-]+$/)
+              .required(),
+            service: validators.service.optional(),
+          }),
+        },
+        response: {
+          schema: isA.object({
+            uid: isA.string().required(),
+            sessionToken: isA.string().required(),
+            verified: isA.boolean().required(),
+            requiresPasswordForSync: isA.boolean().required(),
+            hasPassword: isA.boolean().required(),
+          }),
+        },
+      },
+      handler: async function (request: AuthRequest) {
+        log.begin('passkey.authentication.finish', request);
+        return handler.authenticationFinish(request);
       },
     },
     {

--- a/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/passkeys.in.spec.ts
@@ -11,6 +11,7 @@ import {
   PasskeyChallengeManager,
   PasskeyManager,
   VirtualAuthenticator,
+  VirtualCredential,
 } from '@fxa/accounts/passkey';
 import Config from '../../config';
 import {
@@ -95,6 +96,32 @@ beforeEach(() => {
 
 const password = 'pssssst';
 
+async function getMfaAccessTokenForPasskey(clientInstance: any) {
+  // Request an OTP email for the passkey MFA action
+  await clientInstance.api.doRequest(
+    'POST',
+    `${clientInstance.api.baseURL}/mfa/otp/request`,
+    await clientInstance.api.Token.SessionToken.fromHex(
+      clientInstance.sessionToken
+    ),
+    { action: 'passkey' }
+  );
+
+  // Read OTP code from mailbox
+  const code = await server.mailbox.waitForMfaCode(clientInstance.email);
+
+  // Verify OTP and get back a JWT access token
+  const verifyRes = await clientInstance.api.doRequest(
+    'POST',
+    `${clientInstance.api.baseURL}/mfa/otp/verify`,
+    await clientInstance.api.Token.SessionToken.fromHex(
+      clientInstance.sessionToken
+    ),
+    { action: 'passkey', code }
+  );
+  return verifyRes.accessToken;
+}
+
 describe('#integration - remote passkey registration', () => {
   let passkeyEmail: string;
   let passkeyClient: any;
@@ -111,32 +138,6 @@ describe('#integration - remote passkey registration', () => {
       }
     );
   });
-
-  async function getMfaAccessTokenForPasskey(clientInstance: any) {
-    // Request an OTP email for the passkey MFA action
-    await clientInstance.api.doRequest(
-      'POST',
-      `${clientInstance.api.baseURL}/mfa/otp/request`,
-      await clientInstance.api.Token.SessionToken.fromHex(
-        clientInstance.sessionToken
-      ),
-      { action: 'passkey' }
-    );
-
-    // Read OTP code from mailbox
-    const code = await server.mailbox.waitForMfaCode(clientInstance.email);
-
-    // Verify OTP and get back a JWT access token
-    const verifyRes = await clientInstance.api.doRequest(
-      'POST',
-      `${clientInstance.api.baseURL}/mfa/otp/verify`,
-      await clientInstance.api.Token.SessionToken.fromHex(
-        clientInstance.sessionToken
-      ),
-      { action: 'passkey', code }
-    );
-    return verifyRes.accessToken;
-  }
 
   it('POST /passkey/registration/start - without auth returns 401', async () => {
     await expect(async () => {
@@ -215,5 +216,119 @@ describe('#integration - remote passkey registration', () => {
     expect(result.credentialId).toBeDefined();
     expect(result.name).toBeDefined();
     expect(result.createdAt).toEqual(expect.any(Number));
+  });
+});
+
+describe('#integration - remote passkey authentication', () => {
+  let authEmail: string;
+  let authClient: any;
+  let registeredCred: VirtualCredential;
+
+  beforeEach(async () => {
+    authEmail = server.uniqueEmail();
+    authClient = await Client.createAndVerify(
+      server.publicUrl,
+      authEmail,
+      password,
+      server.mailbox,
+      { version: 'V2' }
+    );
+
+    // Register a passkey so authentication tests have a credential to use
+    const accessToken = await getMfaAccessTokenForPasskey(authClient);
+    const options = await authClient.api.doRequestWithBearerToken(
+      'POST',
+      `${authClient.api.baseURL}/passkey/registration/start`,
+      accessToken,
+      {}
+    );
+    registeredCred = VirtualAuthenticator.createCredential();
+    const registrationResponse = VirtualAuthenticator.createAttestationResponse(
+      registeredCred,
+      {
+        challenge: options.challenge,
+        origin: passkeyOrigin,
+        rpId: passkeyRpId,
+      }
+    );
+    await authClient.api.doRequestWithBearerToken(
+      'POST',
+      `${authClient.api.baseURL}/passkey/registration/finish`,
+      accessToken,
+      { response: registrationResponse, challenge: options.challenge }
+    );
+  });
+
+  it('POST /passkey/authentication/start - returns challenge and options', async () => {
+    const result = await authClient.api.doRequest(
+      'POST',
+      `${authClient.api.baseURL}/passkey/authentication/start`,
+      null,
+      {}
+    );
+    expect(result.challenge).toBeDefined();
+    expect(result.rpId).toBeDefined();
+  });
+
+  it('happy path: /passkey/authentication/start then /passkey/authentication/finish', async () => {
+    const startResult = await authClient.api.doRequest(
+      'POST',
+      `${authClient.api.baseURL}/passkey/authentication/start`,
+      null,
+      {}
+    );
+    expect(startResult.challenge).toBeDefined();
+
+    const assertionResponse = VirtualAuthenticator.createAssertionResponse(
+      registeredCred,
+      {
+        challenge: startResult.challenge,
+        origin: passkeyOrigin,
+        rpId: passkeyRpId,
+      }
+    );
+
+    const finishResult = await authClient.api.doRequest(
+      'POST',
+      `${authClient.api.baseURL}/passkey/authentication/finish`,
+      null,
+      { response: assertionResponse, challenge: startResult.challenge }
+    );
+
+    expect(finishResult.uid).toBeDefined();
+    expect(finishResult.sessionToken).toBeDefined();
+    expect(finishResult.verified).toBe(true);
+    expect(finishResult.hasPassword).toBe(true);
+    expect(finishResult.requiresPasswordForSync).toBe(false);
+  });
+
+  it('POST /passkey/authentication/finish - mismatched challenge returns error', async () => {
+    const startResult = await authClient.api.doRequest(
+      'POST',
+      `${authClient.api.baseURL}/passkey/authentication/start`,
+      null,
+      {}
+    );
+    const assertionResponse = VirtualAuthenticator.createAssertionResponse(
+      registeredCred,
+      {
+        challenge: startResult.challenge,
+        origin: passkeyOrigin,
+        rpId: passkeyRpId,
+      }
+    );
+    // The assertion was signed for startResult.challenge but we submit a
+    // different challenge string, so verifyAuthenticationResponse must fail.
+    await expect(async () => {
+      await authClient.api.doRequest(
+        'POST',
+        `${authClient.api.baseURL}/passkey/authentication/finish`,
+        null,
+        {
+          response: assertionResponse,
+          challenge: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        }
+      );
+    }).rejects.toBeDefined();
   });
 });


### PR DESCRIPTION
## Because

- Passkey sign-in requires a two-step WebAuthn assertion ceremony before a session can be issued.

## This pull request

- Adds `POST /passkey/authentication/start` to generate a WebAuthn assertion challenge
- Adds `POST /passkey/authentication/finish` to verify the assertion and create an AAL2 session token
- Records `account.passkey.authentication_success` and `account.passkey.authentication_failure` security events
- Rate-limits by IP via `customs.checkIpOnly` (note: actions must be registered in customs-server — tracked in FXA-13644)
- Wires `isPasskeyAuthenticationEnabled` into routes, clearing the FXA-13069 TODO
- Adds Swagger docs and unit tests for new paths

## Issue that this pull request solves

Closes: FXA-13095

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `lib/routes/passkeys.ts` (handler methods `authenticationStart`/`authenticationFinish`, route config), `lib/routes/passkeys.spec.ts`
- Risky or complex parts: `auth: false` on unauthenticated routes, AAL2 session creation via `createPasskeySessionToken`, security event attribution (uid is unknown on early auth failures by design)

## Other information (Optional)

Follow-up: [FXA-13644](https://mozilla-hub.atlassian.net/browse/FXA-13644) — register `passkeyAuthStart`/`passkeyAuthFinish` in customs-server with appropriate per-IP rate limits.

[FXA-13644]: https://mozilla-hub.atlassian.net/browse/FXA-13644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ