### PR TITLE
feat(payments-next): add component tests for CheckoutForm

### DIFF
--- a/libs/payments/ui/__mocks__/@radix-ui/react-form.tsx
+++ b/libs/payments/ui/__mocks__/@radix-ui/react-form.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const actual = jest.requireActual('@radix-ui/react-form');
+const ActualRoot = actual.Root;
+
+type RootProps = Omit<React.ComponentPropsWithoutRef<'form'>, 'action'> & {
+  action?: ((formData: FormData) => void | Promise<void>) | string;
+};
+
+const Root = ({ action, onSubmit, ...rest }: RootProps) => (
+  <ActualRoot
+    {...rest}
+    onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+      if (typeof action === 'function') {
+        e.preventDefault();
+        action(new FormData(e.currentTarget));
+      }
+      onSubmit?.(e);
+    }}
+  />
+);
+
+const mocked = { ...actual, Root, Form: Root };
+
+export = mocked;

--- a/libs/payments/ui/jest.config.ts
+++ b/libs/payments/ui/jest.config.ts
@@ -19,14 +19,29 @@ if (swcJestConfig.swcrc === undefined) {
 // jest needs EsModule Interop to find the default exported setup/teardown functions
 // swcJestConfig.module.noInterop = false;
 
+swcJestConfig.jsc.parser.tsx = true;
+swcJestConfig.jsc.transform = {
+  ...swcJestConfig.jsc.transform,
+  react: { runtime: 'automatic' },
+};
+
 const config: Config = {
   displayName: 'payments-ui',
   preset: '../../../jest.preset.js',
   transform: {
-    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+    '^.+\\.[tj]sx?$': ['@swc/jest', swcJestConfig],
   },
-  moduleFileExtensions: ['ts', 'js', 'html'],
-  testEnvironment: 'node',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['node', 'require', 'default'],
+  },
+  setupFilesAfterEnv: ['<rootDir>/test/jest.setup.ts'],
+  moduleNameMapper: {
+    '\\.(css|scss|sass|less)$': 'identity-obj-proxy',
+    '\\.(svg|png|jpg|jpeg|gif|webp|ico)$':
+      '<rootDir>/test/__mocks__/file-mock.js',
+  },
   coverageDirectory: '../../../coverage/libs/payments/ui',
   reporters: [
     'default',

--- a/libs/payments/ui/src/lib/client/components/CancelSubscription/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CancelSubscription/index.test.tsx
@@ -1,0 +1,183 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@radix-ui/react-form');
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt ?? ''} className={className} src="mock-image" />
+  ),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    onClick,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+    className?: string;
+  }) => (
+    <a href={href} onClick={onClick} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockCancelSubscriptionAtPeriodEndAction = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  cancelSubscriptionAtPeriodEndAction: (...args: unknown[]) =>
+    mockCancelSubscriptionAtPeriodEndAction(...args),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  ButtonVariant: {
+    Primary: 'primary',
+    SubscriptionManagementError: 'sub-mgmt-error',
+  },
+  SubmitButton: ({
+    children,
+    className,
+    disabled,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    disabled?: boolean;
+    'aria-label'?: string;
+  }) => (
+    <button
+      type="submit"
+      className={className}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@fxa/shared/react', () => ({
+  __esModule: true,
+  LinkExternal: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+import { CancelSubscription } from './index';
+
+const baseProps = {
+  userId: 'user-id',
+  subscriptionId: 'sub-id',
+  locale: 'en',
+  pageContent: {
+    active: true,
+    cancelAtPeriodEnd: false,
+    productName: 'Mozilla VPN',
+    currentPeriodEnd: 1735689600,
+    supportUrl: 'https://support.example.com',
+    webIcon: 'https://example.com/icon.png',
+  },
+};
+
+describe('CancelSubscription', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockCancelSubscriptionAtPeriodEndAction.mockReset();
+  });
+
+  describe('Already-cancelled variant', () => {
+    it('hides the cancel checkbox and submit button, displays expiry date, and shows the back-to-subscriptions link', () => {
+      render(
+        <CancelSubscription
+          {...baseProps}
+          pageContent={{ ...baseProps.pageContent, cancelAtPeriodEnd: true }}
+        />
+      );
+
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Cancel your subscription/i })
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByRole('heading', { name: /sorry to see you go/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Mozilla VPN subscription has been cancelled/i)
+      ).toBeInTheDocument();
+
+      const backLink = screen.getByRole('link', {
+        name: /Back to subscriptions/i,
+      });
+      expect(backLink).toBeInTheDocument();
+      expect(backLink).toHaveAttribute('href', '/en/subscriptions/landing');
+    });
+  });
+
+  describe('Active subscription error path', () => {
+    it('shows an error, keeps the form interactive, and preserves the checked checkbox when the cancel action fails', async () => {
+      mockCancelSubscriptionAtPeriodEndAction.mockResolvedValue({ ok: false });
+
+      render(<CancelSubscription {...baseProps} />);
+
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+      expect(checkbox).toBeChecked();
+
+      fireEvent.click(
+        screen.getByRole('button', { name: /Cancel your subscription/i })
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/An unexpected error occurred/i)
+        ).toBeInTheDocument();
+      });
+
+      expect(mockCancelSubscriptionAtPeriodEndAction).toHaveBeenCalledWith(
+        'user-id',
+        'sub-id'
+      );
+
+      expect(checkbox).toBeChecked();
+      const submitButton = screen.getByRole('button', {
+        name: /Cancel your subscription/i,
+      });
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.test.tsx
@@ -1,0 +1,373 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+
+const mockPaymentElementListeners: Array<
+  [string, (event?: unknown) => void]
+> = [];
+const mockPaymentElement = {
+  on: (event: string, cb: (event?: unknown) => void) => {
+    mockPaymentElementListeners.push([event, cb]);
+  },
+};
+const mockElementsSubmit = jest.fn();
+const mockElements = {
+  getElement: () => mockPaymentElement,
+  submit: mockElementsSubmit,
+};
+const mockCreateConfirmationToken = jest.fn();
+const mockStripe = { createConfirmationToken: mockCreateConfirmationToken };
+
+jest.mock('@stripe/react-stripe-js', () => ({
+  __esModule: true,
+  useStripe: () => mockStripe,
+  useElements: () => mockElements,
+  PaymentElement: () => <div data-testid="payment-element" />,
+  LinkAuthenticationElement: () => <div data-testid="link-auth-element" />,
+}));
+
+type PayPalButtonsMockProps = {
+  onApprove: (data: { orderID: string }) => unknown;
+  onError: (err: unknown) => unknown;
+  [key: string]: unknown;
+};
+let mockLastPaypalProps: PayPalButtonsMockProps | null = null;
+const mockPaypalScriptState = { isPending: false, isRejected: false };
+
+jest.mock('@paypal/react-paypal-js', () => ({
+  __esModule: true,
+  PayPalButtons: (props: PayPalButtonsMockProps) => {
+    mockLastPaypalProps = props;
+    return <div data-testid="paypal-buttons" />;
+  },
+  usePayPalScriptReducer: () => [mockPaypalScriptState],
+}));
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+  useParams: () => ({ offeringId: 'foo', interval: 'monthly' }),
+  usePathname: () => '/test/checkout/cart-id',
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({
+    alt,
+    className,
+  }: {
+    alt?: string;
+    className?: string;
+    src?: unknown;
+  }) => <img alt={alt ?? ''} className={className} src="mock-image" />,
+}));
+
+const mockGlean = {
+  recordInterstitialOfferView: jest.fn(),
+  recordInterstitialOfferEngage: jest.fn(),
+  recordInterstitialOfferSubmit: jest.fn(),
+};
+
+jest.mock('../../hooks/useGleanMetrics', () => ({
+  __esModule: true,
+  useGleanMetrics: () => mockGlean,
+}));
+
+const mockCheckoutCartWithStripe = jest.fn();
+const mockCheckoutCartWithPaypal = jest.fn();
+const mockFinalizeCartWithError = jest.fn();
+const mockHandleStripeErrorAction = jest.fn();
+const mockRecordEmitterEventAction = jest.fn();
+const mockGetPayPalCheckoutToken = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  checkoutCartWithStripe: (...args: unknown[]) =>
+    mockCheckoutCartWithStripe(...args),
+  checkoutCartWithPaypal: (...args: unknown[]) =>
+    mockCheckoutCartWithPaypal(...args),
+  finalizeCartWithError: (...args: unknown[]) =>
+    mockFinalizeCartWithError(...args),
+  handleStripeErrorAction: (...args: unknown[]) =>
+    mockHandleStripeErrorAction(...args),
+  recordEmitterEventAction: (...args: unknown[]) =>
+    mockRecordEmitterEventAction(...args),
+  getPayPalCheckoutToken: (...args: unknown[]) =>
+    mockGetPayPalCheckoutToken(...args),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  BaseButton: ({
+    children,
+    className,
+    type,
+    'aria-disabled': ariaDisabled,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    type?: 'submit' | 'button' | 'reset';
+    'aria-disabled'?: boolean;
+  }) => (
+    <button type={type} aria-disabled={ariaDisabled} className={className}>
+      {children}
+    </button>
+  ),
+  ButtonVariant: { Primary: 'primary' },
+  CheckoutCheckbox: ({
+    notifyCheckboxChange,
+    disabled,
+  }: {
+    notifyCheckboxChange: (value: boolean) => void;
+    disabled: boolean;
+  }) => (
+    <input
+      type="checkbox"
+      data-testid="consent-checkbox"
+      disabled={disabled}
+      onChange={(e) => notifyCheckboxChange(e.target.checked)}
+    />
+  ),
+}));
+
+jest.mock('@fxa/shared/db/mysql/account/kysely-types', () => ({
+  __esModule: true,
+  CartErrorReasonId: { BASIC_ERROR: 'basic-error' },
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  __esModule: true,
+  captureMessage: jest.fn(),
+}));
+
+import { CheckoutForm } from './index';
+
+const baseCart = {
+  id: 'cart-id',
+  version: 1,
+  uid: 'session-uid',
+  errorReasonId: null,
+  couponCode: null,
+  currency: 'usd',
+  taxAddress: { countryCode: 'US', postalCode: '94107' },
+};
+
+const baseProps = {
+  cmsCommonContent: {
+    termsOfServiceUrl: 'https://example.com/tos',
+    privacyNoticeUrl: 'https://example.com/privacy',
+  },
+  cart: baseCart,
+  locale: 'en',
+  sessionUid: 'session-uid',
+  sessionEmail: 'user@example.com',
+};
+
+const fireStripeReady = () => {
+  const handler = mockPaymentElementListeners.find(
+    ([e]) => e === 'ready'
+  )?.[1];
+  if (!handler) throw new Error('PaymentElement ready listener not registered');
+  act(() => {
+    handler();
+  });
+};
+
+const fireStripeChange = (event: {
+  complete: boolean;
+  value: { type: string; payment_method?: { id?: string } };
+}) => {
+  const handler = mockPaymentElementListeners.findLast(
+    ([e]) => e === 'change'
+  )?.[1];
+  if (!handler)
+    throw new Error('PaymentElement change listener not registered');
+  act(() => {
+    handler(event);
+  });
+};
+
+const renderAndSelectPaypal = () => {
+  render(<CheckoutForm {...baseProps} />);
+  fireStripeReady();
+  fireEvent.click(screen.getByTestId('consent-checkbox'));
+  fireStripeChange({
+    complete: true,
+    value: { type: 'external_paypal' },
+  });
+};
+
+const getPaypalProps = (): PayPalButtonsMockProps => {
+  if (!mockLastPaypalProps) throw new Error('PayPalButtons not rendered');
+  return mockLastPaypalProps;
+};
+
+describe('CheckoutForm', () => {
+  beforeEach(() => {
+    mockPaymentElementListeners.length = 0;
+    mockLastPaypalProps = null;
+    mockPaypalScriptState.isPending = false;
+    mockPaypalScriptState.isRejected = false;
+    mockRouterPush.mockReset();
+    mockElementsSubmit.mockReset();
+    mockCreateConfirmationToken.mockReset();
+    mockCheckoutCartWithStripe.mockReset();
+    mockCheckoutCartWithPaypal.mockReset();
+    mockFinalizeCartWithError.mockReset();
+    mockHandleStripeErrorAction.mockReset();
+    mockRecordEmitterEventAction.mockReset();
+    mockGetPayPalCheckoutToken.mockReset();
+  });
+
+  describe('Stripe payment path', () => {
+    it('renders the payment element, consent checkbox, and submit button when Stripe is ready', () => {
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+
+      expect(screen.getByTestId('payment-element')).toBeInTheDocument();
+      expect(screen.getByTestId('consent-checkbox')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Subscribe Now/i })
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('paypal-buttons')).not.toBeInTheDocument();
+    });
+
+    it('keeps the submit button disabled until consent is given and stripe fields are complete', () => {
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+
+      const submitButton = screen.getByRole('button', {
+        name: /Subscribe Now/i,
+      });
+      expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+
+      fireEvent.click(screen.getByTestId('consent-checkbox'));
+      fireStripeChange({ complete: false, value: { type: 'card' } });
+      expect(submitButton).toHaveAttribute('aria-disabled', 'true');
+
+      fireStripeChange({ complete: true, value: { type: 'card' } });
+      expect(submitButton).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('shows a loading spinner and disables the submit button while submission is in flight', async () => {
+      mockElementsSubmit.mockImplementation(() => new Promise(() => {}));
+
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+      fireEvent.click(screen.getByTestId('consent-checkbox'));
+      fireStripeChange({ complete: true, value: { type: 'card' } });
+
+      const form = screen.getByRole('form', { name: /Checkout form/i });
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        const button = screen.getByRole('button');
+        expect(button).toHaveAttribute('aria-disabled', 'true');
+        expect(button.querySelector('img.animate-spin')).toBeInTheDocument();
+      });
+    });
+
+    it('re-enables the form and calls handleStripeErrorAction when payment confirmation fails', async () => {
+      mockElementsSubmit.mockResolvedValue({ error: undefined });
+      mockCreateConfirmationToken.mockResolvedValue({
+        error: {
+          type: 'card_error',
+          code: 'card_declined',
+          message: 'Your card was declined.',
+        },
+      });
+      mockHandleStripeErrorAction.mockResolvedValue(undefined);
+
+      render(<CheckoutForm {...baseProps} />);
+      fireStripeReady();
+      fireEvent.click(screen.getByTestId('consent-checkbox'));
+      fireStripeChange({ complete: true, value: { type: 'card' } });
+
+      const form = screen.getByRole('form', { name: /Checkout form/i });
+      fireEvent.submit(form);
+
+      await waitFor(() => {
+        expect(mockHandleStripeErrorAction).toHaveBeenCalledWith(
+          'cart-id',
+          expect.objectContaining({ type: 'card_error' }),
+          '/test/checkout/cart-id',
+          expect.any(Object)
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /Subscribe Now/i })
+        ).toHaveAttribute('aria-disabled', 'false');
+      });
+
+      expect(mockCheckoutCartWithStripe).not.toHaveBeenCalled();
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PayPal payment path', () => {
+    it('checks out the cart and routes to processing when PayPal onApprove is invoked', async () => {
+      mockCheckoutCartWithPaypal.mockResolvedValue(undefined);
+      renderAndSelectPaypal();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('paypal-buttons')).toBeInTheDocument();
+      });
+      const { onApprove } = getPaypalProps();
+
+      await act(async () => {
+        await onApprove({ orderID: 'order-id-123' });
+      });
+
+      expect(mockCheckoutCartWithPaypal).toHaveBeenCalledWith(
+        'cart-id',
+        1,
+        expect.any(Object),
+        expect.any(Object),
+        expect.any(Object),
+        'session-uid',
+        'order-id-123'
+      );
+      expect(mockRouterPush).toHaveBeenCalledWith('./processing');
+    });
+
+    it('finalizes the cart with an error and routes to error when PayPal onError is invoked', async () => {
+      mockFinalizeCartWithError.mockResolvedValue(undefined);
+      renderAndSelectPaypal();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('paypal-buttons')).toBeInTheDocument();
+      });
+      const { onError } = getPaypalProps();
+
+      await act(async () => {
+        await onError(new Error('paypal failure'));
+      });
+
+      expect(mockFinalizeCartWithError).toHaveBeenCalledWith(
+        'cart-id',
+        'basic-error'
+      );
+      expect(mockRouterPush).toHaveBeenCalledWith('./error');
+      expect(screen.getByTestId('paypal-buttons')).toBeInTheDocument();
+      expect(mockCheckoutCartWithPaypal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/CouponForm/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/CouponForm/index.test.tsx
@@ -1,0 +1,153 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@radix-ui/react-form');
+
+jest.mock('react-dom', () => {
+  const React = jest.requireActual('react');
+  const actual = jest.requireActual('react-dom');
+  return {
+    ...actual,
+    useFormState: <S, P>(
+      action: (state: S, payload: P) => Promise<S> | S,
+      initial: S
+    ) => {
+      const [state, setState] = React.useState<S>(initial);
+      const formAction = async (payload: P) => {
+        const result = await action(state, payload);
+        setState(result);
+        return result;
+      };
+      return [state, formAction];
+    },
+    useFormStatus: () => ({
+      pending: false,
+      data: null,
+      method: null,
+      action: null,
+    }),
+  };
+});
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockRouterPush = jest.fn();
+const mockSearchParamsRef: { current: URLSearchParams } = {
+  current: new URLSearchParams(''),
+};
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+  usePathname: () => '/test/path',
+  useSearchParams: () => mockSearchParamsRef.current,
+}));
+
+const mockApplyCouponAction = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  applyCouponAction: (...args: unknown[]) => mockApplyCouponAction(...args),
+}));
+
+import { CouponForm } from './index';
+import { CouponErrorMessageType } from '../../../utils/error-ftl-messages';
+
+const baseProps = {
+  cartId: 'cart-id',
+  cartVersion: 1,
+  readOnly: false,
+};
+
+describe('CouponForm', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockApplyCouponAction.mockReset();
+    mockSearchParamsRef.current = new URLSearchParams('');
+  });
+
+  it('submits the entered coupon code to applyCouponAction without setting an error', async () => {
+    mockApplyCouponAction.mockResolvedValue(undefined);
+
+    render(<CouponForm {...baseProps} promoCode={null} />);
+
+    fireEvent.change(screen.getByTestId('coupon-input'), {
+      target: { value: 'SAVE10' },
+    });
+    fireEvent.click(screen.getByTestId('coupon-button'));
+
+    await waitFor(() => {
+      expect(mockApplyCouponAction).toHaveBeenCalledWith(
+        'cart-id',
+        1,
+        'SAVE10'
+      );
+    });
+
+    expect(screen.queryByTestId('coupon-error')).not.toBeInTheDocument();
+  });
+
+  it('shows the error fallback text and keeps the input visible when an invalid coupon is submitted', async () => {
+    mockApplyCouponAction.mockResolvedValue(CouponErrorMessageType.Invalid);
+
+    render(<CouponForm {...baseProps} promoCode={null} />);
+
+    fireEvent.change(screen.getByTestId('coupon-input'), {
+      target: { value: 'BADCODE' },
+    });
+    fireEvent.click(screen.getByTestId('coupon-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('coupon-error')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/code you entered is invalid/i)).toBeInTheDocument();
+    expect(screen.getByTestId('coupon-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('coupon-hascoupon')).not.toBeInTheDocument();
+  });
+
+  it('removes an applied coupon and resets to the input view when re-rendered without a promoCode', async () => {
+    mockApplyCouponAction.mockResolvedValue(undefined);
+
+    const { rerender } = render(
+      <CouponForm {...baseProps} promoCode="SAVE10" />
+    );
+
+    expect(screen.getByTestId('coupon-hascoupon')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('coupon-remove-button'));
+
+    await waitFor(() => {
+      expect(mockApplyCouponAction).toHaveBeenCalledWith('cart-id', 1, '');
+    });
+
+    rerender(<CouponForm {...baseProps} promoCode={null} />);
+
+    expect(screen.queryByTestId('coupon-hascoupon')).not.toBeInTheDocument();
+    expect(screen.getByTestId('coupon-input')).toBeInTheDocument();
+  });
+
+  it('auto-applies a coupon from the search params on mount without user action', async () => {
+    mockApplyCouponAction.mockResolvedValue(undefined);
+    mockSearchParamsRef.current = new URLSearchParams('coupon=AUTOCODE');
+
+    render(<CouponForm {...baseProps} promoCode={null} />);
+
+    await waitFor(() => {
+      expect(mockApplyCouponAction).toHaveBeenCalledWith(
+        'cart-id',
+        1,
+        'AUTOCODE'
+      );
+    });
+
+    expect(screen.queryByTestId('coupon-error')).not.toBeInTheDocument();
+    expect(screen.getByTestId('coupon-input')).toBeInTheDocument();
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/SelectTaxLocation/index.test.tsx
@@ -1,0 +1,340 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@radix-ui/react-form');
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt ?? ''} className={className} src="mock-image" />
+  ),
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+jest.mock('i18n-iso-countries', () => ({
+  __esModule: true,
+  default: {
+    registerLocale: jest.fn(),
+    getNames: () => ({
+      US: 'United States',
+      CA: 'Canada',
+      DE: 'Germany',
+      GB: 'United Kingdom',
+      IR: 'Iran',
+    }),
+  },
+  registerLocale: jest.fn(),
+  getNames: () => ({
+    US: 'United States',
+    CA: 'Canada',
+    DE: 'Germany',
+    GB: 'United Kingdom',
+    IR: 'Iran',
+  }),
+}));
+
+const mockValidateAndFormatPostalCode = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  validateAndFormatPostalCode: (...args: unknown[]) =>
+    mockValidateAndFormatPostalCode(...args),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  ButtonVariant: { Primary: 'primary', Secondary: 'secondary' },
+  BaseButton: ({
+    children,
+    className,
+    disabled,
+    onClick,
+    type = 'button',
+    'data-testid': testId,
+    'aria-disabled': ariaDisabled,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    disabled?: boolean;
+    onClick?: () => void;
+    type?: 'submit' | 'button' | 'reset';
+    'data-testid'?: string;
+    'aria-disabled'?: boolean;
+  }) => (
+    <button
+      type={type}
+      className={className}
+      disabled={disabled}
+      onClick={onClick}
+      data-testid={testId}
+      aria-disabled={ariaDisabled}
+    >
+      {children}
+    </button>
+  ),
+  SubmitButton: ({
+    children,
+    className,
+    'data-testid': testId,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    'data-testid'?: string;
+  }) => (
+    <button type="submit" className={className} data-testid={testId}>
+      {children}
+    </button>
+  ),
+}));
+
+import { SelectTaxLocation } from './index';
+
+const baseSaveAction = jest.fn();
+
+const baseProps = {
+  saveAction: (...args: unknown[]) => baseSaveAction(...args),
+  cmsCountries: ['US', 'CA', 'DE'],
+  locale: 'en',
+  productName: 'Mozilla VPN',
+  unsupportedLocations: 'IR',
+  countryCode: undefined,
+  postalCode: undefined,
+  currentCurrency: 'usd',
+  showNewTaxRateInfoMessage: false,
+};
+
+describe('SelectTaxLocation', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockValidateAndFormatPostalCode.mockReset();
+    baseSaveAction.mockReset();
+  });
+
+  describe('Expanded/collapsed toggle', () => {
+    it('starts collapsed when an existing location is provided, expands on edit, and collapses on cancel', async () => {
+      render(
+        <SelectTaxLocation
+          {...baseProps}
+          countryCode="US"
+          postalCode="94107"
+        />
+      );
+
+      expect(screen.getByTestId('tax-location-haslocation')).toBeInTheDocument();
+      expect(screen.getByText('US, 94107')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('select-location-form')
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('tax-location-edit-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('select-location-form')).toBeInTheDocument();
+      });
+      expect(screen.getByLabelText(/Country/i)).toBeInTheDocument();
+      expect(screen.getByTestId('postal-code')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('tax-location-cancel-button'));
+
+      expect(screen.getByTestId('tax-location-haslocation')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('select-location-form')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Successful save', () => {
+    it('calls saveAction, collapses to the updated location, and shows the success alert', async () => {
+      mockValidateAndFormatPostalCode.mockResolvedValue({
+        isValid: true,
+        formattedPostalCode: 'A1B 2C3',
+      });
+      baseSaveAction.mockResolvedValue({
+        ok: true,
+        data: { countryCode: 'CA', postalCode: 'A1B 2C3' },
+      });
+
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Canada' })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/Country/i), {
+        target: { value: 'CA' },
+      });
+      fireEvent.change(screen.getByTestId('postal-code'), {
+        target: { value: 'a1b2c3' },
+      });
+
+      fireEvent.submit(screen.getByTestId('select-location-form'));
+
+      await waitFor(() => {
+        expect(baseSaveAction).toHaveBeenCalledWith('CA', 'A1B 2C3');
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('tax-location-haslocation')
+        ).toBeInTheDocument();
+      });
+      expect(screen.getByText('CA, A1B 2C3')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Your location has been updated/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Validation and error states', () => {
+    it('flips into the missing-country error state when the country select dispatches an invalid event with no value', async () => {
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Canada' })).toBeInTheDocument();
+      });
+
+      fireEvent.invalid(screen.getByLabelText(/Country/i));
+
+      expect(
+        screen.getByText(/Please select your country/i)
+      ).toBeInTheDocument();
+    });
+
+    it('shows the product-not-available error when a country outside cmsCountryCodes is selected', async () => {
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('option', { name: 'United Kingdom' })
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/Country/i), {
+        target: { value: 'GB' },
+      });
+
+      expect(
+        screen.getByText(/Mozilla VPN is not available in this location/i)
+      ).toBeInTheDocument();
+    });
+
+    it('shows the unsupported-country error when a sanctioned country is selected', async () => {
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Iran' })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/Country/i), {
+        target: { value: 'IR' },
+      });
+
+      expect(
+        screen.getByText(/not supported according to our Terms of Service/i)
+      ).toBeInTheDocument();
+    });
+
+    it('shows the invalid-postal-code error when validation fails', async () => {
+      mockValidateAndFormatPostalCode.mockResolvedValue({ isValid: false });
+
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Canada' })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/Country/i), {
+        target: { value: 'CA' },
+      });
+      fireEvent.change(screen.getByTestId('postal-code'), {
+        target: { value: '!!bad!!' },
+      });
+      fireEvent.submit(screen.getByTestId('select-location-form'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Please enter a valid postal code/i)
+        ).toBeInTheDocument();
+      });
+      expect(baseSaveAction).not.toHaveBeenCalled();
+    });
+
+    it('shows the invalid-currency-change error when saveAction returns a currency_change error', async () => {
+      mockValidateAndFormatPostalCode.mockResolvedValue({
+        isValid: true,
+        formattedPostalCode: '10115',
+      });
+      baseSaveAction.mockResolvedValue({
+        ok: false,
+        error: 'currency_change',
+      });
+
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Germany' })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/Country/i), {
+        target: { value: 'DE' },
+      });
+      fireEvent.change(screen.getByTestId('postal-code'), {
+        target: { value: '10115' },
+      });
+      fireEvent.submit(screen.getByTestId('select-location-form'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Select a country that uses the/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('shows the location-not-updated error and keeps the form interactive when saveAction throws', async () => {
+      mockValidateAndFormatPostalCode.mockResolvedValue({
+        isValid: true,
+        formattedPostalCode: '94107',
+      });
+      baseSaveAction.mockRejectedValue(new Error('network down'));
+
+      render(<SelectTaxLocation {...baseProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: 'Canada' })).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByLabelText(/Country/i), {
+        target: { value: 'CA' },
+      });
+      fireEvent.change(screen.getByTestId('postal-code'), {
+        target: { value: 'A1B 2C3' },
+      });
+      fireEvent.submit(screen.getByTestId('select-location-form'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/Your location could not be updated/i)
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('tax-location-save-button')).not.toBeDisabled();
+      expect(screen.getByLabelText(/Country/i)).not.toBeDisabled();
+      expect(screen.getByTestId('postal-code')).not.toBeDisabled();
+    });
+  });
+});

