### PR TITLE
fix(passkeys): Show passkeys unsupported error in alert bar

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -5,11 +5,13 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { LocationProvider } from '@reach/router';
 
-import { PagePasskeyAdd } from '.';
+import { MfaGuardPagePasskeyAdd, PagePasskeyAdd } from '.';
 import { Account, AppContext } from '../../../models';
 import { mockAppContext, mockSettingsContext } from '../../../models/mocks';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
+import { AlertBarInfo } from '../../../models/AlertBarInfo';
 import { MfaContext } from '../MfaGuard';
 import { createCredential } from '../../../lib/passkeys/webauthn';
 import {
@@ -38,10 +40,12 @@ jest.mock('@sentry/browser', () => ({
 const mockCreateCredential = jest.fn() as jest.MockedFunction<
   typeof createCredential
 >;
+const mockIsWebAuthnLevel3Supported = jest.fn(() => true);
 jest.mock('../../../lib/passkeys/webauthn', () => ({
   createCredential: (
     ...args: Parameters<typeof createCredential>
   ): ReturnType<typeof createCredential> => mockCreateCredential(...args),
+  isWebAuthnLevel3Supported: () => mockIsWebAuthnLevel3Supported(),
 }));
 
 const mockHandleWebAuthnError = jest.fn();
@@ -79,8 +83,9 @@ jest.mock('../../../lib/cache', () => ({
 const mockBeginPasskeyRegistration = jest.fn();
 const mockCompletePasskeyRegistration = jest.fn();
 
-const mockAlertSuccess = jest.fn();
-const mockAlertError = jest.fn();
+let alertBarInfo: AlertBarInfo;
+let mockAlertSuccess: jest.SpyInstance;
+let mockAlertError: jest.SpyInstance;
 
 const mockCreationOptions = {
   rp: { name: 'Mozilla', id: 'accounts.firefox.com' },
@@ -111,19 +116,6 @@ function renderPage() {
     completePasskeyRegistration: mockCompletePasskeyRegistration,
   };
 
-  const alertBarInfo = {
-    success: mockAlertSuccess,
-    error: mockAlertError,
-    info: jest.fn(),
-    show: jest.fn(),
-    hide: jest.fn(),
-    setType: jest.fn(),
-    setContent: jest.fn(),
-    visible: false,
-    type: 'success' as const,
-    content: null,
-  };
-
   return render(
     <AppContext.Provider
       value={mockAppContext({
@@ -131,11 +123,7 @@ function renderPage() {
         authClient: authClient as any,
       })}
     >
-      <SettingsContext.Provider
-        value={mockSettingsContext({
-          alertBarInfo: alertBarInfo as any,
-        })}
-      >
+      <SettingsContext.Provider value={mockSettingsContext({ alertBarInfo })}>
         <MfaContext.Provider value="passkey">
           <PagePasskeyAdd />
         </MfaContext.Provider>
@@ -147,6 +135,9 @@ function renderPage() {
 describe('PagePasskeyAdd', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    alertBarInfo = new AlertBarInfo();
+    mockAlertSuccess = jest.spyOn(alertBarInfo, 'success');
+    mockAlertError = jest.spyOn(alertBarInfo, 'error');
     mockBeginPasskeyRegistration.mockResolvedValue(mockCreationOptions);
     mockCreateCredential.mockResolvedValue(mockCredential);
     mockCompletePasskeyRegistration.mockResolvedValue({
@@ -258,6 +249,32 @@ describe('PagePasskeyAdd', () => {
       expect.any(Function),
       { hadExcludeCredentials: true }
     );
+  });
+
+  it('renders the unsupported-passkey alert (with Learn more link) on NotSupportedError', async () => {
+    const notSupportedError = new DOMException(
+      'not supported',
+      'NotSupportedError'
+    );
+    mockCreateCredential.mockRejectedValue(notSupportedError);
+    mockHandleWebAuthnError.mockReturnValue({
+      category: WebAuthnErrorCategory.DevicePlatform,
+      errorType: WebAuthnErrorType.NotSupported,
+      ftlId: 'passkey-registration-error-not-supported-v2',
+      fallbackText: 'Your browser or device doesn’t support passkeys.',
+      logToSentry: false,
+    });
+
+    renderPage();
+    await waitFor(() => {
+      expect(mockAlertError).toHaveBeenCalledTimes(1);
+    });
+    const [alertContent] = mockAlertError.mock.calls[0];
+    expect(React.isValidElement(alertContent)).toBe(true);
+    // Defensive case: pre-check at MfaGuardPagePasskeyAdd is the
+    // primary handler. If we reach here (race), don't auto-redirect — the user
+    // can use Cancel to navigate away.
+    expect(mockNavigateWithQuery).not.toHaveBeenCalled();
   });
 
   it('handles timeout error', async () => {
@@ -431,5 +448,44 @@ describe('PagePasskeyAdd', () => {
       'Passkey setup was canceled. Try again.'
     );
     expect(mockHandleWebAuthnError).not.toHaveBeenCalled();
+  });
+});
+
+describe('MfaGuardPagePasskeyAdd pre-check', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    alertBarInfo = new AlertBarInfo();
+    mockAlertSuccess = jest.spyOn(alertBarInfo, 'success');
+    mockAlertError = jest.spyOn(alertBarInfo, 'error');
+    mockIsWebAuthnLevel3Supported.mockReturnValue(true);
+  });
+
+  function renderWrapper() {
+    return render(
+      <LocationProvider>
+        <AppContext.Provider value={mockAppContext()}>
+          <SettingsContext.Provider
+            value={mockSettingsContext({ alertBarInfo })}
+          >
+            <MfaContext.Provider value="passkey">
+              <MfaGuardPagePasskeyAdd />
+            </MfaContext.Provider>
+          </SettingsContext.Provider>
+        </AppContext.Provider>
+      </LocationProvider>
+    );
+  }
+
+  it('pushes the unsupported alert and redirects to settings before MFA fires when WebAuthn is unsupported', () => {
+    mockIsWebAuthnLevel3Supported.mockReturnValue(false);
+    const { container } = renderWrapper();
+    expect(mockAlertError).toHaveBeenCalledTimes(1);
+    expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
+      replace: true,
+    });
+    // PagePasskeyAdd never mounts when unsupported.
+    expect(container).toBeEmptyDOMElement();
+    // MFA ceremony is skipped entirely.
+    expect(mockBeginPasskeyRegistration).not.toHaveBeenCalled();
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -15,7 +15,10 @@ import {
   useAuthClient,
   useFtlMsgResolver,
 } from '../../../models';
-import { createCredential } from '../../../lib/passkeys/webauthn';
+import {
+  createCredential,
+  isWebAuthnLevel3Supported,
+} from '../../../lib/passkeys/webauthn';
 import {
   handleWebAuthnError,
   WebAuthnErrorType,
@@ -29,8 +32,28 @@ import {
   HandledError,
 } from '../../../lib/error-utils';
 import { AuthUiErrorNos } from '../../../lib/auth-errors/auth-errors';
+import { unsupportedPasskeyMessage } from '../../../lib/passkeys/unsupported-message';
 
 export const MfaGuardPagePasskeyAdd = (_: RouteComponentProps) => {
+  const alertBar = useAlertBar();
+  const navigateWithQuery = useNavigateWithQuery();
+  // Pre-check before MfaGuard mounts so an unsupported browser never triggers
+  // an MFA prompt. Detection is best-effort; PagePasskeyAdd's catch block still
+  // surfaces NotSupportedError defensively if the ceremony itself rejects.
+  const supported = isWebAuthnLevel3Supported();
+  // prevent multiple redirects before unmount
+  const hasRedirectedRef = useRef(false);
+
+  useEffect(() => {
+    if (!supported && !hasRedirectedRef.current) {
+      hasRedirectedRef.current = true;
+      alertBar.error(unsupportedPasskeyMessage());
+      navigateWithQuery(SETTINGS_PATH + '#security', { replace: true });
+    }
+  }, [supported, alertBar, navigateWithQuery]);
+
+  if (!supported) return null;
+
   return (
     <MfaGuard requiredScope="passkey" reason={MfaReason.createPasskey}>
       <PagePasskeyAdd />
@@ -162,6 +185,14 @@ export const PagePasskeyAdd = () => {
               reason: reasonMap[categorized.errorType] || 'webauthn_unknown',
             },
           });
+          if (categorized.errorType === WebAuthnErrorType.NotSupported) {
+            // Defensive: MfaGuardPagePasskeyAdd should have caught this before
+            // MFA, so we only reach here if detection raced. Push the alert and
+            // leave the user on the page — they can use Cancel to navigate
+            // away themselves.
+            alertBar.error(unsupportedPasskeyMessage());
+            return;
+          }
           alertBar.error(
             ftlMsgResolver.getMsg(categorized.ftlId, categorized.fallbackText)
           );

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/en.ftl
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/en.ftl
@@ -17,9 +17,4 @@ passkey-row-max-limit-banner =
 # Tooltip shown on the disabled Create button when the passkey limit is reached
 passkey-row-max-limit-disabled-reason = You’ve reached the maximum number of passkeys.
 
-## Error / limit messages
-
-# Shown as an error banner when the user's browser or device does not support passkeys (WebAuthn Level 3).
-passkey-row-webauthn-not-supported = Your browser or device doesn’t support passkeys.
-
 ##

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.stories.tsx
@@ -15,6 +15,7 @@ import {
 } from 'fxa-settings/src/models/mocks';
 import { SettingsContext } from 'fxa-settings/src/models/contexts/SettingsContext';
 import { Passkey } from 'fxa-auth-client/browser';
+import AlertBar from '../AlertBar';
 
 function initLocalAccount() {
   const NS = '__fxa_storage';
@@ -93,6 +94,7 @@ const storyWithMockPasskeys = (
           })}
         >
           <SettingsContext.Provider value={mockSettingsContext()}>
+            <AlertBar />
             <UnitRowPasskey />
           </SettingsContext.Provider>
         </AppContext.Provider>

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.test.tsx
@@ -3,13 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { LocationProvider } from '@reach/router';
 import UnitRowPasskey from './index';
 import { renderWithLocalizationProvider } from 'fxa-react/lib/test-utils/localizationProvider';
 import { Passkey } from 'fxa-auth-client/browser';
 import { Account, AppContext } from '../../../models';
-import { MOCK_ACCOUNT, mockAppContext } from '../../../models/mocks';
+import {
+  MOCK_ACCOUNT,
+  mockAppContext,
+  mockSettingsContext,
+} from '../../../models/mocks';
+import { SettingsContext } from '../../../models/contexts/SettingsContext';
+import { AlertBarInfo } from '../../../models/AlertBarInfo';
 
 jest.mock('../SubRow', () => ({
   ...jest.requireActual('../SubRow'),
@@ -63,6 +69,9 @@ let mockAccount = {
   passkeys: mockPasskeys,
 };
 
+let alertBarInfo: AlertBarInfo;
+let alertErrorSpy: jest.SpyInstance;
+
 describe('UnitRowPasskey', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -71,21 +80,26 @@ describe('UnitRowPasskey', () => {
       ...MOCK_ACCOUNT,
       passkeys: mockPasskeys,
     };
+    alertBarInfo = new AlertBarInfo();
+    alertErrorSpy = jest.spyOn(alertBarInfo, 'error');
   });
 
-  const renderUnitRowPasskey = () => {
-    return renderWithLocalizationProvider(
+  const renderUnitRowPasskey = () =>
+    renderWithLocalizationProvider(
       <LocationProvider>
         <AppContext.Provider
           value={mockAppContext({
             account: mockAccount as unknown as Account,
           })}
         >
-          <UnitRowPasskey />
+          <SettingsContext.Provider
+            value={mockSettingsContext({ alertBarInfo })}
+          >
+            <UnitRowPasskey />
+          </SettingsContext.Provider>
         </AppContext.Provider>
       </LocationProvider>
     );
-  };
 
   it('renders header and description', async () => {
     renderUnitRowPasskey();
@@ -128,7 +142,7 @@ describe('UnitRowPasskey', () => {
     });
   });
 
-  it('shows a Create button (not a link) and no error banner until clicked when WebAuthn is not supported', async () => {
+  it('shows a Create button (not a link) and does not push an alert until clicked when WebAuthn is not supported', async () => {
     isWebAuthnLevel3Supported.mockReturnValue(false);
     renderUnitRowPasskey();
     await waitFor(() => {
@@ -139,19 +153,33 @@ describe('UnitRowPasskey', () => {
     expect(
       screen.queryByRole('link', { name: 'Create' })
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Your browser or device doesn’t support passkeys.')
-    ).not.toBeInTheDocument();
+    expect(alertErrorSpy).not.toHaveBeenCalled();
   });
 
-  it('reveals the error banner when the user clicks Create and WebAuthn is not supported', async () => {
+  it('pushes an unsupported-passkey alert when the user clicks Create and WebAuthn is not supported', async () => {
     isWebAuthnLevel3Supported.mockReturnValue(false);
     renderUnitRowPasskey();
     const createButton = await screen.findByRole('button', { name: 'Create' });
     fireEvent.click(createButton);
+    expect(alertErrorSpy).toHaveBeenCalledTimes(1);
+    const [alertContent] = alertErrorSpy.mock.calls[0];
+    expect(React.isValidElement(alertContent)).toBe(true);
+
+    // Render the captured alert node and assert the user-visible content.
+    // Scope queries to the alert's container so they don't collide with the
+    // existing "Learn more" link that lives inside UnitRowPasskey itself.
+    const { container } = renderWithLocalizationProvider(<>{alertContent}</>);
     expect(
-      screen.getByText('Your browser or device doesn’t support passkeys.')
+      within(container).getByText(
+        'Your browser or device doesn’t support passkeys.'
+      )
     ).toBeInTheDocument();
+    expect(
+      within(container).getByRole('link', { name: /Learn more/ })
+    ).toHaveAttribute(
+      'href',
+      'https://support.mozilla.org/kb/placeholder-article'
+    );
   });
 
   it('shows warning banner and disabled Create button when at max passkeys', async () => {

--- a/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/UnitRowPasskey/index.tsx
@@ -2,17 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
+import React from 'react';
 import UnitRow, { UnitRowProps } from '../UnitRow';
-import { useAccount, useFtlMsgResolver, useConfig } from '../../../models';
+import {
+  useAccount,
+  useAlertBar,
+  useFtlMsgResolver,
+  useConfig,
+} from '../../../models';
 import { FtlMsg } from 'fxa-react/lib/utils';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { PasskeySubRow } from '../SubRow';
 import { isWebAuthnLevel3Supported } from '../../../lib/passkeys/webauthn';
+import { PASSKEY_SUPPORT_URL } from '../../../lib/passkeys/constants';
+import { unsupportedPasskeyMessage } from '../../../lib/passkeys/unsupported-message';
 import { Banner } from '../../Banner';
 
 export const UnitRowPasskey = () => {
   const account = useAccount();
+  const alertBar = useAlertBar();
   const ftlMsgResolver = useFtlMsgResolver();
   const config = useConfig();
   const maxPasskeys = config.passkeys.maxPerUser;
@@ -20,7 +28,6 @@ export const UnitRowPasskey = () => {
   const hasPasskeys = passkeys.length > 0;
   const isAtLimit = passkeys.length >= maxPasskeys;
   const webAuthnSupported = isWebAuthnLevel3Supported();
-  const [showWebAuthnError, setShowWebAuthnError] = useState(false);
 
   const conditionalUnitRowProps: Partial<UnitRowProps> = hasPasskeys
     ? {
@@ -37,18 +44,6 @@ export const UnitRowPasskey = () => {
 
   const getSubRows = () => (
     <>
-      {showWebAuthnError && (
-        <Banner
-          type="error"
-          className="mb-2"
-          content={{
-            localizedDescription: ftlMsgResolver.getMsg(
-              'passkey-row-webauthn-not-supported',
-              'Your browser or device doesn’t support passkeys.'
-            ),
-          }}
-        />
-      )}
       {webAuthnSupported && isAtLimit && (
         <Banner
           type="warning"
@@ -70,10 +65,7 @@ export const UnitRowPasskey = () => {
 
   const learnMoreLink = (
     <FtlMsg id="passkey-row-info-link-2">
-      <LinkExternal
-        href="https://support.mozilla.org/kb/placeholder-article" // TODO: Update with actual support article link
-        className="link-blue text-sm"
-      >
+      <LinkExternal href={PASSKEY_SUPPORT_URL} className="link-blue text-sm">
         Learn more
       </LinkExternal>
     </FtlMsg>
@@ -90,7 +82,9 @@ export const UnitRowPasskey = () => {
         webAuthnSupported && !isAtLimit ? '/settings/passkeys/add' : undefined
       }
       revealModal={
-        !webAuthnSupported ? () => setShowWebAuthnError(true) : undefined
+        !webAuthnSupported
+          ? () => alertBar.error(unsupportedPasskeyMessage())
+          : undefined
       }
       disabled={webAuthnSupported && isAtLimit}
       disabledReason={ftlMsgResolver.getMsg(

--- a/packages/fxa-settings/src/lib/passkeys/constants.ts
+++ b/packages/fxa-settings/src/lib/passkeys/constants.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export * from './constants';
-export * from './unsupported-message';
-export * from './webauthn';
-export * from './webauthn-errors';
+// TODO: Update with the actual SUMO support article link once published.
+export const PASSKEY_SUPPORT_URL =
+  'https://support.mozilla.org/kb/placeholder-article';

--- a/packages/fxa-settings/src/lib/passkeys/en.ftl
+++ b/packages/fxa-settings/src/lib/passkeys/en.ftl
@@ -17,8 +17,10 @@ passkey-registration-error-timeout = Passkey setup was canceled. Try again.
 # User clicked the in-page Cancel link while the ceremony was still pending
 passkey-registration-canceled = Passkey setup was canceled. Try again.
 
-# Browser or platform does not support passkeys or the requested options (e.g., UV, discoverable credential)
-passkey-registration-error-not-supported = Passkeys aren’t supported here. Try another method or device.
+# Browser or platform does not support passkeys or the requested options (e.g., user verification, discoverable credential).
+passkey-registration-error-not-supported-v2 = Your browser or device doesn’t support passkeys.
+# Link label appended after passkey-registration-error-not-supported-v2, opens a SUMO support article.
+passkey-registration-error-not-supported-link = Learn more
 
 # RP ID / origin mismatch, or insecure context (e.g., embedded iframe, wrong domain)
 passkey-registration-error-security = Passkeys can’t be set up on this page. Use the secure site and try again.
@@ -47,7 +49,7 @@ passkey-authentication-error-not-allowed-existing = Passkey setup isn’t availa
 passkey-authentication-error-timeout = Passkey request timed out. Please try again.
 
 # Browser or platform does not support passkeys
-passkey-authentication-error-not-supported = Passkeys aren’t supported. Try another method or device.
+passkey-authentication-error-not-supported-v2 = Your browser or device doesn’t support passkeys.
 
 # RP ID / origin mismatch, or insecure context (e.g., embedded iframe)
 passkey-authentication-error-security = Passkeys can’t be used on this page. Check you’re on the correct secure site and try again.

--- a/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
+++ b/packages/fxa-settings/src/lib/passkeys/unsupported-message.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { ReactNode } from 'react';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { FtlMsg } from 'fxa-react/lib/utils';
+import { PASSKEY_SUPPORT_URL } from './constants';
+
+export const unsupportedPasskeyMessage = (): ReactNode => (
+  <>
+    <FtlMsg id="passkey-registration-error-not-supported-v2">
+      <span>Your browser or device doesn’t support passkeys.</span>
+    </FtlMsg>{' '}
+    <FtlMsg id="passkey-registration-error-not-supported-link">
+      <LinkExternal href={PASSKEY_SUPPORT_URL} className="link-blue">
+        Learn more
+      </LinkExternal>
+    </FtlMsg>
+  </>
+);

--- a/packages/fxa-settings/src/lib/passkeys/webauthn-errors.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn-errors.ts
@@ -113,12 +113,12 @@ export const ERROR_MAP: Record<string, ErrorEntry> = {
     errorType: WebAuthnErrorType.NotSupported,
     logToSentry: false,
     ftlId: {
-      registration: 'passkey-registration-error-not-supported',
-      authentication: 'passkey-authentication-error-not-supported',
+      registration: 'passkey-registration-error-not-supported-v2',
+      authentication: 'passkey-authentication-error-not-supported-v2',
     },
     fallbackText: {
-      registration: `Passkeys aren’t supported here. Try another method or device.`,
-      authentication: `Passkeys aren’t supported. Try another method or device.`,
+      registration: `Your browser or device doesn’t support passkeys.`,
+      authentication: `Your browser or device doesn’t support passkeys.`,
     },
   },
   SecurityError: {


### PR DESCRIPTION
## Because

* The implementation matched an outdated design

## This pull request

* Update the error messsage, and include a support link in the error component
* Show the updated message in an alert bar, not inline

## Issue that this pull request solves

Closes: FXA-13683

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

<img width="1288" height="138" alt="Screenshot 2026-05-07 at 5 02 25 PM" src="https://github.com/user-attachments/assets/f1570d14-751a-4daf-ab08-8274328547ac" />

## Other information (Optional)

Any other information that is important to this pull request.
