### PR TITLE
feat(payments): resolve circular dependencies

### DIFF
--- a/apps/payments/api/src/app/app.module.ts
+++ b/apps/payments/api/src/app/app.module.ts
@@ -51,14 +51,12 @@ import {
   ProductConfigurationManager,
   StrapiClient,
 } from '@fxa/shared/cms';
-import {
-  PaymentsGleanManager,
-  PaymentsGleanService,
-} from '@fxa/payments/metrics';
+import { PaymentsGleanManager } from '@fxa/payments/metrics';
 import { PaymentsGleanFactory } from '@fxa/payments/metrics/provider';
 import { PaymentsEmitterService } from '@fxa/payments/events';
 import { NimbusManager, NimbusManagerConfig } from '@fxa/payments/experiments';
 import { NimbusClient, NimbusClientConfig } from '@fxa/shared/experiments';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 
 @Module({
   imports: [
@@ -97,7 +95,7 @@ import { NimbusClient, NimbusClientConfig } from '@fxa/shared/experiments';
     SubscriptionEventsService,
     PaymentsGleanFactory,
     PaymentsGleanManager,
-    PaymentsGleanService,
+    PaymentsMetricsAggregatorService,
     PaymentsEmitterService,
     PriceManager,
     ProductManager,

--- a/libs/payments/cart/src/lib/cart.service.spec.ts
+++ b/libs/payments/cart/src/lib/cart.service.spec.ts
@@ -136,8 +136,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
-} from '@fxa/payments/metrics'; // Circular!
+} from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   MockNimbusManagerConfigProvider,
   NimbusManager,
@@ -238,7 +238,7 @@ describe('CartService', () => {
         PaymentIntentManager,
         PaymentMethodManager,
         PaymentsGleanManager,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         PaypalBillingAgreementManager,
         PayPalClient,
         PaypalCustomerManager,

--- a/libs/payments/cart/src/lib/checkout.service.spec.ts
+++ b/libs/payments/cart/src/lib/checkout.service.spec.ts
@@ -136,8 +136,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   MockNimbusManagerConfigProvider,
   NimbusManager,
@@ -172,7 +172,7 @@ describe('CheckoutService', () => {
   let statsd: StatsD;
   let subscriptionManager: SubscriptionManager;
   let paymentMethodManager: PaymentMethodManager;
-  let gleanService: PaymentsGleanService;
+  let gleanService: PaymentsMetricsAggregatorService;
   let freeTrialManager: FreeTrialManager;
   let nimbusManager: NimbusManager;
 
@@ -230,7 +230,7 @@ describe('CheckoutService', () => {
         PaymentIntentManager,
         PaymentMethodManager,
         PaymentsGleanManager,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         PaypalBillingAgreementManager,
         PayPalClient,
         PaypalClientConfig,
@@ -277,7 +277,7 @@ describe('CheckoutService', () => {
     statsd = moduleRef.get(StatsDService);
     subscriptionManager = moduleRef.get(SubscriptionManager);
     paymentMethodManager = moduleRef.get(PaymentMethodManager);
-    gleanService = moduleRef.get(PaymentsGleanService);
+    gleanService = moduleRef.get(PaymentsMetricsAggregatorService);
     freeTrialManager = moduleRef.get(FreeTrialManager);
     nimbusManager = moduleRef.get(NimbusManager);
   });

--- a/libs/payments/cart/src/lib/checkout.service.ts
+++ b/libs/payments/cart/src/lib/checkout.service.ts
@@ -92,10 +92,8 @@ import { throwIntentFailedError } from './util/throwIntentFailedError';
 import type { AsyncLocalStorage } from 'async_hooks';
 import { AsyncLocalStorageCart } from './cart-als.provider';
 import type { CartStore } from './cart-als.types';
-import {
-  type CommonMetrics,
-  PaymentsGleanService,
-} from '@fxa/payments/metrics';
+import { type CommonMetrics } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import { isCancelInterstitialOffer } from './util/isCancelInterstitialOffer';
 import { FreeTrialManager } from './free-trial.manager';
 import type { PaymentsSearchParams } from './searchParams.schema';
@@ -127,7 +125,7 @@ export class CheckoutService {
     private paymentMethodManager: PaymentMethodManager,
     private freeTrialManager: FreeTrialManager,
     private nimbusManager: NimbusManager,
-    private gleanService: PaymentsGleanService,
+    private gleanService: PaymentsMetricsAggregatorService,
     @Inject(StatsDService) private statsd: StatsD
   ) {}
 

--- a/libs/payments/customer/src/lib/types.ts
+++ b/libs/payments/customer/src/lib/types.ts
@@ -37,6 +37,7 @@ export enum PaymentProvider {
   Stripe = 'stripe',
 }
 
+// Duplicated as enum SubPlatPaymentMethodType in @fxa/payments/metrics — keep in sync.
 export enum SubPlatPaymentMethodType {
   PayPal = 'external_paypal',
   Stripe = 'stripe',
@@ -77,6 +78,7 @@ export interface AccountCreditBalance {
   currency: string | null;
 }
 
+// Duplicated as type PaymentProvidersType in @fxa/payments/metrics — keep in sync.
 export type PaymentProvidersType =
   | 'stripe'
   | 'google_iap'
@@ -203,6 +205,7 @@ export type StripeInvoiceMetadata = StripeMetadata<STRIPE_INVOICE_METADATA>;
 export type StripeInvoiceMetadataInput =
   StripeMetadataInput<STRIPE_INVOICE_METADATA>;
 
+// Duplicated as enum SubplatInterval in @fxa/payments/metrics — keep in sync.
 export enum SubplatInterval {
   Daily = 'daily',
   Weekly = 'weekly',
@@ -211,6 +214,7 @@ export enum SubplatInterval {
   Yearly = 'yearly',
 }
 
+// Duplicated as interface TaxAddress in @fxa/payments/metrics — keep in sync.
 export interface TaxAddress {
   countryCode: string;
   postalCode: string;

--- a/libs/payments/events/src/lib/emitter.service.spec.ts
+++ b/libs/payments/events/src/lib/emitter.service.spec.ts
@@ -42,8 +42,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import { CartManager } from '@fxa/payments/cart';
 import { PaymentsEmitterService } from './emitter.service';
 import {
@@ -101,7 +101,7 @@ describe('PaymentsEmitterService', () => {
   let statsd: StatsD;
   let logger: Logger;
   let subscriptionManager: SubscriptionManager;
-  let paymentsGleanService: PaymentsGleanService;
+  let paymentsGleanService: PaymentsMetricsAggregatorService;
 
   const additionalMetricsData = AdditionalMetricsDataFactory();
   const mockCommonMetricsData = CommonMetricsFactory({
@@ -139,7 +139,7 @@ describe('PaymentsEmitterService', () => {
         StripeClient,
         PriceManager,
         PaymentsGleanManager,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         ProductConfigurationManager,
         PaypalBillingAgreementManager,
         PayPalClient,
@@ -166,7 +166,7 @@ describe('PaymentsEmitterService', () => {
     statsd = moduleRef.get<StatsD>(StatsDService);
     logger = moduleRef.get<Logger>(Logger);
     subscriptionManager = moduleRef.get(SubscriptionManager);
-    paymentsGleanService = moduleRef.get(PaymentsGleanService);
+    paymentsGleanService = moduleRef.get(PaymentsMetricsAggregatorService);
   });
 
   it('should be defined', () => {

--- a/libs/payments/events/src/lib/emitter.service.ts
+++ b/libs/payments/events/src/lib/emitter.service.ts
@@ -8,8 +8,8 @@ import { CartManager, TaxChangeAllowedStatus } from '@fxa/payments/cart';
 import {
   PaymentsGleanManager,
   type GenericGleanSubManageEvent,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import { LocationStatus } from '@fxa/payments/eligibility';
 import {
   CheckoutEvents,
@@ -46,7 +46,7 @@ export class PaymentsEmitterService {
     private log: Logger,
     private nimbusManager: NimbusManager,
     private paymentsGleanManager: PaymentsGleanManager,
-    private paymentsGleanService: PaymentsGleanService,
+    private paymentsGleanService: PaymentsMetricsAggregatorService,
     private paymentMethodManager: PaymentMethodManager,
     private productConfigurationManager: ProductConfigurationManager,
     @Inject(StatsDService) public statsd: StatsD,

--- a/libs/payments/metrics-aggregator/.eslintrc.json
+++ b/libs/payments/metrics-aggregator/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/payments/metrics-aggregator/.swcrc
+++ b/libs/payments/metrics-aggregator/.swcrc
@@ -1,0 +1,14 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}

--- a/libs/payments/metrics-aggregator/README.md
+++ b/libs/payments/metrics-aggregator/README.md
@@ -1,0 +1,26 @@
+# payments-metrics-aggregator
+
+This library was generated with [Nx](https://nx.dev).
+
+It contains the orchestration service that aggregates data from multiple
+domain managers (customer, subscription, account, CMS, experiments) to
+assemble payloads for Glean metrics events. The low-level Glean recording
+primitives (manager, generated events, types, factories) live in
+`@fxa/payments/metrics`.
+
+This split exists so that domain libraries (e.g. `@fxa/payments/customer`,
+`@fxa/payments/experiments`, `@fxa/shared/cms`) can depend on
+`@fxa/payments/metrics` for plain event recording without pulling in the
+managers that the aggregator orchestrates.
+
+## Building
+
+Run `nx build payments-metrics-aggregator` to build the library.
+
+## Running unit tests
+
+Run `nx test-unit payments-metrics-aggregator` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running integration tests
+
+Run `nx test-integration payments-metrics-aggregator` to execute the integration tests via [Jest](https://jestjs.io).

--- a/libs/payments/metrics-aggregator/jest.config.ts
+++ b/libs/payments/metrics-aggregator/jest.config.ts
@@ -1,0 +1,43 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+import { Config } from 'jest';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
+const config: Config = {
+  displayName: 'payments-metrics-aggregator',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
+  coverageDirectory: '../../../coverage/libs/payments/metrics-aggregator',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-metrics-aggregator',
+        outputName: 'payments-metrics-aggregator-jest-unit-results.xml',
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/libs/payments/metrics-aggregator/package.json
+++ b/libs/payments/metrics-aggregator/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fxa/payments/metrics-aggregator",
+  "version": "0.0.1"
+}

--- a/libs/payments/metrics-aggregator/project.json
+++ b/libs/payments/metrics-aggregator/project.json
@@ -1,0 +1,55 @@
+{
+  "name": "payments-metrics-aggregator",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/payments/metrics-aggregator/src",
+  "projectType": "library",
+  "tags": ["scope:shared:lib:payments"],
+  "targets": {
+    "build": {
+      "dependsOn": ["build-ts"],
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "echo Build complete"
+      }
+    },
+    "build-ts": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "main": "libs/payments/metrics-aggregator/src/index.ts",
+        "outputPath": "dist/libs/payments/metrics-aggregator",
+        "tsConfig": "libs/payments/metrics-aggregator/tsconfig.lib.json",
+        "assets": [
+          {
+            "glob": "libs/payments/metrics-aggregator/README.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/payments/metrics-aggregator/**/*.ts"]
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/metrics-aggregator/jest.config.ts",
+        "testPathPattern": ["^(?!.*\\.in\\.spec\\.ts$).*$"]
+      }
+    },
+    "test-integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/metrics-aggregator/jest.config.ts",
+        "testPathPattern": ["\\.in\\.spec\\.ts$"]
+      }
+    }
+  }
+}

--- a/libs/payments/metrics-aggregator/src/index.ts
+++ b/libs/payments/metrics-aggregator/src/index.ts
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export * from './lib/payments-metrics-aggregator.service';
+export * from './lib/payments-metrics-aggregator.test-provider';

--- a/libs/payments/metrics-aggregator/src/lib/payments-metrics-aggregator.service.spec.ts
+++ b/libs/payments/metrics-aggregator/src/lib/payments-metrics-aggregator.service.spec.ts
@@ -3,16 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Test } from '@nestjs/testing';
-import { PaymentsGleanManager } from './glean.manager';
-import { PaymentsGleanService } from './glean.service';
-import { MockPaymentsGleanFactory } from './glean.test-provider';
-import { MockPaymentsGleanConfigProvider, PaymentsGleanConfig } from './glean.config';
 import {
   AccountsMetricsDataFactory,
   CommonMetricsFactory,
   GenericGleanSubManageEventFactory,
   GleanMetricsDataFactory,
-} from './glean.factory';
+  MockPaymentsGleanConfigProvider,
+  MockPaymentsGleanFactory,
+  PaymentsGleanConfig,
+  PaymentsGleanManager,
+} from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from './payments-metrics-aggregator.service';
 import { AccountManager } from '@fxa/shared/account/account';
 import {
   CustomerManager,
@@ -53,8 +54,8 @@ import {
 import { MockFirestoreProvider } from '@fxa/shared/db/firestore';
 import { MockStatsDProvider } from '@fxa/shared/metrics/statsd';
 
-describe('PaymentsGleanService', () => {
-  let paymentsGleanService: PaymentsGleanService;
+describe('PaymentsMetricsAggregatorService', () => {
+  let aggregatorService: PaymentsMetricsAggregatorService;
   let paymentsGleanManager: PaymentsGleanManager;
   let subscriptionManager: SubscriptionManager;
   let productConfigurationManager: ProductConfigurationManager;
@@ -83,7 +84,7 @@ describe('PaymentsGleanService', () => {
         NimbusManager,
         PriceManager,
         PaymentsGleanManager,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         ProductConfigurationManager,
         StrapiClient,
         StripeClient,
@@ -92,7 +93,7 @@ describe('PaymentsGleanService', () => {
       ],
     }).compile();
 
-    paymentsGleanService = moduleRef.get(PaymentsGleanService);
+    aggregatorService = moduleRef.get(PaymentsMetricsAggregatorService);
     paymentsGleanManager = moduleRef.get(PaymentsGleanManager);
     subscriptionManager = moduleRef.get(SubscriptionManager);
     productConfigurationManager = moduleRef.get(ProductConfigurationManager);
@@ -115,7 +116,7 @@ describe('PaymentsGleanService', () => {
     });
 
     it('logs one entry per nimbus user id', () => {
-      paymentsGleanService.handleUserDelete(mockUid);
+      aggregatorService.handleUserDelete(mockUid);
 
       expect(
         nimbusManager.generateAllNimbusIdsForDeletion
@@ -132,7 +133,7 @@ describe('PaymentsGleanService', () => {
     it('still logs deletion even when glean is disabled', () => {
       gleanConfig.enabled = false;
 
-      paymentsGleanService.handleUserDelete(mockUid);
+      aggregatorService.handleUserDelete(mockUid);
 
       expect(
         nimbusManager.generateAllNimbusIdsForDeletion
@@ -153,7 +154,7 @@ describe('PaymentsGleanService', () => {
         .spyOn(nimbusManager, 'generateAllNimbusIdsForDeletion')
         .mockReturnValue(['single-nimbus-id']);
 
-      paymentsGleanService.handleUserDelete(mockUid);
+      aggregatorService.handleUserDelete(mockUid);
 
       expect(logger.log).toHaveBeenCalledTimes(1);
       expect(logger.log).toHaveBeenCalledWith('glean.user.delete', {
@@ -169,7 +170,7 @@ describe('PaymentsGleanService', () => {
     beforeEach(() => {
       jest.spyOn(paymentsGleanManager, 'recordGenericEvent').mockReturnValue();
       jest
-        .spyOn(paymentsGleanService, 'retrieveSubManageMetricsData')
+        .spyOn(aggregatorService, 'retrieveSubManageMetricsData')
         .mockResolvedValue(
           GleanMetricsDataFactory({
             accounts: AccountsMetricsDataFactory({ metricsOptOut: false }),
@@ -178,10 +179,10 @@ describe('PaymentsGleanService', () => {
     });
 
     it('successfully calls GleanManager', async () => {
-      await paymentsGleanService.recordGenericSubManageEvent(mockEventData);
+      await aggregatorService.recordGenericSubManageEvent(mockEventData);
 
       expect(
-        paymentsGleanService.retrieveSubManageMetricsData
+        aggregatorService.retrieveSubManageMetricsData
       ).toHaveBeenCalledWith(
         mockEventData.commonMetrics,
         mockEventData.uid,
@@ -195,16 +196,16 @@ describe('PaymentsGleanService', () => {
 
     it('does not call GleanManager if opted out', async () => {
       jest
-        .spyOn(paymentsGleanService, 'retrieveSubManageMetricsData')
+        .spyOn(aggregatorService, 'retrieveSubManageMetricsData')
         .mockResolvedValue(
           GleanMetricsDataFactory({
             accounts: AccountsMetricsDataFactory({ metricsOptOut: true }),
           })
         );
-      await paymentsGleanService.recordGenericSubManageEvent(mockEventData);
+      await aggregatorService.recordGenericSubManageEvent(mockEventData);
 
       expect(
-        paymentsGleanService.retrieveSubManageMetricsData
+        aggregatorService.retrieveSubManageMetricsData
       ).toHaveBeenCalledWith(
         mockEventData.commonMetrics,
         mockEventData.uid,
@@ -249,18 +250,18 @@ describe('PaymentsGleanService', () => {
       jest
         .spyOn(productConfigurationManager, 'getPageContentByPriceIds')
         .mockResolvedValue(mockPageContentUtil);
-      jest.spyOn(paymentsGleanService, 'mapExperimentationMetricsData');
-      jest.spyOn(paymentsGleanService, 'mapStripeMetricsData');
-      jest.spyOn(paymentsGleanService, 'mapAccountsMetricsData');
-      jest.spyOn(paymentsGleanService, 'mapSubPlatCmsMetricsData');
-      jest.spyOn(paymentsGleanService, 'mapSessionMetricsData');
+      jest.spyOn(aggregatorService, 'mapExperimentationMetricsData');
+      jest.spyOn(aggregatorService, 'mapStripeMetricsData');
+      jest.spyOn(aggregatorService, 'mapAccountsMetricsData');
+      jest.spyOn(aggregatorService, 'mapSubPlatCmsMetricsData');
+      jest.spyOn(aggregatorService, 'mapSessionMetricsData');
       jest
         .spyOn(nimbusManager, 'fetchExperiments')
         .mockResolvedValue(SubPlatNimbusResultFactory());
     });
 
     it('successfully retrieves all data', async () => {
-      await paymentsGleanService.retrieveSubManageMetricsData(
+      await aggregatorService.retrieveSubManageMetricsData(
         mockCommonMetrics,
         mockUid,
         mockSubscriptionId
@@ -277,27 +278,27 @@ describe('PaymentsGleanService', () => {
         productConfigurationManager.getPageContentByPriceIds
       ).toHaveBeenCalledWith([mockPrice.id]);
       expect(
-        paymentsGleanService.mapExperimentationMetricsData
+        aggregatorService.mapExperimentationMetricsData
       ).toHaveBeenCalledWith(mockUid, mockCommonMetrics, mockCustomer);
-      expect(paymentsGleanService.mapStripeMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapStripeMetricsData).toHaveBeenCalledWith(
         mockCustomer,
         mockPrice,
         mockSubscription
       );
-      expect(paymentsGleanService.mapAccountsMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapAccountsMetricsData).toHaveBeenCalledWith(
         mockUid,
         mockAccount
       );
       expect(
-        paymentsGleanService.mapSubPlatCmsMetricsData
+        aggregatorService.mapSubPlatCmsMetricsData
       ).toHaveBeenCalledWith(mockSubscription, mockPageContentUtil);
-      expect(paymentsGleanService.mapSessionMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapSessionMetricsData).toHaveBeenCalledWith(
         mockCommonMetrics
       );
     });
 
     it('successfully complets without calling Stripe data', async () => {
-      await paymentsGleanService.retrieveSubManageMetricsData(
+      await aggregatorService.retrieveSubManageMetricsData(
         mockCommonMetrics,
         mockUid
       );
@@ -309,21 +310,21 @@ describe('PaymentsGleanService', () => {
       ).not.toHaveBeenCalled();
 
       expect(
-        paymentsGleanService.mapExperimentationMetricsData
+        aggregatorService.mapExperimentationMetricsData
       ).toHaveBeenCalledWith(mockUid, mockCommonMetrics, undefined);
-      expect(paymentsGleanService.mapStripeMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapStripeMetricsData).toHaveBeenCalledWith(
         undefined,
         undefined,
         undefined
       );
-      expect(paymentsGleanService.mapAccountsMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapAccountsMetricsData).toHaveBeenCalledWith(
         mockUid,
         mockAccount
       );
       expect(
-        paymentsGleanService.mapSubPlatCmsMetricsData
+        aggregatorService.mapSubPlatCmsMetricsData
       ).toHaveBeenCalledWith(undefined, undefined);
-      expect(paymentsGleanService.mapSessionMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapSessionMetricsData).toHaveBeenCalledWith(
         mockCommonMetrics
       );
     });
@@ -332,28 +333,28 @@ describe('PaymentsGleanService', () => {
       jest
         .spyOn(customerManager, 'retrieve')
         .mockRejectedValue(new Error('testing'));
-      await paymentsGleanService.retrieveSubManageMetricsData(
+      await aggregatorService.retrieveSubManageMetricsData(
         mockCommonMetrics,
         mockUid,
         mockSubscriptionId
       );
 
       expect(
-        paymentsGleanService.mapExperimentationMetricsData
+        aggregatorService.mapExperimentationMetricsData
       ).toHaveBeenCalledWith(mockUid, mockCommonMetrics, undefined);
-      expect(paymentsGleanService.mapStripeMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapStripeMetricsData).toHaveBeenCalledWith(
         undefined,
         mockPrice,
         mockSubscription
       );
-      expect(paymentsGleanService.mapAccountsMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapAccountsMetricsData).toHaveBeenCalledWith(
         mockUid,
         mockAccount
       );
       expect(
-        paymentsGleanService.mapSubPlatCmsMetricsData
+        aggregatorService.mapSubPlatCmsMetricsData
       ).toHaveBeenCalledWith(mockSubscription, mockPageContentUtil);
-      expect(paymentsGleanService.mapSessionMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapSessionMetricsData).toHaveBeenCalledWith(
         mockCommonMetrics
       );
     });
@@ -363,28 +364,28 @@ describe('PaymentsGleanService', () => {
         .spyOn(productConfigurationManager, 'getPageContentByPriceIds')
         .mockRejectedValue(new Error('testing'));
 
-      await paymentsGleanService.retrieveSubManageMetricsData(
+      await aggregatorService.retrieveSubManageMetricsData(
         mockCommonMetrics,
         mockUid,
         mockSubscriptionId
       );
 
       expect(
-        paymentsGleanService.mapExperimentationMetricsData
+        aggregatorService.mapExperimentationMetricsData
       ).toHaveBeenCalledWith(mockUid, mockCommonMetrics, mockCustomer);
-      expect(paymentsGleanService.mapStripeMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapStripeMetricsData).toHaveBeenCalledWith(
         mockCustomer,
         mockPrice,
         mockSubscription
       );
-      expect(paymentsGleanService.mapAccountsMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapAccountsMetricsData).toHaveBeenCalledWith(
         mockUid,
         mockAccount
       );
       expect(
-        paymentsGleanService.mapSubPlatCmsMetricsData
+        aggregatorService.mapSubPlatCmsMetricsData
       ).toHaveBeenCalledWith(mockSubscription, undefined);
-      expect(paymentsGleanService.mapSessionMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapSessionMetricsData).toHaveBeenCalledWith(
         mockCommonMetrics
       );
     });
@@ -394,28 +395,28 @@ describe('PaymentsGleanService', () => {
         .spyOn(accountManager, 'getAccounts')
         .mockRejectedValue(new Error('testing'));
 
-      await paymentsGleanService.retrieveSubManageMetricsData(
+      await aggregatorService.retrieveSubManageMetricsData(
         mockCommonMetrics,
         mockUid,
         mockSubscriptionId
       );
 
       expect(
-        paymentsGleanService.mapExperimentationMetricsData
+        aggregatorService.mapExperimentationMetricsData
       ).toHaveBeenCalledWith(mockUid, mockCommonMetrics, mockCustomer);
-      expect(paymentsGleanService.mapStripeMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapStripeMetricsData).toHaveBeenCalledWith(
         mockCustomer,
         mockPrice,
         mockSubscription
       );
-      expect(paymentsGleanService.mapAccountsMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapAccountsMetricsData).toHaveBeenCalledWith(
         mockUid,
         undefined
       );
       expect(
-        paymentsGleanService.mapSubPlatCmsMetricsData
+        aggregatorService.mapSubPlatCmsMetricsData
       ).toHaveBeenCalledWith(mockSubscription, mockPageContentUtil);
-      expect(paymentsGleanService.mapSessionMetricsData).toHaveBeenCalledWith(
+      expect(aggregatorService.mapSessionMetricsData).toHaveBeenCalledWith(
         mockCommonMetrics
       );
     });
@@ -459,7 +460,7 @@ describe('PaymentsGleanService', () => {
     );
 
     it('successfully returns all data', () => {
-      const result = paymentsGleanService.mapStripeMetricsData(
+      const result = aggregatorService.mapStripeMetricsData(
         mockCustomer,
         mockPrice,
         mockSubscription
@@ -479,7 +480,7 @@ describe('PaymentsGleanService', () => {
     });
 
     it('successfully returns undefined data', () => {
-      const result = paymentsGleanService.mapStripeMetricsData(
+      const result = aggregatorService.mapStripeMetricsData(
         undefined,
         undefined,
         undefined
@@ -502,7 +503,7 @@ describe('PaymentsGleanService', () => {
     const mockUid = mockAccount.uid.toString();
 
     it('successfully returns all data', () => {
-      const result = paymentsGleanService.mapAccountsMetricsData(
+      const result = aggregatorService.mapAccountsMetricsData(
         mockUid,
         mockAccount
       );
@@ -515,7 +516,7 @@ describe('PaymentsGleanService', () => {
     });
 
     it('successfully returns undefined data', () => {
-      const result = paymentsGleanService.mapAccountsMetricsData(
+      const result = aggregatorService.mapAccountsMetricsData(
         mockUid,
         undefined
       );
@@ -546,7 +547,7 @@ describe('PaymentsGleanService', () => {
       PageContentByPriceIdByPriceIdsResultFactory()
     );
     it('successfully returns all data', () => {
-      const result = paymentsGleanService.mapSubPlatCmsMetricsData(
+      const result = aggregatorService.mapSubPlatCmsMetricsData(
         mockSubscription,
         mockPageContentUtil
       );
@@ -558,7 +559,7 @@ describe('PaymentsGleanService', () => {
     });
 
     it('successfully returns undefined data', () => {
-      const result = paymentsGleanService.mapSubPlatCmsMetricsData();
+      const result = aggregatorService.mapSubPlatCmsMetricsData();
 
       expect(result).toEqual({
         offeringId: undefined,
@@ -575,7 +576,7 @@ describe('PaymentsGleanService', () => {
       });
 
       const result =
-        paymentsGleanService.mapSessionMetricsData(mockCommonMetrics);
+        aggregatorService.mapSessionMetricsData(mockCommonMetrics);
       expect(result).toEqual({
         locale: 'en',
         ipAddress: mockCommonMetrics.ipAddress,
@@ -588,7 +589,7 @@ describe('PaymentsGleanService', () => {
       const mockCommonMetrics = CommonMetricsFactory();
 
       const result =
-        paymentsGleanService.mapSessionMetricsData(mockCommonMetrics);
+        aggregatorService.mapSessionMetricsData(mockCommonMetrics);
       expect(result).toEqual({
         locale: undefined,
         ipAddress: mockCommonMetrics.ipAddress,
@@ -631,7 +632,7 @@ describe('PaymentsGleanService', () => {
     });
 
     it('successfully returns data fetched from nimbus', async () => {
-      const result = await paymentsGleanService.mapExperimentationMetricsData(
+      const result = await aggregatorService.mapExperimentationMetricsData(
         mockUid,
         mockCommonMetrics,
         mockCustomer
@@ -646,7 +647,7 @@ describe('PaymentsGleanService', () => {
       jest
         .spyOn(nimbusManager, 'fetchExperiments')
         .mockRejectedValue(new Error('testing'));
-      const result = await paymentsGleanService.mapExperimentationMetricsData(
+      const result = await aggregatorService.mapExperimentationMetricsData(
         mockUid,
         mockCommonMetrics,
         mockCustomer

--- a/libs/payments/metrics-aggregator/src/lib/payments-metrics-aggregator.service.ts
+++ b/libs/payments/metrics-aggregator/src/lib/payments-metrics-aggregator.service.ts
@@ -13,27 +13,27 @@ import {
   PageContentByPriceIdsResultUtil,
   ProductConfigurationManager,
 } from '@fxa/shared/cms';
-import type {
-  AccountsMetricsData,
-  CommonMetrics,
-  ExperimentationData,
-  GenericGleanSubManageEvent,
-  GleanMetricsData,
-  SessionMetricsData,
-  StripeMetricsData,
-  SubPlatCmsMetricsData,
-} from './glean.types';
+import {
+  PaymentsGleanManager,
+  type AccountsMetricsData,
+  type CommonMetrics,
+  type ExperimentationData,
+  type GenericGleanSubManageEvent,
+  type GleanMetricsData,
+  type SessionMetricsData,
+  type StripeMetricsData,
+  type SubPlatCmsMetricsData,
+} from '@fxa/payments/metrics';
 import type {
   StripeCustomer,
   StripePrice,
   StripeSubscription,
 } from '@fxa/payments/stripe';
 import { getPriceFromSubscription } from '@fxa/payments/customer';
-import { PaymentsGleanManager } from './glean.manager';
 import { Logger, Injectable } from '@nestjs/common';
 
 @Injectable()
-export class PaymentsGleanService {
+export class PaymentsMetricsAggregatorService {
   constructor(
     private accountManager: AccountManager,
     private customerManager: CustomerManager,

--- a/libs/payments/metrics-aggregator/src/lib/payments-metrics-aggregator.test-provider.ts
+++ b/libs/payments/metrics-aggregator/src/lib/payments-metrics-aggregator.test-provider.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PaymentsMetricsAggregatorService } from './payments-metrics-aggregator.service';
+
+export const MockPaymentsMetricsAggregatorServiceFactory = {
+  provide: PaymentsMetricsAggregatorService,
+  useFactory: () =>
+    ({
+      handleUserDelete: () => {},
+      recordGenericSubManageEvent: () => {},
+      retrieveSubManageMetricsData: () => {},
+      mapStripeMetricsData: () => {},
+      mapAccountsMetricsData: () => {},
+      mapSubPlatCmsMetricsData: () => {},
+      mapSessionMetricsData: () => {},
+      mapExperimentationMetricsData: () => {},
+    }) as any,
+};

--- a/libs/payments/metrics-aggregator/tsconfig.json
+++ b/libs/payments/metrics-aggregator/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/payments/metrics-aggregator/tsconfig.lib.json
+++ b/libs/payments/metrics-aggregator/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/payments/metrics-aggregator/tsconfig.spec.json
+++ b/libs/payments/metrics-aggregator/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/payments/metrics/src/index.ts
+++ b/libs/payments/metrics/src/index.ts
@@ -4,7 +4,6 @@
 
 export * from './lib/glean/glean.types';
 export * from './lib/glean/glean.manager';
-export * from './lib/glean/glean.service';
 export * from './lib/glean/glean.config';
 export * from './lib/glean/glean.factory';
 export * from './lib/glean/glean.test-provider';

--- a/libs/payments/metrics/src/lib/glean/glean.factory.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.factory.ts
@@ -26,8 +26,9 @@ import {
   type SessionMetricsData,
   type StripeMetricsData,
   type SubPlatCmsMetricsData,
+  TaxAddress,
+  SubplatInterval,
 } from './glean.types';
-import { SubplatInterval, TaxAddressFactory } from '@fxa/payments/customer';
 
 export const CheckoutParamsFactory = (
   override?: Record<string, string>
@@ -119,6 +120,14 @@ export const SubManageMetricsArgsFactory = (
   uid: faker.string.uuid(),
   commonMetrics: CommonMetricsFactory(),
   subscriptionId: `sub_${faker.string.alphanumeric({ length: 14 })}`,
+  ...override,
+});
+
+export const TaxAddressFactory = (
+  override?: Partial<TaxAddress>
+): TaxAddress => ({
+  countryCode: faker.location.countryCode(),
+  postalCode: faker.location.zipCode(),
   ...override,
 });
 

--- a/libs/payments/metrics/src/lib/glean/glean.manager.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.spec.ts
@@ -11,13 +11,15 @@ import {
   SubscriptionCancellationDataFactory,
   TrialConversionDataFactory,
 } from './glean.factory';
-import { PaymentsGleanProvider } from './glean.types';
+import {
+  PaymentsGleanProvider,
+  SubPlatPaymentMethodType,
+} from './glean.types';
 import { MockPaymentsGleanFactory } from './glean.test-provider';
 import {
   MockPaymentsGleanConfigProvider,
   PaymentsGleanConfig,
 } from './glean.config';
-import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
 
 const mockCommonMetricsData = {
   commonMetricsData: CommonMetricsFactory(),

--- a/libs/payments/metrics/src/lib/glean/glean.manager.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.manager.ts
@@ -7,6 +7,7 @@ import {
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
+  PaymentProvidersType,
   PaymentsGleanProvider,
   SubscriptionCancellationData,
   TrialConversionData,
@@ -15,12 +16,9 @@ import {
   type SessionMetricsData,
   type StripeMetricsData,
   type SubPlatCmsMetricsData,
+  type SubPlatPaymentMethodType,
 } from './glean.types';
 import { Inject, Injectable } from '@nestjs/common';
-import {
-  PaymentProvidersType,
-  type SubPlatPaymentMethodType,
-} from '@fxa/payments/customer';
 import { type PaymentsGleanServerEventsLogger } from './glean.provider';
 import { mapSession } from './utils/mapSession';
 import { mapUtm } from './utils/mapUtm';

--- a/libs/payments/metrics/src/lib/glean/glean.test-provider.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.test-provider.ts
@@ -1,4 +1,7 @@
-import { PaymentsGleanService } from './glean.service';
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { PaymentsGleanProvider } from './glean.types';
 
 /**
@@ -17,20 +20,5 @@ export const MockPaymentsGleanFactory = {
       recordPaySetupFail: () => {},
       recordSubscriptionEnded: () => {},
       recordSubscriptionTrialConverted: () => {},
-    }) as any,
-};
-
-export const MockPaymentsGleanServiceFactory = {
-  provide: PaymentsGleanService,
-  useFactory: () =>
-    ({
-      handleUserDelete: () => {},
-      recordGenericSubManageEvent: () => {},
-      retrieveSubManageMetricsData: () => {},
-      mapStripeMetricsData: () => {},
-      mapAccountsMetricsData: () => {},
-      mapSubPlatCmsMetricsData: () => {},
-      mapSessionMetricsData: () => {},
-      mapExperimentationMetricsData: () => {},
     }) as any,
 };

--- a/libs/payments/metrics/src/lib/glean/glean.types.ts
+++ b/libs/payments/metrics/src/lib/glean/glean.types.ts
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import type { SubplatInterval } from '@fxa/payments/customer';
-
 export const CheckoutTypes = [
   'new_account',
   'existing_account',
@@ -11,7 +9,21 @@ export const CheckoutTypes = [
   'unknown',
 ] as const;
 export type CheckoutTypesType = (typeof CheckoutTypes)[number];
-import type { TaxAddress } from '@fxa/payments/customer';
+
+// Should match type TaxAddress in @fxa/payments/customer
+export interface TaxAddress {
+  countryCode: string;
+  postalCode: string;
+}
+
+// Should match enum SubplatInterval in @fxa/payments/customer
+export enum SubplatInterval {
+  Daily = 'daily',
+  Weekly = 'weekly',
+  Monthly = 'monthly',
+  HalfYearly = 'halfyearly',
+  Yearly = 'yearly',
+}
 
 export const PaymentProvidersTypePartial = [
   'stripe',
@@ -19,6 +31,19 @@ export const PaymentProvidersTypePartial = [
   'apple_iap',
   'paypal',
 ] as const;
+
+// Should match type PaymentProvidersType in @fxa/payments/customer
+export type PaymentProvidersType = (typeof PaymentProvidersTypePartial)[number];
+
+// Should match enum SubPlatPaymentMethodType in @fxa/payments/customer
+export enum SubPlatPaymentMethodType {
+  PayPal = 'external_paypal',
+  Stripe = 'stripe',
+  Card = 'card',
+  ApplePay = 'apple_pay',
+  GooglePay = 'google_pay',
+  Link = 'link',
+}
 
 export type CommonMetrics = {
   ipAddress: string;

--- a/libs/payments/metrics/src/lib/glean/utils/mapParams.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapParams.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { SubplatInterval } from '@fxa/payments/customer';
+import { SubplatInterval } from '../glean.types';
 import { normalizeGleanFalsyValues } from './normalizeGleanFalsyValues';
 
 export function mapParams(params: Record<string, string>) {

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscription.spec.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscription.spec.ts
@@ -9,7 +9,7 @@ import {
   CheckoutParamsFactory,
 } from '../glean.factory';
 import { mapSubscription } from './mapSubscription';
-import { SubPlatPaymentMethodType } from '@fxa/payments/customer';
+import { SubPlatPaymentMethodType } from '../glean.types';
 
 describe('mapSubscription', () => {
   it('should map all values', () => {

--- a/libs/payments/metrics/src/lib/glean/utils/mapSubscription.ts
+++ b/libs/payments/metrics/src/lib/glean/utils/mapSubscription.ts
@@ -5,9 +5,10 @@ import {
   CartMetrics,
   CmsMetricsData,
   CommonMetrics,
+  type PaymentProvidersType,
+  type SubPlatPaymentMethodType,
   type SubscriptionCancellationData,
 } from '../glean.types';
-import { PaymentProvidersType, SubPlatPaymentMethodType } from '@fxa/payments/customer';
 import { determineCheckoutType } from './determineCheckoutType';
 import { mapParams } from './mapParams';
 import { normalizeGleanFalsyValues } from './normalizeGleanFalsyValues';

--- a/libs/payments/ui/src/lib/nestapp/app.module.ts
+++ b/libs/payments/ui/src/lib/nestapp/app.module.ts
@@ -42,10 +42,8 @@ import {
   CustomerSessionManager,
   SetupIntentManager,
 } from '@fxa/payments/customer';
-import {
-  PaymentsGleanManager,
-  PaymentsGleanService,
-} from '@fxa/payments/metrics';
+import { PaymentsGleanManager } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import { PaymentsGleanFactory } from '@fxa/payments/metrics/provider';
 import { AccountCustomerManager, StripeClient } from '@fxa/payments/stripe';
 import {
@@ -156,7 +154,7 @@ import { NimbusManager } from '@fxa/payments/experiments';
     SubscriptionManager,
     PaymentsGleanFactory,
     PaymentsGleanManager,
-    PaymentsGleanService,
+    PaymentsMetricsAggregatorService,
     PaymentsEmitterService,
     StripeEventManager,
     SubscriptionEventsService,

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.controller.spec.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.controller.spec.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Test } from '@nestjs/testing';
-import { MockPaymentsGleanServiceFactory } from '@fxa/payments/metrics';
+import { MockPaymentsMetricsAggregatorServiceFactory } from '@fxa/payments/metrics-aggregator';
 import {
   AccountCustomerManager,
   MockStripeConfigProvider,
@@ -29,7 +29,7 @@ describe('FxaWebhooksController', () => {
         MockFxaWebhookConfigProvider,
         MockStatsDProvider,
         MockLoggerProvider,
-        MockPaymentsGleanServiceFactory,
+        MockPaymentsMetricsAggregatorServiceFactory,
         AccountCustomerManager,
         MockAccountDatabaseNestFactory,
         CustomerManager,

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.service.spec.ts
@@ -15,9 +15,9 @@ import { MockLoggerProvider } from '@fxa/shared/log';
 import { MockAccountDatabaseNestFactory } from '@fxa/shared/db/mysql/account';
 import type { StatsD } from 'hot-shots';
 import {
-  MockPaymentsGleanServiceFactory,
-  PaymentsGleanService,
-} from '@fxa/payments/metrics';
+  MockPaymentsMetricsAggregatorServiceFactory,
+  PaymentsMetricsAggregatorService,
+} from '@fxa/payments/metrics-aggregator';
 import {
   AccountCustomerManager,
   AccountCustomerNotFoundError,
@@ -149,7 +149,7 @@ describe('FxaWebhookService', () => {
   let service: FxaWebhookService;
   let statsd: StatsD;
   let logger: LoggerService;
-  let paymentsGleanService: PaymentsGleanService;
+  let paymentsGleanService: PaymentsMetricsAggregatorService;
   let accountCustomerManager: AccountCustomerManager;
   let customerManager: CustomerManager;
   let originalFetch: typeof global.fetch;
@@ -164,7 +164,7 @@ describe('FxaWebhookService', () => {
         MockFxaWebhookConfigProvider,
         MockStatsDProvider,
         MockLoggerProvider,
-        MockPaymentsGleanServiceFactory,
+        MockPaymentsMetricsAggregatorServiceFactory,
         AccountCustomerManager,
         MockAccountDatabaseNestFactory,
         CustomerManager,
@@ -176,7 +176,7 @@ describe('FxaWebhookService', () => {
     service = module.get(FxaWebhookService);
     statsd = module.get(StatsDService);
     logger = module.get<LoggerService>(Logger);
-    paymentsGleanService = module.get(PaymentsGleanService);
+    paymentsGleanService = module.get(PaymentsMetricsAggregatorService);
     accountCustomerManager = module.get(AccountCustomerManager);
     customerManager = module.get(CustomerManager);
 

--- a/libs/payments/webhooks/src/lib/fxa-webhooks.service.ts
+++ b/libs/payments/webhooks/src/lib/fxa-webhooks.service.ts
@@ -15,7 +15,7 @@ import {
   StaleWhileRevalidateWithFallbackStrategy,
 } from '@fxa/shared/db/type-cacheable';
 import { StatsDService } from '@fxa/shared/metrics/statsd';
-import { PaymentsGleanService } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   AccountCustomerManager,
   AccountCustomerNotFoundError,
@@ -67,7 +67,7 @@ export class FxaWebhookService {
     private fxaWebhookConfig: FxaWebhookConfig,
     @Inject(StatsDService) private statsd: StatsD,
     @Inject(Logger) private log: LoggerService,
-    private paymentsGleanService: PaymentsGleanService,
+    private paymentsGleanService: PaymentsMetricsAggregatorService,
     private accountCustomerManager: AccountCustomerManager,
     private customerManager: CustomerManager
   ) {

--- a/libs/payments/webhooks/src/lib/stripe-event.manager.spec.ts
+++ b/libs/payments/webhooks/src/lib/stripe-event.manager.spec.ts
@@ -33,8 +33,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   MockStrapiClientConfigProvider,
   ProductConfigurationManager,
@@ -112,7 +112,7 @@ describe('StripeEventManager', () => {
         CurrencyManager,
         MockCurrencyConfigProvider,
         PaymentsGleanManager,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         MockPaymentsGleanConfigProvider,
         MockPaymentsGleanFactory,
         ProductConfigurationManager,

--- a/libs/payments/webhooks/src/lib/stripe-webhooks.controller.spec.ts
+++ b/libs/payments/webhooks/src/lib/stripe-webhooks.controller.spec.ts
@@ -29,8 +29,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   MockStrapiClientConfigProvider,
   ProductConfigurationManager,
@@ -89,7 +89,7 @@ describe('StripeWebhooksController', () => {
         PayPalClient,
         CurrencyManager,
         MockCurrencyConfigProvider,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         PaymentsGleanManager,
         MockPaymentsGleanConfigProvider,
         MockPaymentsGleanFactory,

--- a/libs/payments/webhooks/src/lib/stripe-webhooks.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/stripe-webhooks.service.spec.ts
@@ -32,8 +32,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   MockStrapiClientConfigProvider,
   ProductConfigurationManager,
@@ -102,7 +102,7 @@ describe('StripeWebhookService', () => {
         PayPalClient,
         CurrencyManager,
         MockCurrencyConfigProvider,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         PaymentsGleanManager,
         MockPaymentsGleanConfigProvider,
         MockPaymentsGleanFactory,

--- a/libs/payments/webhooks/src/lib/subscription-handler.service.spec.ts
+++ b/libs/payments/webhooks/src/lib/subscription-handler.service.spec.ts
@@ -39,8 +39,8 @@ import {
   MockPaymentsGleanConfigProvider,
   MockPaymentsGleanFactory,
   PaymentsGleanManager,
-  PaymentsGleanService,
 } from '@fxa/payments/metrics';
+import { PaymentsMetricsAggregatorService } from '@fxa/payments/metrics-aggregator';
 import {
   MockStrapiClientConfigProvider,
   ProductConfigurationManager,
@@ -113,7 +113,7 @@ describe('SubscriptionEventsService', () => {
         PayPalClient,
         CurrencyManager,
         MockCurrencyConfigProvider,
-        PaymentsGleanService,
+        PaymentsMetricsAggregatorService,
         PaymentsGleanManager,
         MockPaymentsGleanConfigProvider,
         MockPaymentsGleanFactory,

--- a/packages/fxa-admin-server/tsconfig.build.json
+++ b/packages/fxa-admin-server/tsconfig.build.json
@@ -16,6 +16,9 @@
       "@fxa/payments/experiments": ["libs/payments/experiments/src/index"],
       "@fxa/payments/iap": ["libs/payments/iap/src/index"],
       "@fxa/payments/metrics": ["libs/payments/metrics/src/index"],
+      "@fxa/payments/metrics-aggregator": [
+        "libs/payments/metrics-aggregator/src/index"
+      ],
       "@fxa/shared/account/account": ["libs/shared/account/account/src/index"],
       "@fxa/profile/client": ["libs/profile/client/src/index"],
       "@fxa/shared/cms": ["libs/shared/cms/src/index"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -58,6 +58,9 @@
       "@fxa/payments/legacy": ["libs/payments/legacy/src/index.ts"],
       "@fxa/payments/management": ["libs/payments/management/src/index.ts"],
       "@fxa/payments/metrics": ["libs/payments/metrics/src/index.ts"],
+      "@fxa/payments/metrics-aggregator": [
+        "libs/payments/metrics-aggregator/src/index.ts"
+      ],
       "@fxa/payments/metrics/client": ["libs/payments/metrics/src/client.ts"],
       "@fxa/payments/metrics/provider": [
         "libs/payments/metrics/src/provider.ts"


### PR DESCRIPTION
## Because

* The libs/payments/metrics library has the potential to cause additional ciruclar dependencies due to the modules imported from `payments-customer` by the PaymentsGleanService

## This pull request

* Move the PaymentsGleanService to a new library, rename it and update the various dependencies.
* Remove remaining circular dependencies from `payments-metrics` lib.

## Issue that this pull request solves

Closes: #PAY-3698

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
