### PR TITLE
feat(auth): Include ja3, ja4, and fastly signals in security events

### DIFF
--- a/packages/fxa-auth-server/lib/account-events.ts
+++ b/packages/fxa-auth-server/lib/account-events.ts
@@ -39,6 +39,13 @@ interface SecurityEventAdditionalInfo {
   };
   client_id?: string;
   service?: string;
+  waf?: {
+    clientJa4?: string;
+    clientJa3?: string;
+    fastlyRequestId?: string;
+    sigsciRequestId?: string;
+    sigsciTags?: string;
+  };
 }
 
 type SecurityEvent = BaseEvent & {

--- a/packages/fxa-auth-server/lib/routes/account.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/account.spec.ts
@@ -3111,10 +3111,10 @@ describe('/account/login', () => {
               name: 'account.signin_confirm_bypass_new_account',
               uid,
               ipAddr: mockRequest.app.clientAddress,
-              additionalInfo: {
+              additionalInfo: expect.objectContaining({
                 userAgent: mockRequest.headers['user-agent'],
                 location: mockRequest.app.geo.location,
-              },
+              }),
             })
           );
         });
@@ -3149,10 +3149,10 @@ describe('/account/login', () => {
               name: 'account.signin_confirm_bypass_known_ip',
               uid,
               ipAddr: mockRequest.app.clientAddress,
-              additionalInfo: {
+              additionalInfo: expect.objectContaining({
                 userAgent: mockRequest.headers['user-agent'],
                 location: mockRequest.app.geo.location,
-              },
+              }),
             })
           );
         });
@@ -3393,11 +3393,11 @@ describe('/account/login', () => {
               uid: uid,
               ipAddr: requestWithUserAgent.app.clientAddress,
               tokenId: undefined,
-              additionalInfo: {
+              additionalInfo: expect.objectContaining({
                 userAgent:
                   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
                 location: requestWithUserAgent.app.geo.location,
-              },
+              }),
             })
           );
         });

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.spec.ts
@@ -103,7 +103,7 @@ describe('backup authentication codes', () => {
             uid: 'uid',
             ipAddr: '63.245.221.32',
             tokenId: undefined,
-            additionalInfo: {
+            additionalInfo: expect.objectContaining({
               userAgent: 'test user-agent',
               location: {
                 city: 'Mountain View',
@@ -112,7 +112,7 @@ describe('backup authentication codes', () => {
                 state: 'California',
                 stateCode: 'CA',
               },
-            },
+            }),
           });
         }
       );
@@ -142,7 +142,7 @@ describe('backup authentication codes', () => {
             uid: 'uid',
             ipAddr: '63.245.221.32',
             tokenId: undefined,
-            additionalInfo: {
+            additionalInfo: expect.objectContaining({
               userAgent: 'test user-agent',
               location: {
                 city: 'Mountain View',
@@ -151,7 +151,7 @@ describe('backup authentication codes', () => {
                 state: 'California',
                 stateCode: 'CA',
               },
-            },
+            }),
           });
         }
       );
@@ -204,7 +204,7 @@ describe('backup authentication codes', () => {
           uid: 'uid',
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -213,7 +213,7 @@ describe('backup authentication codes', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
     });

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
@@ -161,7 +161,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -170,7 +170,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
       expect(mockStatsd.increment).toHaveBeenCalledTimes(1);
@@ -286,7 +286,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -295,7 +295,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
       expect(mockStatsd.increment).toHaveBeenCalledTimes(1);
@@ -601,7 +601,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -610,7 +610,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
 
@@ -745,7 +745,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -754,7 +754,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
       expect(mockStatsd.increment).toHaveBeenCalledTimes(1);
@@ -792,7 +792,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -801,7 +801,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         });
       }
     });
@@ -843,7 +843,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -852,7 +852,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
       expect(mockStatsd.increment).toHaveBeenCalledTimes(1);
@@ -888,7 +888,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -897,7 +897,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         });
       }
     });
@@ -936,7 +936,7 @@ describe('/recovery_phone', () => {
           uid,
           ipAddr: '63.245.221.32',
           tokenId: undefined,
-          additionalInfo: {
+          additionalInfo: expect.objectContaining({
             userAgent: 'test user-agent',
             location: {
               city: 'Mountain View',
@@ -945,7 +945,7 @@ describe('/recovery_phone', () => {
               state: 'California',
               stateCode: 'CA',
             },
-          },
+          }),
         }
       );
       expect(mockStatsd.increment).toHaveBeenCalledTimes(1);

--- a/packages/fxa-auth-server/lib/routes/session.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/session.spec.ts
@@ -781,7 +781,7 @@ describe('/session/destroy', () => {
         uid: 'foo',
         ipAddr: '63.245.221.32',
         tokenId: undefined,
-        additionalInfo: {
+        additionalInfo: expect.objectContaining({
           userAgent: 'test user-agent',
           location: {
             city: 'Mountain View',
@@ -790,7 +790,7 @@ describe('/session/destroy', () => {
             state: 'California',
             stateCode: 'CA',
           },
-        },
+        }),
       });
     });
   });

