### PR TITLE
feat(admin): expose accountAuthorizations on the admin panel

### DIFF
--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -73,6 +73,30 @@ export abstract class BaseLayout {
     });
   }
 
+  /**
+   * Installs a page-side listener for the next `WebChannelMessageToChrome`
+   * event matching `command` and returns a promise that resolves with the
+   * event's `data` payload. Call BEFORE the action that triggers the message
+   * (e.g. before clicking a sign-in button) to avoid the polling/timeout race
+   * that `checkWebChannelMessage` is subject to on slow runners.
+   */
+  async waitForWebChannelMessage(
+    command: FirefoxCommand
+  ): Promise<Record<string, unknown>> {
+    return this.page.evaluate(
+      (expected) =>
+        new Promise<Record<string, unknown>>((resolve) => {
+          window.addEventListener('WebChannelMessageToChrome', (e: Event) => {
+            const detail = JSON.parse((e as CustomEvent).detail);
+            if (detail.message.command === expected) {
+              resolve(detail.message.data || {});
+            }
+          });
+        }),
+      command
+    );
+  }
+
   async checkWebChannelMessage(command: FirefoxCommand) {
     // Retry across navigations — a client-side redirect after page.goto
     // can destroy the execution context mid-evaluate.

--- a/packages/functional-tests/pages/layout.ts
+++ b/packages/functional-tests/pages/layout.ts
@@ -74,11 +74,20 @@ export abstract class BaseLayout {
   }
 
   /**
-   * Installs a page-side listener for the next `WebChannelMessageToChrome`
-   * event matching `command` and returns a promise that resolves with the
-   * event's `data` payload. Call BEFORE the action that triggers the message
-   * (e.g. before clicking a sign-in button) to avoid the polling/timeout race
-   * that `checkWebChannelMessage` is subject to on slow runners.
+   * Wait for a single `WebChannelMessageToChrome` event matching `command`
+   * and resolve with its `data` payload.
+   *
+   * Use this when the test controls the action that triggers the message
+   * (e.g. a button click) and can install the listener up front. This is
+   * preferred over `checkWebChannelMessage` whenever the message arrives
+   * after a known UI action and crosses an OAuth grant or other multi-step
+   * roundtrip, because there is no fixed sub-budget — the only timeout is
+   * the test's overall Playwright timeout.
+   *
+   * Use `checkWebChannelMessage` instead when the message can fire during
+   * page load, before the test has a chance to install a listener — the
+   * message in that case is read from sessionStorage where fxa-settings
+   * has already saved it.
    */
   async waitForWebChannelMessage(
     command: FirefoxCommand

--- a/packages/functional-tests/tests/admin/adminPanel.spec.ts
+++ b/packages/functional-tests/tests/admin/adminPanel.spec.ts
@@ -68,48 +68,4 @@ test.describe('Admin Panel', () => {
       timeout: 10000,
     });
   });
-
-  test('account by-uid response includes accountAuthorizations field', async ({
-    target,
-    testAccountTracker,
-  }) => {
-    const details = testAccountTracker.generateAccountDetails();
-    const credentials = await target.createAccount(
-      details.email,
-      details.password
-    );
-
-    const res = await fetch(
-      `${ADMIN_SERVER_URL}/api/account/by-uid?uid=${encodeURIComponent(credentials.uid)}`,
-      {
-        headers: {
-          'oidc-claim-id-token-email': 'test-admin@mozilla.com',
-          'remote-groups': 'vpn_fxa_admin_panel_prod',
-        },
-      }
-    );
-    expect(res.status).toBe(200);
-    const data = await res.json();
-    expect(Array.isArray(data.accountAuthorizations)).toBe(true);
-    // A brand-new account has no browser-service authorizations on record.
-    expect(data.accountAuthorizations).toEqual([]);
-  });
-
-  test('admin panel renders the authorized browser services section', async ({
-    target,
-    page,
-    testAccountTracker,
-  }) => {
-    const credentials = testAccountTracker.generateAccountDetails();
-    await target.createAccount(credentials.email, credentials.password);
-
-    await page.goto(`${ADMIN_PANEL_URL}/account-search`);
-    await page.getByTestId('email-input').fill(credentials.email);
-    await page.getByTestId('search-button').click();
-
-    await expect(
-      page.getByRole('heading', { name: /authorized browser services/i })
-    ).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('account-authorizations-none')).toBeVisible();
-  });
 });

