### PR TITLE
feat(auth): accept Bearer + Hawk on all FxA token routes

### DIFF
--- a/docs/adr/0022-deprecate-hawk.md
+++ b/docs/adr/0022-deprecate-hawk.md
@@ -2,6 +2,9 @@
 
 - Deciders: Danny Coates, Ryan Kelly, Les Orchard, Ben Bangert
 - Date: 2020-05-27
+- Status: Partially Implemented (2026-04-23) — client-side Bearer migration
+  complete; server-side Hawk support retained indefinitely for non-monorepo
+  clients (Firefox Desktop, iOS, Android, Sync).
 
 ## Context and Problem Statement
 
@@ -35,6 +38,20 @@ A leaked sessionToken would allow access to personal information, email addresse
 ## Decision Outcome
 
 We will stop using hawk in future work that requires authentication. Selecting a preferred scheme is out of scope of this ADR. Sharing the session token with trusted services is an acceptable interim solution.
+
+### 2026-04-23 update — client-side migration complete (FXA-9392)
+
+The interim scheme chosen was **prefixed Bearer tokens** on the Authorization header (`Authorization: Bearer <prefix>_<hex>`, where `<prefix>` identifies the token kind: `fxs_`, `fxk_`, `fxar_`, `fxpf_`, `fxpc_`). `keyFetchToken` and `keyFetchTokenWithVerificationStatus` share the `fxk_` prefix because the client only derives one keyFetch credential. The prefix avoids collisions with the refresh-token Bearer strategy on routes that accept both. Routes use Hapi multi-strategy chains, trying Bearer first and falling back to Hawk.
+
+**Done:**
+
+- `fxa-auth-client` emits Bearer unconditionally (no Hawk signing code remains in the client).
+- All `fxa-auth-server` protected routes accept `Bearer <prefix>_<hex>` (preferred) and the legacy Hawk header (fallback) — around 65 route auth configs flipped across session / keyFetch / accountReset / passwordForgot / passwordChange / verifiedSession / multi-strategy chains.
+- StatsD emits `auth.strategy.used{scheme=bearer|hawk,kind=<kind>}` so the split is observable in production.
+
+**Not done (intentionally out of scope):**
+
+- Removing server-side Hawk. External clients (Firefox Desktop, iOS, Android, Sync) talk to auth-server via the Hawk wire protocol directly, not via `fxa-auth-client`, and will not migrate on our schedule. Hawk stays as a legacy compat layer.
 
 ## Pros and Cons of the Options
 

