### PR TITLE
feat(payments-next): derive uid from session in sa

### DIFF
--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/checkout/[cartId]/layout.tsx
@@ -150,7 +150,6 @@ export default async function CheckoutLayout({
                         countryCode,
                         postalCode,
                       },
-                      session?.user?.id,
                       resolvedParams.interval
                     );
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/location/page.tsx
@@ -19,7 +19,6 @@ import { getApp, TermsAndPrivacy } from '@fxa/payments/ui/server';
 import locationIcon from '@fxa/shared/assets/images/confirm-pairing.svg';
 import type { PageContentOfferingTransformed } from '@fxa/shared/cms';
 import { config } from 'apps/payments/next/config';
-import { auth } from 'apps/payments/next/auth';
 import { TaxChangeAllowedStatus } from '@fxa/payments/cart';
 
 export const dynamic = 'force-dynamic';
@@ -36,7 +35,6 @@ export default async function Location({
   const acceptLanguage = (await headers()).get('accept-language');
   const l10n = getApp().getL10n(acceptLanguage, resolvedParams.locale);
   const emitterService = getApp().getEmitterService();
-  const session = await auth();
   const providedCountryCode = resolvedSearchParams['countryCode'];
   const providedPostalCode = resolvedSearchParams['postalCode'];
   const taxAddress =
@@ -51,15 +49,13 @@ export default async function Location({
         }
       : undefined;
 
-  const fxaUid = session?.user?.id;
-
   let cms: PageContentOfferingTransformed | undefined;
   let locationStatus: LocationStatus | TaxChangeAllowedStatus | undefined;
   let customerCurrency: string | undefined;
   try {
     const [cmsData, validateLocationResults] = await Promise.all([
       fetchCMSData(resolvedParams.offeringId, acceptLanguage, resolvedParams.locale),
-      validateLocationAction(resolvedParams.offeringId, taxAddress, fxaUid, resolvedParams.interval),
+      validateLocationAction(resolvedParams.offeringId, taxAddress, resolvedParams.interval),
     ]);
     cms = cmsData;
     locationStatus = validateLocationResults.status;
@@ -166,7 +162,6 @@ export default async function Location({
               const result = await validateLocationAction(
                 resolvedParams.offeringId,
                 { countryCode, postalCode },
-                fxaUid,
                 resolvedParams.interval
               );
 

--- a/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
+++ b/apps/payments/next/app/[locale]/[offeringId]/[interval]/new/page.tsx
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { auth } from 'apps/payments/next/auth';
 import { notFound, redirect } from 'next/navigation';
 import {
   validateLocationAction,
@@ -58,9 +57,7 @@ export default async function New({
   const resolvedSearchParams = await searchParams;
   const { offeringId, interval } = resolvedParams;
   const ipAddress = await getIpAddress();
-  const session = await auth();
 
-  const fxaUid = session?.user?.id;
   const searchParamsCoupon = Array.isArray(resolvedSearchParams.coupon)
     ? resolvedSearchParams.coupon[0]
     : resolvedSearchParams.coupon || undefined;
@@ -74,14 +71,13 @@ export default async function New({
   const taxAddress =
     countryCode && postalCode
       ? { countryCode, postalCode }
-      : await getTaxAddressAction(ipAddress, fxaUid);
+      : await getTaxAddressAction(ipAddress);
 
   // Check if the customer is in a location not supported by Subscription Platform
   // or whether the product is not available in the customer's location
   const { isValid: locationIsValid } = await validateLocationAction(
     offeringId,
     taxAddress,
-    fxaUid,
     interval
   );
 
@@ -128,8 +124,7 @@ export default async function New({
       offeringId,
       taxAddress,
       undefined,
-      cartCoupon || searchParamsCoupon,
-      fxaUid
+      cartCoupon || searchParamsCoupon
     );
 
     redirectToUrl = getRedirectToUrl(cart, resolvedParams, resolvedSearchParams);
@@ -143,8 +138,7 @@ export default async function New({
         offeringId,
         taxAddress,
         undefined,
-        undefined,
-        fxaUid
+        undefined
       );
       redirectToUrl = getRedirectToUrl(cart, resolvedParams, resolvedSearchParams);
     } else if (

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/cancel/page.tsx
@@ -29,10 +29,7 @@ export default async function CancelSubscriptionPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   const pageContent = await getCancelFlowContentAction(
-    uid,
     subscriptionId,
     acceptLanguage
   );
@@ -43,7 +40,6 @@ export default async function CancelSubscriptionPage({
 
   return (
     <CancelSubscription
-      userId={uid}
       subscriptionId={subscriptionId}
       locale={locale}
       pageContent={pageContent}

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/error/page.tsx
@@ -43,12 +43,9 @@ export default async function LoyaltyDiscountCancelErrorPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   let pageContent;
   try {
     pageContent = await determineChurnCancelEligibilityAction(
-      uid,
       subscriptionId,
       acceptLanguage
     );

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/cancel/page.tsx
@@ -39,12 +39,9 @@ export default async function LoyaltyDiscountCancelPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   let pageContent;
   try {
     pageContent = await determineChurnCancelEligibilityAction(
-      uid,
       subscriptionId,
       acceptLanguage
     );
@@ -89,7 +86,6 @@ export default async function LoyaltyDiscountCancelPage({
 
   return (
     <ChurnCancel
-      uid={uid}
       metricsEnabled={session?.user?.metricsEnabled ?? true}
       subscriptionId={subscriptionId}
       locale={locale}

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/error/page.tsx
@@ -40,12 +40,9 @@ export default async function LoyaltyDiscountStaySubscribedErrorPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   let pageContent;
   try {
     pageContent = await determineStaySubscribedEligibilityAction(
-      uid,
       subscriptionId,
       acceptLanguage
     );

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/loyalty-discount/stay-subscribed/page.tsx
@@ -39,12 +39,9 @@ export default async function LoyaltyDiscountStaySubscribedPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   let pageContent;
   try {
     pageContent = await determineStaySubscribedEligibilityAction(
-      uid,
       subscriptionId,
       acceptLanguage
     );
@@ -88,7 +85,6 @@ export default async function LoyaltyDiscountStaySubscribedPage({
   if (isAllowedStayReason) {
     return (
       <ChurnStaySubscribed
-        uid={uid}
         metricsEnabled={session?.user?.metricsEnabled ?? true}
         subscriptionId={subscriptionId}
         locale={locale}

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/error/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/error/page.tsx
@@ -44,13 +44,10 @@ export default async function InterstitialOfferErrorPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   let interstitialOfferContent = null;
 
   try {
     interstitialOfferContent = await getInterstitialOfferContentAction(
-      uid,
       subscriptionId,
       acceptLanguage,
       locale

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/offer/page.tsx
@@ -41,12 +41,9 @@ export default async function InterstitialOfferPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   let interstitialOfferContent;
   try {
     interstitialOfferContent = await getInterstitialOfferContentAction(
-      uid,
       subscriptionId,
       acceptLanguage,
       locale
@@ -74,7 +71,6 @@ export default async function InterstitialOfferPage({
 
   return (
     <InterstitialOffer
-      uid={uid}
       metricsEnabled={session?.user?.metricsEnabled ?? true}
       locale={locale}
       subscriptionId={subscriptionId}

--- a/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/[subscriptionId]/stay-subscribed/page.tsx
@@ -30,10 +30,7 @@ export default async function StaySubscribedPage({
     redirect(redirectToUrl.href);
   }
 
-  const uid = session.user.id;
-
   const pageContent = await getStaySubscribedFlowContentAction(
-    uid,
     subscriptionId,
     acceptLanguage
   );
@@ -44,7 +41,6 @@ export default async function StaySubscribedPage({
 
   return (
     <StaySubscribed
-      userId={uid}
       subscriptionId={subscriptionId}
       locale={locale}
       pageContent={pageContent}

--- a/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/manage/page.tsx
@@ -56,7 +56,6 @@ export default async function Manage({
     redirect(redirectToUrl.href);
   }
 
-  const userId = session.user.id;
   const entrypoint =
     resolvedSearchParams?.utm_medium === 'email'
       ? 'email'
@@ -64,7 +63,6 @@ export default async function Manage({
         ? 'internal_nav'
         : undefined;
   const experiments = await getExperimentsAction({
-    fxaUid: userId,
     language: locale,
     experimentationPreview:
       resolvedSearchParams?.experimentationPreview === 'true',
@@ -79,7 +77,6 @@ export default async function Manage({
     googleIapSubscriptions,
     trialSubscriptions,
   } = await getSubManPageContentAction(
-    session.user?.id,
     { ...resolvedParams },
     { ...resolvedSearchParams },
     acceptLanguage,
@@ -343,7 +340,6 @@ export default async function Manage({
                       <FreeTrialContent
                         trial={trial}
                         locale={locale}
-                        userId={userId}
                         updatePaymentUrl={
                           type === SubPlatPaymentMethodType.PayPal
                             ? `${config.paymentsNextHostedUrl}/${locale}/subscriptions/payments/paypal`

--- a/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/paypal/page.tsx
@@ -33,10 +33,9 @@ export default async function PaypalPaymentManagementPage({
   if (!session?.user?.id) {
     redirect(`${config.paymentsNextHostedUrl}/${locale}/subscriptions/landing`);
   }
-  const sessionUid = session.user.id;
   const [paypalBillingAgreementId, currency] = await Promise.all([
-    getPayPalBillingAgreementId(session.user.id),
-    determineCurrencyForCustomerAction(session.user.id),
+    getPayPalBillingAgreementId(),
+    determineCurrencyForCustomerAction(),
   ]);
 
   if (paypalBillingAgreementId || !currency) {
@@ -97,7 +96,6 @@ export default async function PaypalPaymentManagementPage({
             ></div>
           </div>
           <PaypalManagement
-            sessionUid={sessionUid}
             paypalClientId={config.paypal.clientId}
             nonce={nonce}
             currency={currency}

--- a/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
+++ b/apps/payments/next/app/[locale]/subscriptions/payments/stripe/page.tsx
@@ -28,7 +28,7 @@ export default async function StripePaymentManagementPage({
 
   let stripeClientSession;
   try {
-    stripeClientSession = await getStripeClientSession(session.user.id);
+    stripeClientSession = await getStripeClientSession();
   } catch (error) {
     if (error.name === 'AccountCustomerNotFoundError') {
       // TODO: replace with redirect to collect tax location data and create customer / accountCustomer
@@ -58,7 +58,6 @@ export default async function StripePaymentManagementPage({
         instanceKey={instanceKey}
       >
         <PaymentMethodManagement
-          uid={session?.user?.id}
           defaultPaymentMethod={defaultPaymentMethod}
           sessionEmail={session?.user?.email ?? undefined}
           locale={locale}

--- a/apps/payments/next/auth.ts
+++ b/apps/payments/next/auth.ts
@@ -2,115 +2,23 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import NextAuth from 'next-auth';
-import { authConfig } from './auth.config';
+import { setupAuth } from '@fxa/payments/ui-auth';
 import { config } from './config';
-import { BaseError } from '@fxa/shared/error';
 
-import { getApp } from '@fxa/payments/ui/server';
-
-export class AuthError extends BaseError {
-  constructor(...args: ConstructorParameters<typeof BaseError>) {
-    super(...args);
-    this.name = 'AuthError';
-  }
-}
+export { AuthError } from '@fxa/payments/ui-auth';
 
 export const {
   handlers: { GET, POST },
   auth,
   signIn,
   signOut,
-} = NextAuth({
-  ...authConfig,
-  pages: {
-    error: '/auth/error',
-  },
-  providers: [
-    {
-      id: 'fxa',
-      name: 'Firefox Accounts',
-      type: 'oauth',
-      issuer: config.auth.issuerUrl,
-      wellKnown: config.auth.wellKnownUrl,
-      checks: ['state'],
-      authorization: { params: { scope: 'email profile' } },
-      clientId: config.auth.clientId,
-      clientSecret: config.auth.clientSecret,
-      token: config.auth.tokenUrl,
-      profile: (profile) => {
-        return {
-          id: profile.uid,
-          name: profile.displayName,
-          email: profile.email,
-          image: profile.avatar,
-          metricsEnabled: profile.metricsEnabled ?? true,
-        };
-      },
-      userinfo: {
-        url: config.auth.userinfoUrl,
-        request: (context: { tokens: { access_token?: string } }) =>
-          getApp()
-            .getActionsService()
-            .getUserinfo({
-              userinfoUrl: config.auth.userinfoUrl,
-              accessToken: context.tokens.access_token ?? '',
-            }),
-      },
-    },
-  ],
-  callbacks: {
-    async session({ session, token }) {
-      session.user = { ...session.user, ...(token.user as any) };
-      return session;
-    },
-    async jwt({ token, profile }) {
-      // Note profile is only defined once after user sign in and not on subsequent calls.
-      if (profile) {
-        token.user = {
-          id: profile.uid,
-          name: profile.displayName,
-          email: profile.email,
-          image: profile.avatar,
-          metricsEnabled: profile.metricsEnabled ?? true,
-        };
-      }
-      return {
-        ...token,
-      };
-    },
-    async redirect({ url, baseUrl }) {
-      // Allows relative callback URLs
-      if (url.startsWith('/')) return `${baseUrl}${url}`;
-
-      // Allows callback URLs on the same origin and to MzAs content server
-      const urlOrigin = new URL(url).origin;
-      if (
-        urlOrigin === baseUrl ||
-        urlOrigin === config.contentServerUrl ||
-        urlOrigin === config.paymentsNextHostedUrl // Support for local HTTPS
-      ) {
-        return url;
-      }
-
-      return baseUrl;
-    },
-  },
-  events: {
-    async signIn() {
-      getApp().getEmitterService().emit('auth', { type: 'signin' });
-    },
-    async signOut() {
-      getApp().getEmitterService().emit('auth', { type: 'signout' });
-    },
-  },
-  logger: {
-    error(error: Error) {
-      getApp()
-        .getLogger()
-        .error(error.message, {
-          error: new AuthError(error.message, { cause: error }),
-        });
-    },
-  },
+} = setupAuth({
+  issuerUrl: config.auth.issuerUrl,
+  wellKnownUrl: config.auth.wellKnownUrl,
+  tokenUrl: config.auth.tokenUrl,
+  userinfoUrl: config.auth.userinfoUrl,
+  clientId: config.auth.clientId,
+  clientSecret: config.auth.clientSecret,
+  contentServerUrl: config.contentServerUrl,
+  paymentsNextHostedUrl: config.paymentsNextHostedUrl,
 });

--- a/apps/payments/next/instrumentation.ts
+++ b/apps/payments/next/instrumentation.ts
@@ -18,16 +18,23 @@ export async function register() {
 
     const otelConfig = app.getOtelConfig();
     const logger = app.getLogger();
-    initTracing({
-      ...otelConfig,
-      batchProcessor: otelConfig.batchProcessor ?? true,
-      clientName: otelConfig.clientName ?? "",
-      corsUrls: otelConfig.corsUrls ?? "http://localhost:\\d*/",
-      filterPii: otelConfig.filterPii ?? true,
-      sampleRate: otelConfig.sampleRate ?? 0,
-      serviceName: otelConfig.serviceName ?? "",
-    }, logger);
+    initTracing(
+      {
+        ...otelConfig,
+        batchProcessor: otelConfig.batchProcessor ?? true,
+        clientName: otelConfig.clientName ?? '',
+        corsUrls: otelConfig.corsUrls ?? 'http://localhost:\\d*/',
+        filterPii: otelConfig.filterPii ?? true,
+        sampleRate: otelConfig.sampleRate ?? 0,
+        serviceName: otelConfig.serviceName ?? '',
+      },
+      logger
+    );
 
     monkeyPatchServerLogging();
+
+    // Initialize NextAuth singleton so server actions calling getSessionUid()
+    // work regardless of which routes the worker ends up serving.
+    await import('./auth');
   }
 }

--- a/libs/payments/ui-auth/.eslintrc.json
+++ b/libs/payments/ui-auth/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/payments/ui-auth/.swcrc
+++ b/libs/payments/ui-auth/.swcrc
@@ -1,0 +1,14 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    }
+  }
+}

--- a/libs/payments/ui-auth/README.md
+++ b/libs/payments/ui-auth/README.md
@@ -1,0 +1,11 @@
+# payments-ui-auth
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build payments-ui-auth` to build the library.
+
+## Running unit tests
+
+Run `nx run payments-ui-auth:test-unit` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/payments/ui-auth/jest.config.ts
+++ b/libs/payments/ui-auth/jest.config.ts
@@ -1,0 +1,43 @@
+/* eslint-disable */
+import { readFileSync } from 'fs';
+import { Config } from 'jest';
+
+// Reading the SWC compilation config and remove the "exclude"
+// for the test files to be compiled by SWC
+const { exclude: _, ...swcJestConfig } = JSON.parse(
+  readFileSync(`${__dirname}/.swcrc`, 'utf-8')
+);
+
+// disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves.
+// If we do not disable this, SWC Core will read .swcrc and won't transform our test files due to "exclude"
+if (swcJestConfig.swcrc === undefined) {
+  swcJestConfig.swcrc = false;
+}
+
+// Uncomment if using global setup/teardown files being transformed via swc
+// https://nx.dev/packages/jest/documents/overview#global-setup/teardown-with-nx-libraries
+// jest needs EsModule Interop to find the default exported setup/teardown functions
+// swcJestConfig.module.noInterop = false;
+
+const config: Config = {
+  displayName: 'payments-ui-auth',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  testEnvironment: 'node',
+  coverageDirectory: '../../../coverage/libs/payments/ui-auth',
+  reporters: [
+    'default',
+    [
+      'jest-junit',
+      {
+        outputDirectory: 'artifacts/tests/payments-ui-auth',
+        outputName: 'payments-ui-auth-jest-unit-results.xml',
+      },
+    ],
+  ],
+};
+
+export default config;

--- a/libs/payments/ui-auth/package.json
+++ b/libs/payments/ui-auth/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "payments/ui-auth",
+  "version": "0.0.0"
+}

--- a/libs/payments/ui-auth/project.json
+++ b/libs/payments/ui-auth/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "payments-ui-auth",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/payments/ui/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/payments/ui/**/*.{ts,tsx,js,jsx}"]
+      }
+    },
+    "test-unit": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/payments/ui/jest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/payments/ui-auth/src/index.ts
+++ b/libs/payments/ui-auth/src/index.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export { setupAuth, getAuthInstance } from './lib/auth';
+export type { UiAuthOptions } from './lib/auth';
+export { authConfig } from './lib/auth.config';
+export { AuthError, UnauthenticatedError } from './lib/auth.error';
+export { getSessionUid, requireSessionUid } from './lib/session';

--- a/libs/payments/ui-auth/src/lib/auth.config.ts
+++ b/libs/payments/ui-auth/src/lib/auth.config.ts
@@ -5,5 +5,5 @@
 import type { NextAuthConfig } from 'next-auth';
 
 export const authConfig = {
-  providers: [], // Add providers with an empty array for now
+  providers: [],
 } satisfies NextAuthConfig;

--- a/libs/payments/ui-auth/src/lib/auth.error.ts
+++ b/libs/payments/ui-auth/src/lib/auth.error.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { BaseError } from '@fxa/shared/error';
+
+export class AuthError extends BaseError {
+  constructor(...args: ConstructorParameters<typeof BaseError>) {
+    super(...args);
+    this.name = 'AuthError';
+  }
+}
+
+export class UnauthenticatedError extends AuthError {
+  constructor() {
+    super('Unauthenticated');
+    this.name = 'UnauthenticatedError';
+  }
+}

--- a/libs/payments/ui-auth/src/lib/auth.ts
+++ b/libs/payments/ui-auth/src/lib/auth.ts
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import NextAuth from 'next-auth';
+import { authConfig } from './auth.config';
+import { AuthError } from './auth.error';
+import { singleton } from './singleton';
+import { getApp } from '@fxa/payments/ui/server';
+
+export interface UiAuthOptions {
+  issuerUrl: string;
+  wellKnownUrl: string;
+  tokenUrl: string;
+  userinfoUrl: string;
+  clientId: string;
+  clientSecret: string;
+  contentServerUrl: string;
+  paymentsNextHostedUrl: string;
+}
+
+class AuthSingleton {
+  instance: ReturnType<typeof NextAuth> | null = null;
+}
+
+const SINGLETON_NAME = 'uiAuth';
+
+export function setupAuth(opts: UiAuthOptions) {
+  const store = singleton(SINGLETON_NAME, new AuthSingleton()) as AuthSingleton;
+  if (store.instance) {
+    return store.instance;
+  }
+
+  store.instance = NextAuth({
+    ...authConfig,
+    pages: {
+      error: '/auth/error',
+    },
+    providers: [
+      {
+        id: 'fxa',
+        name: 'Firefox Accounts',
+        type: 'oauth',
+        issuer: opts.issuerUrl,
+        wellKnown: opts.wellKnownUrl,
+        checks: ['state'],
+        authorization: { params: { scope: 'email profile' } },
+        clientId: opts.clientId,
+        clientSecret: opts.clientSecret,
+        token: opts.tokenUrl,
+        profile: (profile) => {
+          return {
+            id: profile.uid,
+            name: profile.displayName,
+            email: profile.email,
+            image: profile.avatar,
+            metricsEnabled: profile.metricsEnabled ?? true,
+          };
+        },
+        userinfo: {
+          url: opts.userinfoUrl,
+          request: (context: { tokens: { access_token?: string } }) =>
+            getApp()
+              .getActionsService()
+              .getUserinfo({
+                userinfoUrl: opts.userinfoUrl,
+                accessToken: context.tokens.access_token ?? '',
+              }),
+        },
+      },
+    ],
+    callbacks: {
+      async session({ session, token }) {
+        session.user = { ...session.user, ...(token.user as any) };
+        return session;
+      },
+      async jwt({ token, profile }) {
+        // Note profile is only defined once after user sign in and not on subsequent calls.
+        if (profile) {
+          token.user = {
+            id: profile.uid,
+            name: profile.displayName,
+            email: profile.email,
+            image: profile.avatar,
+            metricsEnabled: profile.metricsEnabled ?? true,
+          };
+        }
+        return {
+          ...token,
+        };
+      },
+      async redirect({ url, baseUrl }) {
+        if (url.startsWith('/')) return `${baseUrl}${url}`;
+
+        const urlOrigin = new URL(url).origin;
+        if (
+          urlOrigin === baseUrl ||
+          urlOrigin === opts.contentServerUrl ||
+          urlOrigin === opts.paymentsNextHostedUrl
+        ) {
+          return url;
+        }
+
+        return baseUrl;
+      },
+    },
+    events: {
+      async signIn() {
+        getApp().getEmitterService().emit('auth', { type: 'signin' });
+      },
+      async signOut() {
+        getApp().getEmitterService().emit('auth', { type: 'signout' });
+      },
+    },
+    logger: {
+      error(error: Error) {
+        getApp()
+          .getLogger()
+          .error(error.message, {
+            error: new AuthError(error.message, { cause: error }),
+          });
+      },
+    },
+  });
+
+  return store.instance;
+}
+
+export function getAuthInstance() {
+  const { instance } = singleton(
+    SINGLETON_NAME,
+    new AuthSingleton()
+  ) as AuthSingleton;
+  if (!instance) {
+    throw new AuthError('setupAuth() must be called before using auth helpers');
+  }
+  return instance;
+}

--- a/libs/payments/ui-auth/src/lib/session.ts
+++ b/libs/payments/ui-auth/src/lib/session.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getAuthInstance } from './auth';
+import { UnauthenticatedError } from './auth.error';
+
+export async function getSessionUid(): Promise<string | undefined> {
+  const session = await getAuthInstance().auth();
+  return session?.user?.id ?? undefined;
+}
+
+export async function requireSessionUid(): Promise<string> {
+  const uid = await getSessionUid();
+  if (!uid) {
+    throw new UnauthenticatedError();
+  }
+  return uid;
+}

--- a/libs/payments/ui-auth/src/lib/singleton.ts
+++ b/libs/payments/ui-auth/src/lib/singleton.ts
@@ -1,0 +1,16 @@
+/***
+ * ISC License
+Copyright 2022 Jon Jensen
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+export function singleton<T>(name: string, value: T, refresh = false) {
+  const yolo = global as any;
+  yolo.__singletons ??= {};
+  if (refresh) {
+    delete yolo.__singletons[name];
+  }
+  yolo.__singletons[name] ??= value;
+  return yolo.__singletons[name];
+}

--- a/libs/payments/ui-auth/tsconfig.json
+++ b/libs/payments/ui-auth/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/payments/ui-auth/tsconfig.lib.json
+++ b/libs/payments/ui-auth/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/payments/ui-auth/tsconfig.spec.json
+++ b/libs/payments/ui-auth/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/payments/ui/src/lib/actions/cancelSubscriptionAtPeriodEnd.ts
+++ b/libs/payments/ui/src/lib/actions/cancelSubscriptionAtPeriodEnd.ts
@@ -5,12 +5,13 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const cancelSubscriptionAtPeriodEndAction = async (
-  uid: string,
   subscriptionId: string
 ) => {
+  const uid = await requireSessionUid();
   const result = await getApp()
     .getActionsService()
     .cancelSubscriptionAtPeriodEnd({

--- a/libs/payments/ui/src/lib/actions/cancelSubscriptionImmediately.ts
+++ b/libs/payments/ui/src/lib/actions/cancelSubscriptionImmediately.ts
@@ -5,12 +5,13 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const cancelSubscriptionImmediatelyAction = async (
-  uid: string,
   subscriptionId: string
 ) => {
+  const uid = await requireSessionUid();
   const result = await getApp()
     .getActionsService()
     .cancelSubscriptionImmediately({

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithPaypal.ts
@@ -4,6 +4,7 @@
 
 'use server';
 
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import type { SubscriptionAttributionParams } from '@fxa/payments/cart';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
@@ -15,9 +16,9 @@ export const checkoutCartWithPaypal = async (
   attribution: SubscriptionAttributionParams,
   params: Record<string, string | string[] | undefined>,
   searchParams: Record<string, string | string[] | undefined>,
-  sessionUid?: string,
   token?: string
 ) => {
+  const sessionUid = await getSessionUid();
   const requestArgs = {
     ...(await getAdditionalRequestArgs()),
     params: flattenRouteParams(params),

--- a/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
+++ b/libs/payments/ui/src/lib/actions/checkoutCartWithStripe.ts
@@ -4,6 +4,7 @@
 
 'use server';
 
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import type { SubscriptionAttributionParams } from '@fxa/payments/cart';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
@@ -15,16 +16,16 @@ export const checkoutCartWithStripe = async (
   confirmationTokenId: string,
   attribution: SubscriptionAttributionParams,
   params: Record<string, string | string[] | undefined>,
-  searchParams: Record<string, string | string[] | undefined>,
-  sessionUid?: string
+  searchParams: Record<string, string | string[] | undefined>
 ) => {
+  const sessionUid = await getSessionUid();
   const requestArgs = {
     ...(await getAdditionalRequestArgs()),
     params: flattenRouteParams(params),
     searchParams: flattenRouteParams(searchParams),
   };
 
-  getApp().getActionsService().checkoutCartWithStripe({
+  return getApp().getActionsService().checkoutCartWithStripe({
     cartId,
     version,
     confirmationTokenId,

--- a/libs/payments/ui/src/lib/actions/createPayPalBillingAgreementId.ts
+++ b/libs/payments/ui/src/lib/actions/createPayPalBillingAgreementId.ts
@@ -4,12 +4,11 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
-export const createPayPalBillingAgreementId = async (
-  uid: string,
-  token: string
-) => {
+export const createPayPalBillingAgreementId = async (token: string) => {
+  const uid = await requireSessionUid();
   return await getApp()
     .getActionsService()
     .createPayPalBillingAgreementId({ uid, token });

--- a/libs/payments/ui/src/lib/actions/determineCancellationIntervention.ts
+++ b/libs/payments/ui/src/lib/actions/determineCancellationIntervention.ts
@@ -4,16 +4,17 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const determineCancellationInterventionAction = async (args: {
-  uid: string;
   subscriptionId: string;
   acceptLanguage?: string | null;
   selectedLanguage?: string;
 }) => {
+  const uid = await requireSessionUid();
   return await getApp().getActionsService().determineCancellationIntervention({
-    uid: args.uid,
+    uid,
     subscriptionId: args.subscriptionId,
     acceptLanguage: args.acceptLanguage,
     selectedLanguage: args.selectedLanguage,

--- a/libs/payments/ui/src/lib/actions/determineChurnCancelEligibility.ts
+++ b/libs/payments/ui/src/lib/actions/determineChurnCancelEligibility.ts
@@ -4,14 +4,15 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const determineChurnCancelEligibilityAction = async (
-  uid: string,
   subscriptionId: string,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   return await getApp().getActionsService().determineChurnCancelEligibility({
     uid,
     subscriptionId,

--- a/libs/payments/ui/src/lib/actions/determineCurrencyForCustomer.ts
+++ b/libs/payments/ui/src/lib/actions/determineCurrencyForCustomer.ts
@@ -4,9 +4,11 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
-export const determineCurrencyForCustomerAction = async (uid: string) => {
+export const determineCurrencyForCustomerAction = async () => {
+  const uid = await requireSessionUid();
   const { currency } = await getApp()
     .getActionsService()
     .determineCurrencyForCustomer({

--- a/libs/payments/ui/src/lib/actions/determineStaySubscribedEligibility.ts
+++ b/libs/payments/ui/src/lib/actions/determineStaySubscribedEligibility.ts
@@ -4,14 +4,15 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const determineStaySubscribedEligibilityAction = async (
-  uid: string,
   subscriptionId: string,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   return await getApp().getActionsService().determineStaySubscribedEligibility({
     uid,
     subscriptionId,

--- a/libs/payments/ui/src/lib/actions/getCancelFlowContent.ts
+++ b/libs/payments/ui/src/lib/actions/getCancelFlowContent.ts
@@ -4,14 +4,15 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const getCancelFlowContentAction = async (
-  uid: string,
   subscriptionId: string,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   const result = await getApp().getActionsService().getCancelFlowContent({
     uid,
     subscriptionId,

--- a/libs/payments/ui/src/lib/actions/getExperimentsAction.ts
+++ b/libs/payments/ui/src/lib/actions/getExperimentsAction.ts
@@ -4,6 +4,7 @@
 
 'use server';
 
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import { getIpAddress } from '../utils/getIpAddress';
 import { headers } from 'next/headers';
@@ -11,8 +12,8 @@ import { headers } from 'next/headers';
 export const getExperimentsAction = async (args: {
   experimentationPreview: boolean;
   language: string;
-  fxaUid?: string;
 }) => {
+  const fxaUid = await getSessionUid();
   const ip = await getIpAddress();
   const experimentationId = (await headers()).get('x-experimentation-id') || '';
 
@@ -21,6 +22,7 @@ export const getExperimentsAction = async (args: {
       .getActionsService()
       .getExperiments({
         ...args,
+        fxaUid,
         ip,
         experimentationId,
       });

--- a/libs/payments/ui/src/lib/actions/getInterstitialOfferContent.ts
+++ b/libs/payments/ui/src/lib/actions/getInterstitialOfferContent.ts
@@ -4,14 +4,15 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const getInterstitialOfferContentAction = async (
-  uid: string,
   subscriptionId: string,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   return getApp().getActionsService().getInterstitialOfferContent({
     uid,
     subscriptionId,

--- a/libs/payments/ui/src/lib/actions/getPayPalBillingAgreementId.ts
+++ b/libs/payments/ui/src/lib/actions/getPayPalBillingAgreementId.ts
@@ -4,9 +4,11 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
-export const getPayPalBillingAgreementId = async (uid: string) => {
+export const getPayPalBillingAgreementId = async () => {
+  const uid = await requireSessionUid();
   const { paypalBillingAgreementId } = await getApp()
     .getActionsService()
     .getPaypalBillingAgreementActiveId({ uid });

--- a/libs/payments/ui/src/lib/actions/getStaySubscribedFlowContent.ts
+++ b/libs/payments/ui/src/lib/actions/getStaySubscribedFlowContent.ts
@@ -4,14 +4,15 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const getStaySubscribedFlowContentAction = async (
-  uid: string,
   subscriptionId: string,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   const result = await getApp()
     .getActionsService()
     .getStaySubscribedFlowContent({

--- a/libs/payments/ui/src/lib/actions/getStripeClientSession.ts
+++ b/libs/payments/ui/src/lib/actions/getStripeClientSession.ts
@@ -3,9 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
-export const getStripeClientSession = async (uid: string) => {
+export const getStripeClientSession = async () => {
+  const uid = await requireSessionUid();
   return getApp().getActionsService().getStripePaymentManagementDetails({
     uid,
   });

--- a/libs/payments/ui/src/lib/actions/getSubManPageContent.ts
+++ b/libs/payments/ui/src/lib/actions/getSubManPageContent.ts
@@ -4,17 +4,18 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import { flattenRouteParams } from '../utils/flatParam';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
 
 export const getSubManPageContentAction = async (
-  uid: string,
   params: Record<string, string | string[] | undefined>,
   searchParams: Record<string, string | string[] | undefined>,
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   const requestArgs = {
     ...(await getAdditionalRequestArgs()),
     params: flattenRouteParams(params),

--- a/libs/payments/ui/src/lib/actions/getTaxAddress.ts
+++ b/libs/payments/ui/src/lib/actions/getTaxAddress.ts
@@ -3,10 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 'use server';
 
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
-export const getTaxAddressAction = async (ipAddress: string, uid?: string) => {
-  const { result } = await getApp().getActionsService().getTaxAddress({ ipAddress, uid });
+export const getTaxAddressAction = async (ipAddress: string) => {
+  const uid = await getSessionUid();
+  const { result } = await getApp()
+    .getActionsService()
+    .getTaxAddress({ ipAddress, uid });
 
   return result;
 };

--- a/libs/payments/ui/src/lib/actions/redeemChurnCoupon.ts
+++ b/libs/payments/ui/src/lib/actions/redeemChurnCoupon.ts
@@ -4,12 +4,12 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import { flattenRouteParams } from '../utils/flatParam';
 import { getAdditionalRequestArgs } from '../utils/getAdditionalRequestArgs';
 
 export const redeemChurnCouponAction = async (
-  uid: string,
   subscriptionId: string,
   churnType: 'cancel' | 'stay_subscribed',
   params: Record<string, string | string[] | undefined>,
@@ -17,6 +17,7 @@ export const redeemChurnCouponAction = async (
   acceptLanguage?: string | null,
   selectedLanguage?: string
 ) => {
+  const uid = await requireSessionUid();
   const requestArgs = {
     ...(await getAdditionalRequestArgs()),
     params: flattenRouteParams(params),

--- a/libs/payments/ui/src/lib/actions/resubscribeSubscription.ts
+++ b/libs/payments/ui/src/lib/actions/resubscribeSubscription.ts
@@ -5,12 +5,11 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
-export const resubscribeSubscriptionAction = async (
-  uid: string,
-  subscriptionId: string
-) => {
+export const resubscribeSubscriptionAction = async (subscriptionId: string) => {
+  const uid = await requireSessionUid();
   const result = await getApp().getActionsService().resubscribeSubscription({
     uid,
     subscriptionId,

--- a/libs/payments/ui/src/lib/actions/setDefaultStripePaymentDetails.ts
+++ b/libs/payments/ui/src/lib/actions/setDefaultStripePaymentDetails.ts
@@ -4,13 +4,14 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import { getIpAddress } from '../utils/getIpAddress';
 
 export const setDefaultStripePaymentDetails = async (
-  uid: string,
-  paymentMethodId: string,
+  paymentMethodId: string
 ) => {
+  const uid = await requireSessionUid();
   const actionsService = getApp().getActionsService();
   const ipAddress = await getIpAddress();
 

--- a/libs/payments/ui/src/lib/actions/setupCart.ts
+++ b/libs/payments/ui/src/lib/actions/setupCart.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 'use server';
 
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import type { SubplatInterval, TaxAddress } from '@fxa/payments/customer';
 
@@ -11,9 +12,9 @@ export const setupCartAction = async (
   offeringConfigId: string,
   taxAddress: TaxAddress,
   experiment?: string,
-  promoCode?: string,
-  uid?: string
+  promoCode?: string
 ) => {
+  const uid = await getSessionUid();
   return getApp().getActionsService().setupCart({
     interval,
     offeringConfigId,

--- a/libs/payments/ui/src/lib/actions/updateStripePaymentDetails.ts
+++ b/libs/payments/ui/src/lib/actions/updateStripePaymentDetails.ts
@@ -4,13 +4,14 @@
 
 'use server';
 
+import { requireSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import { getIpAddress } from '../utils/getIpAddress';
 
 export const updateStripePaymentDetails = async (
-  uid: string,
   confirmationTokenId: string
 ) => {
+  const uid = await requireSessionUid();
   const actionsService = getApp().getActionsService();
   const ipAddress = await getIpAddress();
 

--- a/libs/payments/ui/src/lib/actions/updateTaxAddress.ts
+++ b/libs/payments/ui/src/lib/actions/updateTaxAddress.ts
@@ -6,6 +6,7 @@
 
 import { revalidatePath } from 'next/cache';
 
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 import { TaxAddress } from '@fxa/payments/customer';
 
@@ -14,9 +15,9 @@ export const updateTaxAddressAction = async (
   version: number,
   offeringId: string,
   taxAddress: TaxAddress,
-  uid?: string,
   interval?: string
 ) => {
+  const uid = await getSessionUid();
   const actionsService = getApp().getActionsService();
 
   const result = await actionsService.updateTaxAddress({

--- a/libs/payments/ui/src/lib/actions/validateLocation.ts
+++ b/libs/payments/ui/src/lib/actions/validateLocation.ts
@@ -4,14 +4,15 @@
 'use server';
 
 import { TaxAddress } from '@fxa/payments/customer';
+import { getSessionUid } from '@fxa/payments/ui-auth';
 import { getApp } from '../nestapp/app';
 
 export const validateLocationAction = async (
   offeringId: string,
   taxAddress?: TaxAddress,
-  uid?: string,
   interval?: string
 ) => {
+  const uid = await getSessionUid();
   return await getApp()
     .getActionsService()
     .validateLocation({ offeringId, taxAddress, uid, interval });

--- a/libs/payments/ui/src/lib/client/components/CancelSubscription/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CancelSubscription/index.tsx
@@ -18,7 +18,6 @@ import { getLocalizedDateString } from '@fxa/shared/l10n';
 import { LinkExternal } from '@fxa/shared/react';
 
 interface CancelSubscriptionProps {
-  userId: string;
   subscriptionId: string;
   locale: string;
   pageContent: {
@@ -32,7 +31,6 @@ interface CancelSubscriptionProps {
 }
 
 export function CancelSubscription({
-  userId,
   subscriptionId,
   locale,
   pageContent,
@@ -56,10 +54,7 @@ export function CancelSubscription({
     }
 
     setLoading(true);
-    const result = await cancelSubscriptionAtPeriodEndAction(
-      userId,
-      subscriptionId
-    );
+    const result = await cancelSubscriptionAtPeriodEndAction(subscriptionId);
     if (result.ok) {
       setCheckedState(false);
       setShowCancelActionError(false);

--- a/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/CheckoutForm/index.tsx
@@ -90,7 +90,6 @@ interface CheckoutFormProps {
     };
   };
   locale: string;
-  sessionUid?: string;
   sessionEmail?: string;
   isFreeTrial?: boolean;
   trialLengthDays?: number;
@@ -103,7 +102,6 @@ export function CheckoutForm({
   cmsCommonContent,
   cart,
   locale,
-  sessionUid,
   sessionEmail,
   isFreeTrial,
   trialLengthDays,
@@ -256,8 +254,7 @@ export function CheckoutForm({
         cart.version,
         getAttributionParams(searchParams),
         params,
-        Object.fromEntries(searchParams),
-        sessionUid
+        Object.fromEntries(searchParams)
       );
 
       const queryParamString = searchParams.toString()
@@ -340,8 +337,7 @@ export function CheckoutForm({
       confirmationToken.id,
       getAttributionParams(searchParams),
       params,
-      Object.fromEntries(searchParams),
-      sessionUid
+      Object.fromEntries(searchParams)
     );
 
     const queryParamString = searchParams.toString()
@@ -446,7 +442,6 @@ export function CheckoutForm({
                 cartId={cart.id}
                 cartVersion={cart.version}
                 cartCurrency={cart.currency}
-                sessionUid={sessionUid}
                 searchParams={searchParams}
                 disabled={loading || !formEnabled}
               />
@@ -492,7 +487,6 @@ interface CheckoutPayPalButtonProps {
   cartId: string;
   cartVersion: number;
   cartCurrency: string;
-  sessionUid?: string;
   searchParams: ReadonlyURLSearchParams;
   disabled: boolean;
 }
@@ -501,7 +495,6 @@ function CheckoutPayPalButton({
   cartId,
   cartVersion,
   cartCurrency,
-  sessionUid,
   searchParams,
   disabled,
 }: CheckoutPayPalButtonProps) {
@@ -557,7 +550,6 @@ function CheckoutPayPalButton({
           getAttributionParams(searchParams),
           params,
           Object.fromEntries(searchParams),
-          sessionUid,
           data.orderID
         );
         const queryParamString = searchParams.toString()

--- a/libs/payments/ui/src/lib/client/components/ChurnCancel/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/ChurnCancel/index.tsx
@@ -30,7 +30,6 @@ import { LinkExternal } from '@fxa/shared/react';
 import { useGleanMetrics } from '../../hooks/useGleanMetrics';
 
 interface ChurnCancelProps {
-  uid: string;
   metricsEnabled: boolean;
   subscriptionId: string;
   locale: string;
@@ -72,7 +71,6 @@ interface ChurnCancelProps {
 }
 
 export function ChurnCancel({
-  uid,
   metricsEnabled,
   subscriptionId,
   locale,
@@ -166,7 +164,6 @@ export function ChurnCancel({
 
     try {
       const result = await redeemChurnCouponAction(
-        uid,
         subscriptionId,
         'cancel',
         { ...params },
@@ -220,10 +217,7 @@ export function ChurnCancel({
     });
 
     try {
-      const result = await cancelSubscriptionAtPeriodEndAction(
-        uid,
-        subscriptionId
-      );
+      const result = await cancelSubscriptionAtPeriodEndAction(subscriptionId);
 
       if (result.ok) {
         glean.recordRetentionFlowResult({

--- a/libs/payments/ui/src/lib/client/components/ChurnStaySubscribed/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/ChurnStaySubscribed/index.tsx
@@ -28,7 +28,6 @@ import { LinkExternal } from '@fxa/shared/react';
 import { useGleanMetrics } from '../../hooks/useGleanMetrics';
 
 interface ChurnStaySubscribedProps {
-  uid: string;
   metricsEnabled: boolean;
   subscriptionId: string;
   locale: string;
@@ -69,7 +68,6 @@ interface ChurnStaySubscribedProps {
 }
 
 export function ChurnStaySubscribed({
-  uid,
   metricsEnabled,
   subscriptionId,
   locale,
@@ -157,7 +155,6 @@ export function ChurnStaySubscribed({
 
     try {
       const result = await redeemChurnCouponAction(
-        uid,
         subscriptionId,
         'stay_subscribed',
         { ...params },
@@ -213,7 +210,7 @@ export function ChurnStaySubscribed({
     });
 
     try {
-      const result = await resubscribeSubscriptionAction(uid, subscriptionId);
+      const result = await resubscribeSubscriptionAction(subscriptionId);
       if (result.ok) {
         glean.recordRetentionFlowResult({
           ...retentionFlowBase,

--- a/libs/payments/ui/src/lib/client/components/FreeTrialContent/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/FreeTrialContent/index.tsx
@@ -45,14 +45,12 @@ interface TrialSubscription {
 interface FreeTrialContentProps {
   trial: TrialSubscription;
   locale: string;
-  userId: string;
   updatePaymentUrl?: string;
 }
 
 export const FreeTrialContent = ({
   trial,
   locale,
-  userId,
   updatePaymentUrl,
 }: FreeTrialContentProps) => {
   const {
@@ -175,7 +173,7 @@ export const FreeTrialContent = ({
     setLoading(true);
     setShowActionError(false);
 
-    const result = await cancelSubscriptionAtPeriodEndAction(userId, trial.id);
+    const result = await cancelSubscriptionAtPeriodEndAction(trial.id);
     if (result.ok) {
       setIsCancelled(true);
     } else {
@@ -190,7 +188,7 @@ export const FreeTrialContent = ({
     setLoading(true);
     setShowActionError(false);
 
-    const result = await cancelSubscriptionImmediatelyAction(userId, trial.id);
+    const result = await cancelSubscriptionImmediatelyAction(trial.id);
     if (result.ok) {
       setIsCancelled(true);
     } else {
@@ -205,7 +203,7 @@ export const FreeTrialContent = ({
     setLoading(true);
     setShowActionError(false);
 
-    const result = await resubscribeSubscriptionAction(userId, trial.id);
+    const result = await resubscribeSubscriptionAction(trial.id);
     if (result.ok) {
       setIsCancelled(false);
     } else {

--- a/libs/payments/ui/src/lib/client/components/InterstitialOffer/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/InterstitialOffer/index.tsx
@@ -20,7 +20,6 @@ import { BaseButton } from '../BaseButton';
 import { useGleanMetrics } from '../../hooks/useGleanMetrics';
 
 interface InterstitialOfferProps {
-  uid: string;
   metricsEnabled: boolean;
   locale: string;
   subscriptionId: string;
@@ -52,7 +51,6 @@ interface InterstitialOfferProps {
 }
 
 export function InterstitialOffer({
-  uid,
   metricsEnabled,
   locale,
   subscriptionId,
@@ -153,10 +151,7 @@ export function InterstitialOffer({
     });
 
     try {
-      const result = await cancelSubscriptionAtPeriodEndAction(
-        uid,
-        subscriptionId
-      );
+      const result = await cancelSubscriptionAtPeriodEndAction(subscriptionId);
 
       if (result.ok) {
         glean.recordInterstitialOfferResult({

--- a/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentMethodManagement/index.tsx
@@ -27,12 +27,10 @@ import {
 } from '@fxa/payments/ui/actions';
 
 export function PaymentMethodManagement({
-  uid,
   defaultPaymentMethod,
   sessionEmail,
   locale,
 }: {
-  uid?: string;
   defaultPaymentMethod?: {
     id: string;
     type?: string;
@@ -144,7 +142,6 @@ export function PaymentMethodManagement({
       return await handleNextAction(response.setupIntent.client_secret);
     } else if (response.setupIntent?.status === 'succeeded') {
       await setDefaultStripePaymentDetails(
-        uid ?? '',
         typeof response.setupIntent.payment_method === 'string'
           ? response.setupIntent.payment_method
           : (response.setupIntent.payment_method?.id ?? '')
@@ -189,7 +186,6 @@ export function PaymentMethodManagement({
       }
 
       const { ok, result, errorMessage } = await updateStripePaymentDetails(
-        uid ?? '',
         confirmationToken.id
       );
       if (!ok || !result) {

--- a/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaymentSection/index.tsx
@@ -118,7 +118,6 @@ export function PaymentSection({
           cmsCommonContent={cmsCommonContent}
           cart={cart}
           locale={locale}
-          sessionUid={sessionUid}
           sessionEmail={sessionEmail}
           isFreeTrial={isFreeTrial}
           trialLengthDays={trialLengthDays}

--- a/libs/payments/ui/src/lib/client/components/PaypalManagement/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/PaypalManagement/index.tsx
@@ -31,14 +31,12 @@ const paypalInitialOptions: ReactPayPalScriptOptions = {
 interface PaypalManagementProps {
   nonce?: string;
   paypalClientId: string;
-  sessionUid: string;
   currency: string;
 }
 
 export function PaypalManagement({
   nonce,
   paypalClientId,
-  sessionUid,
   currency,
 }: PaypalManagementProps) {
   const { locale } = useParams();
@@ -58,7 +56,6 @@ export function PaypalManagement({
         <ManagementPayPalButton
           currency={currency}
           locale={Array.isArray(locale) ? locale[0] : locale || ''}
-          sessionUid={sessionUid}
           searchParams={searchParams}
         />
       </div>
@@ -69,14 +66,12 @@ export function PaypalManagement({
 interface ManagementPayPalButtonProps {
   currency: string;
   locale: string;
-  sessionUid: string;
   searchParams: ReadonlyURLSearchParams;
 }
 
 function ManagementPayPalButton({
   currency,
   locale,
-  sessionUid,
   searchParams,
 }: ManagementPayPalButtonProps) {
   const router = useRouter();
@@ -121,7 +116,7 @@ function ManagementPayPalButton({
         getPayPalCheckoutToken(currency.toLowerCase())
       }
       onApprove={async (data: { orderID: string }) => {
-        await createPayPalBillingAgreementId(sessionUid, data.orderID);
+        await createPayPalBillingAgreementId(data.orderID);
         router.push(`/${locale}/subscriptions/manage` + queryParamString);
       }}
       onError={(error) => {

--- a/libs/payments/ui/src/lib/client/components/StaySubscribed/index.tsx
+++ b/libs/payments/ui/src/lib/client/components/StaySubscribed/index.tsx
@@ -21,7 +21,6 @@ import {
 } from '@fxa/shared/l10n';
 
 interface StaySubscribedProps {
-  userId: string;
   subscriptionId: string;
   locale: string;
   pageContent: {
@@ -39,7 +38,6 @@ interface StaySubscribedProps {
 }
 
 export function StaySubscribed({
-  userId,
   subscriptionId,
   locale,
   pageContent,
@@ -67,7 +65,7 @@ export function StaySubscribed({
     setLoading(true);
     setResubscribeActionError(false);
 
-    const result = await resubscribeSubscriptionAction(userId, subscriptionId);
+    const result = await resubscribeSubscriptionAction(subscriptionId);
     if (!result.ok) {
       setResubscribeActionError(true);
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -60,6 +60,7 @@
       "@fxa/payments/paypal": ["libs/payments/paypal/src/index.ts"],
       "@fxa/payments/stripe": ["libs/payments/stripe/src/index.ts"],
       "@fxa/payments/ui": ["libs/payments/ui/src/index.ts"],
+      "@fxa/payments/ui-auth": ["libs/payments/ui-auth/src/index.ts"],
       "@fxa/payments/ui/actions": ["libs/payments/ui/src/lib/actions/index.ts"],
       "@fxa/payments/ui/server": ["libs/payments/ui/src/server.ts"],
       "@fxa/payments/ui/utils": ["libs/payments/ui/src/utils.ts"],


### PR DESCRIPTION
## Because

- client-supplied uid should not be in mutating actions

## This pull request

- adds payments/ui-auth lib wrapping next-auth setup and session helpers
- drops uid params from actions; reads from session via requireSessionUid and getSessionUid

## Issue that this pull request solves

Closes: #PAY-3697

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
- [x] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