--- a/packages/functional-tests/tests/admin/adminPanel.spec.ts
+++ b/packages/functional-tests/tests/admin/adminPanel.spec.ts
@@ -5,7 +5,8 @@
 import { expect, test } from '../../lib/fixtures/standard';
 
 const ADMIN_PANEL_URL = process.env.ADMIN_PANEL_URL ?? 'http://localhost:8091';
-const ADMIN_SERVER_URL = process.env.ADMIN_SERVER_URL ?? 'http://localhost:8095';
+const ADMIN_SERVER_URL =
+  process.env.ADMIN_SERVER_URL ?? 'http://localhost:8095';
 
 // Admin panel tests only run locally (stage/prod require SSO)
 test.skip(({ target }) => target.name !== 'local');
@@ -66,5 +67,49 @@ test.describe('Admin Panel', () => {
     await expect(page.getByText(credentials.email)).toBeVisible({
       timeout: 10000,
     });
+  });
+
+  test('account by-uid response includes accountAuthorizations field', async ({
+    target,
+    testAccountTracker,
+  }) => {
+    const details = testAccountTracker.generateAccountDetails();
+    const credentials = await target.createAccount(
+      details.email,
+      details.password
+    );
+
+    const res = await fetch(
+      `${ADMIN_SERVER_URL}/api/account/by-uid?uid=${encodeURIComponent(credentials.uid)}`,
+      {
+        headers: {
+          'oidc-claim-id-token-email': 'test-admin@mozilla.com',
+          'remote-groups': 'vpn_fxa_admin_panel_prod',
+        },
+      }
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data.accountAuthorizations)).toBe(true);
+    // A brand-new account has no browser-service authorizations on record.
+    expect(data.accountAuthorizations).toEqual([]);
+  });
+
+  test('admin panel renders the authorized browser services section', async ({
+    target,
+    page,
+    testAccountTracker,
+  }) => {
+    const credentials = testAccountTracker.generateAccountDetails();
+    await target.createAccount(credentials.email, credentials.password);
+
+    await page.goto(`${ADMIN_PANEL_URL}/account-search`);
+    await page.getByTestId('email-input').fill(credentials.email);
+    await page.getByTestId('search-button').click();
+
+    await expect(
+      page.getByRole('heading', { name: /authorized browser services/i })
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('account-authorizations-none')).toBeVisible();
   });
 });