--- a/libs/payments/ui/src/lib/client/components/StaySubscribed/index.test.tsx
+++ b/libs/payments/ui/src/lib/client/components/StaySubscribed/index.test.tsx
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+jest.mock('@radix-ui/react-form');
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  Localized: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockRouterPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ alt, className }: { alt?: string; className?: string }) => (
+    <img alt={alt ?? ''} className={className} src="mock-image" />
+  ),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    className,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  }) => (
+    <a href={href} className={className} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockResubscribeSubscriptionAction = jest.fn();
+
+jest.mock('@fxa/payments/ui/actions', () => ({
+  __esModule: true,
+  resubscribeSubscriptionAction: (...args: unknown[]) =>
+    mockResubscribeSubscriptionAction(...args),
+}));
+
+jest.mock('@fxa/payments/ui', () => ({
+  __esModule: true,
+  ButtonVariant: { Primary: 'primary' },
+  SubmitButton: ({
+    children,
+    className,
+    disabled,
+    'aria-label': ariaLabel,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    disabled?: boolean;
+    'aria-label'?: string;
+  }) => (
+    <button
+      type="submit"
+      className={className}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </button>
+  ),
+}));
+
+import { StaySubscribed } from './index';
+
+const basePageContent = {
+  active: true,
+  cancelAtPeriodEnd: true,
+  currency: 'usd',
+  currentPeriodEnd: 1735689600,
+  productName: 'Mozilla VPN',
+  webIcon: 'https://example.com/icon.png',
+};
+
+const baseProps = {
+  userId: 'user-id',
+  subscriptionId: 'sub-id',
+  locale: 'en',
+  pageContent: basePageContent,
+};
+
+describe('StaySubscribed', () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockResubscribeSubscriptionAction.mockReset();
+  });
+
+  describe('Resubscribe view', () => {
+    it('renders the product name, the next charge with a tax line, and a resubscribe button when nextInvoiceTax is present', () => {
+      render(
+        <StaySubscribed
+          {...baseProps}
+          pageContent={{
+            ...basePageContent,
+            nextInvoiceTotal: 999,
+            nextInvoiceTax: 100,
+          }}
+        />
+      );
+
+      expect(
+        screen.getByRole('heading', { name: /Want to keep using Mozilla VPN/i })
+      ).toBeInTheDocument();
+      expect(screen.getByText(/\$1\.00 tax/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Resubscribe to Mozilla VPN/i })
+      ).toBeInTheDocument();
+    });
+
+    it('renders the next charge without a tax line when nextInvoiceTax is absent', () => {
+      render(
+        <StaySubscribed
+          {...baseProps}
+          pageContent={{
+            ...basePageContent,
+            nextInvoiceTotal: 999,
+          }}
+        />
+      );
+
+      expect(
+        screen.getByRole('heading', { name: /Want to keep using Mozilla VPN/i })
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/tax/i)).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Resubscribe to Mozilla VPN/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Resubscribe error path', () => {
+    it('shows an error message and keeps the form interactive when the resubscribe action fails', async () => {
+      mockResubscribeSubscriptionAction.mockResolvedValue({ ok: false });
+
+      render(
+        <StaySubscribed
+          {...baseProps}
+          pageContent={{
+            ...basePageContent,
+            nextInvoiceTotal: 999,
+          }}
+        />
+      );
+
+      const submitButton = screen.getByRole('button', {
+        name: /Resubscribe to Mozilla VPN/i,
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/An unexpected error occurred/i)
+        ).toBeInTheDocument();
+      });
+
+      expect(mockResubscribeSubscriptionAction).toHaveBeenCalledWith(
+        'user-id',
+        'sub-id'
+      );
+
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+});

--- a/libs/payments/ui/test/__mocks__/file-mock.js
+++ b/libs/payments/ui/test/__mocks__/file-mock.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = 'test-file-stub';

--- a/libs/payments/ui/test/jest.setup.ts
+++ b/libs/payments/ui/test/jest.setup.ts
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom';

--- a/libs/payments/ui/tsconfig.spec.json
+++ b/libs/payments/ui/tsconfig.spec.json
@@ -8,7 +8,11 @@
   "include": [
     "jest.config.ts",
     "src/**/*.test.ts",
+    "src/**/*.test.tsx",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.spec.tsx",
+    "src/**/*.d.ts",
+    "test/**/*.ts",
+    "test/**/*.tsx"
   ]
 }


### PR DESCRIPTION
## Because

- We want some basic tests for our components to prevent regressions

## This pull request

- Adds basic tests for our critical components

## Issue that this pull request solves

Closes PAY-3691
Closes PAY-3692
Closes PAY-3693
Closes PAY-3694
Closes PAY-3695