### PR TITLE
fix(payments-next): CreateBillingAgreementActiveBillingAgreement: Account already has an active paypal billing agreement

### DIFF
--- a/libs/payments/management/src/lib/subscriptionManagement.error.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.error.ts
@@ -75,13 +75,6 @@ export class SetDefaultPaymentAccountCustomerMissingStripeId extends Subscriptio
   }
 }
 
-export class CreateBillingAgreementActiveBillingAgreement extends SubscriptionManagementError {
-  constructor(uid: string) {
-    super('Account already has an active paypal billing agreement', { uid });
-    this.name = 'CreateBillingAgreementActiveBillingAgreement';
-  }
-}
-
 export class CreateBillingAgreementAccountCustomerMissingStripeId extends SubscriptionManagementError {
   constructor(uid: string) {
     super(

--- a/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.spec.ts
@@ -112,7 +112,6 @@ import {
   SubscriptionManagementCouldNotRetrieveIapContentFromCMSError,
   UpdateAccountCustomerMissingStripeId,
   CreateBillingAgreementAccountCustomerMissingStripeId,
-  CreateBillingAgreementActiveBillingAgreement,
   CreateBillingAgreementCurrencyNotFound,
   CreateBillingAgreementPaypalSubscriptionNotFound,
 } from './subscriptionManagement.error';
@@ -2574,7 +2573,7 @@ describe('SubscriptionManagementService', () => {
       );
       expect(privateCustomerChanged).toHaveBeenCalled();
     });
-    it('throws an error if the user has an active paypal billing agreement', async () => {
+    it('returns if the user has an active paypal billing agreement', async () => {
       jest
         .spyOn(paypalBillingAgreementManager, 'retrieveActiveId')
         .mockResolvedValue(faker.string.uuid());
@@ -2584,7 +2583,7 @@ describe('SubscriptionManagementService', () => {
           faker.string.uuid(),
           faker.string.uuid()
         )
-      ).rejects.toBeInstanceOf(CreateBillingAgreementActiveBillingAgreement);
+      ).resolves.toBeUndefined();
       expect(privateCustomerChanged).not.toHaveBeenCalled();
     });
     it('throws an error if the account customer has no stripe id', async () => {

--- a/libs/payments/management/src/lib/subscriptionManagement.service.ts
+++ b/libs/payments/management/src/lib/subscriptionManagement.service.ts
@@ -56,7 +56,6 @@ import {
   CancelSubscriptionCustomerMismatch,
   ResubscribeSubscriptionCustomerMismatch,
   CreateBillingAgreementAccountCustomerMissingStripeId,
-  CreateBillingAgreementActiveBillingAgreement,
   CreateBillingAgreementCurrencyNotFound,
   CreateBillingAgreementPaypalSubscriptionNotFound,
 } from './subscriptionManagement.error';
@@ -1266,7 +1265,11 @@ export class SubscriptionManagementService {
     let recentActivePaypalCustomer: ResultPaypalCustomer | undefined;
     try {
       if (await this.paypalBillingAgreementManager.retrieveActiveId(uid)) {
-        throw new CreateBillingAgreementActiveBillingAgreement(uid);
+        this.log.warn(
+          'createPaypalBillingAgreementId: active billing agreement already exists',
+          { uid }
+        );
+        return;
       }
 
       accountCustomer =


### PR DESCRIPTION
## Because

* createPaypalBillingAgreementId throws an error when an active PayPal billing agreement already exists, creating unnecessary noise on Sentry.

## This pull request

* Returns and logs and warning instead of throwing an error.

## Issue that this pull request solves

Closes #[PAY-3663](https://mozilla-hub.atlassian.net/browse/PAY-3663)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

How to reproduce original error:
1. Subscribe to a product with PayPal
2. Cancel the billing agreement
    * Locally, can be done with this query, in Azure Data Studio for ex:
    UPDATE `paypalCustomers`
    SET
        `status` = 'cancelled',
        `endedAt` = NOW()
    WHERE
        `billingAgreementId` = 'B-0YB68515Y24701140';  // replace with actual billingAgreementId

    Or, in DBeaver:
    UPDATE fxa.paypalCustomers
    SET status='cancelled', endedAt=NOW()
    WHERE billingAgreementId='B-0YB68515Y24701140';


3. Go to SubManage, you should see the "There is an issue with your PayPal account." message, click on Manage to go to http://localhost:3035/en-US/subscriptions/payments/paypal
4. Open http://localhost:3035/en-US/subscriptions/payments/paypal in another tab as well (so, you have 2 tabs of http://localhost:3035/en-US/subscriptions/payments/paypal)
5. In both tabs, click on the PayPal button
6. Proceed to regular PayPal payment on one, keep the other PayPal popup still open.
7. After the first one finishes and you are redirected to the SubManage page in that tab, proceed to repeat the same steps from above for the second tab.
Video:

https://github.com/user-attachments/assets/6b64237c-b22c-4768-99f7-8a7bc20261d0

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.


[PAY-3663]: https://mozilla-hub.atlassian.net/browse/PAY-3663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