### PR TITLE
chore(deps): Remove ineffective dependabot rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,6 @@ updates:
       - dependency-name: '*'
         update-types: ['version-update:semver-patch']
     groups:
-      one-package-per-pr: # prevent grouping of unrelated PRs
-        patterns:
-          - '*'
       opentelemetry-packages:
         patterns:
           - '@opentelemetry/*'


### PR DESCRIPTION
## Because

- The `one-package-per-pr` group did not have the desired effect
- Grouping likely stemmed from dependabot settings in github

## This pull request

- Removes the ineffective `one-package-per-pr` group

## Issue that this pull request solves

Closes: (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