--- a/packages/fxa-auth-server/lib/routes/totp.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/totp.spec.ts
@@ -291,7 +291,7 @@ describe('totp', () => {
             uid: 'uid',
             ipAddr: '63.245.221.32',
             tokenId: 'id',
-            additionalInfo: {
+            additionalInfo: expect.objectContaining({
               userAgent: 'test user-agent',
               location: {
                 city: 'Mountain View',
@@ -300,7 +300,7 @@ describe('totp', () => {
                 state: 'California',
                 stateCode: 'CA',
               },
-            },
+            }),
           }
         );
 
@@ -403,7 +403,7 @@ describe('totp', () => {
             uid: 'uid',
             ipAddr: '63.245.221.32',
             tokenId: 'id',
-            additionalInfo: {
+            additionalInfo: expect.objectContaining({
               userAgent: 'test user-agent',
               location: {
                 city: 'Mountain View',
@@ -412,7 +412,7 @@ describe('totp', () => {
                 state: 'California',
                 stateCode: 'CA',
               },
-            },
+            }),
           }
         );
 

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.spec.ts
@@ -2,7 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { isRecognizedDevice } = require('./security-event');
+jest.mock('typedi', () => ({
+  Container: { get: jest.fn() },
+  Token: class Token {
+    constructor(public name: string) {}
+  },
+}));
+
+const { Container } = require('typedi');
+const { isRecognizedDevice, recordSecurityEvent } = require('./security-event');
+
+function makeOpts(extraHeaders: Record<string, string> = {}) {
+  return {
+    db: {},
+    account: { uid: 'test-uid' },
+    request: {
+      headers: { 'user-agent': 'TestAgent/1.0', ...extraHeaders },
+      app: {
+        clientIdTag: undefined,
+        serviceTag: undefined,
+        clientAddress: '127.0.0.1',
+        geo: { location: { city: 'Portland', country: 'US' } },
+      },
+      auth: { credentials: { uid: 'test-uid', id: 'token-id' } },
+    },
+  };
+}
 
 describe('isRecognizedDevice', () => {
   beforeEach(() => {});
@@ -277,5 +302,66 @@ describe('isRecognizedDevice', () => {
     );
 
     expect(result).toBe(true);
+  });
+});
+
+describe('recordSecurityEvent', () => {
+  let mockMgrRecordSecurityEvent: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockMgrRecordSecurityEvent = jest.fn().mockResolvedValue(undefined);
+    Container.get.mockReturnValue({
+      recordSecurityEvent: mockMgrRecordSecurityEvent,
+    });
+  });
+
+  it('includes all WAF headers in additionalInfo.waf when present', async () => {
+    const opts = makeOpts({
+      'client-ja4': 't13d1516h2_test',
+      'client-ja3': 'abcdef123456',
+      'x-fastly-request-id': 'fastly-req-123',
+      'x-sigsci-requestid': 'sigsci-req-456',
+      'x-sigsci-tags': 'SQLI,BOT-CHALLENGED',
+    });
+
+    await recordSecurityEvent('account.login', opts);
+
+    expect(mockMgrRecordSecurityEvent).toHaveBeenCalledWith(
+      opts.db,
+      expect.objectContaining({
+        additionalInfo: expect.objectContaining({
+          waf: expect.objectContaining({
+            clientJa4: 't13d1516h2_test',
+            clientJa3: 'abcdef123456',
+            fastlyRequestId: 'fastly-req-123',
+            sigsciRequestId: 'sigsci-req-456',
+            sigsciTags: 'SQLI,BOT-CHALLENGED',
+          }),
+        }),
+      })
+    );
+  });
+
+  it('omits waf from additionalInfo when no WAF headers are present', async () => {
+    await recordSecurityEvent('account.login', makeOpts());
+
+    const [, message] = mockMgrRecordSecurityEvent.mock.calls[0];
+    expect(message.additionalInfo.waf).toBeUndefined();
+  });
+
+  it('includes waf when only some WAF headers are present', async () => {
+    const opts = makeOpts({
+      'client-ja4': 't13d1516h2_partial',
+      'x-sigsci-tags': 'TRAVERSAL',
+    });
+
+    await recordSecurityEvent('account.login', opts);
+
+    const [, message] = mockMgrRecordSecurityEvent.mock.calls[0];
+    expect(message.additionalInfo.waf).toMatchObject({
+      clientJa4: 't13d1516h2_partial',
+      sigsciTags: 'TRAVERSAL',
+    });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/utils/security-event.ts
+++ b/packages/fxa-auth-server/lib/routes/utils/security-event.ts
@@ -14,6 +14,15 @@ export async function recordSecurityEvent(name: SecurityEventNames, opts: any) {
 
   const clientId = opts?.request?.app?.clientIdTag;
   const service = opts?.request?.app?.serviceTag;
+  const headers = opts?.request?.headers;
+
+  const waf = {
+    clientJa4: headers?.['client-ja4'],
+    clientJa3: headers?.['client-ja3'],
+    fastlyRequestId: headers?.['x-fastly-request-id'],
+    sigsciRequestId: headers?.['x-sigsci-requestid'],
+    sigsciTags: headers?.['x-sigsci-tags'],
+  };
 
   await mgr.recordSecurityEvent(opts.db, {
     name,
@@ -25,6 +34,7 @@ export async function recordSecurityEvent(name: SecurityEventNames, opts: any) {
       location: opts?.request.app.geo.location,
       ...(clientId && { client_id: clientId }),
       ...(service && { service }),
+      waf: Object.values(waf).some(Boolean) ? waf : undefined,
     },
   });
 }


### PR DESCRIPTION
## Because

- We want additional Fastly and sigsci values in security events

## This pull request

- Adds them as optional values recorded on every security event

## Issue that this pull request solves

Closes: FXA-13655

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
