### PR TITLE
fix(admin): register /waf-tokens with SPA fallback handler

### DIFF
--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -131,6 +131,7 @@ if (proxyUrl) {
     '/account-reset',
     '/relying-parties',
     '/rate-limiting',
+    '/waf-tokens',
     '/permissions',
   ].forEach((route) => {
     // FIXME: should set ETag, Not-Modified:


### PR DESCRIPTION
## Because

- Hard reloading or directly visiting `/waf-tokens` returned `404 Cannot GET /waf-tokens` because the path was missing from the SPA route allowlist in `packages/fxa-admin-panel/server/lib/server.ts`.

## This pull request

- Adds `/waf-tokens` to the route array so the server falls through to `index.html` for that path.

## Issue that this pull request solves

Closes: FXA-13701

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- To repro the original bug: check out main, run the admin panel, navigate to `/waf-tokens` via the nav (works), then hard reload — you'll see the 404.