--- a/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
+++ b/packages/functional-tests/tests/misc/vpnIntegration.spec.ts
@@ -33,17 +33,21 @@ test.describe('vpn integration', () => {
     await expect(signin.cachedSigninHeading).toBeVisible();
     await expect(page.getByText(email)).toBeVisible();
 
+    // Install listeners before the click so the dispatched events can't be
+    // missed by a slow polling cycle.
+    const oauthLoginPromise = signin.waitForWebChannelMessage(
+      FirefoxCommand.OAuthLogin
+    );
+    const loginPromise = signin.waitForWebChannelMessage(FirefoxCommand.Login);
+
     await signin.signInButton.click();
 
-    // Verify fxaOAuthLogin was sent with VPN scopes
-    await signin.checkWebChannelMessageScopes(
-      FirefoxCommand.OAuthLogin,
-      'https://identity.mozilla.com/apps/vpn'
+    const oauthLogin = await oauthLoginPromise;
+    expect(oauthLogin.scopes).toEqual(
+      expect.stringContaining('https://identity.mozilla.com/apps/vpn')
     );
 
-    // Verify services data includes vpn
-    await signin.checkWebChannelMessageServices(FirefoxCommand.Login, {
-      vpn: {},
-    });
+    const login = await loginPromise;
+    expect(login.services).toEqual({ vpn: {} });
   });
 });

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.test.tsx
@@ -100,6 +100,7 @@ let accountResponse: AccountProps = {
   linkedAccounts: [],
   accountEvents: [],
   passkeys: [],
+  accountAuthorizations: [],
 };
 
 it('renders without imploding', () => {
@@ -317,6 +318,37 @@ it('displays the locale', async () => {
   const { getByTestId } = render(<Account {...accountResponse} />);
   expect(getByTestId('account-locale')).toHaveTextContent('en-US');
   expect(getByTestId('edit-account-locale')).toBeInTheDocument();
+});
+
+it('shows "no authorizations" message when authorizations list is empty', () => {
+  const { getByTestId } = render(<Account {...accountResponse} />);
+  expect(getByTestId('account-authorizations-none')).toBeInTheDocument();
+});
+
+it('displays authorized browser services', () => {
+  const withAuthorizations = {
+    ...accountResponse,
+    accountAuthorizations: [
+      {
+        service: 'sync',
+        scope: 'https://identity.mozilla.com/apps/oldsync',
+        authorizedAt: 1589467100316,
+      },
+      {
+        service: 'relay',
+        scope: 'https://identity.mozilla.com/apps/relay',
+        authorizedAt: 1589467200000,
+      },
+    ],
+  };
+  const { getAllByTestId, getByRole } = render(
+    <Account {...withAuthorizations} />
+  );
+
+  expect(
+    getByRole('heading', { name: /authorized browser services/i })
+  ).toBeInTheDocument();
+  expect(getAllByTestId('account-authorization-service')).toHaveLength(2);
 });
 
 it('displays key-stretch-version', async () => {

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -16,6 +16,7 @@ import { AdminPanelFeature } from '@fxa/shared/guards';
 import Guard from '../../Guard';
 import Subscription from '../Subscription';
 import { ConnectedServices } from '../ConnectedServices';
+import { AccountAuthorizations } from '../AccountAuthorizations';
 import { TableRowYHeader, TableYHeaders } from '../../TableYHeaders';
 import { TableRowXHeader, TableXHeaders } from '../../TableXHeaders';
 import EmailBounces from '../EmailBounces';
@@ -94,6 +95,7 @@ export const Account = ({
   backupCodes,
   recoveryPhone,
   passkeys,
+  accountAuthorizations,
 }: AccountProps) => {
   const createdAtDate = getFormattedDate(createdAt);
   const disabledAtDate = getFormattedDate(disabledAt);
@@ -417,6 +419,9 @@ export const Account = ({
         <Guard features={[AdminPanelFeature.ConnectedServices]}>
           <h3 className="header-lg">Connected Services</h3>
           <ConnectedServices services={attachedClients} />
+
+          <h3 className="header-lg">Authorized Browser Services</h3>
+          <AccountAuthorizations authorizations={accountAuthorizations} />
         </Guard>
 
         <h3 className="header-lg">Account History</h3>

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/Account/index.tsx
@@ -421,6 +421,14 @@ export const Account = ({
           <ConnectedServices services={attachedClients} />
 
           <h3 className="header-lg">Authorized Browser Services</h3>
+          <p className="mb-2">
+            OAuth consent records, not a record of active usage. A row means the
+            account has authorized the service through a Firefox flow at some
+            point. Note: a Sync row can appear for any browser-service sign-in
+            (Smart Window, Relay, VPN), because Firefox Desktop currently mints
+            a Sync-scoped refresh token on every flow even when the user did not
+            sign in to Sync.
+          </p>
           <AccountAuthorizations authorizations={accountAuthorizations} />
         </Guard>
 

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.test.tsx
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { render, screen } from '@testing-library/react';
+import { AccountAuthorization } from 'fxa-admin-server/src/types';
+import { AccountAuthorizations } from '.';
+
+const AUTHORIZATIONS: AccountAuthorization[] = [
+  {
+    service: 'sync',
+    scope: 'https://identity.mozilla.com/apps/oldsync',
+    authorizedAt: new Date('2026-01-01T00:00:00Z').getTime(),
+  },
+  {
+    service: 'relay',
+    scope: 'https://identity.mozilla.com/apps/relay',
+    authorizedAt: new Date('2026-02-01T00:00:00Z').getTime(),
+  },
+];
+
+it('renders the empty state when there are no authorizations', () => {
+  render(<AccountAuthorizations authorizations={[]} />);
+  expect(screen.getByTestId('account-authorizations-none')).toHaveTextContent(
+    'This account has not authorized any browser services.'
+  );
+});
+
+it('renders the empty state when authorizations is null', () => {
+  render(<AccountAuthorizations authorizations={null} />);
+  expect(screen.getByTestId('account-authorizations-none')).toBeInTheDocument();
+});
+
+it('renders one row per authorization', () => {
+  render(<AccountAuthorizations authorizations={AUTHORIZATIONS} />);
+  const services = screen.getAllByTestId('account-authorization-service');
+  const scopes = screen.getAllByTestId('account-authorization-scope');
+  const dates = screen.getAllByTestId('account-authorization-authorized-at');
+
+  expect(services).toHaveLength(2);
+  expect(scopes).toHaveLength(2);
+  expect(dates).toHaveLength(2);
+
+  expect(services[0]).toHaveTextContent('sync');
+  expect(scopes[0]).toHaveTextContent(
+    'https://identity.mozilla.com/apps/oldsync'
+  );
+  expect(services[1]).toHaveTextContent('relay');
+});

--- a/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.tsx
+++ b/packages/fxa-admin-panel/src/components/PageAccountSearch/AccountAuthorizations/index.tsx
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AccountAuthorization } from 'fxa-admin-server/src/types';
+import { TableRowXHeader, TableXHeaders } from '../../TableXHeaders';
+import { getFormattedDate } from '../../../lib/utils';
+
+export const AccountAuthorizations = ({
+  authorizations,
+}: {
+  authorizations?: Nullable<AccountAuthorization[]>;
+}) => {
+  if (!authorizations || authorizations.length === 0) {
+    return (
+      <p data-testid="account-authorizations-none" className="result-none">
+        This account has not authorized any browser services.
+      </p>
+    );
+  }
+
+  return (
+    <TableXHeaders rowHeaders={['Service', 'Scope', 'Authorized At']}>
+      {authorizations.map(({ service, scope, authorizedAt }) => (
+        <TableRowXHeader key={`${service}-${scope}`}>
+          <td data-testid="account-authorization-service">{service}</td>
+          <td data-testid="account-authorization-scope">{scope}</td>
+          <td data-testid="account-authorization-authorized-at">
+            {getFormattedDate(authorizedAt)}
+          </td>
+        </TableRowXHeader>
+      ))}
+    </TableXHeaders>
+  );
+};

--- a/packages/fxa-admin-server/src/database/database.service.spec.ts
+++ b/packages/fxa-admin-server/src/database/database.service.spec.ts
@@ -18,6 +18,18 @@ describe('#integration - DatabaseService', () => {
 
   beforeAll(async () => {
     knex = await testDatabaseSetup();
+    // Ensure the table exists in the test DB. The shared oauth fixture set
+    // is built once and cached; adding a new fixture file there can be
+    // skipped by stale build caches, so create the table inline here.
+    await knex.raw(
+      'CREATE TABLE IF NOT EXISTS `accountAuthorizations` (' +
+        '`uid` BINARY(16) NOT NULL,' +
+        '`scope` VARCHAR(512) NOT NULL,' +
+        '`service` VARCHAR(64) NOT NULL,' +
+        '`authorizedAt` BIGINT UNSIGNED NOT NULL,' +
+        'PRIMARY KEY (`uid`, `scope`, `service`)' +
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
   });
 
   afterAll(async () => {
@@ -88,5 +100,47 @@ describe('#integration - DatabaseService', () => {
 
   it('should be able to invoke attachedDevices', async () => {
     await service.attachedDevices('AB12');
+  });
+
+  it('returns rows ordered by authorizedAt descending', async () => {
+    const uid = 'aabbccddeeff00112233445566778899';
+    const uidBuffer = Buffer.from(uid, 'hex');
+    const now = Date.now();
+    await service.knexOauth('accountAuthorizations').insert([
+      {
+        uid: uidBuffer,
+        scope: 'https://identity.mozilla.com/apps/oldsync',
+        service: 'sync',
+        authorizedAt: now - 1000,
+      },
+      {
+        uid: uidBuffer,
+        scope: 'https://identity.mozilla.com/apps/relay',
+        service: 'relay',
+        authorizedAt: now,
+      },
+    ]);
+
+    const rows = await service.accountAuthorizations(uid);
+
+    expect(rows).toEqual([
+      {
+        scope: 'https://identity.mozilla.com/apps/relay',
+        service: 'relay',
+        authorizedAt: now,
+      },
+      {
+        scope: 'https://identity.mozilla.com/apps/oldsync',
+        service: 'sync',
+        authorizedAt: now - 1000,
+      },
+    ]);
+  });
+
+  it('returns an empty array when the uid has no authorizations', async () => {
+    const rows = await service.accountAuthorizations(
+      '00000000000000000000000000000001'
+    );
+    expect(rows).toEqual([]);
   });
 });

--- a/packages/fxa-admin-server/src/database/database.service.ts
+++ b/packages/fxa-admin-server/src/database/database.service.ts
@@ -33,6 +33,8 @@ import { MozLoggerService } from '@fxa/shared/mozlog';
 import { StatsD } from 'hot-shots';
 import { Knex, knex } from 'knex';
 import { AppConfig } from '../config';
+import { AccountAuthorization } from '../types';
+import { uuidTransformer } from './transformers';
 
 function typeCasting(field: any, next: any) {
   if (field.type === 'TINY' && field.length === 1) {
@@ -135,6 +137,22 @@ export class DatabaseService implements OnModuleDestroy {
     const cachedSessionTokens =
       await this.connectedServicesDb.cache.getSessionTokens(uid);
     return mergeCachedSessionTokens(dbSessionTokens, cachedSessionTokens, true);
+  }
+
+  public async accountAuthorizations(
+    uid: string
+  ): Promise<AccountAuthorization[]> {
+    const uidBuffer = uuidTransformer.to(uid);
+    const rows = await this.knexOauth('accountAuthorizations')
+      .select('scope', 'service', 'authorizedAt')
+      .where('uid', uidBuffer)
+      .orderBy('authorizedAt', 'desc')
+      .limit(10);
+    return rows.map((row) => ({
+      scope: row.scope,
+      service: row.service,
+      authorizedAt: Number(row.authorizedAt),
+    }));
   }
 
   public async attachedDevices(uid: string) {

--- a/packages/fxa-admin-server/src/rest/account/account.controller.ts
+++ b/packages/fxa-admin-server/src/rest/account/account.controller.ts
@@ -58,6 +58,7 @@ import { BasketService } from '../../newsletters/basket.service';
 import { FidoMdsService } from '../../backend/fido-mds.service';
 import { SubscriptionsService } from '../../subscriptions/subscriptions.service';
 import {
+  AccountAuthorization,
   AccountDeleteResponse,
   AccountDeleteStatus,
   AccountDeleteTaskStatus,
@@ -187,6 +188,7 @@ export class AccountController {
       linkedAccounts,
       attachedClients,
       passkeys,
+      accountAuthorizations,
     ] = await Promise.all([
       this.emails(account),
       this.emailBounces(account),
@@ -201,6 +203,7 @@ export class AccountController {
       this.linkedAccounts(account),
       this.attachedClients(account),
       this.passkeys(account),
+      this.accountAuthorizations(account),
     ]);
 
     return {
@@ -218,6 +221,7 @@ export class AccountController {
       linkedAccounts,
       attachedClients,
       passkeys,
+      accountAuthorizations,
     };
   }
 
@@ -917,6 +921,13 @@ export class AccountController {
         }
       )
     );
+  }
+
+  @Features(AdminPanelFeature.ConnectedServices)
+  public async accountAuthorizations(
+    account: Account
+  ): Promise<AccountAuthorization[]> {
+    return this.db.accountAuthorizations(account.uid);
   }
 
   @Features(AdminPanelFeature.ConnectedServices)

--- a/packages/fxa-admin-server/src/types.ts
+++ b/packages/fxa-admin-server/src/types.ts
@@ -111,6 +111,12 @@ export interface Passkey {
   prfEnabled: boolean;
 }
 
+export interface AccountAuthorization {
+  scope: string;
+  service: string;
+  authorizedAt: number;
+}
+
 export interface LinkedAccount {
   uid?: string;
   authAt?: number;
@@ -209,6 +215,7 @@ export interface Account {
   backupCodes: BackupCodes[];
   recoveryPhone: RecoveryPhone[];
   passkeys: Passkey[];
+  accountAuthorizations: AccountAuthorization[];
 }
 
 export interface RelyingPartyUpdateDto {


### PR DESCRIPTION
  ## Because

  - Admins had no way to see which Firefox browser services (Sync, Smart Window, Relay, VPN) a user has authorized, making consent and connected-services support questions hard to answer
  - 
  ## This pull request

  - Adds `accountAuthorizations(uid)` to `DatabaseService` querying `fxa_oauth.accountAuthorizations`, ordered by `authorizedAt` DESC, capped at 10
  - Adds an `accountAuthorizations` resolver helper to `AccountController`, gated by the existing `ConnectedServices` admin feature, wired into `resolveAccountData`
  - Adds `AccountAuthorizations` React component rendering `(service, scope, authorizedAt)` rows under a new "Authorized Browser Services" section in the account detail page

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-13405

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**
  1. Start the stack, create an account, login to Sync
  2. Open `http://localhost:8091/account-search`, search for any account
  3. Confirm the **Authorized Browser Services** section renders under **Connected Services**
  4. For an account with no authorizations, the empty state ("This account has not authorized any browser services.") should appear
  5. To populate, exercise an OAuth flow on a configured browser service (Sync/Relay/VPN/SmartWindow) — rows show `(service, scope, authorizedAt)` newest first

<img width="763" height="134" alt="Screenshot 2026-05-06 at 8 54 53 PM" src="https://github.com/user-attachments/assets/6294a59d-088f-4d7e-b59c-3594e4a50ce6" />
