### PR TITLE
fix(settings): handle invalid session token on sign out

### DIFF
--- a/packages/fxa-settings/src/models/Session.test.ts
+++ b/packages/fxa-settings/src/models/Session.test.ts
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Session } from './Session';
+import {
+  sessionToken as mockSessionToken,
+  clearSignedInAccountUid,
+} from '../lib/cache';
+import { dispatchStorageEvent } from '../lib/account-storage';
+import { ERRNO } from '@fxa/accounts/errors';
+import AuthClient from 'fxa-auth-client/browser';
+
+jest.mock('../lib/cache', () => {
+  const actual = jest.requireActual('../lib/cache');
+  return {
+    ...actual,
+    sessionToken: jest.fn(),
+    clearSignedInAccountUid: jest.fn(),
+  };
+});
+
+jest.mock('../lib/account-storage', () => ({
+  ...jest.requireActual('../lib/account-storage'),
+  dispatchStorageEvent: jest.fn(),
+}));
+
+describe('Session', () => {
+  describe('destroy', () => {
+    let session: Session;
+    let mockAuthClient: jest.Mocked<AuthClient>;
+    const mockedSessionToken = jest.mocked(mockSessionToken);
+    const mockedClearSignedInAccountUid = jest.mocked(clearSignedInAccountUid);
+    const mockedDispatchStorageEvent = jest.mocked(dispatchStorageEvent);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockAuthClient = { sessionDestroy: jest.fn() } as any;
+      session = new Session(mockAuthClient);
+    });
+
+    it('destroys the server session and clears local state', async () => {
+      mockedSessionToken.mockReturnValue('valid-token');
+      mockAuthClient.sessionDestroy.mockResolvedValue({});
+
+      await session.destroy();
+
+      expect(mockAuthClient.sessionDestroy).toHaveBeenCalledWith('valid-token');
+      expect(mockedClearSignedInAccountUid).toHaveBeenCalled();
+      expect(mockedDispatchStorageEvent).toHaveBeenCalledWith('isSignedIn');
+    });
+
+    it('treats errno 110 (INVALID_TOKEN) as already-destroyed and clears local state', async () => {
+      mockedSessionToken.mockReturnValue('stale-token');
+      mockAuthClient.sessionDestroy.mockRejectedValue({
+        code: 401,
+        errno: ERRNO.INVALID_TOKEN,
+        message: 'Invalid authentication token in request signature',
+      });
+
+      await expect(session.destroy()).resolves.toBeUndefined();
+
+      expect(mockedClearSignedInAccountUid).toHaveBeenCalled();
+      expect(mockedDispatchStorageEvent).toHaveBeenCalledWith('isSignedIn');
+    });
+
+    it('rethrows non-INVALID_TOKEN errors and skips local cleanup', async () => {
+      mockedSessionToken.mockReturnValue('valid-token');
+      const networkError = new Error('Network request failed');
+      mockAuthClient.sessionDestroy.mockRejectedValue(networkError);
+
+      await expect(session.destroy()).rejects.toThrow('Network request failed');
+
+      expect(mockedClearSignedInAccountUid).not.toHaveBeenCalled();
+      expect(mockedDispatchStorageEvent).not.toHaveBeenCalled();
+    });
+
+    it('skips the server call when there is no session token', async () => {
+      mockedSessionToken.mockReturnValue(undefined);
+
+      await session.destroy();
+
+      expect(mockAuthClient.sessionDestroy).not.toHaveBeenCalled();
+      expect(mockedClearSignedInAccountUid).toHaveBeenCalled();
+      expect(mockedDispatchStorageEvent).toHaveBeenCalledWith('isSignedIn');
+    });
+  });
+});

--- a/packages/fxa-settings/src/models/Session.ts
+++ b/packages/fxa-settings/src/models/Session.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import AuthClient from 'fxa-auth-client/browser';
+import { ERRNO } from '@fxa/accounts/errors';
 import {
   sessionToken,
   clearSignedInAccountUid,
@@ -102,7 +103,15 @@ export class Session implements SessionData {
   async destroy() {
     const token = sessionToken();
     if (token) {
-      await this.authClient.sessionDestroy(token);
+      try {
+        await this.authClient.sessionDestroy(token);
+      } catch (e) {
+        // Token already invalid on the server:
+        // treat as already-destroyed so local cleanup + redirect still run.
+        if ((e as { errno?: number })?.errno !== ERRNO.INVALID_TOKEN) {
+          throw e;
+        }
+      }
     }
     clearSignedInAccountUid();
     dispatchStorageEvent('isSignedIn');


### PR DESCRIPTION
## Because

- If the session token no longer exists on the server, sessionDestroy returns 401/errno 110 and the avatar-menu toast strands the user with stale local state.

## This pull request

- Swallows errno 110 in Session.destroy() so local cleanup and redirect proceed. Other errors still surface the toast.
- Adds tests for Session.destroy().

## Issue that this pull request solves

Closes: FXA-13685

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
