### PR TITLE
fix(functional-tests): fix failing stage tests

### DIFF
--- a/packages/functional-tests/tests/pairing/pairChoice.spec.ts
+++ b/packages/functional-tests/tests/pairing/pairChoice.spec.ts
@@ -22,37 +22,19 @@ test.describe('severity-2 #smoke', () => {
       await settings.checkWebChannelMessage(FirefoxCommand.OAuthFlowBegin);
     });
 
-    test('Continue on the choice screen dispatches pair_preferences', async ({
+    test('Continue advances to the download view when no mobile is selected', async ({
       target,
       syncOAuthBrowserPages: { page },
     }) => {
       await page.goto(`${target.contentServerUrl}/pair`);
       // Click the label so React's onChange fires; the radio is hidden behind
       // it, and check() on the input itself fails actionability.
-      await page.locator('label[for="has-mobile"]').click();
+      await page.locator('label[for="needs-mobile"]').click();
       await expect(page.getByTestId('pair-continue-btn')).toBeEnabled();
 
-      // Capture WebChannelMessageToChrome dispatches in a page-side promise
-      // *before* clicking, so we observe pair_preferences even if Firefox's
-      // chrome handler tears the test tab down right after.
-      const dispatched = page.evaluate(
-        () =>
-          new Promise<string>((resolve) => {
-            window.addEventListener(
-              'WebChannelMessageToChrome',
-              (e: Event) => {
-                const detail = JSON.parse((e as CustomEvent).detail);
-                if (detail.message.command === 'fxaccounts:pair_preferences') {
-                  resolve(detail.message.command);
-                }
-              },
-              { once: false }
-            );
-          })
-      );
-
       await page.getByTestId('pair-continue-btn').click();
-      expect(await dispatched).toBe('fxaccounts:pair_preferences');
+
+      await expect(page.locator('#pair-header-mobile')).toBeVisible();
     });
 
     test('direct /connect_another_device dispatches fxa_status and oauth_flow_begin', async ({


### PR DESCRIPTION
  ## Because

  - The "Continue on the choice screen dispatches pair_preferences" stage smoke test was failing reliably with `Target page, context or browser has been closed`.
  - Firefox's chrome handler synchronously navigates the tab to `about:preferences#sync` when it sees the `WebChannelMessageToChrome` dispatch, tearing the page down before any `page.evaluate` reply (or console round-trip) can reach Playwright. There is no observable side effect in the page for the `has-mobile` path that survives the teardown.
  - The dispatch is already covered by unit tests in `packages/fxa-settings/src/pages/Pair/Index/index.test.tsx` with the WebChannel mocked. The functional test added flake without unique coverage.

  ## This pull request

  - Updates `pairChoice.spec.ts` so the Continue-button smoke test selects `needs-mobile`, clicks Continue, and asserts the in-page download view (`#pair-header-mobile`) appears. Same `handleChoiceSubmit` handler, no race against tab teardown.
  - Renames the test to "Continue advances to the download view when no mobile is selected".

  ## Issue that this pull request solves

  ## Checklist

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [ ] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**

  cd packages/functional-tests
  CI_WAF_TOKEN= yarn test-stage --grep "Pair entry flow" --reporter=list