### PR TITLE
fix(settings): show banner when canceling passkey creation from loading state

### DIFF
--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.stories.tsx
@@ -2,17 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import { ReactNode, useEffect, useMemo } from 'react';
 import { Meta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import { withLocalization } from 'fxa-react/lib/storybooks';
-import { LocationProvider } from '@reach/router';
-import { PagePasskeyAdd } from '.';
-import { AppContext } from 'fxa-settings/src/models';
 import {
-  mockAppContext,
-  mockSettingsContext,
-} from 'fxa-settings/src/models/mocks';
-import { SettingsContext } from 'fxa-settings/src/models/contexts/SettingsContext';
+  createHistory,
+  createMemorySource,
+  LocationProvider,
+} from '@reach/router';
+import { PagePasskeyAdd } from '.';
+import { AppContext } from '../../../models';
+import { AlertBarInfo } from '../../../models/AlertBarInfo';
+import { mockAppContext, mockSettingsContext } from '../../../models/mocks';
+import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import { MfaContext } from '../MfaGuard';
 import { getDefault } from '../../../lib/config';
 
@@ -26,11 +29,27 @@ const mockAccount = {
   getCachedJwtByScope: () => 'mock-jwt',
 } as any;
 
-// Auth client that never resolves — keeps the loading page visible.
 const hangingAuthClient = {
   beginPasskeyRegistration: () => new Promise(() => {}),
   completePasskeyRegistration: () => new Promise(() => {}),
 };
