### PR TITLE
fix(settings): show "Passkey limit reached" alert (FXA-13680)

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -310,6 +310,49 @@ describe('PagePasskeyAdd', () => {
     expect(mockCaptureException).toHaveBeenCalledWith(serverError);
   });
 
+  it('shows "Passkey limit reached" when completePasskeyRegistration returns errno 226', async () => {
+    const limitError = {
+      errno: 226,
+      message: 'Maximum number of passkeys reached',
+      code: 400,
+    };
+    mockCompletePasskeyRegistration.mockRejectedValue(limitError);
+
+    renderPage();
+    await waitFor(() => {
+      expect(mockAlertError).toHaveBeenCalledWith('Passkey limit reached');
+    });
+    expect(
+      GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
+    ).toHaveBeenCalledWith({
+      event: { reason: 'auth_error_226' },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
+      replace: true,
+    });
+  });
+
+  it('shows "Passkey limit reached" when beginPasskeyRegistration returns errno 226', async () => {
+    const limitError = {
+      errno: 226,
+      message: 'Maximum number of passkeys reached',
+      code: 400,
+    };
+    mockBeginPasskeyRegistration.mockRejectedValue(limitError);
+
+    renderPage();
+    await waitFor(() => {
+      expect(mockAlertError).toHaveBeenCalledWith('Passkey limit reached');
+    });
+    expect(
+      GleanMetrics.accountPref.passkeyCreateSubmitFrontendError
+    ).toHaveBeenCalledWith({
+      event: { reason: 'auth_error_226' },
+    });
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
   it('cancel button navigates back to settings', () => {
     mockBeginPasskeyRegistration.mockReturnValue(new Promise(() => {}));
     renderPage();

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -24,6 +24,11 @@ import { MfaGuard, useMfaErrorHandler } from '../MfaGuard';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import GleanMetrics from '../../../lib/glean';
+import {
+  getLocalizedErrorMessage,
+  HandledError,
+} from '../../../lib/error-utils';
+import { AuthUiErrorNos } from '../../../lib/auth-errors/auth-errors';
 
 export const MfaGuardPagePasskeyAdd = (_: RouteComponentProps) => {
   return (
@@ -134,16 +139,29 @@ export const PagePasskeyAdd = () => {
         }
 
         // Server error
+        const errno = (error as { errno?: number })?.errno;
+        const isKnownAuthError =
+          typeof errno === 'number' && !!AuthUiErrorNos[errno];
+
         GleanMetrics.accountPref.passkeyCreateSubmitFrontendError({
-          event: { reason: 'server_error' },
+          event: {
+            reason: isKnownAuthError ? `auth_error_${errno}` : 'server_error',
+          },
         });
-        Sentry.captureException(error);
-        alertBar.error(
-          ftlMsgResolver.getMsg(
-            'page-passkey-add-error-system',
-            'System not available. Try again later.'
-          )
-        );
+
+        if (isKnownAuthError) {
+          alertBar.error(
+            getLocalizedErrorMessage(ftlMsgResolver, error as HandledError)
+          );
+        } else {
+          Sentry.captureException(error);
+          alertBar.error(
+            ftlMsgResolver.getMsg(
+              'page-passkey-add-error-system',
+              'System not available. Try again later.'
+            )
+          );
+        }
         navigateToSettings();
       }
     };


### PR DESCRIPTION
## Because

- When a user already at the max passkey limit attempted to register another passkey from a stale Settings session (e.g., a tab on a second device that hadn't refreshed), the auth-server correctly returned a 400 with errno 226 ("Maximum number of passkeys reached"), but `PagePasskeyAdd` ignored `error.errno` and rendered the generic "System not available. Try again later." alert — misleading users into thinking the service was down.

## This pull request

- Inspects `error.errno` in the `PagePasskeyAdd` server-error catch branch. Recognized errnos now render their existing localized `AuthUiErrors` message via `getLocalizedErrorMessage` (errno 226 → "Passkey limit reached"); unknown errors keep the previous generic-fallback + Sentry capture path.
- Widens the Glean error reason to `auth_error_<errno>` for known auth-server errors so dashboards can distinguish them from true `server_error`.
- Adds unit tests covering errno 226 from both `beginPasskeyRegistration` and `completePasskeyRegistration`; existing unknown-error tests continue to pass.
- No new FTL strings or backend changes — `auth-error-226 = Passkey limit reached` and the `PASSKEY_LIMIT_REACHED` `AuthUiErrors` entry already existed.

## Issue that this pull request solves

Closes: FXA-13680

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on: `packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx` (server-error branch).
- Suggested review order: source change, then the two new tests in `index.test.tsx`.
- Risky or complex parts: low risk — the fix is a guarded `errno` check that delegates to the existing `getLocalizedErrorMessage` helper used elsewhere in fxa-settings; all unknown errors retain the original behavior.

## How to manually verify

1. Locally set `PASSKEYS__MAX_PASSKEYS_PER_USER=0` in auth-server config (or hit the real prod limit of 10).
2. Try to add a passkey on settings
3. Expect the alert to read **"Passkey limit reached"** instead of "System not available. Try again later."

