### PR TITLE
fix(otp): Hide 'Use another account' link when signed into Desktop

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -656,6 +656,7 @@ const AuthAndAccountSetupRoutes = ({
             integration,
             serviceName,
             flowQueryParams,
+            isSignedIntoFirefox,
             setCurrentSplitLayout,
           }}
         />
@@ -665,6 +666,7 @@ const AuthAndAccountSetupRoutes = ({
             integration,
             serviceName,
             flowQueryParams,
+            isSignedIntoFirefox,
             setCurrentSplitLayout,
           }}
         />

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/container.tsx
@@ -20,6 +20,7 @@ import { getHandledError, type HandledError } from '../../../lib/error-utils';
 const SigninPasswordlessCodeContainer = ({
   integration,
   flowQueryParams,
+  isSignedIntoFirefox,
   setCurrentSplitLayout,
 }: SigninPasswordlessCodeContainerProps & RouteComponentProps) => {
   const navigateWithQuery = useNavigateWithQuery();
@@ -45,7 +46,7 @@ const SigninPasswordlessCodeContainer = ({
   const [sendError, setSendError] = useState<HandledError | null>(null);
 
   const cmsInfo = integration.getCmsInfo();
-  const splitLayout = cmsInfo?.SigninPasswordlessCodePage?.splitLayout
+  const splitLayout = cmsInfo?.SigninPasswordlessCodePage?.splitLayout;
 
   // If no email in state, redirect to signin
   useEffect(() => {
@@ -120,6 +121,7 @@ const SigninPasswordlessCodeContainer = ({
         sendError,
         setCurrentSplitLayout,
         isSignup,
+        isSignedIntoFirefox,
         resendCountdownSeconds: 5,
       }}
     />

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.stories.tsx
@@ -9,6 +9,7 @@ import { Subject, createMockWebIntegration } from './mocks';
 import { MOCK_CMS_INFO } from '../../mocks';
 import { AppContext } from '../../../models';
 import { mockAppContext } from '../../../models/mocks';
+import { createMockSigninOAuthNativeIntegration } from '../mocks';
 
 export default {
   title: 'Pages/Signin/SigninPasswordlessCode',
@@ -18,11 +19,7 @@ export default {
 
 export const DefaultSignin = () => (
   <AppContext.Provider value={mockAppContext()}>
-    <Subject
-      email="user@example.com"
-      expirationMinutes={5}
-      isSignup={false}
-    />
+    <Subject email="user@example.com" expirationMinutes={5} isSignup={false} />
   </AppContext.Provider>
 );
 
@@ -49,21 +46,13 @@ export const WithCmsInfo = () => (
 
 export const ShortExpiration = () => (
   <AppContext.Provider value={mockAppContext()}>
-    <Subject
-      email="user@example.com"
-      expirationMinutes={1}
-      isSignup={false}
-    />
+    <Subject email="user@example.com" expirationMinutes={1} isSignup={false} />
   </AppContext.Provider>
 );
 
 export const LongExpiration = () => (
   <AppContext.Provider value={mockAppContext()}>
-    <Subject
-      email="user@example.com"
-      expirationMinutes={15}
-      isSignup={false}
-    />
+    <Subject email="user@example.com" expirationMinutes={15} isSignup={false} />
   </AppContext.Provider>
 );
 
@@ -72,6 +61,18 @@ export const LongEmailAddress = () => (
     <Subject
       email="verylongemailaddress.with.multiple.dots@subdomain.example.com"
       expirationMinutes={5}
+      isSignup={false}
+    />
+  </AppContext.Provider>
+);
+
+export const SignedIntoFirefoxDesktop = () => (
+  <AppContext.Provider value={mockAppContext()}>
+    <Subject
+      email="user@example.com"
+      expirationMinutes={5}
+      integration={createMockSigninOAuthNativeIntegration({ isSync: true })}
+      isSignedIntoFirefox={true}
       isSignup={false}
     />
   </AppContext.Provider>
@@ -90,4 +91,3 @@ export const WithSendError = () => (
     />
   </AppContext.Provider>
 );
-

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.test.tsx
@@ -243,6 +243,32 @@ describe('SigninPasswordlessCode page', () => {
   });
 
   describe('"Use a different account" link', () => {
+    it('is hidden when signed into Firefox desktop', () => {
+      const integration = createMockSigninOAuthNativeIntegration();
+      render({ integration, isSignedIntoFirefox: true });
+
+      expect(
+        screen.queryByRole('link', { name: 'Use a different account' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('is shown when signed into Firefox but not a desktop client (mobile)', () => {
+      const integration = createMockSigninOAuthNativeIntegration({
+        isSync: true,
+        isMobile: true,
+      });
+      render({ integration, isSignedIntoFirefox: true });
+
+      screen.getByRole('link', { name: 'Use a different account' });
+    });
+
+    it('is shown when on a desktop Firefox client but not signed into Firefox', () => {
+      const integration = createMockSigninOAuthNativeIntegration();
+      render({ integration, isSignedIntoFirefox: false });
+
+      screen.getByRole('link', { name: 'Use a different account' });
+    });
+
     it('clicking navigates to root and removes email from query params', async () => {
       render({ isSignup: false });
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/index.tsx
@@ -57,6 +57,7 @@ const SigninPasswordlessCode = ({
   sendError,
   setCurrentSplitLayout,
   isSignup = false,
+  isSignedIntoFirefox = false,
   resendCountdownSeconds = 0,
 }: SigninPasswordlessCodeProps & RouteComponentProps) => {
   usePageViewEvent(viewName, REACT_ENTRYPOINT);
@@ -113,6 +114,9 @@ const SigninPasswordlessCode = ({
       sendErrorProcessed.current = true;
     }
   }, [sendError, ftlMsgResolver]);
+
+  const isSignedIntoFirefoxDesktop =
+    isSignedIntoFirefox && integration.isFirefoxDesktopClient();
 
   const localizedCustomCodeRequiredMessage = ftlMsgResolver.getMsg(
     'signin-passwordless-code-required-error',
@@ -511,16 +515,21 @@ const SigninPasswordlessCode = ({
               : `${expirationMinutes} minutes`}
             .
           </span>
-        </FtlMsg>{' '}
-        <FtlMsg id="signin-passwordless-code-other-account-link">
-          <a
-            href="/"
-            className="link-blue"
-            onClick={handleDifferentAccountClick}
-          >
-            Use a different account
-          </a>
         </FtlMsg>
+        {!isSignedIntoFirefoxDesktop && (
+          <>
+            {' '}
+            <FtlMsg id="signin-passwordless-code-other-account-link">
+              <a
+                href="/"
+                className="link-blue"
+                onClick={handleDifferentAccountClick}
+              >
+                Use a different account
+              </a>
+            </FtlMsg>
+          </>
+        )}
       </p>
 
       <FormVerifyCode

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/interfaces.ts
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/interfaces.ts
@@ -21,6 +21,7 @@ export interface PasswordlessLocationState {
 export interface SigninPasswordlessCodeContainerProps {
   integration: SigninIntegration;
   flowQueryParams: QueryParams;
+  isSignedIntoFirefox?: boolean;
   setCurrentSplitLayout?: (value: boolean) => void;
 }
 
@@ -34,6 +35,7 @@ export interface SigninPasswordlessCodeProps {
   setCurrentSplitLayout?: (value: boolean) => void;
   // True if user is signing up (new account)
   isSignup?: boolean;
+  isSignedIntoFirefox?: boolean;
   resendCountdownSeconds?: number;
 }
 

--- a/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
+++ b/packages/fxa-settings/src/pages/Signin/SigninPasswordlessCode/mocks.tsx
@@ -92,6 +92,7 @@ export const Subject = ({
   finishOAuthFlowHandler = mockFinishOAuthFlowHandler,
   integration = createMockWebIntegration(),
   isSignup = false,
+  isSignedIntoFirefox = false,
   sendError = null,
 }: Partial<SigninPasswordlessCodeProps>) => {
   return (
@@ -104,6 +105,7 @@ export const Subject = ({
           flowQueryParams: {},
           integration,
           isSignup,
+          isSignedIntoFirefox,
           sendError,
         }}
       />


### PR DESCRIPTION
Because:
* This link should be hidden if the user is already signed into desktop - otherwise they do not see the 'merge stop'/warning until they've already entered their password for another account (since we check by UID now and not email), and they cannot continue

This commit:
* Hides the link if the user is signed into Firefox desktop

closes FXA-13634