--- a/docs/adr/0050-bearer-token-prefix-naming.md
+++ b/docs/adr/0050-bearer-token-prefix-naming.md
@@ -1,0 +1,74 @@
+# Bearer Token Prefix Naming for FxA Tokens
+
+- Status: proposed
+- Deciders: FxA Engineering
+- Date: 2026-05-11
+
+Technical Story: ADR-0022 (deprecate Hawk) and the Hawk-to-Bearer migration on the auth-server / auth-client.
+
+## Context and Problem Statement
+
+The auth-server accepts multiple token kinds on the same routes (session, keyFetch, accountReset, passwordForgot, passwordChange) and also accepts OAuth refresh tokens as plain `Bearer <hex>`. When migrating in-monorepo FxA tokens from Hawk to Bearer, we needed a wire format that lets every protected route disambiguate which kind of token it received, without colliding with refresh tokens or with the legacy Hawk scheme, and without requiring a new scheme name in the `Authorization` header.
+
+## Decision Drivers
+
+- Disjoint from the existing refresh-token strategy (`Authorization: Bearer <64-hex>`), so a single route can declare both strategies without ambiguity.
+- Disjoint from Hawk (`Authorization: Hawk id="…"`), so Bearer and Hawk can coexist on the same route during the migration.
+- Self-describing: an operator looking at a captured header should be able to identify the token kind without consulting the route definition.
+- Cheap to parse server-side: a single anchored regex per strategy, no JWT verification.
+- Matches the industry pattern (GitHub `ghp_…`, Stripe `sk_live_…`) so a captured token is recognizable without context.
+
+## Considered Options
+
+1. **Plain `Bearer <hex>` for FxA tokens**. Rejected: collides with the existing refresh-token strategy on the same routes (this is exactly what reverted the 2024 attempt), and nothing in the header tells an operator which kind of token was sent.
+2. **Custom Authorization scheme**, e.g. `Authorization: FxaToken kind=sessionToken; id=<hex>`. Rejected: every client (auth-client and any third-party integrator) has to learn a non-standard scheme, browser fetch and edge proxies treat anything other than `Bearer`/`Basic` as a curiosity, and the server-side parser grows attribute-list and quoting surface.
+3. **Typed prefix inside Bearer**, e.g. `Authorization: Bearer fxs_<hex>` (GitHub/Stripe style). **Chosen.**
+4. **JWT access tokens** signed by the auth-server. Rejected: verifying a JWT on every auth-server request is meaningful CPU compared to the DB lookup the strategies already do, revocation still requires server state (so JWTs don't remove the lookup), and the wire-format change is a far larger coordinated effort than the migration we wanted to land.
+
+## Decision Outcome
+
+Chosen option: **Typed prefix inside Bearer**.
+
+The wire format is:
+
+```
+Authorization: Bearer <prefix>_<64 lowercase hex chars>
+```
+
+`<prefix>` is the token kind, every value starts with `fx` (FxA) followed by the first letter(s) of the kind:
+
+| Prefix  | Token kind                          | Notes                                                                                                                                                                           |
+| ------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fxs_`  | sessionToken                        |                                                                                                                                                                                 |
+| `fxk_`  | keyFetchToken                       |                                                                                                                                                                                 |
+| `fxk_`  | keyFetchTokenWithVerificationStatus | Shares `fxk_` with keyFetchToken; the variant only changes which DB lookup runs server-side, the wire id is the same, and the client only ever derives one keyFetch credential. |
+| `fxar_` | accountResetToken                   |                                                                                                                                                                                 |
+| `fxpf_` | passwordForgotToken                 |                                                                                                                                                                                 |
+| `fxpc_` | passwordChangeToken                 |                                                                                                                                                                                 |
+
+The server-side regex per kind is `^Bearer <prefix>_([0-9a-f]{64})$`. The OAuth refresh-token strategy keeps its plain `Bearer <hex>` shape and is distinguishable because it has no underscore. Hawk requests are unchanged.
+
+### Positive Consequences
+
+- Multi-strategy chains (Bearer first, Hawk fallback, refresh-token last) on a single route work without ambiguity.
+- A captured `Bearer fxs_<id>` value is self-identifying in logs and in incident response.
+- Server-side dispatch is a literal-prefix regex check; no per-request parsing of structured payloads.
+- The convention extends naturally to future kinds (`fx*_`).
+
+### Negative Consequences
+
+- The wire format formalizes that FxA tokens are pure replay credentials until rotation. Hawk's MAC, host, uri, and payload bindings were already not validated server-side (see `hawk-fxa-token.js`, which parses the header and looks up by id only), so this is not a regression in enforcement, but it does close the door on enforcing those bindings later without another protocol change. Mitigations remain token rotation cadence and the customs ratelimiter, as called out in ADR-0022.
+- Two server-side kinds (`keyFetchToken` and `keyFetchTokenWithVerificationStatus`) share `fxk_`. This is intentional and documented in the strategy module, but new contributors must read that comment to understand the dispatch.
+
+## Conventions for Future Prefixes
+
+- Always start with `fx` (Firefox Accounts) so a captured value is unmistakably from FxA.
+- Append the first letter(s) of the kind, distinct from existing prefixes (sessionToken → `s`, keyFetch → `k`, accountReset → `ar`, etc.).
+- Keep the prefix all lowercase, followed by a single underscore, then 64 lowercase hex characters.
+- Add the kind to the server-side `KIND_PREFIXES` map in `packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js` and the client-side `TOKEN_PREFIXES` map in `packages/fxa-auth-client/lib/bearer.ts`. Keep the two in sync.
+- Do not reuse a prefix across unrelated token kinds. The `fxk_` sharing between `keyFetchToken` and `keyFetchTokenWithVerificationStatus` is the only documented exception (same underlying token row, different server-side lookup).
+
+## Links
+
+- [ADR-0022](0022-deprecate-hawk.md), the original deprecation decision.
+- [ADR-0048](0048-refresh-tokens-and-account-level-authorization.md), refresh-token semantics that motivated keeping `Bearer <hex>` disjoint.

--- a/packages/fxa-auth-client/lib/bearer.ts
+++ b/packages/fxa-auth-client/lib/bearer.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { deriveTokenCredentials } from './hawk';
+
+// Prefix per FxA token kind. Must stay in sync with the server-side table
+// in `packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js`.
+//
+// Every prefix is `fx` (FxA) plus the first letter(s) of the kind:
+//   fxs_   sessionToken
+//   fxk_   keyFetchToken (server also accepts this for keyFetchTokenWith-
+//          VerificationStatus; the client only derives one keyFetch
+//          credential and never picks the with-verification variant)
+//   fxar_  accountResetToken
+//   fxpf_  passwordForgotToken
+//   fxpc_  passwordChangeToken
+export const TOKEN_PREFIXES = {
+  sessionToken: 'fxs',
+  keyFetchToken: 'fxk',
+  accountResetToken: 'fxar',
+  passwordForgotToken: 'fxpf',
+  passwordChangeToken: 'fxpc',
+} as const;
+
+export type BearerTokenKind = keyof typeof TOKEN_PREFIXES;
+
+export async function bearerHeader(
+  token: hexstring,
+  kind: BearerTokenKind
+): Promise<Headers> {
+  const prefix = TOKEN_PREFIXES[kind];
+  if (!prefix) {
+    throw new Error(`bearerHeader: unknown token kind '${kind}'`);
+  }
+  const { id } = await deriveTokenCredentials(token, kind);
+  return new Headers({ authorization: `Bearer ${prefix}_${id}` });
+}

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -4,13 +4,13 @@
 
 import * as crypto from './crypto';
 import { Credentials } from './crypto';
-import * as hawk from './hawk';
+import { deriveTokenCredentials } from './hawk';
+import { bearerHeader, BearerTokenKind } from './bearer';
 import { SaltVersion, createSaltV2 } from './salt';
 import * as Sentry from '@sentry/browser';
 import { MetricsContext } from '@fxa/shared/metrics/glean';
 
 enum ERRORS {
-  INVALID_TIMESTAMP = 111,
   INCORRECT_EMAIL_CASE = 120,
 }
 
@@ -336,7 +336,6 @@ export type AuthClientOptions = {
 export default class AuthClient {
   static VERSION = 'v1';
   private uri: string;
-  private localtimeOffsetMsec: number;
   private timeout: number;
   private keyStretchVersion: SaltVersion;
   private requireHeaders: boolean;
@@ -357,7 +356,6 @@ export default class AuthClient {
       this.uri = `${authServerUri}/${AuthClient.VERSION}`;
     }
     this.keyStretchVersion = options.keyStretchVersion || 1;
-    this.localtimeOffsetMsec = 0;
     this.timeout = options.timeout || 30000;
     this.requireHeaders = options.requireHeaders === true;
     this.errorHandler =
@@ -444,11 +442,11 @@ export default class AuthClient {
     }
   }
 
-  private async hawkRequest(
+  private async authedRequest(
     method: string,
     path: string,
     token: hexstring,
-    kind: tokenType,
+    kind: BearerTokenKind,
     payload: object | null,
     extraHeaders: Headers | undefined
   ) {
@@ -461,29 +459,11 @@ export default class AuthClient {
       }
     }
 
-    const makeHeaders = async () => {
-      const headers = await hawk.header(method, this.url(path), token, kind, {
-        payload: cleanStringify(payload),
-        contentType: 'application/json',
-        localtimeOffsetMsec: this.localtimeOffsetMsec,
-      });
-      if (extraHeaders) {
-        for (const [name, value] of extraHeaders) {
-          headers.set(name, value);
-        }
-      }
-      return headers;
-    };
-    try {
-      return await this.request(method, path, payload, await makeHeaders());
-    } catch (e: any) {
-      if (e.errno === ERRORS.INVALID_TIMESTAMP) {
-        const serverTime = e.serverTime * 1000 || Date.now();
-        this.localtimeOffsetMsec = serverTime - Date.now();
-        return this.request(method, path, payload, await makeHeaders());
-      }
-      throw e;
+    const headers = await bearerHeader(token, kind);
+    for (const [name, value] of extraHeaders) {
+      headers.set(name, value);
     }
+    return this.request(method, path, payload, headers);
   }
 
   private async sessionGet(
@@ -491,7 +471,7 @@ export default class AuthClient {
     sessionToken: hexstring,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'GET',
       path,
       sessionToken,
@@ -577,7 +557,7 @@ export default class AuthClient {
     payload: object,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       path,
       sessionToken,
@@ -593,7 +573,7 @@ export default class AuthClient {
     payload: object,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'PUT',
       path,
       sessionToken,
@@ -609,7 +589,7 @@ export default class AuthClient {
     payload: object,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'DELETE',
       path,
       sessionToken,
@@ -973,7 +953,7 @@ export default class AuthClient {
       email,
       ...payloadOptions(options),
     };
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/password/forgot/resend_code',
       passwordForgotToken,
@@ -996,7 +976,7 @@ export default class AuthClient {
       code,
       ...options,
     };
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/password/forgot/verify_code',
       passwordForgotToken,
@@ -1007,7 +987,7 @@ export default class AuthClient {
   }
 
   async passwordForgotStatus(passwordForgotToken: string, headers?: Headers) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'GET',
       '/password/forgot/status',
       passwordForgotToken,
@@ -1021,7 +1001,7 @@ export default class AuthClient {
     passwordForgotToken: hexstring,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/recoveryKey/exists',
       passwordForgotToken,
@@ -1061,7 +1041,7 @@ export default class AuthClient {
       ...v2Payload,
       ...payloadOptions(options),
     };
-    const accountData = await this.hawkRequest(
+    const accountData = await this.authedRequest(
       'POST',
       pathWithKeys('/account/reset', options.keys),
       accountResetToken,
@@ -1100,7 +1080,7 @@ export default class AuthClient {
       ...v2Payload,
       ...payloadOptions(options),
     };
-    return await this.hawkRequest(
+    return await this.authedRequest(
       'POST',
       pathWithKeys('/account/reset', options.keys),
       accountResetToken,
@@ -1230,11 +1210,11 @@ export default class AuthClient {
     kA: hexstring;
     kB: hexstring;
   }> {
-    const credentials = await hawk.deriveHawkCredentials(
+    const credentials = await deriveTokenCredentials(
       keyFetchToken,
       'keyFetchToken'
     );
-    const keyData = await this.hawkRequest(
+    const keyData = await this.authedRequest(
       'GET',
       '/account/keys',
       keyFetchToken,
@@ -1253,11 +1233,11 @@ export default class AuthClient {
   }
 
   async wrappedAccountKeys(keyFetchToken: hexstring, headers?: Headers) {
-    const credentials = await hawk.deriveHawkCredentials(
+    const credentials = await deriveTokenCredentials(
       keyFetchToken,
       'keyFetchToken'
     );
-    const keyData = await this.hawkRequest(
+    const keyData = await this.authedRequest(
       'GET',
       '/account/keys',
       keyFetchToken,
@@ -1590,7 +1570,7 @@ export default class AuthClient {
     );
 
     const wrapKb = crypto.unwrapKB(keys.kB, newCredentials.unwrapBKey);
-    const { id: sessionTokenId } = await hawk.deriveHawkCredentials(
+    const { id: sessionTokenId } = await deriveTokenCredentials(
       sessionToken,
       'sessionToken'
     );
@@ -1744,7 +1724,7 @@ export default class AuthClient {
     options: { keys?: boolean },
     headers?: Headers
   ) {
-    const response = await this.hawkRequest(
+    const response = await this.authedRequest(
       'POST',
       pathWithKeys('/password/change/finish', options.keys),
       passwordChangeToken,
@@ -2603,7 +2583,7 @@ export default class AuthClient {
     token: hexstring,
     headers?: Headers
   ): Promise<{ exists: boolean; verified: boolean }> {
-    return this.hawkRequest(
+    return this.authedRequest(
       'GET',
       '/totp/exists',
       token,
@@ -2618,7 +2598,7 @@ export default class AuthClient {
     code: string,
     headers?: Headers
   ): Promise<{ success: boolean }> {
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/totp/verify',
       token,
@@ -2633,7 +2613,7 @@ export default class AuthClient {
     code: string,
     headers?: Headers
   ): Promise<{ success: boolean }> {
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/totp/verify/recoveryCode',
       token,
@@ -2749,7 +2729,7 @@ export default class AuthClient {
     passwordForgotToken: hexstring,
     headers?: Headers
   ): Promise<{ hasBackupCodes?: boolean; count?: number }> {
-    return this.hawkRequest(
+    return this.authedRequest(
       'GET',
       '/recoveryCodes/exists',
       passwordForgotToken,
@@ -2841,7 +2821,7 @@ export default class AuthClient {
     recoveryKeyId: string,
     headers?: Headers
   ): Promise<RecoveryKeyData> {
-    return this.hawkRequest(
+    return this.authedRequest(
       'GET',
       `/recoveryKey/${recoveryKeyId}`,
       accountResetToken,
@@ -2912,7 +2892,7 @@ export default class AuthClient {
       recoveryKeyId,
       isFirefoxMobileClient: options.isFirefoxMobileClient,
     };
-    const accountData = await this.hawkRequest(
+    const accountData = await this.authedRequest(
       'POST',
       pathWithKeys('/account/reset', options.keys),
       accountResetToken,
@@ -2931,7 +2911,7 @@ export default class AuthClient {
    * @deprecated Use deleteRecoveryKeyWithJwt instead
    */
   async deleteRecoveryKey(sessionToken: hexstring, headers?: Headers) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'DELETE',
       '/recoveryKey',
       sessionToken,
@@ -3300,7 +3280,7 @@ export default class AuthClient {
     passwordForgotToken: string,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/recovery_phone/reset_password/send_code',
       passwordForgotToken,
@@ -3323,7 +3303,7 @@ export default class AuthClient {
     code: string,
     headers?: Headers
   ) {
-    return this.hawkRequest(
+    return this.authedRequest(
       'POST',
       '/recovery_phone/reset_password/confirm',
       passwordForgotToken,
@@ -3374,7 +3354,7 @@ export default class AuthClient {
     phoneNumber?: string;
     nationalFormat?: string;
   }> {
-    return this.hawkRequest(
+    return this.authedRequest(
       'GET',
       '/recovery_phone',
       passwordForgotToken,

--- a/packages/fxa-auth-client/lib/hawk.ts
+++ b/packages/fxa-auth-client/lib/hawk.ts
@@ -1,7 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { hexToUint8, uint8ToBase64, uint8ToHex } from './utils';
+
+// NOTE: The Hawk signing implementation was deleted as part of the FXA-9392
+// Bearer migration (ADR-0022). In-monorepo callers now derive credentials
+// here and let `bearerHeader` (lib/bearer.ts) build the Authorization
+// header. The HKDF derivation below stays because it's scheme-neutral —
+// the id/authKey/bundleKey triple is what Bearer, Hawk (server-side
+// legacy), and bundleKey-based payload unwrap all still use.
+//
+// The filename is kept to avoid churn on external imports of
+// `@fxa/auth-client/lib/hawk` and to preserve the legacy
+// `deriveHawkCredentials` export.
+
+import { hexToUint8, uint8ToHex } from './utils';
 import { NAMESPACE } from './salt';
 
 const encoder = () => new TextEncoder();
@@ -36,170 +48,7 @@ export async function deriveHawkCredentials(token: hexstring, context: string) {
   };
 }
 
-// The following is adapted from https://github.com/hapijs/hawk/blob/master/lib/browser.js
-
-/*
- HTTP Hawk Authentication Scheme
- Copyright (c) 2012-2013, Eran Hammer <eran@hueniverse.com>
- MIT Licensed
- */
-
-function parseUri(input: string) {
-  const parts = input.match(
-    /^([^:]+):\/\/(?:[^@/]*@)?([^/:]+)(?::(\d+))?([^#]*)(?:#.*)?$/
-  );
-  if (!parts) {
-    return { host: '', port: '', resource: '' };
-  }
-
-  const scheme = parts[1].toLowerCase();
-  const uri = {
-    host: parts[2],
-    port:
-      parts[3] || (scheme === 'http' ? '80' : scheme === 'https' ? '443' : ''),
-    resource: parts[4],
-  };
-
-  return uri;
-}
-
-function randomString(size: number) {
-  const randomSource =
-    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-  const len = randomSource.length;
-
-  const result: string[] = [];
-  for (let i = 0; i < size; ++i) {
-    result[i] = randomSource[Math.floor(Math.random() * len)];
-  }
-
-  return result.join('');
-}
-
-function generateNormalizedString(type: string, options: any) {
-  let normalized =
-    'hawk.1.' +
-    type +
-    '\n' +
-    options.ts +
-    '\n' +
-    options.nonce +
-    '\n' +
-    (options.method || '').toUpperCase() +
-    '\n' +
-    (options.resource || '') +
-    '\n' +
-    options.host.toLowerCase() +
-    '\n' +
-    options.port +
-    '\n' +
-    (options.hash || '') +
-    '\n';
-
-  if (options.ext) {
-    normalized += options.ext.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
-  }
-
-  normalized += '\n';
-
-  if (options.app) {
-    normalized += options.app + '\n' + (options.dlg || '') + '\n';
-  }
-
-  return normalized;
-}
-
-async function calculatePayloadHash(
-  payload: string = '',
-  contentType: string = ''
-) {
-  const data = encoder().encode(`hawk.1.payload\n${contentType}\n${payload}\n`);
-  const hash = await crypto.subtle.digest('SHA-256', data);
-  return uint8ToBase64(new Uint8Array(hash));
-}
-
-async function calculateMac(type: string, credentials: any, options: any) {
-  const normalized = generateNormalizedString(type, options);
-  const key = await crypto.subtle.importKey(
-    'raw',
-    credentials.key,
-    {
-      name: 'HMAC',
-      hash: 'SHA-256',
-      length: 256,
-    },
-    true,
-    ['sign']
-  );
-  const hmac = await crypto.subtle.sign(
-    'HMAC',
-    key,
-    encoder().encode(normalized)
-  );
-  return uint8ToBase64(new Uint8Array(hmac));
-}
-
-export async function hawkHeader(
-  method: string,
-  uri: string,
-  options: {
-    credentials: {
-      id: string;
-      key: Uint8Array;
-    };
-    payload?: string;
-    timestamp?: number;
-    nonce?: string;
-    contentType?: string;
-    localtimeOffsetMsec?: number;
-  }
-) {
-  const timestamp =
-    options.timestamp ||
-    Math.floor((Date.now() + (options.localtimeOffsetMsec || 0)) / 1000);
-  const parsedUri = parseUri(uri);
-  const hash = await calculatePayloadHash(options.payload, options.contentType);
-  const artifacts = {
-    ts: timestamp,
-    nonce: options.nonce || randomString(6),
-    method,
-    resource: parsedUri.resource,
-    host: parsedUri.host,
-    port: parsedUri.port,
-    hash,
-  };
-  const mac = await calculateMac('header', options.credentials, artifacts);
-  const header =
-    'Hawk id="' +
-    options.credentials.id +
-    '", ts="' +
-    artifacts.ts +
-    '", nonce="' +
-    artifacts.nonce +
-    (artifacts.hash ? '", hash="' + artifacts.hash : '') +
-    '", mac="' +
-    mac +
-    '"';
-  return header;
-}
-
-export async function header(
-  method: string,
-  uri: string,
-  token: string,
-  kind: string,
-  options: {
-    payload?: string;
-    timestamp?: number;
-    nonce?: string;
-    contentType?: string;
-    localtimeOffsetMsec?: number;
-  }
-) {
-  const credentials = await deriveHawkCredentials(token, kind);
-  const authorization = await hawkHeader(method, uri, {
-    credentials,
-    ...options,
-  });
-  return new Headers({ authorization });
-}
+// HKDF derivation is not Hawk-specific — it produces the id/authKey/bundleKey
+// used by both Hawk signing and the Bearer scheme (FXA-9392). Exposed under
+// a scheme-neutral name; the original export stays for back-compat.
+export const deriveTokenCredentials = deriveHawkCredentials;

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -22,6 +22,10 @@
       "import": "./dist/server/esm/packages/fxa-auth-client/lib/hawk.js",
       "require": "./dist/server/cjs/packages/fxa-auth-client/lib/hawk.js"
     },
+    "./lib/bearer": {
+      "import": "./dist/server/esm/packages/fxa-auth-client/lib/bearer.js",
+      "require": "./dist/server/cjs/packages/fxa-auth-client/lib/bearer.js"
+    },
     "./lib/recoveryKey": {
       "import": "./dist/server/esm/packages/fxa-auth-client/lib/recoveryKey.js",
       "require": "./dist/server/cjs/packages/fxa-auth-client/lib/recoveryKey.js"

--- a/packages/fxa-auth-client/server.ts
+++ b/packages/fxa-auth-client/server.ts
@@ -12,3 +12,4 @@ https.globalAgent = new https.Agent({
 export default AuthClient;
 export * from './lib/client';
 export * from './lib/hawk';
+export * from './lib/bearer';

--- a/packages/fxa-auth-client/test/bearer.ts
+++ b/packages/fxa-auth-client/test/bearer.ts
@@ -1,0 +1,66 @@
+import assert from 'assert';
+import '../server'; // must import this to run with nodejs
+import { bearerHeader, TOKEN_PREFIXES } from 'fxa-auth-client/lib/bearer';
+
+// Test vectors pinned against the HKDF derivation so the exact on-the-wire
+// header format is fixed. Any change here means the server-side parser in
+// `packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js`
+// must be updated in lockstep. See FXA-9392 / ADR-0022.
+
+const SESSION_TOKEN =
+  'a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf';
+
+// id derived from HKDF(sessionToken, 'sessionToken'). Pinned in test/hawk.ts.
+const EXPECTED_ID =
+  'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab';
+
+describe('lib/bearer', () => {
+  describe('TOKEN_PREFIXES', () => {
+    it('maps every client-side token kind to a prefix', () => {
+      assert.deepEqual(Object.keys(TOKEN_PREFIXES).sort(), [
+        'accountResetToken',
+        'keyFetchToken',
+        'passwordChangeToken',
+        'passwordForgotToken',
+        'sessionToken',
+      ]);
+    });
+
+    it('matches the server-side prefixes (fxs, fxk, fxar, fxpf, fxpc)', () => {
+      assert.equal(TOKEN_PREFIXES.sessionToken, 'fxs');
+      assert.equal(TOKEN_PREFIXES.keyFetchToken, 'fxk');
+      assert.equal(TOKEN_PREFIXES.accountResetToken, 'fxar');
+      assert.equal(TOKEN_PREFIXES.passwordForgotToken, 'fxpf');
+      assert.equal(TOKEN_PREFIXES.passwordChangeToken, 'fxpc');
+    });
+  });
+
+  describe('bearerHeader', () => {
+    it('emits `Bearer fxs_<id>` for a sessionToken', async () => {
+      const headers = await bearerHeader(SESSION_TOKEN, 'sessionToken');
+      assert.equal(headers.get('authorization'), `Bearer fxs_${EXPECTED_ID}`);
+    });
+
+    it('uses the kind-specific prefix for each token kind', async () => {
+      for (const kind of Object.keys(TOKEN_PREFIXES) as Array<
+        keyof typeof TOKEN_PREFIXES
+      >) {
+        const headers = await bearerHeader(SESSION_TOKEN, kind);
+        const auth = headers.get('authorization');
+        assert.ok(
+          auth && auth.startsWith(`Bearer ${TOKEN_PREFIXES[kind]}_`),
+          `${kind}: expected prefix ${TOKEN_PREFIXES[kind]}_, got ${auth}`
+        );
+        // Exactly one token after "Bearer " and it's 64 hex chars.
+        assert.match(auth!, /^Bearer fx[a-z]+_[0-9a-f]{64}$/);
+      }
+    });
+
+    it('throws on an unknown kind', async () => {
+      await assert.rejects(
+        bearerHeader(SESSION_TOKEN, 'notARealKind' as any),
+        /unknown token kind/
+      );
+    });
+  });
+});

--- a/packages/fxa-auth-client/test/hawk.ts
+++ b/packages/fxa-auth-client/test/hawk.ts
@@ -1,66 +1,45 @@
 import assert from 'assert';
 import '../server'; // must import this to run with nodejs
-import { deriveHawkCredentials, hawkHeader } from 'fxa-auth-client/lib/hawk';
+import {
+  deriveHawkCredentials,
+  deriveTokenCredentials,
+} from 'fxa-auth-client/lib/hawk';
 import { uint8ToHex } from 'fxa-auth-client/lib/utils';
 
+// Hawk header-signing test vectors were removed with the Hawk signing code
+// itself as part of the FXA-9392 Bearer migration. See test/bearer.ts for
+// the replacement header-format tests. The HKDF derivation below is
+// scheme-neutral and still exercised here because `deriveHawkCredentials`
+// remains exported for backwards compatibility.
+
 describe('lib/hawk', () => {
-  describe('header', () => {
-    const encoder = new TextEncoder();
-    const credentials = {
-      id: '123456',
-      key: encoder.encode('werxhqb98rpaxn39848xrunpaw3489ru'),
-    };
-    // Test vectors from https://github.com/hapijs/hawk/blob/master/test/client.js
-    it('returns a valid authorization header (empty payload)', async () => {
-      const h = await hawkHeader(
-        'POST',
-        'https://example.net/somewhere/over/the/rainbow',
-        {
-          credentials,
-          timestamp: 1353809207,
-          nonce: 'Ygvqdz',
-          payload: '',
-          contentType: 'text/plain',
-        }
-      );
-      assert.equal(
-        h,
-        'Hawk id="123456", ts="1353809207", nonce="Ygvqdz", hash="q/t+NNAkQZNlq/aAD6PlexImwQTxwgT2MahfTa9XRLA=", mac="ITZtYMyfEkprrB60U4wPxl+BgV8S/kXb+gbcqt0TfCk="'
-      );
-    });
-    it('returns a valid authorization header with payload', async () => {
-      const h = await hawkHeader(
-        'POST',
-        'https://example.net/somewhere/over/the/rainbow',
-        {
-          credentials,
-          timestamp: 1353809207,
-          nonce: 'Ygvqdz',
-          payload: 'something to write about',
-          contentType: 'text/plain',
-        }
-      );
-      assert.equal(
-        h,
-        'Hawk id="123456", ts="1353809207", nonce="Ygvqdz", hash="2QfCt3GuY9HQnHWyWD3wX68ZOKbynqlfYmuO2ZBRqtY=", mac="T8QFs1YhO9eqsXWKURQgL3vO8XbZIveFYiF/cTYBPYI="'
-      );
-    });
-  });
+  const SESSION_TOKEN =
+    'a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf';
+  const EXPECTED_KEY =
+    '9d8f22998ee7f5798b887042466b72d53e56ab0c094388bf65831f702d2febc0';
+  const EXPECTED_ID =
+    'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab';
 
   describe('deriveHawkCredentials', () => {
     it('returns the correct id and key', async () => {
-      const sessionToken =
-        'a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf';
-      const context = 'sessionToken';
-      const result = await deriveHawkCredentials(sessionToken, context);
-      assert.equal(
-        uint8ToHex(result.key),
-        '9d8f22998ee7f5798b887042466b72d53e56ab0c094388bf65831f702d2febc0'
+      const result = await deriveHawkCredentials(SESSION_TOKEN, 'sessionToken');
+      assert.equal(uint8ToHex(result.key), EXPECTED_KEY);
+      assert.equal(result.id, EXPECTED_ID);
+    });
+  });
+
+  describe('deriveTokenCredentials (alias)', () => {
+    it('is the same function as deriveHawkCredentials', () => {
+      assert.strictEqual(deriveTokenCredentials, deriveHawkCredentials);
+    });
+
+    it('returns the same id/key as deriveHawkCredentials', async () => {
+      const result = await deriveTokenCredentials(
+        SESSION_TOKEN,
+        'sessionToken'
       );
-      assert.equal(
-        result.id,
-        'c0a29dcf46174973da1378696e4c82ae10f723cf4f4d9f75e39f4ae3851595ab'
-      );
+      assert.equal(uint8ToHex(result.key), EXPECTED_KEY);
+      assert.equal(result.id, EXPECTED_ID);
     });
   });
 });

--- a/packages/fxa-auth-client/test/no-hawk-signing.ts
+++ b/packages/fxa-auth-client/test/no-hawk-signing.ts
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+
+// Guard for the FXA-9392 / ADR-0022 Bearer migration: the Hawk signing code
+// (hawk.header / hawkHeader / calculateMac) was removed from fxa-auth-client
+// in M2. This test fails if anything reintroduces it. Type-level enforcement
+// already blocks direct imports, but a string-level check is belt-and-
+// suspenders for re-exports, string builders, or vendored copies.
+
+const BANNED = /hawk\.header\(|\bhawkHeader\(|\bcalculateMac\(/;
+const ROOTS = [
+  path.join(__dirname, '..', 'lib'),
+  path.join(__dirname, '..', 'server.ts'),
+  path.join(__dirname, '..', 'browser.ts'),
+];
+
+function* walk(p: string): Generator<string> {
+  const stat = fs.statSync(p);
+  if (stat.isFile()) {
+    yield p;
+    return;
+  }
+  for (const entry of fs.readdirSync(p, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    yield* walk(path.join(p, entry.name));
+  }
+}
+
+describe('no-hawk-signing guard', () => {
+  it('fxa-auth-client source is free of Hawk signing calls', () => {
+    const offenders: string[] = [];
+    for (const root of ROOTS) {
+      if (!fs.existsSync(root)) continue;
+      for (const file of walk(root)) {
+        if (!/\.(ts|js)$/.test(file)) continue;
+        const text = fs.readFileSync(file, 'utf8');
+        if (BANNED.test(text)) {
+          offenders.push(file);
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `Hawk signing reintroduced in:\n  ${offenders.join('\n  ')}`
+    );
+  });
+});

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1857,7 +1857,10 @@ export class AccountHandler {
   async profile(request: AuthRequest) {
     const auth = request.auth;
     let uid, scope;
-    if (auth.strategy === 'sessionToken') {
+    if (
+      auth.strategy === 'sessionToken' ||
+      auth.strategy === 'sessionTokenBearer'
+    ) {
       uid = auth.credentials.uid;
       scope = { contains: () => true };
     } else {
@@ -2984,7 +2987,7 @@ export const accountRoutes = (
         ...ACCOUNT_DOCS.ACCOUNT_STATUS_GET,
         auth: {
           mode: 'optional',
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           query: {
@@ -3046,7 +3049,7 @@ export const accountRoutes = (
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_PROFILE_GET,
         auth: {
-          strategies: ['sessionToken', 'oauthToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'oauthToken'],
         },
         response: {
           schema: isA.object({
@@ -3074,7 +3077,10 @@ export const accountRoutes = (
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_KEYS_GET,
         auth: {
-          strategy: 'keyFetchTokenWithVerificationStatus',
+          strategies: [
+            'keyFetchTokenWithVerificationStatusBearer',
+            'keyFetchTokenWithVerificationStatus',
+          ],
         },
         response: {
           schema: isA.object({
@@ -3121,7 +3127,7 @@ export const accountRoutes = (
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_RESET_POST,
         auth: {
-          strategy: 'accountResetToken',
+          strategies: ['accountResetTokenBearer', 'accountResetToken'],
           payload: 'required',
         },
         validate: {
@@ -3193,7 +3199,7 @@ export const accountRoutes = (
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_DESTROY_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {
@@ -3232,7 +3238,7 @@ export const accountRoutes = (
       options: {
         ...ACCOUNT_DOCS.ACCOUNT_METRICS_OPT_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           payload: isA.object({
@@ -3248,7 +3254,7 @@ export const accountRoutes = (
       options: {
         ...MISC_DOCS.ACCOUNT_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         response: {
           schema: isA.object({

--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -25,7 +25,7 @@ module.exports = (log, db, devices, clientUtils) => {
       options: {
         ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_CLIENTS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           query: isA.object({
@@ -122,7 +122,7 @@ module.exports = (log, db, devices, clientUtils) => {
       options: {
         ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_OAUTH_CLIENTS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         response: {
           schema: isA
@@ -178,7 +178,7 @@ module.exports = (log, db, devices, clientUtils) => {
       options: {
         ...DEVICES_AND_SESSIONS_DOC.ACCOUNT_ATTACHED_CLIENT_DESTROY_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/attached-clients.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.spec.ts
@@ -436,7 +436,10 @@ describe('/account/attached_client/destroy', () => {
       accountRoutes,
       '/account/attached_client/destroy'
     );
-    expect(routeConfig.options.auth.strategy).toBe('verifiedSessionToken');
+    expect(routeConfig.options.auth.strategies).toEqual([
+      'verifiedSessionTokenBearer',
+      'verifiedSessionToken',
+    ]);
   });
 
   it('can destroy by deviceId', async () => {

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.js
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { AppError } = require('@fxa/accounts/errors');
+const Sentry = require('@sentry/node');
+
+// GitHub/Stripe-style typed prefix per token kind so the FxA strategies
+// never collide with the refresh-token strategy (plain `Bearer <hex>`) on
+// the same route. See ADR-0022.
+//
+// Every prefix is `fx` (FxA) plus the first letter(s) of the kind:
+//   fxs_   sessionToken
+//   fxk_   keyFetchToken
+//   fxk_   keyFetchTokenWithVerificationStatus  (shared with keyFetchToken;
+//          same wire id, the with-verification variant only changes which
+//          DB lookup runs server-side, and the client only ever derives
+//          one keyFetch credential)
+//   fxar_  accountResetToken
+//   fxpf_  passwordForgotToken
+//   fxpc_  passwordChangeToken
+const KIND_PREFIXES = {
+  sessionToken: 'fxs',
+  keyFetchToken: 'fxk',
+  keyFetchTokenWithVerificationStatus: 'fxk',
+  accountResetToken: 'fxar',
+  passwordForgotToken: 'fxpf',
+  passwordChangeToken: 'fxpc',
+};
+
+// Strict on-the-wire format: `Bearer <prefix>_<64 hex chars>`. No leading or
+// trailing whitespace, no mixed case in the prefix or the hex body. This
+// keeps the parser disjoint from plain `Bearer <hex>` (refresh token) and
+// from Hawk.
+function makeHeaderRegex(prefix) {
+  return new RegExp(`^Bearer ${prefix}_([0-9a-f]{64})$`);
+}
+
+function prefixFor(kind) {
+  const prefix = KIND_PREFIXES[kind];
+  if (!prefix) {
+    throw new Error(`bearer-fxa-token: unknown token kind '${kind}'`);
+  }
+  return prefix;
+}
+
+function requireOptions(options) {
+  if (!options || typeof options !== 'object') {
+    throw new Error('bearer-fxa-token: options object is required');
+  }
+  if (typeof options.throwOnFailure !== 'boolean') {
+    throw new Error(
+      'bearer-fxa-token: options.throwOnFailure (boolean) is required'
+    );
+  }
+  if (!options.statsd) {
+    throw new Error('bearer-fxa-token: options.statsd is required');
+  }
+}
+
+/**
+ * Authentication strategy for FxA token types delivered as Bearer tokens.
+ *
+ * Wire format: `Authorization: Bearer <prefix>_<hex>`, where `<prefix>` is
+ * determined by `kind` (see `KIND_PREFIXES`). No HMAC — the id is the raw
+ * lookup key, just like the Hawk strategy's `id=` attribute.
+ *
+ * `throwOnFailure` and `statsd` are required so callers decide explicitly
+ * per registration (single-strategy routes use `true`; multi-strategy
+ * chains use `false` to let Hapi try the next strategy). All failure modes
+ * carry `errno=110` ("Token not found") so a final 401 is wire-compatible
+ * with the single-strategy Hawk response shape.
+ *
+ * `postAuthenticate` is optional and used by `verifiedSessionTokenBearer`
+ * to share post-lookup guards (email/token verified, AAL2) with the
+ * Hawk-backed `verifiedSessionToken` strategy.
+ *
+ * @param {string} kind - token kind, keys of `KIND_PREFIXES`
+ * @param {Function} getCredentialsFunc - id lookup, returns token or null
+ * @param {{ throwOnFailure: boolean, statsd: object, postAuthenticate?: Function }} options
+ */
+function strategy(kind, getCredentialsFunc, options) {
+  requireOptions(options);
+  const { throwOnFailure, postAuthenticate, statsd } = options;
+  const prefix = prefixFor(kind);
+  const headerRe = makeHeaderRegex(prefix);
+
+  const tokenNotFoundError = () => {
+    const err = AppError.unauthorized('Token not found');
+    err.isMissing = true;
+    return err;
+  };
+
+  // Single-strategy routes throw to short-circuit; multi-strategy chains
+  // return so Hapi tries the next strategy. Both paths carry `errno=110`.
+  const failAuth = () => {
+    const err = tokenNotFoundError();
+    if (throwOnFailure) {
+      throw err;
+    }
+    return err;
+  };
+
+  const recordUsed = () => {
+    statsd.increment('auth.strategy.used', [`scheme:bearer`, `kind:${kind}`]);
+  };
+
+  return function (server, options) {
+    return {
+      authenticate: async function (req, h) {
+        const auth = req.headers.authorization;
+
+        if (!auth) {
+          if (req.auth.mode === 'optional') {
+            return h.continue;
+          }
+          return failAuth();
+        }
+
+        const match = auth.match(headerRe);
+        if (!match) {
+          // Wrong scheme/prefix/shape — always return (never throw) so a
+          // Hawk or refresh-token header gets its own chance on the chain.
+          return tokenNotFoundError();
+        }
+
+        const tokenId = match[1];
+        let token;
+        try {
+          token = await getCredentialsFunc(tokenId);
+        } catch (err) {
+          // Treat unexpected DB/driver faults as "token not found" so the
+          // chain falls through, but report them so outages aren't silent.
+          Sentry.captureException(err);
+        }
+
+        if (!token) {
+          return failAuth();
+        }
+
+        if (postAuthenticate) {
+          await postAuthenticate(req, token);
+        }
+
+        recordUsed();
+        return h.authenticated({ credentials: token });
+      },
+      payload: async function (req, h) {
+        // Hapi requires a `payload` hook on the strategy whenever a route
+        // declares `auth: { payload: 'required' }`. Neither this strategy
+        // nor the sibling Hawk one (see hawk-fxa-token.js) validates a
+        // payload signature; this is purely a body-presence check.
+        if (req.route.settings.auth.payload === 'required' && !req.payload) {
+          throw AppError.invalidSignature('Payload is required');
+        }
+        return h.continue;
+      },
+    };
+  };
+}
+
+module.exports = {
+  strategy,
+  KIND_PREFIXES,
+};

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/bearer-fxa-token.spec.ts
@@ -1,0 +1,407 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AppError } from '@fxa/accounts/errors';
+import { strategy, KIND_PREFIXES } from './bearer-fxa-token';
+
+const HEX_64 = 'a'.repeat(64);
+
+// Default test options for tests that don't care about throwOnFailure/statsd.
+// Strategy factory enforces these at construction; tests that exercise specific
+// values pass them explicitly.
+const testOptions = (overrides: any = {}) => ({
+  throwOnFailure: true,
+  statsd: { increment: jest.fn() },
+  ...overrides,
+});
+
+function makeReq(overrides: any = {}) {
+  return {
+    headers: {},
+    auth: { mode: 'required' },
+    route: { settings: { auth: {} } },
+    ...overrides,
+  };
+}
+
+function makeH() {
+  return {
+    continue: Symbol('continue'),
+    authenticated: jest.fn((x) => x),
+  };
+}
+
+async function expectAppErrorTokenNotFound(promise: Promise<any>) {
+  await expect(promise).rejects.toBeInstanceOf(AppError);
+  await expect(promise).rejects.toMatchObject({
+    output: { payload: { code: 401, errno: 110, detail: 'Token not found' } },
+    isMissing: true,
+  });
+}
+
+describe('lib/routes/auth-schemes/bearer-fxa-token', () => {
+  describe('strategy factory', () => {
+    it('throws when given an unknown token kind', () => {
+      expect(() =>
+        strategy('notARealKind' as any, jest.fn(), testOptions())
+      ).toThrow(/unknown token kind/);
+    });
+
+    it('accepts every documented kind', () => {
+      for (const kind of Object.keys(KIND_PREFIXES)) {
+        expect(() =>
+          strategy(kind as any, jest.fn(), testOptions())
+        ).not.toThrow();
+      }
+    });
+
+    it('keyFetchToken and keyFetchTokenWithVerificationStatus share the fxk_ prefix', () => {
+      // The client only derives one keyFetch credential; the with-verification
+      // variant differs server-side only (different DB lookup). Splitting
+      // prefixes would make /account/keys 401 on every Bearer request.
+      expect(KIND_PREFIXES.keyFetchToken).toBe('fxk');
+      expect(KIND_PREFIXES.keyFetchTokenWithVerificationStatus).toBe('fxk');
+    });
+
+    describe('required options', () => {
+      it('throws when options is missing', () => {
+        expect(() => (strategy as any)('sessionToken', jest.fn())).toThrow(
+          /options object/
+        );
+      });
+      it('throws when throwOnFailure is missing', () => {
+        expect(() =>
+          (strategy as any)('sessionToken', jest.fn(), {
+            statsd: { increment: jest.fn() },
+          })
+        ).toThrow(/throwOnFailure/);
+      });
+      it('throws when statsd is missing', () => {
+        expect(() =>
+          (strategy as any)('sessionToken', jest.fn(), {
+            throwOnFailure: true,
+          })
+        ).toThrow(/statsd/);
+      });
+    });
+  });
+
+  describe('authenticate — happy path per kind', () => {
+    it.each(Object.entries(KIND_PREFIXES))(
+      'authenticates kind=%s with prefix=%s',
+      async (kind, prefix) => {
+        const token = { id: 'token-for-' + kind };
+        const getCredentialsFunc = jest.fn().mockResolvedValue(token);
+        const authStrategy = strategy(
+          kind as any,
+          getCredentialsFunc,
+          testOptions()
+        )(null as any, null as any);
+
+        const req = makeReq({
+          headers: { authorization: `Bearer ${prefix}_${HEX_64}` },
+        });
+        const h = makeH();
+
+        await authStrategy.authenticate(req as any, h as any);
+
+        expect(getCredentialsFunc).toHaveBeenCalledWith(HEX_64);
+        expect(h.authenticated).toHaveBeenCalledWith({ credentials: token });
+      }
+    );
+  });
+
+  describe('authenticate — missing header', () => {
+    it('continues when mode is optional', async () => {
+      const getCredentialsFunc = jest.fn();
+      const authStrategy = strategy(
+        'sessionToken',
+        getCredentialsFunc,
+        testOptions()
+      )(null as any, null as any);
+
+      const req = makeReq({ auth: { mode: 'optional' } });
+      const h = makeH();
+
+      const result = await authStrategy.authenticate(req as any, h as any);
+      expect(result).toBe(h.continue);
+      expect(getCredentialsFunc).not.toHaveBeenCalled();
+    });
+
+    it('throws in required mode when throwOnFailure=true (default)', async () => {
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn(),
+        testOptions()
+      )(null as any, null as any);
+      const req = makeReq();
+      const h = makeH();
+
+      await expectAppErrorTokenNotFound(
+        authStrategy.authenticate(req as any, h as any)
+      );
+    });
+
+    it('returns Boom in required mode when throwOnFailure=false', async () => {
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn(),
+        testOptions({ throwOnFailure: false })
+      )(null as any, null as any);
+      const req = makeReq();
+      const h = makeH();
+
+      const result = await authStrategy.authenticate(req as any, h as any);
+      expect(result.isBoom).toBe(true);
+      expect(result.output.statusCode).toBe(401);
+      // errno=110 keeps a final 401 wire-compatible with the typed
+      // "Token not found" response when no later strategy authenticates.
+      expect(result.output.payload.errno).toBe(110);
+    });
+  });
+
+  describe('authenticate — wrong header shape always falls through', () => {
+    const rejectedHeaders: Array<[string, string]> = [
+      ['plain Bearer hex (refresh-token collision)', `Bearer ${HEX_64}`],
+      ['Hawk header', 'Hawk id="123", ts="123", nonce="123", mac="123"'],
+      ['wrong prefix for kind', `Bearer fxpc_${HEX_64}`],
+      ['mixed-case prefix', `Bearer FXS_${HEX_64}`],
+      ['uppercase hex suffix', `Bearer fxs_${'A'.repeat(64)}`],
+      ['too-short suffix', `Bearer fxs_${'a'.repeat(63)}`],
+      ['too-long suffix', `Bearer fxs_${'a'.repeat(65)}`],
+      ['non-hex suffix', `Bearer fxs_${'z'.repeat(64)}`],
+      ['leading whitespace', ` Bearer fxs_${HEX_64}`],
+      ['trailing whitespace', `Bearer fxs_${HEX_64} `],
+      ['double space after Bearer', `Bearer  fxs_${HEX_64}`],
+      ['lowercase scheme name', `bearer fxs_${HEX_64}`],
+      ['missing underscore', `Bearer fxs${HEX_64}`],
+    ];
+
+    it.each(rejectedHeaders)(
+      'returns Boom (does not throw) for %s',
+      async (_label, authHeader) => {
+        const getCredentialsFunc = jest.fn();
+        const authStrategy = strategy(
+          'sessionToken',
+          getCredentialsFunc,
+          testOptions()
+        )(null as any, null as any);
+
+        const req = makeReq({ headers: { authorization: authHeader } });
+        const h = makeH();
+
+        const result = await authStrategy.authenticate(req as any, h as any);
+
+        expect(result.isBoom).toBe(true);
+        expect(result.output.statusCode).toBe(401);
+        expect(getCredentialsFunc).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe('authenticate — prefix matches but lookup fails', () => {
+    const authHeader = `Bearer fxs_${HEX_64}`;
+
+    it('throws when throwOnFailure=true and lookup returns null', async () => {
+      const getCredentialsFunc = jest.fn().mockResolvedValue(null);
+      const authStrategy = strategy(
+        'sessionToken',
+        getCredentialsFunc,
+        testOptions()
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await expectAppErrorTokenNotFound(
+        authStrategy.authenticate(req as any, h as any)
+      );
+      expect(getCredentialsFunc).toHaveBeenCalledWith(HEX_64);
+    });
+
+    it('returns Boom when throwOnFailure=false and lookup returns null', async () => {
+      const getCredentialsFunc = jest.fn().mockResolvedValue(null);
+      const authStrategy = strategy(
+        'sessionToken',
+        getCredentialsFunc,
+        testOptions({ throwOnFailure: false })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      const result = await authStrategy.authenticate(req as any, h as any);
+      expect(result.isBoom).toBe(true);
+      expect(result.output.statusCode).toBe(401);
+    });
+
+    it('treats a thrown DB error as token-not-found', async () => {
+      const getCredentialsFunc = jest
+        .fn()
+        .mockRejectedValue(new Error('DB down'));
+      const authStrategy = strategy(
+        'sessionToken',
+        getCredentialsFunc,
+        testOptions({ throwOnFailure: false })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      const result = await authStrategy.authenticate(req as any, h as any);
+      expect(result.isBoom).toBe(true);
+      expect(result.output.statusCode).toBe(401);
+    });
+  });
+
+  describe('authenticate — postAuthenticate hook', () => {
+    const authHeader = `Bearer fxs_${HEX_64}`;
+
+    it('runs the hook with req and token on success', async () => {
+      const token = { id: 't', tokenVerified: true };
+      const postAuthenticate = jest.fn().mockResolvedValue(undefined);
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn().mockResolvedValue(token),
+        testOptions({ postAuthenticate })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await authStrategy.authenticate(req as any, h as any);
+      expect(postAuthenticate).toHaveBeenCalledWith(req, token);
+      expect(h.authenticated).toHaveBeenCalledWith({ credentials: token });
+    });
+
+    it('propagates errors thrown by the hook', async () => {
+      const token = { id: 't' };
+      const guardErr = AppError.unverifiedAccount();
+      const postAuthenticate = jest.fn().mockRejectedValue(guardErr);
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn().mockResolvedValue(token),
+        testOptions({ postAuthenticate })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await expect(
+        authStrategy.authenticate(req as any, h as any)
+      ).rejects.toBe(guardErr);
+      expect(h.authenticated).not.toHaveBeenCalled();
+    });
+
+    it('does not run the hook when lookup fails', async () => {
+      const postAuthenticate = jest.fn();
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn().mockResolvedValue(null),
+        testOptions({ postAuthenticate, throwOnFailure: false })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await authStrategy.authenticate(req as any, h as any);
+      expect(postAuthenticate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('auth.strategy.used metric', () => {
+    const authHeader = `Bearer fxs_${HEX_64}`;
+
+    it('increments {scheme=bearer, kind=<kind>} on successful auth', async () => {
+      const statsd = { increment: jest.fn() };
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn().mockResolvedValue({ id: 't' }),
+        testOptions({ statsd })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await authStrategy.authenticate(req as any, h as any);
+      expect(statsd.increment).toHaveBeenCalledWith('auth.strategy.used', [
+        'scheme:bearer',
+        'kind:sessionToken',
+      ]);
+    });
+
+    it('does not increment when lookup returns null', async () => {
+      const statsd = { increment: jest.fn() };
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn().mockResolvedValue(null),
+        testOptions({ statsd, throwOnFailure: false })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await authStrategy.authenticate(req as any, h as any);
+      expect(statsd.increment).not.toHaveBeenCalled();
+    });
+
+    it('does not increment when the postAuthenticate hook rejects', async () => {
+      const statsd = { increment: jest.fn() };
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn().mockResolvedValue({ id: 't' }),
+        testOptions({
+          statsd,
+          postAuthenticate: jest
+            .fn()
+            .mockRejectedValue(AppError.unverifiedAccount()),
+        })
+      )(null as any, null as any);
+
+      const req = makeReq({ headers: { authorization: authHeader } });
+      const h = makeH();
+
+      await expect(
+        authStrategy.authenticate(req as any, h as any)
+      ).rejects.toBeInstanceOf(AppError);
+      expect(statsd.increment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('payload', () => {
+    it('enforces payload:required', async () => {
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn(),
+        testOptions()
+      )(null as any, null as any);
+      const req = makeReq({
+        route: { settings: { auth: { payload: 'required' } } },
+        payload: null,
+      });
+      const h = makeH();
+
+      try {
+        await (authStrategy.payload as any)(req as any, h as any);
+        throw new Error('Should have thrown');
+      } catch (err: any) {
+        expect(err).toBeInstanceOf(AppError);
+        expect(err.output.payload.code).toBe(401);
+      }
+    });
+
+    it('continues when payload is not required', async () => {
+      const authStrategy = strategy(
+        'sessionToken',
+        jest.fn(),
+        testOptions()
+      )(null as any, null as any);
+      const req = makeReq();
+      const h = makeH();
+
+      const result = await (authStrategy.payload as any)(req as any, h as any);
+      expect(result).toBe(h.continue);
+    });
+  });
+});

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.js
@@ -71,21 +71,64 @@ function parseAuthorizationHeader(header, keys) {
   return attributes;
 }
 
+function requireOptions(options) {
+  if (!options || typeof options !== 'object') {
+    throw new Error('hawk-fxa-token: options object is required');
+  }
+  if (typeof options.throwOnFailure !== 'boolean') {
+    throw new Error(
+      'hawk-fxa-token: options.throwOnFailure (boolean) is required'
+    );
+  }
+  if (!options.statsd) {
+    throw new Error('hawk-fxa-token: options.statsd is required');
+  }
+  if (!options.kind) {
+    throw new Error('hawk-fxa-token: options.kind is required');
+  }
+}
+
 /**
- * This function defines the authentication strategy for `hawk-fxa-token`.
- * This auth strategy supports Hawk token and FxA token (Session, KeyFetch, PasswordForgotToken) for authentication as a Bearer token.
- * This strategy will be used to slowly phase out the usage of Hawk tokens, see https://github.com/mozilla/fxa/blob/main/docs/adr/0022-deprecate-hawk.md
- * @param {Function} getCredentialsFunc - The function to get the credentials.
- * @returns {Function}
+ * Authentication strategy for Hawk-shaped FxA token headers. Verifies the
+ * scheme is `Hawk`, parses the `id=`, and looks up the credential.
+ *
+ * All three options are required (no implicit defaults) so callers decide
+ * explicitly per registration:
+ *   - `throwOnFailure` — true for single-strategy routes, false for
+ *     multi-strategy chains where Hapi must fall through to the next.
+ *   - `statsd` + `kind` — drive the
+ *     `auth.strategy.used{scheme=hawk,kind=<kind>}` metric that tracks the
+ *     Hawk -> Bearer migration; required so a registration cannot silently
+ *     disappear from the dashboard.
+ *
+ * All failure modes carry `errno=110` ("Token not found") so a final 401
+ * in a multi-strategy chain matches the single-strategy response shape.
+ *
+ * @param {Function} getCredentialsFunc - id lookup, returns token or null
+ * @param {{ throwOnFailure: boolean, statsd: object, kind: string }} options
  */
-function strategy(
-  getCredentialsFunc,
-  authStrategyOptions = { throwOnFailure: true }
-) {
+function strategy(getCredentialsFunc, options) {
+  requireOptions(options);
+  const { throwOnFailure, statsd, kind } = options;
+
   const tokenNotFoundError = () => {
     const error = AppError.unauthorized('Token not found');
     error.isMissing = true;
     return error;
+  };
+
+  // Single-strategy routes throw to short-circuit; multi-strategy chains
+  // return so Hapi tries the next strategy. Both paths carry `errno=110`.
+  const failAuth = () => {
+    const err = tokenNotFoundError();
+    if (throwOnFailure) {
+      throw err;
+    }
+    return err;
+  };
+
+  const recordUsed = () => {
+    statsd.increment('auth.strategy.used', [`scheme:hawk`, `kind:${kind}`]);
   };
 
   return function (server, options) {
@@ -97,54 +140,30 @@ function strategy(
           if (req.auth.mode === 'optional') {
             return h.continue;
           }
-
-          throw tokenNotFoundError();
+          return failAuth();
         }
 
         if (auth.toLowerCase().indexOf('hawk') > -1) {
-          // If a Hawk token is found, lets parse it and get the token's id
           const parsedHeader = parseAuthorizationHeader(auth);
           let token;
-
           try {
             token = await getCredentialsFunc(parsedHeader.id);
           } catch (_) {
-            // we'll handle the empty token case below
+            // empty token case handled below
           }
 
-          // If a token isn't found, this means it doesn't exist or expired and
-          // was removed from database
           if (!token) {
-            if (authStrategyOptions.throwOnFailure) {
-              throw tokenNotFoundError();
-            } else {
-              return Boom.unauthorized(null, 'hawkFxaToken');
-            }
+            return failAuth();
           }
 
-          return h.authenticated({
-            credentials: token,
-          });
+          recordUsed();
+          return h.authenticated({ credentials: token });
         }
 
-        // TODO: Fix in follow up PR, there are conflicts with the refreshToken
-        // ref: https://mozilla-hub.atlassian.net/browse/FXA-9392
-        // strategy that need to also fixed
-        // if (auth.indexOf('Bearer') > -1) {
-        //   const tokenId = auth.split(' ')[1];
-        //   try {
-        //     const token = await getCredentialsFunc(tokenId);
-        //     return h.authenticated({
-        //       credentials: token,
-        //     });
-        //   } catch (err) {}
-        // }
-
-        if (authStrategyOptions.throwOnFailure) {
-          throw tokenNotFoundError();
-        }
-
-        return Boom.unauthorized(null, 'hawkFxaToken');
+        // Header present but not Hawk (e.g. `Bearer fxs_…` from a migrated
+        // client, or `Bearer <refresh-hex>`). Single-strategy routes still
+        // 401; multi-strategy chains fall through to the next strategy.
+        return failAuth();
       },
       payload: async function (req, h) {
         // Since we skip Hawk header validation, we don't need to perform payload validation either...

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/hawk-fxa-token.spec.ts
@@ -7,10 +7,50 @@ import { strategy } from './hawk-fxa-token';
 
 const HAWK_HEADER = 'Hawk id="123", ts="123", nonce="123", mac="123"';
 
+// Default test options for tests that don't care about throwOnFailure/statsd/kind.
+// Strategy factory enforces these at construction; tests that exercise specific
+// values pass them explicitly.
+const testOptions = (overrides: any = {}) => ({
+  throwOnFailure: true,
+  statsd: { increment: jest.fn() },
+  kind: 'sessionToken',
+  ...overrides,
+});
+
 describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
+  describe('strategy factory — required options', () => {
+    it('throws when options is missing', () => {
+      expect(() => (strategy as any)(jest.fn())).toThrow(/options object/);
+    });
+    it('throws when throwOnFailure is missing', () => {
+      expect(() =>
+        (strategy as any)(jest.fn(), {
+          statsd: { increment: jest.fn() },
+          kind: 'sessionToken',
+        })
+      ).toThrow(/throwOnFailure/);
+    });
+    it('throws when statsd is missing', () => {
+      expect(() =>
+        (strategy as any)(jest.fn(), {
+          throwOnFailure: true,
+          kind: 'sessionToken',
+        })
+      ).toThrow(/statsd/);
+    });
+    it('throws when kind is missing', () => {
+      expect(() =>
+        (strategy as any)(jest.fn(), {
+          throwOnFailure: true,
+          statsd: { increment: jest.fn() },
+        })
+      ).toThrow(/kind/);
+    });
+  });
+
   it('should throw an error if no authorization header is provided', async () => {
     const getCredentialsFunc = jest.fn().mockResolvedValue(null);
-    const authStrategy = strategy(getCredentialsFunc)();
+    const authStrategy = strategy(getCredentialsFunc, testOptions())();
 
     const request = { headers: {}, auth: { mode: 'required' } };
     const h = { continue: Symbol('continue') };
@@ -32,7 +72,7 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
     const getCredentialsFunc = jest
       .fn()
       .mockResolvedValue({ id: 'validToken' });
-    const authStrategy = strategy(getCredentialsFunc)();
+    const authStrategy = strategy(getCredentialsFunc, testOptions())();
 
     const request = {
       headers: { authorization: HAWK_HEADER },
@@ -49,7 +89,7 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
 
   it('should not authenticate with parsable Hawk header and invalid token', async () => {
     const getCredentialsFunc = jest.fn().mockResolvedValue(null);
-    const authStrategy = strategy(getCredentialsFunc)();
+    const authStrategy = strategy(getCredentialsFunc, testOptions())();
 
     const request = {
       headers: { authorization: HAWK_HEADER },
@@ -72,7 +112,7 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
 
   it('should not authenticate with unparseable Hawk header', async () => {
     const getCredentialsFunc = jest.fn().mockResolvedValue(null);
-    const authStrategy = strategy(getCredentialsFunc)();
+    const authStrategy = strategy(getCredentialsFunc, testOptions())();
 
     const request = {
       headers: { authorization: 'Invalid Hawk Header' },
@@ -88,5 +128,86 @@ describe('lib/routes/auth-schemes/hawk-fxa-token', () => {
       expect(errorResponse.statusCode).toBe(401);
       expect(errorResponse.message).toBe('Unauthorized');
     }
+  });
+
+  describe('multi-strategy fallthrough (throwOnFailure=false)', () => {
+    it('returns Boom (does not throw) when the auth header is missing in required mode', async () => {
+      const authStrategy = strategy(
+        jest.fn(),
+        testOptions({ throwOnFailure: false })
+      )();
+      const request = { headers: {}, auth: { mode: 'required' } };
+      const h = { continue: Symbol('continue') };
+
+      const result = await authStrategy.authenticate(request, h);
+      expect(result.isBoom).toBe(true);
+      expect(result.output.statusCode).toBe(401);
+      // errno=110 keeps a final 401 wire-compatible with the typed
+      // "Token not found" response when no later strategy authenticates.
+      expect(result.output.payload.errno).toBe(110);
+    });
+
+    it('returns Boom (does not throw) when the header is a Bearer, not a Hawk', async () => {
+      const authStrategy = strategy(
+        jest.fn(),
+        testOptions({ throwOnFailure: false })
+      )();
+      const request = {
+        headers: {
+          authorization: `Bearer fxs_${'a'.repeat(64)}`,
+        },
+        auth: { mode: 'required' },
+      };
+      const h = { continue: Symbol('continue') };
+
+      const result = await authStrategy.authenticate(request, h);
+      expect(result.isBoom).toBe(true);
+      expect(result.output.statusCode).toBe(401);
+    });
+  });
+
+  describe('auth.strategy.used metric', () => {
+    it('increments {scheme=hawk, kind=<kind>} on successful auth when statsd+kind are provided', async () => {
+      const statsd = { increment: jest.fn() };
+      const getCredentialsFunc = jest
+        .fn()
+        .mockResolvedValue({ id: 'validToken' });
+      const authStrategy = strategy(
+        getCredentialsFunc,
+        testOptions({ statsd })
+      )();
+
+      const request = {
+        headers: { authorization: HAWK_HEADER },
+        auth: { mode: 'required' },
+      };
+      const h = { authenticated: jest.fn() };
+
+      await authStrategy.authenticate(request, h);
+      expect(statsd.increment).toHaveBeenCalledWith('auth.strategy.used', [
+        'scheme:hawk',
+        'kind:sessionToken',
+      ]);
+    });
+
+    it('does not increment when auth fails', async () => {
+      const statsd = { increment: jest.fn() };
+      const authStrategy = strategy(
+        jest.fn().mockResolvedValue(null),
+        testOptions({ statsd })
+      )();
+      const request = {
+        headers: { authorization: HAWK_HEADER },
+        auth: { mode: 'required' },
+      };
+      const h = { continue: Symbol('continue') };
+
+      try {
+        await authStrategy.authenticate(request, h);
+      } catch {
+        // expected
+      }
+      expect(statsd.increment).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/verified-session-token.js
@@ -18,14 +18,10 @@ const { parseAuthorizationHeader } = require('./hawk-fxa-token');
  * @param {Object} db - database interface to fetch account and factors
  * @returns {Function}
  */
-function strategy(getCredentialsFunc, db, config, statsd) {
-  const tokenNotFoundError = () => {
-    const error = AppError.unauthorized('Token not found');
-    error.isMissing = true;
-    return error;
-  };
-
-  // Extract regular expressions to allow for optional skipping of certain routes for certain checks.
+// Exported so the Bearer-backed `verifiedSessionTokenBearer` strategy can
+// reuse the exact same email/token/AAL checks via its `postAuthenticate`
+// hook (see `server.js`).
+function makePostLookupGuard(db, config, statsd) {
   const verifiedSessionTokenConfig =
     config?.authStrategies?.verifiedSessionToken;
 
@@ -43,6 +39,71 @@ function strategy(getCredentialsFunc, db, config, statsd) {
     verifiedSessionTokenConfig?.skipAalCheckForRoutes
       ? new RegExp(verifiedSessionTokenConfig.skipAalCheckForRoutes)
       : null;
+
+  return async function postLookupGuard(req, token) {
+    const account = await db.account(token.uid);
+
+    // 1) account email is verified
+    if (!account?.primaryEmail?.isVerified) {
+      if (skipEmailVerifiedCheckForRoutes?.test(req.route.path)) {
+        // Important! Using req.route.path which has much lower cardinality than req.path
+        statsd?.increment(
+          'verified_session_token.primary_email_not_verified.skipped',
+          [`path:${req.route.path}`]
+        );
+      } else {
+        statsd?.increment(
+          'verified_session_token.primary_email_not_verified.error',
+          [`path:${req.route.path}`]
+        );
+        throw AppError.unverifiedAccount();
+      }
+    }
+
+    // 2) session token is verified
+    if (!token.tokenVerified) {
+      if (skipTokenVerifiedCheckForRoutes?.test(req.route.path)) {
+        statsd?.increment('verified_session_token.token_verified.skipped', [
+          `path:${req.route.path}`,
+        ]);
+      } else {
+        statsd?.increment('verified_session_token.token_verified.error', [
+          `path:${req.route.path}`,
+        ]);
+        throw AppError.unverifiedSession();
+      }
+    }
+
+    // 3) session AAL satisfies account requirements
+    const accountRequiresAal2 = await authMethods.accountRequiresAAL2(
+      db,
+      account
+    );
+    const sessionAal = token.authenticatorAssuranceLevel;
+
+    if (accountRequiresAal2 && sessionAal < 2) {
+      if (skipAalCheckForRoutes?.test(req.route.path)) {
+        statsd?.increment('verified_session_token.aal.skipped', [
+          `path:${req.route.path}`,
+        ]);
+      } else {
+        statsd?.increment('verified_session_token.aal.error', [
+          `path:${req.route.path}`,
+        ]);
+        throw AppError.insufficientAal();
+      }
+    }
+  };
+}
+
+function strategy(getCredentialsFunc, db, config, statsd) {
+  const tokenNotFoundError = () => {
+    const error = AppError.unauthorized('Token not found');
+    error.isMissing = true;
+    return error;
+  };
+
+  const postLookupGuard = makePostLookupGuard(db, config, statsd);
 
   return function (server, options) {
     return {
@@ -65,59 +126,7 @@ function strategy(getCredentialsFunc, db, config, statsd) {
           throw tokenNotFoundError();
         }
 
-        // Fetch the account for further checks
-        const account = await db.account(token.uid);
-
-        // 1) account email is verified
-        if (!account?.primaryEmail?.isVerified) {
-          if (skipEmailVerifiedCheckForRoutes?.test(req.route.path)) {
-            // Important! Using req.route.path which has much lower cardinality than req.path
-            statsd?.increment(
-              'verified_session_token.primary_email_not_verified.skipped',
-              [`path:${req.route.path}`]
-            );
-          } else {
-            statsd?.increment(
-              'verified_session_token.primary_email_not_verified.error',
-              [`path:${req.route.path}`]
-            );
-            throw AppError.unverifiedAccount();
-          }
-        }
-
-        // 2) session token is verified
-        if (!token.tokenVerified) {
-          if (skipTokenVerifiedCheckForRoutes?.test(req.route.path)) {
-            statsd?.increment('verified_session_token.token_verified.skipped', [
-              `path:${req.route.path}`,
-            ]);
-          } else {
-            statsd?.increment('verified_session_token.token_verified.error', [
-              `path:${req.route.path}`,
-            ]);
-            throw AppError.unverifiedSession();
-          }
-        }
-
-        // 3) session AAL satisfies account requirements
-        const accountRequiresAal2 = await authMethods.accountRequiresAAL2(
-          db,
-          account
-        );
-        const sessionAal = token.authenticatorAssuranceLevel;
-
-        if (accountRequiresAal2 && sessionAal < 2) {
-          if (skipAalCheckForRoutes?.test(req.route.path)) {
-            statsd?.increment('verified_session_token.aal.skipped', [
-              `path:${req.route.path}`,
-            ]);
-          } else {
-            statsd?.increment('verified_session_token.aal.error', [
-              `path:${req.route.path}`,
-            ]);
-            throw AppError.insufficientAal();
-          }
-        }
+        await postLookupGuard(req, token);
 
         return h.authenticated({
           credentials: token,
@@ -129,4 +138,5 @@ function strategy(getCredentialsFunc, db, config, statsd) {
 
 module.exports = {
   strategy,
+  makePostLookupGuard,
 };

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -99,7 +99,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICE_POST,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
         },
         validate: {
           payload: isA
@@ -206,7 +206,7 @@ module.exports = (
           }),
         },
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
         },
         response: {
           schema: isA
@@ -296,7 +296,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICES_INVOKE_COMMAND_POST,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
         },
         validate: {
           payload: isA.object({
@@ -445,7 +445,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICES_NOTIFY_POST,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
         },
         validate: {
           payload: isA.alternatives().try(
@@ -588,7 +588,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICES_GET,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
         },
         validate: {
           query: isA.object({
@@ -724,8 +724,8 @@ module.exports = (
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_SESSIONS_GET,
         auth: {
           strategies: [
+            'sessionTokenBearer',
             'sessionToken',
-            // this endpoint is only used by the content server
             // no refreshToken access here
           ],
         },
@@ -831,7 +831,7 @@ module.exports = (
       options: {
         ...DEVICES_AND_SERVICES_DOCS.ACCOUNT_DEVICE_DESTROY_POST,
         auth: {
-          strategies: ['sessionToken', 'refreshToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'refreshToken'],
         },
         validate: {
           payload: isA.object({

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -632,7 +632,7 @@ module.exports = (
       options: {
         ...EMAILS_DOCS.RECOVERY_EMAIL_STATUS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           query: {
@@ -731,7 +731,7 @@ module.exports = (
       options: {
         ...EMAILS_DOCS.RECOVERY_EMAIL_RESEND_CODE_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {
@@ -1098,7 +1098,7 @@ module.exports = (
       options: {
         ...EMAILS_DOCS.RECOVERY_EMAILS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         response: {
           schema: isA.array().items(
@@ -1557,7 +1557,7 @@ module.exports = (
       options: {
         ...EMAILS_DOCS.EMAILS_REMINDERS_CAD_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
       },

--- a/packages/fxa-auth-server/lib/routes/geo-location.ts
+++ b/packages/fxa-auth-server/lib/routes/geo-location.ts
@@ -52,7 +52,9 @@ export class GeoLocationHandler {
   ) {
     const rulesFromConfig = (config.geoEligibility?.rules ??
       {}) as GeoEligibilityRules;
-    this.geoEligibilityCheckService = new GeoEligibilityCheckService(rulesFromConfig);
+    this.geoEligibilityCheckService = new GeoEligibilityCheckService(
+      rulesFromConfig
+    );
   }
 
   geoEligibilityCheck = (request: AuthRequest) => {
@@ -69,7 +71,10 @@ export class GeoLocationHandler {
     }
 
     const country = request.app.geo?.location?.countryCode ?? null;
-    const eligible = this.geoEligibilityCheckService.isAllowed(feature, country);
+    const eligible = this.geoEligibilityCheckService.isAllowed(
+      feature,
+      country
+    );
 
     this.log.info('geo.eligibility.checked', {
       feature,
@@ -93,7 +98,7 @@ export const geoRoutes = (config: ConfigType, log: AuthLogger) => {
       options: {
         ...MISC_DOCS.GEO_ELIGIBILITY_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           mode: 'required',
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/linked-accounts.ts
+++ b/packages/fxa-auth-server/lib/routes/linked-accounts.ts
@@ -717,7 +717,7 @@ export const linkedAccountRoutes = (
       options: {
         ...THIRD_PARTY_AUTH_DOCS.LINKED_ACCOUNT_UNLINK_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           payload: isA.object({

--- a/packages/fxa-auth-server/lib/routes/mfa.ts
+++ b/packages/fxa-auth-server/lib/routes/mfa.ts
@@ -285,7 +285,7 @@ export const mfaRoutes = (
       options: {
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -307,7 +307,7 @@ export const mfaRoutes = (
       path: '/mfa/otp/verify',
       options: {
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/newsletters.js
+++ b/packages/fxa-auth-server/lib/routes/newsletters.js
@@ -20,7 +20,7 @@ module.exports = (log, db) => {
       options: {
         ...MISC_DOCS.NEWSLETTERS_POST,
         auth: {
-          strategies: ['sessionToken', 'oauthToken'],
+          strategies: ['sessionTokenBearer', 'sessionToken', 'oauthToken'],
         },
         validate: {
           payload: Joi.object({
@@ -31,7 +31,9 @@ module.exports = (log, db) => {
       handler: async function (request) {
         log.begin('newsletters', request);
 
-        const usingSessionToken = request.auth.strategy === 'sessionToken';
+        const usingSessionToken =
+          request.auth.strategy === 'sessionToken' ||
+          request.auth.strategy === 'sessionTokenBearer';
 
         if (!usingSessionToken) {
           const scope = ScopeSet.fromArray(request.auth.credentials.scope);

--- a/packages/fxa-auth-server/lib/routes/oauth/authorization.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/authorization.js
@@ -345,7 +345,7 @@ module.exports = ({ log, oauthDB, config }) => {
       config: {
         ...OAUTH_DOCS.OAUTH_AUTHORIZATION_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/oauth/key_data.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/key_data.js
@@ -130,7 +130,7 @@ module.exports = ({ log, oauthDB, statsd }) => {
       config: {
         ...OAUTH_DOCS.ACCOUNT_SCOPED_KEY_DATA_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/oauth/token.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/token.js
@@ -612,7 +612,7 @@ module.exports = ({ log, oauthDB, db, mailer, devices, statsd, glean }) => {
           // XXX TODO: To be able to fully replace the /token route from oauth-server,
           // this route must also be able to accept 'client_secret' as Basic Auth in header.
           mode: 'optional',
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           // Note: the use of 'alternatives' here means that `grant_type` will default to

--- a/packages/fxa-auth-server/lib/routes/passkeys.ts
+++ b/packages/fxa-auth-server/lib/routes/passkeys.ts
@@ -690,7 +690,7 @@ export const passkeyRoutes = (
         ...PASSKEYS_API_DOCS.PASSKEYS_GET,
         pre: [{ method: passkeysEnabledCheck }],
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         response: {

--- a/packages/fxa-auth-server/lib/routes/password.ts
+++ b/packages/fxa-auth-server/lib/routes/password.ts
@@ -90,7 +90,7 @@ module.exports = function (
       options: {
         ...PASSWORD_DOCS.PASSWORD_CHANGE_START_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -203,7 +203,7 @@ module.exports = function (
       options: {
         ...PASSWORD_DOCS.PASSWORD_CHANGE_FINISH_POST,
         auth: {
-          strategy: 'passwordChangeToken',
+          strategies: ['passwordChangeTokenBearer', 'passwordChangeToken'],
           payload: 'required',
         },
         validate: {
@@ -1201,7 +1201,7 @@ module.exports = function (
       options: {
         ...PASSWORD_DOCS.PASSWORD_FORGOT_VERIFY_CODE_POST,
         auth: {
-          strategy: 'passwordForgotToken',
+          strategies: ['passwordForgotTokenBearer', 'passwordForgotToken'],
           payload: 'required',
         },
         validate: {
@@ -1334,7 +1334,7 @@ module.exports = function (
       options: {
         ...PASSWORD_DOCS.PASSWORD_CREATE_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-codes.js
@@ -37,7 +37,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       options: {
         ...RECOVERY_CODES_DOCS.RECOVERYCODES_GET,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         response: {
@@ -96,7 +96,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       options: {
         ...RECOVERY_CODES_DOCS.RECOVERY_CODES_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -179,7 +179,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       options: {
         ...RECOVERY_CODES_DOCS.RECOVERY_CODES_PUT,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -272,6 +272,8 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       options: {
         auth: {
           strategies: [
+            'multiStrategySessionTokenBearer',
+            'multiStrategyPasswordForgotTokenBearer',
             'multiStrategySessionToken',
             'multiStrategyPasswordForgotToken',
           ],
@@ -305,7 +307,7 @@ module.exports = (log, db, config, customs, mailer, glean, statsd) => {
       options: {
         ...RECOVERY_CODES_DOCS.SESSION_VERIFY_RECOVERYCODE_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -36,7 +36,7 @@ module.exports = (
       options: {
         ...RECOVERY_KEY_DOCS.RECOVERYKEY_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -247,7 +247,7 @@ module.exports = (
       options: {
         ...RECOVERY_KEY_DOCS.RECOVERYKEY_VERIFY_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -336,7 +336,7 @@ module.exports = (
       options: {
         ...RECOVERY_KEY_DOCS.RECOVERYKEY_RECOVERYKEYID_GET,
         auth: {
-          strategy: 'accountResetToken',
+          strategies: ['accountResetTokenBearer', 'accountResetToken'],
         },
         validate: {
           params: isA.object({
@@ -366,6 +366,8 @@ module.exports = (
         ...RECOVERY_KEY_DOCS.RECOVERYKEY_EXISTS_POST,
         auth: {
           strategies: [
+            'multiStrategySessionTokenBearer',
+            'multiStrategyPasswordForgotTokenBearer',
             'multiStrategySessionToken',
             'multiStrategyPasswordForgotToken',
           ],
@@ -419,7 +421,7 @@ module.exports = (
         auth: {
           // hint update is only possible when authenticated
           // from /settings or (eventually) after signup, signin or successful password reset
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           payload: isA.object({
@@ -455,7 +457,7 @@ module.exports = (
       options: {
         ...RECOVERY_KEY_DOCS.RECOVERYKEY_DELETE,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
       },

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.spec.ts
@@ -233,7 +233,10 @@ describe('/recovery_phone', () => {
         '/recovery_phone/signin/send_code',
         'POST'
       );
-      expect(route.options.auth.strategy).toBe('sessionToken');
+      expect(route.options.auth.strategies).toEqual([
+        'sessionTokenBearer',
+        'sessionToken',
+      ]);
     });
   });
 
@@ -374,7 +377,10 @@ describe('/recovery_phone', () => {
         '/recovery_phone/reset_password/send_code',
         'POST'
       );
-      expect(route.options.auth.strategy).toBe('passwordForgotToken');
+      expect(route.options.auth.strategies).toEqual([
+        'passwordForgotTokenBearer',
+        'passwordForgotToken',
+      ]);
     });
   });
 
@@ -546,7 +552,10 @@ describe('/recovery_phone', () => {
 
     it('requires verified session authorization', () => {
       const route = getRoute(routes, '/recovery_phone/create', 'POST');
-      expect(route.options.auth.strategy).toBe('verifiedSessionToken');
+      expect(route.options.auth.strategies).toEqual([
+        'verifiedSessionTokenBearer',
+        'verifiedSessionToken',
+      ]);
     });
   });
 

--- a/packages/fxa-auth-server/lib/routes/recovery-phone.ts
+++ b/packages/fxa-auth-server/lib/routes/recovery-phone.ts
@@ -977,7 +977,10 @@ class RecoveryPhoneHandler {
     // the session is not verified. e.g. The user has entered the correct password,
     // but failed to provide 2FA.
     const shouldStripNumber = (() => {
-      if (request.auth.strategy === 'multiStrategySessionToken') {
+      if (
+        request.auth.strategy === 'multiStrategySessionToken' ||
+        request.auth.strategy === 'multiStrategySessionTokenBearer'
+      ) {
         const { emailVerified, mustVerify, tokenVerified } = request.auth
           .credentials as SessionTokenAuthCredential;
         return !emailVerified || (mustVerify && !tokenVerified);
@@ -1122,7 +1125,7 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_CREATE_POST,
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -1169,7 +1172,7 @@ export const recoveryPhoneRoutes = (
       options: {
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_AVAILABLE_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
       },
       handler: function (request: AuthRequest) {
@@ -1184,7 +1187,7 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_CONFIRM_POST,
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -1248,7 +1251,7 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_SIGNIN_SEND_CODE_POST,
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
       },
       handler: function (request: AuthRequest) {
@@ -1263,7 +1266,7 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_SIGNIN_CONFIRM_POST,
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         validate: {
           payload: isA.object({
@@ -1283,7 +1286,7 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_RESET_PASSWORD_SEND_CODE_POST,
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'passwordForgotToken',
+          strategies: ['passwordForgotTokenBearer', 'passwordForgotToken'],
         },
       },
       handler: function (request: AuthRequest) {
@@ -1298,7 +1301,7 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_RESET_PASSWORD_CONFIRM_POST,
         pre: [{ method: featureEnabledCheck }],
         auth: {
-          strategy: 'passwordForgotToken',
+          strategies: ['passwordForgotTokenBearer', 'passwordForgotToken'],
         },
       },
       handler: function (request: AuthRequest) {
@@ -1312,7 +1315,7 @@ export const recoveryPhoneRoutes = (
       options: {
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_DELETE,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
       },
@@ -1348,6 +1351,8 @@ export const recoveryPhoneRoutes = (
         ...RECOVERY_PHONE_DOCS.RECOVERY_PHONE_GET,
         auth: {
           strategies: [
+            'multiStrategySessionTokenBearer',
+            'multiStrategyPasswordForgotTokenBearer',
             'multiStrategySessionToken',
             'multiStrategyPasswordForgotToken',
           ],

--- a/packages/fxa-auth-server/lib/routes/security-events.js
+++ b/packages/fxa-auth-server/lib/routes/security-events.js
@@ -15,7 +15,7 @@ module.exports = (log, db, config) => {
       options: {
         ...SECURITY_EVENTS_DOCS.SECURITYEVENTS_GET,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
       },

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -57,7 +57,7 @@ module.exports = function (
       options: {
         ...SESSION_DOCS.SESSION_DESTROY_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           // since payload is allowed to be empty we do not
           // do hawk payload validation otherwise we may break existing clients
         },
@@ -121,7 +121,7 @@ module.exports = function (
       options: {
         ...SESSION_DOCS.SESSION_REAUTH_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {
@@ -305,7 +305,7 @@ module.exports = function (
       options: {
         ...SESSION_DOCS.SESSION_STATUS_GET,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
         response: {
           schema: isA.object({
@@ -370,7 +370,7 @@ module.exports = function (
       options: {
         ...SESSION_DOCS.SESSION_DUPLICATE_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {
@@ -452,7 +452,7 @@ module.exports = function (
       options: {
         ...SESSION_DOCS.SESSION_VERIFY_CODE_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {
@@ -576,7 +576,7 @@ module.exports = function (
       options: {
         ...SESSION_DOCS.SESSION_RESEND_CODE_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
         },
       },
       handler: async function (request) {

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -398,7 +398,7 @@ module.exports = (
       options: {
         ...TOTP_DOCS.TOTP_CREATE_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -513,7 +513,7 @@ module.exports = (
       options: {
         ...TOTP_DOCS.TOTP_SETUP_VERIFY_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -650,7 +650,7 @@ module.exports = (
       options: {
         ...TOTP_DOCS.TOTP_SETUP_COMPLETE_POST,
         auth: {
-          strategy: 'verifiedSessionToken',
+          strategies: ['verifiedSessionTokenBearer', 'verifiedSessionToken'],
           payload: false,
         },
         validate: {
@@ -840,6 +840,8 @@ module.exports = (
         ...TOTP_DOCS.TOTP_EXISTS_GET,
         auth: {
           strategies: [
+            'multiStrategySessionTokenBearer',
+            'multiStrategyPasswordForgotTokenBearer',
             'multiStrategySessionToken',
             'multiStrategyPasswordForgotToken',
           ],
@@ -880,7 +882,7 @@ module.exports = (
       options: {
         ...TOTP_DOCS.TOTP_VERIFY_POST,
         auth: {
-          strategy: 'passwordForgotToken',
+          strategies: ['passwordForgotTokenBearer', 'passwordForgotToken'],
           payload: 'required',
         },
         validate: {
@@ -960,7 +962,7 @@ module.exports = (
       options: {
         ...TOTP_DOCS.TOTP_VERIFY_RECOVERY_CODE_POST,
         auth: {
-          strategy: 'passwordForgotToken',
+          strategies: ['passwordForgotTokenBearer', 'passwordForgotToken'],
         },
         validate: {
           payload: isA.object({
@@ -1074,7 +1076,7 @@ module.exports = (
       options: {
         ...TOTP_DOCS.SESSION_VERIFY_TOTP_POST,
         auth: {
-          strategy: 'sessionToken',
+          strategies: ['sessionTokenBearer', 'sessionToken'],
           payload: 'required',
         },
         validate: {

--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -10,14 +10,24 @@ const {
   reportValidationError,
 } = require('fxa-shared/sentry/report-validation-error');
 
-// Anything with these keys containing these strings will be redacted.
-const SENSITIVE_KEY_TERMS = new Set(['auth', 'pw', 'kb', 'key']);
+// Case-insensitive substrings: any key containing one of these is redacted
+// before reaching Sentry. Covers `authorization`, `set-cookie`, `authPW`,
+// `kB`, `keyFetchToken`, etc.
+const REDACTED_KEY_FRAGMENTS = ['auth', 'cookie', 'pw', 'kb', 'key'];
+
+// Unanchored so a token id embedded in a larger string (stack frame, URL,
+// error message) is still redacted. Under Bearer the raw id is a replay
+// credential.
+const TOKEN_VALUE_RE = /\bfx[a-z]+_[0-9a-f]{64}\b/;
 
 function filterExtras(obj, depth = 0) {
   return Object.fromEntries(
     Object.entries(obj).map(([k, v]) => {
       const lower = k.toLowerCase();
-      if ([...SENSITIVE_KEY_TERMS].some((term) => lower.includes(term))) {
+      if (REDACTED_KEY_FRAGMENTS.some((term) => lower.includes(term))) {
+        return [k, '[Filtered]'];
+      }
+      if (typeof v === 'string' && TOKEN_VALUE_RE.test(v)) {
         return [k, '[Filtered]'];
       }
       if (v && typeof v === 'object' && !Array.isArray(v)) {

--- a/packages/fxa-auth-server/lib/sentry.spec.ts
+++ b/packages/fxa-auth-server/lib/sentry.spec.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 import * as Hapi from '@hapi/hapi';
 import * as verror from 'verror';
 
@@ -32,10 +31,7 @@ jest.mock('@sentry/node', () => ({
 
 const { AppError: error } = require('@fxa/accounts/errors');
 const config = require('../config').default.getProperties();
-const {
-  configureSentry,
-  filterExtras,
-} = require('./sentry');
+const { configureSentry, filterExtras } = require('./sentry');
 
 describe('Sentry', () => {
   let server: Hapi.Server;
@@ -107,6 +103,38 @@ describe('Sentry', () => {
         l1: { l2: { l3: { l4: { l5: { l6: { authPW: 'secret123' } } } } } },
       })
     ).toEqual({ l1: { l2: { l3: { l4: { l5: '[Filtered]' } } } } });
+  });
+
+  it('redacts cookie and set-cookie headers', () => {
+    expect(filterExtras({ cookie: 'session=abc; other=def' })).toEqual({
+      cookie: '[Filtered]',
+    });
+    expect(filterExtras({ Cookie: 'session=abc' })).toEqual({
+      Cookie: '[Filtered]',
+    });
+    expect(filterExtras({ 'set-cookie': 'session=abc; HttpOnly' })).toEqual({
+      'set-cookie': '[Filtered]',
+    });
+  });
+
+  it('redacts prefixed bearer token values regardless of key', () => {
+    const hex = 'a'.repeat(64);
+    expect(filterExtras({ harmlessLabel: `fxs_${hex}` })).toEqual({
+      harmlessLabel: '[Filtered]',
+    });
+    expect(filterExtras({ x: { y: `fxkv_${hex}` } })).toEqual({
+      x: { y: '[Filtered]' },
+    });
+    // Non-matching values are untouched.
+    expect(filterExtras({ harmlessLabel: 'not-a-token' })).toEqual({
+      harmlessLabel: 'not-a-token',
+    });
+    // Tokens embedded in a larger string are still redacted: a stack
+    // frame, URL, or error message that pastes a raw token id must not
+    // leak the credential just because it has surrounding text.
+    expect(filterExtras({ harmlessLabel: `Bearer fxs_${hex}` })).toEqual({
+      harmlessLabel: '[Filtered]',
+    });
   });
 
   it('can be set up when sentry is enabled', async () => {
@@ -191,5 +219,4 @@ describe('Sentry', () => {
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
   });
-
 });

--- a/packages/fxa-auth-server/lib/server.in.spec.ts
+++ b/packages/fxa-auth-server/lib/server.in.spec.ts
@@ -112,7 +112,7 @@ describe('lib/server', () => {
       config = getConfig();
       log = mocks.mockLog();
       routes = getRoutes();
-      statsd = { timing: jest.fn() };
+      statsd = { timing: jest.fn(), increment: jest.fn() };
     });
 
     describe('create:', () => {
@@ -844,7 +844,7 @@ describe('lib/server', () => {
           config: {
             auth: {
               mode: 'required',
-              strategy: 'sessionToken',
+              strategies: ['sessionTokenBearer', 'sessionToken'],
             },
           },
           handler() {

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -418,31 +418,58 @@ async function create(
 
   const hawkFxAToken = require('./routes/auth-schemes/hawk-fxa-token');
   // Register auth strategies for all token types. These strategies support Hawk (without validation) and FxA token types.
+  // `statsd`+`kind` drive the `auth.strategy.used{scheme,kind}` metric that
+  // tracks Hawk vs Bearer traffic during the FXA-9392 migration.
   server.auth.scheme(
     'fxa-hawk-session-token',
-    hawkFxAToken.strategy(makeCredentialFn(db.sessionToken.bind(db)))
+    hawkFxAToken.strategy(makeCredentialFn(db.sessionToken.bind(db)), {
+      throwOnFailure: true,
+      statsd,
+      kind: 'sessionToken',
+    })
   );
   server.auth.scheme(
     'fxa-hawk-keyFetch-token',
-    hawkFxAToken.strategy(makeCredentialFn(db.keyFetchToken.bind(db)))
+    hawkFxAToken.strategy(makeCredentialFn(db.keyFetchToken.bind(db)), {
+      throwOnFailure: true,
+      statsd,
+      kind: 'keyFetchToken',
+    })
   );
   server.auth.scheme(
     'fxa-hawk-keyFetch-with-verification-token',
     hawkFxAToken.strategy(
-      makeCredentialFn(db.keyFetchTokenWithVerificationStatus.bind(db))
+      makeCredentialFn(db.keyFetchTokenWithVerificationStatus.bind(db)),
+      {
+        throwOnFailure: true,
+        statsd,
+        kind: 'keyFetchTokenWithVerificationStatus',
+      }
     )
   );
   server.auth.scheme(
     'fxa-hawk-accountReset-token',
-    hawkFxAToken.strategy(makeCredentialFn(db.accountResetToken.bind(db)))
+    hawkFxAToken.strategy(makeCredentialFn(db.accountResetToken.bind(db)), {
+      throwOnFailure: true,
+      statsd,
+      kind: 'accountResetToken',
+    })
   );
   server.auth.scheme(
     'fxa-hawk-passwordForgot-token',
-    hawkFxAToken.strategy(makeCredentialFn(db.passwordForgotToken.bind(db)))
+    hawkFxAToken.strategy(makeCredentialFn(db.passwordForgotToken.bind(db)), {
+      throwOnFailure: true,
+      statsd,
+      kind: 'passwordForgotToken',
+    })
   );
   server.auth.scheme(
     'fxa-hawk-passwordChange-token',
-    hawkFxAToken.strategy(makeCredentialFn(db.passwordChangeToken.bind(db)))
+    hawkFxAToken.strategy(makeCredentialFn(db.passwordChangeToken.bind(db)), {
+      throwOnFailure: true,
+      statsd,
+      kind: 'passwordChangeToken',
+    })
   );
 
   // the recoveryKey/exists route accepts a session token or a password-forgot
@@ -454,12 +481,16 @@ async function create(
     'multi-strategy-fxa-hawk-session-token',
     hawkFxAToken.strategy(makeCredentialFn(db.sessionToken.bind(db)), {
       throwOnFailure: false,
+      statsd,
+      kind: 'sessionToken',
     })
   );
   server.auth.scheme(
     'multi-strategy-fxa-hawk-passwordForgot-token',
     hawkFxAToken.strategy(makeCredentialFn(db.passwordForgotToken.bind(db)), {
       throwOnFailure: false,
+      statsd,
+      kind: 'passwordForgotToken',
     })
   );
 
@@ -482,6 +513,105 @@ async function create(
   server.auth.strategy(
     'multiStrategyPasswordForgotToken',
     'multi-strategy-fxa-hawk-passwordForgot-token'
+  );
+
+  // Additive Bearer-token strategies for the Hawk -> Bearer migration
+  // (FXA-9392, ADR-0022). Wire format: `Authorization: Bearer <prefix>_<hex>`
+  // where `<prefix>` disambiguates token kinds. Routes are not wired yet; M2
+  // flips the client and the first route batch.
+  const bearerFxaToken = require('./routes/auth-schemes/bearer-fxa-token');
+  server.auth.scheme(
+    'fxa-bearer-session-token',
+    bearerFxaToken.strategy(
+      'sessionToken',
+      makeCredentialFn(db.sessionToken.bind(db)),
+      { throwOnFailure: true, statsd }
+    )
+  );
+  server.auth.scheme(
+    'fxa-bearer-keyFetch-token',
+    bearerFxaToken.strategy(
+      'keyFetchToken',
+      makeCredentialFn(db.keyFetchToken.bind(db)),
+      { throwOnFailure: true, statsd }
+    )
+  );
+  server.auth.scheme(
+    'fxa-bearer-keyFetch-with-verification-token',
+    bearerFxaToken.strategy(
+      'keyFetchTokenWithVerificationStatus',
+      makeCredentialFn(db.keyFetchTokenWithVerificationStatus.bind(db)),
+      { throwOnFailure: true, statsd }
+    )
+  );
+  server.auth.scheme(
+    'fxa-bearer-accountReset-token',
+    bearerFxaToken.strategy(
+      'accountResetToken',
+      makeCredentialFn(db.accountResetToken.bind(db)),
+      { throwOnFailure: true, statsd }
+    )
+  );
+  server.auth.scheme(
+    'fxa-bearer-passwordForgot-token',
+    bearerFxaToken.strategy(
+      'passwordForgotToken',
+      makeCredentialFn(db.passwordForgotToken.bind(db)),
+      { throwOnFailure: true, statsd }
+    )
+  );
+  server.auth.scheme(
+    'fxa-bearer-passwordChange-token',
+    bearerFxaToken.strategy(
+      'passwordChangeToken',
+      makeCredentialFn(db.passwordChangeToken.bind(db)),
+      { throwOnFailure: true, statsd }
+    )
+  );
+
+  // Non-throwing variants for routes that chain Bearer with another strategy.
+  server.auth.scheme(
+    'multi-strategy-fxa-bearer-session-token',
+    bearerFxaToken.strategy(
+      'sessionToken',
+      makeCredentialFn(db.sessionToken.bind(db)),
+      { throwOnFailure: false, statsd }
+    )
+  );
+  server.auth.scheme(
+    'multi-strategy-fxa-bearer-passwordForgot-token',
+    bearerFxaToken.strategy(
+      'passwordForgotToken',
+      makeCredentialFn(db.passwordForgotToken.bind(db)),
+      { throwOnFailure: false, statsd }
+    )
+  );
+
+  server.auth.strategy('sessionTokenBearer', 'fxa-bearer-session-token');
+  server.auth.strategy('keyFetchTokenBearer', 'fxa-bearer-keyFetch-token');
+  server.auth.strategy(
+    'keyFetchTokenWithVerificationStatusBearer',
+    'fxa-bearer-keyFetch-with-verification-token'
+  );
+  server.auth.strategy(
+    'accountResetTokenBearer',
+    'fxa-bearer-accountReset-token'
+  );
+  server.auth.strategy(
+    'passwordForgotTokenBearer',
+    'fxa-bearer-passwordForgot-token'
+  );
+  server.auth.strategy(
+    'passwordChangeTokenBearer',
+    'fxa-bearer-passwordChange-token'
+  );
+  server.auth.strategy(
+    'multiStrategySessionTokenBearer',
+    'multi-strategy-fxa-bearer-session-token'
+  );
+  server.auth.strategy(
+    'multiStrategyPasswordForgotTokenBearer',
+    'multi-strategy-fxa-bearer-passwordForgot-token'
   );
 
   server.auth.scheme(authOauth.AUTH_SCHEME, authOauth.strategy);
@@ -535,6 +665,29 @@ async function create(
     )
   );
   server.auth.strategy('verifiedSessionToken', 'verified-session-token');
+
+  // Bearer counterpart — same post-lookup guard (email verified, token
+  // verified, AAL2) as the Hawk-backed strategy above.
+  server.auth.scheme(
+    'verified-session-token-bearer',
+    bearerFxaToken.strategy(
+      'sessionToken',
+      makeCredentialFn(db.sessionToken.bind(db)),
+      {
+        throwOnFailure: true,
+        statsd,
+        postAuthenticate: verifiedSessionToken.makePostLookupGuard(
+          db,
+          config,
+          statsd
+        ),
+      }
+    )
+  );
+  server.auth.strategy(
+    'verifiedSessionTokenBearer',
+    'verified-session-token-bearer'
+  );
 
   // register all plugins and Swagger configuration
   await server.register([

--- a/packages/fxa-auth-server/test/remote/bearer_scheme_registered.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/bearer_scheme_registered.in.spec.ts
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  getSharedTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
+
+// Smoke test for the Bearer auth scheme: a Bearer header with an unknown id
+// must 401, and a plain `Bearer <hex>` (refresh-token shape) must not be
+// accepted on session-token routes. Guards the prefix-disjoint property
+// that lets Bearer and Hawk coexist on multi-strategy chains.
+let server: TestServerInstance;
+let serverPort: number;
+
+beforeAll(async () => {
+  server = await getSharedTestServer();
+  const url = new URL(server.publicUrl);
+  serverPort = parseInt(url.port, 10);
+}, 120000);
+
+afterAll(async () => {
+  await server.stop();
+});
+
+describe('#integration - Bearer scheme registration', () => {
+  it('rejects a well-formed Bearer header with an unknown token id (401)', async () => {
+    const hex64 = 'a'.repeat(64);
+    const res = await fetch(
+      `http://localhost:${serverPort}/v1/session/destroy`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer fxs_${hex64}`,
+          'content-type': 'application/json',
+        },
+        body: '{}',
+      }
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a malformed Bearer (plain hex, no prefix) with 401', async () => {
+    const hex64 = 'b'.repeat(64);
+    const res = await fetch(
+      `http://localhost:${serverPort}/v1/session/destroy`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${hex64}`,
+          'content-type': 'application/json',
+        },
+        body: '{}',
+      }
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/fxa-auth-server/test/remote/misc_tests.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/misc_tests.in.spec.ts
@@ -292,5 +292,45 @@ describe.each(testVersions)(
       });
       expect(res.statusCode).toBe(200);
     });
+
+    // Proves the `['sessionTokenBearer', 'sessionToken']` multi-strategy chain
+    // works end-to-end against a real Hapi server: a Bearer header authenticates
+    // on the first strategy, and a Hawk header falls through Bearer (which
+    // returns Boom on a non-matching prefix) and authenticates on the second.
+    describe('Bearer + Hawk multi-strategy fallthrough', () => {
+      it('accepts Bearer fxs_<id> on a sessionToken route', async () => {
+        const client = await Client.createAndVerify(
+          server.publicUrl,
+          server.uniqueEmail(),
+          'allyourbasearebelongtous',
+          server.mailbox,
+          testOptions
+        );
+        const token = await client.api.Token.SessionToken.fromHex(
+          client.sessionToken
+        );
+        const res = await httpGet(`${client.api.baseURL}/account/devices`, {
+          headers: { Authorization: `Bearer fxs_${token.id}` },
+        });
+        expect(res.statusCode).toBe(200);
+      });
+
+      it('accepts Hawk on the same sessionToken route (falls through Bearer)', async () => {
+        const client = await Client.createAndVerify(
+          server.publicUrl,
+          server.uniqueEmail(),
+          'allyourbasearebelongtous',
+          server.mailbox,
+          testOptions
+        );
+        const token = await client.api.Token.SessionToken.fromHex(
+          client.sessionToken
+        );
+        const res = await httpGet(`${client.api.baseURL}/account/devices`, {
+          headers: { Authorization: `Hawk id="${token.id}"` },
+        });
+        expect(res.statusCode).toBe(200);
+      });
+    });
   }
 );

--- a/packages/fxa-auth-server/test/remote/totp.in.spec.ts
+++ b/packages/fxa-auth-server/test/remote/totp.in.spec.ts
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { createTestServer, TestServerInstance } from '../support/helpers/test-server';
+import {
+  createTestServer,
+  TestServerInstance,
+} from '../support/helpers/test-server';
 import crypto from 'crypto';
 
 const Client = require('../client')();
@@ -328,6 +331,45 @@ describe.each(testVersions)(
       expect(res.authAt).toBeTruthy();
     });
 
+    it('should reset password after verifying totp via Bearer header', async () => {
+      // Companion to the Hawk-path test above. Drives `/totp/verify` directly
+      // with a Bearer passwordForgotToken header to prove the Bearer strategy
+      // is wired end-to-end. The Hawk path is exercised by the preceding test.
+      const newPassword = 'anotherPassword';
+
+      const loginClient = await Client.login(
+        server.publicUrl,
+        email,
+        password,
+        { ...testOptions, keys: true }
+      );
+      await loginClient.forgotPassword();
+      const otpCode = await server.mailbox.waitForCode(email);
+      const result = await loginClient.verifyPasswordForgotOtp(otpCode);
+
+      const totpCode = authenticator.generate();
+      const pwForgotToken = await tokens.PasswordForgotToken.fromHex(
+        loginClient.passwordForgotToken
+      );
+      const res = await fetch(`${server.publicUrl}/v1/totp/verify`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer fxpf_${pwForgotToken.id}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ code: totpCode }),
+      });
+      expect(res.status).toBe(200);
+
+      await loginClient.verifyPasswordResetCode(result.code);
+      const resetRes = await loginClient.resetPassword(
+        newPassword,
+        {},
+        { keys: true }
+      );
+      expect(resetRes.sessionToken).toBeTruthy();
+    });
+
     describe('totp code verification', () => {
       beforeEach(async () => {
         client = await Client.login(
@@ -398,11 +440,9 @@ describe.each(testVersions)(
 
       it('should verify totp code from previous code window', async () => {
         const futureAuthenticator = new otplib.authenticator.Authenticator();
-        futureAuthenticator.options = Object.assign(
-          {},
-          authenticator.options,
-          { epoch: Date.now() / 1000 - 30 }
-        );
+        futureAuthenticator.options = Object.assign({}, authenticator.options, {
+          epoch: Date.now() / 1000 - 30,
+        });
         const code = futureAuthenticator.generate();
         const response = await client.verifyTotpCode(code, {
           metricsContext,
@@ -416,11 +456,9 @@ describe.each(testVersions)(
 
       it('should not verify totp code from future code window', async () => {
         const futureAuthenticator = new otplib.authenticator.Authenticator();
-        futureAuthenticator.options = Object.assign(
-          {},
-          authenticator.options,
-          { epoch: Date.now() / 1000 + 3000 }
-        );
+        futureAuthenticator.options = Object.assign({}, authenticator.options, {
+          epoch: Date.now() / 1000 + 3000,
+        });
         const code = futureAuthenticator.generate();
         const response = await client.verifyTotpCode(code, {
           metricsContext,

--- a/packages/fxa-settings/src/lib/auth-key-stretch-upgrade.ts
+++ b/packages/fxa-settings/src/lib/auth-key-stretch-upgrade.ts
@@ -11,7 +11,7 @@ import {
   unwrapKB,
 } from 'fxa-auth-client/lib/crypto';
 import { createSaltV2 } from 'fxa-auth-client/lib/salt';
-import { deriveHawkCredentials } from 'fxa-auth-client/lib/hawk';
+import { deriveTokenCredentials } from 'fxa-auth-client/lib/hawk';
 import { getHandledError } from './error-utils';
 import { SensitiveDataClient } from './sensitive-data-client';
 import { ERRNO } from '@fxa/accounts/errors';
@@ -191,7 +191,9 @@ export class AuthKeyStretchUpgrade {
       } else if (errno === ERRNO.SESSION_UNVERIFIED) {
         console.info('Key stretch upgrade deferred: session not verified');
       } else {
-        console.info(`Key stretch upgrade deferred: unexpected error (errno: ${errno})`);
+        console.info(
+          `Key stretch upgrade deferred: unexpected error (errno: ${errno})`
+        );
       }
 
       Sentry.captureMessage(
@@ -239,7 +241,7 @@ export class AuthKeyStretchUpgrade {
       v2: v2Credentials,
     });
     try {
-      const credentials = await deriveHawkCredentials(
+      const credentials = await deriveTokenCredentials(
         sessionToken,
         'sessionToken'
       );


### PR DESCRIPTION
  ## Because

  - ADR-0022 sanctioned dropping Hawk for in-monorepo callers; the 2024 attempt was reverted because plain `Bearer <hex>` collided with the OAuth refresh-token strategy on the same routes.
  - Hawk's host/uri/payload MAC adds no real value when auth-client and auth-server live in the same monorepo, but every authenticated browser call still pays the cost.

  ## This pull request

  - Adds a server-side `bearer-fxa-token` Hapi scheme accepting `Authorization: Bearer <prefix>_<hex>` (`fxs_`, `fxk_`, `fxar_`, `fxpf_`, `fxpc_`). The GitHub/Stripe-style prefix keeps the wire format disjoint from refresh tokens and Hawk so all three coexist on the same route.
  - Flips ~65 auth configs across 17 route files to multi-strategy chains (Bearer first, Hawk fallback), including the deprecated `/account/sessions`. Extracts `makePostLookupGuard` so `verifiedSessionToken` enforces the same email/token/AAL2 checks on both paths.
  - Fixes the Hawk scheme's missing-header branch to honor `throwOnFailure: false` for clean fall-through, and adds an `auth.strategy.used{scheme,kind}` StatsD counter for migration observability.
  - Migrates `fxa-auth-client` to `bearerHeader`/`authedRequest`, deletes the Hawk signing code in `lib/hawk.ts`, and adds `test/no-hawk-signing.ts` as a regression guard.
  - Hardens `lib/sentry.js` `filterExtras` with an explicit header allowlist and an unanchored value-pattern redactor (`/\bfx[a-z]+_[0-9a-f]{64}\b/`) so a bearer token id cannot leak into Sentry, even embedded in a stack frame.
  - Updates ADR-0022 to "Partially Implemented"; server-side Hawk stays for external clients (Firefox Desktop, iOS, Android, Sync).

  ## Issue that this pull request solves

  Closes: https://mozilla-hub.atlassian.net/browse/FXA-9392

  ## Checklist

  _Put an `x` in the boxes that apply_

  - [x] My commit is GPG signed.
  - [x] If applicable, I have modified or added tests which pass locally.
  - [x] I have added necessary documentation (if appropriate).
  - [ ] I have verified that my changes render correctly in RTL (if appropriate).
  - [x] I have manually reviewed all AI generated code.

  ## Other information

  **How to test:**
  1. `nx test-unit fxa-auth-server` and `nx test-unit fxa-auth-client`. Remote suite covers the Bearer path via `bearer_scheme_registered.in.spec.ts` and the Bearer arm of `totp.in.spec.ts`; `test/client/api.js` continues to exercise Hawk fallback.
  2. Manual: sign in via `fxa-settings`, exercise `/account/keys`, `/recovery_email/status`, `/account/sessions`, TOTP verify. DevTools should show `Bearer fxs_<hex>` / `Bearer fxk_<hex>` headers. Hawk callers (Firefox Desktop / Sync) are unaffected.

  **Note:** Token replay scope widens under Bearer (no host/uri/nonce binding); rotation cadence and the customs ratelimiter remain the primary mitigations, as documented in ADR-0022.