+
+// Mirrors AlertBarInfo calls into the Actions panel; the real banner shows
+// on the destination settings page, not here.
+class StoryAlertBarInfo extends AlertBarInfo {
+  success(message: string | ReactNode, gleanEvent?: () => void) {
+    action('alertBar.success')(message);
+    super.success(message, gleanEvent);
+  }
+  error(message: string | ReactNode, error?: Error) {
+    action('alertBar.error')(message);
+    super.error(message, error);
+  }
+  info(message: string | ReactNode) {
+    action('alertBar.info')(message);
+    super.info(message);
+  }
+}
 
 function initLocalAccount() {
   const NS = '__fxa_storage';
@@ -58,8 +77,23 @@ const configWithPasskeys = {
 
 export const CeremonyInProgress = () => {
   initLocalAccount();
+  // In-memory history so navigation doesn't change the storybook iframe's
+  // real URL (which would unmount the story). Memoized so toolbar-driven
+  // re-renders (theme, direction, etc.) don't accumulate listeners or
+  // recreate the history on every render.
+  const history = useMemo(
+    () => createHistory(createMemorySource('/settings/passkeys/add')),
+    []
+  );
+  useEffect(
+    () =>
+      history.listen(({ location }) =>
+        action('navigate')(`${location.pathname}${location.hash ?? ''}`)
+      ),
+    [history]
+  );
   return (
-    <LocationProvider>
+    <LocationProvider history={history}>
       <AppContext.Provider
         value={mockAppContext({
           account: mockAccount,
@@ -67,7 +101,9 @@ export const CeremonyInProgress = () => {
           config: configWithPasskeys,
         })}
       >
-        <SettingsContext.Provider value={mockSettingsContext()}>
+        <SettingsContext.Provider
+          value={mockSettingsContext({ alertBarInfo: new StoryAlertBarInfo() })}
+        >
           <MfaContext.Provider value="passkey">
             <PagePasskeyAdd />
           </MfaContext.Provider>

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.test.tsx
@@ -11,6 +11,7 @@ import { Account, AppContext } from '../../../models';
 import { mockAppContext, mockSettingsContext } from '../../../models/mocks';
 import { SettingsContext } from '../../../models/contexts/SettingsContext';
 import { MfaContext } from '../MfaGuard';
+import { createCredential } from '../../../lib/passkeys/webauthn';
 import {
   WebAuthnErrorCategory,
   WebAuthnErrorType,
@@ -34,10 +35,13 @@ jest.mock('@sentry/browser', () => ({
   captureException: (...args: unknown[]) => mockCaptureException(...args),
 }));
 
-// Mock WebAuthn utilities
-const mockCreateCredential = jest.fn();
+const mockCreateCredential = jest.fn() as jest.MockedFunction<
+  typeof createCredential
+>;
 jest.mock('../../../lib/passkeys/webauthn', () => ({
-  createCredential: (...args: unknown[]) => mockCreateCredential(...args),
+  createCredential: (
+    ...args: Parameters<typeof createCredential>
+  ): ReturnType<typeof createCredential> => mockCreateCredential(...args),
 }));
 
 const mockHandleWebAuthnError = jest.fn();
@@ -93,6 +97,7 @@ const mockCredential = {
     clientDataJSON: 'ZXlK',
     attestationObject: 'bzJO',
   },
+  clientExtensionResults: {},
 };
 
 function renderPage() {
@@ -183,7 +188,11 @@ describe('PagePasskeyAdd', () => {
       replace: true,
     });
     expect(mockBeginPasskeyRegistration).toHaveBeenCalledWith('mock-jwt');
-    expect(mockCreateCredential).toHaveBeenCalledWith(mockCreationOptions);
+    expect(mockCreateCredential).toHaveBeenCalledWith(
+      mockCreationOptions,
+      undefined,
+      expect.any(AbortSignal)
+    );
     expect(mockCompletePasskeyRegistration).toHaveBeenCalledWith(
       'mock-jwt',
       mockCredential,
@@ -353,12 +362,74 @@ describe('PagePasskeyAdd', () => {
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-  it('cancel button navigates back to settings', () => {
+  it('cancel button shows cancellation banner and navigates back to settings', () => {
     mockBeginPasskeyRegistration.mockReturnValue(new Promise(() => {}));
     renderPage();
     fireEvent.click(screen.getByTestId('passkey-add-cancel'));
+    expect(mockAlertError).toHaveBeenCalledWith(
+      'Passkey setup was canceled. Try again.'
+    );
     expect(mockNavigateWithQuery).toHaveBeenCalledWith('/settings#security', {
       replace: true,
     });
+  });
+
+  it('cancel button aborts the in-flight WebAuthn ceremony', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    mockCreateCredential.mockImplementation((_opts, _timeoutMs, signal) => {
+      capturedSignal = signal;
+      return new Promise(() => {});
+    });
+    renderPage();
+    await waitFor(() => expect(capturedSignal).toBeDefined());
+    expect(capturedSignal!.aborted).toBe(false);
+    fireEvent.click(screen.getByTestId('passkey-add-cancel'));
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it('cancel between createCredential and completePasskeyRegistration skips the server completion call', async () => {
+    // Hold createCredential resolution so we can click cancel after it resolves
+    // but before the success path proceeds.
+    let resolveCreate: (value: typeof mockCredential) => void = () => {};
+    mockCreateCredential.mockImplementation(
+      () =>
+        new Promise<typeof mockCredential>((resolve) => {
+          resolveCreate = resolve;
+        })
+    );
+    renderPage();
+    await waitFor(() => expect(mockCreateCredential).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId('passkey-add-cancel'));
+    resolveCreate(mockCredential);
+    // Yield twice so the awaited continuation runs and observes wasCanceled.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mockCompletePasskeyRegistration).not.toHaveBeenCalled();
+    expect(mockAlertSuccess).not.toHaveBeenCalled();
+    expect(mockAlertError).toHaveBeenCalledWith(
+      'Passkey setup was canceled. Try again.'
+    );
+  });
+
+  it('cancel does not double-fire alerts when the AbortError surfaces in the catch block', async () => {
+    mockCreateCredential.mockImplementation(
+      (_opts, _timeoutMs, signal) =>
+        new Promise<typeof mockCredential>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          });
+        })
+    );
+    renderPage();
+    await waitFor(() => expect(mockCreateCredential).toHaveBeenCalled());
+    fireEvent.click(screen.getByTestId('passkey-add-cancel'));
+    await Promise.resolve();
+    await Promise.resolve();
+    // Only the cancel banner — the catch block must not fire its own banner.
+    expect(mockAlertError).toHaveBeenCalledTimes(1);
+    expect(mockAlertError).toHaveBeenCalledWith(
+      'Passkey setup was canceled. Try again.'
+    );
+    expect(mockHandleWebAuthnError).not.toHaveBeenCalled();
   });
 });

--- a/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/PagePasskeyAdd/index.tsx
@@ -48,25 +48,47 @@ export const PagePasskeyAdd = () => {
 
   const ceremonyStarted = useRef(false);
   const isMounted = useRef(true);
+  const wasCanceled = useRef(false);
+  const abortController = useRef<AbortController | null>(null);
 
   const navigateToSettings = useCallback(() => {
     navigateWithQuery(SETTINGS_PATH + '#security', { replace: true });
   }, [navigateWithQuery]);
 
   const handleCancel = useCallback(() => {
+    if (wasCanceled.current) return;
+    // Mark cancellation before aborting so the in-flight ceremony's catch
+    // block can suppress the resulting AbortError instead of double-firing
+    // alert/navigate.
+    wasCanceled.current = true;
+    abortController.current?.abort();
+    alertBar.error(
+      ftlMsgResolver.getMsg(
+        'passkey-registration-canceled',
+        'Passkey setup was canceled. Try again.'
+      )
+    );
     navigateToSettings();
-  }, [navigateToSettings]);
+  }, [alertBar, ftlMsgResolver, navigateToSettings]);
 
   useEffect(() => {
     isMounted.current = true;
     return () => {
       isMounted.current = false;
+      // Sticky guard so a StrictMode dry-run unmount doesn't surface as a
+      // spurious error banner on remount.
+      wasCanceled.current = true;
+      abortController.current?.abort();
+      abortController.current = null;
     };
   }, []);
 
   useEffect(() => {
     if (ceremonyStarted.current) return;
     ceremonyStarted.current = true;
+
+    const controller = new AbortController();
+    abortController.current = controller;
 
     const runCeremony = async () => {
       GleanMetrics.accountPref.passkeyCreateView();
@@ -83,12 +105,19 @@ export const PagePasskeyAdd = () => {
         const challenge = creationOptions.challenge;
         hadExcludeCredentials = !!creationOptions.excludeCredentials?.length;
 
-        if (!isMounted.current) return;
+        if (!isMounted.current || wasCanceled.current) return;
 
         // Step 2: Browser WebAuthn prompt
-        const credential = await createCredential(creationOptions);
+        const credential = await createCredential(
+          creationOptions,
+          undefined,
+          controller.signal
+        );
 
-        if (!isMounted.current) return;
+        // After the WebAuthn prompt resolves we're past the abortable window;
+        // if the user has clicked Cancel by this point, skip the server call
+        // so we don't create a passkey the user thinks they canceled.
+        if (!isMounted.current || wasCanceled.current) return;
 
         // Step 3: Complete registration with server
         await authClient.completePasskeyRegistration(
@@ -98,7 +127,7 @@ export const PagePasskeyAdd = () => {
         );
         await account.refresh('passkeys');
 
-        if (!isMounted.current) return;
+        if (!isMounted.current || wasCanceled.current) return;
 
         // Success
         GleanMetrics.accountPref.passkeyCreateSuccessView();
@@ -107,7 +136,9 @@ export const PagePasskeyAdd = () => {
         );
         navigateToSettings();
       } catch (error) {
-        if (!isMounted.current) return;
+        // handleCancel already showed the cancellation banner and navigated;
+        // suppress the AbortError side effects so they don't double-fire.
+        if (!isMounted.current || wasCanceled.current) return;
 
         // Check if MFA JWT expired
         if (handleMfaError(error)) return;

--- a/packages/fxa-settings/src/lib/passkeys/en.ftl
+++ b/packages/fxa-settings/src/lib/passkeys/en.ftl
@@ -14,6 +14,9 @@ passkey-registration-error-not-allowed-existing = Passkey setup isn’t availabl
 # The ceremony timed out before the user responded
 passkey-registration-error-timeout = Passkey setup was canceled. Try again.
 
+# User clicked the in-page Cancel link while the ceremony was still pending
+passkey-registration-canceled = Passkey setup was canceled. Try again.
+
 # Browser or platform does not support passkeys or the requested options (e.g., UV, discoverable credential)
 passkey-registration-error-not-supported = Passkeys aren’t supported here. Try another method or device.
 

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.test.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.test.ts
@@ -167,6 +167,50 @@ describe('createCredential', () => {
     await expect(promise).rejects.toMatchObject({ name: 'TimeoutError' });
   });
 
+  it('propagates AbortError when an external signal aborts before completion', async () => {
+    mockCreate.mockImplementation(({ signal }: { signal: AbortSignal }) => {
+      return new Promise((_, reject) => {
+        signal.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        );
+      });
+    });
+
+    const externalController = new AbortController();
+    const promise = createCredential(
+      mockCreationOptions,
+      undefined,
+      externalController.signal
+    );
+    externalController.abort();
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('rejects immediately when the external signal is already aborted', async () => {
+    // Real browsers reject navigator.credentials.create() synchronously when
+    // passed an already-aborted signal; mirror that behaviour in the mock.
+    mockCreate.mockImplementation(({ signal }: { signal: AbortSignal }) => {
+      if (signal.aborted) {
+        return Promise.reject(new DOMException('Aborted', 'AbortError'));
+      }
+      return new Promise((_, reject) => {
+        signal.addEventListener('abort', () =>
+          reject(new DOMException('Aborted', 'AbortError'))
+        );
+      });
+    });
+
+    const externalController = new AbortController();
+    externalController.abort();
+    await expect(
+      createCredential(
+        mockCreationOptions,
+        undefined,
+        externalController.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
   it('clears the timeout after successful credential creation', async () => {
     const spy = jest.spyOn(global, 'clearTimeout');
     await createCredential(mockCreationOptions);

--- a/packages/fxa-settings/src/lib/passkeys/webauthn.ts
+++ b/packages/fxa-settings/src/lib/passkeys/webauthn.ts
@@ -226,14 +226,20 @@ const DEFAULT_TIMEOUT_MS = 60_000;
  * them via PublicKeyCredential.parseCreationOptionsFromJSON(), invokes the
  * browser prompt, and returns the serialized credential via toJSON().
  *
+ * Pass `externalSignal` to actively cancel the ceremony from outside (e.g.
+ * a Cancel button); aborting it propagates as the underlying AbortError so
+ * callers can distinguish it from the internal timeout (TimeoutError).
+ *
  * Throws:
  * - DOMException('NotSupportedError') when required WebAuthn APIs are absent
  * - DOMException('TimeoutError') when the operation exceeds timeoutMs
+ * - DOMException('AbortError') when externalSignal aborts before completion
  * - Any DOMException thrown by the browser (propagated as-is)
  */
 export async function createCredential(
   options: PublicKeyCredentialCreationOptionsJSON,
-  timeoutMs = DEFAULT_TIMEOUT_MS
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  externalSignal?: AbortSignal
 ): Promise<PublicKeyCredentialJSON> {
   if (!isWebAuthnLevel3Supported()) {
     throw new DOMException(
@@ -248,6 +254,15 @@ export async function createCredential(
     timedOut = true;
     controller.abort();
   }, timeoutMs);
+
+  const onExternalAbort = () => controller.abort();
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener('abort', onExternalAbort, { once: true });
+    }
+  }
 
   try {
     const parsedOptions = (
@@ -266,6 +281,7 @@ export async function createCredential(
     throw e;
   } finally {
     clearTimeout(timer);
+    externalSignal?.removeEventListener('abort', onExternalAbort);
   }
 }
 


### PR DESCRIPTION
## Because

- The "Cancel" button on the "Creating passkey…" loading page navigated back to settings without any feedback. When a credential manager popup (e.g., Bitwarden) is dismissed via focus loss, the WebAuthn ceremony stays pending and Cancel is the user's only escape — but it returned silently, leaving no confirmation that cancellation was processed.

## This pull request

- Shows the standard cancellation banner ("Passkey setup was canceled. Try again.") in the alert bar when navigating back to settings, mirroring the feedback the user gets when the ceremony itself reports a cancel/timeout.

## Issue that this pull request solves

Closes: FXA-13681

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
- [ ] I have manually reviewed all AI generated code.

## How to review (Optional)

- Key files/areas to focus on:
- Suggested review order:
- Risky or complex parts:

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
